### PR TITLE
update danger badge view text color

### DIFF
--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -430,7 +430,7 @@ public final class Colors: NSObject {
         public static var backgroundWarningSelected: UIColor = warning
         public static var textSelected: UIColor = textOnAccent
         public static var textDisabled: UIColor = textSecondary
-        public static var textError = UIColor(light: Palette.dangerShade10.color, dark: Palette.dangerShade20.color)
+        public static var textError: UIColor = Palette.dangerShade20.color
         public static var textErrorSelected: UIColor = textOnAccent
         public static var textWarning = UIColor(light: Palette.warningShade30.color, dark: Palette.warningPrimary.color)
         public static var textWarningSelected = UIColor(light: Palette.warningShade30.color, dark: .black)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

update danger badge view text color to danger shade 20 for both light and dark mode.

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_light](https://user-images.githubusercontent.com/20715435/87453205-0ada7f00-c5b7-11ea-96cc-db1bf5780fa3.png) | ![Simulator Screen Shot - iPhone 8 Plus - 2020-07-14 at 09 42 15](https://user-images.githubusercontent.com/20715435/87452952-b33c1380-c5b6-11ea-8b2d-ab9f46279ba6.png)|
|![after_dark](https://user-images.githubusercontent.com/20715435/87453244-13cb5080-c5b7-11ea-9064-003aba353b7a.png) |![Simulator Screen Shot - iPhone 8 Plus - 2020-07-14 at 09 42 00](https://user-images.githubusercontent.com/20715435/87452942-b0d9b980-c5b6-11ea-8e52-fdaa2bacaa39.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/120)