### PR TITLE
Customize ShimmerView with individual properties instead of objects

### DIFF
--- a/ios/FluentUI/Shimmer/ShimmerAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerAppearance.swift
@@ -11,6 +11,8 @@ public typealias MSShimmerAppearance = ShimmerAppearance
 /**
  Object describing how a shimmer should look and function.
  */
+
+@available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerAppearance)
 public class ShimmerAppearance: NSObject {
     @objc public let alpha: CGFloat

--- a/ios/FluentUI/Shimmer/ShimmerAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerAppearance.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@available(*, deprecated, renamed: "ShimmerAppearance")
+@available(*, deprecated, renamed: "ShimmerAppearance", message: "Use individual properties instead")
 public typealias MSShimmerAppearance = ShimmerAppearance
 
 /**
@@ -15,27 +15,27 @@ public typealias MSShimmerAppearance = ShimmerAppearance
 @available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerAppearance)
 public class ShimmerAppearance: NSObject {
-    @objc public let alpha: CGFloat
-    @objc public let width: CGFloat
+	@objc public let alpha: CGFloat
+	@objc public let width: CGFloat
 
-    /// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
-    @objc public let angle: CGFloat
+	/// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
+	@objc public let angle: CGFloat
 
-    /// Speed of the animation, in point/seconds.
-    @objc public let speed: CGFloat
+	/// Speed of the animation, in point/seconds.
+	@objc public let speed: CGFloat
 
-    /// Delay between the end of a shimmering animation and the beginning of the next one.
-    @objc public let delay: TimeInterval
+	/// Delay between the end of a shimmering animation and the beginning of the next one.
+	@objc public let delay: TimeInterval
 
-    @objc public init(alpha: CGFloat = 0.4,
-                      width: CGFloat = 180,
-                      angle: CGFloat = -(CGFloat.pi / 45.0),
-                      speed: CGFloat = 350,
-                      delay: TimeInterval = 0.4) {
-        self.alpha = alpha
-        self.width = width
-        self.angle = angle
-        self.speed = speed
-        self.delay = delay
-    }
+	@objc public init(alpha: CGFloat = 0.4,
+					  width: CGFloat = 180,
+					  angle: CGFloat = -(CGFloat.pi / 45.0),
+					  speed: CGFloat = 350,
+					  delay: TimeInterval = 0.4) {
+		self.alpha = alpha
+		self.width = width
+		self.angle = angle
+		self.speed = speed
+		self.delay = delay
+	}
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -13,81 +13,120 @@ public typealias MSShimmerLinesView = ShimmerLinesView
  */
 @objc(MSFShimmerLinesView)
 open class ShimmerLinesView: ShimmerView {
-    @objc public static func sizeThatFits(_ size: CGSize, appearance: ShimmerLinesViewAppearance) -> CGSize {
-        let desiredLineCount = CGFloat(ShimmerLinesView.lineCount(for: appearance, availableHeight: size.height))
-        let height = desiredLineCount * appearance.lineHeight + (desiredLineCount - 1) * appearance.lineSpacing
-        return CGSize(width: size.width, height: height)
-    }
 
-    @objc private static func lineCount(for appearance: ShimmerLinesViewAppearance, availableHeight: CGFloat) -> Int {
-        if appearance.lineCount == 0 {
-            // Deduce lines count based on available height
-            return Int(floor((availableHeight + appearance.lineSpacing) / (appearance.lineHeight + appearance.lineSpacing)))
-        } else {
-            // Hardcoded lines count
-            return appearance.lineCount
-        }
-    }
+	@available(*, deprecated, message: "Use individual properties instead")
+	@objc public var shimmerLinesViewAppearance = ShimmerLinesViewAppearance() {
+		didSet {
+			lineCount = shimmerLinesViewAppearance.lineCount
+			lineHeight = shimmerLinesViewAppearance.lineHeight
+			lineSpacing = shimmerLinesViewAppearance.lineSpacing
+			firstLineFillPercent = shimmerLinesViewAppearance.firstLineFillPercent
+			lastLineFillPercent = shimmerLinesViewAppearance.lastLineFillPercent
 
-    @objc public var shimmerLinesViewAppearance = ShimmerLinesViewAppearance() {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+			setNeedsLayout()
+		}
+	}
 
-    open override func layoutSubviews() {
-        super.layoutSubviews()
+	/// Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+	@objc open var lineCount: Int = 3 {
+		didSet {
+			setNeedsLayout()
+		}
+	}
 
-        var currentTop: CGFloat = 0
-        for (index, linelayer) in viewCoverLayers.enumerated() {
-            let fillPercent: CGFloat = {
-                if index == 0 && viewCoverLayers.count > 2 {
-                    return shimmerLinesViewAppearance.firstLineFillPercent
-                } else if index == viewCoverLayers.count - 1 {
-                    return shimmerLinesViewAppearance.lastLineFillPercent
-                } else {
-                    return 1
-                }
-            }()
+	/// Height of shimmering line
+	@objc open var lineHeight: CGFloat = 11 {
+		didSet {
+			setNeedsLayout()
+		}
+	}
 
-            linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: shimmerLinesViewAppearance.lineHeight)
+	/// Spacing between lines (if lines > 1)
+	@objc open var lineSpacing: CGFloat = 11 {
+		didSet {
+			setNeedsLayout()
+		}
+	}
 
-            currentTop += shimmerLinesViewAppearance.lineHeight + shimmerLinesViewAppearance.lineSpacing
-        }
+	/// The percent the first line (if 2+ lines) should fill the available horizontal space
+	@objc open var firstLineFillPercent: CGFloat = 0.94 {
+		didSet {
+			setNeedsLayout()
+		}
+	}
 
-        shimmeringLayer.frame = CGRect(x: -shimmerAppearance.width, y: 0.0, width: frame.width + 2 * shimmerAppearance.width, height: frame.height)
+	/// The percent the last line should fill the available horizontal space.
+	@objc open var lastLineFillPercent: CGFloat = 0.6 {
+		didSet {
+			setNeedsLayout()
+		}
+	}
 
-        viewCoverLayers.forEach { $0.frame = flipRectForRTL($0.frame) }
+	open override func layoutSubviews() {
+		super.layoutSubviews()
 
-        updateShimmeringLayer()
-        updateShimmeringAnimation()
-    }
+		var currentTop: CGFloat = 0
+		for (index, linelayer) in viewCoverLayers.enumerated() {
+			let fillPercent: CGFloat = {
+				if index == 0 && viewCoverLayers.count > 2 {
+					return firstLineFillPercent
+				} else if index == viewCoverLayers.count - 1 {
+					return lastLineFillPercent
+				} else {
+					return 1
+				}
+			}()
 
-    open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        return ShimmerLinesView.sizeThatFits(size, appearance: shimmerLinesViewAppearance)
-    }
+			linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: lineHeight)
 
-    open override var intrinsicContentSize: CGSize {
-        return CGSize(width: UIView.noIntrinsicMetric, height: sizeThatFits(CGSize(width: frame.width, height: .infinity)).height)
-    }
+			currentTop += lineHeight + lineSpacing
+		}
 
