### PR TITLE
Add large content interaction for buttons in table view cell file accessory views

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Help_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Help_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_help_24_outlined.pdf"
+      "filename" : "ic_help_24_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Help_Selected_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Help_Selected_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_help_24_filled.pdf"
+      "filename" : "ic_help_24_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Home_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Home_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_home_24_outlined.pdf"
+      "filename" : "ic_home_24_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Home_Selected_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Home_Selected_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_home_24_filled.pdf"
+      "filename" : "ic_home_24_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_add_to_24_outlined.pdf"
+      "filename" : "ic_add_to_24_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_28.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_28.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_add_to_28_outlined.pdf"
+      "filename" : "ic_add_to_28_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_Selected_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_Selected_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_add_to_24_filled.pdf"
+      "filename" : "ic_add_to_24_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_Selected_28.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/New_Selected_28.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_add_to_28_filled.pdf"
+      "filename" : "ic_add_to_28_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_folder_24_outlined.pdf"
+      "filename" : "ic_folder_24_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_28.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_28.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_folder_28_outlined.pdf"
+      "filename" : "ic_folder_28_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_Selected_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_Selected_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_folder_24_filled.pdf"
+      "filename" : "ic_folder_24_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_Selected_28.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Open_Selected_28.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_folder_28_filled.pdf"
+      "filename" : "ic_folder_28_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Settings_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Settings_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_settings_24_outlined.pdf"
+      "filename" : "ic_settings_24_outlined.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Settings_Selected_24.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TabBarView/Settings_Selected_24.imageset/Contents.json
@@ -1,15 +1,16 @@
 {
   "images" : [
     {
-      "idiom" : "universal",
-      "filename" : "ic_settings_24_filled.pdf"
+      "filename" : "ic_settings_24_filled.pdf",
+      "idiom" : "universal"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -380,6 +380,13 @@ private class FileAccessoryViewActionView: UIButton {
             widthAnchor.constraint(equalToConstant: FileAccessoryViewActionView.size.width),
             heightAnchor.constraint(greaterThanOrEqualToConstant: FileAccessoryViewActionView.size.height)
         ])
+
+        if #available(iOS 13, *) {
+            addInteraction(UILargeContentViewerInteraction())
+            showsLargeContentViewer = true
+            scalesLargeContentImage = true
+            largeContentTitle = action.title
+        }
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added a large content interaction for buttons in table view cell file accessory views.

Note that large text accessibility is not supported in the demo controller for these cells because the cells are not being added to a UITableView. The cells do support large text accessibility.

<img width="1046" alt="Screen Shot 2020-08-05 at 4 56 52 PM" src="https://user-images.githubusercontent.com/4185114/89475388-d16fdc00-d73c-11ea-8b6d-9ae9dc97e1b8.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/181)