### PR TITLE
Fix the potential crash in BadgeField when the string is empty

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -1144,7 +1144,7 @@ extension BadgeField: UITextFieldDelegate {
             // Insert the new char at beginning of text field
             if let formerTextFieldText = self.textField.text {
                 let newTextFieldText = NSMutableString(string: formerTextFieldText)
-                newTextFieldText.insert(string, at: 1)
+                newTextFieldText.insert(string, at: newTextFieldText.length == 0 ? 0 : 1)
                 self.textField.text = newTextFieldText as String
                 badgeFieldDelegate?.badgeField?(self, willChangeTextFieldContentWithText: self.textField.text!.trimmed())
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fix the potential NSRange crash

### Verification

<img width="1630" alt="Screen Shot 2020-06-29 at 1 32 43 PM" src="https://user-images.githubusercontent.com/7663073/85993599-2414f480-ba29-11ea-99d0-b6a98a4bccfd.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/106)