### PR TITLE
make sure Separator's init(frame: CGRect) will call initialize(style: .default, orientation: .horizontal)

### DIFF
--- a/ios/FluentUI/Controls/Separator.swift
+++ b/ios/FluentUI/Controls/Separator.swift
@@ -39,6 +39,11 @@ public typealias MSSeparator = Separator
 open class Separator: UIView {
     private var orientation: SeparatorOrientation = .horizontal
 
+    @objc public override init(frame: CGRect) {
+        super.init(frame: frame)
+        initialize(style: .default, orientation: .horizontal)
+    }
+
     @objc public init(style: SeparatorStyle = .default, orientation: SeparatorOrientation = .horizontal) {
         super.init(frame: .zero)
         initialize(style: style, orientation: orientation)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
make sure Separator's init(frame: CGRect) will call initialize(style: .default, orientation: .horizontal)

### Verification
SegmentControl separator is drawn
### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
