### PR TITLE
Make adjustments to spacing in SideTabBar to match the figma designs

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -124,11 +124,10 @@ open class SideTabBar: UIView {
         static let maxTabCount: Int = 5
         static let viewWidth: CGFloat = 62.0
         static let avatarViewTopPadding: CGFloat = 18.0
-        static let topStackViewTopPadding: CGFloat = 30.0
         static let avatarViewTopStackViewPadding: CGFloat = 34.0
-        static let bottomStackViewBottomPadding: CGFloat = 10.0
-        static let topItemSpacing: CGFloat = 30.0
-        static let bottomItemSpacing: CGFloat = 28.0
+        static let bottomStackViewBottomPadding: CGFloat = 14.0
+        static let topItemSpacing: CGFloat = 32.0
+        static let bottomItemSpacing: CGFloat = 24.0
         static let topItemSize: CGFloat = 28.0
         static let bottomItemSize: CGFloat = 24.0
     }
@@ -170,7 +169,7 @@ open class SideTabBar: UIView {
                 topStackView.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: Constants.avatarViewTopStackViewPadding)
             ])
         } else {
-            layoutConstraints.append(topStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.topStackViewTopPadding))
+            layoutConstraints.append(topStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.topItemSpacing))
         }
 
         layoutConstraints.append(contentsOf: [


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Made some small adjustments to spacing in the SideTabBar to match the designs.

Before
<img width="1034" alt="before" src="https://user-images.githubusercontent.com/4185114/87708277-51ff7600-c757-11ea-81cb-72073a27c403.png">     

After
<img width="1034" alt="after" src="https://user-images.githubusercontent.com/4185114/87708327-6479af80-c757-11ea-9046-07b570765226.png">
 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/127)