### PR TITLE
Don't dismiss vertical drawers when the origin is fixed

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -517,8 +517,21 @@ open class DrawerController: UIViewController {
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        if !isBeingPresented && presentationController is DrawerPresentationController &&
-            (presentationDirection.isVertical || presentationOrigin != nil) {
+
+        // Dismiss the drawer if it has a custom origin, since its coordinates only make sense on a specific frame.
+        // No need to dismiss drawers whose origin is fixed (up, down, sides) since they are presented the same for any frame,
+        // with one exception handled in the willTransition(to: with:) method.
+        if !isBeingPresented && presentationController is DrawerPresentationController && presentationOrigin != nil {
+            presentingViewController?.dismiss(animated: false)
+        }
+    }
+
+    open override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
+
+        // Vertical drawers change their presentation style in compact vs. regular split view on iPad, so they need to be dismissed.
+        if !isBeingPresented && traitCollection.userInterfaceIdiom == .pad && presentationDirection.isVertical &&
+            traitCollection.horizontalSizeClass != newCollection.horizontalSizeClass {
             presentingViewController?.dismiss(animated: false)
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

We currently do NOT dismiss horizontal drawers upon device rotation, because they have a fixed origin (sides) so they will be presented from the same origin in any orientation or screen size. However, we DO dismiss vertical drawers with fixed origin, even though in most scenarios they will also be presented with the same origin for any device orientation. I believe we do this because there is one exception, when switching horizontal size class on iPad, we change the drawer for a popover and vice versa.

Let's handle that one exception, and dismiss the drawer, but allow vertical drawers NOT to be dismissed if we don't have to. This will help mobile clients that do not want the drawer to be dismissed upon device rotation, for instance, when the user had data input that can be lost.

We cannot avoid dismissal when using custom origins, because those origins can't be translated into a new frame, unless a complex coordinates logic is applied with multiple edge cases. If clients use custom origins, it'll be easier for them to persist the drawer, listen for orientation changes, and present it again, if that is absolutely required.

iPad is an interesting scenario. Popovers actually do not dismiss upon rotation or size change (even before this change). I think this is out of luck because of how the native popover controller behaves, but it will be buggy when the origin coordinates are in edge cases.

### Verification

iPhone, device rotation doesn't dismiss drawers when they have fixed origins
Rotate device with vertical drawer, make sure all actions work as expected (expand, contract, change size, etc)
iPad compact, change between compact sizes while different drawer types are up.
iPad regular, change between regular sizes while different drawer types are up.
Change between iPad regular and iPad compact while different drawer types are up.

Before, upon rotation, vertical drawers will be dismissed.
After, they won't:
![Simulator Screen Shot - iPhone 11 Pro - 2020-06-16 at 09 26 11](https://user-images.githubusercontent.com/63825111/84802379-5e0be280-afb5-11ea-9a65-196e792ed967.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-06-16 at 09 26 15](https://user-images.githubusercontent.com/63825111/84802339-4fbdc680-afb5-11ea-8471-e759aa85fc18.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/96)