-    override func updateViewCoverLayers() {
-        var newLineLayers = [CALayer]()
-        let desiredLineCount = ShimmerLinesView.lineCount(for: shimmerLinesViewAppearance, availableHeight: frame.height)
+		shimmeringLayer.frame = CGRect(x: -shimmerWidth, y: 0.0, width: frame.width + 2 * shimmerWidth, height: frame.height)
 
-        for i in 0..<desiredLineCount {
-            let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
+		viewCoverLayers.forEach { $0.frame = flipRectForRTL($0.frame) }
 
-            lineLayer.cornerRadius = appearance.labelCornerRadius >= 0 ? appearance.labelCornerRadius : appearance.cornerRadius
-            lineLayer.backgroundColor = appearance.tintColor.cgColor
+		updateShimmeringLayer()
+		updateShimmeringAnimation()
+	}
 
-            // Add layer
-            newLineLayers.append(lineLayer)
-            layer.addSublayer(lineLayer)
-        }
+	open override func sizeThatFits(_ size: CGSize) -> CGSize {
+		let desiredLineCount = CGFloat(lineCount(for: size.height))
+		let height = desiredLineCount * lineHeight + (desiredLineCount - 1) * lineSpacing
+		return CGSize(width: size.width, height: height)
+	}
 
-        Set(viewCoverLayers).subtracting(Set(newLineLayers)).forEach { $0.removeFromSuperlayer() }
+	open override var intrinsicContentSize: CGSize {
+		return CGSize(width: UIView.noIntrinsicMetric, height: sizeThatFits(CGSize(width: frame.width, height: .infinity)).height)
+	}
 
