### PR TITLE
Update protocol constraint `class` to `AnyObject`

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -10,7 +10,7 @@ import UIKit
 public typealias MSBadgeFieldDelegate = BadgeFieldDelegate
 
 @objc(MSFBadgeFieldDelegate)
-public protocol BadgeFieldDelegate: class {
+public protocol BadgeFieldDelegate: AnyObject {
     @objc optional func badgeField(_ badgeField: BadgeField, badgeDataSourceForText text: String) -> BadgeViewDataSource
 
     @objc optional func badgeField(_ badgeField: BadgeField, willChangeTextFieldContentWithText newText: String)

--- a/ios/FluentUI/Calendar/CalendarViewDataSource.swift
+++ b/ios/FluentUI/Calendar/CalendarViewDataSource.swift
@@ -7,7 +7,7 @@ import UIKit
 
 // MARK: CalendarViewStyleDataSource
 
-protocol CalendarViewStyleDataSource: class {
+protocol CalendarViewStyleDataSource: AnyObject {
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, textStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellTextStyle
 
     // Suggestion: Use provided components for performance improvements. Check where it's called to see what's available

--- a/ios/FluentUI/Calendar/CalendarViewLayout.swift
+++ b/ios/FluentUI/Calendar/CalendarViewLayout.swift
@@ -7,7 +7,7 @@ import UIKit
 
 // MARK: CalendarViewLayoutDelegate
 
-protocol CalendarViewLayoutDelegate: class {
+protocol CalendarViewLayoutDelegate: AnyObject {
     func calendarViewLayout(_ calendarViewLayout: CalendarViewLayout, shouldShowMonthBannerForSectionIndex sectionIndex: Int) -> Bool
 }
 

--- a/ios/FluentUI/Controls/ScrollView.swift
+++ b/ios/FluentUI/Controls/ScrollView.swift
@@ -7,7 +7,7 @@ import UIKit
 
 protocol ContainerView { }
 
-protocol ScrollableContainerView: class {
+protocol ScrollableContainerView: AnyObject {
     func makeFirstResponderVisible()
 }
 

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -12,7 +12,7 @@ public typealias MSSearchBarDelegate = SearchBarDelegate
 
 /// Various state update methods coming from the SearchBar
 @objc(MSFSearchBarDelegate)
-public protocol SearchBarDelegate: class, NSObjectProtocol {
+public protocol SearchBarDelegate: AnyObject, NSObjectProtocol {
     func searchBarDidBeginEditing(_ searchBar: SearchBar)
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?)
     @objc optional func searchBarDidFinishEditing(_ searchBar: SearchBar)

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -12,7 +12,7 @@ public typealias MSSearchBarDelegate = SearchBarDelegate
 
 /// Various state update methods coming from the SearchBar
 @objc(MSFSearchBarDelegate)
-public protocol SearchBarDelegate: AnyObject, NSObjectProtocol {
+public protocol SearchBarDelegate: AnyObject {
     func searchBarDidBeginEditing(_ searchBar: SearchBar)
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?)
     @objc optional func searchBarDidFinishEditing(_ searchBar: SearchBar)

--- a/ios/FluentUI/Controls/TwoLineTitleView.swift
+++ b/ios/FluentUI/Controls/TwoLineTitleView.swift
@@ -11,7 +11,7 @@ import UIKit
 public typealias MSTwoLineTitleViewDelegate = TwoLineTitleViewDelegate
 
 @objc(MSFTwoLineTitleViewDelegate)
-public protocol TwoLineTitleViewDelegate: class {
+public protocol TwoLineTitleViewDelegate: AnyObject {
     func twoLineTitleViewDidTapOnTitle(_ twoLineTitleView: TwoLineTitleView)
 }
 

--- a/ios/FluentUI/Core/Obscurable.swift
+++ b/ios/FluentUI/Core/Obscurable.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 /// Obscurable represents any UIView containing class that obscures views behind it. It is used to generically use different styles of background obscuring for modals, as well as provide an interface to turn their effect on or off.
-protocol Obscurable: class {
+protocol Obscurable: AnyObject {
     var view: UIView { get }
     var isObscuring: Bool { get set }
 }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -18,7 +18,7 @@ enum DateTimePickerViewMode {
 
 // MARK: - DateTimePickerViewDelegate
 
-protocol DateTimePickerViewDelegate: class {
+protocol DateTimePickerViewDelegate: AnyObject {
     func dateTimePickerView(_ dateTimePickerView: DateTimePickerView, accessibilityValueOverwriteForDate date: Date, originalValue: String?) -> String?
 }
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponent.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponent.swift
@@ -7,7 +7,7 @@ import UIKit
 
 // MARK: DateTimePickerViewComponentDelegate
 
-protocol DateTimePickerViewComponentDelegate: class {
+protocol DateTimePickerViewComponentDelegate: AnyObject {
     func dateTimePickerComponentDidScroll(_ component: DateTimePickerViewComponent, userInitiated: Bool)
     func dateTimePickerComponent(_ component: DateTimePickerViewComponent, didSelectItemAtIndexPath indexPath: IndexPath, userInitiated: Bool)
     func dateTimePickerComponent(_ component: DateTimePickerViewComponent, accessibilityValueForDateComponents dateComponents: DateComponents?, originalValue: String?) -> String?

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewDataSource.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewDataSource.swift
@@ -41,7 +41,7 @@ enum DateTimePickerViewAMPM {
  * DataSource of a component of DateTimePickerView. All dataSources must follow this protocol and be private to this file.
  * Use the factory to instantiate the specific dataSources based on a type. (should be used only by DateTimePickerView and not used or instantiated on its own)
  */
-protocol DateTimePickerViewDataSource: class {
+protocol DateTimePickerViewDataSource: AnyObject {
     func numberOfItems() -> Int
 
     // If the item is present multiple times, return the indexPath at the center

--- a/ios/FluentUI/Date Time Pickers/DateTimePicker.swift
+++ b/ios/FluentUI/Date Time Pickers/DateTimePicker.swift
@@ -27,7 +27,7 @@ public enum DateTimePickerMode: Int {
 public typealias MSDateTimePickerDelegate = DateTimePickerDelegate
 
 @objc(MSFDateTimePickerDelegate)
-public protocol DateTimePickerDelegate: class {
+public protocol DateTimePickerDelegate: AnyObject {
     /// Allows a class to be notified when a user confirms their selected date
     func dateTimePicker(_ dateTimePicker: DateTimePicker, didPickStartDate startDate: Date, endDate: Date)
     /// Allows for some validation and cancellation of picking behavior, including the dismissal of DateTimePicker classes when Done is pressed. If false is returned, the dismissal and `didPickStartDate` delegate calls will not occur. This is not called when dismissing the modal without selection, such as when tapping outside to dismiss.

--- a/ios/FluentUI/Date Time Pickers/GenericDateTimePicker.swift
+++ b/ios/FluentUI/Date Time Pickers/GenericDateTimePicker.swift
@@ -7,7 +7,7 @@ import UIKit
 
 // MARK: GenericDateTimePicker
 
-protocol GenericDateTimePicker: class {
+protocol GenericDateTimePicker: AnyObject {
     var startDate: Date { get set }
     var endDate: Date { get set }
     var delegate: GenericDateTimePickerDelegate? { get set }
@@ -24,7 +24,7 @@ extension GenericDateTimePicker where Self: UIViewController {
 
 // MARK: - GenericDateTimePickerDelegate
 
-protocol GenericDateTimePickerDelegate: class {
+protocol GenericDateTimePickerDelegate: AnyObject {
     func dateTimePicker(_ dateTimePicker: GenericDateTimePicker, didPickStartDate startDate: Date, endDate: Date)
     func dateTimePicker(_ dateTimePicker: GenericDateTimePicker, didSelectStartDate startDate: Date, endDate: Date)
     func dateTimePicker(_ dateTimePicker: GenericDateTimePicker, shouldEndPickingStartDate startDate: Date, endDate: Date) -> Bool

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -78,7 +78,7 @@ public enum DrawerPresentationBackground: Int {
 public typealias MSDrawerControllerDelegate = DrawerControllerDelegate
 
 @objc(MSFDrawerControllerDelegate)
-public protocol DrawerControllerDelegate: class {
+public protocol DrawerControllerDelegate: AnyObject {
     /**
      Called when a user resizes the drawer enough to change its expanded state. Use `isExpanded` property to get the current state.
 

--- a/ios/FluentUI/HUD/HUD.swift
+++ b/ios/FluentUI/HUD/HUD.swift
@@ -11,7 +11,7 @@ import UIKit
 public typealias MSHUDDelegate = HUDDelegate
 
 @objc(MSFHUDDelegate)
-public protocol HUDDelegate: class {
+public protocol HUDDelegate: AnyObject {
     func defaultWindowForHUD(_ hud: HUD) -> UIWindow?
 }
 

--- a/ios/FluentUI/Presenters/PageCardPresenterController.swift
+++ b/ios/FluentUI/Presenters/PageCardPresenterController.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-protocol CardPresentable: class {
+protocol CardPresentable: AnyObject {
     func idealSize() -> CGSize
 }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -11,7 +11,7 @@ import UIKit
 public typealias MSTableViewHeaderFooterViewDelegate = TableViewHeaderFooterViewDelegate
 
 @objc(MSFTableViewHeaderFooterViewDelegate)
-public protocol TableViewHeaderFooterViewDelegate: class {
+public protocol TableViewHeaderFooterViewDelegate: AnyObject {
     /// Returns: true if the interaction with the header view should be allowed; false if the interaction should not be allowed.
     @objc optional func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool
 }

--- a/ios/FluentUI/Utilities/AnimationSynchronizer.swift
+++ b/ios/FluentUI/Utilities/AnimationSynchronizer.swift
@@ -11,7 +11,7 @@ public typealias MSAnimationSynchronizerProtocol = AnimationSynchronizerProtocol
 /// An animation synchronizer syncs homogeneous layer animations by calculating the appropriate timeOffset
 /// of a referenceLayer so that newly added animations can stay in sync with existing animations.
 @objc(MSFAnimationSynchronizerProtocol)
-public protocol AnimationSynchronizerProtocol: class {
+public protocol AnimationSynchronizerProtocol: AnyObject {
     /// Current reference layer to compare timing against.
     @objc var referenceLayer: CALayer? { get set }
 

--- a/macos/FluentUI/DatePicker/CalendarHeaderView.swift
+++ b/macos/FluentUI/DatePicker/CalendarHeaderView.swift
@@ -155,7 +155,7 @@ class CalendarHeaderView: NSView {
 	}
 }
 
-protocol CalendarHeaderViewDelegate: class {
+protocol CalendarHeaderViewDelegate: AnyObject {
 	
 	/// Tells the delegate that the leading arrow button was pressed.
 	///

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -139,7 +139,7 @@ class CalendarView: NSView {
 	}
 }
 
-protocol CalendarViewDelegate: class {
+protocol CalendarViewDelegate: AnyObject {
 	
 	/// Tells the delegate that a date was selected.
 	///

--- a/macos/FluentUI/DatePicker/DatePickerController.swift
+++ b/macos/FluentUI/DatePicker/DatePickerController.swift
@@ -477,7 +477,7 @@ extension Calendar {
 }
 
 @objc(MSFDatePickerControllerDelegate)
-public protocol DatePickerControllerDelegate : class {
+public protocol DatePickerControllerDelegate : AnyObject {
 	
 	/// Tells the delegate that a new date was selected.
 	///

--- a/macos/FluentUI/DatePicker/DatePickerView.swift
+++ b/macos/FluentUI/DatePicker/DatePickerView.swift
@@ -409,7 +409,7 @@ extension DatePickerView: CalendarHeaderViewDelegate {
 	}
 }
 
-protocol DatePickerViewDelegate: class {
+protocol DatePickerViewDelegate: AnyObject {
 	
 	/// Tells the delegate that a new date was selected.
 	///
@@ -462,7 +462,7 @@ extension DatePickerViewDelegate {
 	}
 }
 
-protocol DatePickerViewDataSource: class {
+protocol DatePickerViewDataSource: AnyObject {
 	
 	/// Currently selected date
 	var selectedDate: Date { get }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

`: class` is no longer preferred in Swift, updated with `: AnyObject`.

### Verification

No visual changes.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/76)