### PR TITLE
[Localization] Run Workflow on Linux and scope to strings file changes

### DIFF
--- a/.github/workflows/localize.yml
+++ b/.github/workflows/localize.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '**.strings'
+      - '**.stringsdict'
   # Also run every day at midnight to pick up new localizations
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -11,7 +14,7 @@ on:
 
 jobs:
   Localize:
-    runs-on: macos-10.15
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Summary
macOS agents on GitHub are more limited and thus more costly to run on (in terms of parallelism). We shouldn't use macOS agents for workflows where we can instead use Linux. Since our localization workflow is just bash, it runs fine on linux agents.

# Changes
- Switch runs-on to the latest Ubuntu image
- Only run this workflow on push when there are changes to strings or stringsdict files, as those are the only files we localize
- Note, the scheduled runs will still happen regardless.