### PR TITLE
Use 24x24 TabBar icon size when label is shown

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -33,11 +33,21 @@ class TabBarViewDemoController: DemoController {
 
         let updatedTabBarView = TabBarView(showsItemTitles: showsItemTitles)
         updatedTabBarView.delegate = self
-        updatedTabBarView.items = [
-            TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!),
-            TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),
-            TabBarItem(title: "Open", image: UIImage(named: "Open_28")!, selectedImage: UIImage(named: "Open_Selected_28")!, landscapeImage: UIImage(named: "Open_24")!, landscapeSelectedImage: UIImage(named: "Open_Selected_24")!)
-        ]
+        
+        if showsItemTitles {
+            updatedTabBarView.items = [
+                TabBarItem(title: "Home", image: UIImage(named: "Home_24")!, selectedImage: UIImage(named: "Home_Selected_24")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!),
+                TabBarItem(title: "New", image: UIImage(named: "New_24")!, selectedImage: UIImage(named: "New_Selected_24")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),
+                TabBarItem(title: "Open", image: UIImage(named: "Open_24")!, selectedImage: UIImage(named: "Open_Selected_24")!, landscapeImage: UIImage(named: "Open_24")!, landscapeSelectedImage: UIImage(named: "Open_Selected_24")!)
+            ]
+        } else {
+            updatedTabBarView.items = [
+                TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!),
+                TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),
+                TabBarItem(title: "Open", image: UIImage(named: "Open_28")!, selectedImage: UIImage(named: "Open_Selected_28")!, landscapeImage: UIImage(named: "Open_24")!, landscapeSelectedImage: UIImage(named: "Open_Selected_24")!)
+            ]
+        }
+
         updatedTabBarView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(updatedTabBarView)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -36,9 +36,9 @@ class TabBarViewDemoController: DemoController {
         
         if showsItemTitles {
             updatedTabBarView.items = [
-                TabBarItem(title: "Home", image: UIImage(named: "Home_24")!, selectedImage: UIImage(named: "Home_Selected_24")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!),
-                TabBarItem(title: "New", image: UIImage(named: "New_24")!, selectedImage: UIImage(named: "New_Selected_24")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),
-                TabBarItem(title: "Open", image: UIImage(named: "Open_24")!, selectedImage: UIImage(named: "Open_Selected_24")!, landscapeImage: UIImage(named: "Open_24")!, landscapeSelectedImage: UIImage(named: "Open_Selected_24")!)
+                TabBarItem(title: "Home", image: UIImage(named: "Home_24")!, selectedImage: UIImage(named: "Home_Selected_24")!),
+                TabBarItem(title: "New", image: UIImage(named: "New_24")!, selectedImage: UIImage(named: "New_Selected_24")!),
+              TabBarItem(title: "Open", image: UIImage(named: "Open_24")!, selectedImage: UIImage(named: "Open_Selected_24")!)
             ]
         } else {
             updatedTabBarView.items = [

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -21,8 +21,8 @@ open class TabBarItem: NSObject {
     /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
     /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
     /// - Parameter selectedImage: Used for imageView when tabbar item view is selected.  If it is nil, it will use `image`.
-    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`.
-    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`.
+    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. Will be used in portrait mode if the tab bar item shows a label.
+    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. Will be used in portrait mode if the tab bar item shows a label.
     /// - Parameter largeContentImage: Used for tabbar item view's accessibility largeContentImage.
     @objc public init(title: String, image: UIImage, selectedImage: UIImage? = nil, landscapeImage: UIImage? = nil, landscapeSelectedImage: UIImage? = nil, largeContentImage: UIImage? = nil) {
         self.image = image
@@ -34,17 +34,17 @@ open class TabBarItem: NSObject {
         super.init()
     }
 
-    func selectedImage(isInPortraitMode: Bool) -> UIImage? {
+    func selectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {
-            return selectedImage ?? image
+            return (labelIsHidden ? selectedImage : landscapeSelectedImage) ?? image
         } else {
             return landscapeSelectedImage ?? selectedImage ?? image
         }
     }
 
-    func unselectedImage(isInPortraitMode: Bool) -> UIImage? {
+    func unselectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {
-            return image
+            return labelIsHidden ? image : landscapeImage
         } else {
             return landscapeImage ?? image
         }

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -21,8 +21,8 @@ open class TabBarItem: NSObject {
     /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
     /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
     /// - Parameter selectedImage: Used for imageView when tabbar item view is selected.  If it is nil, it will use `image`.
-    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. Will be used in portrait mode if the tab bar item shows a label.
-    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. Will be used in portrait mode if the tab bar item shows a label.
+    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. The image will be used in portrait mode if the tab bar item shows a label.
+    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
     /// - Parameter largeContentImage: Used for tabbar item view's accessibility largeContentImage.
     @objc public init(title: String, image: UIImage, selectedImage: UIImage? = nil, landscapeImage: UIImage? = nil, landscapeSelectedImage: UIImage? = nil, largeContentImage: UIImage? = nil) {
         self.image = image
@@ -44,7 +44,7 @@ open class TabBarItem: NSObject {
 
     func unselectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {
-            return labelIsHidden ? image : landscapeImage
+            return (labelIsHidden ? image : landscapeImage) ?? image
         } else {
             return landscapeImage ?? image
         }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -110,8 +110,8 @@ class TabBarItemView: UIView {
         if isInPortraitMode {
             container.axis = .vertical
             container.spacing = spacingVertical
-            imageHeightConstraint?.constant = portraitImageSize
-            imageWidthConstraint?.constant = portraitImageSize
+            imageHeightConstraint?.constant = titleLabel.isHidden ? portraitImageSize : landscapeImageSize
+            imageWidthConstraint?.constant = titleLabel.isHidden ? portraitImageSize : landscapeImageSize
             titleLabel.style = .button3
         } else {
             container.axis = .horizontal

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -110,8 +110,8 @@ class TabBarItemView: UIView {
         if isInPortraitMode {
             container.axis = .vertical
             container.spacing = spacingVertical
-            imageHeightConstraint?.constant = titleLabel.isHidden ? portraitImageSize : landscapeImageSize
-            imageWidthConstraint?.constant = titleLabel.isHidden ? portraitImageSize : landscapeImageSize
+            imageHeightConstraint?.constant = titleLabel.isHidden ? portraitImageSize : portraitImageWithLabelSize
+            imageWidthConstraint?.constant = titleLabel.isHidden ? portraitImageSize : portraitImageWithLabelSize
             titleLabel.style = .button3
         } else {
             container.axis = .horizontal
@@ -120,8 +120,8 @@ class TabBarItemView: UIView {
             imageWidthConstraint?.constant = landscapeImageSize
             titleLabel.style = .footnoteUnscaled
         }
-        imageView.image = item.unselectedImage(isInPortraitMode: isInPortraitMode)
-        imageView.highlightedImage = item.selectedImage(isInPortraitMode: isInPortraitMode)
+        imageView.image = item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
+        imageView.highlightedImage = item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
     }
 }
 
@@ -129,4 +129,5 @@ private let unselectedColor = Colors.foreground2c
 private let spacingVertical: CGFloat = 3.0
 private let spacingHorizontal: CGFloat = 8.0
 private let portraitImageSize: CGFloat = 28.0
+private let portraitImageWithLabelSize: CGFloat = 24.0
 private let landscapeImageSize: CGFloat = 24.0


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes
`TabBarItemView.swift`

TabBar icon size will use 24x24 (portrait image size) when a label is present, otherwise it will use 28x28 (landscape image size). I reused the `landscapeImageSize` variable because it was the correct size that was required, but an alternative solution would be to create a new variable specifically for when a label is added (e.g. `portraitImageSizeWithLabel`)

### Verification
The change was manually verified in the Xcode simulator using an iPhone 11. The change in icon size was verified visually in both portrait and landscape orientations. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/15377548/83807061-510efb00-a667-11ea-83c4-d7e6622a4983.png) | ![after_portrait](https://user-images.githubusercontent.com/15377548/83806188-f75a0100-a665-11ea-9242-b65625d5ea73.png) |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/89)