### PR TITLE
Layout improvements for NavigationBar top accessory view

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -103,7 +103,7 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.navigationBarStyle = style
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
-        content.navigationItem.topAccessoryViewAttributes = createTopAccessoryViewAttributes()
+        content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTabs = !showShadow
         content.showsTopAccessoryView = showsTopAccessory
@@ -145,14 +145,6 @@ class NavigationControllerDemoController: DemoController {
         return searchBar
     }
 
-    private func createTopAccessoryViewAttributes() -> NavigationBarTopAccessoryViewAttributes {
-        let attributes = NavigationBarTopAccessoryViewAttributes(widthMultiplier: Constants.topAccessoryViewWidthMultiplier,
-                                                                 maxWidth: Constants.topAccessoryViewMaxWidth,
-                                                                 minWidth: Constants.topAccessoryViewMinWidth)
-
-        return attributes
-    }
-
     private func presentSideDrawer(presentingGesture: UIPanGestureRecognizer? = nil) {
         let meControl = Label(style: .title2, colorStyle: .regular)
         meControl.text = "Me Control goes here"
@@ -174,12 +166,6 @@ class NavigationControllerDemoController: DemoController {
         if gesture.state == .began {
             presentSideDrawer(presentingGesture: gesture)
         }
-    }
-
-    private struct Constants {
-        static let topAccessoryViewWidthMultiplier: CGFloat = 0.375
-        static let topAccessoryViewMinWidth: CGFloat = 264
-        static let topAccessoryViewMaxWidth: CGFloat = 552
     }
 }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -235,8 +235,7 @@ open class NavigationBar: UINavigationBar {
     private let contentStackView = ContentStackView() //used to contain the various custom UI Elements
     private let rightBarButtonItemsStackView = UIStackView()
     private let leftBarButtonItemsStackView = UIStackView()
-    private let trailingSpacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
-    private let leadingSpacerView = UIView() //defines the trailing space between the left and right barbuttonitems stack
+    private let spacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
@@ -295,19 +294,11 @@ open class NavigationBar: UINavigationBar {
         titleView.setContentHuggingPriority(.required, for: .horizontal)
         titleView.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        //leadingSpacerView
-        contentStackView.addArrangedSubview(leadingSpacerView)
-        leadingSpacerView.backgroundColor = .clear
-        leadingSpacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        leadingSpacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        //trailingSpacerView
-        contentStackView.addArrangedSubview(trailingSpacerView)
-        trailingSpacerView.backgroundColor = .clear
-        trailingSpacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        trailingSpacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        trailingSpacerView.widthAnchor.constraint(equalTo: leadingSpacerView.widthAnchor).isActive = true
+        //spacerView
+        contentStackView.addArrangedSubview(spacerView)
+        spacerView.backgroundColor = .clear
+        spacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         //rightBarButtonItemsStackView: layout priorities are slightly lower to make sure titleView has the highest priority in horizontal spacing
         contentStackView.addArrangedSubview(rightBarButtonItemsStackView)
@@ -330,8 +321,7 @@ open class NavigationBar: UINavigationBar {
         self.topAccessoryView = navigationItem?.topAccessoryView
 
         if let topAccessoryView = self.topAccessoryView {
-            let insertionIndex = contentStackView.arrangedSubviews.firstIndex(of: leadingSpacerView)! + 1
-            contentStackView.insertArrangedSubview(topAccessoryView, at: insertionIndex)
+            contentStackView.addSubview(topAccessoryView)
 
             NSLayoutConstraint.deactivate(topAccessoryViewConstraints)
             topAccessoryViewConstraints.removeAll()
@@ -345,7 +335,9 @@ open class NavigationBar: UINavigationBar {
                 topAccessoryViewConstraints.append(contentsOf: [
                     widthConstraint,
                     topAccessoryView.widthAnchor.constraint(lessThanOrEqualToConstant: attributes.maxWidth),
-                    topAccessoryView.widthAnchor.constraint(greaterThanOrEqualToConstant: attributes.minWidth)
+                    topAccessoryView.widthAnchor.constraint(greaterThanOrEqualToConstant: attributes.minWidth),
+                    topAccessoryView.centerXAnchor.constraint(equalTo: contentStackView.centerXAnchor),
+                    topAccessoryView.centerYAnchor.constraint(equalTo: contentStackView.centerYAnchor)
                 ])
 
                 NSLayoutConstraint.activate(topAccessoryViewConstraints)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -22,7 +22,7 @@ public extension Colors {
 
 // MARK: - NavigationBarTopAccessoryViewAttributes
 
-/// Attributes for a navigation bar's top accessory view.
+/// Layout attributes for a navigation bar's top accessory view.
 @objc(MSFNavigationBarTopAccessoryViewAttributes)
 open class NavigationBarTopAccessoryViewAttributes: NSObject {
     /// The width multiplier is the propotion of the navigation bar's width that the top accessory view will occupy.
@@ -39,6 +39,20 @@ open class NavigationBarTopAccessoryViewAttributes: NSObject {
         self.maxWidth = maxWidth
         self.minWidth = minWidth
         super.init()
+    }
+}
+
+/// Layout attributes for a navigation bar's top search bar.
+@objc(MSFNavigationBarTopSearchBarAttributes)
+open class NavigationBarTopSearchBarAttributes: NavigationBarTopAccessoryViewAttributes {
+    @objc public init() {
+        super.init(widthMultiplier: Constants.widthMultiplier, maxWidth: Constants.viewMaxWidth, minWidth: Constants.viewMinWidth)
+    }
+
+    private struct Constants {
+        static let widthMultiplier: CGFloat = 0.375
+        static let viewMinWidth: CGFloat = 264
+        static let viewMaxWidth: CGFloat = 552
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The layout logic for the top accessory view in NavigationBar works in a way that is probably not going to be optimal for most use cases. Currently, we add the top accessory view to the NavigationBar's horizontal stack view, in the center. Although this could be a valid way of positioning the top accessory view, it will most likely cause the top accessory view to not be centered horizontally inside the NavigationBar. Instead, the top accessory view will be centered between the title and right bar elements. In most scenarios, it is preferable to center the top accessory view in the NavigationBar.
We could make this a configuration param but this adds too much complexity to the API. Let's simply update the layout logic to center the top accessory view.

Also included in this change is a new class called NavigationBarTopSearchBarAttributes. This class inherits from NavigationBarTopAccessoryViewAttributes and provides default values for setting a search bar as the top accessory view. This will be useful to make the experience uniform across apps.

### Verification

Apply new layout logic, make sure that the top accessory view is centered correctly when using the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1364" alt="Screen Shot 2020-08-26 at 11 59 10 PM" src="https://user-images.githubusercontent.com/4185114/91408146-35476b00-e7f8-11ea-9881-8ac61e22dafc.png"> | <img width="1364" alt="Screen Shot 2020-08-26 at 11 58 16 PM" src="https://user-images.githubusercontent.com/4185114/91408118-2bbe0300-e7f8-11ea-9487-df47810185c8.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/207)