### PR TITLE
[Fonts] Give objc name to Fonts class

### DIFF
--- a/ios/FluentUI/Core/Fonts.swift
+++ b/ios/FluentUI/Core/Fonts.swift
@@ -8,6 +8,7 @@ import UIKit
 @available(*, deprecated, renamed: "Fonts")
 public typealias MSFonts = Fonts
 
+@objc(MSFFonts)
 public final class Fonts: NSObject {
     /// Bold 30pt - Does not scale automatically with Dynamic Type
     @objc public static let largeTitle = UIFont.systemFont(ofSize: 30, weight: .bold)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When renaming classes we missed giving Fonts an Obj-C name. Give it one.

### Verification

Build and check out the generated header to ensure the new Obj-C class name is present.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| [Fonts footnote] | [MSFFonts footnote] |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
