### PR TITLE
Revert the fix to range crash

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -1144,7 +1144,7 @@ extension BadgeField: UITextFieldDelegate {
             // Insert the new char at beginning of text field
             if let formerTextFieldText = self.textField.text {
                 let newTextFieldText = NSMutableString(string: formerTextFieldText)
-                newTextFieldText.insert(string, at: newTextFieldText.length == 0 ? 0 : 1)
+                newTextFieldText.insert(string, at: 1)
                 self.textField.text = newTextFieldText as String
                 badgeFieldDelegate?.badgeField?(self, willChangeTextFieldContentWithText: self.textField.text!.trimmed())
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Revert the change fix. 

If newTextFieldText is empty, we will face other bugs. We heavily rely on the non-fake text field to start with .

This workaround is hiding an issue rather than the real cause. Given we're using `zeroWidthSpace: String = "\u{200B}"`, the string length will always be `1`, so my previous change is redundant.

### Verification

Sorry @lugonzal I was trying to fix a similar crash for Outlook Mobile iOS. But somehow this seems to be the false alarm. The real issue seems to be realted to our own codes.

Sorry for the inconvenience.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/107)