### PR TITLE
Implement an initializer without paramters for Button.swift

### DIFF
--- a/macos/FluentUI/Button.swift
+++ b/macos/FluentUI/Button.swift
@@ -25,7 +25,7 @@ open class Button: NSButton {
 		super.init(frame: .zero)
 		initialize(title: title, image: nil, style: style)
     }
-	
+
 	/// Initializes a Fluent UI Button with an image, setting the imagePosition to imageOnly
 	/// - Parameters:
 	///   - image: The NSImage to diplay in the button
@@ -34,6 +34,13 @@ open class Button: NSButton {
 		super.init(frame: .zero)
 		imagePosition = .imageOnly
 		initialize(title: nil, image: image, style: style)
+    }
+
+	/// Initializes a Fluent UI Button
+	/// Set style to primaryFilled as default
+	@objc public init() {
+		super.init(frame: .zero)
+		initialize(title: nil, image: nil, style: .primaryFilled)
     }
 
 	@available(*, unavailable)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X ] macOS

### Description of changes
There's a need for initializing a button without a button title, this change will create that flexibility.

### Verification
Instantiated a button without parameters in the test app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/140)