### PR TITLE
Reset customBorderImageSize, so that this cached value works when the…

### DIFF
--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -133,6 +133,7 @@ open class AvatarView: UIView {
                 borderView.isHidden = false
                 updateCustomBorder()
             } else {
+                customBorderImageSize = .zero
                 hasCustomBorder = false
                 borderView.isHidden = !hasBorder
                 updateBorder()


### PR DESCRIPTION
… customBorderImage is set, nil, then set again

### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Reset customBorderImageSize, so that this cached value works when the…

### Verification

test setting an image, then nil, then setting an image again

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/79)