### PR TITLE
Update ContactCollectionView data source

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ContactCollectionViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ContactCollectionViewDemoController.swift
@@ -7,6 +7,34 @@ import FluentUI
 import UIKit
 
 class ContactCollectionViewDemoController: UIViewController {
+    let samplePersonas: [AvatarData] = [
+        AvatarData(primaryText: "Kat", secondaryText: "Larrson", image: UIImage(named: "avatar_kat_larsson")),
+        AvatarData(primaryText: "Kristin", secondaryText: "Patterson", image: nil),
+        AvatarData(primaryText: "Ashley", secondaryText: "McCarthy", image: UIImage(named: "avatar_ashley_mccarthy")),
+        AvatarData(primaryText: "Allan", secondaryText: "Munger", image: UIImage(named: "avatar_allan_munger")),
+        AvatarData(primaryText: "Amanda", secondaryText: "Brady", image: UIImage(named: "avatar_amanda_brady")),
+        AvatarData(primaryText: "Kevin", secondaryText: "Sturgis", image: nil),
+        AvatarData(primaryText: "Lydia", secondaryText: "Bauer", image: UIImage(named: "avatar_lydia_bauer")),
+        AvatarData(primaryText: "Robin", secondaryText: "Counts", image: UIImage(named: "avatar_robin_counts")),
+        AvatarData(primaryText: "Tim", secondaryText: "Deboer", image: UIImage(named: "avatar_tim_deboer")),
+        AvatarData(primaryText: "wanda.howard@contoso.com", secondaryText: "", image: nil),
+        AvatarData(primaryText: "Daisy", secondaryText: "Phillips", image: UIImage(named: "avatar_daisy_phillips")),
+        AvatarData(primaryText: "Katri", secondaryText: "Ahokas", image: UIImage(named: "avatar_katri_ahokas")),
+        AvatarData(primaryText: "Colin", secondaryText: "Ballinger", image: UIImage(named: "avatar_colin_ballinger")),
+        AvatarData(primaryText: "Mona", secondaryText: "Kane", image: nil),
+        AvatarData(primaryText: "Elvia", secondaryText: "Atkins", image: UIImage(named: "avatar_elvia_atkins")),
+        AvatarData(primaryText: "Johnie", secondaryText: "McConnell", image: UIImage(named: "avatar_johnie_mcconnell")),
+        AvatarData(primaryText: "Charlotte", secondaryText: "Waltsson", image: nil),
+        AvatarData(primaryText: "Mauricio", secondaryText: "August", image: UIImage(named: "avatar_mauricio_august")),
+        AvatarData(primaryText: "Robert", secondaryText: "Tolbert", image: UIImage(named: "avatar_robert_tolbert")),
+        AvatarData(primaryText: "Isaac", secondaryText: "Fielder", image: UIImage(named: "avatar_isaac_fielder")),
+        AvatarData(primaryText: "Carole", secondaryText: "Poland", image: nil),
+        AvatarData(primaryText: "Elliot", secondaryText: "Woodward", image: nil),
+        AvatarData(primaryText: "carlos.slattery@contoso.com", secondaryText: "", image: nil),
+        AvatarData(primaryText: "Henry", secondaryText: "Brill", image: UIImage(named: "avatar_henry_brill")),
+        AvatarData(primaryText: "Cecil", secondaryText: "Folk", image: UIImage(named: "avatar_cecil_folk"))
+    ]
+
     private let contactCollectionView = ContactCollectionView()
 
     override func viewDidLoad() {
@@ -28,8 +56,8 @@ class ContactCollectionViewDemoController: UIViewController {
 }
 
 extension ContactCollectionViewDemoController: ContactCollectionViewDelegate {
-    func didTapOnContactViewAtIndex(index: Int, personaData: PersonaData) {
-        let identifier = personaData.name.count > 0 ? personaData.name : personaData.email
+    func didTapOnContactViewAtIndex(index: Int, avatarData: AvatarData) {
+        let identifier = avatarData.secondaryText.count > 0 ? "\(avatarData.primaryText) \(avatarData.secondaryText)"  : avatarData.primaryText
         let alert = UIAlertController(title: "\(identifier) was selected", message: nil, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: nil)
         alert.addAction(action)

--- a/ios/FluentUI/People Picker/ContactCollectionView.swift
+++ b/ios/FluentUI/People Picker/ContactCollectionView.swift
@@ -11,7 +11,7 @@ public typealias MSFContactCollectionViewDelegate = ContactCollectionViewDelegat
 
 @objc(MSFContactCollectionViewDelegate)
 public protocol ContactCollectionViewDelegate: AnyObject {
-    @objc optional func didTapOnContactViewAtIndex(index: Int, personaData: PersonaData)
+    @objc optional func didTapOnContactViewAtIndex(index: Int, avatarData: AvatarData)
 }
 
 // MARK: ContactCollectionView
@@ -22,14 +22,14 @@ open class ContactCollectionView: UICollectionView {
     /// Initializes the collection view by setting the layout, constraints, and cell to be used.
     ///
     /// - Parameters:
-    ///   - personaData: Array of PersonaData used to create each individual ContactView
-    @objc public init(personaData: [PersonaData] = []) {
+    ///   - avatarData: Array of AvatarData used to create each individual ContactView
+    @objc public init(avatarData: [AvatarData] = []) {
         layout = ContactCollectionViewLayout()
         layout.scrollDirection = .horizontal
         super.init(frame: .zero, collectionViewLayout: layout)
 
-        if personaData.count > 0 {
-            contactList = personaData
+        if avatarData.count > 0 {
+            contactList = avatarData
         }
 
         heightConstraint.isActive = true
@@ -43,9 +43,9 @@ open class ContactCollectionView: UICollectionView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    /// The array of PersonaData which is used to create each ContactView.
+    /// The array of AvatarData which is used to create each ContactView.
     /// The height constraint of the ContactCollectionView is updated when the count increases from 0 or decreases to 0.
-    @objc public var contactList: [PersonaData] = [] {
+    @objc public var contactList: [AvatarData] = [] {
         didSet {
             if (oldValue.count == 0 && contactList.count > 0) || (oldValue.count > 0 && contactList.count == 0) {
                 setupHeightConstraint()
@@ -117,7 +117,7 @@ extension ContactCollectionView: ContactViewDelegate {
         if let contactCollectionViewDelegate = contactCollectionViewDelegate, let currentTappedIndex = contactViewToIndexMap[contact] {
             let indexPath = IndexPath(item: currentTappedIndex, section: 0)
             scrollToContact(at: indexPath)
-            contactCollectionViewDelegate.didTapOnContactViewAtIndex?(index: currentTappedIndex, personaData: contactList[currentTappedIndex])
+            contactCollectionViewDelegate.didTapOnContactViewAtIndex?(index: currentTappedIndex, avatarData: contactList[currentTappedIndex])
         }
     }
 }
@@ -141,23 +141,23 @@ extension UIContentSizeCategory {
     var contactHeight: CGFloat {
         switch self {
         case .extraSmall:
-            return 115.0
-        case .small:
             return 117.0
+        case .small:
+            return 119.0
         case .medium:
-            return 118.0
+            return 120.0
         case .large:
-            return 121.0
+            return 123.0
         case .extraLarge:
-            return 125.0
+            return 127.0
         case .extraExtraLarge:
-            return 129.0
+            return 131.0
         case .extraExtraExtraLarge, .accessibilityMedium,
              .accessibilityLarge, .accessibilityExtraLarge,
              .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge:
-            return 135.0
+            return 137.0
         default:
-            return 135.0
+            return 137.0
         }
     }
 }

--- a/ios/FluentUI/People Picker/ContactCollectionViewCell.swift
+++ b/ios/FluentUI/People Picker/ContactCollectionViewCell.swift
@@ -18,12 +18,16 @@ class ContactCollectionViewCell: UICollectionViewCell {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    func setup(contact persona: PersonaData) {
-        let identifier = (persona.name.count > 0) ? persona.name : persona.email
-        contactView = ContactView(identifier: identifier)
+    func setup(contact avatar: AvatarData) {
+        if avatar.primaryText.count > 0 && avatar.secondaryText.count > 0 {
+            contactView = ContactView(title: avatar.primaryText, subtitle: avatar.secondaryText)
+        } else {
+            contactView = ContactView(identifier: avatar.primaryText)
+        }
+
         contactView.translatesAutoresizingMaskIntoConstraints = false
 
-        if let avatarImage = persona.avatarImage {
+        if let avatarImage = avatar.image {
             contactView.avatarImage = avatarImage
         }
 

--- a/ios/FluentUI/People Picker/ContactCollectionViewLayout.swift
+++ b/ios/FluentUI/People Picker/ContactCollectionViewLayout.swift
@@ -105,7 +105,7 @@ class ContactCollectionViewLayout: UICollectionViewFlowLayout {
     }
 
     private struct Constants {
-        static let itemWidth: CGFloat = 70.0
+        static let itemWidth: CGFloat = AvatarSize.extraExtraLarge.size.width
         static let minLineSpacing: CGFloat = 14.0
         static let maxLineSpacing: CGFloat = 16.0
     }

--- a/ios/FluentUI/People Picker/ContactView.swift
+++ b/ios/FluentUI/People Picker/ContactView.swift
@@ -144,12 +144,17 @@ open class ContactView: UIControl {
     }
 
     private func labelContainerLayoutConstraints() -> [NSLayoutConstraint] {
+        let contactHeight = UIApplication.shared.preferredContentSizeCategory.contactHeight
+        let avatarHeight = AvatarSize.extraExtraLarge.size.height
+        let spacingHeight = Constants.spacingBetweenAvatarAndLabelContainer
+        let height = contactHeight - avatarHeight - spacingHeight
+
         return [
             labelContainer.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: Constants.spacingBetweenAvatarAndLabelContainer),
             labelContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             labelContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             labelContainer.bottomAnchor.constraint(equalTo: bottomAnchor),
-            labelContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: 2.0 * Constants.labelMinimumHeight)
+            labelContainer.heightAnchor.constraint(equalToConstant: height)
         ]
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Changing the data source from `PersonaData` to `AvatarData` as `PersonaData` doesn't allow for the separation between first name and last name (which `AvatarData` does allow). This allows the displayed text to more closely match the design redlines.

#### ContactCollectionViewDemoController.swift
- Changed how the demo data is being supplied

#### ContactCollectionView.swift
- Change occurrences of `personaData` to `avatarData`
- Update the heights of each size category since the size of `AvatarViews` were changed to snap to a 4px grid in #119 

#### ContactCollectionViewCell.swift
- Change occurrences of `personaData` to `avatarData`
- Use both initializers of `ContactView` in order to properly show subtitles in a different font and colour

#### ContactCollectionViewLayout.swift
- Change hardcoded value to reference other constant to prevent "forgotten updates" when a constant is changed (such as when `AvatarViews` were snapped to a 4px grid and the constraints for `AvatarView` in `ContactView` weren't updates respectively.

#### ContactView.swift
- Use a calculated height constraint to be more specific (instead of just a minimum)

### Verification

Manual verification by observing the iOS simulator.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/15377548/90292620-18458c00-de37-11ea-8144-3cd97d28ee3e.png) | ![image](https://user-images.githubusercontent.com/15377548/90292432-b7b64f00-de36-11ea-9643-447eb014169c.png) |
| ![image](https://user-images.githubusercontent.com/15377548/90292646-2a272f00-de37-11ea-8050-6ae1e7c2574f.png) | ![image](https://user-images.githubusercontent.com/15377548/90292362-96edf980-de36-11ea-97d2-275c0b963bc6.png) |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/192)