### PR TITLE
[CI] Set fail-fast to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   xcodebuild:
     runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
         build_command: [
           'macos_build OfficeUIFabricTestApp Debug build test',


### PR DESCRIPTION
By default, matrix builds have the [fail-fast](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) strategy set to `true`. This means if any build fails, all remaining builds will be cancelled as seen [here](https://github.com/microsoft/fluentui-apple/actions/runs/75504059). Instead, let's get the specific information about *what* all will fail by not failing fast.