### PR TITLE
Added new property shimmersLeafViews to ShimmerView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		B4EF66562295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4EF66552295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift */; };
 		B9450C42DB92C964C77483FF /* Pods_FluentUI_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC7D5AF5DAF7393E14BF5B28 /* Pods_FluentUI_Demo.framework */; };
 		C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */; };
-		C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */; };
+		C0938E4A235F733100256251 /* ShimmerViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0938E49235F733100256251 /* ShimmerViewDemoController.swift */; };
 		E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842973247B672000A29C40 /* SceneDelegate.swift */; };
 		E6842996247C350700A29C40 /* DemoColorThemeWindows.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemeWindows.swift */; };
 		FD41C8F422E28EEB0086F899 /* NavigationControllerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD41C8F322E28EEB0086F899 /* NavigationControllerDemoController.swift */; };
@@ -106,7 +106,7 @@
 		B4EF66532295F1A8007FEAB0 /* TableViewHeaderFooterViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterViewDemoController.swift; sourceTree = "<group>"; };
 		B4EF66552295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterSampleData.swift; sourceTree = "<group>"; };
 		C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellShimmerDemoController.swift; sourceTree = "<group>"; };
-		C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerLinesViewDemoController.swift; sourceTree = "<group>"; };
+		C0938E49235F733100256251 /* ShimmerViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerViewDemoController.swift; sourceTree = "<group>"; };
 		E6842973247B672000A29C40 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E6842995247C350700A29C40 /* DemoColorThemeWindows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoColorThemeWindows.swift; sourceTree = "<group>"; };
 		E6D2996ECAAD9A81A6338783 /* Pods-FluentUI.Demo.dogfood.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FluentUI.Demo.dogfood.xcconfig"; path = "Target Support Files/Pods-FluentUI.Demo/Pods-FluentUI.Demo.dogfood.xcconfig"; sourceTree = "<group>"; };
@@ -271,7 +271,7 @@
 				497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */,
 				A5961FA8218A61BB00E2A506 /* PopupMenuDemoController.swift */,
 				FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */,
-				C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */,
+				C0938E49235F733100256251 /* ShimmerViewDemoController.swift */,
 				11047D2522932DB1001F0F59 /* TabBarViewDemoController.swift */,
 				7DC2FB2A24C0F4FD00367A55 /* TableViewCellFileAccessoryViewDemoController.swift */,
 				B498141521E42C140077B48D /* TableViewCellDemoController.swift */,
@@ -478,7 +478,7 @@
 				A5CEC21220E436F10016922A /* DemoListViewController.swift in Sources */,
 				B498141621E42C140077B48D /* TableViewCellDemoController.swift in Sources */,
 				FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */,
