### PR TITLE
Implement MSFTextStyle for macOS

### DIFF
--- a/macos/FluentUI/Button.swift
+++ b/macos/FluentUI/Button.swift
@@ -22,9 +22,9 @@ open class Button: NSButton {
 	/// - Parameters:
 	///   - title: String displayed in the button
 	///   - style: The ButtonStyle, defaulting to primaryFilled
-	@objc public init(title: String, style: ButtonStyle = .primaryFilled) {
+	@objc public init(title: String, textStyle: TextStyle = .body ,style: ButtonStyle = .primaryFilled) {
 		super.init(frame: .zero)
-		initialize(title: title, image: nil, style: style)
+		initialize(title: title, textStyle: textStyle, image: nil, style: style)
     }
 
 	/// Initializes a Fluent UI Button with an image, setting the imagePosition to imageOnly
@@ -49,17 +49,18 @@ open class Button: NSButton {
 		preconditionFailure()
 	}
 	
-	private func initialize(title: String?, image: NSImage?, style: ButtonStyle = .primaryFilled) {
+	private func initialize(title: String?, textStyle: TextStyle = .body, image: NSImage?, style: ButtonStyle = .primaryFilled) {
 		// Do common initialization work
 		isBordered = false
 		wantsLayer = true
-		
+
+		self.textStyle = textStyle
 		self.style = style
 		
 		if let title = title {
 			self.title = title
 		}
-		
+
 		if let image = image {
 			self.image = image
 		}
@@ -151,7 +152,7 @@ open class Button: NSButton {
 	@objc public var primaryColor: NSColor = defaultPrimaryColor {
 		didSet {
 			if primaryColor != oldValue {
-				needsDisplay = true
+				setNeedsDisplay()
 			}
 		}
 	}
@@ -160,7 +161,15 @@ open class Button: NSButton {
 	@objc public var style: ButtonStyle = .primaryFilled {
 		didSet {
 			if style != oldValue {
-				needsDisplay = true
+				setNeedsDisplay()
+			}
+		}
+	}
+	
+	@objc public var textStyle: TextStyle = .body {
+		didSet {
+			if textStyle != oldValue {
+				font = textStyle.font()
 			}
 		}
 	}

--- a/macos/FluentUI/Label.swift
+++ b/macos/FluentUI/Label.swift
@@ -1,0 +1,99 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AppKit
+
+@objc(MSFTextStyle)
+public enum TextStyle: Int, CaseIterable {
+    case largeTitle
+    case title1
+    case title2
+    case title3
+    case headline
+    case body
+    case callout
+    case subheadline
+    case footnote
+    case caption1
+    case caption2
+	
+	public func font() -> NSFont
+	{
+		switch self {
+		case .largeTitle:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .largeTitle)
+			} else {
+				return NSFont.systemFont(ofSize: 26, weight: .regular)
+			}
+		case .title1:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .title1)
+			} else {
+				return NSFont.systemFont(ofSize: 22, weight: .regular)
+			}
+		case .title2:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .title2)
+			} else {
+				return NSFont.systemFont(ofSize: 17, weight: .regular)
+			}
+		case .title3:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .title3)
+			} else {
+				return NSFont.systemFont(ofSize: 15, weight: .regular)
+			}
+		case .headline:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .headline)
+			} else {
+				return NSFont.systemFont(ofSize: 13, weight: .black)
+			}
+		case .body:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .body)
+			} else {
+				return NSFont.systemFont(ofSize: 13, weight: .regular)
+			}
+		case .callout:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .callout)
+			} else {
+				return NSFont.systemFont(ofSize: 12, weight: .regular)
+			}
+		case .subheadline:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .subheadline)
+			} else {
+				return NSFont.systemFont(ofSize: 11, weight: .regular)
+			}
+		case .footnote:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .footnote)
+			} else {
+				return NSFont.systemFont(ofSize: 10, weight: .regular)
+			}
+		case .caption1:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .caption1)
+			} else {
+				return NSFont.systemFont(ofSize:10, weight: .regular)
+			}
+		case .caption2:
+			if #available(macOS 11.0, *) {
+				return NSFont.preferredFont(forTextStyle: .caption2)
+			} else {
+				return NSFont.systemFont(ofSize: 10, weight: .medium)
+			}
+		}
+	}
+}
+
+public func Label(withString string: String, forTextStyle TextStyle: TextStyle) -> NSTextField {
+	let label = NSTextField(labelWithString: string)
+	label.font = TextStyle.font()
+	return label
+}

