### PR TITLE
[FluentUI-macOS] Use preconditionFailure() instead of fatalError()

### DIFF
--- a/macos/FluentUI/AvatarView.swift
+++ b/macos/FluentUI/AvatarView.swift
@@ -60,7 +60,7 @@ open class AvatarView : NSView {
 	}
 	
 	@available(*, unavailable) required public init?(coder decoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 
 	override open func updateLayer() {

--- a/macos/FluentUI/AvatarView.swift
+++ b/macos/FluentUI/AvatarView.swift
@@ -59,8 +59,9 @@ open class AvatarView : NSView {
 		updateAvatarViewContents()
 	}
 	
-	@available(*, unavailable) required public init?(coder decoder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+	@available(*, unavailable)
+	required public init?(coder decoder: NSCoder) {
+		preconditionFailure()
 	}
 
 	override open func updateLayer() {

--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -73,7 +73,7 @@ class CalendarDayButton: NSButton {
 	}
 	
 	required init?(coder decoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 	
 	override func updateLayer() {

--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -72,8 +72,9 @@ class CalendarDayButton: NSButton {
 		updateViewStyle()
 	}
 	
+	@available(*, unavailable)
 	required init?(coder decoder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+		preconditionFailure()
 	}
 	
 	override func updateLayer() {

--- a/macos/FluentUI/DatePicker/CalendarHeaderView.swift
+++ b/macos/FluentUI/DatePicker/CalendarHeaderView.swift
@@ -114,7 +114,7 @@ class CalendarHeaderView: NSView {
 	}
 	
 	required init?(coder decoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 	
 	weak var delegate: CalendarHeaderViewDelegate?

--- a/macos/FluentUI/DatePicker/CalendarHeaderView.swift
+++ b/macos/FluentUI/DatePicker/CalendarHeaderView.swift
@@ -113,8 +113,9 @@ class CalendarHeaderView: NSView {
 		])
 	}
 	
+	@available(*, unavailable)
 	required init?(coder decoder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+		preconditionFailure()
 	}
 	
 	weak var delegate: CalendarHeaderViewDelegate?

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -67,8 +67,9 @@ class CalendarView: NSView {
 		))
 	}
 	
+	@available(*, unavailable)
 	required init?(coder decoder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+		preconditionFailure()
 	}
 	
 	/// Updates the underlying button views with given days using the correct font colors

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -68,7 +68,7 @@ class CalendarView: NSView {
 	}
 	
 	required init?(coder decoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 	
 	/// Updates the underlying button views with given days using the correct font colors

--- a/macos/FluentUI/DatePicker/DatePickerController.swift
+++ b/macos/FluentUI/DatePicker/DatePickerController.swift
@@ -32,8 +32,9 @@ open class DatePickerController: NSViewController {
 		datePicker.dataSource = self
 	}
 	
+	@available(*, unavailable)
 	required public init?(coder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+		preconditionFailure()
 	}
 	
 	override open func loadView() {

--- a/macos/FluentUI/DatePicker/DatePickerController.swift
+++ b/macos/FluentUI/DatePicker/DatePickerController.swift
@@ -33,7 +33,7 @@ open class DatePickerController: NSViewController {
 	}
 	
 	required public init?(coder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 	
 	override open func loadView() {

--- a/macos/FluentUI/DatePicker/DatePickerView.swift
+++ b/macos/FluentUI/DatePicker/DatePickerView.swift
@@ -104,7 +104,7 @@ class DatePickerView: NSView {
 	}
 	
 	required init?(coder decoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 	
 	/// Scrolls in the leading direction

--- a/macos/FluentUI/DatePicker/DatePickerView.swift
+++ b/macos/FluentUI/DatePicker/DatePickerView.swift
@@ -103,8 +103,9 @@ class DatePickerView: NSView {
 		updateTextDatePicker()
 	}
 	
+	@available(*, unavailable)
 	required init?(coder decoder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+		preconditionFailure()
 	}
 	
 	/// Scrolls in the leading direction

--- a/macos/FluentUITestApp/TestDatePickerController.swift
+++ b/macos/FluentUITestApp/TestDatePickerController.swift
@@ -25,7 +25,7 @@ class TestDatePickerController: NSViewController {
 	}
 	
 	required init?(coder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 	
 	override func loadView() {

--- a/macos/FluentUITestApp/TestDatePickerController.swift
+++ b/macos/FluentUITestApp/TestDatePickerController.swift
@@ -24,8 +24,9 @@ class TestDatePickerController: NSViewController {
 		menuDatePickerController?.hasEdgePadding = true
 	}
 	
+	@available(*, unavailable)
 	required init?(coder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
+		preconditionFailure()
 	}
 	
 	override func loadView() {


### PR DESCRIPTION
fatalError() has a default parameter which takes in the #file and on failure will log the full source path of the file. This also encodes our full source path into the binary even in release configurations which is a security concern.

preconditionFailure works in essentially the same way but doesn't encode the full source path in release configurations.