### PR TITLE
add new properties to customize popupmenucontroller and drawercontroller colors

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -140,7 +140,7 @@ class PopupMenuDemoController: DemoController {
             PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: calendarLayout == .threeDay, onSelected: { self.calendarLayout = .threeDay })
         ]
 
-        let menuBackgroundColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 1.0)
+        let menuBackgroundColor: UIColor = .darkGray
 
         for item in items {
             item.titleColor = .white
@@ -154,7 +154,7 @@ class PopupMenuDemoController: DemoController {
 
         controller.backgroundColor = menuBackgroundColor
         controller.resizingHandleViewBackgroundColor = menuBackgroundColor
-        controller.separatorColor = UIColor(red: 0.3333333333, green: 0.3333333333, blue: 0.3333333333, alpha: 1.0)
+        controller.separatorColor = .lightGray
 
         present(controller, animated: true)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -37,6 +37,7 @@ class PopupMenuDemoController: DemoController {
 
         container.addArrangedSubview(createButton(title: "Show with sections", action: #selector(showTopMenuWithSectionsButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show with scrollable items and no icons", action: #selector(showTopMenuWithScrollableItemsButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show items with custom colors", action: #selector(showCustomColorsButtonTapped)))
         container.addArrangedSubview(UIView())
         addTitle(text: "Show with...")
     }
@@ -126,6 +127,34 @@ class PopupMenuDemoController: DemoController {
 
         let items = samplePersonas.map { PopupMenuItem(title: !$0.name.isEmpty ? $0.name : $0.email) }
         controller.addItems(items)
+
+        present(controller, animated: true)
+    }
+
+    @objc private func showCustomColorsButtonTapped(sender: UIButton) {
+        let controller = PopupMenuController(sourceView: sender, sourceRect: sender.bounds, presentationDirection: .down)
+
+        let items = [
+            PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: calendarLayout == .agenda, onSelected: { self.calendarLayout = .agenda }),
+            PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: calendarLayout == .day, onSelected: { self.calendarLayout = .day }),
+            PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: calendarLayout == .threeDay, onSelected: { self.calendarLayout = .threeDay })
+        ]
+
+        let menuBackgroundColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 1.0)
+
+        for item in items {
+            item.titleColor = .white
+            item.titleSelectedColor = .white
+            item.imageSelectedColor = .white
+            item.accessoryCheckmarkColor = .white
+            item.backgroundColor = menuBackgroundColor
+        }
+
+        controller.addItems(items)
+
+        controller.backgroundColor = menuBackgroundColor
+        controller.resizingHandleViewBackgroundColor = menuBackgroundColor
+        controller.separatorColor = UIColor(red: 0.3333333333, green: 0.3333333333, blue: 0.3333333333, alpha: 1.0)
 
         present(controller, animated: true)
     }

--- a/ios/FluentUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/FluentUI.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:OfficeUIFabric.xcodeproj">
+      location = "self:FluentUI.xcodeproj">
    </FileRef>
 </Workspace>

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -126,12 +126,6 @@ open class DrawerController: UIViewController {
         }
     }
 
