### PR TITLE
[Modify] Implement PopupMenu Protocols for Objective-C customization support

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -38,6 +38,7 @@ class PopupMenuDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with sections", action: #selector(showTopMenuWithSectionsButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show with scrollable items and no icons", action: #selector(showTopMenuWithScrollableItemsButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show items with custom colors", action: #selector(showCustomColorsButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show items without dismissal after being tapped", action: #selector(showNoDismissalItemsButtonTapped)))
         container.addArrangedSubview(UIView())
         addTitle(text: "Show with...")
     }
@@ -138,6 +139,34 @@ class PopupMenuDemoController: DemoController {
             PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: calendarLayout == .agenda, onSelected: { self.calendarLayout = .agenda }),
             PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: calendarLayout == .day, onSelected: { self.calendarLayout = .day }),
             PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: calendarLayout == .threeDay, onSelected: { self.calendarLayout = .threeDay })
+        ]
+
+        let menuBackgroundColor: UIColor = .darkGray
+
+        for item in items {
+            item.titleColor = .white
+            item.titleSelectedColor = .white
+            item.imageSelectedColor = .white
+            item.accessoryCheckmarkColor = .white
+            item.backgroundColor = menuBackgroundColor
+        }
+
+        controller.addItems(items)
+
+        controller.backgroundColor = menuBackgroundColor
+        controller.resizingHandleViewBackgroundColor = menuBackgroundColor
+        controller.separatorColor = .lightGray
+
+        present(controller, animated: true)
+    }
+
+    @objc private func showNoDismissalItemsButtonTapped(sender: UIButton) {
+        let controller = PopupMenuController(sourceView: sender, sourceRect: sender.bounds, presentationDirection: .down)
+
+        let items = [
+            PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: calendarLayout == .agenda, executes: .onSelectionWithoutDismissal, onSelected: { self.calendarLayout = .agenda }),
+            PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: calendarLayout == .day, executes: .onSelectionWithoutDismissal, onSelected: { self.calendarLayout = .day }),
+            PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: calendarLayout == .threeDay, executes: .onSelectionWithoutDismissal, onSelected: { self.calendarLayout = .threeDay })
         ]
 
         let menuBackgroundColor: UIColor = .darkGray

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0BCEFADE2485FEC00088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
+		0BCEFAE1248650F10088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
 		11104BCE233ACA9500CCB232 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118D9847230BBA2300BC0B72 /* TabBarItem.swift */; };
 		1168630422E131CF0088B302 /* TabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168630222E131CF0088B302 /* TabBarItemView.swift */; };
 		1168630522E131CF0088B302 /* TabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168630222E131CF0088B302 /* TabBarItemView.swift */; };
@@ -1182,6 +1183,7 @@
 				8FD0119A228A82A600D25925 /* DrawerController.swift in Sources */,
 				8FD0119B228A82A600D25925 /* DrawerPresentationController.swift in Sources */,
 				8FD0119C228A82A600D25925 /* DrawerTransitionAnimator.swift in Sources */,
+				0BCEFAE1248650F10088CEE5 /* PopupMenuProtocols.swift in Sources */,
 				8FD0119D228A82A600D25925 /* DrawerShadowView.swift in Sources */,
 				8FD0119E228A82A600D25925 /* CALayer+Extensions.swift in Sources */,
 				8FD0119F228A82A600D25925 /* Calendar+Extensions.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0BCEFADE2485FEC00088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
 		11104BCE233ACA9500CCB232 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118D9847230BBA2300BC0B72 /* TabBarItem.swift */; };
 		1168630422E131CF0088B302 /* TabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168630222E131CF0088B302 /* TabBarItemView.swift */; };
 		1168630522E131CF0088B302 /* TabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168630222E131CF0088B302 /* TabBarItemView.swift */; };
