### PR TITLE
Fix Xcode select parameter path

### DIFF
--- a/.ado/templates/apple-xcode-select.yml
+++ b/.ado/templates/apple-xcode-select.yml
@@ -9,4 +9,4 @@ steps:
     displayName: 'Switch to current version of Xcode'
     failOnStderr: true
     env:
-      XCODE_PATH_OVERRIDE: $(xcode_path_override)
+      XCODE_PATH_OVERRIDE: ${{ parameters.xcode_path_override }}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

In #114 I accidentally used the environment variable syntax instead of the parameter syntax for the xcode-select pattern, which led to broken nuget pipeline builds. Switch to the proper syntax.

### Verification

Not really an easy way to test these unfortunately.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/116)