### PR TITLE
add support for action button in notification bar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -13,6 +13,8 @@ class NotificationViewDemoController: DemoController {
         case primaryBar
         case primaryOutlineBar
         case neutralBar
+        case persistentBarWithAction
+        case persistentBarWithCancel
 
         var displayText: String {
             switch self {
@@ -28,6 +30,10 @@ class NotificationViewDemoController: DemoController {
                 return "Primary Outline Bar"
             case .neutralBar:
                 return "Neutral Bar"
+            case .persistentBarWithAction:
+                return "Persistent Bar with Action"
+            case .persistentBarWithCancel:
+                return "Persistent Bar with Cancel"
             }
         }
 
@@ -73,6 +79,10 @@ class NotificationViewDemoController: DemoController {
             view.setup(style: .primaryOutlineBar, message: "Mail Sent")
         case .neutralBar:
             view.setup(style: .neutralBar, message: "No internet connection")
+        case .persistentBarWithAction:
+            view.setup(style: .neutralBar, message: "This error can be taken action on with the action on the right.", actionTitle: "Action", action: { [unowned self] in self.showMessage("`Action` tapped") })
+        case .persistentBarWithCancel:
+            view.setup(style: .neutralBar, message: "This error can be tapped or dismissed with the icon to the right.", action: { [unowned self] in self.showMessage("`Dismiss` tapped") })
         }
         return view
     }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Before only toast style supported action button on the trailing edge. Now, bar style can also have action button so that the bar can stay persistently until user taps on action button.

- make sure message text style for bar is adhere to latest design
- messageText is natural align when there is an action button but center if it is a simple bar
- add demo example of persistent bar with action button
### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![iPhone_before](https://user-images.githubusercontent.com/20715435/88350772-f6aa2680-cd08-11ea-87e1-119460ed5b3d.png) | ![iPhone_after](https://user-images.githubusercontent.com/20715435/88350786-fdd13480-cd08-11ea-8b23-47be04c57011.png) |
| ![IPad_before](https://user-images.githubusercontent.com/20715435/88350794-0590d900-cd09-11ea-925a-152649740a7a.png) | ![iPad_after](https://user-images.githubusercontent.com/20715435/88350803-0d507d80-cd09-11ea-8250-daf921fc896b.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/134)