-        viewCoverLayers = newLineLayers
-    }
+	override func updateViewCoverLayers() {
+		var newLineLayers = [CALayer]()
+		let desiredLineCount = lineCount(for: frame.height)
+
+		for i in 0..<desiredLineCount {
+			let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
+
+			lineLayer.cornerRadius = labelCornerRadius >= 0 ? labelCornerRadius : cornerRadius
+			lineLayer.backgroundColor = viewTintColor.cgColor
+
+			// Add layer
+			newLineLayers.append(lineLayer)
+			layer.addSublayer(lineLayer)
+		}
+
+		Set(viewCoverLayers).subtracting(Set(newLineLayers)).forEach { $0.removeFromSuperlayer() }
+
+		viewCoverLayers = newLineLayers
+	}
+	
+	@objc private func lineCount(for availableHeight: CGFloat) -> Int {
+		if lineCount == 0 {
+			// Deduce lines count based on available height
+			return Int(floor((availableHeight + lineSpacing) / (lineHeight + lineSpacing)))
+		} else {
+			// Hardcoded lines count
+			return lineCount
+		}
+	}
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@available(*, deprecated, renamed: "ShimmerLinesView")
+@available(*, deprecated, renamed: "ShimmerLinesView", message: "Use individual properties instead")
 public typealias MSShimmerLinesView = ShimmerLinesView
 
 /**
@@ -129,4 +129,6 @@ open class ShimmerLinesView: ShimmerView {
 			return lineCount
 		}
 	}
+	
+	
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesViewAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesViewAppearance.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@available(*, deprecated, renamed: "ShimmerLinesViewAppearance")
+@available(*, deprecated, renamed: "ShimmerLinesViewAppearance", message: "Use individual properties instead")
 public typealias MSShimmerLinesViewAppearance = ShimmerLinesViewAppearance
 
 /**
@@ -15,27 +15,27 @@ public typealias MSShimmerLinesViewAppearance = ShimmerLinesViewAppearance
 @available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerLinesViewAppearance)
 public class ShimmerLinesViewAppearance: NSObject {
-    @objc public let lineCount: Int // use 0 if the number of lines should adapt to the available height
-    @objc public let lineHeight: CGFloat
-    @objc public let lineSpacing: CGFloat
-    @objc public let firstLineFillPercent: CGFloat
-    @objc public let lastLineFillPercent: CGFloat
+	@objc public let lineCount: Int // use 0 if the number of lines should adapt to the available height
+	@objc public let lineHeight: CGFloat
+	@objc public let lineSpacing: CGFloat
+	@objc public let firstLineFillPercent: CGFloat
+	@objc public let lastLineFillPercent: CGFloat
 
-    /// Create an apperance shimmer view apperance object
-    /// - Parameter lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-    /// - Parameter lineHeight: Height of shimmering line
-    /// - Parameter lineSpacing: Spacing between lines (if lines > 1)
-    /// - Parameter firstLineFillPercent: if two or more lines, the percent the first line should fill the available horizontal space
-    /// - Parameter lastLineFillPercent: the percent the last line should fill the available horizontal space.
-    @objc public init(lineCount: Int = 3,
-                      lineHeight: CGFloat = 11,
-                      lineSpacing: CGFloat = 11,
-                      firstLineFillPercent: CGFloat = 0.94,
-                      lastLineFillPercent: CGFloat = 0.6) {
-        self.lineCount = lineCount
-        self.lineHeight = lineHeight
-        self.lineSpacing = lineSpacing
-        self.firstLineFillPercent = firstLineFillPercent
-        self.lastLineFillPercent = lastLineFillPercent
-    }
+	/// Create an apperance shimmer view apperance object
+	/// - Parameter lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+	/// - Parameter lineHeight: Height of shimmering line
+	/// - Parameter lineSpacing: Spacing between lines (if lines > 1)
+	/// - Parameter firstLineFillPercent: if two or more lines, the percent the first line should fill the available horizontal space
+	/// - Parameter lastLineFillPercent: the percent the last line should fill the available horizontal space.
+	@objc public init(lineCount: Int = 3,
+					  lineHeight: CGFloat = 11,
+					  lineSpacing: CGFloat = 11,
+					  firstLineFillPercent: CGFloat = 0.94,
+					  lastLineFillPercent: CGFloat = 0.6) {
+		self.lineCount = lineCount
+		self.lineHeight = lineHeight
+		self.lineSpacing = lineSpacing
+		self.firstLineFillPercent = firstLineFillPercent
+		self.lastLineFillPercent = lastLineFillPercent
+	}
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesViewAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesViewAppearance.swift
@@ -11,6 +11,8 @@ public typealias MSShimmerLinesViewAppearance = ShimmerLinesViewAppearance
 /**
  `ShimmerLinesViewAppearance` describes the appearance of a shimmer view (ie loading content view)
  */
