### PR TITLE
Keep top accessory view in the nav bar's content stack view, use different constraints to center it

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -249,7 +249,8 @@ open class NavigationBar: UINavigationBar {
     private let contentStackView = ContentStackView() //used to contain the various custom UI Elements
     private let rightBarButtonItemsStackView = UIStackView()
     private let leftBarButtonItemsStackView = UIStackView()
-    private let spacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
+    private let leadingSpacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
+    private let trailingSpacerView = UIView() //defines the trailing space between the left and right barbuttonitems stack
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
@@ -308,11 +309,17 @@ open class NavigationBar: UINavigationBar {
         titleView.setContentHuggingPriority(.required, for: .horizontal)
         titleView.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        //spacerView
-        contentStackView.addArrangedSubview(spacerView)
-        spacerView.backgroundColor = .clear
-        spacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        spacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        //leadingSpacerView
+        contentStackView.addArrangedSubview(leadingSpacerView)
+        leadingSpacerView.backgroundColor = .clear
+        leadingSpacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        leadingSpacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        //trailingSpacerView
+        contentStackView.addArrangedSubview(trailingSpacerView)
+        trailingSpacerView.backgroundColor = .clear
+        trailingSpacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        trailingSpacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         //rightBarButtonItemsStackView: layout priorities are slightly lower to make sure titleView has the highest priority in horizontal spacing
         contentStackView.addArrangedSubview(rightBarButtonItemsStackView)
@@ -335,27 +342,34 @@ open class NavigationBar: UINavigationBar {
         self.topAccessoryView = navigationItem?.topAccessoryView
 
         if let topAccessoryView = self.topAccessoryView {
-            contentStackView.addSubview(topAccessoryView)
+            topAccessoryView.translatesAutoresizingMaskIntoConstraints = false
+
+            let insertionIndex = contentStackView.arrangedSubviews.firstIndex(of: leadingSpacerView)! + 1
+            contentStackView.insertArrangedSubview(topAccessoryView, at: insertionIndex)
 
             NSLayoutConstraint.deactivate(topAccessoryViewConstraints)
             topAccessoryViewConstraints.removeAll()
 
-            if let attributes = navigationItem?.topAccessoryViewAttributes {
-                topAccessoryView.translatesAutoresizingMaskIntoConstraints = false
+            topAccessoryViewConstraints.append(contentsOf: [
+                topAccessoryView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                topAccessoryView.centerYAnchor.constraint(equalTo: centerYAnchor)
+            ])
 
+            if let attributes = navigationItem?.topAccessoryViewAttributes {
                 let widthConstraint = topAccessoryView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: attributes.widthMultiplier)
                 widthConstraint.priority = .defaultHigh
 
+                let maxWidthConstraint = topAccessoryView.widthAnchor.constraint(lessThanOrEqualToConstant: attributes.maxWidth)
+                maxWidthConstraint.priority = .defaultHigh
+
                 topAccessoryViewConstraints.append(contentsOf: [
                     widthConstraint,
-                    topAccessoryView.widthAnchor.constraint(lessThanOrEqualToConstant: attributes.maxWidth),
-                    topAccessoryView.widthAnchor.constraint(greaterThanOrEqualToConstant: attributes.minWidth),
-                    topAccessoryView.centerXAnchor.constraint(equalTo: contentStackView.centerXAnchor),
-                    topAccessoryView.centerYAnchor.constraint(equalTo: contentStackView.centerYAnchor)
+                    maxWidthConstraint,
+                    topAccessoryView.widthAnchor.constraint(greaterThanOrEqualToConstant: attributes.minWidth)
                 ])
-
-                NSLayoutConstraint.activate(topAccessoryViewConstraints)
             }
+
+            NSLayoutConstraint.activate(topAccessoryViewConstraints)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In a previous change, the NavigationBar's top accessory view was moved out of the contentStackView. This caused a few bugs. The NavigationBar assumes that all its subviews are arranged subviews of the contentStackView.
Let's add the top accessory view back into the contentStackView, reverting most of the recent change.
We can make a small change to the layout constraints to center the top accessory view.

Regression was caused by https://github.com/microsoft/fluentui-apple/pull/207

### Verification

- Test VoiceOver accessibility on device.
- Test on iPhone and iPad.
- Test NavigationBar show/hide animations.
- Test compact/regular transitions and screen rotation.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/209)