### PR TITLE
[Xcode] Update Actions/Pipelines to Xcode 11.4.1

### DIFF
--- a/scripts/nuget_publish.sh
+++ b/scripts/nuget_publish.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# nuget_publish.sh
+# A local version of the fluentui-apple-publish-nuget.yml Azure Pipeline that fires all the jobs sequentially.
+# Useful for local validation, keep in sync with .ado/fluentui-apple-publish-nuget.yml
+# Note: Execute this script from the root of the repository, such as `./scripts/nuget_publish.sh`
+
+# Keep an exit code so that we can return a non-zero exit code if any build fails
+# while still running all builds each time.
+EXIT_CODE=0
+
+# Path to the xcode build wrapper script
+XCODEBUILD_WRAPPER_LOCATION='scripts/xcodebuild_wrapper.sh'
+
+# Extra arguments for xcode build to mimic nuget publishing environment  
+XCODEBUILD_EXTRA_ARGS='-xcconfig .ado/xcconfig/publish_overrides.xcconfig -derivedDataPath DerivedData'
+
+function handle_exit_code()
+{
+	if [ $? -ne 0 ]
+	then
+		echo "Previous command exited with non-zero exit code"
+		# Intentionally changing the global EXIT_CODE variable
+		EXIT_CODE=1
+	fi
+}
+
+echo "Building and Testing macOS Debug"
+$XCODEBUILD_WRAPPER_LOCATION macos_build FluentUI-macOS Debug build $XCODEBUILD_EXTRA_ARGS
+handle_exit_code
+
+echo "Building and Testing macOS Release"
+$XCODEBUILD_WRAPPER_LOCATION macos_build FluentUI-macOS Release build $XCODEBUILD_EXTRA_ARGS
+handle_exit_code
+
+echo "Building iOS Static Lib Debug Simulator"
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS-StaticLib Debug build $XCODEBUILD_EXTRA_ARGS
+handle_exit_code
+
+echo "Building iOS Static Lib Release Simulator"
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS-StaticLib Release build $XCODEBUILD_EXTRA_ARGS
+handle_exit_code
+
+echo "Building Static Lib iOS Debug Device"
+$XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS-StaticLib Debug build $XCODEBUILD_EXTRA_ARGS
+handle_exit_code
+
+echo "Building iOS Release Static Lib Device"
+$XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS-StaticLib Release build $XCODEBUILD_EXTRA_ARGS
+handle_exit_code
+
+echo "Running scripts/prepare_for_nuget_pack.sh"
+scripts/prepare_for_nuget_pack.sh
+handle_exit_code
+
+# Check if any of our individual build steps failed
+if [ $EXIT_CODE -ne 0 ]
+then
+	echo "NuGet Pack Build Failed, please check logs for failures"
+else
+	echo "NuGet Pack Build Succeeded"
+fi
+
+exit $EXIT_CODE

--- a/scripts/prepare_for_nuget_pack.sh
+++ b/scripts/prepare_for_nuget_pack.sh
@@ -15,32 +15,6 @@ function make_dir_if_necessary()
     fi
 }
 
-# Invoke rsync -am but exclude swiftsourceinfo and swiftdoc file types
-#
-# \param $@ additional arguments to rsync, see man rsync for more details
-function rsync_excluding_swiftsourceinfo_swiftdoc()
-{
-    rsync -am --exclude '*.swiftsourceinfo' --exclude '*.swiftdoc' "$@"
-}
-
-# Invoke rsync_excluding_swiftsourceinfo_swiftdoc but also exclude nested .swiftmodule files.
-# For use when rsync'ing an entire framework directory that contains a .swiftmodule folder
-#
-# \param $@ additional arguments to rsync, see man rsync for more details
-function rsync_excluding_binary_swift_module_files_framework()
-{
-    rsync_excluding_swiftsourceinfo_swiftdoc --exclude '*.swiftmodule/*.swiftmodule' "$@"
-}
-
-# Invoke rsync_excluding_swiftsourceinfo_swiftdoc but also exclude .swiftmodule files.
-# For use when rsync'ing an existing .swiftmodule folder
-#
-# \param $@ additional arguments to rsync, see man rsync for more details
-function rsync_excluding_binary_swift_module_files_swiftmodule_folder()
-{
-    rsync_excluding_swiftsourceinfo_swiftdoc --exclude '*.swiftmodule' "$@"
-}
-
 # Build up our output directory in Products/nuget
 PRODUCTS_DIR="DerivedData/Build/Products"
 NUGET_OUTPUT_DIR="$PRODUCTS_DIR/nuget"
