### PR TITLE
Change navigationBar dark elevated color back to gray 900

### DIFF
--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -473,11 +473,11 @@ public final class Colors: NSObject {
                 public static var textWeekend: UIColor = textOnAccent.withAlphaComponent(0.7)
             }
         }
-        public static var background: UIColor = NavigationBar.background
+        public static var background = UIColor(light: surfacePrimary, dark: surfaceTertiary)
     }
 
     public struct DateTimePicker {
-        public static var background: UIColor = NavigationBar.background
+        public static var background: UIColor = Calendar.background
         public static var text: UIColor = textSecondary
     }
 

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -400,7 +400,7 @@ public final class Colors: NSObject {
 
     @objc public static let surfacePrimary = UIColor(light: .white, dark: .black, darkElevated: gray950)
     @objc public static let surfaceSecondary = UIColor(light: gray25, dark: gray950, darkElevated: gray900)
-    @objc public static let surfaceTertiary = UIColor(light: gray50, dark: gray900)
+    @objc public static let surfaceTertiary = UIColor(light: gray50, dark: gray900, darkElevated: gray800)
     /// also used for disabled background color
     @objc public static let surfaceQuaternary = UIColor(light: gray100, dark: gray600)
 
@@ -519,7 +519,7 @@ public final class Colors: NSObject {
     }
 
     public struct NavigationBar {
-        public static var background = UIColor(light: surfacePrimary, dark: surfaceTertiary)
+        public static var background = UIColor(light: surfacePrimary, dark: gray900)
         public static var tint: UIColor = iconPrimary
         public static var title: UIColor = textDominant
     }

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -400,7 +400,7 @@ public final class Colors: NSObject {
 
     @objc public static let surfacePrimary = UIColor(light: .white, dark: .black, darkElevated: gray950)
     @objc public static let surfaceSecondary = UIColor(light: gray25, dark: gray950, darkElevated: gray900)
-    @objc public static let surfaceTertiary = UIColor(light: gray50, dark: gray900, darkElevated: gray800)
+    @objc public static let surfaceTertiary = UIColor(light: gray50, dark: gray900)
     /// also used for disabled background color
     @objc public static let surfaceQuaternary = UIColor(light: gray100, dark: gray600)
 


### PR DESCRIPTION
We need it to contrast with its non-elevated version to distinguish between a presented window and the window behind on iPhone. It sounds counterintuitive to select the same color, but iOS applies a dim to the window behind, which makes the current gray800 color look like gray900, which doesn't make a contrast.

### Platforms Impacted
- [X] iOS
- [ ] macOS

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone Xs Max - 2020-07-10 at 09 43 10](https://user-images.githubusercontent.com/63825111/87178853-b1124600-c292-11ea-9d82-16755cfbf8ad.png) | ![Simulator Screen Shot - iPhone Xs Max - 2020-07-10 at 09 45 51](https://user-images.githubusercontent.com/63825111/87178871-b5d6fa00-c292-11ea-912f-d5e4adf99476.png) |


Issue that we're fixing:
![Screen Shot 2020-07-08 at 3 31 52 PM](https://user-images.githubusercontent.com/63825111/87179046-f6367800-c292-11ea-93d9-6dbac1974df3.png)


### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/117)