--- a/macos/FluentUI/Link.swift
+++ b/macos/FluentUI/Link.swift
@@ -13,8 +13,9 @@ open class Link: NSButton {
 	/// - Parameters:
 	///   - title: The visible text of the link that the user sees.
 	///   - url: The URL that is opened when the link is clicked
-	@objc public init(title: String, url: NSURL) {
+	@objc public init(title: String, textStyle: TextStyle = .body, url: NSURL) {
 		self.url = url
+		self.textStyle = textStyle
 		super.init(frame: .zero)
 		self.title = title
 		initialize()
@@ -23,7 +24,8 @@ open class Link: NSButton {
 	/// Initializes a hyperlink with a title and no URL, useful if you plan to override the Target/Action
 	/// - Parameters:
 	///   - title: The visible text of the link that the user sees.
-	@objc public init(title: String) {
+	@objc public init(title: String, textStyle: TextStyle = .body) {
+		self.textStyle = textStyle
 		super.init(frame: .zero)
 		self.title = title
 		initialize()
@@ -46,6 +48,15 @@ open class Link: NSButton {
 		target = self
 		action = #selector(linkClicked)
 		updateTitle()
+	}
+	
+	@objc public var textStyle: TextStyle = .body {
+		didSet {
+			guard oldValue != textStyle else {
+				return
+			}
+			updateTitle()
+		}
 	}
 	
 	/// The URL that is opened when the link is clicked
@@ -110,7 +121,10 @@ open class Link: NSButton {
 	}
 	
 	private func updateTitle() {
-		let titleAttributes = (showsUnderlineWhileMouseInside && mouseEntered) ? underlinedlinkAttributes: linkAttributes
+		
+		let shouldUnderline = showsUnderlineWhileMouseInside && mouseEntered
+		
+		let titleAttributes = (shouldUnderline) ? underlinedlinkAttributes: linkAttributes
 		self.attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
 	}
 	
@@ -119,13 +133,21 @@ open class Link: NSButton {
 			NSWorkspace.shared.open(url as URL)
 		}
 	}
+	
+	private var linkAttributes: [NSAttributedString.Key: Any] {
+		return [
+			.foregroundColor: NSColor.linkColor,
+			.font: textStyle.font()
+	  ]
+	}
+
+	private var underlinedlinkAttributes: [NSAttributedString.Key: Any] {
+		return [
+			.foregroundColor: NSColor.linkColor,
+			.font: textStyle.font(),
+			.underlineStyle: NSUnderlineStyle.single.rawValue
+		]
+	}
 }
 
-fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
-	.foregroundColor: NSColor.linkColor
-]
 
-fileprivate let underlinedlinkAttributes: [NSAttributedString.Key: Any] = [
-	.foregroundColor: NSColor.linkColor,
-	.underlineStyle: NSUnderlineStyle.single.rawValue
-]

--- a/macos/FluentUITestViewControllers/TestLabelViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLabelViewController.swift
@@ -1,0 +1,87 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AppKit
+import FluentUI
+
+
+class TestLabelViewController: NSViewController {
+
+	override func loadView() {
+
+
+		let labels = TextStyle.allCases.map {textStyle -> NSTextField in
+			return Label(withString: string(ForTextStyle: textStyle), forTextStyle: textStyle)
+		}
+		
+		let buttons = TextStyle.allCases.map {textStyle -> Button in
+			return Button(title: string(ForTextStyle: textStyle), textStyle: textStyle, style: .primaryFilled)
+		}
+		
+		let links = TextStyle.allCases.map {textStyle -> Link in
+			return Link(title: string(ForTextStyle: textStyle), textStyle: textStyle)
+		}
+	
+
+		let gridView = NSGridView(frame: .zero)
+		gridView.rowSpacing = gridViewRowSpacing
+		gridView.columnSpacing = gridViewColumnSpacing
+		gridView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+		gridView.addColumn(with: labels)
+		gridView.addColumn(with: buttons)
+		gridView.addColumn(with: links)
+
+		let containerView = NSStackView()
+		containerView.orientation = .vertical
+		containerView.translatesAutoresizingMaskIntoConstraints = false
+		containerView.edgeInsets = NSEdgeInsets(
+			top: containerViewEdgeInsets,
+			left: containerViewEdgeInsets,
+			bottom: containerViewEdgeInsets,
+			right: containerViewEdgeInsets
+		)
+
+		containerView.addView(gridView, in: .top)
+
+		view = containerView
+	}
+	
+	func string(ForTextStyle textStyle: TextStyle) -> String {
+		switch textStyle {
+
+		case .largeTitle:
+			return "Large Title"
+		case .title1:
+			return "Title 1"
+		case .title2:
+			return "Title 2"
+		case .title3:
+			return "Title 3"
+		case .headline:
+			return "Headline"
+		case .body:
+			return "Body"
+		case .callout:
+			return "Callout"
+		case .subheadline:
+			return "Subheadline"
+		case .footnote:
+			return "Footnote"
+		case .caption1:
+			return "Caption 1"
+		case .caption2:
+			return "Caption 2"
+		}
+	}
+}
+
+// MARK: - Constants
+
+fileprivate let gridViewRowSpacing: CGFloat = 20
+
+fileprivate let gridViewColumnSpacing: CGFloat = 20
+
+fileprivate let containerViewEdgeInsets: CGFloat = 20

--- a/macos/FluentUITestViewControllers/TestViewControllers.swift
+++ b/macos/FluentUITestViewControllers/TestViewControllers.swift
@@ -11,12 +11,15 @@ public struct TestViewController: Identifiable {
 	public let type: NSViewController.Type
 }
 
+// Keep this list alphabetical
 public let testViewControllers = [TestViewController(title: "Avatar View",
 													 type: TestAvatarViewController.self),
 								  TestViewController(title: "Button",
 													 type: TestButtonViewController.self),
 								  TestViewController(title: "Date Picker",
 													 type: TestDatePickerController.self),
+								  TestViewController(title: "Label",
+													 type: TestLabelViewController.self),
 								  TestViewController(title: "Link",
 													 type: TestLinkViewController.self),
 								  TestViewController(title: "Separator",

--- a/macos/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/macos/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -21,9 +21,11 @@
 		8F5368072295F4C10098AC8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8F5368062295F4C10098AC8F /* Assets.xcassets */; };
 		8F53680A2295F4C10098AC8F /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8F5368082295F4C10098AC8F /* MainMenu.xib */; };
 		8F79191B24589B4E00C84086 /* FluentUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8F7918F624589B4E00C84086 /* FluentUI.strings */; };
+		AC350F0624D55A8300536FE4 /* TestLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC350F0524D55A8300536FE4 /* TestLabelViewController.swift */; };
 		AC68D3192474863A000DACD1 /* Link.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC68D3182474863A000DACD1 /* Link.swift */; };
 		AC7235D82492E0D000D0DCA8 /* FluentUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E61C96B22295E8D60006561F /* FluentUI.framework */; };
 		AC7235D92492E0D000D0DCA8 /* FluentUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E61C96B22295E8D60006561F /* FluentUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AC78D53924D54C1B003DC675 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC78D53824D54C1B003DC675 /* Label.swift */; };
 		AC97EFE2247541C700DADC99 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC97EFE1247541C700DADC99 /* Button.swift */; };
 		AC97EFE7247FA17000DADC99 /* Separator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC97EFE6247FA17000DADC99 /* Separator.swift */; };
 		E61C96BC2295E8D60006561F /* FluentUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E61C96B22295E8D60006561F /* FluentUI.framework */; };
