### PR TITLE
Spacing adjustments for FileAccessoryViewAction

### DIFF
--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -131,7 +131,7 @@ open class TableViewCellFileAccessoryView: UIView {
     private struct Constants {
         static let layoutBreakPoints: [CGFloat] = [424, 504, 584, 616, 752, 900, 1092]
         static let maxVisibleActionCount: UInt8 = 4
-        static let  minimumViewHeight: CGFloat = 24
+        static let minimumViewHeight: CGFloat = 24
         static let actionsSpacingDefault: CGFloat = 16
         static let actionsSpacingLarge: CGFloat = 24
         static let columnSpacing: CGFloat = 24

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -129,17 +129,18 @@ open class TableViewCellFileAccessoryView: UIView {
     }
 
     private struct Constants {
-        static let layoutBreakPoints: [CGFloat] = [424.0, 504.0, 584.0, 616.0, 752.0, 900.0, 1092.0]
+        static let layoutBreakPoints: [CGFloat] = [424, 504, 584, 616, 752, 900, 1092]
         static let maxVisibleActionCount: UInt8 = 4
-        static let minimumViewHeight: CGFloat = 24.0
-        static let actionsSpacingDefault: CGFloat = 16.0
-        static let actionsSpacingLarge: CGFloat = 24.0
-        static let columnSpacing: CGFloat = 24.0
-        static let reservedCellSpace: [CGFloat] = [460.0, 600.0]
-        static let columnMinWidth: CGFloat = 150.0
-        static let fullDateMinWidth: CGFloat = 170.0
-        static let sharedIconSize: CGFloat = 24.0
-        static let sharedStatusSpacing: CGFloat = 8.0
+        static let minimumViewHeight: CGFloat = 24
+        static let actionsSpacingDefault: CGFloat = 16
+        static let actionsSpacingLarge: CGFloat = 24
+        static let columnSpacing: CGFloat = 24
+        static let leadingOffset: CGFloat = 8
+        static let reservedCellSpace: [CGFloat] = [460, 600]
+        static let columnMinWidth: CGFloat = 150
+        static let fullDateMinWidth: CGFloat = 170
+        static let sharedIconSize: CGFloat = 24
+        static let sharedStatusSpacing: CGFloat = 8
     }
 
     private lazy var actionsStackView: UIStackView = {
@@ -177,7 +178,7 @@ open class TableViewCellFileAccessoryView: UIView {
     }()
 
     private lazy var dateLabelWidth: NSLayoutConstraint = {
-        return dateLabel.widthAnchor.constraint(equalToConstant: 0.0)
+        return dateLabel.widthAnchor.constraint(equalToConstant: 0)
     }()
 
     private func updateSharedStatus() {
@@ -229,7 +230,7 @@ open class TableViewCellFileAccessoryView: UIView {
     }()
 
     private lazy var sharedStatusViewWidth: NSLayoutConstraint = {
-        return sharedStatusView.widthAnchor.constraint(equalToConstant: 0.0)
+        return sharedStatusView.widthAnchor.constraint(equalToConstant: 0)
     }()
 
     private func updateActions() {
@@ -312,18 +313,17 @@ open class TableViewCellFileAccessoryView: UIView {
         let isShowingDate = canShowFirstColumn && date != nil
         let isShowingSharedStatus = showSharedStatus && (canShowSecondColumn || (canShowFirstColumn && !isShowingDate))
 
-        var columnWidth: CGFloat = 0.0
+        var columnWidth: CGFloat = 0
         if isShowingDate || isShowingSharedStatus {
-            columnWidth = cellSize.width - reservedCellSpace - width
+            columnWidth = availableColumnSpace
 
             if isShowingDate && isShowingSharedStatus {
-                columnWidth = round(columnWidth / 2.0)
-                columnWidth -= Constants.columnSpacing
-                width += columnWidth + Constants.columnSpacing
+                columnWidth = round(columnWidth / 2) - 2 * Constants.columnSpacing
+                width += 2 * columnWidth + 2 * Constants.columnSpacing - Constants.leadingOffset
+            } else {
+                width += columnWidth
+                columnWidth -= 2 * Constants.columnSpacing - Constants.leadingOffset
             }
-
-            columnWidth -= Constants.columnSpacing
-            width += columnWidth + Constants.columnSpacing
         }
 
         dateLabel.removeFromSuperview()
@@ -342,6 +342,10 @@ open class TableViewCellFileAccessoryView: UIView {
             sharedStatusViewWidth.isActive = true
         }
 
+        if isShowingDate && isShowingSharedStatus {
+            columnStackView.setCustomSpacing(0, after: dateLabel)
+        }
+
         var height: CGFloat = FileAccessoryViewActionView.size.height
         if isShowingDate {
             height = max(height, dateLabel.intrinsicContentSize.height)
@@ -351,7 +355,7 @@ open class TableViewCellFileAccessoryView: UIView {
             height = max(height, sharedStatusLabel.intrinsicContentSize.height)
         }
 
-        let newFrame = CGRect(x: 0.0, y: 0.0, width: width, height: height)
+        let newFrame = CGRect(x: 0, y: 0, width: width, height: height)
 
         if !frame.equalTo(newFrame) {
             frame = newFrame
@@ -365,7 +369,7 @@ open class TableViewCellFileAccessoryView: UIView {
 // MARK: - FileAccessoryViewActionView
 
 private class FileAccessoryViewActionView: UIButton {
-    fileprivate static let size = CGSize(width: 24.0, height: 60.0)
+    fileprivate static let size = CGSize(width: 24, height: 60)
 
     fileprivate init(action: FileAccessoryViewAction, window: UIWindow) {
         super.init(frame: .zero)

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -131,7 +131,7 @@ open class TableViewCellFileAccessoryView: UIView {
     private struct Constants {
         static let layoutBreakPoints: [CGFloat] = [424, 504, 584, 616, 752, 900, 1092]
         static let maxVisibleActionCount: UInt8 = 4
-        static let minimumViewHeight: CGFloat = 24
+        static let  minimumViewHeight: CGFloat = 24
         static let actionsSpacingDefault: CGFloat = 16
         static let actionsSpacingLarge: CGFloat = 24
         static let columnSpacing: CGFloat = 24


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The date or shared column was off-center when FileAccessoryViewAction has a single row.
When FileAccessoryViewAction has two rows, the space between the date and shared columns needs to be reduced.

Before
<img width="1404" alt="Screen Shot 2020-08-26 at 10 24 27 AM" src="https://user-images.githubusercontent.com/4185114/91336300-90d91080-e786-11ea-8357-db70bdf163e4.png">
<img width="1404" alt="Screen Shot 2020-08-26 at 10 24 29 AM" src="https://user-images.githubusercontent.com/4185114/91336313-97678800-e786-11ea-9b5f-61875d27819e.png">

After
<img width="1404" alt="Screen Shot 2020-08-26 at 10 25 55 AM" src="https://user-images.githubusercontent.com/4185114/91336344-9f272c80-e786-11ea-9f6c-4a57f4f5186c.png">
<img width="1404" alt="Screen Shot 2020-08-26 at 10 25 52 AM" src="https://user-images.githubusercontent.com/4185114/91336366-a51d0d80-e786-11ea-9932-3f758eef4e15.png">

### Verification

- Test on iPhone and iPad.
- Test with single row and double row.
- Alternate between showing the shared and date row in single row mode.
- Measure the distance between rows and make sure that red lines are respected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/205)