### PR TITLE
allow warnings when pushing Pod

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -33,7 +33,7 @@ class TabBarViewDemoController: DemoController {
 
         let updatedTabBarView = TabBarView(showsItemTitles: showsItemTitles)
         updatedTabBarView.delegate = self
-        
+
         if showsItemTitles {
             updatedTabBarView.items = [
                 TabBarItem(title: "Home", image: UIImage(named: "Home_24")!, selectedImage: UIImage(named: "Home_Selected_24")!),

--- a/scripts/publishCocoaPod.sh
+++ b/scripts/publishCocoaPod.sh
@@ -3,4 +3,4 @@
 # A simple script to publish our pod to cocoapods.org. Run from the root of the repo.
 
 # Note: In CI/CD scenarios, expect the COCOAPODS_TRUNK_TOKEN env variable to be set which allows this to run automatically
-pod trunk push MicrosoftFluentUI.podspec
+pod trunk push MicrosoftFluentUI.podspec --allow-warnings


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS

allow warnings when pushing Pod since we need to support some deprecated colors for backwards compatibility.
Fix a small warning about new line with spaces

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/93)