### PR TITLE
[NuGet] Remove destination specifier in builds

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -38,7 +38,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-iOS-StaticLib'
       xcode_configuration: 'Debug'
-      xcode_extraArgs: '-destination "platform=iOS Simulator,name=iPhone 8" -xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
   
   # iphonesimulator Library Release
   - template: apple-xcode-build.yml
@@ -48,7 +48,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-iOS-StaticLib'
       xcode_configuration: 'Release'
-      xcode_extraArgs: '-destination "platform=iOS Simulator,name=iPhone 8" -xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
 
   # iphoneos Library Debug
   - template: apple-xcode-build.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         build_command: [
           'macos_build FluentUITestApp-macOS Debug build test',
           'macos_build FluentUITestApp-macOS Release build test',
-          'ios_simulator_build FluentUI-iOS Debug build test',
+          'ios_simulator_build FluentUI-iOS Debug build test -destination "platform=iOS Simulator,name=iPhone 8"', # Provide a destination for the iOS simulator unit tests
           'ios_simulator_build FluentUI-iOS Release build',
           'ios_simulator_build FluentUI-iOS-StaticLib Debug build',
           'ios_simulator_build FluentUI-iOS-StaticLib Release build',

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -30,7 +30,7 @@ $XCODEBUILD_WRAPPER_LOCATION macos_build FluentUITestApp-macOS Release build tes
 handle_exit_code
 
 echo "Building and Testing iOS Framework Debug Simulator"
-$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS Debug build test
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS Debug build test -destination "platform=iOS Simulator,name=iPhone 8"
 handle_exit_code
 
 echo "Building iOS Framework Release Simulator"

--- a/scripts/xcodebuild_wrapper.sh
+++ b/scripts/xcodebuild_wrapper.sh
@@ -30,7 +30,7 @@ function invoke_xcodebuild()
 # \param $3+ build commands
 function ios_simulator_build()
 {
-    invoke_xcodebuild workspace "ios/FluentUI.xcworkspace" "$1" "$2" iphonesimulator "${@:3}" -destination "platform=iOS Simulator,name=iPhone 8"
+    invoke_xcodebuild workspace "ios/FluentUI.xcworkspace" "$1" "$2" iphonesimulator "${@:3}"
     return $?
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We're seeing an issue in the built products from NuGet where there are random crashes on older OSs. These seem to be fixed by removing the destination specifier on the build.

### Verification

Build this locally with `scripts/publish_nuget.sh` and manually verify on iOS 12.0, 12.2, 12.4, and 13.4.1 with a test app, ensure that resources work as expected in all cases.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/69)