### PR TITLE
Added gradient style to pill buttons

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -83,7 +83,7 @@ class PillButtonBarDemoController: DemoController {
     }
 
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsBackground: Bool = false) -> UIView {
-        let bar = PillButtonBar(pillButtonStyle: style)
+        let bar = useCustomPillsBackground ? PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: Colors.Palette.successShade20.color) : PillButtonBar(pillButtonStyle: style)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
         bar.barDelegate = self
@@ -96,10 +96,6 @@ class PillButtonBarDemoController: DemoController {
         let backgroundView = UIView()
         if style == .outline {
             backgroundView.backgroundColor = Colors.Navigation.System.background
-        }
-
-        if useCustomPillsBackground == true {
-            bar.pillsBackgroundColor(UIColor.black.withAlphaComponent(0.2))
         }
 
         backgroundView.addSubview(bar)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -30,17 +30,6 @@ class PillButtonBarDemoController: DemoController {
         self.filledBar = filledBar
         container.addArrangedSubview(UIView())
 
-        let disableGradientSwitchView = UISwitch()
-        disableGradientSwitchView.isOn = true
-        disableGradientSwitchView.addTarget(self, action: #selector(toggleGradientPills(switchView:)), for: .valueChanged)
-
-        container.addArrangedSubview(createLabelWithText("Gradient"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in Gradient Pill Bar below"), disableGradientSwitchView], itemSpacing: 20, centerItems: true)
-        let gradientBar = createBar(items: items, style: .gradient)
-        container.addArrangedSubview(gradientBar)
-        self.gradientBar = gradientBar
-        container.addArrangedSubview(UIView())
-
         let disableOutlinedSwitchView = UISwitch()
         disableOutlinedSwitchView.isOn = true
         disableOutlinedSwitchView.addTarget(self, action: #selector(toggleOutlinedPills(switchView:)), for: .valueChanged)
@@ -95,35 +84,11 @@ class PillButtonBarDemoController: DemoController {
         let backgroundView = UIView()
         if style == .outline {
             backgroundView.backgroundColor = Colors.Navigation.System.background
-        } else if style == .gradient {
-            backgroundView.backgroundColor = getCustomBackgroundColor(width: view.frame.width)
         }
-
         backgroundView.addSubview(bar)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0.0)
         fitViewIntoSuperview(bar, margins: margins)
         return backgroundView
-    }
-
-    func getCustomBackgroundColor(width: CGFloat) -> UIColor {
-        let startColor: UIColor = #colorLiteral(red: 0.01404584414, green: 0.4073548353, blue: 0.8523316062, alpha: 1)
-        let midColor: UIColor = #colorLiteral(red: 0.2156807228, green: 0.6311728202, blue: 0.9168139814, alpha: 1)
-        let endColor: UIColor = #colorLiteral(red: 0.3765182292, green: 0.7099975095, blue: 0.9298384652, alpha: 1)
-
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.frame = CGRect(x: 0.0, y: 0.0, width: width, height: 1.0)
-        gradientLayer.colors = [startColor.cgColor, midColor.cgColor, endColor.cgColor]
-        gradientLayer.locations = [0.0, 0.5, 1.0]
-        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
-        gradientLayer.endPoint = CGPoint(x: 1.0, y: 0.5)
-
-        UIGraphicsBeginImageContext(gradientLayer.bounds.size)
-        if let context = UIGraphicsGetCurrentContext() {
-            gradientLayer.render(in: context)
-        }
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return UIColor(light: image != nil ? UIColor(patternImage: image!) : endColor, dark: Colors.Navigation.System.background)
     }
 
     func createLabelWithText(_ text: String = "") -> Label {
@@ -166,19 +131,12 @@ class PillButtonBarDemoController: DemoController {
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
-    @objc private func toggleGradientPills(switchView: UISwitch) {
-        let pillBar = self.gradientBar?.subviews[0] as! PillButtonBar
-        togglePills(pillBar: pillBar, enable: switchView.isOn)
-    }
-
     @objc private func toggleOutlinedPills(switchView: UISwitch) {
         let pillBar = self.outlineBar?.subviews[0] as! PillButtonBar
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
     private var filledBar: UIView?
-
-    private var gradientBar: UIView?
 
     private var outlineBar: UIView?
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -24,10 +24,21 @@ class PillButtonBarDemoController: DemoController {
         disableFilledSwitchView.addTarget(self, action: #selector(toggleFilledPills(switchView:)), for: .valueChanged)
 
         container.addArrangedSubview(createLabelWithText("Filled"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in Filled Pill Bar below"), disableFilledSwitchView], itemSpacing: 20, centerItems: true)
+        addRow(items: [createLabelWithText("Enable/Disable pills in Filled Pill Bar"), disableFilledSwitchView], itemSpacing: 20, centerItems: true)
         let filledBar = createBar(items: items, style: .filled)
         container.addArrangedSubview(filledBar)
         self.filledBar = filledBar
+        container.addArrangedSubview(UIView())
+
+        let disableCustomFilledSwitchView = UISwitch()
+        disableCustomFilledSwitchView.isOn = true
+        disableCustomFilledSwitchView.addTarget(self, action: #selector(toggleCustomFilledPills(switchView:)), for: .valueChanged)
+
+        container.addArrangedSubview(createLabelWithText("Filled With Custom Pills Background"))
+        addRow(items: [createLabelWithText("Enable/Disable pills in custom Filled Pill Bar"), disableCustomFilledSwitchView], itemSpacing: 20, centerItems: true)
+        let customBar = createBar(items: items, style: .filled, useCustomPillsBackground: true)
+        container.addArrangedSubview(customBar)
+        self.customBar = customBar
         container.addArrangedSubview(UIView())
 
         let disableOutlinedSwitchView = UISwitch()
@@ -35,7 +46,7 @@ class PillButtonBarDemoController: DemoController {
         disableOutlinedSwitchView.addTarget(self, action: #selector(toggleOutlinedPills(switchView:)), for: .valueChanged)
 
         container.addArrangedSubview(createLabelWithText("Outline"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in Outline Pill bar below"), disableOutlinedSwitchView], itemSpacing: 20, centerItems: true)
+        addRow(items: [createLabelWithText("Enable/Disable pills in Outline Pill bar"), disableOutlinedSwitchView], itemSpacing: 20, centerItems: true)
         let outlineBar = createBar(items: items)
         container.addArrangedSubview(outlineBar)
         self.outlineBar = outlineBar
@@ -67,10 +78,11 @@ class PillButtonBarDemoController: DemoController {
         super.viewDidAppear(animated)
         if let window = view.window {
             filledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
+            customBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
         }
     }
 
-    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false) -> UIView {
+    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsBackground: Bool = false) -> UIView {
         let bar = PillButtonBar(pillButtonStyle: style)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
@@ -85,6 +97,11 @@ class PillButtonBarDemoController: DemoController {
         if style == .outline {
             backgroundView.backgroundColor = Colors.Navigation.System.background
         }
+
+        if useCustomPillsBackground == true {
+            bar.pillsBackgroundColor(UIColor.black.withAlphaComponent(0.2))
+        }
+
         backgroundView.addSubview(bar)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0.0)
         fitViewIntoSuperview(bar, margins: margins)
@@ -131,12 +148,19 @@ class PillButtonBarDemoController: DemoController {
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
+    @objc private func toggleCustomFilledPills(switchView: UISwitch) {
+        let pillBar = self.customBar?.subviews[0] as! PillButtonBar
+        togglePills(pillBar: pillBar, enable: switchView.isOn)
+    }
+
     @objc private func toggleOutlinedPills(switchView: UISwitch) {
         let pillBar = self.outlineBar?.subviews[0] as! PillButtonBar
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
     private var filledBar: UIView?
+
+    private var customBar: UIView?
 
     private var outlineBar: UIView?
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -30,6 +30,17 @@ class PillButtonBarDemoController: DemoController {
         self.filledBar = filledBar
         container.addArrangedSubview(UIView())
 
+        let disableGradientSwitchView = UISwitch()
+        disableGradientSwitchView.isOn = true
+        disableGradientSwitchView.addTarget(self, action: #selector(toggleGradientPills(switchView:)), for: .valueChanged)
+
+        container.addArrangedSubview(createLabelWithText("Gradient"))
+        addRow(items: [createLabelWithText("Enable/Disable pills in Gradient Pill Bar below"), disableGradientSwitchView], itemSpacing: 20, centerItems: true)
+        let gradientBar = createBar(items: items, style: .gradient)
+        container.addArrangedSubview(gradientBar)
+        self.gradientBar = gradientBar
+        container.addArrangedSubview(UIView())
+
         let disableOutlinedSwitchView = UISwitch()
         disableOutlinedSwitchView.isOn = true
         disableOutlinedSwitchView.addTarget(self, action: #selector(toggleOutlinedPills(switchView:)), for: .valueChanged)
@@ -84,11 +95,35 @@ class PillButtonBarDemoController: DemoController {
         let backgroundView = UIView()
         if style == .outline {
             backgroundView.backgroundColor = Colors.Navigation.System.background
+        } else if style == .gradient {
+            backgroundView.backgroundColor = getCustomBackgroundColor(width: view.frame.width)
         }
+
         backgroundView.addSubview(bar)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0.0)
         fitViewIntoSuperview(bar, margins: margins)
         return backgroundView
+    }
+
+    func getCustomBackgroundColor(width: CGFloat) -> UIColor {
+        let startColor: UIColor = #colorLiteral(red: 0.01404584414, green: 0.4073548353, blue: 0.8523316062, alpha: 1)
+        let midColor: UIColor = #colorLiteral(red: 0.2156807228, green: 0.6311728202, blue: 0.9168139814, alpha: 1)
+        let endColor: UIColor = #colorLiteral(red: 0.3765182292, green: 0.7099975095, blue: 0.9298384652, alpha: 1)
+
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = CGRect(x: 0.0, y: 0.0, width: width, height: 1.0)
+        gradientLayer.colors = [startColor.cgColor, midColor.cgColor, endColor.cgColor]
+        gradientLayer.locations = [0.0, 0.5, 1.0]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1.0, y: 0.5)
+
+        UIGraphicsBeginImageContext(gradientLayer.bounds.size)
+        if let context = UIGraphicsGetCurrentContext() {
+            gradientLayer.render(in: context)
+        }
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return UIColor(light: image != nil ? UIColor(patternImage: image!) : endColor, dark: Colors.Navigation.System.background)
     }
 
     func createLabelWithText(_ text: String = "") -> Label {
@@ -131,12 +166,19 @@ class PillButtonBarDemoController: DemoController {
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
+    @objc private func toggleGradientPills(switchView: UISwitch) {
+        let pillBar = self.gradientBar?.subviews[0] as! PillButtonBar
+        togglePills(pillBar: pillBar, enable: switchView.isOn)
+    }
+
     @objc private func toggleOutlinedPills(switchView: UISwitch) {
         let pillBar = self.outlineBar?.subviews[0] as! PillButtonBar
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
     private var filledBar: UIView?
+
+    private var gradientBar: UIView?
 
     private var outlineBar: UIView?
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -83,7 +83,7 @@ class PillButtonBarDemoController: DemoController {
     }
 
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsBackground: Bool = false) -> UIView {
-        let bar = useCustomPillsBackground ? PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: Colors.Palette.successShade20.color) : PillButtonBar(pillButtonStyle: style)
+        let bar = PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: useCustomPillsBackground ? Colors.Palette.successShade20.color : nil)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
         bar.barDelegate = self

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -83,7 +83,7 @@ class PillButtonBarDemoController: DemoController {
     }
 
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsBackground: Bool = false) -> UIView {
-        let bar = PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: useCustomPillsBackground ? Colors.Palette.successShade20.color : nil)
+        let bar = PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: useCustomPillsBackground ? Colors.Palette.communicationBlueShade30.color : nil)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
         bar.barDelegate = self

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -131,7 +131,7 @@ open class PillButton: UIButton {
     }
 
     /// Set `backgroundColor` to customize background color of the pill button
-    @objc open var customBackgroundColor: UIColor = Colors.Drawer.background {
+    @objc open var customBackgroundColor: UIColor? {
         didSet {
             useCustomBackgroundColor = true
             self.backgroundColor = customBackgroundColor

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -198,11 +198,7 @@ open class PillButton: UIButton {
                     setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
                 }
             } else {
-                if useCustomBackgroundColor {
-                    backgroundColor = customBackgroundColor
-                } else {
-                    backgroundColor = style.backgroundColor(for: window)
-                }
+                backgroundColor = useCustomBackgroundColor ? customBackgroundColor : style.backgroundColor(for: window)
                 if isEnabled {
                     setTitleColor(style.titleColor, for: .normal)
                 } else {

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -110,6 +110,8 @@ open class PillButton: UIButton {
         static let topInset: CGFloat = 6.0
     }
 
+    private var useCustomBackgroundColor: Bool = false
+
     @objc public let pillBarItem: PillButtonBarItem
 
     @objc public let style: PillButtonStyle
@@ -125,6 +127,14 @@ open class PillButton: UIButton {
         didSet {
             updateAppearance()
             updateAccessibilityTraits()
+        }
+    }
+
+    /// Set `backgroundColor` to customize background color of the pill button
+    @objc open var customBackgroundColor: UIColor = Colors.Drawer.background {
+        didSet {
+            useCustomBackgroundColor = true
+            self.backgroundColor = customBackgroundColor
         }
     }
 
@@ -188,7 +198,11 @@ open class PillButton: UIButton {
                     setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
                 }
             } else {
-                backgroundColor = style.backgroundColor(for: window)
+                if useCustomBackgroundColor {
+                    backgroundColor = customBackgroundColor
+                } else {
+                    backgroundColor = style.backgroundColor(for: window)
+                }
                 if isEnabled {
                     setTitleColor(style.titleColor, for: .normal)
                 } else {

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -17,9 +17,6 @@ public extension Colors {
         public struct Filled {
             public static var title = UIColor(light: textOnAccent, dark: Outline.title)
         }
-        public struct Gradient {
-            public static var background = UIColor(light: UIColor.black.withAlphaComponent(0.2), dark: surfaceSecondary)
-        }
     }
 }
 
@@ -32,7 +29,6 @@ public typealias MSPillButtonStyle = PillButtonStyle
 public enum PillButtonStyle: Int {
     case outline
     case filled
-    case gradient
 
     func backgroundColor(for window: UIWindow) -> UIColor {
         switch self {
@@ -40,8 +36,6 @@ public enum PillButtonStyle: Int {
             return Colors.PillButton.Outline.background
         case .filled:
             return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.PillButton.Outline.background)
-        case .gradient:
-            return UIColor(light: Colors.PillButton.Gradient.background, dark: Colors.PillButton.Outline.background)
         }
     }
 
@@ -50,8 +44,6 @@ public enum PillButtonStyle: Int {
         case .outline:
             return UIColor(light: Colors.primary(for: window), dark: Colors.surfaceQuaternary)
         case .filled:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        case .gradient:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
@@ -62,8 +54,6 @@ public enum PillButtonStyle: Int {
             return Colors.PillButton.Outline.title
         case .filled:
             return Colors.PillButton.Filled.title
-        case .gradient:
-            return Colors.PillButton.Filled.title
         }
     }
 
@@ -72,8 +62,6 @@ public enum PillButtonStyle: Int {
         case .outline:
             return  Colors.PillButton.Outline.titleSelected
         case .filled:
-            return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
-        case .gradient:
             return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
         }
     }
@@ -84,8 +72,6 @@ public enum PillButtonStyle: Int {
             return Colors.textDisabled
         case .filled:
             return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
-        case .gradient:
-            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
         }
     }
 
@@ -95,8 +81,6 @@ public enum PillButtonStyle: Int {
             return Colors.surfaceQuaternary
         case .filled:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        case .gradient:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
 
@@ -105,8 +89,6 @@ public enum PillButtonStyle: Int {
         case .outline:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
         case .filled:
-            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
-        case .gradient:
             return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -17,6 +17,9 @@ public extension Colors {
         public struct Filled {
             public static var title = UIColor(light: textOnAccent, dark: Outline.title)
         }
+        public struct Gradient {
+            public static var background = UIColor(light: UIColor.black.withAlphaComponent(0.2), dark: surfaceSecondary)
+        }
     }
 }
 
@@ -29,6 +32,7 @@ public typealias MSPillButtonStyle = PillButtonStyle
 public enum PillButtonStyle: Int {
     case outline
     case filled
+    case gradient
 
     func backgroundColor(for window: UIWindow) -> UIColor {
         switch self {
@@ -36,6 +40,8 @@ public enum PillButtonStyle: Int {
             return Colors.PillButton.Outline.background
         case .filled:
             return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.PillButton.Outline.background)
+        case .gradient:
+            return UIColor(light: Colors.PillButton.Gradient.background, dark: Colors.PillButton.Outline.background)
         }
     }
 
@@ -44,6 +50,8 @@ public enum PillButtonStyle: Int {
         case .outline:
             return UIColor(light: Colors.primary(for: window), dark: Colors.surfaceQuaternary)
         case .filled:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
+        case .gradient:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
@@ -54,6 +62,8 @@ public enum PillButtonStyle: Int {
             return Colors.PillButton.Outline.title
         case .filled:
             return Colors.PillButton.Filled.title
+        case .gradient:
+            return Colors.PillButton.Filled.title
         }
     }
 
@@ -62,6 +72,8 @@ public enum PillButtonStyle: Int {
         case .outline:
             return  Colors.PillButton.Outline.titleSelected
         case .filled:
+            return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
+        case .gradient:
             return UIColor(light: Colors.primary(for: window), dark: Colors.PillButton.Outline.titleSelected)
         }
     }
@@ -72,6 +84,8 @@ public enum PillButtonStyle: Int {
             return Colors.textDisabled
         case .filled:
             return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
+        case .gradient:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
         }
     }
 
@@ -81,6 +95,8 @@ public enum PillButtonStyle: Int {
             return Colors.surfaceQuaternary
         case .filled:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
+        case .gradient:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
 
@@ -89,6 +105,8 @@ public enum PillButtonStyle: Int {
         case .outline:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
         case .filled:
+            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
+        case .gradient:
             return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -137,8 +137,11 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
-    @objc public init(pillButtonStyle: PillButtonStyle = .outline) {
+    private var customPillButtonBackgroundColor:UIColor?
+
+    @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil) {
         self.pillButtonStyle = pillButtonStyle
+        self.customPillButtonBackgroundColor = pillButtonBackgroundColor
         super.init(frame: .zero)
         setupScrollView()
         setupStackView()
@@ -226,6 +229,9 @@ open class PillButtonBar: UIScrollView {
             buttons.append(button)
             stackView.addArrangedSubview(button)
             button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+            if let customButtonBackgroundColor = self.customPillButtonBackgroundColor {
+                button.customBackgroundColor = customButtonBackgroundColor
+            }
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -148,6 +148,10 @@ open class PillButtonBar: UIScrollView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+    @objc public func pillsBackgroundColor(_ backgroundColor: UIColor) {
+        buttons.forEach { $0.customBackgroundColor = backgroundColor }
+    }
+
     @objc public func selectItem(_ item: PillButtonBarItem) {
         guard let index = indexOfButtonWithItem(item) else {
             return

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -115,6 +115,8 @@ open class PillButtonBar: UIScrollView {
         return view
     }()
 
+    private var customPillButtonBackgroundColor: UIColor?
+
     private var leadingConstraint: NSLayoutConstraint?
 
     private var centerConstraint: NSLayoutConstraint?
@@ -137,8 +139,6 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
-    private var customPillButtonBackgroundColor:UIColor?
-
     @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil) {
         self.pillButtonStyle = pillButtonStyle
         self.customPillButtonBackgroundColor = pillButtonBackgroundColor
@@ -149,10 +149,6 @@ open class PillButtonBar: UIScrollView {
 
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    @objc public func pillsBackgroundColor(_ backgroundColor: UIColor) {
-        buttons.forEach { $0.customBackgroundColor = backgroundColor }
     }
 
     @objc public func selectItem(_ item: PillButtonBarItem) {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -139,6 +139,13 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
+    @objc public init(pillButtonStyle: PillButtonStyle = .outline) {
+        self.pillButtonStyle = pillButtonStyle
+        super.init(frame: .zero)
+        setupScrollView()
+        setupStackView()
+    }
+
     @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil) {
         self.pillButtonStyle = pillButtonStyle
         self.customPillButtonBackgroundColor = pillButtonBackgroundColor

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -139,11 +139,8 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
-    @objc public init(pillButtonStyle: PillButtonStyle = .outline) {
-        self.pillButtonStyle = pillButtonStyle
-        super.init(frame: .zero)
-        setupScrollView()
-        setupStackView()
+    @objc public convenience init(pillButtonStyle: PillButtonStyle = .outline) {
+        self.init(pillButtonStyle: pillButtonStyle, pillButtonBackgroundColor: nil)
     }
 
     @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Exposed a new property in PillButtonBar to allow user to set the background color of pills in default state.

PillButton.swift
- Exposed a variable pillCustomBackground to store the custom background set by user for pills
- everytime the appearance of pill is updated for default pills, the background if updated to the user provided custom color.

PillButtonBarDemoController.swift
- added a new view with pills bar with custom background set for pills. Added a switch to disable these pills as well.


### Verification

- Added a new pill bar in demo controller on top of a gradient background and verified that the custom background color is applied and only for pills in default state
- Also, added a swift to enable/disable custom pills

| Before                                                        | After                                                       |
|----------------------------------------------|--------------------------------------------|
| User did not had ability to set pill's background color | user can set background color for pills |

### Snapshots

![Simulator Screen Shot - iPhone X - 2020-08-12 at 22 50 55](https://user-images.githubusercontent.com/68395453/90049054-ed055480-dcf1-11ea-9014-841d2cc0afa3.png)

![Simulator Screen Shot - iPhone X - 2020-08-12 at 22 50 48](https://user-images.githubusercontent.com/68395453/90049076-f1ca0880-dcf1-11ea-92cd-f4f86e575347.png)

![Simulator Screen Shot - iPhone X - 2020-08-12 at 12 11 53](https://user-images.githubusercontent.com/68395453/90049079-f2629f00-dcf1-11ea-8cb8-b934857063d6.png)

![Simulator Screen Shot - iPhone X - 2020-08-12 at 12 11 47](https://user-images.githubusercontent.com/68395453/90049082-f2fb3580-dcf1-11ea-85e1-5caf0b95e7f3.png)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/175)