### PR TITLE
remove width and height anchors

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -198,22 +198,12 @@ open class SideTabBar: UIView {
 
         let stackView = self.stackView(in: section)
 
-        let itemSize = section == .top ? Constants.topItemSize : Constants.bottomItemSize
-        var constraints: [NSLayoutConstraint] = []
-
         for item in allItems {
             let tabBarItemView = TabBarItemView(item: item, showsTitle: false, canResizeImage: false)
             tabBarItemView.translatesAutoresizingMaskIntoConstraints = false
 
             let tapGesture = UITapGestureRecognizer(target: self, action: (section == .top) ? #selector(handleTopItemTapped(_:)) : #selector(handleBottomItemTapped(_:)))
             tabBarItemView.addGestureRecognizer(tapGesture)
-
-            // Issue #110: TabBarItemViews don't have an intrinsic size so we need to set the height with constraints.
-            constraints.append(contentsOf: [
-                tabBarItemView.widthAnchor.constraint(equalToConstant: itemSize),
-                tabBarItemView.heightAnchor.constraint(equalToConstant: itemSize)
-            ])
-
             stackView.addArrangedSubview(tabBarItemView)
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Implement intrinsic content size for TabBarItemView

### Verification

iPad sidebar/tabbar, and iPhone tabbar landscape/portrait

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![before_sidebar](https://user-images.githubusercontent.com/20715435/88890837-0e951500-d1f7-11ea-975a-71631e840d83.png)| ![after_sidebar](https://user-images.githubusercontent.com/20715435/88890920-2bc9e380-d1f7-11ea-8c5b-97014313ec80.png)|
|![before_tabbar_landscape_label](https://user-images.githubusercontent.com/20715435/88890849-1359c900-d1f7-11ea-82bd-4d035f462aec.png)| ![after_tabbar_landscape_label](https://user-images.githubusercontent.com/20715435/88890935-308e9780-d1f7-11ea-9153-45dc0343a93c.png)|
|![before_tabbar_landscape](https://user-images.githubusercontent.com/20715435/88890853-15bc2300-d1f7-11ea-8c1b-ff81f63d2b5e.png)|![after_tabbar_landscape](https://user-images.githubusercontent.com/20715435/88890948-34221e80-d1f7-11ea-8521-6f7329a83e42.png)|
|![before_tabbar_portrait_label](https://user-images.githubusercontent.com/20715435/88890866-194faa00-d1f7-11ea-9851-54cdac09a761.png)|![after_tabbar_portrait_label](https://user-images.githubusercontent.com/20715435/88890969-3b492c80-d1f7-11ea-8205-753f2697391a.png)|
|![before_tabbar_portrait](https://user-images.githubusercontent.com/20715435/88890880-1b196d80-d1f7-11ea-8287-4210fca7fa49.png)|![after_tabbar_portrait](https://user-images.githubusercontent.com/20715435/88890984-40a67700-d1f7-11ea-92c9-2bb0bd16e417.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/147)