@@ -273,6 +274,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuProtocols.swift; sourceTree = "<group>"; };
 		1168630222E131CF0088B302 /* TabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemView.swift; sourceTree = "<group>"; };
 		1168630322E131CF0088B302 /* TabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		118D9847230BBA2300BC0B72 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 				A5961FA0218A25C400E2A506 /* PopupMenuSection.swift */,
 				A5961FA2218A25D100E2A506 /* PopupMenuItemCell.swift */,
 				A5961FA4218A260500E2A506 /* PopupMenuSectionHeaderView.swift */,
+				0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */,
 			);
 			path = "Popup Menu";
 			sourceTree = "<group>";
@@ -1284,6 +1287,7 @@
 				B42661422148568800E25423 /* AvatarView.swift in Sources */,
 				118D9848230BBA2300BC0B72 /* TabBarItem.swift in Sources */,
 				1168630422E131CF0088B302 /* TabBarItemView.swift in Sources */,
+				0BCEFADE2485FEC00088CEE5 /* PopupMenuProtocols.swift in Sources */,
 				A578C4A22321CFD6002D5C40 /* Avatar.swift in Sources */,
 				B444D6B62183A9740002B4D4 /* BadgeView.swift in Sources */,
 				FD7254E72146E946002F4069 /* CalendarViewDayCell.swift in Sources */,

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -302,6 +302,7 @@ extension PopupMenuController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! PopupMenuItemTemplateCell
         cell.setup(item: item)
         cell.preservesSpaceForImage = itemsHaveImages
