### PR TITLE
Do not show avatar presence status for the square style

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
@@ -61,15 +61,11 @@ class AvatarViewDemoController: DemoController {
         didSet {
             if oldValue != isShowingPresence {
                 for avatarView in avatarViewsWithImages {
-                    if avatarView.style == .circle {
-                        avatarView.presence = isShowingPresence ? avatarView.avatarSize.presenceWithImage : .none
-                    }
+                    avatarView.presence = isShowingPresence ? avatarView.avatarSize.presenceWithImage : .none
                 }
 
                 for avatarView in avatarViewsWithInitials {
-                    if avatarView.style == .circle {
-                        avatarView.presence = isShowingPresence ? avatarView.avatarSize.presenceWithInitials : .none
-                    }
+                    avatarView.presence = isShowingPresence ? avatarView.avatarSize.presenceWithInitials : .none
                 }
 
                 opaquePresenceBorderSettingView.isHidden = !isShowingPresence

--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -124,31 +124,6 @@ public typealias MSAvatarView = AvatarView
  */
 @objc(MSFAvatarView)
 open class AvatarView: UIView {
-    private struct Constants {
-        static let borderWidth: CGFloat = 2
-        static let extraExtraLargeBorderWidth: CGFloat = 4
-        static let animationDuration: TimeInterval = 0.2
-
-        /// If a customBorderImage is set, a custom border of this width will be added to the avatar view.
-        static let customBorderWidth: CGFloat = 3
-
-        /// The width for the presence status border.
-        static let presenceBorderWidth: CGFloat = 2
-    }
-
-    private struct SetupData: Equatable {
-        let primaryText: String?
-        let secondaryText: String?
-
-        init(avatarView: AvatarView) {
-            self.primaryText = avatarView.primaryText
-            self.secondaryText = avatarView.secondaryText
-        }
-    }
-
-    /// Set this to override the avatar view's default accessibility label.
-    @objc open var overrideAccessibilityLabel: String?
-
     @objc open var avatarSize: AvatarSize {
         didSet {
             updatePresenceImage()
@@ -187,12 +162,14 @@ open class AvatarView: UIView {
     @objc open var style: AvatarStyle {
         didSet {
             if style != oldValue {
+                updatePresenceImage()
                 setNeedsLayout()
             }
         }
     }
 
     /// The avatar view's presence state.
+    /// The presence state is only shown when the style is set to AvatarStyle.circle.
     @objc open var presence: Presence = .none {
         didSet {
             if oldValue != presence {
@@ -208,21 +185,8 @@ open class AvatarView: UIView {
         }
     }
 
-    private var hasBorder: Bool = false
-    private var hasCustomBorder: Bool = false
-    private var customBorderImageSize: CGSize = .zero
-    private var primaryText: String?
-    private var secondaryText: String?
-
-    private var initialsView: InitialsView
-    private let imageView: UIImageView
-    private let containerView: UIView
-
-    // Use a view as a border to avoid leaking pixels on corner radius
-    private let borderView: UIView
-
-    private var presenceImageView: UIImageView?
-    private var presenceBorderView: UIView?
+    /// Set this to override the avatar view's default accessibility label.
+    @objc open var overrideAccessibilityLabel: String?
 
     /// Initializes the avatar view with a size and an optional border
     ///
@@ -295,10 +259,6 @@ open class AvatarView: UIView {
         }
     }
 
-    private func cornerRadius(for width: CGFloat) -> CGFloat {
-        return style == .circle ? width / 2 : avatarSize.squareCornerRadius
-    }
-
     // MARK: Setup
 
     /// Sets up the avatarView to show an image or initials based on if an image is provided
@@ -340,6 +300,44 @@ open class AvatarView: UIView {
     @objc public func setup(avatar: Avatar?) {
         setup(primaryText: avatar?.primaryText, secondaryText: avatar?.secondaryText, image: avatar?.image, presence: avatar?.presence ?? .none)
         customBorderImage = avatar?.customBorderImage
+    }
+
+    private var hasBorder: Bool = false
+    private var hasCustomBorder: Bool = false
+    private var customBorderImageSize: CGSize = .zero
+    private var primaryText: String?
+    private var secondaryText: String?
+
+    private var initialsView: InitialsView
+    private let imageView: UIImageView
+    private let containerView: UIView
+
+    // Use a view as a border to avoid leaking pixels on corner radius
+    private let borderView: UIView
+
+    private var presenceImageView: UIImageView?
+    private var presenceBorderView: UIView?
+
+    private struct Constants {
+        static let borderWidth: CGFloat = 2
+        static let extraExtraLargeBorderWidth: CGFloat = 4
+        static let animationDuration: TimeInterval = 0.2
+
+        /// If a customBorderImage is set, a custom border of this width will be added to the avatar view.
+        static let customBorderWidth: CGFloat = 3
+
+        /// The width for the presence status border.
+        static let presenceBorderWidth: CGFloat = 2
+    }
+
+    private struct SetupData: Equatable {
+        let primaryText: String?
+        let secondaryText: String?
+
+        init(avatarView: AvatarView) {
+            self.primaryText = avatarView.primaryText
+            self.secondaryText = avatarView.secondaryText
+        }
     }
 
     private func setupWithInitials() {
@@ -496,7 +494,11 @@ open class AvatarView: UIView {
     }
 
     private func isDisplayingPresence() -> Bool {
-        return presence != .none && avatarSize != .extraSmall
+        return presence != .none && avatarSize != .extraSmall && style == .circle
+    }
+
+    private func cornerRadius(for width: CGFloat) -> CGFloat {
+        return style == .circle ? width / 2 : avatarSize.squareCornerRadius
     }
 
     // MARK: Accessibility


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Never show presence when the avatar view's style is square.

<img width="1404" alt="Screen Shot 2020-07-30 at 12 49 12 AM" src="https://user-images.githubusercontent.com/4185114/88896374-9c283300-d1fe-11ea-8ba5-276e05aecc19.png">


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/149)