### PR TITLE
Remove echo statement from script

### DIFF
--- a/scripts/publishCocoaPod.sh
+++ b/scripts/publishCocoaPod.sh
@@ -3,4 +3,4 @@
 # A simple script to publish our pod to cocoapods.org. Run from the root of the repo.
 
 # Note: In CI/CD scenarios, expect the COCOAPODS_TRUNK_TOKEN env variable to be set which allows this to run automatically
-echo "pod trunk push MicrosoftFluentUI.podspec"
+pod trunk push MicrosoftFluentUI.podspec


### PR DESCRIPTION
The publishCocoaPod.sh script accidentally contained the "echo" call I was using to test it. Remove it and actually invoke `pod trunk push`.