### PR TITLE
Pointer interaction for TableViewCell accessory view buttons

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1488,6 +1488,11 @@ internal class TableViewCellAccessoryView: UIView {
         button.accessibilityLabel = "Accessibility.TableViewCell.MoreActions.Label".localized
         button.accessibilityHint = "Accessibility.TableViewCell.MoreActions.Hint".localized
         button.addTarget(self, action: #selector(handleOnAccessoryTapped), for: .touchUpInside)
+
+        if #available(iOS 13.4, *) {
+            button.isPointerInteractionEnabled = true
+        }
+
         return button
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Accessory view buttons in TableViewCell should use the default pointer interaction for UIButtons.


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/224)