### PR TITLE
Fix bug where wrong image is shown in horizontal compact in tab bar view

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -36,7 +36,7 @@ open class TabBarItem: NSObject {
 
     func selectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {
-            return (labelIsHidden ? selectedImage : landscapeSelectedImage) ?? image
+            return (labelIsHidden ? selectedImage : landscapeSelectedImage) ?? selectedImage ?? image
         } else {
             return landscapeSelectedImage ?? selectedImage ?? image
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Wrong image is shown in TabBarView in horizontal compact + vertical regular mode when no explicit landscape selected image is selected.
This is because our logic falls back to the wrong image. If no landscape selected image is provided, we should fallback to the selected image first, then fallback to the default image if the selected image is not available.

### Verification

- Tested on iPhone portrait and horizontal with/without labels.
- Tested on iPad compact/regular with/without labels.
- Tested by providing explicit selected and landscape selected images in the demo controller.
- Tested by not providing explicit selected and landscape selected images in the demo controller.

Before:
<img width="1404" alt="Screen Shot 2020-07-29 at 1 59 28 PM" src="https://user-images.githubusercontent.com/4185114/88853035-f7790780-d1a3-11ea-923f-a29447f0d981.png">

After:
<img width="1404" alt="Screen Shot 2020-07-29 at 2 00 48 PM" src="https://user-images.githubusercontent.com/4185114/88853043-f9db6180-d1a3-11ea-8327-ee1cce3c3b22.png">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/145)