-				C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */,
+				C0938E4A235F733100256251 /* ShimmerViewDemoController.swift in Sources */,
 				C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */,
 				114CF8B82423E10900D064AA /* ColorDemoController.swift in Sources */,
 				A589F856211BA71000471C23 /* LabelDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -26,7 +26,7 @@ let demos: [(title: String, controllerClass: UIViewController.Type)] = [
     ("PillButtonBar", PillButtonBarDemoController.self),
     ("PopupMenuController", PopupMenuDemoController.self),
     ("SegmentedControl", SegmentedControlDemoController.self),
-    ("ShimmerLinesView", ShimmerLinesViewDemoController.self),
+    ("ShimmerView", ShimmerViewDemoController.self),
     ("SideTabBar", SideTabBarDemoController.self),
     ("TabBarView", TabBarViewDemoController.self),
     ("TableViewCell", TableViewCellDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerViewDemoController.swift
@@ -10,14 +10,14 @@ class ShimmerViewDemoController: DemoController {
 		super.viewDidLoad()
 
 		let contentView = { () -> UIStackView in
-			let label1 = UILabel()
+			let label1 = Label()
 			label1.text = "Label 1"
 			label1.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
-			let label2 = UILabel()
+			let label2 = Label()
 			label2.text = "Label 2"
 
-			let label3 = UILabel()
+			let label3 = Label()
 			label3.text = "label 3"
 
 			let verticalStackView = UIStackView(arrangedSubviews: [label2, label3])
@@ -41,7 +41,7 @@ class ShimmerViewDemoController: DemoController {
 			return containerView
 		}
 
-		let shimmerViewLabel = { (text: String) -> UILabel in
+		let shimmerViewLabel = { (text: String) -> Label in
 			let label = Label(style: .headline)
 			label.numberOfLines = 0
 			label.text = text

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerViewDemoController.swift
@@ -48,11 +48,6 @@ class ShimmerViewDemoController: DemoController {
 			return label
 		}
 
-		container.addArrangedSubview(shimmerViewLabel("A ShimmerLinesView needs no containerview or subviews"))
-		container.addArrangedSubview(Separator())
-		container.addArrangedSubview(ShimmerLinesView())
-		container.addArrangedSubview(Separator())
-
 		container.addArrangedSubview(shimmerViewLabel("ShimmerView shimmers all the top level subviews of it's container view"))
 		container.addArrangedSubview(Separator())
 		container.addArrangedSubview(shimmeringContentView(false))
@@ -61,5 +56,12 @@ class ShimmerViewDemoController: DemoController {
 		container.addArrangedSubview(shimmerViewLabel("With shimmersLeafViews set, the ShimmerView will shimmer the labels inside the stackview"))
 		container.addArrangedSubview(Separator())
 		container.addArrangedSubview(shimmeringContentView(true))
+		container.addArrangedSubview(Separator())
+
+		container.addArrangedSubview(shimmerViewLabel("A ShimmerLinesView needs no containerview or subviews, and handles it's own appearance"))
+		container.addArrangedSubview(Separator())
+		container.addArrangedSubview(ShimmerLinesView())
+		container.addArrangedSubview(Separator())
+
 	}
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -9,7 +9,7 @@ import FluentUI
 // MARK: TableViewCellDemoController
 
 class TableViewCellDemoController: DemoController {
-    let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections 
+    let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
 
     private var isGrouped: Bool = false {
         didSet {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -9,7 +9,7 @@ import FluentUI
 // MARK: TableViewCellDemoController
 
 class TableViewCellDemoController: DemoController {
-    let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
+    let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections 
 
     private var isGrouped: Bool = false {
         didSet {

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -119,7 +119,7 @@ open class ShimmerLinesView: ShimmerView {
 
 		viewCoverLayers = newLineLayers
 	}
-	
+
 	@objc private func lineCount(for availableHeight: CGFloat) -> Int {
 		if lineCount == 0 {
 			// Deduce lines count based on available height
@@ -129,6 +129,6 @@ open class ShimmerLinesView: ShimmerView {
 			return lineCount
 		}
 	}
-	
-	
+
+
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -129,6 +129,4 @@ open class ShimmerLinesView: ShimmerView {
 			return lineCount
 		}
 	}
-
-
 }

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -306,7 +306,7 @@ open class ShimmerView: UIView {
 	private static let defaultUsesTextHeightForLabels: Bool = false
 	private static let defaultLabelHeight: CGFloat = 11
 
-	private let defaultShimmersLeafViews: Bool = false
+	private static let defaultShimmersLeafViews: Bool = false
 }
 
 public extension Colors {

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -293,7 +293,7 @@ open class ShimmerView: UIView {
 			}
 		}
 	}
-	
+
 	private static let defaultAlpha: CGFloat = 0.4
 	private static let defaultWidth: CGFloat = 180
 	private static let defaultAngle: CGFloat = -(CGFloat.pi / 45.0)
@@ -314,5 +314,3 @@ public extension Colors {
 		public static var tint = UIColor(light: surfaceTertiary, dark: surfaceQuaternary)
 	}
 }
-
-


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We want to use the ShimmerView in FluentUI Rect Native. React Native however, uses flexbox for it's layout, which likes to wrap views inside views inside views for it's layout. This is incompatible with ShimmerView's current implementation, which only shimmers the top level subviews of it's containerview.

In order to support React Native's flexbox, we need to make 2 changes:

1. Add a new property "shimmersLeafViews", which will determine whether we shimmer the top level subviews, or the leaf views of containerview's view heirarchy. This will be by default off, and can be set to true when we create an instance for React Native.

2. Allow the containerView to be self. ShimmerView normally expects to have a container view passed to it on initialization, who's subviews it will shimmer. Because of how RCTViewManager in React Native works, the subviews in React's DOM will become subviews of ShimmerView, so we need to allow shimmerview's containerview to be "self". In other words, Shimmer view should be able to shimmer it's own subviews. This is simply dont with a nil coalesce check.

### Verification

Copied the ShimmerView implementation to FURN to test locally in my [FluentUI React Native PR ](https://github.com/microsoft/fluentui-react-native/pull/372) to wrap shimmer.

Made sure no changes happened to the default shimmer (when `shimmersLeafViews = false`)

![Screen Shot 2020-09-03 at 9 14 01 PM](https://user-images.githubusercontent.com/6722175/92198942-968bc180-ee2a-11ea-85f9-3e4bc08ea855.png)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/219)