### PR TITLE
Fix for callback not being called on avatar var view tap in SideTabBar

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -164,7 +164,7 @@ open class SideTabBar: UIView {
         return createStackView(spacing: Constants.bottomItemSpacing)
     }()
 
-    private let avatarViewGestureRecognizer: UITapGestureRecognizer = {
+    private lazy var avatarViewGestureRecognizer: UITapGestureRecognizer = {
         return UITapGestureRecognizer(target: self, action: #selector(handleAvatarViewTapped))
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The callback for the tap even in the SideTabBar's AvatarView was not getting called.
This is because the gesture recognizer was being initialized with self as the target before the constructor is called.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/188)