### PR TITLE
PillButton new style

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -28,6 +28,10 @@ class PillButtonBarDemoController: DemoController {
         container.addArrangedSubview(createLabelWithText("Outline"))
         container.addArrangedSubview(createBar(items: items))
         container.addArrangedSubview(UIView())
+        
+        container.addArrangedSubview(createLabelWithText("Transparent"))
+        container.addArrangedSubview(createBar(items: items, style: .transparent))
+        container.addArrangedSubview(UIView())
 
         // When inserting longer button "Templates" instead of shorter "Other" button as the fourth button, compact layouts (most iPhones)
         // will end up with a button configuration where the last visible button won't be a clear indication that the view is scrollable,
@@ -66,7 +70,7 @@ class PillButtonBarDemoController: DemoController {
         bar.centerAligned = centerAligned
 
         let backgroundView = UIView()
-        if style == .outline {
+        if style == .outline || style == .transparent {
             backgroundView.backgroundColor = Colors.Navigation.System.background
         }
         backgroundView.addSubview(bar)

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -57,6 +57,24 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.primary(for: window), dark: Colors.primaryShade10(for: window))
         }
     }
+    
+    func font() -> UIFont {
+        switch self {
+        case .outline, .filled:
+            return Fonts.button4
+        case .transparent:
+            return Fonts.button1
+        }
+    }
+    
+    func selectedFont() -> UIFont {
+        switch self {
+        case .outline, .filled:
+            return Fonts.button4
+        case .transparent:
+            return Fonts.preferredFont(forTextStyle: .subheadline, weight: .bold)
+        }
+    }
 }
 
 // MARK: PillButton
@@ -70,7 +88,6 @@ open class PillButton: UIButton {
     private struct Constants {
         static let bottomInset: CGFloat = 6.0
         static let cornerRadius: CGFloat = 16.0
-        static let font: UIFont = Fonts.button4
         static let horizontalInset: CGFloat = 16.0
         static let topInset: CGFloat = 6.0
     }
@@ -105,7 +122,7 @@ open class PillButton: UIButton {
 
     private func setupView() {
         setTitle(pillBarItem.title, for: .normal)
-        titleLabel?.font = style == .transparent ? Fonts.button1 : Constants.font
+        titleLabel?.font = style.font()
         layer.cornerRadius = Constants.cornerRadius
         clipsToBounds = true
 
@@ -143,8 +160,6 @@ open class PillButton: UIButton {
     }
     
     private func updateFont() {
-        if style == .transparent {
-            titleLabel?.font = isSelected ? Fonts.preferredFont(forTextStyle: .subheadline, weight: .bold) : Fonts.button1
-        }
+        titleLabel?.font = isSelected ? style.selectedFont() : style.font()
     }
 }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -14,6 +14,7 @@ public typealias MSPillButtonStyle = PillButtonStyle
 public enum PillButtonStyle: Int {
     case outline
     case filled
+    case transparent
 
     func backgroundColor(for window: UIWindow) -> UIColor {
         switch self {
@@ -21,6 +22,8 @@ public enum PillButtonStyle: Int {
             return Colors.PillButton.Outline.background
         case .filled:
             return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.PillButton.Outline.background)
+        case .transparent:
+            return .clear
         }
     }
 
@@ -30,12 +33,14 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.primary(for: window), dark: Colors.surfaceQuaternary)
         case .filled:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
+        case .transparent:
+            return Colors.primaryTint40(for: window)
         }
     }
 
     var titleColor: UIColor {
         switch self {
-        case .outline:
+        case .outline, .transparent:
             return Colors.PillButton.Outline.title
         case .filled:
             return Colors.PillButton.Filled.title
@@ -48,6 +53,8 @@ public enum PillButtonStyle: Int {
             return  Colors.PillButton.Outline.titleSelected
         case .filled:
             return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
+        case .transparent:
+            return UIColor(light: Colors.primary(for: window), dark: Colors.primaryShade10(for: window))
         }
     }
 }
@@ -76,6 +83,7 @@ open class PillButton: UIButton {
         didSet {
             updateAppearance()
             updateAccessibilityTraits()
+            updateFont()
         }
     }
 
@@ -97,7 +105,7 @@ open class PillButton: UIButton {
 
     private func setupView() {
         setTitle(pillBarItem.title, for: .normal)
-        titleLabel?.font = Constants.font
+        titleLabel?.font = style == .transparent ? Fonts.button1 : Constants.font
         layer.cornerRadius = Constants.cornerRadius
         clipsToBounds = true
 
@@ -131,6 +139,12 @@ open class PillButton: UIButton {
             } else {
                 setTitleColor(style.titleColor, for: .normal)
             }
+        }
+    }
+    
+    private func updateFont() {
+        if style == .transparent {
+            titleLabel?.font = isSelected ? Fonts.preferredFont(forTextStyle: .subheadline, weight: .bold) : Fonts.button1
         }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added an extra PillButtonStyle with new title/background colors and fonts for normal/selected states.

### Verification

1. Run FluentUI.Demo to open the app
2. Navigate to Pill Button Bar
3. See Transparent bar

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
<img width="369" alt="Screen Shot 2020-06-27 at 9 21 20 PM" src="https://user-images.githubusercontent.com/65185855/85939897-ed769700-b8cd-11ea-878b-805269c1065b.png">
<img width="371" alt="Screen Shot 2020-06-27 at 9 21 52 PM" src="https://user-images.githubusercontent.com/65185855/85939898-f49da500-b8cd-11ea-9f05-40b06b6c4f45.png">
<img width="391" alt="Screen Shot 2020-06-29 at 3 30 06 PM" src="https://user-images.githubusercontent.com/65185855/86063029-c8456e00-ba1e-11ea-98eb-756a429c430a.png">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/105)