### PR TITLE
[NuGet Publish] Fix broken ship macos command and check for errors

### DIFF
--- a/scripts/prepare_for_nuget_pack.sh
+++ b/scripts/prepare_for_nuget_pack.sh
@@ -2,6 +2,9 @@
 
 # NuGet packing doesn't support symlinks, so zip up our frameworks first to preserve the symlinks
 
+# Fail if any of the commands fails to run
+set -e
+
 # Make a directory if necessary, no-op if it already exists
 #
 # \param $1 the name of the folder to create
@@ -32,6 +35,7 @@ make_dir_if_necessary "$NUGET_OUTPUT_INCLUDE_DIR_IOS_FLUENTUI"
 # Copy a single generated header into our output directory in an includes folder. Ensure we nest a FluentUI folder for proper `#import <FluentUI/FluentUI-Swift.h>` imports
 # Pick the release simulator header since the device target has some arm64 specific ifdefs while the simulator version works on all platforms.
 # Rename the FluentUILib-Swift.h to FluentUI-Swift.h for consistency with Framework consumption
+echo "Copy iOS generated Swift header to include dir"
 rsync -a "DerivedData/Build/Intermediates.noindex/FluentUI.build/Release-iphonesimulator/FluentUILib.build/DerivedSources/FluentUILib-Swift.h" "$NUGET_OUTPUT_INCLUDE_DIR_IOS_FLUENTUI/FluentUI-Swift.h"
 
 # cd into the products directory to make copying all the output easier
@@ -39,27 +43,33 @@ cd $PRODUCTS_DIR
 
 # Copy each platform
 make_dir_if_necessary "nuget/Debug-macosx"
+echo "Copy Debug-macosx Framework into nuget folder"
 rsync -a Debug/FluentUI.framework/ nuget/Debug-macosx/FluentUI.framework/
 
 make_dir_if_necessary "nuget/Ship-macosx"
-rsync_excluding_binary_swift_module_files_framework Release/FluentUI.framework/ nuget/Ship-macosx/FluentUI.framework/
+echo "Copy Ship-macosx Framework into nuget folder"
+rsync -a Release/FluentUI.framework/ nuget/Ship-macosx/FluentUI.framework/
 
 make_dir_if_necessary "nuget/Debug-iphoneos"
+echo "Copy Debug-iphoneos build output into nuget folder"
 rsync -a Debug-iphoneos/libFluentUILib.a nuget/Debug-iphoneos/
 rsync -a Debug-iphoneos/FluentUILib.swiftmodule/ nuget/Debug-iphoneos/FluentUILib.swiftmodule/
 rsync -a Debug-iphoneos/FluentUIResources-ios.bundle/ nuget/Debug-iphoneos/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Ship-iphoneos"
+echo "Copy Ship-iphoneos build output into nuget folder"
 rsync -a Release-iphoneos/libFluentUILib.a nuget/Ship-iphoneos/
 rsync -a Release-iphoneos/FluentUILib.swiftmodule/ nuget/Ship-iphoneos/FluentUILib.swiftmodule/
 rsync -a Release-iphoneos/FluentUIResources-ios.bundle/ nuget/Ship-iphoneos/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Debug-iphonesimulator"
+echo "Copy Debug-iphonesimulator build output into nuget folder"
 rsync -a Debug-iphonesimulator/libFluentUILib.a nuget/Debug-iphonesimulator/
 rsync -a Debug-iphonesimulator/FluentUILib.swiftmodule/ nuget/Debug-iphonesimulator/FluentUILib.swiftmodule/
 rsync -a Debug-iphonesimulator/FluentUIResources-ios.bundle/ nuget/Debug-iphonesimulator/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Ship-iphonesimulator"
+echo "Copy Ship-iphonesimulator build output into nuget folder"
 rsync -a Release-iphonesimulator/libFluentUILib.a nuget/Ship-iphonesimulator/
 rsync -a Release-iphonesimulator/FluentUILib.swiftmodule/ nuget/Ship-iphonesimulator/FluentUILib.swiftmodule/
 rsync -a Release-iphonesimulator/FluentUIResources-ios.bundle/ nuget/Ship-iphonesimulator/FluentUIResources-ios.bundle/


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

There was an unintentional `rsync_excluding_binary_swift_module_files_framework` call left in the prepare_for_nuget_pack.sh script which caused the ship macOS builds to not be properly copied into the zip build output file. This allowed us to publish a nuget package without the proper build output.

This highlighted that we weren't properly checking exit codes on our commands allowing this to publish even though the script failed to execute as expected. Add extra logging and the `set -e` command to exit the script as a failure on any failure inside this script.

### Verification

Leave the error in and locally call nuget_publish.sh. The script now fails. Fix the error and run again. The script succeeds as expected. Run with existing build output and with fresh build output and expect successes in both cases.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/59)