### PR TITLE
[Accessibility] Enable full macOS date picker accessibility

### DIFF
--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -64,9 +64,6 @@ class CalendarDayButton: NSButton {
 			upperLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
 		])
 		
-		if DatePickerView.accessibilityTemporarilyRestricted {
-			cell?.setAccessibilityElement(false)
-		}
 		setAccessibilityLabel(day?.accessibilityLabel)
 		
 		updateViewStyle()

--- a/macos/FluentUI/DatePicker/CalendarHeaderView.swift
+++ b/macos/FluentUI/DatePicker/CalendarHeaderView.swift
@@ -57,20 +57,14 @@ class CalendarHeaderView: NSView {
 		
 		leadingButton.isBordered = false
 		trailingButton.isBordered = false
-		
-		if DatePickerView.accessibilityTemporarilyRestricted {
-			leadingButton.cell?.setAccessibilityElement(false)
-		}
+
 		leadingButton.setAccessibilityLabel(NSLocalizedString(
 			"DATEPICKER_ACCESSIBILITY_PREVIOUS_MONTH_LABEL",
 			tableName: "FluentUI",
 			bundle: FluentUIResources.resourceBundle,
 			comment: ""
 		))
-		
-		if DatePickerView.accessibilityTemporarilyRestricted {
-			trailingButton.cell?.setAccessibilityElement(false)
-		}
+
 		trailingButton.setAccessibilityLabel(NSLocalizedString(
 			"DATEPICKER_ACCESSIBILITY_NEXT_MONTH_LABEL",
 			tableName: "FluentUI",
@@ -124,10 +118,6 @@ class CalendarHeaderView: NSView {
 		let textField = NSTextField(labelWithString: "")
 		textField.font = NSFont.boldSystemFont(ofSize: Constants.fontSize)
 		
-		if DatePickerView.accessibilityTemporarilyRestricted {
-			textField.cell?.setAccessibilityElement(false)
-		}
-		
 		return textField
 	}()
 	
@@ -149,10 +139,6 @@ class CalendarHeaderView: NSView {
 		for _ in 0..<Constants.weekdayCount {
 			let label = NSTextField(labelWithString: "")
 			label.alignment = .center
-			
-			if DatePickerView.accessibilityTemporarilyRestricted {
-				label.cell?.setAccessibilityElement(false)
-			}
 			label.setAccessibilityRole(.staticText)
 			label.widthAnchor.constraint(equalToConstant: Constants.weekdayLabelWidth).isActive = true
 			labels.append(label)

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -58,7 +58,7 @@ class CalendarView: NSView {
 		}
 		
 		// Accessibility
-		setAccessibilityElement(!DatePickerView.accessibilityTemporarilyRestricted)
+		setAccessibilityElement(true)
 		setAccessibilityLabel(NSLocalizedString(
 			"DATEPICKER_ACCESSIBILITY_CALENDAR_VIEW_LABEL",
 			tableName: "FluentUI",

--- a/macos/FluentUI/DatePicker/DatePickerView.swift
+++ b/macos/FluentUI/DatePicker/DatePickerView.swift
@@ -91,7 +91,7 @@ class DatePickerView: NSView {
 		textDatePicker.setContentHuggingPriority(.required, for: .horizontal)
 		
 		// Accessibility
-		setAccessibilityElement(!DatePickerView.accessibilityTemporarilyRestricted)
+		setAccessibilityElement(true)
 		setAccessibilityRole(.group)
 		setAccessibilityLabel(NSLocalizedString(
 			"DATEPICKER_ACCESSIBILITY_DATEPICKER_LABEL",
@@ -347,9 +347,6 @@ class DatePickerView: NSView {
 		case left
 		case right
 	}
-	
-	// Undo this restriction after localization pipeline is set up.
-	static let accessibilityTemporarilyRestricted = true
 }
 
 extension DatePickerView: CalendarViewDelegate {


### PR DESCRIPTION
## Summary
We limited date picker accessibility as a workaround for not having localized accessibility strings. Now that localization works, we can get rid of that workaround.

## The Change
Remove all references to `accessibilityTemporarilyRestricted` and its definition.

## Verification
Accessibility inspector in the mac test app to check we have the correct view hierarchy and strings. VoiceOver sanity check.
