### PR TITLE
Mechanism to auto-launch a demo controller on boot of the demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -8,9 +8,6 @@ import FluentUI
 
 class DemoListViewController: UITableViewController {
 
-    /// Set this to a non-zero value to automatically launch the demo controller at this index when the demo app launches.
-    private var autoLaunchDemoIndex: Int = 0
-
     static func addDemoListTo(window: UIWindow, pushing viewController: UIViewController?) {
         if let colorProvider = window as? ColorProviding {
             Colors.setProvider(provider: colorProvider, for: window)
@@ -59,9 +56,15 @@ class DemoListViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if autoLaunchDemoIndex != 0 {
-            tableView(tableView, didSelectRowAt: IndexPath(row: autoLaunchDemoIndex - 1, section: 0))
-            autoLaunchDemoIndex = 0
+        if didAutoLaunch {
+            UserDefaults.standard.set(0, forKey: DemoListViewController.lastDemoControllerKey)
+        } else {
+            let lastDemoController = UserDefaults.standard.integer(forKey: DemoListViewController.lastDemoControllerKey)
+            if lastDemoController != 0 {
+                tableView(tableView, didSelectRowAt: IndexPath(row: lastDemoController - 1, section: 0))
+            }
+
+            didAutoLaunch = true
         }
     }
 
@@ -83,7 +86,11 @@ class DemoListViewController: UITableViewController {
         let demoController = demo.controllerClass.init(nibName: nil, bundle: nil)
         demoController.title = demo.title
         navigationController?.pushViewController(demoController, animated: true)
+
+        UserDefaults.standard.set(indexPath.row + 1, forKey: DemoListViewController.lastDemoControllerKey)
     }
 
     let cellReuseIdentifier: String = "TableViewCell"
+    private var didAutoLaunch: Bool = false
+    private static let lastDemoControllerKey: String = "LastDemoController"
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -60,10 +60,13 @@ class DemoListViewController: UITableViewController {
             UserDefaults.standard.set(nil, forKey: DemoListViewController.lastDemoControllerKey)
         } else {
             let lastDemoController = UserDefaults.standard.string(forKey: DemoListViewController.lastDemoControllerKey)
-            for (index, demo) in demos.enumerated() {
-                if demo.title == lastDemoController {
-                    tableView(tableView, didSelectRowAt: IndexPath(row: index, section: 0))
-                    break
+
+            if lastDemoController?.count ?? -1 > 0 {
+                for (index, demo) in demos.enumerated() {
+                    if demo.title == lastDemoController {
+                        tableView(tableView, didSelectRowAt: IndexPath(row: index, section: 0))
+                        break
+                    }
                 }
             }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -57,11 +57,14 @@ class DemoListViewController: UITableViewController {
         super.viewDidAppear(animated)
 
         if didAutoLaunch {
-            UserDefaults.standard.set(0, forKey: DemoListViewController.lastDemoControllerKey)
+            UserDefaults.standard.set(nil, forKey: DemoListViewController.lastDemoControllerKey)
         } else {
-            let lastDemoController = UserDefaults.standard.integer(forKey: DemoListViewController.lastDemoControllerKey)
-            if lastDemoController != 0 {
-                tableView(tableView, didSelectRowAt: IndexPath(row: lastDemoController - 1, section: 0))
+            let lastDemoController = UserDefaults.standard.string(forKey: DemoListViewController.lastDemoControllerKey)
+            for (index, demo) in demos.enumerated() {
+                if demo.title == lastDemoController {
+                    tableView(tableView, didSelectRowAt: IndexPath(row: index, section: 0))
+                    break
+                }
             }
 
             didAutoLaunch = true
@@ -87,7 +90,7 @@ class DemoListViewController: UITableViewController {
         demoController.title = demo.title
         navigationController?.pushViewController(demoController, animated: true)
 
-        UserDefaults.standard.set(indexPath.row + 1, forKey: DemoListViewController.lastDemoControllerKey)
+        UserDefaults.standard.set(demo.title, forKey: DemoListViewController.lastDemoControllerKey)
     }
 
     let cellReuseIdentifier: String = "TableViewCell"

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -8,9 +8,6 @@ import FluentUI
 
 class DemoListViewController: UITableViewController {
 
-    /// Set this to a non-zero value to automatically launch the demo controller at this index when the demo app launches.
-    private var autoLaunchDemoIndex: Int = 0
-
     static func addDemoListTo(window: UIWindow, pushing viewController: UIViewController?) {
         if let colorProvider = window as? ColorProviding {
             Colors.setProvider(provider: colorProvider, for: window)
@@ -31,11 +28,11 @@ class DemoListViewController: UITableViewController {
     }
 
     let demos: [(title: String, controllerClass: UIViewController.Type)] = FluentUI_Demo.demos.filter { demo in
-#if DEBUG
+        #if DEBUG
         return true
-#else
+        #else
         return !demo.title.hasPrefix("DEBUG")
-#endif
+        #endif
     }
 
     override func viewDidLoad() {
@@ -54,15 +51,6 @@ class DemoListViewController: UITableViewController {
         tableView.separatorStyle = .none
 
         tableView.register(TableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if autoLaunchDemoIndex != 0 {
-            tableView(tableView, didSelectRowAt: IndexPath(row: autoLaunchDemoIndex - 1, section: 0))
-            autoLaunchDemoIndex = 0
-        }
     }
 
     // MARK: Table View

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -56,21 +56,15 @@ class DemoListViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if didAutoLaunch {
-            UserDefaults.standard.set(nil, forKey: DemoListViewController.lastDemoControllerKey)
-        } else {
-            let lastDemoController = UserDefaults.standard.string(forKey: DemoListViewController.lastDemoControllerKey)
-
-            if lastDemoController?.count ?? -1 > 0 {
-                for (index, demo) in demos.enumerated() {
-                    if demo.title == lastDemoController {
-                        tableView(tableView, didSelectRowAt: IndexPath(row: index, section: 0))
-                        break
-                    }
-                }
+        if isFirstLaunch {
+            if let lastDemoController = UserDefaults.standard.string(forKey: DemoListViewController.lastDemoControllerKey),
+                let index = demos.firstIndex(where: { $0.title == lastDemoController }) {
+                tableView(tableView, didSelectRowAt: IndexPath(row: index, section: 0))
             }
 
-            didAutoLaunch = true
+            isFirstLaunch = false
+        } else {
+            UserDefaults.standard.set(nil, forKey: DemoListViewController.lastDemoControllerKey)
         }
     }
 
@@ -97,6 +91,6 @@ class DemoListViewController: UITableViewController {
     }
 
     let cellReuseIdentifier: String = "TableViewCell"
-    private var didAutoLaunch: Bool = false
+    private var isFirstLaunch: Bool = true
     private static let lastDemoControllerKey: String = "LastDemoController"
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -8,6 +8,9 @@ import FluentUI
 
 class DemoListViewController: UITableViewController {
 
+    /// Set this to a non-zero value to automatically launch the demo controller at this index when the demo app launches.
+    private var autoLaunchDemoIndex: Int = 0
+
     static func addDemoListTo(window: UIWindow, pushing viewController: UIViewController?) {
         if let colorProvider = window as? ColorProviding {
             Colors.setProvider(provider: colorProvider, for: window)
@@ -28,11 +31,11 @@ class DemoListViewController: UITableViewController {
     }
 
     let demos: [(title: String, controllerClass: UIViewController.Type)] = FluentUI_Demo.demos.filter { demo in
-        #if DEBUG
+#if DEBUG
         return true
-        #else
+#else
         return !demo.title.hasPrefix("DEBUG")
-        #endif
+#endif
     }
 
     override func viewDidLoad() {
@@ -51,6 +54,15 @@ class DemoListViewController: UITableViewController {
         tableView.separatorStyle = .none
 
         tableView.register(TableViewCell.self, forCellReuseIdentifier: cellReuseIdentifier)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if autoLaunchDemoIndex != 0 {
+            tableView(tableView, didSelectRowAt: IndexPath(row: autoLaunchDemoIndex - 1, section: 0))
+            autoLaunchDemoIndex = 0
+        }
     }
 
     // MARK: Table View

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -7,9 +7,10 @@ import FluentUI
 import UIKit
 
 class SideTabBarDemoController: DemoController {
-    override func loadView() {
-        view = UIView(frame: .zero)
-        container.addArrangedSubview(createButton(title: "Show side tab bar", action: #selector(presentSideTabBar)))
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        presentSideTabBar()
     }
 
     private struct Constants {
@@ -48,7 +49,7 @@ class SideTabBarDemoController: DemoController {
         return createButton(title: "-", action: #selector(decrementBadgeNumbers))
     }()
 
-    @objc private func presentSideTabBar() {
+    private func presentSideTabBar() {
         let contentViewController = UIViewController(nibName: nil, bundle: nil)
         self.contentViewController = contentViewController
 
@@ -139,7 +140,9 @@ class SideTabBarDemoController: DemoController {
     }
 
     @objc private func dismissSideTabBar() {
-        dismiss(animated: false, completion: nil)
+        dismiss(animated: false) {
+            self.navigationController?.popViewController(animated: true)
+        }
     }
 
     @objc private func toggleAvatarView(switchView: UISwitch) {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -55,6 +55,11 @@ class TabBarItemView: UIView {
 
         container.addSubview(badgeView)
 
+        if #available(iOS 13.4, *) {
+            let pointerInteraction = UIPointerInteraction(delegate: self)
+            addInteraction(pointerInteraction)
+        }
+
         isAccessibilityElement = true
         updateAccessibilityLabel()
 
@@ -311,5 +316,26 @@ class TabBarItemView: UIView {
         } else {
             accessibilityLabel = item.title
         }
+    }
+}
+
+// MARK: - TabBarItemView UIPointerInteractionDelegate
+
+extension TabBarItemView: UIPointerInteractionDelegate {
+    @available(iOS 13.4, *)
+    func pointerInteraction(_ interaction: UIPointerInteraction, regionFor request: UIPointerRegionRequest, defaultRegion: UIPointerRegion) -> UIPointerRegion? {
+        return UIPointerRegion(rect: bounds.insetBy(dx: -20, dy: -20))
+    }
+
+    @available(iOS 13.4, *)
+    func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
+        var pointerStyle: UIPointerStyle?
+
+        if let interactionView = interaction.view {
+            let targetedPreview = UITargetedPreview(view: interactionView)
+            pointerStyle = UIPointerStyle(effect: UIPointerEffect.hover(targetedPreview, preferredTintMode: .overlay, prefersShadow: true, prefersScaledContent: true))
+        }
+
+        return pointerStyle
     }
 }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -55,11 +55,6 @@ class TabBarItemView: UIView {
 
         container.addSubview(badgeView)
 
-        if #available(iOS 13.4, *) {
-            let pointerInteraction = UIPointerInteraction(delegate: self)
-            addInteraction(pointerInteraction)
-        }
-
         isAccessibilityElement = true
         updateAccessibilityLabel()
 
@@ -316,26 +311,5 @@ class TabBarItemView: UIView {
         } else {
             accessibilityLabel = item.title
         }
-    }
-}
-
-// MARK: - TabBarItemView UIPointerInteractionDelegate
-
-extension TabBarItemView: UIPointerInteractionDelegate {
-    @available(iOS 13.4, *)
-    func pointerInteraction(_ interaction: UIPointerInteraction, regionFor request: UIPointerRegionRequest, defaultRegion: UIPointerRegion) -> UIPointerRegion? {
-        return UIPointerRegion(rect: bounds.insetBy(dx: -20, dy: -20))
-    }
-
-    @available(iOS 13.4, *)
-    func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
-        var pointerStyle: UIPointerStyle?
-
-        if let interactionView = interaction.view {
-            let targetedPreview = UITargetedPreview(view: interactionView)
-            pointerStyle = UIPointerStyle(effect: UIPointerEffect.hover(targetedPreview, preferredTintMode: .overlay, prefersShadow: true, prefersScaledContent: true))
-        }
-
-        return pointerStyle
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

It can be repetitive to scroll down the list of demo controllers every time the demo app reboots, especially when working on a specific demo controller.
Let's add a simple mechanism that can be used to setup a demo controller for auto-launch on boot.
The last opened demo controller will automatically launch.
We will save whichever demo controller is opened to the user defaults.
If the user navigates out of a demo controller, then nothing will auto-launch on the next boot.

### Verification

Launch first time, nothing auto-launches.
Open a demo controller, reboot the app, make sure that this demo controller automatically reopens.
Open a demo controller, close it, reboot the app, make sure that nothing auto-launches.
Open a demo controller, close it, open a different demo controller, reboot the app, make sure that this last demo controller automatically reopens.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/220)