### PR TITLE
add new property to lock navigation bar collapse/expand position

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -314,7 +314,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     @objc private func showSelectionMode() {
         isInSelectionMode = true
-        msfNavigationController?.contractNavigationBar(animated: false)
+        msfNavigationController?.contractNavigationBar(animated: true)
         msfNavigationController?.allowResizeOfNavigationBarOnScroll = false
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -315,12 +315,13 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     @objc private func showSelectionMode() {
         isInSelectionMode = true
         msfNavigationController?.contractNavigationBar(animated: false)
-        msfNavigationController?.lockNavBarPosition = true
+        msfNavigationController?.allowResizeOfNavigationBarOnScroll = false
     }
 
     @objc private func dismissSelectionMode() {
         isInSelectionMode = false
-        msfNavigationController?.lockNavBarPosition = false
+        msfNavigationController?.allowResizeOfNavigationBarOnScroll = true
+        msfNavigationController?.expandNavigationBar(animated: true)
     }
 
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -314,10 +314,13 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     @objc private func showSelectionMode() {
         isInSelectionMode = true
+        msfNavigationController?.contractNavigationBar(animated: false)
+        msfNavigationController?.lockNavBarPosition = true
     }
 
     @objc private func dismissSelectionMode() {
         isInSelectionMode = false
+        msfNavigationController?.lockNavBarPosition = false
     }
 
 }

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -13,8 +13,8 @@ public typealias MSNavigationController = NavigationController
 /// `UINavigationController` subclass that supports Large Title presentation and accessory view by wrapping each view controller that needs this functionality into a controller that provides the required behavior. The original view controller can be accessed by using `topContentViewController` or `contentViewController(for:)`.
 @objc(MSFNavigationController)
 open class NavigationController: UINavigationController {
-    // allow clients to lock navigation bar position which will prevent collapsing or expanding the large header view animation
-    @objc open var lockNavBarPosition: Bool = false
+    // allow users to collapse or expand the large header view while scrolling `contentScrollView`
+    @objc open var allowResizeOfNavigationBarOnScroll: Bool = true
 
     @objc open var msfNavigationBar: NavigationBar {
         guard let msfNavBar = navigationBar as? NavigationBar else {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -13,7 +13,7 @@ public typealias MSNavigationController = NavigationController
 /// `UINavigationController` subclass that supports Large Title presentation and accessory view by wrapping each view controller that needs this functionality into a controller that provides the required behavior. The original view controller can be accessed by using `topContentViewController` or `contentViewController(for:)`.
 @objc(MSFNavigationController)
 open class NavigationController: UINavigationController {
-    // allow users to collapse or expand the large header view while scrolling `contentScrollView`
+    /// allow users to collapse or expand the large header view while scrolling `contentScrollView`
     @objc open var allowResizeOfNavigationBarOnScroll: Bool = true
 
     @objc open var msfNavigationBar: NavigationBar {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -13,6 +13,9 @@ public typealias MSNavigationController = NavigationController
 /// `UINavigationController` subclass that supports Large Title presentation and accessory view by wrapping each view controller that needs this functionality into a controller that provides the required behavior. The original view controller can be accessed by using `topContentViewController` or `contentViewController(for:)`.
 @objc(MSFNavigationController)
 open class NavigationController: UINavigationController {
+    // allow clients to lock navigation bar position which will prevent collapsing or expanding the large header view animation
+    @objc open var lockNavBarPosition: Bool = false
+
     @objc open var msfNavigationBar: NavigationBar {
         guard let msfNavBar = navigationBar as? NavigationBar else {
             preconditionFailure("The navigation bar is either not present or not the correct class")

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -475,8 +475,8 @@ class ShyHeaderController: UIViewController {
     ///
     /// - Parameter progress: progress, represented as a fraction (0.5) not a percent (50.0)
     private func updateHeader(with progress: CGFloat, expanding: Bool) {
-        //fall out to ignore repeated animations resulting in the same layout
-        guard shyHeaderView.exposure.progress != progress else {
+        // fall out to ignore repeated animations resulting in the same layout
+        guard shyHeaderView.exposure.progress != progress, msfNavigationController?.lockNavBarPosition == false else {
             return
         }
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -476,7 +476,7 @@ class ShyHeaderController: UIViewController {
     /// - Parameter progress: progress, represented as a fraction (0.5) not a percent (50.0)
     private func updateHeader(with progress: CGFloat, expanding: Bool) {
         // fall out to ignore repeated animations resulting in the same layout
-        guard shyHeaderView.exposure.progress != progress, msfNavigationController?.lockNavBarPosition == false else {
+        guard shyHeaderView.exposure.progress != progress, msfNavigationController?.allowResizeOfNavigationBarOnScroll == true else {
             return
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

allow clients to lock header's expand or collapse position

### Verification
[locking headerview.mov.zip](https://github.com/microsoft/fluentui-apple/files/4647672/locking.headerview.mov.zip)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/63)