### PR TITLE
Added disable pill functionality

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -80,7 +80,7 @@ class PillButtonBarDemoController: DemoController {
         if (disabledItems) {
             items.forEach { bar.disableItem($0) }
         }
-        
+
         let backgroundView = UIView()
         if style == .outline {
             backgroundView.backgroundColor = Colors.Navigation.System.background

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -77,7 +77,7 @@ class PillButtonBarDemoController: DemoController {
         bar.barDelegate = self
         bar.centerAligned = centerAligned
 
-        if (disabledItems) {
+        if disabledItems {
             items.forEach { bar.disableItem($0) }
         }
 
@@ -114,12 +114,11 @@ class PillButtonBarDemoController: DemoController {
 
     func togglePills(pillBar: PillButtonBar, enable: Bool) {
         let items = pillBar.items
-        if (enable) {
+        if enable {
             for item in items! {
                 pillBar.enableItem(item)
             }
-        }
-        else {
+        } else {
             for item in items! {
                 pillBar.disableItem(item)
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -19,26 +19,28 @@ class PillButtonBarDemoController: DemoController {
                                           PillButtonBarItem(title: "Actions"),
                                           PillButtonBarItem(title: "More")]
 
+        let disableFilledSwitchView = UISwitch()
+        disableFilledSwitchView.isOn = true
+        disableFilledSwitchView.addTarget(self, action: #selector(toggleFilledPills(switchView:)), for: .valueChanged)
+
         container.addArrangedSubview(createLabelWithText("Filled"))
+        addRow(items: [createLabelWithText("Enable/Disable pills in Filled Pill Bar below"), disableFilledSwitchView], itemSpacing: 20, centerItems: true)
         let filledBar = createBar(items: items, style: .filled)
         container.addArrangedSubview(filledBar)
         self.filledBar = filledBar
         container.addArrangedSubview(UIView())
 
-        container.addArrangedSubview(createLabelWithText("Filled - Disabled"))
-        let filledDisabledBar = createBar(items: items, style: .filled, disabledItems: true)
-        container.addArrangedSubview(filledDisabledBar)
-        self.filledDisabledBar = filledDisabledBar
-        container.addArrangedSubview(UIView())
-        
+        let disableOutlinedSwitchView = UISwitch()
+        disableOutlinedSwitchView.isOn = true
+        disableOutlinedSwitchView.addTarget(self, action: #selector(toggleOutlinedPills(switchView:)), for: .valueChanged)
+
         container.addArrangedSubview(createLabelWithText("Outline"))
-        container.addArrangedSubview(createBar(items: items))
+        addRow(items: [createLabelWithText("Enable/Disable pills in Outline Pill bar below"), disableOutlinedSwitchView], itemSpacing: 20, centerItems: true)
+        let outlineBar = createBar(items: items)
+        container.addArrangedSubview(outlineBar)
+        self.outlineBar = outlineBar
         container.addArrangedSubview(UIView())
 
-        container.addArrangedSubview(createLabelWithText("Outline - Disabled"))
-        container.addArrangedSubview(createBar(items: items, disabledItems: true))
-        container.addArrangedSubview(UIView())
-        
         // When inserting longer button "Templates" instead of shorter "Other" button as the fourth button, compact layouts (most iPhones)
         // will end up with a button configuration where the last visible button won't be a clear indication that the view is scrollable,
         // so our algorithm to adjust insets and spacings will kick in, making the three first buttons longer than in the previous line.
@@ -65,7 +67,6 @@ class PillButtonBarDemoController: DemoController {
         super.viewDidAppear(animated)
         if let window = view.window {
             filledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
-            filledDisabledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
         }
     }
 
@@ -111,9 +112,33 @@ class PillButtonBarDemoController: DemoController {
         NSLayoutConstraint.activate(constraints)
     }
 
+    func togglePills(pillBar: PillButtonBar, enable: Bool) {
+        let items = pillBar.items
+        if (enable) {
+            for item in items! {
+                pillBar.enableItem(item)
+            }
+        }
+        else {
+            for item in items! {
+                pillBar.disableItem(item)
+            }
+        }
+    }
+
+    @objc private func toggleFilledPills(switchView: UISwitch) {
+        let pillBar = self.filledBar?.subviews[0] as! PillButtonBar
+        togglePills(pillBar: pillBar, enable: switchView.isOn)
+    }
+
+    @objc private func toggleOutlinedPills(switchView: UISwitch) {
+        let pillBar = self.outlineBar?.subviews[0] as! PillButtonBar
+        togglePills(pillBar: pillBar, enable: switchView.isOn)
+    }
+
     private var filledBar: UIView?
-    
-    private var filledDisabledBar: UIView?
+
+    private var outlineBar: UIView?
 }
 
 // MARK: - PillButtonBarDemoController: PillButtonBarDelegate

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -62,6 +62,7 @@ class PillButtonBarDemoController: DemoController {
         let bar = PillButtonBar(pillButtonStyle: style)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
+        _ = bar.disableItem(atIndex: 1)
         bar.barDelegate = self
         bar.centerAligned = centerAligned
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -25,10 +25,20 @@ class PillButtonBarDemoController: DemoController {
         self.filledBar = filledBar
         container.addArrangedSubview(UIView())
 
+        container.addArrangedSubview(createLabelWithText("Filled - Disabled"))
+        let filledDisabledBar = createBar(items: items, style: .filled, disabledItems: true)
+        container.addArrangedSubview(filledDisabledBar)
+        self.filledDisabledBar = filledDisabledBar
+        container.addArrangedSubview(UIView())
+        
         container.addArrangedSubview(createLabelWithText("Outline"))
         container.addArrangedSubview(createBar(items: items))
         container.addArrangedSubview(UIView())
 
+        container.addArrangedSubview(createLabelWithText("Outline - Disabled"))
+        container.addArrangedSubview(createBar(items: items, disabledItems: true))
+        container.addArrangedSubview(UIView())
+        
         // When inserting longer button "Templates" instead of shorter "Other" button as the fourth button, compact layouts (most iPhones)
         // will end up with a button configuration where the last visible button won't be a clear indication that the view is scrollable,
         // so our algorithm to adjust insets and spacings will kick in, making the three first buttons longer than in the previous line.
@@ -55,17 +65,21 @@ class PillButtonBarDemoController: DemoController {
         super.viewDidAppear(animated)
         if let window = view.window {
             filledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
+            filledDisabledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
         }
     }
 
-    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false) -> UIView {
+    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false) -> UIView {
         let bar = PillButtonBar(pillButtonStyle: style)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
-        _ = bar.disableItem(atIndex: 1)
         bar.barDelegate = self
         bar.centerAligned = centerAligned
 
+        if (disabledItems) {
+            items.forEach { bar.disableItem($0) }
+        }
+        
         let backgroundView = UIView()
         if style == .outline {
             backgroundView.backgroundColor = Colors.Navigation.System.background
@@ -98,6 +112,8 @@ class PillButtonBarDemoController: DemoController {
     }
 
     private var filledBar: UIView?
+    
+    private var filledDisabledBar: UIView?
 }
 
 // MARK: - PillButtonBarDemoController: PillButtonBarDelegate

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -113,14 +113,15 @@ class PillButtonBarDemoController: DemoController {
     }
 
     func togglePills(pillBar: PillButtonBar, enable: Bool) {
-        let items = pillBar.items
-        if enable {
-            for item in items! {
-                pillBar.enableItem(item)
-            }
-        } else {
-            for item in items! {
-                pillBar.disableItem(item)
+        if let items = pillBar.items {
+            if enable {
+                for item in items {
+                    pillBar.enableItem(item)
+                }
+            } else {
+                for item in items {
+                    pillBar.disableItem(item)
+                }
             }
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -50,7 +50,7 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
         }
     }
-    
+
     func disabledTitleColor(for window: UIWindow) -> UIColor {
         switch self {
         case .outline:
@@ -59,7 +59,7 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
         }
     }
-    
+
     func selectedDisabledBackgroundColor(for window: UIWindow) -> UIColor {
         switch self {
         case .outline:
@@ -68,7 +68,7 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
-    
+
     func selectedDisabledTitleColor(for window: UIWindow) -> UIColor {
         switch self {
         case .outline:
@@ -77,7 +77,6 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
         }
     }
-    
 }
 
 // MARK: PillButton
@@ -155,7 +154,7 @@ open class PillButton: UIButton {
         } else {
             accessibilityTraits.remove(.selected)
         }
-        
+    
         if (!isEnabled) {
             accessibilityTraits.insert(.notEnabled)
         } else {
@@ -175,7 +174,6 @@ open class PillButton: UIButton {
                 }
             } else {
                 backgroundColor = style.backgroundColor(for: window)
-                
                 if isEnabled {
                     setTitleColor(style.titleColor, for: .normal)
                 } else {

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -155,10 +155,10 @@ open class PillButton: UIButton {
             accessibilityTraits.remove(.selected)
         }
 
-        if !isEnabled {
-            accessibilityTraits.insert(.notEnabled)
-        } else {
+        if isEnabled {
             accessibilityTraits.remove(.notEnabled)
+        } else {
+            accessibilityTraits.insert(.notEnabled)
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -107,6 +107,13 @@ open class PillButton: UIButton {
         }
     }
 
+    public override var isEnabled: Bool {
+        didSet {
+            updateAppearance()
+            updateAccessibilityTraits()
+        }
+    }
+
     @objc public init(pillBarItem: PillButtonBarItem, style: PillButtonStyle = .outline) {
         self.pillBarItem = pillBarItem
         self.style = style

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -65,14 +65,14 @@ public enum PillButtonStyle: Int {
         case .outline:
             return Colors.surfaceQuaternary
         case .filled:
-            return UIColor(light: .white, dark: Colors.surfaceQuaternary)
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
     
     func selectedDisabledTitleColor(for window: UIWindow) -> UIColor {
         switch self {
         case .outline:
-            return UIColor(light: .white, dark: Colors.gray500)
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
         case .filled:
             return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
         }
@@ -148,31 +148,32 @@ open class PillButton: UIButton {
         } else {
             accessibilityTraits.remove(.selected)
         }
+        
+        if (!isEnabled) {
+            accessibilityTraits.insert(.notEnabled)
+        } else {
+            accessibilityTraits.remove(.notEnabled)
+        }
     }
 
     private func updateAppearance() {
         if let window = window {
-            if (isSelected && !isEnabled) {
-                backgroundColor = style.selectedDisabledBackgroundColor(for: window)
-            }
-            else if (isSelected) {
-                backgroundColor = style.selectedBackgroundColor(for: window)
-            }
-            else {
+            if isSelected {
+                if isEnabled {
+                    backgroundColor = style.selectedBackgroundColor(for: window)
+                    setTitleColor(style.selectedTitleColor(for: window), for: .normal)
+                } else {
+                    backgroundColor = style.selectedDisabledBackgroundColor(for: window)
+                    setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
+                }
+            } else {
                 backgroundColor = style.backgroundColor(for: window)
-            }
-
-            if isSelected && !isEnabled {
-                setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
-            }
-            else if isSelected {
-                setTitleColor(style.selectedTitleColor(for: window), for: .normal)
-            }
-            else if !isEnabled {
-                setTitleColor(style.disabledTitleColor(for: window), for: .disabled)
-            }
-            else {
-                setTitleColor(style.titleColor, for: .normal)
+                
+                if isEnabled {
+                    setTitleColor(style.titleColor, for: .normal)
+                } else {
+                    setTitleColor(style.disabledTitleColor(for: window), for: .disabled)
+                }
             }
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -154,8 +154,8 @@ open class PillButton: UIButton {
         } else {
             accessibilityTraits.remove(.selected)
         }
-    
-        if (!isEnabled) {
+
+        if !isEnabled {
             accessibilityTraits.insert(.notEnabled)
         } else {
             accessibilityTraits.remove(.notEnabled)

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -50,6 +50,34 @@ public enum PillButtonStyle: Int {
             return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
         }
     }
+    
+    func disabledTitleColor(for window: UIWindow) -> UIColor {
+        switch self {
+        case .outline:
+            return Colors.textDisabled
+        case .filled:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
+        }
+    }
+    
+    func selectedDisabledBackgroundColor(for window: UIWindow) -> UIColor {
+        switch self {
+        case .outline:
+            return Colors.surfaceQuaternary
+        case .filled:
+            return UIColor(light: .white, dark: Colors.surfaceQuaternary)
+        }
+    }
+    
+    func selectedDisabledTitleColor(for window: UIWindow) -> UIColor {
+        switch self {
+        case .outline:
+            return UIColor(light: .white, dark: Colors.gray500)
+        case .filled:
+            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
+        }
+    }
+    
 }
 
 // MARK: PillButton
@@ -124,11 +152,26 @@ open class PillButton: UIButton {
 
     private func updateAppearance() {
         if let window = window {
-            backgroundColor = isSelected ? style.selectedBackgroundColor(for: window) : style.backgroundColor(for: window)
+            if (isSelected && !isEnabled) {
+                backgroundColor = style.selectedDisabledBackgroundColor(for: window)
+            }
+            else if (isSelected) {
+                backgroundColor = style.selectedBackgroundColor(for: window)
+            }
+            else {
+                backgroundColor = style.backgroundColor(for: window)
+            }
 
-            if isSelected {
+            if isSelected && !isEnabled {
+                setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
+            }
+            else if isSelected {
                 setTitleColor(style.selectedTitleColor(for: window), for: .normal)
-            } else {
+            }
+            else if !isEnabled {
+                setTitleColor(style.disabledTitleColor(for: window), for: .disabled)
+            }
+            else {
                 setTitleColor(style.titleColor, for: .normal)
             }
         }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -186,10 +186,7 @@ open class PillButtonBar: UIScrollView {
             return
         }
 
-        let button = buttons[index]
-        if !button.isEnabled {
-            button.isEnabled = true
-        }
+        buttons[index].isEnabled = true
     }
 
     @objc public func enableItem(atIndex index: Int) {
@@ -197,10 +194,7 @@ open class PillButtonBar: UIScrollView {
             return
         }
 
-        let button = buttons[index]
-        if !button.isEnabled {
-            button.isEnabled = true
-        }
+        buttons[index].isEnabled = true
     }
 
     open override func layoutSubviews() {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -104,6 +104,30 @@ open class PillButtonBar: UIScrollView {
         buttons[index].isEnabled = false
     }
     
+    @objc public func enableItem(_ item: PillButtonBarItem) {
+        guard let index = indexOfButtonWithItem(item) else {
+            return
+        }
+
+        let button = buttons[index]
+        if (!button.isEnabled)
+        {
+            button.isEnabled = true
+        }
+    }
+    
+    @objc public func enableItem(atIndex index: Int) {
+        if index < 0 || index >= buttons.count {
+            return
+        }
+
+        let button = buttons[index]
+        if (!button.isEnabled)
+        {
+            button.isEnabled = true
+        }
+    }
+    
     private var buttonExtraSidePadding: CGFloat = 0.0
 
     private var buttons = [PillButton]()

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -88,6 +88,22 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
+    @objc public func disableItem(_ item: PillButtonBarItem) {
+        guard let index = indexOfButtonWithItem(item) else {
+            return
+        }
+
+        buttons[index].isEnabled = false
+    }
+    
+    @objc public func disableItem(atIndex index: Int) {
+        if index < 0 || index >= buttons.count {
+            return
+        }
+
+        buttons[index].isEnabled = false
+    }
+    
     private var buttonExtraSidePadding: CGFloat = 0.0
 
     private var buttons = [PillButton]()

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -88,46 +88,6 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
-    @objc public func disableItem(_ item: PillButtonBarItem) {
-        guard let index = indexOfButtonWithItem(item) else {
-            return
-        }
-
-        buttons[index].isEnabled = false
-    }
-    
-    @objc public func disableItem(atIndex index: Int) {
-        if index < 0 || index >= buttons.count {
-            return
-        }
-
-        buttons[index].isEnabled = false
-    }
-    
-    @objc public func enableItem(_ item: PillButtonBarItem) {
-        guard let index = indexOfButtonWithItem(item) else {
-            return
-        }
-
-        let button = buttons[index]
-        if (!button.isEnabled)
-        {
-            button.isEnabled = true
-        }
-    }
-    
-    @objc public func enableItem(atIndex index: Int) {
-        if index < 0 || index >= buttons.count {
-            return
-        }
-
-        let button = buttons[index]
-        if (!button.isEnabled)
-        {
-            button.isEnabled = true
-        }
-    }
-    
     private var buttonExtraSidePadding: CGFloat = 0.0
 
     private var buttons = [PillButton]()
@@ -205,6 +165,46 @@ open class PillButtonBar: UIScrollView {
         return true
     }
 
+    @objc public func disableItem(_ item: PillButtonBarItem) {
+        guard let index = indexOfButtonWithItem(item) else {
+            return
+        }
+
+        buttons[index].isEnabled = false
+    }
+    
+    @objc public func disableItem(atIndex index: Int) {
+        if index < 0 || index >= buttons.count {
+            return
+        }
+
+        buttons[index].isEnabled = false
+    }
+    
+    @objc public func enableItem(_ item: PillButtonBarItem) {
+        guard let index = indexOfButtonWithItem(item) else {
+            return
+        }
+
+        let button = buttons[index]
+        if (!button.isEnabled)
+        {
+            button.isEnabled = true
+        }
+    }
+    
+    @objc public func enableItem(atIndex index: Int) {
+        if index < 0 || index >= buttons.count {
+            return
+        }
+
+        let button = buttons[index]
+        if (!button.isEnabled)
+        {
+            button.isEnabled = true
+        }
+    }
+    
     open override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -172,7 +172,7 @@ open class PillButtonBar: UIScrollView {
 
         buttons[index].isEnabled = false
     }
-    
+
     @objc public func disableItem(atIndex index: Int) {
         if index < 0 || index >= buttons.count {
             return
@@ -180,7 +180,7 @@ open class PillButtonBar: UIScrollView {
 
         buttons[index].isEnabled = false
     }
-    
+
     @objc public func enableItem(_ item: PillButtonBarItem) {
         guard let index = indexOfButtonWithItem(item) else {
             return
@@ -192,7 +192,7 @@ open class PillButtonBar: UIScrollView {
             button.isEnabled = true
         }
     }
-    
+
     @objc public func enableItem(atIndex index: Int) {
         if index < 0 || index >= buttons.count {
             return
@@ -204,7 +204,7 @@ open class PillButtonBar: UIScrollView {
             button.isEnabled = true
         }
     }
-    
+
     open override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -187,8 +187,7 @@ open class PillButtonBar: UIScrollView {
         }
 
         let button = buttons[index]
-        if (!button.isEnabled)
-        {
+        if !button.isEnabled {
             button.isEnabled = true
         }
     }
@@ -199,8 +198,7 @@ open class PillButtonBar: UIScrollView {
         }
 
         let button = buttons[index]
-        if (!button.isEnabled)
-        {
+        if !button.isEnabled {
             button.isEnabled = true
         }
     }


### PR DESCRIPTION
### Platforms Impacted

- [x]   iOS
- [ ]  macOS

### Description of changes
Disable pill functionality based on index or given pill

PillButton.swift:
Added api's for setting disabled colors:
- disabledTitleColor
- selectedDisabledTitleColor
- disabledBackgroundColor

Invoked one of the above api's based on the pill style.

PillButtonBar.swift:
Added api's the pill status as disabled for a given index/pill:
- disableItem(_ item: PillButtonBarItem)
- disableItem(atIndex index: Int)
Added api's the pill status as enabled for a given index/pill:
- enableItem(_ item: PillButtonBarItem)
- enableItem(atIndex index: Int)

PillButtonBarDemoController.swift:
- Added switches for disable/enable pills on filled and outline pill bar views

### Verification

in the demo app, added a switch that disables/enables pills over filled and outline bar both
Snapshot captured below.

Accessibility announcements for disabled pills are :
suffixed with "not enabled"

Before:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-07-24 at 18 24 24](https://user-images.githubusercontent.com/68395453/88393285-02feb400-cddb-11ea-950b-f33abbaa3d92.png)


After:

Pill bar demo view opened with all enabled pills
![Simulator Screen Shot - iPhone 11 - 2020-07-24 at 18 22 13](https://user-images.githubusercontent.com/68395453/88393102-bf0baf00-cdda-11ea-909a-364e72383e72.png)

 filled bar pills switch disabled
![Simulator Screen Shot - iPhone 11 - 2020-07-24 at 18 22 18](https://user-images.githubusercontent.com/68395453/88393099-be731880-cdda-11ea-80b6-da798fad1d08.png)

 outline bar pills switch disabled
![Simulator Screen Shot - iPhone 11 - 2020-07-24 at 18 22 24](https://user-images.githubusercontent.com/68395453/88393097-bdda8200-cdda-11ea-9c65-909a9bb337c0.png)

 Both switches disabled
![Simulator Screen Shot - iPhone 11 - 2020-07-24 at 18 22 31](https://user-images.githubusercontent.com/68395453/88393088-ba46fb00-cdda-11ea-84a9-768e0e30ed52.png)


### Pull request checklist

This PR has considered:

- [x]  Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/133)