### PR TITLE
Fix regression in TableViewHeaderFooterView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -90,12 +90,11 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
         let section = tableView.style == .grouped ? groupedSections[section] : plainSections[section]
         if section.hasCustomAccessoryView {
-            header.customAccessoryView = createCustomAccessoryView()
+            header.setup(style: section.headerStyle, title: section.title, accessoryView: createCustomAccessoryView())
         } else {
-            header.customAccessoryView = nil
+            header.setup(style: section.headerStyle, title: section.title, accessoryButtonTitle: section.hasAccessory ? "See More" : "")
         }
 
-        header.setup(style: section.headerStyle, title: section.title, accessoryButtonTitle: section.hasAccessory ? "See More" : "")
         header.titleNumberOfLines = section.numberOfLines
         header.accessoryButtonStyle = section.accessoryButtonStyle
         header.onAccessoryButtonTapped = { [unowned self] in self.showAlertForAccessoryTapped(title: section.title) }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -89,13 +89,16 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
         let section = tableView.style == .grouped ? groupedSections[section] : plainSections[section]
+        if section.hasCustomAccessoryView {
+            header.customAccessoryView = createCustomAccessoryView()
+        } else {
+            header.customAccessoryView = nil
+        }
+
         header.setup(style: section.headerStyle, title: section.title, accessoryButtonTitle: section.hasAccessory ? "See More" : "")
         header.titleNumberOfLines = section.numberOfLines
         header.accessoryButtonStyle = section.accessoryButtonStyle
         header.onAccessoryButtonTapped = { [unowned self] in self.showAlertForAccessoryTapped(title: section.title) }
-        if section.hasCustomAccessoryView {
-            header.customAccessoryView = createCustomAccessoryView()
-        }
 
         return header
     }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -282,7 +282,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         }
 
         if customAccessoryView == nil {
-            accessoryView = accessoryButtonTitle != "" ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
+            accessoryButton = accessoryButtonTitle != "" ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
         }
 
         self.style = style

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -151,15 +151,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         }
     }
 
-    /// A custom accessory view to be used instead of the accessory button in the trailing edge of this view.
-    /// If set, the accessory button (if any) will be replaced by this custom view. Clients are responsible
-    /// for the appeareance and behavior of this view, including event handling and accessibility.
-     @objc open var customAccessoryView: UIView? = nil {
-        didSet {
-            accessoryView = customAccessoryView
-        }
-    }
-
     /// The maximum number of lines to be shown for `title`
     @objc open var titleNumberOfLines: Int = 1 {
         didSet {
@@ -269,6 +260,14 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         setup(style: style, accessoryButtonTitle: accessoryButtonTitle)
     }
 
+    /// The custom accessory view  be used instead of the accessory button in the trailing edge of this view.
+    /// If set, the accessory button (if any) will be replaced by this custom view. Clients are responsible
+    /// for the appeareance and behavior of this view, including event handling and accessibility.
+    @objc open func setup(style: Style, title: String, accessoryView: UIView) {
+        setup(style: style, title: title)
+        self.accessoryView = accessoryView
+    }
+
     private func setup(style: Style, accessoryButtonTitle: String) {
         updateTitleViewFont()
         switch style {
@@ -281,9 +280,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             titleView.isAccessibilityElement = true
         }
 
-        if customAccessoryView == nil {
-            accessoryButton = accessoryButtonTitle != "" ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
-        }
+        accessoryButton = accessoryButtonTitle != "" ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
 
         self.style = style
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

accessoryButton is supposed to be initialized, not accessoryView

### Verification

Demo, play with setting regular and custom accessory view

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/83)