### PR TITLE
Add an Xcode 12 beta NuGet publish pipeline

### DIFF
--- a/.ado/fluentui-apple-publish-nuget-xcode12-beta.yml
+++ b/.ado/fluentui-apple-publish-nuget-xcode12-beta.yml
@@ -1,0 +1,14 @@
+# 1. `production` tag at pipeline level declares that it builds
+#     binaries that can ship to external customers.
+#
+# 2. `multi-phased` tag declares that this is a multi phased build
+#     and indicates that the system should look for required steps
+#     in individual phases. This tag is important because otherwise
+#     the system would look for all tasks in all phases.
+variables: { tags: "production, multi-phased" }
+
+# This file defines the Apple publish build steps
+name: 1.$(Date:yyyy).$(Date:MMdd)-v$(Rev:r)
+
+jobs:
+- template: templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml

--- a/.ado/templates/apple-xcode-select.yml
+++ b/.ado/templates/apple-xcode-select.yml
@@ -1,7 +1,12 @@
 #
 # Task Group: Xcode select proper version
 #
+parameters:
+  xcode_path_override: '' # Leaving this blank results in the repo default being applied
+
 steps:
   - bash: scripts/xcode_select_current_version.sh
     displayName: 'Switch to current version of Xcode'
     failOnStderr: true
+    env:
+      XCODE_PATH_OVERRIDE: $(xcode_path_override)

--- a/.ado/templates/fluentui-apple-build-zip.yml
+++ b/.ado/templates/fluentui-apple-build-zip.yml
@@ -1,0 +1,67 @@
+#
+# Build and zip up the Fluent UI Apple libraries
+#
+steps:
+  # macOS Framework Debug
+  - template: apple-xcode-build.yml
+    parameters:
+      xcode_sdk: 'macosx'
+      xcode_workspacePath: 'macos/xcode/FluentUI.xcodeproj'
+      xcode_actions: 'build'
+      xcode_scheme: 'FluentUI-macOS'
+      xcode_configuration: 'Debug'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_macos.xcconfig'
+  
+  # macOS Framework Release
+  - template: apple-xcode-build.yml
+    parameters:
+      xcode_sdk: 'macosx'
+      xcode_workspacePath: 'macos/xcode/FluentUI.xcodeproj'
+      xcode_actions: 'build'
+      xcode_scheme: 'FluentUI-macOS'
+      xcode_configuration: 'Release'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_macos.xcconfig'
+
+  # iphonesimulator Library Debug
+  - template: apple-xcode-build.yml
+    parameters:
+      xcode_sdk: 'iphonesimulator'
+      xcode_workspacePath: 'ios/FluentUI.xcworkspace'
+      xcode_actions: 'build'
+      xcode_scheme: 'FluentUI-iOS-StaticLib'
+      xcode_configuration: 'Debug'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
+  
+  # iphonesimulator Library Release
+  - template: apple-xcode-build.yml
+    parameters:
+      xcode_sdk: 'iphonesimulator'
+      xcode_workspacePath: 'ios/FluentUI.xcworkspace'
+      xcode_actions: 'build'
+      xcode_scheme: 'FluentUI-iOS-StaticLib'
+      xcode_configuration: 'Release'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
+
+  # iphoneos Library Debug
+  - template: apple-xcode-build.yml
+    parameters:
+      xcode_sdk: 'iphoneos'
+      xcode_workspacePath: 'ios/FluentUI.xcworkspace'
+      xcode_actions: 'build'
+      xcode_scheme: 'FluentUI-iOS-StaticLib'
+      xcode_configuration: 'Debug'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
+  
+  # iphoneos Library Release
+  - template: apple-xcode-build.yml
+    parameters:
+      xcode_sdk: 'iphoneos'
+      xcode_workspacePath: 'ios/FluentUI.xcworkspace'
+      xcode_actions: 'build'
+      xcode_scheme: 'FluentUI-iOS-StaticLib'
+      xcode_configuration: 'Release'
+      xcode_extraArgs: '-xcconfig $(Build.Repository.LocalPath)/.ado/xcconfig/publish_overrides_ios.xcconfig'
+      
+  # Zip our build output. It's important to zip here to preserve symlinks
+  - bash: 'scripts/prepare_for_nuget_pack.sh'
+    displayName: 'Zip build output for NuGet'

