### PR TITLE
[CI] Add initial CI for both platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,98 +9,24 @@ on:
       - master
 
 jobs:
-  macos_debug_build_test:
+  xcodebuild:
     runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: macOS Debug Build and Test
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        macos_build OfficeUIFabricTestApp Debug build test
-  
-  macos_release_build_test:
-    runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: macOS Release Build and Test
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        macos_build OfficeUIFabricTestApp Release build test
+    strategy:
+      matrix:
+        build_command: [
+          'macos_build OfficeUIFabricTestApp Debug build test',
+          'macos_build OfficeUIFabricTestApp Release build test',
+          'ios_simulator_build OfficeUIFabric Debug build test',
+          'ios_simulator_build OfficeUIFabric Release build',
+          'ios_simulator_build Demo.Development Debug build',
+          'ios_simulator_build Demo.Development Release build',
+          'ios_device_build Demo.Development Debug build',
+          'ios_device_build Demo.Development Release build',
+        ]
 
-  ios_simulator_debug_build_test:
-    runs-on: macos-10.15
-    
     steps:
     - uses: actions/checkout@v2
     - name: Switch to Xcode 11.2.1
       run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: iOS Simulator Debug Build and Test
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        ios_simulator_build OfficeUIFabric Debug build test
-  
-  ios_simulator_release_build:
-    runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: iOS Simulator Release Build
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        ios_simulator_build OfficeUIFabric Release build
-
-  ios_testapp_simulator_debug_build:
-    runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: iOS Testapp Simulator Debug Build
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        ios_simulator_build Demo.Development Debug build
-  
-  ios_testapp_simulator_release_build:
-    runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: iOS Testapp Simulator Release Build
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        ios_simulator_build Demo.Development Release build
-
-  ios_testapp_device_debug_build:
-    runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: iOS Testapp Device Debug Build
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        ios_device_build Demo.Development Debug build
-  
-  ios_testapp_device_release_build:
-    runs-on: macos-10.15
-    
-    steps:
-    - uses: actions/checkout@v2
-    - name: Switch to Xcode 11.2.1
-      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
-    - name: iOS Testapp Device Release Build
-      run: |
-        source scripts/xcodebuild_wrapper.sh
-        ios_device_build Demo.Development Release build
+    - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
+      run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,98 @@ on:
       - master
 
 jobs:
-  ci:
-
-    runs-on: macOS-latest
+  macos_debug_build_test:
+    runs-on: macos-10.15
     
     steps:
-    - uses: actions/checkout@master
-    - name: Running CI
-      run: scripts/ci.sh
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: macOS Debug Build and Test
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        macos_build OfficeUIFabricTestApp Debug build test
+  
+  macos_release_build_test:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: macOS Release Build and Test
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        macos_build OfficeUIFabricTestApp Release build test
+
+  ios_simulator_debug_build_test:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: iOS Simulator Debug Build and Test
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        ios_simulator_build OfficeUIFabric Debug build test
+  
+  ios_simulator_release_build:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: iOS Simulator Release Build
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        ios_simulator_build OfficeUIFabric Release build
+
+  ios_testapp_simulator_debug_build:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: iOS Testapp Simulator Debug Build
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        ios_simulator_build Demo.Development Debug build
+  
+  ios_testapp_simulator_release_build:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: iOS Testapp Simulator Release Build
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        ios_simulator_build Demo.Development Release build
+
+  ios_testapp_device_debug_build:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: iOS Testapp Device Debug Build
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        ios_device_build Demo.Development Debug build
+  
+  ios_testapp_device_release_build:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Switch to Xcode 11.2.1
+      run: sudo xcode-select --switch /Applications/Xcode_11.2.1.app/Contents/Developer
+    - name: iOS Testapp Device Release Build
+      run: |
+        source scripts/xcodebuild_wrapper.sh
+        ios_device_build Demo.Development Release build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+
+    runs-on: macOS-latest
+    
+    steps:
+    - uses: actions/checkout@master
+    - name: Running CI
+      run: scripts/ci.sh

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,73 +1,65 @@
 #!/bin/bash
 
-# Invoke xcodebuild
-#
-# \param $1 type of project (Project or Workspace)
-# \param $2 path to  to run against
-# \param $3 scheme to build
-# \param $4 configuration
-# \param $5 sdk
-# \param $6+ build commands
-function invoke_xcodebuild()
+# ci.sh
+# A local version of the ci.yml github action that fires all the jobs sequentially.
+# Useful for local validation, keep in sync with .github/workflows/ci.yml
+# Note: Execute this script from the root of the repository, such as `./scripts/ci.sh`
+
+source "scripts/xcodebuild_wrapper.sh"
+
+# Keep an exit code so that we can return a non-zero exit code if any build fails
+# while still running all builds each time.
+EXIT_CODE=0
+
+function handle_exit_code()
 {
-    /usr/bin/xcodebuild \
-        -"$1" "$2" \
-        -scheme "$3" \
-        -configuration "$4" \
-        -sdk "$5" \
-        "${@:6}" \
-        CODE_SIGNING_ALLOWED=NO
-    
-    return $?
+	if [ $? -ne 0 ]
+	then
+		echo "Previous command exited with non-zero exit code"
+		# Intentionally changing the global EXIT_CODE variable
+		EXIT_CODE=1
+	fi
 }
 
