### PR TITLE
Hyshin/update buttoncolors

### DIFF
--- a/ios/FluentUI/Controls/MSButton.swift
+++ b/ios/FluentUI/Controls/MSButton.swift
@@ -27,6 +27,15 @@ import UIKit
         }
     }
 
+    var cornerRadius: CGFloat {
+        switch self {
+        case .primaryFilled, .primaryOutline, .secondaryOutline, .borderless:
+            return 8
+        case .tertiaryOutline:
+            return 5
+        }
+    }
+
     var hasBorders: Bool {
         switch self {
         case .primaryOutline, .secondaryOutline, .tertiaryOutline:
@@ -44,6 +53,15 @@ import UIKit
             return 18
         }
     }
+
+    var titleFont: UIFont {
+        switch self {
+        case .primaryFilled, .primaryOutline, .borderless:
+            return MSFonts.button1
+        case .secondaryOutline, .tertiaryOutline:
+            return MSFonts.button2
+        }
+    }
 }
 
 // MARK: - MSButton
@@ -53,8 +71,6 @@ import UIKit
 open class MSButton: UIButton {
     private struct Constants {
         static let borderWidth: CGFloat = 1
-        static let cornerRadius: CGFloat = 8
-        static var titleFont: UIFont { return MSFonts.button1 }
     }
 
     @objc open var style: MSButtonStyle = .secondaryOutline {
@@ -114,12 +130,12 @@ open class MSButton: UIButton {
     }
 
     open func initialize() {
-        layer.cornerRadius = Constants.cornerRadius
+        layer.cornerRadius = style.cornerRadius
         if #available(iOS 13.0, *) {
             layer.cornerCurve = .continuous
         }
 
-        titleLabel?.font = Constants.titleFont
+        titleLabel?.font = style.titleFont
         titleLabel?.adjustsFontForContentSizeCategory = true
         update()
     }

--- a/ios/FluentUI/Controls/MSButton.swift
+++ b/ios/FluentUI/Controls/MSButton.swift
@@ -186,13 +186,17 @@ open class MSButton: UIButton {
     }
 
     private func updateBorderColor() {
+        if !style.hasBorders {
+            return
+        }
+
         let borderColor: UIColor
         if isHighlighted {
             borderColor = MSColors.Button.borderHighlighted
         } else if !isEnabled {
             borderColor = MSColors.Button.borderDisabled
         } else {
-            borderColor = MSColors.Button.border
+            borderColor = style == .tertiaryOutline ? MSColors.Button.borderTertiary : MSColors.Button.border
         }
         layer.borderColor = borderColor.cgColor
     }

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -52,7 +52,6 @@ public final class MSColors: NSObject {
          case communicationBlueTint30
          case communicationBlueTint20
          case communicationBlueTint10
-         case communicationBlueShade40
          case communicationBlueShade30
          case communicationBlueShade20
          case communicationBlueShade10
@@ -153,8 +152,6 @@ public final class MSColors: NSObject {
                  return "communicationBlueTint20"
              case .communicationBlueTint10:
                  return "communicationBlueTint10"
-             case .communicationBlueShade40:
-                 return "communicationBlueShade40"
              case .communicationBlueShade30:
                  return "communicationBlueShade30"
              case .communicationBlueShade20:
@@ -319,13 +316,13 @@ public final class MSColors: NSObject {
         public static var background: UIColor = .clear
         public static var backgroundFilled: UIColor = primary
         public static var backgroundFilledDisabled: UIColor = disabled
-        public static var backgroundFilledHighlighted = UIColor(light: primaryTint10, dark: primaryShade20)
+        public static var backgroundFilledHighlighted = UIColor(light: primaryTint10, dark: primaryTint20)
         public static var border: UIColor = backgroundFilledHighlighted
         public static var borderDisabled: UIColor = disabled
-        public static var borderHighlighted = UIColor(light: primaryTint20, dark: primaryShade20)
+        public static var borderHighlighted: UIColor = primaryTint20
         public static var title: UIColor = primary
         public static var titleDisabled: UIColor = foreground4
-        public static var titleHighlighted = UIColor(light: primaryTint10, dark: primaryShade20)
+        public static var titleHighlighted = UIColor(light: primaryTint10, dark: primaryTint20)
         public static var titleWithFilledBackground: UIColor = foregroundOnPrimary
     }
 

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -317,7 +317,8 @@ public final class MSColors: NSObject {
         public static var backgroundFilled: UIColor = primary
         public static var backgroundFilledDisabled: UIColor = disabled
         public static var backgroundFilledHighlighted = UIColor(light: primaryTint10, dark: primaryTint20)
-        public static var border: UIColor = backgroundFilledHighlighted
+        public static var border = UIColor(light: primary, dark: primaryTint20)
+        public static var borderTertiary: UIColor = primaryTint20
         public static var borderDisabled: UIColor = disabled
         public static var borderHighlighted: UIColor = primaryTint20
         public static var title: UIColor = primary


### PR DESCRIPTION
update button colors based on new communicationBlue theme
update rounding corder, font size, and border color for secondary and tertiary outline style buttons

Before | After
------------ | -------------
![before_light](https://user-images.githubusercontent.com/20715435/79611665-f5d17b00-80af-11ea-90c4-05adad71018b.png) | ![after_light](https://user-images.githubusercontent.com/20715435/79611682-fc5ff280-80af-11ea-859c-9ad9e28a0ee9.png)
![before_dark](https://user-images.githubusercontent.com/20715435/79612057-c53e1100-80b0-11ea-9b3b-e74c5f5ea1b8.png) | ![after_dark](https://user-images.githubusercontent.com/20715435/79612070-ca9b5b80-80b0-11ea-94fc-55383c63301c.png)


