### PR TITLE
snap tabbar height to 4pt grid

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -29,7 +29,7 @@ public typealias MSTabBarView = TabBarView
 open class TabBarView: UIView {
     private struct Constants {
         static let maxTabCount: Int = 5
-        static let portraitHeight: CGFloat = 49.0
+        static let portraitHeight: CGFloat = 48.0
         static let landscapeHeight: CGFloat = 40.0
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Portrait tab height is no longer 49 it is 48.

### Verification

iPhone 11 Pro
- landscape/portrait 
- with label/ without label 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/20715435/89064329-aa6d7080-d31e-11ea-81dd-7151cba103bd.png)|![after](https://user-images.githubusercontent.com/20715435/89064342-ae998e00-d31e-11ea-9628-a773a1a19eaf.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/157)