### PR TITLE
fix pillbuttonbar demo color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -54,7 +54,7 @@ class PillButtonBarDemoController: DemoController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if let window = view.window {
-            filledBar?.backgroundColor = Colors.primary(for: window)
+            filledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

fix pillbuttonbar demo color

Before
<img width="401" alt="Screen Shot 2020-07-09 at 8 53 52 AM" src="https://user-images.githubusercontent.com/63825111/87062358-d1260480-c1c1-11ea-848c-8c68d064b293.png">

After
<img width="407" alt="Screen Shot 2020-07-09 at 8 53 23 AM" src="https://user-images.githubusercontent.com/63825111/87062365-d3885e80-c1c1-11ea-91ef-f018be65809a.png">


### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/115)