### PR TITLE
update HUDView sizes according the new design redlines

### DIFF
--- a/ios/FluentUI/Controls/ActivityIndicatorView.swift
+++ b/ios/FluentUI/Controls/ActivityIndicatorView.swift
@@ -26,13 +26,13 @@ public enum ActivityIndicatorViewSize: Int, CaseIterable {
         case .xSmall:
             return 12
         case .small:
-            return 17
+            return 16
         case .medium:
-            return 26
+            return 24
         case .large:
-            return 35
+            return 32
         case .xLarge:
-            return 40
+            return 36
         }
     }
 

--- a/ios/FluentUI/HUD/HUD.swift
+++ b/ios/FluentUI/HUD/HUD.swift
@@ -256,7 +256,7 @@ public class HUD: NSObject {
             return
         }
 
-        bottomConstraint?.constant = keyboardHeight != 0 ? (Constants.keyboardMarginTop + keyboardHeight ) : 0
+        bottomConstraint?.constant = keyboardHeight != 0 ? -1 * (Constants.keyboardMarginTop + keyboardHeight ) : 0
     }
 
     // MARK: Observations

--- a/ios/FluentUI/HUD/HUD.swift
+++ b/ios/FluentUI/HUD/HUD.swift
@@ -126,7 +126,7 @@ public class HUD: NSObject {
     @objc public func show(in view: UIView, with params: HUDParams, onTap: (() -> Void)? = nil) {
         resetIfNeeded()
 
-        presentedHUDView = HUDView(label: params.caption, type: params.hudType)
+        presentedHUDView = HUDView(title: params.caption, type: params.hudType)
 
         guard let presentedHUDView = presentedHUDView else {
             preconditionFailure("HUD could not create HUDView")
@@ -136,7 +136,7 @@ public class HUD: NSObject {
         containerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(containerView)
         bottomConstraint = containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        updateBottomConstraint()
+        updateBottomConstraintConstant()
 
         NSLayoutConstraint.activate([
             bottomConstraint!,
@@ -239,7 +239,6 @@ public class HUD: NSObject {
 
     @objc public func update(with caption: String) {
         presentedHUDView?.label.text = caption
-        presentedHUDView?.label.sizeToFit()
     }
 
     private func hostWindow(for controller: UIViewController) -> UIWindow? {
@@ -251,7 +250,7 @@ public class HUD: NSObject {
         presentedHUDView = nil
     }
 
-    private func updateBottomConstraint() {
+    private func updateBottomConstraintConstant() {
         guard self.presentedHUDView != nil else {
             return
         }
@@ -271,7 +270,7 @@ public class HUD: NSObject {
 
         // Animate position of HUD view
         keyboardHeight = keyboardFrame.height
-        UIView.animate(withDuration: keyboardAnimationDuration, animations: updateBottomConstraint)
+        UIView.animate(withDuration: keyboardAnimationDuration, animations: updateBottomConstraintConstant)
     }
 
     @objc private func handleKeyboardWillHide(_ notification: Notification) {
@@ -283,6 +282,6 @@ public class HUD: NSObject {
 
         // Animate position of HUD view
         keyboardHeight = 0
-        UIView.animate(withDuration: keyboardAnimationDuration, animations: updateBottomConstraint)
+        UIView.animate(withDuration: keyboardAnimationDuration, animations: updateBottomConstraintConstant)
     }
 }

--- a/ios/FluentUI/HUD/HUDView.swift
+++ b/ios/FluentUI/HUD/HUDView.swift
@@ -19,13 +19,13 @@ enum HUDType {
 class HUDView: UIView {
     private struct Constants {
         static let backgroundCornerRadius: CGFloat = 4.0
-        static let maxWidth: CGFloat = 200.0
-        static let minSideSizeWithoutLabel: CGFloat = 98.0
+        static let maxWidth: CGFloat = 212.0
+        static let minSideSizeWithoutLabel: CGFloat = 100.0
         static let minSideSizeWithLabel: CGFloat = 108.0
-        static let paddingHorizontalWithoutLabel: CGFloat = 30.0
-        static let paddingHorizontalWithLabel: CGFloat = 24.0
-        static let paddingVerticalWithLabel: CGFloat = 18.0
-        static let labelMarginTop: CGFloat = 14.0
+        static let paddingHorizontalWithoutLabel: CGFloat = 32.0
+        static let paddingHorizontalWithLabel: CGFloat = 12.0
+        static let paddingVerticalWithLabel: CGFloat = 20.0
+        static let labelMarginTop: CGFloat = 15.0
         static let labelMaxWidth: CGFloat = maxWidth - 2 * paddingHorizontalWithLabel
     }
 
@@ -158,11 +158,6 @@ class HUDView: UIView {
 
 /// A container view of a fixed size which accepts a `HUDType` and centers its visual presentation.
 private class HUDIndicatorView: UIView {
-    private struct Constants {
-        static let width: CGFloat = 40.0
-        static let height: CGFloat = 40.0
-    }
-
     private static func createContentView(type: HUDType) -> UIView {
         switch type {
         case .activity:
@@ -205,7 +200,7 @@ private class HUDIndicatorView: UIView {
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {
-        return CGSize(width: Constants.width, height: Constants.height)
+        return CGSize(width: ActivityIndicatorViewSize.xLarge.sideSize, height: ActivityIndicatorViewSize.xLarge.sideSize)
     }
 
     override var accessibilityLabel: String? {

--- a/ios/FluentUI/HUD/HUDView.swift
+++ b/ios/FluentUI/HUD/HUDView.swift
@@ -19,9 +19,9 @@ enum HUDType: Equatable {
 class HUDView: UIView {
     private struct Constants {
         static let backgroundCornerRadius: CGFloat = 4.0
-        static let maxWidthInLargerContent: CGFloat = 256.0
-        static let maxWidth: CGFloat = 192.0
-        static let minWidth: CGFloat = 100.0
+        static let maxSizeInLargerContent: CGFloat = 256.0
+        static let maxSize: CGFloat = 192.0
+        static let minSize: CGFloat = 100.0
         static let paddingVertical: CGFloat = 20.0
         static let paddingHorizontal: CGFloat = 12.0
         static let labelMarginTop: CGFloat = 15.0
@@ -57,7 +57,7 @@ class HUDView: UIView {
 
     private let indicatorView: UIView
 
-    public init(label: String = "", type: HUDType) {
+    public init(title: String = "", type: HUDType) {
         self.type = type
         indicatorView = HUDView.createIndicatorView(type: type)
 
@@ -73,18 +73,18 @@ class HUDView: UIView {
 
         container.addArrangedSubview(indicatorView)
 
-        self.label.isHidden = label.isEmpty
-        if !self.label.isHidden {
-            self.label.text = label
-            container.addArrangedSubview(self.label)
+        label.isHidden = title.isEmpty
+        if !label.isHidden {
+            label.text = title
+            container.addArrangedSubview(label)
 
-            self.label.setContentCompressionResistancePriority(.required, for: .vertical)
+            label.setContentCompressionResistancePriority(.required, for: .vertical)
             if traitCollection.preferredContentSizeCategory > .large {
-                self.label.setContentCompressionResistancePriority(.required, for: .horizontal)
-                self.label.adjustsFontSizeToFitWidth = true
+                label.setContentCompressionResistancePriority(.required, for: .horizontal)
+                label.adjustsFontSizeToFitWidth = true
             } else {
                 // label should try to grow vertically before it tries to grow horizontally
-                self.label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+                label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             }
         }
 
@@ -116,21 +116,20 @@ class HUDView: UIView {
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
         if label.isHidden {
-            return CGSize(width: Constants.minWidth, height: Constants.minWidth)
+            return CGSize(width: Constants.minSize, height: Constants.minSize)
         } else {
             let activitySize = ActivityIndicatorViewSize.xLarge.sideSize
-            let maxWidth = traitCollection.preferredContentSizeCategory > .large ? Constants.maxWidthInLargerContent : Constants.maxWidth
+            let maxSize = traitCollection.preferredContentSizeCategory > .large ? Constants.maxSizeInLargerContent : Constants.maxSize
 
-            let labelSize = label.sizeThatFits(CGSize(width: maxWidth - 2 * Constants.paddingHorizontal, height: .greatestFiniteMagnitude))
+            let labelSize = label.systemLayoutSizeFitting(CGSize(width: maxSize - 2 * Constants.paddingHorizontal, height: 0.0), withHorizontalFittingPriority: .defaultLow, verticalFittingPriority: .defaultLow)
 
             let fittingWidth = max(activitySize, labelSize.width) + 2 * Constants.paddingHorizontal
-            let fittingHeight = activitySize + Constants.labelMarginTop + labelSize.height + (2 * Constants.paddingVertical)
-
-            var suggestedSize = max(fittingWidth, fittingHeight)
-            suggestedSize = max(ceil(suggestedSize), Constants.minWidth)
-            suggestedSize = min(maxWidth, suggestedSize)
+            let fittingHeight = labelSize.height + activitySize + Constants.labelMarginTop + 2 * Constants.paddingVertical
 
             // make sure HUD is always a square
+            var suggestedSize = max(fittingWidth, fittingHeight)
+            suggestedSize = max(ceil(suggestedSize), Constants.minSize)
+            suggestedSize = min(maxSize, suggestedSize)
             return CGSize(width: suggestedSize, height: suggestedSize)
         }
     }
@@ -188,7 +187,7 @@ class HUDView: UIView {
             return activityIndicatorView
         case .success:
             let imageView = UIImageView(image: .staticImageNamed("checkmark-white-40x40"))
-            // unfortuantely, this resource image isn't the right size
+            // TODO: unfortuantely, this resource image isn't currently the right size
             imageView.contentMode = .scaleAspectFit
             return imageView
         case .failure:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- use autolayout to position the HUDView in the center of the screen
- use UIStackView to layout the activity indicator view and the label below
- bug fix: make sure HUDView is always a square
- For large content sizes, we should grow the HUDView's width and adjust the font of the label if necessary.
- label of the HUDView shouldn't be more than 2 lines according to design

### Verification

Attached video
[HUD_PR.mov.zip](https://github.com/microsoft/fluentui-apple/files/4636372/HUD_PR.mov.zip)
Tested on iPad and iPhone: Rotate while showing HUDView.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/60)