### PR TITLE
Top accessory view for navigation bar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -31,6 +31,9 @@ class NavigationControllerDemoController: DemoController {
 
         addTitle(text: "Custom Navigation Bar Color")
         container.addArrangedSubview(createButton(title: "Show with gradient navigation bar color", action: #selector(showLargeTitleWithCustomizedColor)))
+
+        addTitle(text: "Top Accessory View")
+        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
     }
 
     @objc func showLargeTitle() {
@@ -83,15 +86,28 @@ class NavigationControllerDemoController: DemoController {
         presentController(withLargeTitle: true, style: .primary, accessoryView: createAccessoryView(), showAvatar: false)
     }
 
+    @objc func showWithTopSearchBar() {
+        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false)
+    }
+
     @discardableResult
-    private func presentController(withLargeTitle useLargeTitle: Bool, style: NavigationBar.Style = .primary, accessoryView: UIView? = nil, contractNavigationBarOnScroll: Bool = true, showShadow: Bool = true, showAvatar: Bool = true) -> NavigationController {
+    private func presentController(withLargeTitle useLargeTitle: Bool,
+                                   style: NavigationBar.Style = .primary,
+                                   accessoryView: UIView? = nil,
+                                   showsTopAccessory: Bool = false,
+                                   contractNavigationBarOnScroll: Bool = true,
+                                   showShadow: Bool = true,
+                                   showAvatar: Bool = true) -> NavigationController {
         let content = RootViewController()
         content.navigationItem.usesLargeTitle = useLargeTitle
         content.navigationItem.navigationBarStyle = style
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
+        content.navigationItem.topAccessoryViewAttributes = createTopAccessoryViewAttributes()
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTabs = !showShadow
+        content.showsTopAccessoryView = showsTopAccessory
+
         if style == .custom {
             content.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
         }
@@ -122,11 +138,19 @@ class NavigationControllerDemoController: DemoController {
         return controller
     }
 
-    private func createAccessoryView(with style: SearchBar.Style = .lightContent) -> UIView {
+    private func createAccessoryView(with style: SearchBar.Style = .lightContent) -> SearchBar {
         let searchBar = SearchBar()
         searchBar.style = style
         searchBar.placeholderText = "Search"
         return searchBar
+    }
+
+    private func createTopAccessoryViewAttributes() -> NavigationBarTopAccessoryViewAttributes {
+        let attributes = NavigationBarTopAccessoryViewAttributes(widthMultiplier: Constants.topAccessoryViewWidthMultiplier,
+                                                                 maxWidth: Constants.topAccessoryViewMaxWidth,
+                                                                 minWidth: Constants.topAccessoryViewMinWidth)
+
+        return attributes
     }
 
     private func presentSideDrawer(presentingGesture: UIPanGestureRecognizer? = nil) {
@@ -150,6 +174,12 @@ class NavigationControllerDemoController: DemoController {
         if gesture.state == .began {
             presentSideDrawer(presentingGesture: gesture)
         }
+    }
+
+    private struct Constants {
+        static let topAccessoryViewWidthMultiplier: CGFloat = 0.375
+        static let topAccessoryViewMinWidth: CGFloat = 264
+        static let topAccessoryViewMaxWidth: CGFloat = 552
     }
 }
 
@@ -231,6 +261,8 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
     }
 
+    var showsTopAccessoryView: Bool = false
+
     private var isInSelectionMode: Bool = false {
         didSet {
             tableView.allowsMultipleSelection = isInSelectionMode
@@ -276,9 +308,10 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if self.navigationItem.accessoryView != nil {
+        if navigationItem.accessoryView != nil {
             container.addArrangedSubview(searchProgressSpinnerSwitchView)
         }
+
         container.addArrangedSubview(tableView)
         updateNavigationTitle()
         updateLeftBarButtonItems()
@@ -292,6 +325,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             tabBarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tabBarView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ]
+
         NSLayoutConstraint.activate(tabBarViewConstraints)
     }
 
@@ -307,6 +341,28 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         navigationBarFrameObservation = navigationController?.navigationBar.observe(\.frame, options: [.old, .new]) { [unowned self] navigationBar, change in
             if change.newValue?.width != change.oldValue?.width && self.navigationItem.navigationBarStyle == .custom {
                 self.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: navigationBar.frame.width)
+            }
+        }
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        if showsTopAccessoryView {
+            let showTopAccessoryView = view.frame.size.width >= Constants.topAccessoryViewWidthThreshold
+
+            if showTopAccessoryView && navigationItem.accessoryView != nil {
+                let accessoryView = navigationItem.accessoryView as! SearchBar
+                accessoryView.hidesNavigationBarDuringSearch = false
+
+                navigationItem.accessoryView = nil
+                navigationItem.topAccessoryView = accessoryView
+            } else if !showTopAccessoryView && navigationItem.topAccessoryView != nil {
+                let accessoryView = navigationItem.topAccessoryView as! SearchBar
+                accessoryView.hidesNavigationBarDuringSearch = true
+
+                navigationItem.topAccessoryView = nil
+                navigationItem.accessoryView = accessoryView
             }
         }
     }
@@ -405,7 +461,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 // MARK: - RootViewController: SearchBarDelegate
 
 extension RootViewController: SearchBarDelegate {
-
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
         searchBar.progressSpinner.stopAnimating()
     }
@@ -421,6 +476,10 @@ extension RootViewController: SearchBarDelegate {
         if showSearchProgressSpinner {
             searchBar.progressSpinner.startAnimating()
         }
+    }
+
+    private struct Constants {
+        static let topAccessoryViewWidthThreshold: CGFloat = 768
     }
 }
 

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -152,6 +152,18 @@ open class SearchBar: UIView {
         static let defaultStyle: Style = .lightContent
     }
 
+    @objc open var hidesNavigationBarDuringSearch: Bool = true {
+        didSet {
+            if oldValue != hidesNavigationBarDuringSearch && isActive {
+                if hidesNavigationBarDuringSearch {
+                    hideNavigationBar()
+                } else {
+                    unhideNavigationBar()
+                }
+            }
+        }
+    }
+
     @objc open var cornerRadius: CGFloat = Constants.searchTextFieldCornerRadius {
         didSet {
             searchTextField.layer.cornerRadius = cornerRadius
@@ -268,14 +280,16 @@ open class SearchBar: UIView {
         if isActive {
             return
         }
+
         attributePlaceholderText()
         showCancelButton()
-        originalIsNavigationBarHidden = navigationController?.isNavigationBarHidden ?? false
-        // Using delayed async to work around a bug on iOS when it restores responder status for the text field when controller appears (due to navigation controller's pop action) even though text field resigned responder status before a detail controller was pushed
-        let isTransitioning = navigationController?.transitionCoordinator != nil
-        DispatchQueue.main.asyncAfter(deadline: .now() + (isTransitioning ? Constants.navigationBarTransitionHidingDelay : 0)) {
-            self.navigationController?.setNavigationBarHidden(true, animated: true)
+
+        if hidesNavigationBarDuringSearch {
+            originalIsNavigationBarHidden = navigationController?.isNavigationBarHidden ?? false
+
+            hideNavigationBar()
         }
+
         isActive = true
     }
 
@@ -283,12 +297,28 @@ open class SearchBar: UIView {
         if !isActive {
             return
         }
+
         isActive = false
         searchTextField.resignFirstResponder()
         searchTextField.text = nil
         searchTextDidChange(shouldUpdateDelegate: false)
         delegate?.searchBarDidCancel(self)
         hideCancelButton()
+
+        if hidesNavigationBarDuringSearch {
+            unhideNavigationBar()
+        }
+    }
+
+    private func hideNavigationBar() {
+        // Using delayed async to work around a bug on iOS when it restores responder status for the text field when controller appears (due to navigation controller's pop action) even though text field resigned responder status before a detail controller was pushed
+        let isTransitioning = navigationController?.transitionCoordinator != nil
+        DispatchQueue.main.asyncAfter(deadline: .now() + (isTransitioning ? Constants.navigationBarTransitionHidingDelay : 0)) {
+            self.navigationController?.setNavigationBarHidden(true, animated: true)
+        }
+    }
+
+    private func unhideNavigationBar() {
         navigationController?.setNavigationBarHidden(originalIsNavigationBarHidden, animated: true)
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -214,7 +214,8 @@ open class NavigationBar: UINavigationBar {
     private let contentStackView = ContentStackView() //used to contain the various custom UI Elements
     private let rightBarButtonItemsStackView = UIStackView()
     private let leftBarButtonItemsStackView = UIStackView()
-    private let leadingSpacerView = UIView()
+    private let trailingSpacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
+    private let leadingSpacerView = UIView() //defines the trailing space between the left and right barbuttonitems stack
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
@@ -232,6 +233,12 @@ open class NavigationBar: UINavigationBar {
     private var rightBarButtonItemsObserver: NSKeyValueObservation?
     private var titleObserver: NSKeyValueObservation?
     private var navigationBarColorObserver: NSKeyValueObservation?
+    private var accessoryViewObserver: NSKeyValueObservation?
+    private var topAccessoryViewObserver: NSKeyValueObservation?
+    private var topAccessoryViewAttributesObserver: NSKeyValueObservation?
+    private var navigationBarStyleObserver: NSKeyValueObservation?
+    private var navigationBarShadowObserver: NSKeyValueObservation?
+    private var usesLargeTitleObserver: NSKeyValueObservation?
 
     @objc public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -274,7 +281,6 @@ open class NavigationBar: UINavigationBar {
         leadingSpacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         //trailingSpacerView
-        let trailingSpacerView = UIView()
         contentStackView.addArrangedSubview(trailingSpacerView)
         trailingSpacerView.backgroundColor = .clear
         trailingSpacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
@@ -462,13 +468,6 @@ open class NavigationBar: UINavigationBar {
         }
     }
 
-    @objc private func updateNavigationItem(notification: NSNotification) {
-        let item = notification.object as? UINavigationItem
-        if let item = item {
-            update(with: item)
-        }
-    }
-
     func update(with navigationItem: UINavigationItem) {
         let (actualStyle, actualItem) = actualStyleAndItem(for: navigationItem)
         style = actualStyle
@@ -476,15 +475,6 @@ open class NavigationBar: UINavigationBar {
         showsLargeTitle = navigationItem.usesLargeTitle
         updateShadow(for: navigationItem)
         updateTopAccessoryView(for: navigationItem)
-
-        NotificationCenter.default.removeObserver(self,
-                                                  name: UINavigationItem.navigationItemDidChangeNotification,
-                                                  object: nil)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(updateNavigationItem(notification:)),
-                                               name: UINavigationItem.navigationItemDidChangeNotification,
-                                               object: navigationItem)
 
         titleView.update(with: navigationItem)
 
@@ -501,6 +491,24 @@ open class NavigationBar: UINavigationBar {
             self.navigationItemDidUpdate(item)
         }
         titleObserver = navigationItem.observe(\UINavigationItem.title) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        accessoryViewObserver = navigationItem.observe(\UINavigationItem.accessoryView) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        topAccessoryViewObserver = navigationItem.observe(\UINavigationItem.topAccessoryView) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        topAccessoryViewAttributesObserver = navigationItem.observe(\UINavigationItem.topAccessoryViewAttributes) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        navigationBarStyleObserver = navigationItem.observe(\UINavigationItem.navigationBarStyle) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        navigationBarShadowObserver = navigationItem.observe(\UINavigationItem.navigationBarShadow) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        usesLargeTitleObserver = navigationItem.observe(\UINavigationItem.usesLargeTitle) { [unowned self] item, _ in
             self.navigationItemDidUpdate(item)
         }
     }

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -8,6 +8,8 @@ import UIKit
 @objc public extension UINavigationItem {
     private struct AssociatedKeys {
         static var accessoryView: String = "accessoryView"
+        static var topAccessoryView: String = "topAccessoryView"
+        static var topAccessoryViewAttributes: String = "topAccessoryViewAttributes"
         static var contentScrollView: String = "contentScrollView"
         static var navigationBarStyle: String = "navigationBarStyle"
         static var navigationBarShadow: String = "navigationBarShadow"
@@ -15,12 +17,35 @@ import UIKit
         static var customNavigationBarColor: String = "customNavigationBarColor"
     }
 
+    static let navigationItemDidChangeNotification = NSNotification.Name(rawValue: "MSFNavigationItemDidChangeNotification")
+
     var accessoryView: UIView? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.accessoryView) as? UIView
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.accessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
+        }
+    }
+
+    var topAccessoryView: UIView? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.topAccessoryView) as? UIView
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.topAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
+        }
+    }
+
+    var topAccessoryViewAttributes: NavigationBarTopAccessoryViewAttributes? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.topAccessoryViewAttributes) as? NavigationBarTopAccessoryViewAttributes
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.topAccessoryViewAttributes, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -30,6 +55,7 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.contentScrollView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -39,6 +65,7 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.navigationBarStyle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -48,6 +75,7 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.navigationBarShadow, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -57,6 +85,7 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.usesLargeTitle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -70,6 +99,7 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.customNavigationBarColor, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 }

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -17,15 +17,12 @@ import UIKit
         static var customNavigationBarColor: String = "customNavigationBarColor"
     }
 