@@ -204,7 +206,9 @@
 		8F79192724589B6D00C84086 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		8F79192924589B6E00C84086 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		8F931A6C22BD593300311764 /* FluentUI_unittest.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FluentUI_unittest.xcconfig; sourceTree = "<group>"; };
+		AC350F0524D55A8300536FE4 /* TestLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLabelViewController.swift; sourceTree = "<group>"; };
 		AC68D3182474863A000DACD1 /* Link.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Link.swift; sourceTree = "<group>"; };
+		AC78D53824D54C1B003DC675 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
 		AC97EFE1247541C700DADC99 /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		AC97EFE3247541E100DADC99 /* TestButtonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestButtonViewController.swift; sourceTree = "<group>"; };
 		AC97EFE6247FA17000DADC99 /* Separator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Separator.swift; sourceTree = "<group>"; };
@@ -371,6 +375,7 @@
 				8F250B8A22B3045100142B0E /* AvatarView.swift */,
 				AC97EFE1247541C700DADC99 /* Button.swift */,
 				804626C722D7909200AFA48C /* DatePicker */,
+				AC78D53824D54C1B003DC675 /* Label.swift */,
 				AC68D3182474863A000DACD1 /* Link.swift */,
 				AC97EFE6247FA17000DADC99 /* Separator.swift */,
 				E61C96B62295E8D60006561F /* FluentUI-Info.plist */,
