### PR TITLE
Add MSF prefix for ObjC name

### DIFF
--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -43,7 +43,7 @@ open class FileAccessoryViewAction: NSObject {
 // MARK: - TableViewCellFileAccessoryView
 
 /// Class that represents a table view cell accessory view representing a file or folder.
-@objc (TableViewCellFileAccessoryView)
+@objc (MSFTableViewCellFileAccessoryView)
 open class TableViewCellFileAccessoryView: UIView {
     /// The date will be displayed in a friendly format in the accessory view's first column.
     @objc public var date: Date? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Class is missing "MSF" prefix for ObjC name.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/180)