-# Run a macOS build and test with the specified configuration
-# 
-# \param $1 configuration
-function macos_build_test()
-{
-    invoke_xcodebuild project "macos/xcode/OfficeUIFabric.xcodeproj" OfficeUIFabricTestApp "$1" macosx build test
-}
-
-# Run an iOS simulator xcodebuild invocation with the specified scheme, configuration, and build commands
-#
-# \param $1 scheme
-# \param $2 configuration
-# \param $3+ build commands
-function ios_simulator()
-{
-    invoke_xcodebuild workspace "ios/OfficeUIFabric.xcworkspace" "$1" "$2" iphonesimulator "${@:3}" -destination "platform=iOS Simulator,name=iPhone 8"
-}
-
-# Run an iOS device xcodebuild invocation with the specified scheme and configuration
-#
-# \param $1 scheme
-# \param $2 configuration
-function ios_build_device()
-{
-    invoke_xcodebuild workspace "ios/OfficeUIFabric.xcworkspace" "$1" "$2" iphoneos build
-}
 
 echo "Building and Testing macOS Debug"
-macos_build_test Debug
+macos_build OfficeUIFabricTestApp Debug build test
+handle_exit_code
 
 echo "Building and Testing macOS Release"
-macos_build_test Release
+macos_build OfficeUIFabricTestApp Release build test
+handle_exit_code
 
 echo "Building and Testing iOS Debug Simulator"
-ios_simulator OfficeUIFabric Debug build test
+ios_simulator_build OfficeUIFabric Debug build test
+handle_exit_code
 
 echo "Building iOS Release Simulator"
-ios_simulator OfficeUIFabric Release build
+ios_simulator_build OfficeUIFabric Release build
+handle_exit_code
 
 echo "Building iOS Testapp Debug Simulator"
-ios_simulator Demo.Development Debug build
+ios_simulator_build Demo.Development Debug build
+handle_exit_code
 
 echo "Building iOS Testapp Release Simulator"
-ios_simulator Demo.Development Release build
+ios_simulator_build Demo.Development Release build
+handle_exit_code
 
 echo "Building iOS Testapp Debug Device"
-ios_build_device Demo.Development Debug
+ios_device_build Demo.Development Debug build
+handle_exit_code
 
 echo "Building iOS Testapp Release Device"
-ios_build_device Demo.Development Release
+ios_device_build Demo.Development Release build
+handle_exit_code
+
+# Check if any of our individual build steps failed
+if [ $EXIT_CODE -ne 0 ]
+then
+	echo "CI Build Failed, please check logs for failures"
+else
+	echo "CI Build Succeeded"
+fi
+
+exit $EXIT_CODE

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Invoke xcodebuild
+#
+# \param $1 type of project (Project or Workspace)
+# \param $2 path to  to run against
+# \param $3 scheme to build
+# \param $4 configuration
+# \param $5 sdk
+# \param $6+ build commands
+function invoke_xcodebuild()
+{
+    /usr/bin/xcodebuild \
+        -"$1" "$2" \
+        -scheme "$3" \
+        -configuration "$4" \
+        -sdk "$5" \
+        "${@:6}" \
+        CODE_SIGNING_ALLOWED=NO
+    
+    return $?
+}
+
+# Run a macOS build and test with the specified configuration
+# 
+# \param $1 configuration
+function macos_build_test()
+{
+    invoke_xcodebuild project "macos/xcode/OfficeUIFabric.xcodeproj" OfficeUIFabricTestApp "$1" macosx build test
+}
+
+# Run an iOS simulator xcodebuild invocation with the specified scheme, configuration, and build commands
+#
+# \param $1 scheme
+# \param $2 configuration
+# \param $3+ build commands
+function ios_simulator()
+{
+    invoke_xcodebuild workspace "ios/OfficeUIFabric.xcworkspace" "$1" "$2" iphonesimulator "${@:3}" -destination "platform=iOS Simulator,name=iPhone 8"
+}
+
+# Run an iOS device xcodebuild invocation with the specified scheme and configuration
+#
+# \param $1 scheme
+# \param $2 configuration
+function ios_build_device()
+{
+    invoke_xcodebuild workspace "ios/OfficeUIFabric.xcworkspace" "$1" "$2" iphoneos build
+}
+
+echo "Building and Testing macOS Debug"
+macos_build_test Debug
+
+echo "Building and Testing macOS Release"
+macos_build_test Release
+
+echo "Building and Testing iOS Debug Simulator"
+ios_simulator OfficeUIFabric Debug build test
+
+echo "Building iOS Release Simulator"
+ios_simulator OfficeUIFabric Release build
+
+echo "Building iOS Testapp Debug Simulator"
+ios_simulator Demo.Development Debug build
+
+echo "Building iOS Testapp Release Simulator"
+ios_simulator Demo.Development Release build
+
+echo "Building iOS Testapp Debug Device"
+ios_build_device Demo.Development Debug
+
+echo "Building iOS Testapp Release Device"
+ios_build_device Demo.Development Release

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,11 +5,10 @@
 # Useful for local validation, keep in sync with .github/workflows/ci.yml
 # Note: Execute this script from the root of the repository, such as `./scripts/ci.sh`
 
