### PR TITLE
FluentUI.framework should not embed swift standard libraries by default

### DIFF
--- a/macos/xcode/FluentUI_framework.xcconfig
+++ b/macos/xcode/FluentUI_framework.xcconfig
@@ -15,7 +15,7 @@ INFOPLIST_EXPAND_BUILD_SETTINGS = YES
 CLANG_ENABLE_MODULES = YES
 DEFINES_MODULE = YES
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/Frameworks
-ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = $(inherited)
 
 // The framework specifies that it can be found relative to the RUNPATH hierarchy
 // that is specified by additional loader commands in other frameworks and apps


### PR DESCRIPTION
FluentUI.framework currently bundles all swift standard libraries by default.
This is currently increasing the framework bundle size by 11.1MB.

- libswiftAppKit.dylib
- libswiftCore.dylib
- libswiftCoreData.dylib
- libswiftCoreFoundation.dylib
- libswiftCoreGraphics.dylib
- libswiftCoreImage.dylib
- libswiftDarwin.dylib
- libswiftDispatch.dylib
- libswiftFoundation.dylib
- libswiftIOKit.dylib
- libswiftMetal.dylib
- libswiftObjectiveC.dylib
- libswiftQuartzCore.dylib
- libswiftXPC.dylib
- libswiftos.dylib

### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Changed the ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES setting to $(inherited) in the FluentUI_framework.xcconfig file.

### Verification

1. Confirmed the Frameworks folder in the bundle does not contain the list of standard libraries mentioned in the description.
2. Ran the FluentUI mac test app to ensure the libraries liked were provided from the OS, and not embedded in the framework.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/208)