### PR TITLE
latest update from design with outline button colors:

### DIFF
--- a/ios/FluentUI/Controls/MSButton.swift
+++ b/ios/FluentUI/Controls/MSButton.swift
@@ -196,7 +196,7 @@ open class MSButton: UIButton {
         } else if !isEnabled {
             borderColor = MSColors.Button.borderDisabled
         } else {
-            borderColor = style == .tertiaryOutline ? MSColors.Button.borderTertiary : MSColors.Button.border
+            borderColor = MSColors.Button.border
         }
         layer.borderColor = borderColor.cgColor
     }

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -317,13 +317,12 @@ public final class MSColors: NSObject {
         public static var backgroundFilled: UIColor = primary
         public static var backgroundFilledDisabled: UIColor = disabled
         public static var backgroundFilledHighlighted = UIColor(light: primaryTint10, dark: primaryTint20)
-        public static var border = UIColor(light: primary, dark: primaryTint20)
-        public static var borderTertiary: UIColor = primaryTint20
+        public static var border: UIColor = primaryTint20
         public static var borderDisabled: UIColor = disabled
-        public static var borderHighlighted: UIColor = primaryTint20
+        public static var borderHighlighted: UIColor = primaryTint30
         public static var title: UIColor = primary
         public static var titleDisabled: UIColor = foreground4
-        public static var titleHighlighted = UIColor(light: primaryTint10, dark: primaryTint20)
+        public static var titleHighlighted: UIColor = primaryTint20
         public static var titleWithFilledBackground: UIColor = foregroundOnPrimary
     }
 


### PR DESCRIPTION
Now all different style of outline buttons have same title and border colors for default and highlight state.

Before | After
------------ | -------------
![before_light](https://user-images.githubusercontent.com/20715435/79812531-13ac1380-832e-11ea-8b96-9aa0800086e1.png)|![after_light](https://user-images.githubusercontent.com/20715435/79812542-1c044e80-832e-11ea-9c3e-966c2e0492ed.png)
![before_dark](https://user-images.githubusercontent.com/20715435/79812558-24f52000-832e-11ea-9656-7b7dbf1609f3.png) |![after_dark](https://user-images.githubusercontent.com/20715435/79812565-2a526a80-832e-11ea-9ad8-8a42d550971f.png)
