### PR TITLE
Making some members of PeoplePicker public to be customizable outside

### DIFF
--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -88,8 +88,13 @@ open class PeoplePicker: BadgeField {
         }
     }
 
+    /// The UIView used to present 'suggestedPersonas'
+    @objc public let personaSuggestionsView = UIView()
+
+    @objc public let personaListView = PersonaListView()
+
     /// The `suggestedPersonas` are personas that appear in the persona list that can be picked and added to `pickedPersonas`.
-    open var suggestedPersonas: [Persona] = [] {
+    private var suggestedPersonas: [Persona] = [] {
         didSet {
             personaListView.personaList = suggestedPersonas
         }
@@ -112,10 +117,6 @@ open class PeoplePicker: BadgeField {
     private var keyboardHeight: CGFloat = 0
 
     private var containingViewBoundsObservation: NSKeyValueObservation?
-
-    public let personaSuggestionsView = UIView()
-
-    public let personaListView = PersonaListView()
 
     private let separator = Separator()
 
@@ -231,7 +232,7 @@ open class PeoplePicker: BadgeField {
         containingViewBoundsObservation = nil
     }
 
-    open func getSuggestedPersonas() {
+    private func getSuggestedPersonas() {
         // Use `getSuggestedPersonasForText` delegate method if implemented, otherwise filter `availablePersonas` with `textFieldContent` and remove any personas that have already been picked (checks for matching name and email) if `allowPickedPersonasToAppearAsSuggested` is set to false.
         if delegate?.peoplePicker(_:getSuggestedPersonasForText:completion:) != nil {
             delegate?.peoplePicker?(self, getSuggestedPersonasForText: textFieldContent, completion: {

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -88,9 +88,10 @@ open class PeoplePicker: BadgeField {
         }
     }
 
-    /// The UIView used to present 'suggestedPersonas'
+    /// The UIView used to present 'suggestedPersonas'. It includes personaListView
     @objc public let personaSuggestionsView = UIView()
 
+    /// The UITableView used to present 'availablePersonas'
     @objc public let personaListView = PersonaListView()
 
     /// The `suggestedPersonas` are personas that appear in the persona list that can be picked and added to `pickedPersonas`.
@@ -178,6 +179,25 @@ open class PeoplePicker: BadgeField {
         layoutPersonaSuggestions()
     }
 
+    /// layouts personaSuggestionsView in available window frame
+    @objc open func showPersonaSuggestions() {
+        personaListView.contentOffset = .zero
+        window?.addSubview(personaSuggestionsView)
+        containingViewBoundsObservation = window?.observe(\.bounds) { [unowned self] (_, _) in
+            self.layoutPersonaSuggestions()
+        }
+
+        personaListView.searchDirectoryState = .idle
+
+        setNeedsLayout()
+    }
+
+    /// Hides personaSuggestionsView
+    @objc open func hidePersonaSuggestions() {
+        personaSuggestionsView.removeFromSuperview()
+        containingViewBoundsObservation = nil
+    }
+
     private func layoutPersonaSuggestions() {
         if !isShowingPersonaSuggestions {
             return
@@ -214,23 +234,6 @@ open class PeoplePicker: BadgeField {
     }
 
     // MARK: Personas
-
-    open func showPersonaSuggestions() {
-        personaListView.contentOffset = .zero
-        window?.addSubview(personaSuggestionsView)
-        containingViewBoundsObservation = window?.observe(\.bounds) { [unowned self] (_, _) in
-            self.layoutPersonaSuggestions()
-        }
-
-        personaListView.searchDirectoryState = .idle
-
-        setNeedsLayout()
-    }
-
-    open func hidePersonaSuggestions() {
-        personaSuggestionsView.removeFromSuperview()
-        containingViewBoundsObservation = nil
-    }
 
     private func getSuggestedPersonas() {
         // Use `getSuggestedPersonasForText` delegate method if implemented, otherwise filter `availablePersonas` with `textFieldContent` and remove any personas that have already been picked (checks for matching name and email) if `allowPickedPersonasToAppearAsSuggested` is set to false.

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -89,7 +89,7 @@ open class PeoplePicker: BadgeField {
     }
 
     /// The `suggestedPersonas` are personas that appear in the persona list that can be picked and added to `pickedPersonas`.
-    private var suggestedPersonas: [Persona] = [] {
+    open var suggestedPersonas: [Persona] = [] {
         didSet {
             personaListView.personaList = suggestedPersonas
         }
@@ -113,9 +113,9 @@ open class PeoplePicker: BadgeField {
 
     private var containingViewBoundsObservation: NSKeyValueObservation?
 
-    private let personaSuggestionsView = UIView()
+    public let personaSuggestionsView = UIView()
 
-    private let personaListView = PersonaListView()
+    public let personaListView = PersonaListView()
 
     private let separator = Separator()
 
@@ -214,7 +214,7 @@ open class PeoplePicker: BadgeField {
 
     // MARK: Personas
 
-    private func showPersonaSuggestions() {
+    open func showPersonaSuggestions() {
         personaListView.contentOffset = .zero
         window?.addSubview(personaSuggestionsView)
         containingViewBoundsObservation = window?.observe(\.bounds) { [unowned self] (_, _) in
@@ -226,12 +226,12 @@ open class PeoplePicker: BadgeField {
         setNeedsLayout()
     }
 
-    private func hidePersonaSuggestions() {
+    open func hidePersonaSuggestions() {
         personaSuggestionsView.removeFromSuperview()
         containingViewBoundsObservation = nil
     }
 
-    private func getSuggestedPersonas() {
+    open func getSuggestedPersonas() {
         // Use `getSuggestedPersonasForText` delegate method if implemented, otherwise filter `availablePersonas` with `textFieldContent` and remove any personas that have already been picked (checks for matching name and email) if `allowPickedPersonasToAppearAsSuggested` is set to false.
         if delegate?.peoplePicker(_:getSuggestedPersonasForText:completion:) != nil {
             delegate?.peoplePicker?(self, getSuggestedPersonasForText: textFieldContent, completion: {

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -38,7 +38,7 @@ open class PersonaListView: UITableView {
         case searchDirectory
     }
 
-    enum SearchDirectoryState {
+    public enum SearchDirectoryState {
         case idle
         case searching
         case displayingSearchResults
@@ -72,7 +72,7 @@ open class PersonaListView: UITableView {
         }
     }
 
-    var searchDirectoryState: SearchDirectoryState = .idle {
+    public var searchDirectoryState: SearchDirectoryState = .idle {
         didSet {
             if searchDirectoryState != oldValue {
                 UIView.performWithoutAnimation {
@@ -156,6 +156,7 @@ open class PersonaListView: UITableView {
                 self.searchResultText = "%d results found from directory".localized.formatted(with: self.personaList.count)
             }
         })
+        searchDirectoryState = .idle
     }
 }
 

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -33,21 +33,33 @@ public typealias MSPersonaListView = PersonaListView
 
 @objc(MSFPersonaListView)
 open class PersonaListView: UITableView {
-    private enum Section: Int {
-        case personas
-        case searchDirectory
-    }
-
+    /// SearchDirectory button state enum
     public enum SearchDirectoryState {
         case idle
         case searching
         case displayingSearchResults
     }
 
+    private enum Section: Int {
+        case personas
+        case searchDirectory
+    }
+
     /// The personas to display in the list view
     @objc open var personaList: [Persona] = [] {
         didSet {
             reloadData()
+        }
+    }
+
+    /// searchDIrectoryState variable (persona list to reload rows on state change)
+    public var searchDirectoryState: SearchDirectoryState = .idle {
+        didSet {
+            if searchDirectoryState != oldValue {
+                UIView.performWithoutAnimation {
+                    reloadRows(at: [IndexPath(row: 0, section: 1)], with: .none)
+                }
+            }
         }
     }
 
@@ -69,16 +81,6 @@ open class PersonaListView: UITableView {
     private var searchResultText: String = "" {
         didSet {
             searchDirectoryState = .displayingSearchResults
-        }
-    }
-
-    public var searchDirectoryState: SearchDirectoryState = .idle {
-        didSet {
-            if searchDirectoryState != oldValue {
-                UIView.performWithoutAnimation {
-                    reloadRows(at: [IndexPath(row: 0, section: 1)], with: .none)
-                }
-            }
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`ios/FluentUI/People Picker/PeoplePicker.swift`
Making personaSuggestionsView, personaListView as public and extendable so that any product using FluentUI peoplePicker can extend it (change the list view and also change the state of searchDirectory button)

`ios/FluentUI/People Picker/PersonaListView.swift`
Modified the searchDirectoryState enum to public so that its state can be modified depending on product requirement (currently only on button click but we want to start searching and show searching spinner when there are no matching results in available list)

Also, there was a bug on searchDirectoryState that has also been addressed in the PR (https://github.com/microsoft/fluentui-apple/issues/98)

### Verification

Verification was done using manual testing(integrated fluentUI pod in List app and tested the changes)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/102)