### PR TITLE
[CocoaPods] Add a workflow to publish to CocoaPods on new tags

### DIFF
--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -1,0 +1,16 @@
+name: Pod-Publish
+on:
+  push:
+    tags:
+      - 0.[0-9]+.[0-9]+ # Run automatically on new tags matching a 0.N.M pattern
+
+jobs:
+  Pod-Publish:
+    runs-on: macOS-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish to CocoaPod register
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      run: scripts/publishCocoaPod.sh

--- a/scripts/publishCocoaPod.sh
+++ b/scripts/publishCocoaPod.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# A simple script to publish our pod to cocoapods.org. Run from the root of the repo.
+
+# Note: In CI/CD scenarios, expect the COCOAPODS_TRUNK_TOKEN env variable to be set which allows this to run automatically
+echo "pod trunk push MicrosoftFluentUI.podspec"


### PR DESCRIPTION
Add a simple workflow that detects new tags that match our repo release pattern and publish a new version to CocoaPods trunk using the repo secret CocoaPods token.

Verification:
Modify the script locally to echo out the expected build command and run it. We'll have to fully confirm this really works as expected on our next actual release (which will be tagged 0.0.7).