### PR TITLE
Add arm64 macOS build arch for future Apple Silicon mac support

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -18,7 +18,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-macOS'
       xcode_configuration: 'Debug'
-      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_macos.xcconfig'
   
   # macOS Framework Release
   - template: apple-xcode-build.yml
@@ -28,7 +28,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-macOS'
       xcode_configuration: 'Release'
-      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_macos.xcconfig'
 
   # iphonesimulator Library Debug
   - template: apple-xcode-build.yml
@@ -38,7 +38,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-iOS-StaticLib'
       xcode_configuration: 'Debug'
-      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
   
   # iphonesimulator Library Release
   - template: apple-xcode-build.yml
@@ -48,7 +48,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-iOS-StaticLib'
       xcode_configuration: 'Release'
-      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
 
   # iphoneos Library Debug
   - template: apple-xcode-build.yml
@@ -58,7 +58,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-iOS-StaticLib'
       xcode_configuration: 'Debug'
-      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
   
   # iphoneos Library Release
   - template: apple-xcode-build.yml
@@ -68,7 +68,7 @@ jobs:
       xcode_actions: 'build'
       xcode_scheme: 'FluentUI-iOS-StaticLib'
       xcode_configuration: 'Release'
-      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides.xcconfig'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
       
   # Zip our build output. It's important to zip here to preserve symlinks
   - bash: 'scripts/prepare_for_nuget_pack.sh'

--- a/.ado/xcconfig/publish_overrides.xcconfig
+++ b/.ado/xcconfig/publish_overrides.xcconfig
@@ -11,6 +11,3 @@ ONLY_ACTIVE_ARCH=NO
 
 // Build for distribution so that this is consumable from other versions of Xcode
 BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-
-// Explicitly build arm64e for iOS device builds in case our clients need it
-ARCHS = $(ARCHS_STANDARD) arm64e

--- a/.ado/xcconfig/publish_overrides_ios.xcconfig
+++ b/.ado/xcconfig/publish_overrides_ios.xcconfig
@@ -1,0 +1,4 @@
+#include "publish_overrides.xcconfig"
+
+// Explicitly build arm64e for iOS device builds in case our clients need it
+ARCHS = $(ARCHS_STANDARD) arm64e

--- a/.ado/xcconfig/publish_overrides_macos.xcconfig
+++ b/.ado/xcconfig/publish_overrides_macos.xcconfig
@@ -1,0 +1,5 @@
+#include "publish_overrides.xcconfig"
+
+// opt into arm64 on macOS
+// note: the arm64 arch is safely ignored on versions of Xcode where macOS doesn't support arm64
+ARCHS = $(ARCHS_STANDARD) arm64

--- a/scripts/nuget_publish.sh
+++ b/scripts/nuget_publish.sh
@@ -13,7 +13,9 @@ EXIT_CODE=0
 XCODEBUILD_WRAPPER_LOCATION='scripts/xcodebuild_wrapper.sh'
 
 # Extra arguments for xcode build to mimic nuget publishing environment  
-XCODEBUILD_EXTRA_ARGS='-xcconfig .ado/xcconfig/publish_overrides.xcconfig -derivedDataPath DerivedData'
+DERIVED_DATA_EXTRA_ARG='-derivedDataPath DerivedData'
+IOS_XCCONFIG_EXTRA_ARG='-xcconfig .ado/xcconfig/publish_overrides_ios.xcconfig'
+MACOS_XCCONFIG_EXTRA_ARG='-xcconfig .ado/xcconfig/publish_overrides_macos.xcconfig'
 
 function handle_exit_code()
 {
@@ -26,27 +28,27 @@ function handle_exit_code()
 }
 
 echo "Building and Testing macOS Debug"
-$XCODEBUILD_WRAPPER_LOCATION macos_build FluentUI-macOS Debug build $XCODEBUILD_EXTRA_ARGS
+$XCODEBUILD_WRAPPER_LOCATION macos_build FluentUI-macOS Debug build $DERIVED_DATA_EXTRA_ARG $MACOS_XCCONFIG_EXTRA_ARG
 handle_exit_code
 
 echo "Building and Testing macOS Release"
-$XCODEBUILD_WRAPPER_LOCATION macos_build FluentUI-macOS Release build $XCODEBUILD_EXTRA_ARGS
+$XCODEBUILD_WRAPPER_LOCATION macos_build FluentUI-macOS Release build $DERIVED_DATA_EXTRA_ARG $MACOS_XCCONFIG_EXTRA_ARG
 handle_exit_code
 
 echo "Building iOS Static Lib Debug Simulator"
-$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS-StaticLib Debug build $XCODEBUILD_EXTRA_ARGS
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS-StaticLib Debug build $DERIVED_DATA_EXTRA_ARG $IOS_XCCONFIG_EXTRA_ARG
 handle_exit_code
 
 echo "Building iOS Static Lib Release Simulator"
-$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS-StaticLib Release build $XCODEBUILD_EXTRA_ARGS
+$XCODEBUILD_WRAPPER_LOCATION ios_simulator_build FluentUI-iOS-StaticLib Release build $DERIVED_DATA_EXTRA_ARG $IOS_XCCONFIG_EXTRA_ARG
 handle_exit_code
 
 echo "Building Static Lib iOS Debug Device"
-$XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS-StaticLib Debug build $XCODEBUILD_EXTRA_ARGS
+$XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS-StaticLib Debug build $DERIVED_DATA_EXTRA_ARG $IOS_XCCONFIG_EXTRA_ARG
 handle_exit_code
 
 echo "Building iOS Release Static Lib Device"
-$XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS-StaticLib Release build $XCODEBUILD_EXTRA_ARGS
+$XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS-StaticLib Release build $DERIVED_DATA_EXTRA_ARG $IOS_XCCONFIG_EXTRA_ARG
 handle_exit_code
 
 echo "Running scripts/prepare_for_nuget_pack.sh"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Add platform-specific versions of our publish_overrides.xcconfig file that include publish_overrides.xcconfig but then independently specify the extra archs necessary for each platform. On macOS we want to add arm64 (but not arm64e yet). On iOS we want to continue to build arm64e slices.

Update our Azure Pipeline yaml to respect the new override xcconfigs, and separately update our local script that mirrors the logic in the azure pipeline to match as well.

### Verification

Run `scripts/nuget_publish.sh` to simulate publishing the NuGet package, ensure it succeeds as expected. Ensure that the proper archs are built for each.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/658243/87003051-bfb40c80-c16f-11ea-8be9-96b207f2481f.png) | ![image](https://user-images.githubusercontent.com/658243/87002987-a4e19800-c16f-11ea-9f12-4f9a84351816.png) ![image](https://user-images.githubusercontent.com/658243/87003196-0a358900-c170-11ea-9d60-b53ee1e27593.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/113)