### PR TITLE
Reverting change that removed swift standard libraries from the bundle.

### DIFF
--- a/macos/xcode/FluentUI_framework.xcconfig
+++ b/macos/xcode/FluentUI_framework.xcconfig
@@ -15,7 +15,7 @@ INFOPLIST_EXPAND_BUILD_SETTINGS = YES
 CLANG_ENABLE_MODULES = YES
 DEFINES_MODULE = YES
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/../Frameworks @loader_path/Frameworks
-ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = $(inherited)
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 
 // The framework specifies that it can be found relative to the RUNPATH hierarchy
 // that is specified by additional loader commands in other frameworks and apps


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

Removing swift standard libraries broke a test app.
Let's revert PR #208 so we can investigate a fix the issue.

### Verification

Rebuilt the library and ensured the swift system libraries were embedded in the framework.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/210)