### PR TITLE
Add new property in DrawerController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -173,7 +173,7 @@ class DrawerDemoController: DemoController {
         contentController.preferredContentSize = CGSize(width: 400, height: 400)
         contentControllerOriginalPreferredContentHeight = contentController.preferredContentSize.height
 
-        let drawer = presentDrawer(sourceView: sender, presentationDirection: .up, presentationStyle: .slideover, presentationOffset: 20, presentationBackground: traitCollection.horizontalSizeClass == .regular ? .none : .black, contentController: contentController, resizingBehavior: .dismissOrExpand)
+        let drawer = presentDrawer(sourceView: sender, presentationDirection: .up, presentationStyle: .slideover, presentationOffset: 20, presentationBackground: .black, contentController: contentController, resizingBehavior: .dismissOrExpand)
 
         drawer.contentScrollView = personaListView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -17,7 +17,7 @@ class DrawerDemoController: DemoController {
         addTitle(text: "Top Drawer")
         container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showTopDrawerButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showTopDrawerNotAnimatedButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show from custom base", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show from custom base with width", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
 
         addTitle(text: "Left/Right Drawer")
         addRow(
@@ -54,7 +54,7 @@ class DrawerDemoController: DemoController {
     }
 
     @discardableResult
-    private func presentDrawer(sourceView: UIView? = nil, barButtonItem: UIBarButtonItem? = nil, presentationOrigin: CGFloat = -1, presentationDirection: DrawerPresentationDirection, presentationStyle: DrawerPresentationStyle = .automatic, presentationOffset: CGFloat = 0, presentationBackground: DrawerPresentationBackground = .black, presentingGesture: UIPanGestureRecognizer? = nil, permittedArrowDirections: UIPopoverArrowDirection = [.left, .right], contentController: UIViewController? = nil, contentView: UIView? = nil, resizingBehavior: DrawerResizingBehavior = .none, adjustHeightForKeyboard: Bool = false, animated: Bool = true) -> DrawerController {
+    private func presentDrawer(sourceView: UIView? = nil, barButtonItem: UIBarButtonItem? = nil, presentationOrigin: CGFloat = -1, presentationDirection: DrawerPresentationDirection, presentationStyle: DrawerPresentationStyle = .automatic, presentationOffset: CGFloat = 0, presentationBackground: DrawerPresentationBackground = .black, presentingGesture: UIPanGestureRecognizer? = nil, permittedArrowDirections: UIPopoverArrowDirection = [.left, .right], contentController: UIViewController? = nil, contentView: UIView? = nil, resizingBehavior: DrawerResizingBehavior = .none, adjustHeightForKeyboard: Bool = false, animated: Bool = true, customWidth: Bool = false) -> DrawerController {
         let controller: DrawerController
         if let sourceView = sourceView {
             controller = DrawerController(sourceView: sourceView, sourceRect: sourceView.bounds.insetBy(dx: sourceView.bounds.width / 2, dy: 0), presentationOrigin: presentationOrigin, presentationDirection: presentationDirection)
@@ -76,8 +76,10 @@ class DrawerDemoController: DemoController {
             // `preferredContentSize` can be used to specify the preferred size of a drawer,
             // but here we just define the width and allow it to calculate height automatically
             controller.preferredContentSize.width = 360
-            //controller.preferredContentSize.height = 230
             controller.contentView = contentView
+            if customWidth {
+                controller.shouldUseWindowFullWidth = false
+            }
         } else {
             controller.contentController = contentController
         }
@@ -126,7 +128,7 @@ class DrawerDemoController: DemoController {
 
     @objc private func showTopDrawerCustomOffsetButtonTapped(sender: UIButton) {
         let rect = sender.superview!.convert(sender.frame, to: nil)
-        presentDrawer(sourceView: sender, presentationOrigin: rect.maxY, presentationDirection: .down, contentView: containerForActionViews())
+        presentDrawer(sourceView: sender, presentationOrigin: rect.maxY, presentationDirection: .down, contentView: containerForActionViews(), customWidth: true)
     }
 
     @objc private func showLeftDrawerButtonTapped(sender: UIButton) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -17,7 +17,7 @@ class DrawerDemoController: DemoController {
         addTitle(text: "Top Drawer")
         container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showTopDrawerButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showTopDrawerNotAnimatedButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show from custom base with width", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show from custom base with width on landscape", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
 
         addTitle(text: "Left/Right Drawer")
         addRow(
@@ -78,7 +78,7 @@ class DrawerDemoController: DemoController {
             controller.preferredContentSize.width = 360
             controller.contentView = contentView
             if customWidth {
-                controller.shouldUseWindowFullWidth = false
+                controller.shouldUseWindowFullWidthInLandscape = false
             }
         } else {
             controller.contentController = contentController

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -320,6 +320,10 @@ open class DrawerController: UIViewController {
             }
         }
     }
+
+    /// For `vertical` presentation on compact mode, the content width will be the full width of the window. If set to false, the `preferredContentSize.width` will be used for calculation.
+    @objc open var shouldUseWindowFullWidth: Bool = true
+
     // Override to provide the preferred size based on specifics of the concrete drawer subclass (see popup menu, for example)
     open var preferredContentWidth: CGFloat { return 0 }
     open var preferredContentHeight: CGFloat { return 0 }
@@ -531,15 +535,12 @@ open class DrawerController: UIViewController {
         }
 
         if presentationDirection.isVertical {
-            if let window = sourceViewController.view?.window {
-                return window.traitCollection.horizontalSizeClass == .compact ? .slideover : .popover
-            } else {
-                // No window, use the device type as last resort.
-                // It will be a problem:
-                //   - on iPhone Plus/X in landscape orientation
-                //   - on iPad in split view
-                return traitCollection.userInterfaceIdiom == .phone ? .slideover : .popover
+            if traitCollection.userInterfaceIdiom == .phone {
+                return .slideover
+            } else if let window = sourceViewController.view?.window, window.traitCollection.horizontalSizeClass == .compact {
+                return .slideover
             }
+            return .popover
         } else {
             return .slideover
         }
@@ -849,7 +850,7 @@ extension DrawerController: UIViewControllerTransitioningDelegate {
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         switch presentationStyle(for: source) {
         case .slideover:
-            return DrawerPresentationController(presentedViewController: presented, presenting: presenting, source: source, sourceObject: sourceView ?? barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: presentationDirection(for: source.view), presentationOffset: presentationOffset, presentationBackground: presentationBackground, adjustHeightForKeyboard: adjustsHeightForKeyboard)
+            return DrawerPresentationController(presentedViewController: presented, presenting: presenting, source: source, sourceObject: sourceView ?? barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: presentationDirection(for: source.view), presentationOffset: presentationOffset, presentationBackground: presentationBackground, adjustHeightForKeyboard: adjustsHeightForKeyboard, shouldUseWindowFullWidth: shouldUseWindowFullWidth)
         case .popover:
             let presentationController = UIPopoverPresentationController(presentedViewController: presented, presenting: presenting)
             presentationController.backgroundColor = backgroundColor

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -321,8 +321,8 @@ open class DrawerController: UIViewController {
         }
     }
 
-    /// For `vertical` presentation on compact mode, the content width will be the full width of the window. If set to false, the `preferredContentSize.width` will be used for calculation.
-    @objc open var shouldUseWindowFullWidth: Bool = true
+    /// For `vertical` presentation shown when horizontal size is `.compact`, the content width will be the full width of the presenting window. If set to false, the `preferredContentSize.width` will be used for calculation in landscape mode.
+    @objc open var shouldUseWindowFullWidthInLandscape: Bool = true
 
     // Override to provide the preferred size based on specifics of the concrete drawer subclass (see popup menu, for example)
     open var preferredContentWidth: CGFloat { return 0 }
@@ -850,7 +850,7 @@ extension DrawerController: UIViewControllerTransitioningDelegate {
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         switch presentationStyle(for: source) {
         case .slideover:
-            return DrawerPresentationController(presentedViewController: presented, presenting: presenting, source: source, sourceObject: sourceView ?? barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: presentationDirection(for: source.view), presentationOffset: presentationOffset, presentationBackground: presentationBackground, adjustHeightForKeyboard: adjustsHeightForKeyboard, shouldUseWindowFullWidth: shouldUseWindowFullWidth)
+            return DrawerPresentationController(presentedViewController: presented, presenting: presenting, source: source, sourceObject: sourceView ?? barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: presentationDirection(for: source.view), presentationOffset: presentationOffset, presentationBackground: presentationBackground, adjustHeightForKeyboard: adjustsHeightForKeyboard, shouldUseWindowFullWidthInLandscape: shouldUseWindowFullWidthInLandscape)
         case .popover:
             let presentationController = UIPopoverPresentationController(presentedViewController: presented, presenting: presenting)
             presentationController.backgroundColor = backgroundColor

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -318,7 +318,13 @@ class DrawerPresentationController: UIPresentationController {
         var contentFrame = bounds.inset(by: marginsForContentView())
 
         var contentSize = presentedViewController.preferredContentSize
-        let landscapeMode = contentFrame.width > contentFrame.height
+
+        let landscapeMode: Bool
+        if let windowSize = sourceViewController.view.window?.frame.size {
+            landscapeMode = windowSize.width > windowSize.height
+        } else {
+            landscapeMode = false
+        }
 
         if presentationDirection.isVertical {
             if contentSize.width == 0 ||

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -16,21 +16,21 @@ class DrawerPresentationController: UIPresentationController {
 
     let presentationDirection: DrawerPresentationDirection
 
-    private let shouldUseWindowFullWidth: Bool
+    private let shouldUseWindowFullWidthInLandscape: Bool
     private let sourceViewController: UIViewController
     private let sourceObject: Any?
     private let presentationOrigin: CGFloat?
     private let presentationOffset: CGFloat
     private let presentationBackground: DrawerPresentationBackground
 
-    init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, source: UIViewController, sourceObject: Any?, presentationOrigin: CGFloat?, presentationDirection: DrawerPresentationDirection, presentationOffset: CGFloat, presentationBackground: DrawerPresentationBackground, adjustHeightForKeyboard: Bool, shouldUseWindowFullWidth: Bool) {
+    init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, source: UIViewController, sourceObject: Any?, presentationOrigin: CGFloat?, presentationDirection: DrawerPresentationDirection, presentationOffset: CGFloat, presentationBackground: DrawerPresentationBackground, adjustHeightForKeyboard: Bool, shouldUseWindowFullWidthInLandscape: Bool) {
         sourceViewController = source
         self.sourceObject = sourceObject
         self.presentationOrigin = presentationOrigin
         self.presentationDirection = presentationDirection
         self.presentationOffset = presentationOffset
         self.presentationBackground = presentationBackground
-        self.shouldUseWindowFullWidth = shouldUseWindowFullWidth
+        self.shouldUseWindowFullWidthInLandscape = shouldUseWindowFullWidthInLandscape
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
 
         backgroundView.gestureRecognizers = [UITapGestureRecognizer(target: self, action: #selector(handleBackgroundViewTapped(_:)))]
@@ -318,8 +318,12 @@ class DrawerPresentationController: UIPresentationController {
         var contentFrame = bounds.inset(by: marginsForContentView())
 
         var contentSize = presentedViewController.preferredContentSize
+        let landscapeMode = contentFrame.width > contentFrame.height
+
         if presentationDirection.isVertical {
-            if contentSize.width == 0 || ((traitCollection.userInterfaceIdiom == .phone || traitCollection.horizontalSizeClass == .compact) && shouldUseWindowFullWidth) {
+            if contentSize.width == 0 ||
+                (traitCollection.userInterfaceIdiom == .phone && landscapeMode && shouldUseWindowFullWidthInLandscape) ||
+                (traitCollection.horizontalSizeClass == .compact && !landscapeMode) {
                 contentSize.width = contentFrame.width
             }
             if actualPresentationOffset == 0 && (presentationDirection == .down || keyboardHeight == 0) {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -14,20 +14,23 @@ class DrawerPresentationController: UIPresentationController {
         static let minVerticalMargin: CGFloat = 20
     }
 
-    let sourceViewController: UIViewController
-    let sourceObject: Any?
-    let presentationOrigin: CGFloat?
     let presentationDirection: DrawerPresentationDirection
-    let presentationOffset: CGFloat
-    let presentationBackground: DrawerPresentationBackground
 
-    init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, source: UIViewController, sourceObject: Any?, presentationOrigin: CGFloat?, presentationDirection: DrawerPresentationDirection, presentationOffset: CGFloat, presentationBackground: DrawerPresentationBackground, adjustHeightForKeyboard: Bool) {
+    private let shouldUseWindowFullWidth: Bool
+    private let sourceViewController: UIViewController
+    private let sourceObject: Any?
+    private let presentationOrigin: CGFloat?
+    private let presentationOffset: CGFloat
+    private let presentationBackground: DrawerPresentationBackground
+
+    init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, source: UIViewController, sourceObject: Any?, presentationOrigin: CGFloat?, presentationDirection: DrawerPresentationDirection, presentationOffset: CGFloat, presentationBackground: DrawerPresentationBackground, adjustHeightForKeyboard: Bool, shouldUseWindowFullWidth: Bool) {
         sourceViewController = source
         self.sourceObject = sourceObject
         self.presentationOrigin = presentationOrigin
         self.presentationDirection = presentationDirection
         self.presentationOffset = presentationOffset
         self.presentationBackground = presentationBackground
+        self.shouldUseWindowFullWidth = shouldUseWindowFullWidth
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
 
         backgroundView.gestureRecognizers = [UITapGestureRecognizer(target: self, action: #selector(handleBackgroundViewTapped(_:)))]
@@ -316,7 +319,7 @@ class DrawerPresentationController: UIPresentationController {
 
         var contentSize = presentedViewController.preferredContentSize
         if presentationDirection.isVertical {
-            if contentSize.width == 0 || traitCollection.horizontalSizeClass == .compact {
+            if contentSize.width == 0 || ((traitCollection.userInterfaceIdiom == .phone || traitCollection.horizontalSizeClass == .compact) && shouldUseWindowFullWidth) {
                 contentSize.width = contentFrame.width
             }
             if actualPresentationOffset == 0 && (presentationDirection == .down || keyboardHeight == 0) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

DrawerController thinks it should present as UIPopoverPresentationController when the horizontal size is compact. But for larger phones like iPhone 11 Pro Max even in portrait orientation, horizontal size is regular. 
(1) make sure in iPhone the vertical drawers are presented in slider mode. 
(2) add a new property that clients can force the slider to be drawn in preferred content width in landscape in compact horizontal size.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-01 at 08 40 56](https://user-images.githubusercontent.com/20715435/83426196-a3d88080-a3e3-11ea-8f8f-2e15b1aaf07d.png)  | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-01 at 08 28 28](https://user-images.githubusercontent.com/20715435/83426107-82779480-a3e3-11ea-835b-6c56036ddab5.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/85)