### PR TITLE
Add observation to UINavigationItem's accessoryView

### DIFF
--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -44,6 +44,8 @@ class ShyHeaderController: UIViewController {
         return maxHeight
     }
 
+    private var accessoryViewObservation: NSKeyValueObservation?
+
     private var navigationBarCenterObservation: NSKeyValueObservation?
     private var navigationBarHeightObservation: NSKeyValueObservation?
     private var navigationBarColorObservation: NSKeyValueObservation?
@@ -87,6 +89,10 @@ class ShyHeaderController: UIViewController {
         }
         defer {
             contentScrollView = contentViewController.navigationItem.contentScrollView
+        }
+
+        accessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.accessoryView) { [unowned self] item, _ in
+            self.shyHeaderView.accessoryView = item.accessoryView
         }
     }
 


### PR DESCRIPTION
Add observation to UINavigationItem's accessoryView property so that shyheadercontroller should adjust its subview

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Sometime client apps wants to change the accessoryView of the large title navigation controller, but the shyheaderView isn't updating its subview accordingly. Make sure that in the initialization process of shy header we add a listener to property changes.

### Verification
iPad/ iPhone large title : test collapsible searchbar scenarios.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/123)