### PR TITLE
Allow customization of NavigationBar's content margin

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -118,9 +118,6 @@ open class NavigationBar: UINavigationBar {
         static let leftBarButtonItemLeadingMargin: CGFloat = 8
         static let rightBarButtonItemHorizontalPadding: CGFloat = 10
 
-        static let contentLeadingMargin: CGFloat = 8
-        static let contentTrailingMargin: CGFloat = 6
-
         static let obscuringAnimationDuration: TimeInterval = 0.12
         static let revealingAnimationDuration: TimeInterval = 0.25
     }
@@ -183,6 +180,30 @@ open class NavigationBar: UINavigationBar {
     @objc open var onAvatarTapped: (() -> Void)? {
         didSet {
             titleView.onAvatarTapped = onAvatarTapped
+        }
+    }
+
+     /// The navigation bar's default leading content margin.
+    @objc public static let defaultContentLeadingMargin: CGFloat = 8
+
+     /// The navigation bar's default trailing content margin.
+    @objc public static let defaultContentTrailingMargin: CGFloat = 6
+
+    /// The navigation bar's leading content margin.
+    @objc open var contentLeadingMargin: CGFloat = defaultContentLeadingMargin {
+        didSet {
+            if oldValue != contentLeadingMargin {
+                updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
+            }
+        }
+    }
+
+    /// The navigation bar's leading content margin.
+    @objc open var contentTrailingMargin: CGFloat = defaultContentTrailingMargin{
+        didSet {
+            if oldValue != contentLeadingMargin {
+                updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
+            }
         }
     }
 
@@ -359,9 +380,9 @@ open class NavigationBar: UINavigationBar {
         let contentHeight = contentIsExpanded ? Constants.expandedContentHeight : Constants.normalContentHeight
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,
-            leading: Constants.contentLeadingMargin,
+            leading: contentLeadingMargin,
             bottom: -(contentHeight - Constants.systemHeight),
-            trailing: Constants.contentTrailingMargin
+            trailing: contentTrailingMargin
         )
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -199,7 +199,7 @@ open class NavigationBar: UINavigationBar {
     }
 
     /// The navigation bar's leading content margin.
-    @objc open var contentTrailingMargin: CGFloat = defaultContentTrailingMargin{
+    @objc open var contentTrailingMargin: CGFloat = defaultContentTrailingMargin {
         didSet {
             if oldValue != contentLeadingMargin {
                 updateContentStackViewMargins(forExpandedContent: contentIsExpanded)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The content margin of the navigation bar often varies based on the design. 
FluentUI needs to be more flexible and allow the customization of its NavigationBar's content margins (leading and trailing).

### Verification

- Test on iPhone and iPad (compact/regular).
- Set custom content margins and make sure that they are respected.
- Set the custom content margins after the navigation bar is presented. Make sure that the layout updates correctly.
- Make sure that nothing changed when the content margins are not customized.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/206)