### PR TITLE
Update MSFPillButton with latest Fluent Designers redlines

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -52,7 +52,7 @@ class PillButtonBarDemoController: DemoController {
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false) -> UIView {
         let bar = PillButtonBar(pillButtonStyle: style)
         bar.items = items
-        _ = bar.selectItem(_atIndex: 0)
+        _ = bar.selectItem(atIndex: 0)
         bar.barDelegate = self
         bar.centerAligned = centerAligned
 

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -424,19 +424,17 @@ public final class Colors: NSObject {
 
     public struct PillButton {
         public struct Outline {
-            public static var background = UIColor(light: UIColor.black.withAlphaComponent(0.0), dark: .black)
-            public static var title = UIColor(light: gray500, dark: gray200)
-            public static var backgroundSelected = UIColor(light: primary, dark: gray500)
-            public static var titleSelected: UIColor = .white
+            public static var background = UIColor(light: gray50, dark: gray950)
+            public static var title = UIColor(light: gray500, dark: gray100)
+            public static var backgroundSelected = UIColor(light: primary, dark: gray600)
+            public static var titleSelected = UIColor(light: gray25, dark: .white)
         }
         public struct Filled {
-            public static var background = UIColor(light: UIColor.black.withAlphaComponent(0.2), dark: Outline.background)
+            public static var background = UIColor(light: primaryShade10, dark: Outline.background)
             public static var title = UIColor(light: .white, dark: Outline.title)
             public static var backgroundSelected = UIColor(light: .white, dark: Outline.backgroundSelected)
             public static var titleSelected = UIColor(light: primary, dark: Outline.titleSelected)
         }
-
-        public static var border: UIColor = Colors.gray100
     }
 
     public struct PopupMenu {

--- a/ios/FluentUI/Core/Fonts.swift
+++ b/ios/FluentUI/Core/Fonts.swift
@@ -33,8 +33,8 @@ public final class Fonts: NSObject {
     @objc public static var button2: UIFont { return preferredFont(forTextStyle: .footnote, weight: .medium) }
     /// Medium 10pt - Does not scale automatically with Dynamic Type
     @objc public static let button3 = UIFont.systemFont(ofSize: 10, weight: .medium)
-    /// Medium 15pt - Does not scale automatically with Dynamic Type
-    @objc public static let button4 = UIFont.systemFont(ofSize: 15, weight: .medium)
+    /// Medium 16pt - Does not scale automatically with Dynamic Type
+    @objc public static let button4 = UIFont.systemFont(ofSize: 16, weight: .regular)
     /// Regular 12pt
     @objc public static var caption1: UIFont { return .preferredFont(forTextStyle: .caption1) }
     /// Regular 11pt

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -61,7 +61,6 @@ public typealias MSPillButton = PillButton
 @objc(MSFPillButton)
 open class PillButton: UIButton {
     private struct Constants {
-        static let borderWidth: CGFloat = 1.0
         static let bottomInset: CGFloat = 6.0
         static let cornerRadius: CGFloat = 16.0
         static let font: UIFont = Fonts.button4

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -50,19 +50,6 @@ public enum PillButtonStyle: Int {
             return Colors.PillButton.Filled.titleSelected
         }
     }
-
-    var borderColor: UIColor {
-        return  Colors.PillButton.border
-    }
-
-    func hasBorder(isSelected: Bool = false, isDarkMode: Bool = false) -> Bool {
-        switch self {
-        case .outline:
-            return !isSelected && !isDarkMode
-        case .filled:
-            return false
-        }
-    }
 }
 
 // MARK: PillButton
@@ -76,10 +63,10 @@ open class PillButton: UIButton {
     private struct Constants {
         static let borderWidth: CGFloat = 1.0
         static let bottomInset: CGFloat = 6.0
-        static let cornerRadius: CGFloat = 15.0
+        static let cornerRadius: CGFloat = 16.0
         static let font: UIFont = Fonts.button4
         static let horizontalInset: CGFloat = 16.0
-        static let topInset: CGFloat = 4.0
+        static let topInset: CGFloat = 6.0
     }
 
     public let pillBarItem: PillButtonBarItem
@@ -106,7 +93,6 @@ open class PillButton: UIButton {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        updateBorder()
     }
 
     private func setupView() {
@@ -144,25 +130,6 @@ open class PillButton: UIButton {
         } else {
             backgroundColor = style.backgroundColor
             setTitleColor(style.titleColor, for: .normal)
-        }
-
-        updateBorder()
-    }
-
-    private func updateBorder() {
-        let isDarkMode: Bool
-        if #available(iOS 13, *) {
-            isDarkMode = traitCollection.userInterfaceStyle == .dark
-        } else {
-            isDarkMode = false
-        }
-
-        if style.hasBorder(isSelected: isSelected, isDarkMode: isDarkMode) {
-            layer.borderWidth = Constants.borderWidth
-            layer.borderColor = style.borderColor.cgColor
-        } else {
-            layer.borderWidth = 0.0
-            layer.borderColor = nil
         }
     }
 }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -90,10 +90,6 @@ open class PillButton: UIButton {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-    }
-
     private func setupView() {
         setTitle(pillBarItem.title, for: .normal)
         titleLabel?.font = Constants.font

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -148,7 +148,15 @@ open class PillButtonBar: UIScrollView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    @objc public func selectItem(_atIndex index: Int) -> Bool {
+   @objc public func selectItem(_ item: PillButtonBarItem) {
+        guard let index = indexOfButtonWithItem(item) else {
+            return
+        }
+
+        selectedButton = buttons[index]
+    }
+
+    @objc public func selectItem(atIndex index: Int) -> Bool {
         if index < 0 || index >= buttons.count {
             return false
         }
@@ -390,14 +398,6 @@ open class PillButtonBar: UIScrollView {
         if let index = buttons.firstIndex(of: button) {
             barDelegate?.pillBar?(self, didSelectItem: button.pillBarItem, atIndex: index)
         }
-    }
-
-    private func selectItem(_ item: PillButtonBarItem) {
-        guard let index = indexOfButtonWithItem(item) else {
-            return
-        }
-
-        selectedButton = buttons[index]
     }
 
     private func updateHeightConstraint() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update MSFPillButton based on new redlines developed by Microsoft Fluent designers. That includes modifications in colors, padding, font, radius, border.

Naming tweaks in MSFPillButtonBar: Make the selectItem private method public, since it should be the main way to publicly select a button. Fix a param name error in the method selectItem(atIndex: )

### Verification

Tested Demo App

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/63825111/81129163-56f2ae80-8ef8-11ea-99fe-bf5de99ff135.png) | ![image](https://user-images.githubusercontent.com/63825111/81129249-9de0a400-8ef8-11ea-8863-03a222efc5e4.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