+        cell.separatorColor = separatorColor
         
         let isLastInSection = row == tableView.numberOfRows(inSection: section) - 1
         let isLastSection = section == tableView.numberOfSections - 1

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -305,10 +305,10 @@ extension PopupMenuController: UITableViewDataSource {
 
         let isLastInSection = row == tableView.numberOfRows(inSection: section) - 1
         if section == tableView.numberOfSections - 1 && isLastInSection {
-            cell.expectedSeparatorType = .none
+            cell.bottomSeparatorType = .none
         } else {
-            cell.expectedSeparatorColor = self.separatorColor
-            cell.expectedSeparatorType = isLastInSection ? .full : .inset
+            cell.customSeparatorColor = self.separatorColor
+            cell.bottomSeparatorType = isLastInSection ? .full : .inset
         }
 
         return cell

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -305,10 +305,10 @@ extension PopupMenuController: UITableViewDataSource {
 
         let isLastInSection = row == tableView.numberOfRows(inSection: section) - 1
         if section == tableView.numberOfSections - 1 && isLastInSection {
-            cell.separatorType = .none
+            cell.expectedSeparatorType = .none
         } else {
-            cell.separatorColor = separatorColor
-            cell.separatorType = isLastInSection ? .full : .inset
+            cell.expectedSeparatorColor = self.separatorColor
+            cell.expectedSeparatorType = isLastInSection ? .full : .inset
         }
 
         return cell

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -294,21 +294,23 @@ extension PopupMenuController: UITableViewDataSource {
         let section = indexPath.section
         let row = indexPath.row
         let item = sections[section].items[row]
-        
+
         let cellClass = item.cellClass
         let identifier = String(describing: cellClass)
         self.tableView.register(cellClass, forCellReuseIdentifier: identifier)
-        
+
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! PopupMenuItemTemplateCell
         cell.setup(item: item)
         cell.preservesSpaceForImage = itemsHaveImages
-        cell.separatorColor = separatorColor
-        
+
         let isLastInSection = row == tableView.numberOfRows(inSection: section) - 1
-        let isLastSection = section == tableView.numberOfSections - 1
-        cell.isLastItemInSection = isLastInSection
-        cell.isInLastSection = isLastSection
-        
+        if section == tableView.numberOfSections - 1 && isLastInSection {
+            cell.separatorType = .none
+        } else {
+            cell.separatorColor = separatorColor
+            cell.separatorType = isLastInSection ? .full : .inset
+        }
+
         return cell
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -297,7 +297,7 @@ extension PopupMenuController: UITableViewDataSource {
 
         let cellClass = item.cellClass
         let identifier = String(describing: cellClass)
-        self.tableView.register(cellClass, forCellReuseIdentifier: identifier)
+        tableView.register(cellClass, forCellReuseIdentifier: identifier)
 
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! PopupMenuItemTemplateCell
         cell.setup(item: item)
@@ -307,7 +307,7 @@ extension PopupMenuController: UITableViewDataSource {
         if section == tableView.numberOfSections - 1 && isLastInSection {
             cell.bottomSeparatorType = .none
         } else {
-            cell.customSeparatorColor = self.separatorColor
+            cell.customSeparatorColor = separatorColor
             cell.bottomSeparatorType = isLastInSection ? .full : .inset
         }
 

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -13,9 +13,9 @@ public typealias MSPopupMenuItem = PopupMenuItem
  */
 @objc(MSFPopupMenuItem)
 open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
-    
+
     @objc public var cellClass: PopupMenuItemTemplateCell.Type
-    
+
     @objc public let image: UIImage?
     @objc public let selectedImage: UIImage?
     @objc public let accessoryImage: UIImage?

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -12,18 +12,10 @@ public typealias MSPopupMenuItem = PopupMenuItem
  `PopupMenuItem` represents a menu item inside `PopupMenuController`.
  */
 @objc(MSFPopupMenuItem)
-open class PopupMenuItem: NSObject {
-    /// Defines the timing for the call of the onSelected closure/block
-    @objc(MSFPopupMenuItemExecutionMode)
-    public enum ExecutionMode: Int {
-        /// `onSelected` is called right after item is tapped, before popup menu dismissal
-        case onSelection
-        /// `onSelected` is called after popup menu is dismissed, but before its `onDismissCompleted` is called
-        case afterPopupMenuDismissal
-        /// `onSelected` is called after popup menu is dismissed and its `onDismissCompleted` is called
-        case afterPopupMenuDismissalCompleted
-    }
-
+open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
+    
+    @objc public var cellClass: PopupMenuItemTemplateCell.Type
+    
     @objc public let image: UIImage?
     @objc public let selectedImage: UIImage?
     @objc public let accessoryImage: UIImage?
@@ -58,6 +50,7 @@ open class PopupMenuItem: NSObject {
     @objc public let isAccessoryCheckmarkVisible: Bool
 
     @objc public init(image: UIImage? = nil, selectedImage: UIImage? = nil, accessoryImage: UIImage? = nil, title: String, subtitle: String? = nil, accessoryView: UIView? = nil, isEnabled: Bool = true, isSelected: Bool = false, executes executionMode: ExecutionMode = .onSelection, onSelected: (() -> Void)? = nil, isAccessoryCheckmarkVisible: Bool = true) {
+        self.cellClass = PopupMenuItemCell.self
         self.image = image?.renderingMode == .automatic ? image?.withRenderingMode(.alwaysTemplate) : image
         self.selectedImage = selectedImage ?? image?.withRenderingMode(.alwaysTemplate)
         self.accessoryImage = accessoryImage

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -9,16 +9,15 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     
     var isLastItemInSection: Bool = false {
         didSet {
-            if isLastItemInSection, isInLastSection {
-                self.bottomSeparatorType = .none
-            } else {
-                self.bottomSeparatorType = isInLastSection ? .full : .inset
-                self.bottomSeparator.backgroundColor = self.separatorColor
-            }
+            self.updateSeparatorColors()
         }
     }
     
-    var isInLastSection: Bool = false
+    var isInLastSection: Bool = false {
+        didSet {
+            self.updateSeparatorColors()
+        }
+    }
     
     var separatorColor: UIColor?
     
@@ -219,6 +218,15 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             } else {
                 _accessoryType = .none
             }
+        }
+    }
+    
+    private func updateSeparatorColors() {
+        if isLastItemInSection, isInLastSection {
+            self.bottomSeparatorType = .none
+        } else {
+            self.bottomSeparatorType = isInLastSection ? .full : .inset
+            self.bottomSeparator.backgroundColor = self.separatorColor
         }
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -7,15 +7,9 @@ import UIKit
 
 class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
-    var expectedSeparatorColor: UIColor? {
+    var customSeparatorColor: UIColor? {
         didSet {
-            self.bottomSeparator.backgroundColor = self.expectedSeparatorColor
-        }
-    }
-
-    var expectedSeparatorType: TableViewCell.SeparatorType = .full {
-        didSet {
-            self.bottomSeparatorType = self.expectedSeparatorType
+            self.bottomSeparator.backgroundColor = self.customSeparatorColor
         }
     }
 
@@ -36,6 +30,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     static func preferredWidth(for item: PopupMenuTemplateItem, preservingSpaceForImage preserveSpaceForImage: Bool) -> CGFloat {
         guard let item = item as? PopupMenuItem else {
+            assertionFailure("Invalid item type for cell.")
             return 0
         }
 
@@ -45,6 +40,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     static func preferredHeight(for item: PopupMenuTemplateItem) -> CGFloat {
         guard let item = item as? PopupMenuItem else {
+            assertionFailure("Invalid item type for cell.")
             return 0
         }
 
@@ -97,8 +93,10 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     func setup(item: PopupMenuTemplateItem) {
         guard let item = item as? PopupMenuItem else {
+            assertionFailure("Invalid item type for cell.")
             return
         }
+
         self.item = item
 
         _imageView.image = item.image

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -5,7 +5,23 @@
 
 import UIKit
 
-class PopupMenuItemCell: TableViewCell {
+class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
+    
+    var isLastItemInSection: Bool = false {
+        didSet {
+            if isLastItemInSection, isInLastSection {
+                self.bottomSeparatorType = .none
+            } else {
+                self.bottomSeparatorType = isInLastSection ? .full : .inset
+                self.bottomSeparator.backgroundColor = self.separatorColor
+            }
+        }
+    }
+    
+    var isInLastSection: Bool = false
+    
+    var separatorColor: UIColor?
+    
     private struct Constants {
         static let labelVerticalMarginForOneLine: CGFloat = 14
         static let accessoryImageViewOffset: CGFloat = 5
@@ -21,12 +37,21 @@ class PopupMenuItemCell: TableViewCell {
 
     override class var labelVerticalMarginForOneAndThreeLines: CGFloat { return Constants.labelVerticalMarginForOneLine }
 
-    static func preferredWidth(for item: PopupMenuItem, preservingSpaceForImage preserveSpaceForImage: Bool) -> CGFloat {
+    
+    static func preferredWidth(for item: PopupMenuTemplateItem, preservingSpaceForImage preserveSpaceForImage: Bool) -> CGFloat {
+        guard let item = item as? PopupMenuItem else {
+            return 0
+        }
+        
         let imageViewSize: CustomViewSize = item.image != nil || preserveSpaceForImage ? Constants.imageViewSize : .zero
         return preferredWidth(title: item.title, subtitle: item.subtitle ?? "", customViewSize: imageViewSize, customAccessoryView: item.accessoryView, accessoryType: .checkmark)
     }
-
-    static func preferredHeight(for item: PopupMenuItem) -> CGFloat {
+    
+    static func preferredHeight(for item: PopupMenuTemplateItem) -> CGFloat {
+        guard let item = item as? PopupMenuItem else {
+            return 0
+        }
+        
         return height(title: item.title, subtitle: item.subtitle ?? "", customViewSize: Constants.imageViewSize, customAccessoryView: item.accessoryView, accessoryType: .checkmark)
     }
 
@@ -74,7 +99,11 @@ class PopupMenuItemCell: TableViewCell {
         isAccessibilityElement = true
     }
 
-    func setup(item: PopupMenuItem) {
+    
+    func setup(item: PopupMenuTemplateItem) {
+        guard let item = item as? PopupMenuItem else {
+            return
+        }
         self.item = item
 
         _imageView.image = item.image

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -7,12 +7,15 @@ import UIKit
 
 class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
-    var separatorColor: UIColor?
-
-    var separatorType: TableViewCell.SeparatorType = .inset {
+    var expectedSeparatorColor: UIColor? {
         didSet {
-            self.bottomSeparatorType = self.separatorType
-            self.bottomSeparator.backgroundColor = self.separatorColor
+            self.bottomSeparator.backgroundColor = self.expectedSeparatorColor
+        }
+    }
+
+    var expectedSeparatorType: TableViewCell.SeparatorType = .full {
+        didSet {
+            self.bottomSeparatorType = self.expectedSeparatorType
         }
     }
 

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -36,7 +36,6 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     override class var labelVerticalMarginForOneAndThreeLines: CGFloat { return Constants.labelVerticalMarginForOneLine }
 
-    
     static func preferredWidth(for item: PopupMenuTemplateItem, preservingSpaceForImage preserveSpaceForImage: Bool) -> CGFloat {
         guard let item = item as? PopupMenuItem else {
             return 0
@@ -98,7 +97,6 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         isAccessibilityElement = true
     }
 
-    
     func setup(item: PopupMenuTemplateItem) {
         guard let item = item as? PopupMenuItem else {
             return

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -6,21 +6,16 @@
 import UIKit
 
 class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
-    
-    var isLastItemInSection: Bool = false {
-        didSet {
-            self.updateSeparatorColors()
-        }
-    }
-    
-    var isInLastSection: Bool = false {
-        didSet {
-            self.updateSeparatorColors()
-        }
-    }
-    
+
     var separatorColor: UIColor?
-    
+
+    var separatorType: TableViewCell.SeparatorType = .inset {
+        didSet {
+            self.bottomSeparatorType = .inset
+            self.bottomSeparator.backgroundColor = self.separatorColor
+        }
+    }
+
     private struct Constants {
         static let labelVerticalMarginForOneLine: CGFloat = 14
         static let accessoryImageViewOffset: CGFloat = 5
@@ -40,16 +35,16 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         guard let item = item as? PopupMenuItem else {
             return 0
         }
-        
+
         let imageViewSize: CustomViewSize = item.image != nil || preserveSpaceForImage ? Constants.imageViewSize : .zero
         return preferredWidth(title: item.title, subtitle: item.subtitle ?? "", customViewSize: imageViewSize, customAccessoryView: item.accessoryView, accessoryType: .checkmark)
     }
-    
+
     static func preferredHeight(for item: PopupMenuTemplateItem) -> CGFloat {
         guard let item = item as? PopupMenuItem else {
             return 0
         }
-        
+
         return height(title: item.title, subtitle: item.subtitle ?? "", customViewSize: Constants.imageViewSize, customAccessoryView: item.accessoryView, accessoryType: .checkmark)
     }
 
@@ -216,15 +211,6 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             } else {
                 _accessoryType = .none
             }
-        }
-    }
-    
-    private func updateSeparatorColors() {
-        if isLastItemInSection, isInLastSection {
-            self.bottomSeparatorType = .none
-        } else {
-            self.bottomSeparatorType = isInLastSection ? .full : .inset
-            self.bottomSeparator.backgroundColor = self.separatorColor
         }
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -9,7 +9,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     var customSeparatorColor: UIColor? {
         didSet {
-            self.bottomSeparator.backgroundColor = self.customSeparatorColor
+            bottomSeparator.backgroundColor = customSeparatorColor
         }
     }
 

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -11,7 +11,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     var separatorType: TableViewCell.SeparatorType = .inset {
         didSet {
-            self.bottomSeparatorType = .inset
+            self.bottomSeparatorType = self.separatorType
             self.bottomSeparator.backgroundColor = self.separatorColor
         }
     }

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -42,9 +42,10 @@ public protocol PopupMenuItemTemplateCell where Self: UITableViewCell {
     /// `PopupMenuController` will notify that one or more items in the list contain image(s)
     @objc var preservesSpaceForImage: Bool { get set }
     /// `PopupMenuController` will notify the expected separatorColor.
-    /// For custom cell, you should add your own separator
+    /// For custom cell, you should add your own separator.
     @objc var separatorColor: UIColor? { get set }
-    /// `PopupMenuController` will notify the expected bottomSeparatorType
+    /// `PopupMenuController` will notify the expected separatorType.
+    /// For `PopupMenuItemCell`, the separator is at the bottom.
     @objc var separatorType: TableViewCell.SeparatorType { get set }
 
     /// Called when `PopupMenuController` setup the cell with the item

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -41,12 +41,12 @@ public protocol PopupMenuTemplateItem: AnyObject {
 public protocol PopupMenuItemTemplateCell where Self: UITableViewCell {
     /// `PopupMenuController` will notify that one or more items in the list contain image(s)
     @objc var preservesSpaceForImage: Bool { get set }
-    /// `PopupMenuController` will notify the expected separatorColor.
+    /// `PopupMenuController` will notify the custom separatorColor.
     /// For custom cell, you should add your own separator.
-    @objc var expectedSeparatorColor: UIColor? { get set }
-    /// `PopupMenuController` will notify the expected separatorType.
+    @objc var customSeparatorColor: UIColor? { get set }
+    /// `PopupMenuController` will notify the expected bottom separatorType.
     /// For `PopupMenuItemCell`, the separator is at the bottom.
-    @objc var expectedSeparatorType: TableViewCell.SeparatorType { get set }
+    @objc var bottomSeparatorType: TableViewCell.SeparatorType { get set }
 
     /// Called when `PopupMenuController` setup the cell with the item
     @objc func setup(item: PopupMenuTemplateItem)

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -20,8 +20,8 @@ public enum ExecutionMode: Int {
 
 /**
 `PopupMenuTemplateItem` represents a template item protocol inside `PopupMenuController`.
- The built-in type is `PopupMenuItem`
- You can use object conforms to this protocol for customization
+ The built-in type is `PopupMenuItem`.
+ You can use object conforms to this protocol for customization.
 */
 @objc(MSFPopupMenuTemplateItem)
 public protocol PopupMenuTemplateItem: AnyObject {
@@ -34,24 +34,22 @@ public protocol PopupMenuTemplateItem: AnyObject {
 
 /**
 `PopupMenuItemTemplateCell` represents a template cell protocol inside `PopupMenuController`.
- The built-in type is `PopupMenuItemCell`
- You can use UITableViewCell conforms to this protocol for customization
+ The built-in type is `PopupMenuItemCell`.
+ You can use `UITableViewCell` conforms to this protocol for customization.
 */
 @objc(MSFPopupMenuItemTemplateCell)
 public protocol PopupMenuItemTemplateCell where Self: UITableViewCell {
-    /// `PopupMenuController` will notify that if the cell in the last item in the section
-    @objc var isLastItemInSection: Bool { get set }
-    /// `PopupMenuController` will notify that if the cell in the last section
-    @objc var isInLastSection: Bool { get set }
     /// `PopupMenuController` will notify that one or more items in the list contain image(s)
     @objc var preservesSpaceForImage: Bool { get set }
-    /// `PopupMenuController` will notify the specified separatorColor
+    /// `PopupMenuController` will notify the expected separatorColor.
     /// For custom cell, you should add your own separator
     @objc var separatorColor: UIColor? { get set }
+    /// `PopupMenuController` will notify the expected bottomSeparatorType
+    @objc var separatorType: TableViewCell.SeparatorType { get set }
 
     /// Called when `PopupMenuController` setup the cell with the item
     @objc func setup(item: PopupMenuTemplateItem)
-    
+
     @objc static func preferredWidth(for item: PopupMenuTemplateItem, preservingSpaceForImage preserveSpaceForImage: Bool) -> CGFloat
     @objc static func preferredHeight(for item: PopupMenuTemplateItem) -> CGFloat
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Defines the timing for the call of the onSelected closure/block
+@objc(MSFPopupMenuItemExecutionMode)
+public enum ExecutionMode: Int {
+    /// `onSelected` is called right after item is tapped, before popup menu dismissal
+    case onSelection
+    /// `onSelected` is called right after item is tapped, but prevent popup menu dismissal
+    case onSelectionWithoutDismissal
+    /// `onSelected` is called after popup menu is dismissed, but before its `onDismissCompleted` is called
+    case afterPopupMenuDismissal
+    /// `onSelected` is called after popup menu is dismissed and its `onDismissCompleted` is called
+    case afterPopupMenuDismissalCompleted
+}
+
+/**
+`PopupMenuTemplateItem` represents a template item protocol inside `PopupMenuController`.
+ The built-in type is `PopupMenuItem`
+ You can use object conforms to this protocol for customization
+*/
+@objc(MSFPopupMenuTemplateItem)
+public protocol PopupMenuTemplateItem: AnyObject {
+    /// The custom cell class for `PopupMenuController`
+    @objc var cellClass: PopupMenuItemTemplateCell.Type { get set}
+    @objc var executionMode: ExecutionMode { get }
+    @objc var isSelected: Bool { get set }
+    @objc var onSelected: (() -> Void)? { get }
+}
+
+/**
+`PopupMenuItemTemplateCell` represents a template cell protocol inside `PopupMenuController`.
+ The built-in type is `PopupMenuItemCell`
+ You can use UITableViewCell conforms to this protocol for customization
+*/
+@objc(MSFPopupMenuItemTemplateCell)
+public protocol PopupMenuItemTemplateCell where Self: UITableViewCell {
+    /// `PopupMenuController` will notify that if the cell in the last item in the section
+    @objc var isLastItemInSection: Bool { get set }
+    /// `PopupMenuController` will notify that if the cell in the last section
+    @objc var isInLastSection: Bool { get set }
+    /// `PopupMenuController` will notify that one or more items in the list contain image(s)
+    @objc var preservesSpaceForImage: Bool { get set }
+    /// `PopupMenuController` will notify the specified separatorColor
+    /// For custom cell, you should add your own separator
+    @objc var separatorColor: UIColor? { get set }
+
+    /// Called when `PopupMenuController` setup the cell with the item
+    @objc func setup(item: PopupMenuTemplateItem)
+    
+    @objc static func preferredWidth(for item: PopupMenuTemplateItem, preservingSpaceForImage preserveSpaceForImage: Bool) -> CGFloat
+    @objc static func preferredHeight(for item: PopupMenuTemplateItem) -> CGFloat
+}

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -43,10 +43,10 @@ public protocol PopupMenuItemTemplateCell where Self: UITableViewCell {
     @objc var preservesSpaceForImage: Bool { get set }
     /// `PopupMenuController` will notify the expected separatorColor.
     /// For custom cell, you should add your own separator.
-    @objc var separatorColor: UIColor? { get set }
+    @objc var expectedSeparatorColor: UIColor? { get set }
     /// `PopupMenuController` will notify the expected separatorType.
     /// For `PopupMenuItemCell`, the separator is at the bottom.
-    @objc var separatorType: TableViewCell.SeparatorType { get set }
+    @objc var expectedSeparatorType: TableViewCell.SeparatorType { get set }
 
     /// Called when `PopupMenuController` setup the cell with the item
     @objc func setup(item: PopupMenuTemplateItem)

--- a/ios/FluentUI/Popup Menu/PopupMenuSection.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuSection.swift
@@ -14,9 +14,9 @@ public typealias MSPopupMenuSection = PopupMenuSection
 @objc(MSFPopupMenuSection)
 open class PopupMenuSection: NSObject {
     @objc public let title: String?
-    @objc public var items: [PopupMenuItem]
+    @objc public var items: [PopupMenuTemplateItem]
 
-    @objc public init(title: String?, items: [PopupMenuItem]) {
+    @objc public init(title: String?, items: [PopupMenuTemplateItem]) {
         self.title = title
         self.items = items
         super.init()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

1. Support **protocol-oriented for PopupMenuController**, can let Objective-C users to customize their own cells and items by conforming protocols since **Swift classes can't be inherited by Obj-C object**. (Except for headerItem because it isn't used for UITableView)
2. Add one more `ExecutionMode` : `onSelectionWithoutDismissal`

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Only support built-in styles with combinations | Just add the ActivityIndicatorView inside my custom cell <img width="218" alt="image" src="https://user-images.githubusercontent.com/25728869/83501572-e76de000-a4f2-11ea-891a-9e1d903547c9.png">|
||**Note:** The bottom separator of custom cell is not implemented in demo.|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/86)