@@ -65,29 +39,29 @@ cd $PRODUCTS_DIR
 
 # Copy each platform
 make_dir_if_necessary "nuget/Debug-macosx"
-rsync_excluding_binary_swift_module_files_framework Debug/FluentUI.framework/ nuget/Debug-macosx/FluentUI.framework/
+rsync -a Debug/FluentUI.framework/ nuget/Debug-macosx/FluentUI.framework/
 
 make_dir_if_necessary "nuget/Ship-macosx"
 rsync_excluding_binary_swift_module_files_framework Release/FluentUI.framework/ nuget/Ship-macosx/FluentUI.framework/
 
 make_dir_if_necessary "nuget/Debug-iphoneos"
 rsync -a Debug-iphoneos/libFluentUILib.a nuget/Debug-iphoneos/
-rsync_excluding_binary_swift_module_files_swiftmodule_folder Debug-iphoneos/FluentUILib.swiftmodule/ nuget/Debug-iphoneos/FluentUILib.swiftmodule/
+rsync -a Debug-iphoneos/FluentUILib.swiftmodule/ nuget/Debug-iphoneos/FluentUILib.swiftmodule/
 rsync -a Debug-iphoneos/FluentUIResources-ios.bundle/ nuget/Debug-iphoneos/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Ship-iphoneos"
 rsync -a Release-iphoneos/libFluentUILib.a nuget/Ship-iphoneos/
-rsync_excluding_binary_swift_module_files_swiftmodule_folder Release-iphoneos/FluentUILib.swiftmodule/ nuget/Ship-iphoneos/FluentUILib.swiftmodule/
+rsync -a Release-iphoneos/FluentUILib.swiftmodule/ nuget/Ship-iphoneos/FluentUILib.swiftmodule/
 rsync -a Release-iphoneos/FluentUIResources-ios.bundle/ nuget/Ship-iphoneos/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Debug-iphonesimulator"
 rsync -a Debug-iphonesimulator/libFluentUILib.a nuget/Debug-iphonesimulator/
-rsync_excluding_binary_swift_module_files_swiftmodule_folder Debug-iphonesimulator/FluentUILib.swiftmodule/ nuget/Debug-iphonesimulator/FluentUILib.swiftmodule/
+rsync -a Debug-iphonesimulator/FluentUILib.swiftmodule/ nuget/Debug-iphonesimulator/FluentUILib.swiftmodule/
 rsync -a Debug-iphonesimulator/FluentUIResources-ios.bundle/ nuget/Debug-iphonesimulator/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Ship-iphonesimulator"
 rsync -a Release-iphonesimulator/libFluentUILib.a nuget/Ship-iphonesimulator/
-rsync_excluding_binary_swift_module_files_swiftmodule_folder Release-iphonesimulator/FluentUILib.swiftmodule/ nuget/Ship-iphonesimulator/FluentUILib.swiftmodule/
+rsync -a Release-iphonesimulator/FluentUILib.swiftmodule/ nuget/Ship-iphonesimulator/FluentUILib.swiftmodule/
 rsync -a Release-iphonesimulator/FluentUIResources-ios.bundle/ nuget/Ship-iphonesimulator/FluentUIResources-ios.bundle/
 
 # cd into our nuget folder to finally zip up our build output

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -1,3 +1,3 @@
 # Select the current officially supported version of Xcode with the naming convention used by GitHub Actions/Azure DevOps Build Pipelines
-echo "Running command: sudo xcode-select --switch '/Applications/Xcode_11.2.1.app/Contents/Developer'"
-sudo xcode-select --switch '/Applications/Xcode_11.2.1.app/Contents/Developer'
+echo "Running command: sudo xcode-select --switch '/Applications/Xcode_11.4.1.app/Contents/Developer'"
+sudo xcode-select --switch '/Applications/Xcode_11.4.1.app/Contents/Developer'


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Update CI/NuGet Publish build environments from 11.2.1 to 11.4.1. No change in supported Xcode versions.

Alongside this, update our nuget publishing step to include the binary output. 

### Verification

Added a new NuGet Publish script to simulate a NuGet pipeline locally, right up to the point of making the zip file that would be packed and pushed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| CI and Publish steps would run with Xcode 11.2.1 | CI and Publish steps run with Xcode 11.4.1 |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