--- a/.ado/templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml
@@ -1,14 +1,16 @@
 jobs:
-- job: fluentui_apple_publish_nuget
+- job: fluentui_apple_publish_nuget_xcode12_beta
   pool:
     vmImage: 'macos-10.15'
-  displayName: FluentUI Apple Publish NuGet
+  displayName: FluentUI Apple Publish NuGet Xcode 12 Beta
   timeoutInMinutes: 60 # how long to run the job before automatically cancelling
   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
   
   steps:
-  # Select proper Xcode version
+  # Select Xcode 12 beta version
   - template: apple-xcode-select.yml
+    parameters:
+      xcode_path_override: '/Applications/Xcode_12_beta.app/Contents/Developer'
 
   # Build and zip the libraries
   - template: fluentui-apple-build-zip.yml
@@ -16,6 +18,8 @@ jobs:
   # generate the sanitizedBuildNumber environment variable
   - bash: 'scripts/generate_build_number.sh'
     displayName: 'Generate Build Number'
+    env:
+      BUILD_NUMBER_SUFFIX_OVERRIDE: 'xcode12betabuild'
 
   # pack the nuspec
   - task: NuGetCommand@2

--- a/scripts/generate_build_number.sh
+++ b/scripts/generate_build_number.sh
@@ -4,7 +4,12 @@
 BUILD_VERSION_SUFFIX=""
 BUILD_VERSION_STRING="0.0.0.1"
 
-if [ -n "$BUILD_SOURCEBRANCHNAME" ] && [ "$BUILD_SOURCEBRANCHNAME" != "master" ]; then
+if [ -n "$BUILD_NUMBER_SUFFIX_OVERRIDE" ]; then 
+    # Allow someone calling us to provide an override to always add a suffix to a given build number by providing an env variable
+    ADJUSTED_BUILD_NUMBER_SUFFIX_OVERRIDE="${BUILD_NUMBER_SUFFIX_OVERRIDE//[^a-z0-9A-Z]/}"
+    BUILD_VERSION_SUFFIX="-$ADJUSTED_BUILD_NUMBER_SUFFIX_OVERRIDE"
+elif [ -n "$BUILD_SOURCEBRANCHNAME" ] && [ "$BUILD_SOURCEBRANCHNAME" != "master" ]; then 
+    # Otherwise append the branch name unless we're the main branch for this repo
     ADJUSTED_SOURCEBRANCHNAME="${BUILD_SOURCEBRANCHNAME//[^a-z0-9A-Z]/}"
     BUILD_VERSION_SUFFIX="-$ADJUSTED_SOURCEBRANCHNAME"
 fi

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -1,3 +1,10 @@
 # Select the current officially supported version of Xcode with the naming convention used by GitHub Actions/Azure DevOps Build Pipelines
-echo "Running command: sudo xcode-select --switch '/Applications/Xcode_11.4.1.app/Contents/Developer'"
-sudo xcode-select --switch '/Applications/Xcode_11.4.1.app/Contents/Developer'
+
+if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
+    XCODE_PATH="$XCODE_PATH_OVERRIDE"
+else
+    XCODE_PATH='/Applications/Xcode_11.4.1.app/Contents/Developer'
+fi
+
+echo "Running command: sudo xcode-select --switch $XCODE_PATH"
+sudo xcode-select --switch "$XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] macOS

### Description of changes

Add a new NuGet publishing pipeline that builds with the Xcode 12 beta.

- Update generate_build_number.sh to take in a suffix override so our beta builds get tagged as such
- Update xcode_select_current_version.sh to allow the caller to override which version of Xcode they want selected
- Pull out the core build logic into a template to share between the standard publish job and the Xcode 12 beta publish job. 

### Verification

For the bash scripts, run them under various circumstances and ensure they work as expected. For the ADO publishing steps, we'll have to verify after this gets merged to ensure everything is working as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/114)