-    static let navigationItemDidChangeNotification = NSNotification.Name(rawValue: "MSFNavigationItemDidChangeNotification")
-
     var accessoryView: UIView? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.accessoryView) as? UIView
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.accessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -35,7 +32,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.topAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -45,7 +41,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.topAccessoryViewAttributes, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -55,7 +50,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.contentScrollView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -65,7 +59,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.navigationBarStyle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -75,7 +68,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.navigationBarShadow, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -85,7 +77,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.usesLargeTitle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 
@@ -99,7 +90,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.customNavigationBarColor, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UINavigationItem.navigationItemDidChangeNotification, object: self)
         }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add support for a top accessory view in the FluentUI navigation bar.
For now, this top accessory view will always be centered and uses a new class called NavigationBarTopAccessoryViewAttributes to configure its layout. It should be relatively straight forward in the future to add more to this class to configure the position of the top accessory view differently.

The immediate need for the top accessory view is to support a SearchBar that can move between the top section of the navigation bar and the default bottom section depending on the screen's width.
The demo controller implements this behavior with a new option called "Show with top search bar for large screen width".

To support the search bar scenario, we also need to add a property in SearchBar to prevent it from hiding the navigation bar when a search is in progress. We only want to hide the navigation bar if the SearchBar is in the default bottom section.

Side change:
When the custom UINavigationItem properties are changed, we can reflect those change in the navigation bar by sending/handling a notification. Otherwise, changes to these properties are not reflected until the view controller is re-presented.

### Verification

- Tested on iPhone and iPad.
- Test iPad compact/regular size transitions.
- Make sure that nothing has changed in the navigation bar when the top accessory view is nil.
- Start a search while the search bar is in the top section. Reduce the size of the window. Observe that the search bar moves to the bottom section and maintains the same state. Make sure that the navigation bar's title hides as expected. 
- Test the opposite transition from the bottom section to top section.

<img width="1063" alt="Screen Shot 2020-08-24 at 10 30 02 PM" src="https://user-images.githubusercontent.com/4185114/91127450-237c9100-e65b-11ea-898d-f8d95e6c2c47.png">

![Untitled](https://user-images.githubusercontent.com/4185114/91127864-fd0b2580-e65b-11ea-9c56-6bc81f7a3ad8.gif)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility 
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/202)