-source "scripts/xcodebuild_wrapper.sh"
-
 # Keep an exit code so that we can return a non-zero exit code if any build fails
 # while still running all builds each time.
 EXIT_CODE=0
+XCODEBUILD_WRAPPER_LOCATION='scripts/xcodebuild_wrapper.sh'
 
 function handle_exit_code()
 {
@@ -23,35 +22,35 @@ function handle_exit_code()
 
 
 echo "Building and Testing macOS Debug"
-macos_build OfficeUIFabricTestApp Debug build test
+$XCODEBUILD_WRAPPER_LOCATION macos_build OfficeUIFabricTestApp Debug build test
 handle_exit_code
 
 echo "Building and Testing macOS Release"
-macos_build OfficeUIFabricTestApp Release build test
+$XCODEBUILD_WRAPPER_LOCATION macos_build OfficeUIFabricTestApp Release build test
 handle_exit_code
 
 echo "Building and Testing iOS Debug Simulator"
-ios_simulator_build OfficeUIFabric Debug build test
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build OfficeUIFabric Debug build test
 handle_exit_code
 
 echo "Building iOS Release Simulator"
-ios_simulator_build OfficeUIFabric Release build
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build OfficeUIFabric Release build
 handle_exit_code
 
 echo "Building iOS Testapp Debug Simulator"
-ios_simulator_build Demo.Development Debug build
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build Demo.Development Debug build
 handle_exit_code
 
 echo "Building iOS Testapp Release Simulator"
-ios_simulator_build Demo.Development Release build
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build Demo.Development Release build
 handle_exit_code
 
 echo "Building iOS Testapp Debug Device"
-ios_device_build Demo.Development Debug build
+$XCODEBUILD_WRAPPER_LOCATION ios_device_build Demo.Development Debug build
 handle_exit_code
 
 echo "Building iOS Testapp Release Device"
-ios_device_build Demo.Development Release build
+$XCODEBUILD_WRAPPER_LOCATION ios_device_build Demo.Development Release build
 handle_exit_code
 
 # Check if any of our individual build steps failed

--- a/scripts/xcodebuild_wrapper.sh
+++ b/scripts/xcodebuild_wrapper.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Invoke xcodebuild
+#
+# Match Azure DevOps xcodebuild invocations by not codesigning on CI builds
+#
+# \param $1 type of project (Project or Workspace)
+# \param $2 path to  to run against
+# \param $3 scheme to build
+# \param $4 configuration
+# \param $5 sdk
+# \param $6+ build commands
+function invoke_xcodebuild()
+{
+    /usr/bin/xcodebuild \
+        -"$1" "$2" \
+        -scheme "$3" \
+        -configuration "$4" \
+        -sdk "$5" \
+        "${@:6}" \
+        CODE_SIGNING_ALLOWED=NO
+    
+    return $?
+}
+
+# Run an iOS simulator xcodebuild invocation with the specified scheme, configuration, and build commands
+#
+# \param $1 scheme
+# \param $2 configuration
+# \param $3+ build commands
+function ios_simulator_build()
+{
+    invoke_xcodebuild workspace "ios/OfficeUIFabric.xcworkspace" "$1" "$2" iphonesimulator "${@:3}" -destination "platform=iOS Simulator,name=iPhone 8"
+    return $?
+}
+
+# Run an iOS device xcodebuild invocation with the specified scheme, configuration, and build commands
+#
+# \param $1 scheme
+# \param $2 configuration
+# \param $3+ build commands
+function ios_device_build()
+{
+    invoke_xcodebuild workspace "ios/OfficeUIFabric.xcworkspace" "$1" "$2" iphoneos "${@:3}"
+    return $?
+}
+
+# Run a macOS build and test with the specified scheme, configuration, and build commands
+# 
+# \param $1 scheme
+# \param $2 configuration
+# \param $3+ build commands
+function macos_build()
+{
+    invoke_xcodebuild project "macos/xcode/OfficeUIFabric.xcodeproj" "$1" "$2" macosx "${@:3}"
+    return $?
+}

--- a/scripts/xcodebuild_wrapper.sh
+++ b/scripts/xcodebuild_wrapper.sh
@@ -55,3 +55,7 @@ function macos_build()
     invoke_xcodebuild project "macos/xcode/OfficeUIFabric.xcodeproj" "$1" "$2" macosx "${@:3}"
     return $?
 }
+
+# Execute commands passed in to this script and forward on the exit code.
+"$@"
+exit $?


### PR DESCRIPTION
Add a GitHub action for CI.
Build and Test
- macOS Debug and Release configurations of the test app
- iOS Debug simulator configuration of the unit test target

Build
- iOS release simulator configuration of the unit test target
- iOS Debug and Release simulator configurations of the test app target
- iOS Debug and Release device configurations of the test app target