### PR TITLE
for iPad, no matter what orientation in what screen width mode, tabba…

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -29,8 +29,9 @@ public typealias MSTabBarView = TabBarView
 open class TabBarView: UIView {
     private struct Constants {
         static let maxTabCount: Int = 5
-        static let portraitHeight: CGFloat = 48.0
-        static let landscapeHeight: CGFloat = 40.0
+        static let phonePortraitHeight: CGFloat = 48.0
+        static let phoneLandscapeHeight: CGFloat = 40.0
+        static let padHeight: CGFloat = 48.0
     }
 
     /// List of TabBarItems in the TabBarView. Order of the array is the order of the subviews.
@@ -109,7 +110,7 @@ open class TabBarView: UIView {
         topBorderLine.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topBorderLine)
 
-        heightConstraint = stackView.heightAnchor.constraint(equalToConstant: Constants.portraitHeight)
+        heightConstraint = stackView.heightAnchor.constraint(equalToConstant: traitCollection.userInterfaceIdiom == .phone ? Constants.phonePortraitHeight : Constants.padHeight)
         NSLayoutConstraint.activate([heightConstraint!,
                                      topBorderLine.bottomAnchor.constraint(equalTo: topAnchor),
                                      topBorderLine.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -142,8 +143,10 @@ open class TabBarView: UIView {
     }
 
     private func updateHeight() {
-        let isPortrait = traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular
-        heightConstraint?.constant = isPortrait ? Constants.portraitHeight : Constants.landscapeHeight
+        if traitCollection.userInterfaceIdiom == .phone {
+            let isPortrait = traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .regular
+            heightConstraint?.constant = isPortrait ? Constants.phonePortraitHeight : Constants.phoneLandscapeHeight
+        }
     }
 
     @objc private func handleTabBarItemTapped(_ recognizer: UITapGestureRecognizer) {


### PR DESCRIPTION
…rview will always be 48 pt height.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In all orientations of iPad, tabbar will have 48pt height (not including the home indicator).

### Verification

iPhone, iPad (compact/regular mode)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![before](https://user-images.githubusercontent.com/20715435/89078178-b8c88600-d338-11ea-9e78-d687f7119e2e.png)|![after](https://user-images.githubusercontent.com/20715435/89078194-bfef9400-d338-11ea-9d4c-96af4e46b6f0.png)|


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/161)