### PR TITLE
calendar weekdayheading background color matches navigationbar background

### DIFF
--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -24,7 +24,7 @@ public extension Colors {
             public struct Light {
                 public static var textRegular = UIColor(light: gray600, lightHighContrast: gray700, dark: textPrimary)
                 public static var textWeekend: UIColor = textSecondary
-                public static var background: UIColor = Calendar.background
+                public static var background: UIColor = NavigationBar.background
             }
             public struct Dark {
                 public static var textRegular: UIColor = textOnAccent


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

calendar weekdayheading background color matches navigationbar background in darkmode

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![before_light](https://user-images.githubusercontent.com/20715435/89076995-29ba6e80-d336-11ea-92e5-723299fc7352.png)|![after_light](https://user-images.githubusercontent.com/20715435/89077000-2b843200-d336-11ea-9582-e0b792c71631.png)|
|![before_dark](https://user-images.githubusercontent.com/20715435/89077011-2e7f2280-d336-11ea-9a7d-1933c7ef5296.png)|![after_dark](https://user-images.githubusercontent.com/20715435/89077023-317a1300-d336-11ea-9f57-abea2a08fd0d.png)|


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/160)