@@ -415,6 +420,7 @@
 				8F250B8C22B3062A00142B0E /* TestAvatarViewController.swift */,
 				AC97EFE3247541E100DADC99 /* TestButtonViewController.swift */,
 				8061BF8222EF957200F2D245 /* TestDatePickerController.swift */,
+				AC350F0524D55A8300536FE4 /* TestLabelViewController.swift */,
 				E61C96D622987B3C0006561F /* TestLinkViewController.swift */,
 				AC97EFE8247FAB1D00DADC99 /* TestSeparatorViewController.swift */,
 				E6A92D4E24BEAEEA00562BCA /* TestViewControllers.swift */,
@@ -742,6 +748,7 @@
 				8061BF7E22EF936800F2D245 /* DatePickerView.swift in Sources */,
 				8061BF7F22EF936800F2D245 /* DatePickerController.swift in Sources */,
 				8F250B8B22B3045100142B0E /* AvatarView.swift in Sources */,
+				AC78D53924D54C1B003DC675 /* Label.swift in Sources */,
 				8F41CC682447B5580040B851 /* FluentUIResources.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -762,6 +769,7 @@
 				E6A92D2F24BEA8AC00562BCA /* TestButtonViewController.swift in Sources */,
 				E6A92D2D24BEA8AC00562BCA /* TestSeparatorViewController.swift in Sources */,
 				E6A92D3024BEA8AC00562BCA /* TestLinkViewController.swift in Sources */,
+				AC350F0624D55A8300536FE4 /* TestLabelViewController.swift in Sources */,
 				E6A92D2E24BEA8AC00562BCA /* TestAvatarViewController.swift in Sources */,
 				E6A92D4F24BEAEEA00562BCA /* TestViewControllers.swift in Sources */,
 				E6A92D3124BEA8AC00562BCA /* TestDatePickerController.swift in Sources */,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

At WWDC 2020, Apple revealed that they are creating default text styles for macOS. 
New HIG Guidelines [here](https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/typography/), and developer documentation [here](https://developer.apple.com/documentation/appkit/nsfont/textstyle)

Let's add a new enum MSFTextStyle (similar to the one we already have on iOS) for macOS, which just calls the Apple API for macOS 11+, and mimics the style for older OS's. 
Let's also add textStyle as a property for existing controls, and as a param to their initializers.

Apple's WWDC Talk 

![Screen Shot 2020-06-29 at 2 17 08 PM](https://user-images.githubusercontent.com/6722175/89098116-89963100-d399-11ea-858b-09697bda4a79.png)


Our new Text Styles

![Screen Shot 2020-08-01 at 1 37 48 AM](https://user-images.githubusercontent.com/6722175/89098118-91ee6c00-d399-11ea-8c61-aabbfe8e7b43.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/164)