### PR TITLE
SideTabBar spacing should not only rely on safe layout guides

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -177,6 +177,9 @@ open class SideTabBar: UIView {
         }
 
         if let avatarView = avatarView {
+            // The avatar view's distance from the top of the side tab bar depends on safe layout guides.
+            // There is a minimum spacing. If the layout guide spacing is large than the minimum spacing,
+            // then the spacing will be layoutGuideSpacing + safeTopSpacing.
             let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewSafeTopSpacing)
             topSafeConstraint.priority = .defaultHigh
 

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -134,10 +134,10 @@ open class SideTabBar: UIView {
         static let maxTabCount: Int = 5
         static let viewWidth: CGFloat = 62
         static let avatarViewSafeTopSpacing: CGFloat = 18
-		static let avatarViewMinTopSpacing: CGFloat = 36
+        static let avatarViewMinTopSpacing: CGFloat = 36
         static let avatarViewTopStackViewSpacing: CGFloat = 34
         static let bottomStackViewSafeSpacing: CGFloat = 14
-		static let bottomStackViewMinSpacing: CGFloat = 24
+        static let bottomStackViewMinSpacing: CGFloat = 24
         static let topItemSpacing: CGFloat = 32
         static let bottomItemSpacing: CGFloat = 24
         static let topItemSize: CGFloat = 28
@@ -177,12 +177,12 @@ open class SideTabBar: UIView {
         }
 
         if let avatarView = avatarView {
-			let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewSafeTopSpacing)
-			topSafeConstraint.priority = .defaultHigh
+            let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewSafeTopSpacing)
+            topSafeConstraint.priority = .defaultHigh
 
             layoutConstraints.append(contentsOf: [
                 topSafeConstraint,
-				avatarView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: Constants.avatarViewMinTopSpacing),
+                avatarView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: Constants.avatarViewMinTopSpacing),
                 avatarView.centerXAnchor.constraint(equalTo: centerXAnchor),
                 topStackView.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: Constants.avatarViewTopStackViewSpacing)
             ])
@@ -190,8 +190,8 @@ open class SideTabBar: UIView {
             layoutConstraints.append(topStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.topItemSpacing))
         }
 
-		let bottomSafeConstraint = bottomStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Constants.bottomStackViewSafeSpacing)
-		bottomSafeConstraint.priority = .defaultHigh
+        let bottomSafeConstraint = bottomStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Constants.bottomStackViewSafeSpacing)
+        bottomSafeConstraint.priority = .defaultHigh
 
         layoutConstraints.append(contentsOf: [
             topStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -199,7 +199,7 @@ open class SideTabBar: UIView {
             bottomStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             bottomStackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor),
             bottomSafeConstraint,
-			bottomStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -Constants.bottomStackViewMinSpacing)
+            bottomStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -Constants.bottomStackViewMinSpacing)
         ])
 
         NSLayoutConstraint.activate(layoutConstraints)

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -132,16 +132,18 @@ open class SideTabBar: UIView {
 
     private struct Constants {
         static let maxTabCount: Int = 5
-        static let viewWidth: CGFloat = 62.0
-        static let avatarViewTopPadding: CGFloat = 18.0
-        static let avatarViewTopStackViewPadding: CGFloat = 34.0
-        static let bottomStackViewBottomPadding: CGFloat = 14.0
-        static let topItemSpacing: CGFloat = 32.0
-        static let bottomItemSpacing: CGFloat = 24.0
-        static let topItemSize: CGFloat = 28.0
-        static let bottomItemSize: CGFloat = 24.0
-        static let badgeTopSectionPadding: CGFloat = 2.0
-        static let badgeBottomSectionPadding: CGFloat = 4.0
+        static let viewWidth: CGFloat = 62
+        static let avatarViewSafeTopSpacing: CGFloat = 18
+		static let avatarViewMinTopSpacing: CGFloat = 36
+        static let avatarViewTopStackViewSpacing: CGFloat = 34
+        static let bottomStackViewSafeSpacing: CGFloat = 14
+		static let bottomStackViewMinSpacing: CGFloat = 24
+        static let topItemSpacing: CGFloat = 32
+        static let bottomItemSpacing: CGFloat = 24
+        static let topItemSize: CGFloat = 28
+        static let bottomItemSize: CGFloat = 24
+        static let badgeTopSectionPadding: CGFloat = 2
+        static let badgeBottomSectionPadding: CGFloat = 4
     }
 
     private var layoutConstraints: [NSLayoutConstraint] = []
@@ -175,21 +177,29 @@ open class SideTabBar: UIView {
         }
 
         if let avatarView = avatarView {
+			let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewSafeTopSpacing)
+			topSafeConstraint.priority = .defaultHigh
+
             layoutConstraints.append(contentsOf: [
-                avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewTopPadding),
+                topSafeConstraint,
+				avatarView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: Constants.avatarViewMinTopSpacing),
                 avatarView.centerXAnchor.constraint(equalTo: centerXAnchor),
-                topStackView.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: Constants.avatarViewTopStackViewPadding)
+                topStackView.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: Constants.avatarViewTopStackViewSpacing)
             ])
         } else {
             layoutConstraints.append(topStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.topItemSpacing))
         }
+
+		let bottomSafeConstraint = bottomStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Constants.bottomStackViewSafeSpacing)
+		bottomSafeConstraint.priority = .defaultHigh
 
         layoutConstraints.append(contentsOf: [
             topStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             topStackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor),
             bottomStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             bottomStackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor),
-            bottomStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Constants.bottomStackViewBottomPadding)
+            bottomSafeConstraint,
+			bottomStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -Constants.bottomStackViewMinSpacing)
         ])
 
         NSLayoutConstraint.activate(layoutConstraints)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently, the SideTabBar layout assumes that safe layout guides are not at the edges of the screen.
This causes the layout to look bad on older devices that don't have spacing for safe layout guides.
Let's set the minimum top and bottom spacing according to the spacing in the red lines for the side tab bar.
In case the safe layout guides have a lot of space, let's keep the old constraints that add space relative to the layout guides. We'll lower the priority of the constraints.

### Verification
- Tested on many different iPad devices with/without bezels.
- Tested on iPhone (even though SideTabBar is not meant to be used on iPhone)

Before:
<img width="807" alt="before" src="https://user-images.githubusercontent.com/4185114/91100681-7eda5f00-e61a-11ea-827d-4dcd3d493401.png">

After:
<img width="613" alt="after" src="https://user-images.githubusercontent.com/4185114/91100717-8994f400-e61a-11ea-8dd5-fb2b8ac775ce.png">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/201)