### PR TITLE
Update min height for single-line cells from 44 to 48 points

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -217,7 +217,7 @@ open class TableViewCell: UITableViewCell {
         static let labelVerticalMarginForTwoLines: CGFloat = 12
         static let labelVerticalSpacing: CGFloat = 0
 
-        static let minHeight: CGFloat = 44
+        static let minHeight: CGFloat = 48
 
         static let selectionImageMarginTrailing: CGFloat = horizontalSpacing
         static let selectionImageOff = UIImage.staticImageNamed("selection-off")


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Single-line table view cells min height has been updated from 44 to 48 points in the mobile toolkit.
Let's update the code to reflect this change.

Before:
<img width="1338" alt="before" src="https://user-images.githubusercontent.com/4185114/88584424-71738a00-d006-11ea-976e-87192243c636.png">

After:
<img width="1338" alt="after" src="https://user-images.githubusercontent.com/4185114/88584429-746e7a80-d006-11ea-8d7d-085e1856b433.png">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/137)