### PR TITLE
Remove alpha value from MSButton colors and use the property primary …

### DIFF
--- a/ios/OfficeUIFabric/Controls/MSButton.swift
+++ b/ios/OfficeUIFabric/Controls/MSButton.swift
@@ -131,7 +131,7 @@ open class MSButton: UIButton {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        if #available(iOS 12, *) {
+        if #available(iOS 13, *) {
             if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
                 updateBorderColor()
             }

--- a/ios/OfficeUIFabric/Controls/MSButton.swift
+++ b/ios/OfficeUIFabric/Controls/MSButton.swift
@@ -129,6 +129,15 @@ open class MSButton: UIButton {
         proposedTitleLabelWidth = bounds.width - (contentEdgeInsets.left + contentEdgeInsets.right)
     }
 
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 12, *) {
+            if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+                updateBorderColor()
+            }
+        }
+    }
+
     public func updateTitleColors() {
         let titleColor = style == .primaryFilled ? MSColors.Button.titleWithFilledBackground : MSColors.Button.title
         let titleColorHighlighted = style == .primaryFilled ? titleColor : MSColors.Button.titleHighlighted
@@ -140,23 +149,35 @@ open class MSButton: UIButton {
 
     private func update() {
         updateTitleColors()
+        updateBackgroundColor()
+        updateBorderColor()
 
-        let backgroundColor: UIColor
-        let borderColor: UIColor
-        if isHighlighted {
-            backgroundColor = style == .primaryFilled ? MSColors.Button.backgroundFilledHighlighted : MSColors.Button.background
-            borderColor = MSColors.Button.borderHighlighted
-        } else if !isEnabled {
-            backgroundColor = style == .primaryFilled ? MSColors.Button.backgroundFilledDisabled : MSColors.Button.background
-            borderColor = MSColors.Button.borderDisabled
-        } else {
-            backgroundColor = style == .primaryFilled ? MSColors.Button.backgroundFilled : MSColors.Button.background
-            borderColor = MSColors.Button.border
-        }
-        self.backgroundColor = backgroundColor
-        layer.borderColor = borderColor.cgColor
         layer.borderWidth = style.hasBorders ? Constants.borderWidth : 0
 
         contentEdgeInsets = style.contentEdgeInsets
+    }
+
+    private func updateBackgroundColor() {
+        let backgroundColor: UIColor
+        if isHighlighted {
+            backgroundColor = style == .primaryFilled ? MSColors.Button.backgroundFilledHighlighted : MSColors.Button.background
+        } else if !isEnabled {
+            backgroundColor = style == .primaryFilled ? MSColors.Button.backgroundFilledDisabled : MSColors.Button.background
+        } else {
+            backgroundColor = style == .primaryFilled ? MSColors.Button.backgroundFilled : MSColors.Button.background
+        }
+        self.backgroundColor = backgroundColor
+    }
+
+    private func updateBorderColor() {
+        let borderColor: UIColor
+        if isHighlighted {
+            borderColor = MSColors.Button.borderHighlighted
+        } else if !isEnabled {
+            borderColor = MSColors.Button.borderDisabled
+        } else {
+            borderColor = MSColors.Button.border
+        }
+        layer.borderColor = borderColor.cgColor
     }
 }

--- a/ios/OfficeUIFabric/Core/Colors.swift
+++ b/ios/OfficeUIFabric/Core/Colors.swift
@@ -320,13 +320,13 @@ public final class MSColors: NSObject {
         public static var background: UIColor = .clear
         public static var backgroundFilled: UIColor = primary
         public static var backgroundFilledDisabled: UIColor = disabled
-        public static var backgroundFilledHighlighted: UIColor = primary.withAlphaComponent(0.5)
-        public static var border = UIColor(light: primary.withAlphaComponent(0.2), dark: primary.withAlphaComponent(0.6))
+        public static var backgroundFilledHighlighted = UIColor(light: primaryTint10, dark: primaryShade20)
+        public static var border: UIColor = backgroundFilledHighlighted
         public static var borderDisabled: UIColor = disabled
-        public static var borderHighlighted = UIColor(light: primary.withAlphaComponent(0.08), dark: primary.withAlphaComponent(0.4))
+        public static var borderHighlighted = UIColor(light: primaryTint20, dark: primaryShade20)
         public static var title: UIColor = primary
         public static var titleDisabled: UIColor = foreground4
-        public static var titleHighlighted: UIColor = primary.withAlphaComponent(0.4)
+        public static var titleHighlighted = UIColor(light: primaryTint10, dark: primaryShade20)
         public static var titleWithFilledBackground: UIColor = foregroundOnPrimary
     }
 


### PR DESCRIPTION
…theme color.
Before | After
------------ | -------------
![before_light](https://user-images.githubusercontent.com/20715435/79265915-aee34b80-7e4b-11ea-8ce1-8408d8a9547b.png)  | ![after_light](https://user-images.githubusercontent.com/20715435/79265935-b4d92c80-7e4b-11ea-9ee9-fb29473e3d16.png)
![before_dark](https://user-images.githubusercontent.com/20715435/79266035-d5a18200-7e4b-11ea-9c85-573b51f0cd80.png) | ![after_dark](https://user-images.githubusercontent.com/20715435/79266157-fe297c00-7e4b-11ea-916f-2e49e068e8c3.png)
