### PR TITLE
Support for setting title, subTitle and Footer label color in MSTableViewCell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -919,29 +919,36 @@ open class TableViewCell: UITableViewCell {
 
         selectionStyle = isInSelectionMode ? .none : .default
     }
+    
+    private var isUsingCustomTextColors: Bool = false
 
     public func updateTextColors() {
-        titleLabel.textColor = Colors.Table.Cell.title
-        subtitleLabel.textColor = Colors.Table.Cell.subtitle
-        footerLabel.textColor = Colors.Table.Cell.footer
+        if !isUsingCustomTextColors {
+            titleLabel.textColor = Colors.Table.Cell.title
+            subtitleLabel.textColor = Colors.Table.Cell.subtitle
+            footerLabel.textColor = Colors.Table.Cell.footer
+        }
     }
     
     /// To set color for title label
     /// - Parameter color: UIColor to set
     public func setTitleLabelTextColor(color: UIColor) {
         titleLabel.textColor = color
+        isUsingCustomTextColors = true
     }
     
     /// To set color for subTitle label
     /// - Parameter color: UIColor to set
     public func setSubTitleLabelTextColor(color: UIColor) {
         subtitleLabel.textColor = color
+        isUsingCustomTextColors = true
     }
     
     /// To set color for footer label
     /// - Parameter color: UIColor to set
     public func setFooterLabelTextColor(color: UIColor) {
         footerLabel.textColor = color
+        isUsingCustomTextColors = true
     }
 
     open override func layoutSubviews() {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -925,6 +925,24 @@ open class TableViewCell: UITableViewCell {
         subtitleLabel.textColor = Colors.Table.Cell.subtitle
         footerLabel.textColor = Colors.Table.Cell.footer
     }
+    
+    /// To set color for title label
+    /// - Parameter color: UIColor to set
+    public func setTitleLabelTextColor(color: UIColor) {
+        titleLabel.textColor = color
+    }
+    
+    /// To set color for subTitle label
+    /// - Parameter color: UIColor to set
+    public func setSubTitleLabelTextColor(color: UIColor) {
+        subtitleLabel.textColor = color
+    }
+    
+    /// To set color for footer label
+    /// - Parameter color: UIColor to set
+    public func setFooterLabelTextColor(color: UIColor) {
+        footerLabel.textColor = color
+    }
 
     open override func layoutSubviews() {
         super.layoutSubviews()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Since title, subTitle and footer labels are private, hence exposed a method to set text color.

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/25812641/87527889-646fa600-c6aa-11ea-8542-70eb26ab7b4b.png) | ![image](https://user-images.githubusercontent.com/25812641/87527791-3c804280-c6aa-11ea-98f8-919235378c6c.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/125)