### PR TITLE
DrawerController should respect safe area when presenting vertically.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -18,6 +18,7 @@ class DrawerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showTopDrawerButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showTopDrawerNotAnimatedButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show from custom base with width on landscape", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show respecting safe area width", action: #selector(showTopDrawerSafeAreaButtonTapped)))
 
         addTitle(text: "Left/Right Drawer")
         addRow(
@@ -54,7 +55,22 @@ class DrawerDemoController: DemoController {
     }
 
     @discardableResult
-    private func presentDrawer(sourceView: UIView? = nil, barButtonItem: UIBarButtonItem? = nil, presentationOrigin: CGFloat = -1, presentationDirection: DrawerPresentationDirection, presentationStyle: DrawerPresentationStyle = .automatic, presentationOffset: CGFloat = 0, presentationBackground: DrawerPresentationBackground = .black, presentingGesture: UIPanGestureRecognizer? = nil, permittedArrowDirections: UIPopoverArrowDirection = [.left, .right], contentController: UIViewController? = nil, contentView: UIView? = nil, resizingBehavior: DrawerResizingBehavior = .none, adjustHeightForKeyboard: Bool = false, animated: Bool = true, customWidth: Bool = false) -> DrawerController {
+    private func presentDrawer(sourceView: UIView? = nil,
+                               barButtonItem: UIBarButtonItem? = nil,
+                               presentationOrigin: CGFloat = -1,
+                               presentationDirection: DrawerPresentationDirection,
+                               presentationStyle: DrawerPresentationStyle = .automatic,
+                               presentationOffset: CGFloat = 0,
+                               presentationBackground: DrawerPresentationBackground = .black,
+                               presentingGesture: UIPanGestureRecognizer? = nil,
+                               permittedArrowDirections: UIPopoverArrowDirection = [.left, .right],
+                               contentController: UIViewController? = nil,
+                               contentView: UIView? = nil,
+                               resizingBehavior: DrawerResizingBehavior = .none,
+                               adjustHeightForKeyboard: Bool = false,
+                               animated: Bool = true,
+                               customWidth: Bool = false,
+                               respectSafeAreaWidth: Bool = false) -> DrawerController {
         let controller: DrawerController
         if let sourceView = sourceView {
             controller = DrawerController(sourceView: sourceView, sourceRect: sourceView.bounds.insetBy(dx: sourceView.bounds.width / 2, dy: 0), presentationOrigin: presentationOrigin, presentationDirection: presentationDirection)
@@ -71,6 +87,7 @@ class DrawerDemoController: DemoController {
         controller.permittedArrowDirections = permittedArrowDirections
         controller.resizingBehavior = resizingBehavior
         controller.adjustsHeightForKeyboard = adjustHeightForKeyboard
+        controller.shouldRespectSafeAreaForWindowFullWidth = respectSafeAreaWidth
 
         if let contentView = contentView {
             // `preferredContentSize` can be used to specify the preferred size of a drawer,
@@ -129,6 +146,10 @@ class DrawerDemoController: DemoController {
     @objc private func showTopDrawerCustomOffsetButtonTapped(sender: UIButton) {
         let rect = sender.superview!.convert(sender.frame, to: nil)
         presentDrawer(sourceView: sender, presentationOrigin: rect.maxY, presentationDirection: .down, contentView: containerForActionViews(), customWidth: true)
+    }
+
+    @objc private func showTopDrawerSafeAreaButtonTapped(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand, respectSafeAreaWidth: true)
     }
 
     @objc private func showLeftDrawerButtonTapped(sender: UIButton) {

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -334,6 +334,9 @@ open class DrawerController: UIViewController {
     /// For `vertical` presentation shown when horizontal size is `.compact`, the content width will be the full width of the presenting window. If set to false, the `preferredContentSize.width` will be used for calculation in landscape mode.
     @objc open var shouldUseWindowFullWidthInLandscape: Bool = true
 
+    /// Limits the full window width to its safe area for `vertical` presentation.
+    @objc open var shouldRespectSafeAreaForWindowFullWidth: Bool = true
+
     // Override to provide the preferred size based on specifics of the concrete drawer subclass (see popup menu, for example)
     open var preferredContentWidth: CGFloat { return 0 }
     open var preferredContentHeight: CGFloat { return 0 }
@@ -892,7 +895,17 @@ extension DrawerController: UIViewControllerTransitioningDelegate {
             if #available(iOS 13.0, *) {
                 useNavigationBarBackgroundColor = (direction.isVertical && source.traitCollection.userInterfaceLevel == .elevated)
             }
-            return DrawerPresentationController(presentedViewController: presented, presenting: presenting, source: source, sourceObject: sourceView ?? barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: direction, presentationOffset: presentationOffset, presentationBackground: presentationBackground, adjustHeightForKeyboard: adjustsHeightForKeyboard, shouldUseWindowFullWidthInLandscape: shouldUseWindowFullWidthInLandscape)
+            return DrawerPresentationController(presentedViewController: presented,
+                                                presentingViewController: presenting,
+                                                source: source,
+                                                sourceObject: sourceView ?? barButtonItem,
+                                                presentationOrigin: presentationOrigin,
+                                                presentationDirection: direction,
+                                                presentationOffset: presentationOffset,
+                                                presentationBackground: presentationBackground,
+                                                adjustHeightForKeyboard: adjustsHeightForKeyboard,
+                                                shouldUseWindowFullWidthInLandscape: shouldUseWindowFullWidthInLandscape,
+                                                shouldRespectSafeAreaForWindowFullWidth: shouldRespectSafeAreaForWindowFullWidth)
         case .popover:
             let presentationController = UIPopoverPresentationController(presentedViewController: presented, presenting: presenting)
             presentationController.backgroundColor = backgroundColor

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -335,7 +335,7 @@ open class DrawerController: UIViewController {
     @objc open var shouldUseWindowFullWidthInLandscape: Bool = true
 
     /// Limits the full window width to its safe area for `vertical` presentation.
-    @objc open var shouldRespectSafeAreaForWindowFullWidth: Bool = true
+    @objc open var shouldRespectSafeAreaForWindowFullWidth: Bool = false
 
     // Override to provide the preferred size based on specifics of the concrete drawer subclass (see popup menu, for example)
     open var preferredContentWidth: CGFloat { return 0 }

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -17,13 +17,23 @@ class DrawerPresentationController: UIPresentationController {
     let presentationDirection: DrawerPresentationDirection
 
     private let shouldUseWindowFullWidthInLandscape: Bool
+    private let shouldRespectSafeAreaForWindowFullWidth: Bool
     private let sourceViewController: UIViewController
     private let sourceObject: Any?
     private let presentationOrigin: CGFloat?
     private let presentationOffset: CGFloat
     private let presentationBackground: DrawerPresentationBackground
 
-    init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?, source: UIViewController, sourceObject: Any?, presentationOrigin: CGFloat?, presentationDirection: DrawerPresentationDirection, presentationOffset: CGFloat, presentationBackground: DrawerPresentationBackground, adjustHeightForKeyboard: Bool, shouldUseWindowFullWidthInLandscape: Bool) {
+    init(presentedViewController: UIViewController,
+         presentingViewController:UIViewController?,
+         source: UIViewController, sourceObject: Any?,
+         presentationOrigin: CGFloat?,
+         presentationDirection: DrawerPresentationDirection,
+         presentationOffset: CGFloat,
+         presentationBackground: DrawerPresentationBackground,
+         adjustHeightForKeyboard: Bool,
+         shouldUseWindowFullWidthInLandscape: Bool,
+         shouldRespectSafeAreaForWindowFullWidth: Bool) {
         sourceViewController = source
         self.sourceObject = sourceObject
         self.presentationOrigin = presentationOrigin
@@ -31,6 +41,8 @@ class DrawerPresentationController: UIPresentationController {
         self.presentationOffset = presentationOffset
         self.presentationBackground = presentationBackground
         self.shouldUseWindowFullWidthInLandscape = shouldUseWindowFullWidthInLandscape
+        self.shouldRespectSafeAreaForWindowFullWidth = shouldRespectSafeAreaForWindowFullWidth
+
         super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
 
         backgroundView.gestureRecognizers = [UITapGestureRecognizer(target: self, action: #selector(handleBackgroundViewTapped(_:)))]
@@ -373,6 +385,12 @@ class DrawerPresentationController: UIPresentationController {
 
         let presentationOffsetMargin = actualPresentationOffset > 0 ? safeAreaPresentationOffset + actualPresentationOffset : 0
         var margins: UIEdgeInsets = .zero
+
+        if presentationDirection.isVertical && shouldRespectSafeAreaForWindowFullWidth {
+            margins.left = containerView.safeAreaInsets.left
+            margins.right = containerView.safeAreaInsets.right
+        }
+
         switch presentationDirection {
         case .down:
             margins.top = presentationOffsetMargin


### PR DESCRIPTION
The Drawer controller currently uses all the window width to present itself by default.
On devices with the notch (landscape mode) this can be a problem because the entire window width does consider the safe area.

![no_safe_area](https://user-images.githubusercontent.com/68076145/92645712-218d1180-f29a-11ea-8cc6-b8e07ebab798.png)

The design guidelines for some cases define that the entire drawer should limit itself to the safe area. So, we need to add support for that.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change adds this behavior, but the default is still set to take the entire width space. The client code is able to configure the drawer to respect the safe areas through a property.

### Verification

(how the change was tested, including both manual and automated tests)


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2020-09-09 at 12 47 26 PM](https://user-images.githubusercontent.com/68076145/92646391-36b67000-f29b-11ea-832d-42fff63165b4.png) | ![Screen Shot 2020-09-09 at 12 49 10 PM](https://user-images.githubusercontent.com/68076145/92646702-ab89aa00-f29b-11ea-932a-6ea83e301756.png) |
| ![Screen Shot 2020-09-09 at 12 47 42 PM](https://user-images.githubusercontent.com/68076145/92646566-7b420b80-f29b-11ea-8b87-b120591dd499.png) | ![Screen Shot 2020-09-09 at 12 49 19 PM](https://user-images.githubusercontent.com/68076145/92646729-b6443f00-f29b-11ea-8eb1-1ee6030e6236.png) |

![Screen Shot 2020-09-09 at 12 51 20 PM](https://user-images.githubusercontent.com/68076145/92646811-d542d100-f29b-11ea-87d6-29d8dc3fb7b6.png)
![Screen Shot 2020-09-09 at 12 49 54 PM](https://user-images.githubusercontent.com/68076145/92646826-d96eee80-f29b-11ea-9169-e88d93b5061d.png)
![Screen Shot 2020-09-09 at 12 50 03 PM](https://user-images.githubusercontent.com/68076145/92646829-dbd14880-f29b-11ea-8ea1-c8682652fee2.png)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/225)