### PR TITLE
remove isImageAppTinted in TabBarItemView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -64,8 +64,14 @@ class SideTabBarDemoController: DemoController {
             TabBarItem(title: "Open", image: UIImage(named: "Open_28")!, selectedImage: UIImage(named: "Open_Selected_28")!)
         ]
 
+        var premiumImage = UIImage(named: "ic_fluent_premium_24_regular")!
+        if let window = view.window {
+            let primaryColor = Colors.primary(for: window)
+            premiumImage = premiumImage.image(withPrimaryColor: primaryColor)
+        }
+
         sideTabBar.bottomItems = [
-            TabBarItem(title: "Go Premium", image: UIImage(named: "ic_fluent_premium_24_regular")!, isImageAppTinted: true),
+            TabBarItem(title: "Go Premium", image: premiumImage),
             TabBarItem(title: "Help", image: UIImage(named: "Help_24")!),
             TabBarItem(title: "Settings", image: UIImage(named: "Settings_24")!)
         ]

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -10,8 +10,13 @@ public typealias MSTabBarItem = TabBarItem
 
 @objc(MSFTabBarItem)
 open class TabBarItem: NSObject {
-    /// The item's title
     @objc public let title: String
+    let image: UIImage
+    let selectedImage: UIImage?
+    let landscapeImage: UIImage?
+    let landscapeSelectedImage: UIImage?
+    let largeContentImage: UIImage?
+    let accessibilityLabelBadgeFormatString: String?
 
     /// The badge value will be displayed in a red oval above the tab bar item.
     /// Set the badge value to nil to hide the red oval.
@@ -33,45 +38,12 @@ open class TabBarItem: NSObject {
         }
     }
 
-    /// Initializes `TabBarItem`
-    /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
-    /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
-    @objc public convenience init(title: String, image: UIImage) {
-        self.init(title: title,
-                  image: image,
-                  isImageAppTinted: false,
-                  selectedImage: nil,
-                  landscapeImage: nil,
-                  landscapeSelectedImage: nil,
-                  largeContentImage: nil,
-                  accessibilityLabelBadgeFormatString: nil)
-    }
+    /// Notification sent when the tab bar item's badge value changes.
+    static let badgeValueDidChangeNotification: NSNotification.Name = NSNotification.Name(rawValue: "TabBarItemBadgeValueDidChangeNotification")
 
-    /// Initializes `TabBarItem`
+    /// Initializes `TabBarItem
     /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
     /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
-    /// - Parameter selectedImage: Used for imageView when tabbar item view is selected.  If it is nil, it will use `image`.
-    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. The image will be used in portrait mode if the tab bar item shows a label.
-    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
-    @objc public convenience init(title: String,
-                                  image: UIImage,
-                                  selectedImage: UIImage? = nil,
-                                  landscapeImage: UIImage? = nil,
-                                  landscapeSelectedImage: UIImage? = nil) {
-        self.init(title: title,
-                  image: image,
-                  isImageAppTinted: false,
-                  selectedImage: selectedImage,
-                  landscapeImage: landscapeImage,
-                  landscapeSelectedImage: landscapeSelectedImage,
-                  largeContentImage: nil,
-                  accessibilityLabelBadgeFormatString: nil)
-    }
-
-    /// Initializes `TabBarItem`
-    /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
-    /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
-    /// - Parameter isImageAppTinted: Set to true if the image should be app tinted, false otherwise. Note that the selected image will always be app tinted.
     /// - Parameter selectedImage: Used for imageView when tabbar item view is selected.  If it is nil, it will use `image`.
     /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. The image will be used in portrait mode if the tab bar item shows a label.
     /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
@@ -79,14 +51,12 @@ open class TabBarItem: NSObject {
     /// - Parameter accessibilityLabelBadgeFormatString: Format string to use for the tabbar item's accessibility label when the badge number is greater than zero. When the badge number is zero, the accessibility label is set to the item's title. By default, when the badge number is greater than zero, the following format is used to builds the accessibility label: "%@, %ld items" where the item's title and the badge number are used to populate the format specifiers. If a format string is provided through this parameter, it must contain "%@" and "%ld" in the same order and will be populated with the title and badge number.
     @objc public init(title: String,
                       image: UIImage,
-                      isImageAppTinted: Bool = false,
                       selectedImage: UIImage? = nil,
                       landscapeImage: UIImage? = nil,
                       landscapeSelectedImage: UIImage? = nil,
                       largeContentImage: UIImage? = nil,
                       accessibilityLabelBadgeFormatString: String? = nil) {
         self.image = image
-        self.isImageAppTinted = isImageAppTinted
         self.selectedImage = selectedImage
         self.title = title
         self.largeContentImage = largeContentImage
@@ -95,17 +65,6 @@ open class TabBarItem: NSObject {
         self.accessibilityLabelBadgeFormatString = accessibilityLabelBadgeFormatString
         super.init()
     }
-
-    /// Notification sent when the tab bar item's badge value changes.
-    static let badgeValueDidChangeNotification = NSNotification.Name(rawValue: "TabBarItemBadgeValueDidChangeNotification")
-
-    let image: UIImage
-    let isImageAppTinted: Bool
-    let selectedImage: UIImage?
-    let landscapeImage: UIImage?
-    let landscapeSelectedImage: UIImage?
-    let largeContentImage: UIImage?
-    let accessibilityLabelBadgeFormatString: String?
 
     func selectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -201,7 +201,7 @@ class TabBarItemView: UIView {
         if let window = window {
             let primaryColor = Colors.primary(for: window)
             titleLabel.highlightedTextColor = primaryColor
-            imageView.tintColor = isSelected || item.isImageAppTinted ? primaryColor : Constants.unselectedColor
+            imageView.tintColor = isSelected ? primaryColor : Constants.unselectedColor
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Now that we expose tinting colors for UIImage through our extension, this is a partial revert of d38fa9c 

### Verification

|                                       |                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2020-08-19 at 12 03 57 PM](https://user-images.githubusercontent.com/20715435/90685872-45bb7c80-e21f-11ea-8472-38c9d14f480d.png) | ![Screen Shot 2020-08-19 at 12 05 09 PM](https://user-images.githubusercontent.com/20715435/90685876-48b66d00-e21f-11ea-89f3-39656baf1804.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
