### PR TITLE
Fixing bug: when customEdgeInsets are set for the MSFButton and the b…

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -18,9 +18,9 @@ class ButtonDemoController: DemoController {
             let button = Button(style: style)
             button.setTitle("Button", for: .normal)
 
-			if style == .borderless {
-				button.contentEdgeInsets = .zero
-			}
+            if style == .borderless {
+                button.contentEdgeInsets = .zero
+            }
 
             let disabledButton = Button(style: style)
             disabledButton.isEnabled = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -18,10 +18,6 @@ class ButtonDemoController: DemoController {
             let button = Button(style: style)
             button.setTitle("Button", for: .normal)
 
-            if style == .borderless {
-                button.contentEdgeInsets = .zero
-            }
-
             let disabledButton = Button(style: style)
             disabledButton.isEnabled = false
             disabledButton.setTitle("Button", for: .normal)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -18,6 +18,10 @@ class ButtonDemoController: DemoController {
             let button = Button(style: style)
             button.setTitle("Button", for: .normal)
 
+			if style == .borderless {
+				button.contentEdgeInsets = .zero
+			}
+
             let disabledButton = Button(style: style)
             disabledButton.isEnabled = false
             disabledButton.setTitle("Button", for: .normal)

--- a/ios/FluentUI/Controls/Button.swift
+++ b/ios/FluentUI/Controls/Button.swift
@@ -105,6 +105,12 @@ open class Button: UIButton {
         }
     }
 
+	open override var contentEdgeInsets: UIEdgeInsets {
+		didSet {
+			isUsingCustomContentEdgeInsets = true
+		}
+	}
+
     open override var intrinsicContentSize: CGSize {
         var size = titleLabel?.systemLayoutSizeFitting(CGSize(width: proposedTitleLabelWidth == 0 ? .greatestFiniteMagnitude : proposedTitleLabelWidth, height: .greatestFiniteMagnitude)) ?? .zero
         size.width = ceil(size.width + contentEdgeInsets.left + contentEdgeInsets.right)
@@ -120,6 +126,8 @@ open class Button: UIButton {
             }
         }
     }
+
+	private var isUsingCustomContentEdgeInsets: Bool = false
 
     @objc public init(style: ButtonStyle = .secondaryOutline) {
         self.style = style
@@ -187,7 +195,9 @@ open class Button: UIButton {
 
         layer.borderWidth = style.hasBorders ? Constants.borderWidth : 0
 
-        contentEdgeInsets = style.contentEdgeInsets
+		if !isUsingCustomContentEdgeInsets {
+			contentEdgeInsets = style.contentEdgeInsets
+		}
     }
 
     private func updateBackgroundColor() {

--- a/ios/FluentUI/Controls/Button.swift
+++ b/ios/FluentUI/Controls/Button.swift
@@ -105,11 +105,11 @@ open class Button: UIButton {
         }
     }
 
-	open override var contentEdgeInsets: UIEdgeInsets {
-		didSet {
-			isUsingCustomContentEdgeInsets = true
-		}
-	}
+    open override var contentEdgeInsets: UIEdgeInsets {
+        didSet {
+            isUsingCustomContentEdgeInsets = true
+        }
+    }
 
     open override var intrinsicContentSize: CGSize {
         var size = titleLabel?.systemLayoutSizeFitting(CGSize(width: proposedTitleLabelWidth == 0 ? .greatestFiniteMagnitude : proposedTitleLabelWidth, height: .greatestFiniteMagnitude)) ?? .zero
@@ -127,7 +127,7 @@ open class Button: UIButton {
         }
     }
 
-	private var isUsingCustomContentEdgeInsets: Bool = false
+    private var isUsingCustomContentEdgeInsets: Bool = false
 
     @objc public init(style: ButtonStyle = .secondaryOutline) {
         self.style = style
@@ -195,9 +195,9 @@ open class Button: UIButton {
 
         layer.borderWidth = style.hasBorders ? Constants.borderWidth : 0
 
-		if !isUsingCustomContentEdgeInsets {
-			contentEdgeInsets = style.contentEdgeInsets
-		}
+        if !isUsingCustomContentEdgeInsets {
+            contentEdgeInsets = style.contentEdgeInsets
+        }
     }
 
     private func updateBackgroundColor() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixing bug: when customEdgeInsets are set for the MSFButton and the button is tapped, the update method resets the edge insets to the default value set for the style

### Verification

Changed the FluentUI Demo app to set the contentEdgeInsets of the button to zero when the style is borderless, tapped the button to make sure the insets would not be changed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/68076145/87470619-e3dd7680-c5d1-11ea-819a-09a76c71a5f6.PNG) | ![after](https://user-images.githubusercontent.com/68076145/87470673-f5bf1980-c5d1-11ea-9157-078d84ae07fb.PNG) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/121)