+
+@available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerLinesViewAppearance)
 public class ShimmerLinesViewAppearance: NSObject {
     @objc public let lineCount: Int // use 0 if the number of lines should adapt to the available height

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -12,9 +12,9 @@ public typealias MSShimmerView = ShimmerView
 @objc(MSFShimmerView)
 open class ShimmerView: UIView {
 
-    @available(*, deprecated, message: "Use individual properties instead")
-    @objc open var shimmerAppearance = ShimmerAppearance() {
-        didSet {
+	@available(*, deprecated, message: "Use individual properties instead")
+	@objc open var shimmerAppearance = ShimmerAppearance() {
+		didSet {
 			shimmerAlpha = shimmerAppearance.alpha
 			shimmerWidth = shimmerAppearance.width
 			shimmerAngle = shimmerAppearance.angle
@@ -26,35 +26,35 @@ open class ShimmerView: UIView {
 	}
 
 	/// The alpha value of the center of the gradient in the animation
-	@objc open var shimmerAlpha: CGFloat = 0.4 {
+	@objc open var shimmerAlpha: CGFloat = defaultAlpha {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
 	/// the wirth of the gradient in the animation
-	@objc open var shimmerWidth: CGFloat = 180 {
+	@objc open var shimmerWidth: CGFloat = defaultWidth {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
 	/// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
-	@objc open var shimmerAngle: CGFloat = -(CGFloat.pi / 45.0) {
+	@objc open var shimmerAngle: CGFloat = defaultAngle {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
 	/// Speed of the animation, in point/seconds.
-	@objc open var shimmerSpeed: CGFloat = 350 {
+	@objc open var shimmerSpeed: CGFloat = defaultSpeed {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
 	/// Delay between the end of a shimmering animation and the beginning of the next one.
-	@objc open var shimmerDelay: TimeInterval = 0.4 {
+	@objc open var shimmerDelay: TimeInterval = defaultDelay {
 		didSet {
 			setNeedsLayout()
 		}
@@ -81,14 +81,14 @@ open class ShimmerView: UIView {
 	}
 
 	/// Corner radius on each view.
-	@objc open var cornerRadius: CGFloat = 4.0 {
+	@objc open var cornerRadius: CGFloat = defaultCornerRadius {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
 	/// Corner radius on each UILabel. Set to  0 to disable and use default `cornerRadius`.
-	@objc open var labelCornerRadius: CGFloat = 2.0 {
+	@objc open var labelCornerRadius: CGFloat = defaultLabelCornerRadius {
 		didSet {
 			setNeedsLayout()
 		}
@@ -96,180 +96,198 @@ open class ShimmerView: UIView {
 
 	/// True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box.
 	/// `labelHeight` will take precendence over this property.
-	@objc open var usesTextHeightForLabels: Bool = false {
+	@objc open var usesTextHeightForLabels: Bool = defaultUsesTextHeightForLabels {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
 	/// If greater than 0, a fixed height to use for all UILabels. This will take precedence over `usesTextHeightForLabels`. Set to less than 0 to disable.
-	@objc open var labelHeight: CGFloat = 11 {
+	@objc open var labelHeight: CGFloat = defaultLabelHeight {
 		didSet {
 			setNeedsLayout()
 		}
 	}
 
-    /// Optional synchronizer to sync multiple shimmer views
-    @objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
+	/// Optional synchronizer to sync multiple shimmer views
+	@objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
 
-    open override var intrinsicContentSize: CGSize { return bounds.size }
+	open override var intrinsicContentSize: CGSize { return bounds.size }
 
-    /// Layers covering the subviews of the container
-    var viewCoverLayers = [CALayer]()
+	/// Layers covering the subviews of the container
+	var viewCoverLayers = [CALayer]()
 
-    /// Layer that slides to provide the "shimmer" effect
-    var shimmeringLayer = CAGradientLayer()
+	/// Layer that slides to provide the "shimmer" effect
+	var shimmeringLayer = CAGradientLayer()
 
-    private weak var containerView: UIView?
-    private var excludedViews: [UIView]
+	private weak var containerView: UIView?
+	private var excludedViews: [UIView]
 
-    /// Create a shimmer view
-    /// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored
-    /// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer
-    /// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views
-    @objc public init(containerView: UIView? = nil,
-                      excludedViews: [UIView] = [],
-                      animationSynchronizer: AnimationSynchronizerProtocol? = nil) {
-        self.containerView = containerView
-        self.excludedViews = excludedViews
-        self.animationSynchronizer = animationSynchronizer
-        super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
-    }
+	/// Create a shimmer view
+	/// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored
+	/// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer
+	/// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views
+	@objc public init(containerView: UIView? = nil,
+					  excludedViews: [UIView] = [],
+					  animationSynchronizer: AnimationSynchronizerProtocol? = nil) {
+		self.containerView = containerView
+		self.excludedViews = excludedViews
+		self.animationSynchronizer = animationSynchronizer
+		super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
+	}
 
-    required public init?(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
+	required public init?(coder: NSCoder) {
+		preconditionFailure("init(coder:) has not been implemented")
+	}
 
-    open override func layoutSubviews() {
-        super.layoutSubviews()
+	open override func layoutSubviews() {
+		super.layoutSubviews()
 
-        updateViewCoverLayers()
+		updateViewCoverLayers()
 
-        guard let containerView = containerView else {
-            return
-        }
+		guard let containerView = containerView else {
+			return
+		}
 
-        shimmeringLayer.frame = CGRect(x: -containerView.frame.width,
-                                       y: 0.0,
-                                       width: containerView.bounds.width + 2 * containerView.frame.width,
-                                       height: containerView.frame.height)
+		shimmeringLayer.frame = CGRect(x: -containerView.frame.width,
+									   y: 0.0,
+									   width: containerView.bounds.width + 2 * containerView.frame.width,
+									   height: containerView.frame.height)
 
-        updateShimmeringLayer()
-        updateShimmeringAnimation()
-    }
+		updateShimmeringLayer()
+		updateShimmeringAnimation()
+	}
 
-    /// Manaully sync with the synchronizer
-    @objc open func syncAnimation() {
-        updateShimmeringAnimation()
-    }
+	/// Manaully sync with the synchronizer
+	@objc open func syncAnimation() {
+		updateShimmeringAnimation()
+	}
 
-    /// Update the frame of each layer covering views in the containerView
-    func updateViewCoverLayers() {
-        guard let containerView = containerView else {
-            return
-        }
+	/// Update the frame of each layer covering views in the containerView
+	func updateViewCoverLayers() {
+		guard let containerView = containerView else {
+			return
+		}
 
-        viewCoverLayers.forEach { $0.removeFromSuperlayer() }
+		viewCoverLayers.forEach { $0.removeFromSuperlayer() }
 
-        let subviews = Set(containerView.subviews).subtracting(Set(excludedViews))
+		let subviews = Set(containerView.subviews).subtracting(Set(excludedViews))
 
-        viewCoverLayers = subviews.filter({ !$0.isHidden && !($0 is ShimmerView) }).map { subview in
-            let coverLayer = CALayer()
+		viewCoverLayers = subviews.filter({ !$0.isHidden && !($0 is ShimmerView) }).map { subview in
+			let coverLayer = CALayer()
 
-            let shouldApplyLabelCornerRadius = subview is UILabel && labelCornerRadius >= 0
-            coverLayer.cornerRadius = shouldApplyLabelCornerRadius ? labelCornerRadius : cornerRadius
-            coverLayer.backgroundColor = viewTintColor.cgColor
+			let shouldApplyLabelCornerRadius = subview is UILabel && labelCornerRadius >= 0
+			coverLayer.cornerRadius = shouldApplyLabelCornerRadius ? labelCornerRadius : cornerRadius
+			coverLayer.backgroundColor = viewTintColor.cgColor
 
-            var coverFrame = subview.frame
-            if let label = subview as? UILabel {
-                let viewLabelHeight: CGFloat? = {
-                    if labelHeight >= 0 {
-                        return labelHeight
-                    } else if usesTextHeightForLabels {
-                        return label.font.deviceLineHeight
-                    }
-                    return nil
-                }()
+			var coverFrame = subview.frame
+			if let label = subview as? UILabel {
+				let viewLabelHeight: CGFloat? = {
+					if labelHeight >= 0 {
+						return labelHeight
+					} else if usesTextHeightForLabels {
+						return label.font.deviceLineHeight
+					}
+					return nil
+				}()
 
-                if let viewLabelHeight = viewLabelHeight {
-                    let delta = coverFrame.height - viewLabelHeight
-                    coverFrame.size.height = viewLabelHeight
-                    coverFrame.origin.y += delta / 2
-                }
-            }
-            coverLayer.frame = coverFrame
+				if let viewLabelHeight = viewLabelHeight {
+					let delta = coverFrame.height - viewLabelHeight
+					coverFrame.size.height = viewLabelHeight
+					coverFrame.origin.y += delta / 2
+				}
+			}
+			coverLayer.frame = coverFrame
 
-            return coverLayer
-        }
+			return coverLayer
+		}
 
-        viewCoverLayers.forEach { layer.addSublayer($0) }
-    }
+		viewCoverLayers.forEach { layer.addSublayer($0) }
+	}
 
-    /// Update the gradient layer that animates to provide the shimmer effect (also updates the animation)
-    func updateShimmeringLayer() {
-        let light = UIColor.white.withAlphaComponent(shimmerAlpha).cgColor
-        let dark = UIColor.black.cgColor
-        let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
+	/// Update the gradient layer that animates to provide the shimmer effect (also updates the animation)
+	func updateShimmeringLayer() {
+		let light = UIColor.white.withAlphaComponent(shimmerAlpha).cgColor
+		let dark = UIColor.black.cgColor
+		let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
 
-        shimmeringLayer.colors = [dark, light, dark]
+		shimmeringLayer.colors = [dark, light, dark]
 
-        let startPoint = CGPoint(x: 0.0, y: 0.5)
-        let endPoint = CGPoint(x: 1.0, y: 0.5 - tan(shimmerAngle * (isRTL ? -1 : 1)))
-        if isRTL {
-            shimmeringLayer.startPoint = endPoint
-            shimmeringLayer.endPoint = startPoint
-        } else {
-            shimmeringLayer.startPoint = startPoint
-            shimmeringLayer.endPoint = endPoint
-        }
+		let startPoint = CGPoint(x: 0.0, y: 0.5)
+		let endPoint = CGPoint(x: 1.0, y: 0.5 - tan(shimmerAngle * (isRTL ? -1 : 1)))
+		if isRTL {
+			shimmeringLayer.startPoint = endPoint
+			shimmeringLayer.endPoint = startPoint
+		} else {
+			shimmeringLayer.startPoint = startPoint
+			shimmeringLayer.endPoint = endPoint
+		}
 
-        let widthPercentage = Float(shimmerWidth / shimmeringLayer.frame.width)
-        let locationStart = NSNumber(value: 0.5 - widthPercentage / 2)
-        let locationMiddle = NSNumber(value: 0.5)
-        let locationEnd = NSNumber(value: 0.5 + widthPercentage / 2)
+		let widthPercentage = Float(shimmerWidth / shimmeringLayer.frame.width)
+		let locationStart = NSNumber(value: 0.5 - widthPercentage / 2)
+		let locationMiddle = NSNumber(value: 0.5)
+		let locationEnd = NSNumber(value: 0.5 + widthPercentage / 2)
 
-        let locations = [locationStart, locationMiddle, locationEnd]
-        shimmeringLayer.locations = isRTL ? locations.reversed() : locations
+		let locations = [locationStart, locationMiddle, locationEnd]
+		shimmeringLayer.locations = isRTL ? locations.reversed() : locations
 
-        layer.mask = shimmeringLayer
+		layer.mask = shimmeringLayer
 
-        updateShimmeringAnimation()
-    }
+		updateShimmeringAnimation()
+	}
 
-    /// Update the shimmer animation
-    func updateShimmeringAnimation() {
-        if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
-            animationSynchronizer.referenceLayer = shimmeringLayer
-        }
+	/// Update the shimmer animation
+	func updateShimmeringAnimation() {
+		if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
+			animationSynchronizer.referenceLayer = shimmeringLayer
+		}
 
-        shimmeringLayer.removeAnimation(forKey: "shimmering")
+		shimmeringLayer.removeAnimation(forKey: "shimmering")
 
-        let animation = CABasicAnimation(keyPath: "locations")
+		let animation = CABasicAnimation(keyPath: "locations")
 
-        let widthPercentage = Float(shimmerWidth / shimmeringLayer.frame.width)
+		let widthPercentage = Float(shimmerWidth / shimmeringLayer.frame.width)
 
-        let fromLocationStart = NSNumber(value: 0.0)
-        let fromLocationMiddle = NSNumber(value: widthPercentage / 2.0)
-        let fromLocationEnd = NSNumber(value: widthPercentage)
+		let fromLocationStart = NSNumber(value: 0.0)
+		let fromLocationMiddle = NSNumber(value: widthPercentage / 2.0)
+		let fromLocationEnd = NSNumber(value: widthPercentage)
 
-        let toLocationStart = NSNumber(value: 1.0 - widthPercentage)
-        let toLocationMiddle = NSNumber(value: 1.0 - (widthPercentage / 2.0))
-        let toLocationEnd = NSNumber(value: 1.0)
+		let toLocationStart = NSNumber(value: 1.0 - widthPercentage)
+		let toLocationMiddle = NSNumber(value: 1.0 - (widthPercentage / 2.0))
+		let toLocationEnd = NSNumber(value: 1.0)
 
-        // Do not flip values from / to for RTL. These are already relative to the layout direction.
-        animation.fromValue = [fromLocationStart, fromLocationMiddle, fromLocationEnd]
-        animation.toValue = [toLocationStart, toLocationMiddle, toLocationEnd]
+		// Do not flip values from / to for RTL. These are already relative to the layout direction.
+		animation.fromValue = [fromLocationStart, fromLocationMiddle, fromLocationEnd]
+		animation.toValue = [toLocationStart, toLocationMiddle, toLocationEnd]
 
-        let distance = (frame.width + shimmerWidth) / cos(shimmerAngle)
-        animation.duration = CFTimeInterval(distance / shimmerSpeed)
-        animation.fillMode = .forwards
+		let distance = (frame.width + shimmerWidth) / cos(shimmerAngle)
+		animation.duration = CFTimeInterval(distance / shimmerSpeed)
+		animation.fillMode = .forwards
 
-        // Add animation (use a group to add a delay between animations)
-        let animationGroup = CAAnimationGroup()
-        animationGroup.animations = [animation]
-        animationGroup.duration = animation.duration + shimmerDelay
-        animationGroup.repeatCount = .infinity
-        animationGroup.timeOffset = animationSynchronizer?.timeOffset(for: shimmeringLayer) ?? 0
-        shimmeringLayer.add(animationGroup, forKey: "shimmering")
-    }
+		// Add animation (use a group to add a delay between animations)
+		let animationGroup = CAAnimationGroup()
+		animationGroup.animations = [animation]
+		animationGroup.duration = animation.duration + shimmerDelay
+		animationGroup.repeatCount = .infinity
+		animationGroup.timeOffset = animationSynchronizer?.timeOffset(for: shimmeringLayer) ?? 0
+		shimmeringLayer.add(animationGroup, forKey: "shimmering")
+	}
 }
+
+public extension Colors {
+	struct Shimmer {
+		public static var tint = UIColor(light: surfaceTertiary, dark: surfaceQuaternary)
+	}
+}
+
+fileprivate let defaultAlpha: CGFloat = 0.4
+fileprivate let defaultWidth: CGFloat = 180
+fileprivate let defaultAngle: CGFloat = -(CGFloat.pi / 45.0)
+fileprivate let defaultSpeed: CGFloat = 350
+fileprivate let defaultDelay: TimeInterval = 0.4
+
+fileprivate let defaultViewTintColor: UIColor = Colors.Shimmer.tint
+fileprivate let defaultCornerRadius: CGFloat = 4.0
+fileprivate let defaultLabelCornerRadius: CGFloat = 2.0
+fileprivate let defaultUsesTextHeightForLabels: Bool = false
+fileprivate let defaultLabelHeight: CGFloat = 11

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -15,11 +15,11 @@ open class ShimmerView: UIView {
     @available(*, deprecated, message: "Use individual properties instead")
     @objc open var shimmerAppearance = ShimmerAppearance() {
         didSet {
-			self.shimmerAlpha = shimmerAppearance.alpha
-			self.shimmerWidth = shimmerAppearance.width
-			self.shimmerAngle = shimmerAppearance.angle
-			self.shimmerSpeed = shimmerAppearance.speed
-			self.shimmerDelay = shimmerAppearance.delay
+			shimmerAlpha = shimmerAppearance.alpha
+			shimmerWidth = shimmerAppearance.width
+			shimmerAngle = shimmerAppearance.angle
+			shimmerSpeed = shimmerAppearance.speed
+			shimmerDelay = shimmerAppearance.delay
 
 			setNeedsLayout()
 		}
@@ -63,11 +63,11 @@ open class ShimmerView: UIView {
 	@available(*, deprecated, message: "Use individual properties instead")
 	@objc open var appearance = ShimmerViewAppearance() {
 		didSet {
-			self.viewTintColor = appearance.tintColor
-			self.cornerRadius = appearance.cornerRadius
-			self.labelCornerRadius = appearance.labelCornerRadius
-			self.usesTextHeightForLabels = appearance.usesTextHeightForLabels
-			self.labelHeight = appearance.labelHeight
+			viewTintColor = appearance.tintColor
+			cornerRadius = appearance.cornerRadius
+			labelCornerRadius = appearance.labelCornerRadius
+			usesTextHeightForLabels = appearance.usesTextHeightForLabels
+			labelHeight = appearance.labelHeight
 
 			setNeedsLayout()
 		}

--- a/ios/FluentUI/Shimmer/ShimmerViewAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerViewAppearance.swift
@@ -18,6 +18,7 @@ public extension Colors {
 @available(*, deprecated, renamed: "ShimmerViewAppearance")
 public typealias MSShimmerViewAppearance = ShimmerViewAppearance
 
+@available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerViewAppearence)
 public class ShimmerViewAppearance: NSObject {
     @objc public let tintColor: UIColor

--- a/ios/FluentUI/Shimmer/ShimmerViewAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerViewAppearance.swift
@@ -5,43 +5,35 @@
 
 import UIKit
 
-// MARK: Shimmer Colors
-
-public extension Colors {
-    struct Shimmer {
-        public static var tint = UIColor(light: surfaceTertiary, dark: surfaceQuaternary)
-    }
-}
-
 // MARK: - ShimmerViewAppearance
 
-@available(*, deprecated, renamed: "ShimmerViewAppearance")
+@available(*, deprecated, renamed: "ShimmerViewAppearance", message: "Use individual properties instead")
 public typealias MSShimmerViewAppearance = ShimmerViewAppearance
 
 @available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerViewAppearence)
 public class ShimmerViewAppearance: NSObject {
-    @objc public let tintColor: UIColor
-    @objc public let cornerRadius: CGFloat
-    @objc public let labelCornerRadius: CGFloat
-    @objc public let usesTextHeightForLabels: Bool
-    @objc public let labelHeight: CGFloat
+	@objc public let tintColor: UIColor
+	@objc public let cornerRadius: CGFloat
+	@objc public let labelCornerRadius: CGFloat
+	@objc public let usesTextHeightForLabels: Bool
+	@objc public let labelHeight: CGFloat
 
-    /// Create an apperance shimmer view apperance object
-    /// - Parameter tintColor: Tint color of the view.
-    /// - Parameter cornerRadius: Corner radius on each view.
-    /// - Parameter labelCornerRadius: Corner radius on each UILabel. Set to < 0 to disable and use default `cornerRadius`.
-    /// - Parameter usesTextHeightForLabels: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box. `labelHeight` will take precendence over this property.
-    /// - Parameter labelHeight: If greater than 0, a fixed height to use for all UILabels. This will take precedence over `usesTextHeightForLabels`. Set to less than 0 to disable.
-    @objc public init(tintColor: UIColor = Colors.Shimmer.tint,
-                      cornerRadius: CGFloat = 4.0,
-                      labelCornerRadius: CGFloat = 2.0,
-                      usesTextHeightForLabels: Bool = false,
-                      labelHeight: CGFloat = 11) {
-        self.tintColor = tintColor
-        self.cornerRadius = cornerRadius
-        self.labelCornerRadius = labelCornerRadius
-        self.usesTextHeightForLabels = usesTextHeightForLabels
-        self.labelHeight = labelHeight
-    }
+	/// Create an apperance shimmer view apperance object
+	/// - Parameter tintColor: Tint color of the view.
+	/// - Parameter cornerRadius: Corner radius on each view.
+	/// - Parameter labelCornerRadius: Corner radius on each UILabel. Set to < 0 to disable and use default `cornerRadius`.
+	/// - Parameter usesTextHeightForLabels: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box. `labelHeight` will take precendence over this property.
+	/// - Parameter labelHeight: If greater than 0, a fixed height to use for all UILabels. This will take precedence over `usesTextHeightForLabels`. Set to less than 0 to disable.
+	@objc public init(tintColor: UIColor = Colors.Shimmer.tint,
+					  cornerRadius: CGFloat = 4.0,
+					  labelCornerRadius: CGFloat = 2.0,
+					  usesTextHeightForLabels: Bool = false,
+					  labelHeight: CGFloat = 11) {
+		self.tintColor = tintColor
+		self.cornerRadius = cornerRadius
+		self.labelCornerRadius = labelCornerRadius
+		self.usesTextHeightForLabels = usesTextHeightForLabels
+		self.labelHeight = labelHeight
+	}
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The Shimmer view has two objects "ShimmerAppearance" and "ShimmerViewAppearance", each of which contains 5 properties that control the shimmer view's appearance.

Let's just make these individual properties, and deprecate the objects

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/215)