### PR TITLE
Fix incorrect deprecation message on ShimmerView

### DIFF
--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@available(*, deprecated, renamed: "ShimmerLinesView", message: "Use individual properties instead")
+@available(*, deprecated, renamed: "ShimmerLinesView")
 public typealias MSShimmerLinesView = ShimmerLinesView
 
 /**

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@available(*, deprecated, renamed: "ShimmerView")
+@available(*, deprecated, renamed: "ShimmerView", message: "Use individual properties instead")
 public typealias MSShimmerView = ShimmerView
 
 /// View that converts the subviews of a container view into a loading state with the "shimmering" effect

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@available(*, deprecated, renamed: "ShimmerView", message: "Use individual properties instead")
+@available(*, deprecated, renamed: "ShimmerView")
 public typealias MSShimmerView = ShimmerView
 
 /// View that converts the subviews of a container view into a loading state with the "shimmering" effect


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In my last PR, I incorrectly added a message to one of the API deprection decorators. Removing that message

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/217)