-    @objc open var resizingHandleViewBackgroundColor: UIColor = Colors.ResizingHandle.background {
-        didSet {
-            resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
-        }
-    }
-
     /**
      Set `contentController` to provide a controller that will represent drawer's content. Its view will be hosted in the root view of the drawer and will be sized and positioned to accommodate any shell UI of the drawer.
 
@@ -241,6 +235,13 @@ open class DrawerController: UIViewController {
             }
         }
     }
+
+    @objc open var resizingHandleViewBackgroundColor: UIColor = Colors.ResizingHandle.background {
+        didSet {
+            resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
+        }
+    }
+
     /**
      Set `isExpanded` to `true` to maximize the drawer's height to fill the device screen vertically minus the safe areas. Set to `false` to restore it to the normal size.
 
@@ -457,6 +458,7 @@ open class DrawerController: UIViewController {
             if showsResizingHandle {
                 if resizingHandleView == nil {
                     resizingHandleView = ResizingHandleView()
+                    resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
                 }
             } else {
                 resizingHandleView = nil
@@ -652,7 +654,6 @@ open class DrawerController: UIViewController {
 
     private func initResizingHandleView() {
         if resizingHandleIsInteractive {
-            resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
             resizingHandleView?.isUserInteractionEnabled = true
             resizingHandleView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleResizingHandleViewTap)))
         }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -120,6 +120,18 @@ open class DrawerController: UIViewController {
         case popover
     }
 
+    @objc open var backgroundColor: UIColor = Colors.Drawer.background {
+        didSet {
+            view.backgroundColor = backgroundColor
+        }
+    }
+
+    @objc open var resizingHandleViewBackgroundColor: UIColor = Colors.ResizingHandle.background {
+        didSet {
+            resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
+        }
+    }
+
     /**
      Set `contentController` to provide a controller that will represent drawer's content. Its view will be hosted in the root view of the drawer and will be sized and positioned to accommodate any shell UI of the drawer.
 
@@ -415,7 +427,7 @@ open class DrawerController: UIViewController {
 
     open override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = Colors.Drawer.background
+        view.backgroundColor = backgroundColor
         if #available(iOS 13.0, *) {
             view.layer.cornerCurve = .continuous
         }
@@ -640,6 +652,7 @@ open class DrawerController: UIViewController {
 
     private func initResizingHandleView() {
         if resizingHandleIsInteractive {
+            resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
             resizingHandleView?.isUserInteractionEnabled = true
             resizingHandleView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleResizingHandleViewTap)))
         }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -120,6 +120,7 @@ open class DrawerController: UIViewController {
         case popover
     }
 
+    /// Set `backgroundColor` to customize background color of the drawer
     @objc open var backgroundColor: UIColor = Colors.Drawer.background {
         didSet {
             view.backgroundColor = backgroundColor
@@ -236,6 +237,7 @@ open class DrawerController: UIViewController {
         }
     }
 
+    /// Set `resizingHandleViewBackgroundColor` to customize background color of resizingHandleView if it is shown
     @objc open var resizingHandleViewBackgroundColor: UIColor = Colors.ResizingHandle.background {
         didSet {
             resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -66,6 +66,17 @@ open class PopupMenuController: DrawerController {
         }
         return height
     }
+
+    open override var backgroundColor: UIColor {
+        get {
+            return super.backgroundColor
+        }
+        set {
+            super.backgroundColor = newValue
+            tableView.backgroundColor = newValue
+        }
+    }
+
     override var tracksContentHeight: Bool { return false }
 
     /**
@@ -110,7 +121,7 @@ open class PopupMenuController: DrawerController {
         }
     }
 
-    @objc var separatorColor: UIColor = Colors.Separator.default {
+    @objc open var separatorColor: UIColor = Colors.Separator.default {
         didSet {
             separator?.backgroundColor = separatorColor
         }
@@ -232,7 +243,7 @@ open class PopupMenuController: DrawerController {
     }
 
     private func initTableView() {
-        tableView.backgroundColor = Colors.Table.background
+        tableView.backgroundColor = backgroundColor
         tableView.separatorStyle = .none
         // Helps reduce the delay between touch and action due to a bug in iOS 11
         if #available(iOS 12.0, *) { } else {

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -110,6 +110,12 @@ open class PopupMenuController: DrawerController {
         }
     }
 
+    @objc var separatorColor: UIColor = Colors.Separator.default {
+        didSet {
+            separator?.backgroundColor = separatorColor
+        }
+    }
+
     private var sections: [PopupMenuSection] = []
     private var itemForExecutionAfterPopupMenuDismissal: PopupMenuItem?
     private var itemsHaveImages: Bool {
@@ -124,6 +130,8 @@ open class PopupMenuController: DrawerController {
         view.addArrangedSubview(tableView)
         return view
     }()
+
+    private var separator: Separator?
     private lazy var descriptionView: UIView = {
         let view = UIView()
         view.isAccessibilityElement = true
@@ -141,15 +149,17 @@ open class PopupMenuController: DrawerController {
             )
         )
 
-        let separator = Separator()
-        view.addSubview(separator)
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            separator.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-
+        separator = Separator()
+        if let separator = separator {
+            separator.backgroundColor = separatorColor
+            view.addSubview(separator)
+            separator.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                separator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                separator.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
+        }
         return view
     }()
     private let descriptionLabel: Label = {
@@ -274,9 +284,12 @@ extension PopupMenuController: UITableViewDataSource {
         cell.setup(item: item)
         cell.preservesSpaceForImage = itemsHaveImages
         let isLastInSection = row == tableView.numberOfRows(inSection: section) - 1
-        let isLast = section == tableView.numberOfSections - 1 && isLastInSection
-        cell.bottomSeparatorType = isLast ? .none : (isLastInSection ? .full : .inset)
-
+        if section == tableView.numberOfSections - 1 && isLastInSection {
+            cell.bottomSeparatorType = .none
+        } else {
+            cell.bottomSeparatorType = isLastInSection ? .full : .inset
+            cell.bottomSeparator.backgroundColor = separatorColor
+        }
         return cell
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -67,13 +67,10 @@ open class PopupMenuController: DrawerController {
         return height
     }
 
+    /// Set `backgroundColor` to customize background color of controller' view and its tableView
     open override var backgroundColor: UIColor {
-        get {
-            return super.backgroundColor
-        }
-        set {
-            super.backgroundColor = newValue
-            tableView.backgroundColor = newValue
+        didSet {
+            tableView.backgroundColor = backgroundColor
         }
     }
 
@@ -121,6 +118,7 @@ open class PopupMenuController: DrawerController {
         }
     }
 
+    /// set `separatorColor` to customize separator colors of  PopupMenuItem cells and the drawer
     @objc open var separatorColor: UIColor = Colors.Separator.default {
         didSet {
             separator?.backgroundColor = separatorColor

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -36,13 +36,21 @@ open class PopupMenuItem: NSObject {
     @objc public var isEnabled: Bool = true
     @objc public var isSelected: Bool = false
 
+    @objc public var titleColor: UIColor = Colors.Table.Cell.title
+    @objc public var subtitleColor: UIColor = Colors.Table.Cell.subtitle
+    @objc public var titleSelectedColor: UIColor = Colors.PopupMenu.Item.titleSelected
+    @objc public var subtitleSelectedColor: UIColor = Colors.PopupMenu.Item.subtitleSelected
+    @objc public var imageSelectedColor: UIColor = Colors.PopupMenu.Item.imageSelected
+    @objc public var backgroundColor: UIColor = Colors.Table.Cell.background
+    @objc public var accessoryCheckmarkColor: UIColor = Colors.Table.Cell.accessoryCheckmark
+
     @objc public let onSelected: (() -> Void)?
 
     @objc public let isAccessoryCheckmarkVisible: Bool
 
     @objc public init(image: UIImage? = nil, selectedImage: UIImage? = nil, accessoryImage: UIImage? = nil, title: String, subtitle: String? = nil, accessoryView: UIView? = nil, isEnabled: Bool = true, isSelected: Bool = false, executes executionMode: ExecutionMode = .onSelection, onSelected: (() -> Void)? = nil, isAccessoryCheckmarkVisible: Bool = true) {
         self.image = image?.renderingMode == .automatic ? image?.withRenderingMode(.alwaysTemplate) : image
-        self.selectedImage = selectedImage ?? image?.image(withPrimaryColor: Colors.PopupMenu.Item.imageSelected)
+        self.selectedImage = selectedImage ?? image?.withRenderingMode(.alwaysTemplate)
         self.accessoryImage = accessoryImage
         self.title = title
         self.subtitle = subtitle

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -36,12 +36,21 @@ open class PopupMenuItem: NSObject {
     @objc public var isEnabled: Bool = true
     @objc public var isSelected: Bool = false
 
+    /// `title` color
     @objc public var titleColor: UIColor = Colors.Table.Cell.title
+    /// `subtitle` color
     @objc public var subtitleColor: UIColor = Colors.Table.Cell.subtitle
+    /// `image` tint color if it is rendered as template
+    @objc public var imageColor: UIColor = Colors.Table.Cell.image
+    /// `title` color when`isSelected` is true
     @objc public var titleSelectedColor: UIColor = Colors.PopupMenu.Item.titleSelected
+    /// `subtitle` color when`isSelected` is true
     @objc public var subtitleSelectedColor: UIColor = Colors.PopupMenu.Item.subtitleSelected
+    /// tint color if `selectedImage` is rendered as template and `isSelected` is true
     @objc public var imageSelectedColor: UIColor = Colors.PopupMenu.Item.imageSelected
+    /// background color of PopupMenuItem corresponding cell
     @objc public var backgroundColor: UIColor = Colors.Table.Cell.background
+    /// checkmark color `isAccessoryCheckmarkVisible` and `isSelected` is true
     @objc public var accessoryCheckmarkColor: UIColor = Colors.Table.Cell.accessoryCheckmark
 
     @objc public let onSelected: (() -> Void)?

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -111,7 +111,7 @@ class PopupMenuItemCell: TableViewCell {
         }
 
         // Override default background color change
-        backgroundColor = Colors.Table.Cell.background
+        backgroundColor = item?.backgroundColor ?? Colors.Table.Cell.background
 
         if animated {
             UIView.animate(withDuration: Constants.animationDuration) {

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -161,10 +161,18 @@ class PopupMenuItemCell: TableViewCell {
         customAccessoryView?.alpha = alpha
 
         // Selection
+        if let item = item {
+            _imageView.tintColor = isSelected ? item.imageSelectedColor : Colors.Table.Cell.image
+            titleLabel.textColor = isSelected ? item.titleSelectedColor : item.titleColor
+            subtitleLabel.textColor = isSelected ? item.subtitleSelectedColor : item.subtitleColor
+            backgroundColor = item.backgroundColor
+        }
         _imageView.isHighlighted = isSelected
-        titleLabel.textColor = isSelected ? Colors.PopupMenu.Item.titleSelected : Colors.Table.Cell.title
-        subtitleLabel.textColor = isSelected ? Colors.PopupMenu.Item.subtitleSelected : Colors.Table.Cell.subtitle
-
-        _accessoryType = (isSelected && item?.isAccessoryCheckmarkVisible == true) ? .checkmark : .none
+        if isSelected && item?.isAccessoryCheckmarkVisible == true {
+            accessoryTypeView?.customTintColor = item?.accessoryCheckmarkColor
+            _accessoryType = .checkmark
+        } else {
+            _accessoryType = .none
+        }
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -54,7 +54,6 @@ class PopupMenuItemCell: TableViewCell {
     private let _imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = Colors.Table.Cell.image
         return imageView
     }()
 
@@ -162,7 +161,7 @@ class PopupMenuItemCell: TableViewCell {
 
         // Selection
         if let item = item {
-            _imageView.tintColor = isSelected ? item.imageSelectedColor : Colors.Table.Cell.image
+            _imageView.tintColor = isSelected ? item.imageSelectedColor : item.imageColor
             titleLabel.textColor = isSelected ? item.titleSelectedColor : item.titleColor
             subtitleLabel.textColor = isSelected ? item.subtitleSelectedColor : item.subtitleColor
             backgroundColor = item.backgroundColor

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -169,8 +169,8 @@ class PopupMenuItemCell: TableViewCell {
         }
         _imageView.isHighlighted = isSelected
         if isSelected && item?.isAccessoryCheckmarkVisible == true {
-            accessoryTypeView?.customTintColor = item?.accessoryCheckmarkColor
             _accessoryType = .checkmark
+            accessoryTypeView?.customTintColor = item?.accessoryCheckmarkColor
         } else {
             _accessoryType = .none
         }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -798,7 +798,7 @@ open class TableViewCell: UITableViewCell {
     private var footerLeadingAccessoryViewSize: CGSize = .zero
     private var footerTrailingAccessoryViewSize: CGSize = .zero
 
-    private var accessoryTypeView: TableViewCellAccessoryView? {
+    internal var accessoryTypeView: TableViewCellAccessoryView? {
         didSet {
             oldValue?.removeFromSuperview()
             if let accessoryTypeView = accessoryTypeView {
@@ -814,8 +814,8 @@ open class TableViewCell: UITableViewCell {
         return imageView
     }()
 
-    private let topSeparator = Separator(style: .default, orientation: .horizontal)
-    private let bottomSeparator = Separator(style: .default, orientation: .horizontal)
+    internal let topSeparator = Separator(style: .default, orientation: .horizontal)
+    internal let bottomSeparator = Separator(style: .default, orientation: .horizontal)
 
     private var superTableView: UITableView? {
         return findSuperview(of: UITableView.self) as? UITableView
@@ -1281,14 +1281,21 @@ open class TableViewCell: UITableViewCell {
 
 // MARK: - TableViewCellAccessoryView
 
-private class TableViewCellAccessoryView: UIView {
+internal class TableViewCellAccessoryView: UIView {
     override var accessibilityElementsHidden: Bool { get { return !isUserInteractionEnabled } set { } }
     override var intrinsicContentSize: CGSize { return type.size }
 
     let type: TableViewCellAccessoryType
-
+    var iconView: UIImageView?
     /// `onTapped` is called when `detailButton` is tapped
     var onTapped: (() -> Void)?
+    var customTintColor: UIColor? {
+        didSet {
+            if let iconView = iconView {
+                iconView.tintColor = customTintColor
+            }
+        }
+    }
 
     init(type: TableViewCellAccessoryType) {
         self.type = type
@@ -1323,12 +1330,14 @@ private class TableViewCellAccessoryView: UIView {
     }
 
     private func addIconView(type: TableViewCellAccessoryType) {
-        let iconView = UIImageView(image: type.icon)
-        iconView.frame.size = type.size
-        iconView.contentMode = .center
-        iconView.tintColor = type.iconColor
-        addSubview(iconView)
-        iconView.fitIntoSuperview()
+        iconView = UIImageView(image: type.icon)
+        if let iconView = iconView {
+            iconView.frame.size = type.size
+            iconView.contentMode = .center
+            iconView.tintColor = customTintColor ?? type.iconColor
+            addSubview(iconView)
+            iconView.fitIntoSuperview()
+        }
     }
 
     @objc private func handleOnAccessoryTapped() {


### PR DESCRIPTION
Instead of forcing clients to override the sdk static color variable to change the colors of popupmenucontroller or drawer controller, add new properties for clients to change the colors of the instance of those classes.

Before | After
------------ | -------------
![Screen Shot 2020-05-01 at 4 40 47 PM](https://user-images.githubusercontent.com/20715435/80850821-d6b80a80-8bd2-11ea-8791-ea18f09665e8.png)|![Simulator Screen Shot - iPhone Xʀ - 2020-05-06 at 17 09 58](https://user-images.githubusercontent.com/20715435/81240526-781cd300-8fbc-11ea-851c-9a6a2bd73662.png)


