### PR TITLE
let clients to override separator background color

### DIFF
--- a/ios/FluentUI/Controls/Separator.swift
+++ b/ios/FluentUI/Controls/Separator.swift
@@ -37,8 +37,6 @@ public typealias MSSeparator = Separator
 
 @objc(MSFSeparator)
 open class Separator: UIView {
-    open override var backgroundColor: UIColor? { get { return super.backgroundColor } set { } }
-
     private var orientation: SeparatorOrientation = .horizontal
 
     @objc public init(style: SeparatorStyle = .default, orientation: SeparatorOrientation = .horizontal) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

let clients to override `separator` background color

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone Xʀ - 2020-05-06 at 15 52 29](https://user-images.githubusercontent.com/20715435/81253080-73681700-8fdc-11ea-9288-8a3524e3058b.png)| ![Simulator Screen Shot - iPhone Xʀ - 2020-05-06 at 20 57 56](https://user-images.githubusercontent.com/20715435/81253047-5fbcb080-8fdc-11ea-8e8e-f48d08be9969.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
