### PR TITLE
Increase the range for the Calendar start/end year in Fluent. 

### DIFF
--- a/ios/FluentUI/Core/CalendarConfiguration.swift
+++ b/ios/FluentUI/Core/CalendarConfiguration.swift
@@ -13,8 +13,8 @@ public typealias MSCalendarConfiguration = CalendarConfiguration
 @objc(MSFCalendarConfiguration)
 open class CalendarConfiguration: NSObject {
     private struct Constants {
-        static let startYearsAgo: Int = -100
-        static let endYearsInterval: Int = 200
+        static let startYearsAgo: Int = -3
+        static let endYearsInterval: Int = 10
     }
 
     // swiftlint:disable:next explicit_type_interface
@@ -22,8 +22,11 @@ open class CalendarConfiguration: NSObject {
 
     @objc open var firstWeekday: Int = Calendar.current.firstWeekday
 
-    let referenceStartDate: Date
-    let referenceEndDate: Date
+    /// By default, this is today minus 3 years. If overridden, make sure it's before (less than) the 'referenceEndDate'
+    @objc open var referenceStartDate: Date
+
+    /// By default, this is the default 'referenceStartDate' plus 10 years.  If overridden, make sure it's after (greater than) the 'referenceStartDate'
+    @objc open var referenceEndDate: Date
 
     @objc init(calendar: Calendar = .current) {
         // Compute a start date (January 1st on a year a default number of years ago)

--- a/ios/FluentUI/Core/CalendarConfiguration.swift
+++ b/ios/FluentUI/Core/CalendarConfiguration.swift
@@ -13,10 +13,8 @@ public typealias MSCalendarConfiguration = CalendarConfiguration
 @objc(MSFCalendarConfiguration)
 open class CalendarConfiguration: NSObject {
     private struct Constants {
-        static let baseReferenceStartTimestamp: TimeInterval = 1420416000 // January 3 2015
-        static let baseReferenceEndTimestamp: TimeInterval = 1736035200 // January 5 2025
-        static let startYearsAgo: Int = -3
-        static let endYearsInterval: Int = 10
+        static let startYearsAgo: Int = -100
+        static let endYearsInterval: Int = 200
     }
 
     // swiftlint:disable:next explicit_type_interface

--- a/ios/FluentUI/Date Time Pickers/DateTimePicker.swift
+++ b/ios/FluentUI/Date Time Pickers/DateTimePicker.swift
@@ -101,6 +101,7 @@ public class DateTimePicker: NSObject {
     private var datePickerType: DatePickerType = .calendar
 
     /// Presents a picker or set of pickers from a `presentingController` depending on the mode selected. Also handles accessibility replacement presentation.
+    /// The picker has a default range of dates available that works for most scenarios. To change that range, override referenceStartDate and referenceEndDate in the default instance of CalendarConfiguration.
     ///
     /// - Parameters:
     ///   - presentingController: The view controller that is presenting these pickers


### PR DESCRIPTION
Allow customizing the calendar's reference dates

### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Allow customizing the calendar's reference dates, so there's more flexibility for clients to decide what ranges are appropriate for their applications.

### Verification

Make sure date time pickers have a -100 + 100 range. And make sure all usages of these constants are run.

Before
![Screen Shot 2020-07-06 at 12 03 45 PM](https://user-images.githubusercontent.com/63825111/86629923-f1b34c00-bf80-11ea-9caf-984663f98459.png)
![Screen Shot 2020-07-06 at 12 03 38 PM](https://user-images.githubusercontent.com/63825111/86629924-f24be280-bf80-11ea-84a1-98270ef9825c.png)

After
![Screen Shot 2020-07-06 at 12 02 33 PM](https://user-images.githubusercontent.com/63825111/86629893-e5c78a00-bf80-11ea-8bf0-b6b2dfdf8652.png)
![Screen Shot 2020-07-06 at 12 02 11 PM](https://user-images.githubusercontent.com/63825111/86629896-e6602080-bf80-11ea-8694-2e35208220aa.png)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/109)