### PR TITLE
Added search progress spinner in search bar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -278,7 +278,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        container.addArrangedSubview(searchProgressSpinnerSwitchView)
+        if self.navigationItem.accessoryView != nil {
+            container.addArrangedSubview(searchProgressSpinnerSwitchView)
+        }
         container.addArrangedSubview(tableView)
         updateNavigationTitle()
         updateLeftBarButtonItems()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -91,7 +91,6 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
-
         content.showsTabs = !showShadow
         if style == .custom {
             content.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
@@ -157,7 +156,6 @@ class NavigationControllerDemoController: DemoController {
 // MARK: - NavigationControllerDemoController: UIGestureRecognizerDelegate
 
 extension NavigationControllerDemoController: UIGestureRecognizerDelegate {
-
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         // Only show side drawer for the root view controller
         if let controller = presentedViewController as? UINavigationController,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -105,8 +105,10 @@ class NavigationControllerDemoController: DemoController {
             content.allowsCellSelection = true
         }
 
-        let searchBarView = accessoryView as! SearchBar
-        searchBarView.delegate = content
+        if accessoryView != nil {
+            let searchBarView = accessoryView as! SearchBar
+            searchBarView.delegate = content
+        }
 
         controller.modalPresentationStyle = .fullScreen
         if useLargeTitle {
@@ -184,18 +186,18 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         itemRow.distribution = .equalCentering
         itemRow.alignment = .leading
         itemRow.isLayoutMarginsRelativeArrangement = true
-        itemRow.layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        itemRow.layoutMargins = UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 15)
         itemRow.translatesAutoresizingMaskIntoConstraints = false
 
-        let label = Label(style: .subhead, colorStyle: .regular)
-        label.text = "Show search spinner when user hits search"
-        itemRow.addArrangedSubview(label)
+        let searchSpinnerSwitchLabel = Label(style: .subhead, colorStyle: .regular)
+        searchSpinnerSwitchLabel.text = "Show spinner while using the search bar:"
+        itemRow.addArrangedSubview(searchSpinnerSwitchLabel)
 
         let searchSpinnerSwitch = UISwitch()
-        searchSpinnerSwitch.isOn = false
+        searchSpinnerSwitch.isOn = true
         searchSpinnerSwitch.addTarget(self, action: #selector(shouldShowSearchSpinner(switchView:)), for: .valueChanged)
 
-        itemRow.addArrangedSubview(label)
+        itemRow.addArrangedSubview(searchSpinnerSwitchLabel)
         itemRow.addArrangedSubview(searchSpinnerSwitch)
 
         let itemsContainer = UIView()
@@ -207,13 +209,15 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             itemsContainer.topAnchor.constraint(equalTo: itemRow.topAnchor),
             itemsContainer.bottomAnchor.constraint(equalTo: itemRow.bottomAnchor),
             itemsContainer.leadingAnchor.constraint(equalTo: itemRow.leadingAnchor),
-            itemsContainer.trailingAnchor.constraint(equalTo: itemRow.trailingAnchor)
+            itemsContainer.trailingAnchor.constraint(equalTo: itemRow.trailingAnchor),
+            searchSpinnerSwitchLabel.centerYAnchor.constraint(equalTo: itemsContainer.centerYAnchor),
+            searchSpinnerSwitch.centerYAnchor.constraint(equalTo: itemsContainer.centerYAnchor)
         ])
 
         return itemsContainer
     }()
 
-    var showSearchProgressSpinner: Bool = false
+    var showSearchProgressSpinner: Bool = true
 
     var allowsCellSelection: Bool = false {
         didSet {
@@ -396,7 +400,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         msfNavigationController?.expandNavigationBar(animated: true)
         container.insertArrangedSubview(searchProgressSpinnerSwitchView, at: 0 /* index */)
     }
-
 }
 
 // MARK: - RootViewController: SearchBarDelegate

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -155,7 +155,6 @@ extension NavigationControllerDemoController: UIGestureRecognizerDelegate, Searc
 
        func searchBarDidBeginEditing(_ searchBar: SearchBar) {
                searchBar.progressSpinner.stopAnimating()
-               searchBar.progressSpinner.isHidden = true
        }
 
        func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
@@ -164,11 +163,9 @@ extension NavigationControllerDemoController: UIGestureRecognizerDelegate, Searc
 
        func searchBarDidCancel(_ searchBar: SearchBar) {
                searchBar.progressSpinner.stopAnimating()
-               searchBar.progressSpinner.isHidden = true
        }
 
        func searchBarDidRequestSearch(_ searchBar: SearchBar) {
-               searchBar.progressSpinner.isHidden = false
                searchBar.progressSpinner.startAnimating()
        }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -153,21 +153,20 @@ class NavigationControllerDemoController: DemoController {
 
 extension NavigationControllerDemoController: UIGestureRecognizerDelegate, SearchBarDelegate {
 
-       func searchBarDidBeginEditing(_ searchBar: SearchBar) {
-               searchBar.progressSpinner.stopAnimating()
-       }
+    func searchBarDidBeginEditing(_ searchBar: SearchBar) {
+        searchBar.progressSpinner.stopAnimating()
+    }
 
-       func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
-               // Do Nothing
-       }
+    func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
+    }
 
-       func searchBarDidCancel(_ searchBar: SearchBar) {
-               searchBar.progressSpinner.stopAnimating()
-       }
+    func searchBarDidCancel(_ searchBar: SearchBar) {
+        searchBar.progressSpinner.stopAnimating()
+    }
 
-       func searchBarDidRequestSearch(_ searchBar: SearchBar) {
-               searchBar.progressSpinner.startAnimating()
-       }
+    func searchBarDidRequestSearch(_ searchBar: SearchBar) {
+        searchBar.progressSpinner.startAnimating()
+    }
 
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         // Only show side drawer for the root view controller

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -199,7 +199,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         itemRow.addArrangedSubview(searchSpinnerSwitch)
 
         let itemsContainer = UIView()
-		itemsContainer.backgroundColor = Colors.tableBackground
+        itemsContainer.backgroundColor = Colors.tableBackground
         itemsContainer.addSubview(itemRow)
         itemsContainer.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -119,6 +119,7 @@ class NavigationControllerDemoController: DemoController {
 
     private func createAccessoryView(with style: SearchBar.Style = .lightContent) -> UIView {
         let searchBar = SearchBar()
+        searchBar.delegate = self
         searchBar.style = style
         searchBar.placeholderText = "Search"
         return searchBar
@@ -150,7 +151,27 @@ class NavigationControllerDemoController: DemoController {
 
 // MARK: - NavigationControllerDemoController: UIGestureRecognizerDelegate
 
-extension NavigationControllerDemoController: UIGestureRecognizerDelegate {
+extension NavigationControllerDemoController: UIGestureRecognizerDelegate, SearchBarDelegate {
+
+       func searchBarDidBeginEditing(_ searchBar: SearchBar) {
+               searchBar.progressSpinner.stopAnimating()
+               searchBar.progressSpinner.isHidden = true
+       }
+
+       func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
+               // Do Nothing
+       }
+
+       func searchBarDidCancel(_ searchBar: SearchBar) {
+               searchBar.progressSpinner.stopAnimating()
+               searchBar.progressSpinner.isHidden = true
+       }
+
+       func searchBarDidRequestSearch(_ searchBar: SearchBar) {
+               searchBar.progressSpinner.isHidden = false
+               searchBar.progressSpinner.startAnimating()
+       }
+
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         // Only show side drawer for the root view controller
         if let controller = presentedViewController as? UINavigationController,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -188,7 +188,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         itemRow.translatesAutoresizingMaskIntoConstraints = false
 
         let searchSpinnerSwitchLabel = Label(style: .subhead, colorStyle: .regular)
-        searchSpinnerSwitchLabel.text = "Show spinner while using the search bar:"
+        searchSpinnerSwitchLabel.text = "Show spinner while using the search bar"
         itemRow.addArrangedSubview(searchSpinnerSwitchLabel)
 
         let searchSpinnerSwitch = UISwitch()

--- a/ios/FluentUI/Controls/ActivityIndicatorView.swift
+++ b/ios/FluentUI/Controls/ActivityIndicatorView.swift
@@ -158,7 +158,7 @@ open class ActivityIndicatorView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13, *) {
             if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
-            setupLoaderLayer()
+                setupLoaderLayer()
             }
         }
     }

--- a/ios/FluentUI/Controls/ActivityIndicatorView.swift
+++ b/ios/FluentUI/Controls/ActivityIndicatorView.swift
@@ -154,6 +154,15 @@ open class ActivityIndicatorView: UIView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if #available(iOS 13, *) {
+            if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            setupLoaderLayer()
+            }
+        }
+    }
+
     @objc open func startAnimating() {
         if isAnimating {
             return

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -178,13 +178,13 @@ open class SearchBar: UIView {
 
     weak var navigationController: NavigationController?
 
-    //used to hide the cancelButton in non-active states
+    /// used to hide the cancelButton in non-active states
     private var searchTextFieldBackgroundViewTrailingConstraint: NSLayoutConstraint?
     private var cancelButtonTrailingConstraint: NSLayoutConstraint?
 
     private lazy var searchIconImageViewContainerView = UIView()
 
-    //Leading-edge aligned Icon
+    /// Leading-edge aligned Icon
     private lazy var searchIconImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage.staticImageNamed("search-20x20")
@@ -192,7 +192,7 @@ open class SearchBar: UIView {
         return imageView
     }()
 
-    //user interaction point
+    /// user interaction point
     private lazy var searchTextField: UITextField = {
         let textField = UITextField()
         textField.font = Constants.searchTextFieldTextStyle.font
@@ -207,8 +207,8 @@ open class SearchBar: UIView {
         return textField
     }()
 
-    //a "searchTextField" in native iOS is comprised of an inset Magnifying Glass image followed by an inset textfield.
-    //backgroundview is used to achive an inset textfield
+    /// a "searchTextField" in native iOS is comprised of an inset Magnifying Glass image followed by an inset textfield.
+    /// backgroundview is used to achive an inset textfield
     private lazy var searchTextFieldBackgroundView: UIView = {
         let backgroundView = UIView()
         backgroundView.backgroundColor = style.backgroundColor
@@ -216,7 +216,7 @@ open class SearchBar: UIView {
         return backgroundView
     }()
 
-    //removes text from the searchTextField
+    /// removes text from the searchTextField
     private lazy var clearButton: UIButton = {
         let clearButton = UIButton()
         clearButton.addTarget(self, action: #selector(SearchBar.clearButtonTapped(sender:)), for: .touchUpInside)
@@ -225,14 +225,14 @@ open class SearchBar: UIView {
         return clearButton
     }()
 
-    //indicates search in progress
+    /// indicates search in progress
     @objc public var progressSpinner: ActivityIndicatorView = {
         let progressSpinner = ActivityIndicatorView(size: .medium)
         progressSpinner.isHidden = true
         return progressSpinner
     }()
 
-    //hidden when the textfield is not active
+    /// hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = Constants.cancelButtonTextStyle.font
@@ -269,7 +269,7 @@ open class SearchBar: UIView {
         attributePlaceholderText()
         showCancelButton()
         originalIsNavigationBarHidden = navigationController?.isNavigationBarHidden ?? false
-        // Using delayed async to work around a bug on iOS when it restores responder status for the text field when controller appears (due to navigation controller's pop action) even though text field resigned responder status before a detail controller was pushed
+        /// Using delayed async to work around a bug on iOS when it restores responder status for the text field when controller appears (due to navigation controller's pop action) even though text field resigned responder status before a detail controller was pushed
         let isTransitioning = navigationController?.transitionCoordinator != nil
         DispatchQueue.main.asyncAfter(deadline: .now() + (isTransitioning ? Constants.navigationBarTransitionHidingDelay : 0)) {
             self.navigationController?.setNavigationBarHidden(true, animated: true)
@@ -307,10 +307,10 @@ open class SearchBar: UIView {
             addInteraction(UILargeContentViewerInteraction())
         }
 
-        //Autolayout is more efficent if all constraints are activated simultaneously
+        /// Autolayout is more efficent if all constraints are activated simultaneously
         var constraints = [NSLayoutConstraint]()
 
-        //textfield background
+        /// textfield background
         addSubview(searchTextFieldBackgroundView)
         searchTextFieldBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         searchTextFieldBackgroundView.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -322,7 +322,7 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundViewTrailingConstraint = searchTextFieldBackgroundViewTrailing
         constraints.append(searchTextFieldBackgroundViewTrailing)
 
-        //search icon container
+        /// search icon container
         searchTextFieldBackgroundView.addSubview(searchIconImageViewContainerView)
         searchIconImageViewContainerView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -331,7 +331,7 @@ open class SearchBar: UIView {
         constraints.append(searchIconImageViewContainerView.heightAnchor.constraint(equalTo: searchIconImageViewContainerView.widthAnchor))
         constraints.append(searchIconImageViewContainerView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        //search icon
+        /// search icon
         searchIconImageViewContainerView.addSubview(searchIconImageView)
         searchIconImageView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -340,7 +340,7 @@ open class SearchBar: UIView {
         constraints.append(searchIconImageView.centerXAnchor.constraint(equalTo: searchIconImageViewContainerView.centerXAnchor))
         constraints.append(searchIconImageView.centerYAnchor.constraint(equalTo: searchIconImageViewContainerView.centerYAnchor))
 
-        //search textfield
+        /// search textfield
         searchTextFieldBackgroundView.addSubview(searchTextField)
         searchTextField.translatesAutoresizingMaskIntoConstraints = false
 
@@ -348,27 +348,25 @@ open class SearchBar: UIView {
         constraints.append(searchTextField.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
         constraints.append(searchTextField.heightAnchor.constraint(equalTo: searchTextFieldBackgroundView.heightAnchor, constant: -2 * Constants.searchTextFieldVerticalInset))
 
-        //progressSpinner
+        /// progressSpinner
         searchTextFieldBackgroundView.addSubview(progressSpinner)
         progressSpinner.translatesAutoresizingMaskIntoConstraints = false
 
         constraints.append(progressSpinner.leadingAnchor.constraint(equalTo: searchTextField.trailingAnchor, constant: Constants.clearButtonLeadingInset))
-        constraints.append(progressSpinner.widthAnchor.constraint(equalToConstant: Constants.clearButtonWidth))
         constraints.append(progressSpinner.heightAnchor.constraint(equalTo: clearButton.widthAnchor))
         constraints.append(progressSpinner.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
         constraints.append(progressSpinner.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        //clearButton
+        /// clearButton
         searchTextFieldBackgroundView.addSubview(clearButton)
         clearButton.translatesAutoresizingMaskIntoConstraints = false
 
         constraints.append(clearButton.leadingAnchor.constraint(equalTo: searchTextField.trailingAnchor, constant: Constants.clearButtonLeadingInset))
-        constraints.append(clearButton.widthAnchor.constraint(equalToConstant: Constants.clearButtonWidth))
         constraints.append(clearButton.heightAnchor.constraint(equalTo: clearButton.widthAnchor))
         constraints.append(clearButton.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
         constraints.append(clearButton.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        //cancelButton
+        /// cancelButton
         addSubview(cancelButton)
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
@@ -386,7 +384,7 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundView.backgroundColor = style.backgroundColor
         searchIconImageView.tintColor = style.searchIconColor
         searchTextField.textColor = style.textColor
-        // used for cursor or selection handle
+        /// used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
         progressSpinner.tintColor = style.progressSpinnerColor
@@ -396,13 +394,13 @@ open class SearchBar: UIView {
 
     // MARK: - UIActions
 
-    // Target for the search "cancel" button, outside the search text field
+    /// Target for the search "cancel" button, outside the search text field
     @objc private func cancelButtonTapped(sender: UIButton) {
         cancelSearch()
     }
 
-    // Target for the clearing "X" button within the search text field
-    // Clears all text by setting searchText to nil
+    /// Target for the clearing "X" button within the search text field
+    /// Clears all text by setting searchText to nil
     @objc private func clearButtonTapped(sender: UIButton) {
         searchTextField.text = nil
         searchTextDidChange(shouldUpdateDelegate: true)

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -140,7 +140,7 @@ open class SearchBar: UIView {
         static let searchTextFieldVerticalInset: CGFloat = 2
         static let clearButtonLeadingInset: CGFloat = 10
         static let clearButtonWidth: CGFloat = 8 + 16 + 8   // padding + image + padding
-        static let clearButtonTrailingInset: CGFloat = 0
+        static let clearButtonTrailingInset: CGFloat = 10
         static let cancelButtonLeadingInset: CGFloat = 8.0
 
         static let searchTextFieldTextStyle: TextStyle = .bodyUnscaled
@@ -177,13 +177,13 @@ open class SearchBar: UIView {
 
     weak var navigationController: NavigationController?
 
-    //used to hide the cancelButton in non-active states
+    // used to hide the cancelButton in non-active states
     private var searchTextFieldBackgroundViewTrailingConstraint: NSLayoutConstraint?
     private var cancelButtonTrailingConstraint: NSLayoutConstraint?
 
     private lazy var searchIconImageViewContainerView = UIView()
 
-    //Leading-edge aligned Icon
+    // Leading-edge aligned Icon
     private lazy var searchIconImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage.staticImageNamed("search-20x20")
@@ -191,7 +191,7 @@ open class SearchBar: UIView {
         return imageView
     }()
 
-    //user interaction point
+    // user interaction point
     private lazy var searchTextField: UITextField = {
         let textField = UITextField()
         textField.font = Constants.searchTextFieldTextStyle.font
@@ -206,8 +206,8 @@ open class SearchBar: UIView {
         return textField
     }()
 
-    //a "searchTextField" in native iOS is comprised of an inset Magnifying Glass image followed by an inset textfield.
-    //backgroundview is used to achive an inset textfield
+    // a "searchTextField" in native iOS is comprised of an inset Magnifying Glass image followed by an inset textfield.
+    // backgroundview is used to achive an inset textfield
     private lazy var searchTextFieldBackgroundView: UIView = {
         let backgroundView = UIView()
         backgroundView.backgroundColor = style.backgroundColor
@@ -215,7 +215,7 @@ open class SearchBar: UIView {
         return backgroundView
     }()
 
-    //removes text from the searchTextField
+    // removes text from the searchTextField
     private lazy var clearButton: UIButton = {
         let clearButton = UIButton()
         clearButton.addTarget(self, action: #selector(SearchBar.clearButtonTapped(sender:)), for: .touchUpInside)
@@ -224,7 +224,7 @@ open class SearchBar: UIView {
         return clearButton
     }()
 
-    //hidden when the textfield is not active
+    // hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = Constants.cancelButtonTextStyle.font
@@ -309,10 +309,10 @@ open class SearchBar: UIView {
             addInteraction(UILargeContentViewerInteraction())
         }
 
-        //Autolayout is more efficent if all constraints are activated simultaneously
+        // Autolayout is more efficent if all constraints are activated simultaneously
         var constraints = [NSLayoutConstraint]()
 
-        //textfield background
+        // textfield background
         addSubview(searchTextFieldBackgroundView)
         searchTextFieldBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         searchTextFieldBackgroundView.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -324,7 +324,7 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundViewTrailingConstraint = searchTextFieldBackgroundViewTrailing
         constraints.append(searchTextFieldBackgroundViewTrailing)
 
-        //search icon container
+        // search icon container
         searchTextFieldBackgroundView.addSubview(searchIconImageViewContainerView)
         searchIconImageViewContainerView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -333,7 +333,7 @@ open class SearchBar: UIView {
         constraints.append(searchIconImageViewContainerView.heightAnchor.constraint(equalTo: searchIconImageViewContainerView.widthAnchor))
         constraints.append(searchIconImageViewContainerView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        //search icon
+        // search icon
         searchIconImageViewContainerView.addSubview(searchIconImageView)
         searchIconImageView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -342,7 +342,7 @@ open class SearchBar: UIView {
         constraints.append(searchIconImageView.centerXAnchor.constraint(equalTo: searchIconImageViewContainerView.centerXAnchor))
         constraints.append(searchIconImageView.centerYAnchor.constraint(equalTo: searchIconImageViewContainerView.centerYAnchor))
 
-        //search textfield
+        // search textfield
         searchTextFieldBackgroundView.addSubview(searchTextField)
         searchTextField.translatesAutoresizingMaskIntoConstraints = false
 
@@ -350,7 +350,7 @@ open class SearchBar: UIView {
         constraints.append(searchTextField.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
         constraints.append(searchTextField.heightAnchor.constraint(equalTo: searchTextFieldBackgroundView.heightAnchor, constant: -2 * Constants.searchTextFieldVerticalInset))
 
-        //progressSpinner
+        // progressSpinner
         searchTextFieldBackgroundView.addSubview(progressSpinner)
         progressSpinner.translatesAutoresizingMaskIntoConstraints = false
 
@@ -359,7 +359,7 @@ open class SearchBar: UIView {
         constraints.append(progressSpinner.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
         constraints.append(progressSpinner.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        //clearButton
+        // clearButton
         searchTextFieldBackgroundView.addSubview(clearButton)
         clearButton.translatesAutoresizingMaskIntoConstraints = false
 
@@ -368,7 +368,7 @@ open class SearchBar: UIView {
         constraints.append(clearButton.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
         constraints.append(clearButton.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        //cancelButton
+        // cancelButton
         addSubview(cancelButton)
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -322,7 +322,7 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundViewTrailingConstraint = searchTextFieldBackgroundViewTrailing
         constraints.append(searchTextFieldBackgroundViewTrailing)
 
-        /// search icon container
+        //search icon container
         searchTextFieldBackgroundView.addSubview(searchIconImageViewContainerView)
         searchIconImageViewContainerView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -348,7 +348,7 @@ open class SearchBar: UIView {
         constraints.append(searchTextField.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
         constraints.append(searchTextField.heightAnchor.constraint(equalTo: searchTextFieldBackgroundView.heightAnchor, constant: -2 * Constants.searchTextFieldVerticalInset))
 
-        /// progressSpinner
+        //progressSpinner
         searchTextFieldBackgroundView.addSubview(progressSpinner)
         progressSpinner.translatesAutoresizingMaskIntoConstraints = false
 
@@ -357,7 +357,7 @@ open class SearchBar: UIView {
         constraints.append(progressSpinner.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
         constraints.append(progressSpinner.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        /// clearButton
+        //clearButton
         searchTextFieldBackgroundView.addSubview(clearButton)
         clearButton.translatesAutoresizingMaskIntoConstraints = false
 
@@ -384,7 +384,7 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundView.backgroundColor = style.backgroundColor
         searchIconImageView.tintColor = style.searchIconColor
         searchTextField.textColor = style.textColor
-        /// used for cursor or selection handle
+        // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
         progressSpinner.tintColor = style.progressSpinnerColor

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -14,8 +14,8 @@ public extension Colors {
             public static var cancelButton = UIColor(light: textSecondary, dark: LightContent.cancelButton)
             public static var clearIcon = UIColor(light: iconPrimary, dark: LightContent.clearIcon)
             public static var placeholderText = UIColor(light: textSecondary, dark: LightContent.placeholderText)
-            public static var progressSpinner = UIColor(light: iconPrimary, dark: LightContent.searchIcon)
-            public static var searchIcon: UIColor = progressSpinner
+            public static var progressSpinner: UIColor = DarkContent.searchIcon
+            public static var searchIcon = UIColor(light: iconPrimary, dark: LightContent.searchIcon)
             public static var text = UIColor(light: textDominant, dark: LightContent.text)
             public static var tint = UIColor(light: iconSecondary, dark: LightContent.tint)
         }
@@ -24,7 +24,7 @@ public extension Colors {
             public static var cancelButton: UIColor = LightContent.text
             public static var clearIcon = UIColor(light: iconOnAccent, dark: textSecondary)
             public static var placeholderText = UIColor(light: textOnAccent, dark: textSecondary)
-            public static var progressSpinner: UIColor = placeholderText
+            public static var progressSpinner = placeholderText
             public static var searchIcon: UIColor = placeholderText
             public static var text = UIColor(light: textOnAccent, dark: textDominant)
             public static var tint: UIColor = LightContent.text
@@ -178,13 +178,13 @@ open class SearchBar: UIView {
 
     weak var navigationController: NavigationController?
 
-    /// used to hide the cancelButton in non-active states
+    //used to hide the cancelButton in non-active states
     private var searchTextFieldBackgroundViewTrailingConstraint: NSLayoutConstraint?
     private var cancelButtonTrailingConstraint: NSLayoutConstraint?
 
     private lazy var searchIconImageViewContainerView = UIView()
 
-    /// Leading-edge aligned Icon
+    //Leading-edge aligned Icon
     private lazy var searchIconImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage.staticImageNamed("search-20x20")
@@ -192,7 +192,7 @@ open class SearchBar: UIView {
         return imageView
     }()
 
-    /// user interaction point
+    //user interaction point
     private lazy var searchTextField: UITextField = {
         let textField = UITextField()
         textField.font = Constants.searchTextFieldTextStyle.font
@@ -207,8 +207,8 @@ open class SearchBar: UIView {
         return textField
     }()
 
-    /// a "searchTextField" in native iOS is comprised of an inset Magnifying Glass image followed by an inset textfield.
-    /// backgroundview is used to achive an inset textfield
+    //a "searchTextField" in native iOS is comprised of an inset Magnifying Glass image followed by an inset textfield.
+    //backgroundview is used to achive an inset textfield
     private lazy var searchTextFieldBackgroundView: UIView = {
         let backgroundView = UIView()
         backgroundView.backgroundColor = style.backgroundColor
@@ -216,7 +216,7 @@ open class SearchBar: UIView {
         return backgroundView
     }()
 
-    /// removes text from the searchTextField
+    //removes text from the searchTextField
     private lazy var clearButton: UIButton = {
         let clearButton = UIButton()
         clearButton.addTarget(self, action: #selector(SearchBar.clearButtonTapped(sender:)), for: .touchUpInside)
@@ -225,14 +225,7 @@ open class SearchBar: UIView {
         return clearButton
     }()
 
-    /// indicates search in progress
-    @objc public var progressSpinner: ActivityIndicatorView = {
-        let progressSpinner = ActivityIndicatorView(size: .medium)
-        progressSpinner.isHidden = true
-        return progressSpinner
-    }()
-
-    /// hidden when the textfield is not active
+    //hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
         button.titleLabel?.font = Constants.cancelButtonTextStyle.font
@@ -246,6 +239,13 @@ open class SearchBar: UIView {
     }()
 
     private var originalIsNavigationBarHidden: Bool = false
+
+    ///indicates search in progress
+    @objc public var progressSpinner: ActivityIndicatorView = {
+        let progressSpinner = ActivityIndicatorView(size: .medium)
+        progressSpinner.isHidden = true
+        return progressSpinner
+    }()
 
     @objc public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -269,7 +269,7 @@ open class SearchBar: UIView {
         attributePlaceholderText()
         showCancelButton()
         originalIsNavigationBarHidden = navigationController?.isNavigationBarHidden ?? false
-        /// Using delayed async to work around a bug on iOS when it restores responder status for the text field when controller appears (due to navigation controller's pop action) even though text field resigned responder status before a detail controller was pushed
+        // Using delayed async to work around a bug on iOS when it restores responder status for the text field when controller appears (due to navigation controller's pop action) even though text field resigned responder status before a detail controller was pushed
         let isTransitioning = navigationController?.transitionCoordinator != nil
         DispatchQueue.main.asyncAfter(deadline: .now() + (isTransitioning ? Constants.navigationBarTransitionHidingDelay : 0)) {
             self.navigationController?.setNavigationBarHidden(true, animated: true)
@@ -307,10 +307,10 @@ open class SearchBar: UIView {
             addInteraction(UILargeContentViewerInteraction())
         }
 
-        /// Autolayout is more efficent if all constraints are activated simultaneously
+        //Autolayout is more efficent if all constraints are activated simultaneously
         var constraints = [NSLayoutConstraint]()
 
-        /// textfield background
+        //textfield background
         addSubview(searchTextFieldBackgroundView)
         searchTextFieldBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         searchTextFieldBackgroundView.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -331,7 +331,7 @@ open class SearchBar: UIView {
         constraints.append(searchIconImageViewContainerView.heightAnchor.constraint(equalTo: searchIconImageViewContainerView.widthAnchor))
         constraints.append(searchIconImageViewContainerView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        /// search icon
+        //search icon
         searchIconImageViewContainerView.addSubview(searchIconImageView)
         searchIconImageView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -340,7 +340,7 @@ open class SearchBar: UIView {
         constraints.append(searchIconImageView.centerXAnchor.constraint(equalTo: searchIconImageViewContainerView.centerXAnchor))
         constraints.append(searchIconImageView.centerYAnchor.constraint(equalTo: searchIconImageViewContainerView.centerYAnchor))
 
-        /// search textfield
+        //search textfield
         searchTextFieldBackgroundView.addSubview(searchTextField)
         searchTextField.translatesAutoresizingMaskIntoConstraints = false
 
@@ -366,7 +366,7 @@ open class SearchBar: UIView {
         constraints.append(clearButton.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
         constraints.append(clearButton.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
 
-        /// cancelButton
+        //cancelButton
         addSubview(cancelButton)
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         cancelButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
@@ -394,13 +394,13 @@ open class SearchBar: UIView {
 
     // MARK: - UIActions
 
-    /// Target for the search "cancel" button, outside the search text field
+    // Target for the search "cancel" button, outside the search text field
     @objc private func cancelButtonTapped(sender: UIButton) {
         cancelSearch()
     }
 
-    /// Target for the clearing "X" button within the search text field
-    /// Clears all text by setting searchText to nil
+    // Target for the clearing "X" button within the search text field
+    // Clears all text by setting searchText to nil
     @objc private func clearButtonTapped(sender: UIButton) {
         searchTextField.text = nil
         searchTextDidChange(shouldUpdateDelegate: true)

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -24,7 +24,6 @@ public extension Colors {
             public static var cancelButton: UIColor = LightContent.text
             public static var clearIcon = UIColor(light: iconOnAccent, dark: textSecondary)
             public static var placeholderText = UIColor(light: textOnAccent, dark: textSecondary)
-            public static var progressSpinner = placeholderText
             public static var searchIcon: UIColor = placeholderText
             public static var text = UIColor(light: textOnAccent, dark: textDominant)
             public static var tint: UIColor = LightContent.text
@@ -95,15 +94,6 @@ open class SearchBar: UIView {
             }
         }
 
-       var progressSpinnerColor: UIColor {
-            switch self {
-            case .lightContent:
-                return Colors.SearchBar.LightContent.progressSpinner
-            case .darkContent:
-                return Colors.SearchBar.DarkContent.progressSpinner
-            }
-        }
-
         var searchIconColor: UIColor {
             switch self {
             case .lightContent:
@@ -128,6 +118,15 @@ open class SearchBar: UIView {
                 return Colors.SearchBar.LightContent.tint
             case .darkContent:
                 return Colors.SearchBar.DarkContent.tint
+            }
+        }
+
+        func progressSpinnerColor(for window: UIWindow) -> UIColor {
+            switch self {
+            case .lightContent:
+                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.iconSecondary)
+            case .darkContent:
+                return Colors.SearchBar.DarkContent.progressSpinner
             }
         }
     }
@@ -241,7 +240,7 @@ open class SearchBar: UIView {
     private var originalIsNavigationBarHidden: Bool = false
 
     ///indicates search in progress
-    @objc public var progressSpinner: ActivityIndicatorView = {
+    @objc public lazy var progressSpinner: ActivityIndicatorView = {
         let progressSpinner = ActivityIndicatorView(size: .medium)
         progressSpinner.isHidden = true
         return progressSpinner
@@ -258,8 +257,12 @@ open class SearchBar: UIView {
     }
 
     private func initialize() {
-        updateColorsForStyle()
         setupLayout()
+    }
+
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateColorsForStyle()
     }
 
     private func startSearch() {
@@ -387,7 +390,9 @@ open class SearchBar: UIView {
         // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
-        progressSpinner.tintColor = style.progressSpinnerColor
+        if let window = window {
+            progressSpinner.tintColor = style.progressSpinnerColor(for: window)
+        }
         cancelButton.setTitleColor(style.cancelButtonColor, for: .normal)
         attributePlaceholderText()
     }

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -14,7 +14,8 @@ public extension Colors {
             public static var cancelButton = UIColor(light: textSecondary, dark: LightContent.cancelButton)
             public static var clearIcon = UIColor(light: iconPrimary, dark: LightContent.clearIcon)
             public static var placeholderText = UIColor(light: textSecondary, dark: LightContent.placeholderText)
-            public static var searchIcon = UIColor(light: iconPrimary, dark: LightContent.searchIcon)
+            public static var progressSpinner = UIColor(light: iconPrimary, dark: LightContent.searchIcon)
+            public static var searchIcon: UIColor = progressSpinner
             public static var text = UIColor(light: textDominant, dark: LightContent.text)
             public static var tint = UIColor(light: iconSecondary, dark: LightContent.tint)
         }
@@ -23,6 +24,7 @@ public extension Colors {
             public static var cancelButton: UIColor = LightContent.text
             public static var clearIcon = UIColor(light: iconOnAccent, dark: textSecondary)
             public static var placeholderText = UIColor(light: textOnAccent, dark: textSecondary)
+            public static var progressSpinner: UIColor = placeholderText
             public static var searchIcon: UIColor = placeholderText
             public static var text = UIColor(light: textOnAccent, dark: textDominant)
             public static var tint: UIColor = LightContent.text
@@ -90,6 +92,15 @@ open class SearchBar: UIView {
                 return Colors.SearchBar.LightContent.placeholderText
             case .darkContent:
                 return Colors.SearchBar.DarkContent.placeholderText
+            }
+        }
+
+       var progressSpinnerColor: UIColor {
+            switch self {
+            case .lightContent:
+                return Colors.SearchBar.LightContent.progressSpinner
+            case .darkContent:
+                return Colors.SearchBar.DarkContent.progressSpinner
             }
         }
 
@@ -214,6 +225,13 @@ open class SearchBar: UIView {
         return clearButton
     }()
 
+    //indicates search in progress
+    @objc public var progressSpinner: ActivityIndicatorView = {
+        let progressSpinner = ActivityIndicatorView(size: .medium)
+        progressSpinner.isHidden = true
+        return progressSpinner
+    }()
+
     //hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
@@ -330,6 +348,16 @@ open class SearchBar: UIView {
         constraints.append(searchTextField.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
         constraints.append(searchTextField.heightAnchor.constraint(equalTo: searchTextFieldBackgroundView.heightAnchor, constant: -2 * Constants.searchTextFieldVerticalInset))
 
+        //progressSpinner
+        searchTextFieldBackgroundView.addSubview(progressSpinner)
+        progressSpinner.translatesAutoresizingMaskIntoConstraints = false
+
+        constraints.append(progressSpinner.leadingAnchor.constraint(equalTo: searchTextField.trailingAnchor, constant: Constants.clearButtonLeadingInset))
+        constraints.append(progressSpinner.widthAnchor.constraint(equalToConstant: Constants.clearButtonWidth))
+        constraints.append(progressSpinner.heightAnchor.constraint(equalTo: clearButton.widthAnchor))
+        constraints.append(progressSpinner.trailingAnchor.constraint(equalTo: searchTextFieldBackgroundView.trailingAnchor, constant: -1 * Constants.clearButtonTrailingInset))
+        constraints.append(progressSpinner.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
+
         //clearButton
         searchTextFieldBackgroundView.addSubview(clearButton)
         clearButton.translatesAutoresizingMaskIntoConstraints = false
@@ -361,6 +389,7 @@ open class SearchBar: UIView {
         // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
+        progressSpinner.tintColor = style.progressSpinnerColor
         cancelButton.setTitleColor(style.cancelButtonColor, for: .normal)
         attributePlaceholderText()
     }

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -14,7 +14,7 @@ public extension Colors {
             public static var cancelButton = UIColor(light: textSecondary, dark: LightContent.cancelButton)
             public static var clearIcon = UIColor(light: iconPrimary, dark: LightContent.clearIcon)
             public static var placeholderText = UIColor(light: textSecondary, dark: LightContent.placeholderText)
-            public static var progressSpinner: UIColor = DarkContent.searchIcon
+            public static var progressSpinner = UIColor(light: iconDisabled, dark: textPrimary)
             public static var searchIcon = UIColor(light: iconPrimary, dark: LightContent.searchIcon)
             public static var text = UIColor(light: textDominant, dark: LightContent.text)
             public static var tint = UIColor(light: iconSecondary, dark: LightContent.tint)
@@ -124,7 +124,7 @@ open class SearchBar: UIView {
         func progressSpinnerColor(for window: UIWindow) -> UIColor {
             switch self {
             case .lightContent:
-                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.iconSecondary)
+                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textPrimary)
             case .darkContent:
                 return Colors.SearchBar.DarkContent.progressSpinner
             }
@@ -242,7 +242,6 @@ open class SearchBar: UIView {
     ///indicates search in progress
     @objc public lazy var progressSpinner: ActivityIndicatorView = {
         let progressSpinner = ActivityIndicatorView(size: .medium)
-        progressSpinner.isHidden = true
         return progressSpinner
     }()
 
@@ -391,7 +390,7 @@ open class SearchBar: UIView {
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
         if let window = window {
-            progressSpinner.tintColor = style.progressSpinnerColor(for: window)
+            progressSpinner.color = style.progressSpinnerColor(for: window)
         }
         cancelButton.setTitleColor(style.cancelButtonColor, for: .normal)
         attributePlaceholderText()

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -239,7 +239,7 @@ open class SearchBar: UIView {
 
     private var originalIsNavigationBarHidden: Bool = false
 
-    ///indicates search in progress
+    /// indicates search in progress
     @objc public lazy var progressSpinner: ActivityIndicatorView = {
         let progressSpinner = ActivityIndicatorView(size: .medium)
         return progressSpinner


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added a search progress spinner in search bar with spinner start+visible and stop+hide control given to user.

SearchBar.swift:
- inside search bar, added a new element for progress spinner which is enclosing the clear button in search bar.
- User will have control over hide/show and start/stop animating the progress spinner.
- tint color of progress spinner is kept same as that of other elements on search bar

NavigationControllerDemoController.swift
- Made the root controller to implement the search bar delegate
- Added a switch in root controller's view to let user select if they want to show progress spinner when user hits search or not
- upon updating the text in search bar or cancel button press, stopping+hiding the progress spinner 
- when user hits search for a keyword, the progress spinner appears and starts spinning (if above switch is enabled)

### Verification

- Validated that user is able to show and hide the spinner and start and stop the spinner animation depending on switch status
- validated that the other search bar controls are working as before.

| Before                                                                  | After                                                                 |
|----------------------------------------------|--------------------------------------------|
| No progress Spinner was present in search bar | Progress spinner ui element is added inside search bar surrounding clear button |

### Screenshots

![Simulator Screen Shot - iPhone 8 Plus - 2020-08-15 at 00 08 10](https://user-images.githubusercontent.com/68395453/90282224-9a5fa000-de8b-11ea-9a5e-de698b402694.png)

![Simulator Screen Shot - iPhone 8 Plus - 2020-08-15 at 00 27 05](https://user-images.githubusercontent.com/68395453/90283706-3b4f5a80-de8e-11ea-8eb0-da4927eaf1c8.png)

![Simulator Screen Shot - iPhone 8 Plus - 2020-08-15 at 00 26 54](https://user-images.githubusercontent.com/68395453/90283715-40140e80-de8e-11ea-8f4e-89ad059ad517.png)

![Simulator Screen Shot - iPhone 8 Plus - 2020-08-15 at 00 26 44](https://user-images.githubusercontent.com/68395453/90283718-40aca500-de8e-11ea-83cf-159552f0a03f.png)

![Simulator Screen Shot - iPhone 8 Plus - 2020-08-15 at 00 28 52](https://user-images.githubusercontent.com/68395453/90283746-50c48480-de8e-11ea-97b6-b869a95c96f1.png)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/174)