### PR TITLE
change the tabbar background effect to be .systemChromeMaterial

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -214,6 +214,16 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
     }
 
+    private let tabBarView: TabBarView = {
+        let tabBarView = TabBarView()
+        tabBarView.items = [
+            TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!),
+            TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),
+            TabBarItem(title: "Open", image: UIImage(named: "Open_28")!, selectedImage: UIImage(named: "Open_Selected_28")!, landscapeImage: UIImage(named: "Open_24")!, landscapeSelectedImage: UIImage(named: "Open_Selected_24")!)
+        ]
+        return tabBarView
+    }()
+
     override func loadView() {
         let container = UIStackView()
         container.axis = .vertical
@@ -226,6 +236,16 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         updateNavigationTitle()
         updateLeftBarButtonItems()
         updateRightBarButtonItems()
+
+        tabBarView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tabBarView)
+
+        let tabBarViewConstraints = [
+            tabBarView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tabBarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tabBarView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ]
+        NSLayoutConstraint.activate(tabBarViewConstraints)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -233,6 +253,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         if let indexPath = tableView.indexPathForSelectedRow {
             tableView.deselectRow(at: indexPath, animated: true)
         }
+
+        let size = tabBarView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        tableView.contentInset.bottom = size.height
 
         navigationBarFrameObservation = navigationController?.navigationBar.observe(\.frame, options: [.old, .new]) { [unowned self] navigationBar, change in
             if change.newValue?.width != change.oldValue?.width && self.navigationItem.navigationBarStyle == .custom {
@@ -247,7 +270,8 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as! TableViewCell
-        cell.setup(title: "Cell #\(1 + indexPath.row)", accessoryType: .disclosureIndicator)
+        let imageView = UIImageView(image: UIImage(named: "excelIcon"))
+        cell.setup(title: "Cell #\(1 + indexPath.row)", customView: imageView, accessoryType: .disclosureIndicator)
         cell.isInSelectionMode = isInSelectionMode
         return cell
     }

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -75,7 +75,7 @@ open class TabBarView: UIView {
     private let backgroundView: UIVisualEffectView = {
         var style = UIBlurEffect.Style.regular
         if #available(iOS 13, *) {
-            style = .systemMaterial
+            style = .systemChromeMaterial
         }
         return UIVisualEffectView(effect: UIBlurEffect(style: style))
     }()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

iOS 13 and above, use systemChromeMaterial blur effect for TabBarView
Update the demo app so that example of NavigationController would show tab bar as well.

### Verification

tested iPad/iPhone : light and dark mode
[demo_tabbar.mov.zip](https://github.com/microsoft/fluentui-apple/files/4719997/demo_tabbar.mov.zip)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/87)