### PR TITLE
Make the image tinting utility method public

### DIFF
--- a/ios/FluentUI/Extensions/UIImage+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIImage+Extensions.swift
@@ -5,15 +5,15 @@
 
 import UIKit
 
-extension UIImage {
-    class func staticImageNamed(_ name: String) -> UIImage? {
+@objc public extension UIImage {
+    internal class func staticImageNamed(_ name: String) -> UIImage? {
         guard let image = UIImage(named: name, in: FluentUIFramework.resourceBundle, compatibleWith: nil) else {
             preconditionFailure("Missing image asset with name: \(name)")
         }
         return image
     }
 
-    func image(withPrimaryColor primaryColor: UIColor) -> UIImage {
+    @objc func image(withPrimaryColor primaryColor: UIColor) -> UIImage {
         if #available(iOS 13.0, *) {
             return self.withTintColor(primaryColor, renderingMode: .alwaysOriginal)
         } else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

FluentUI has an internal method that makes it easy to tint images on iOS 12 and 13 using different APIs based on availability.
Let's expose this utility method outside of the framework since it is useful.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/195)