### PR TITLE
Pointer interactions for PillButtonBar

### DIFF
--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -829,15 +829,15 @@ class OverflowAvatarView: AvatarView {
 extension AvatarView: UIPointerInteractionDelegate {
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
-        if let superview = window {
-            let frame = superview.convert(bounds, from: self)
-            let target = UIPreviewTarget(container: superview, center: CGPoint(x: frame.midX, y: frame.midY))
-            let preview = UITargetedPreview(view: self, parameters: UIPreviewParameters(), target: target)
-            let pointerEffect = UIPointerEffect.lift(preview)
-
-            return UIPointerStyle(effect: pointerEffect, shape: nil)
+        guard let superview = window else {
+            return nil
         }
 
-        return nil
+        let frame = superview.convert(bounds, from: self)
+        let target = UIPreviewTarget(container: superview, center: CGPoint(x: frame.midX, y: frame.midY))
+        let preview = UITargetedPreview(view: self, parameters: UIPreviewParameters(), target: target)
+        let pointerEffect = UIPointerEffect.lift(preview)
+
+        return UIPointerStyle(effect: pointerEffect, shape: nil)
     }
 }

--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -829,7 +829,15 @@ class OverflowAvatarView: AvatarView {
 extension AvatarView: UIPointerInteractionDelegate {
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
-        let pointerEffect = UIPointerEffect.lift(.init(view: self))
-        return UIPointerStyle(effect: pointerEffect, shape: nil)
+        if let superview = window {
+            let frame = superview.convert(bounds, from: self)
+            let target = UIPreviewTarget(container: superview, center: CGPoint(x: frame.midX, y: frame.midY))
+            let preview = UITargetedPreview(view: self, parameters: UIPreviewParameters(), target: target)
+            let pointerEffect = UIPointerEffect.lift(preview)
+
+            return UIPointerStyle(effect: pointerEffect, shape: nil)
+        }
+
+        return nil
     }
 }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -48,6 +48,15 @@ public enum PillButtonStyle: Int {
         }
     }
 
+    func hoverBackgroundColor(for window: UIWindow) -> UIColor {
+        switch self {
+        case .outline:
+            return Colors.surfaceQuaternary
+        case .filled:
+            return UIColor(light: Colors.primaryShade20(for: window), dark: Colors.surfaceQuaternary)
+        }
+    }
+
     var titleColor: UIColor {
         switch self {
         case .outline:
@@ -110,8 +119,6 @@ open class PillButton: UIButton {
         static let topInset: CGFloat = 6.0
     }
 
-    private var useCustomBackgroundColor: Bool = false
-
     @objc public let pillBarItem: PillButtonBarItem
 
     @objc public let style: PillButtonStyle
@@ -133,8 +140,7 @@ open class PillButton: UIButton {
     /// Set `backgroundColor` to customize background color of the pill button
     @objc open var customBackgroundColor: UIColor? {
         didSet {
-            useCustomBackgroundColor = true
-            self.backgroundColor = customBackgroundColor
+            updateAppearance()
         }
     }
 
@@ -198,7 +204,12 @@ open class PillButton: UIButton {
                     setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
                 }
             } else {
-                backgroundColor = useCustomBackgroundColor ? customBackgroundColor : style.backgroundColor(for: window)
+                if let customBackgroundColor = customBackgroundColor {
+                    backgroundColor = customBackgroundColor
+                } else {
+                    backgroundColor = style.backgroundColor(for: window)
+                }
+
                 if isEnabled {
                     setTitleColor(style.titleColor, for: .normal)
                 } else {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -481,17 +481,17 @@ extension PillButtonBar: UIPointerInteractionDelegate {
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
         let index = region.identifier as! Int
-        if let superview = window, index < buttons.count {
-            let pillButton = buttons[index]
-            let pillButtonFrame = stackView.convert(pillButton.frame, to: superview)
-            let target = UIPreviewTarget(container: superview, center: CGPoint(x: pillButtonFrame.midX, y: pillButtonFrame.midY))
-            let preview = UITargetedPreview(view: pillButton, parameters: UIPreviewParameters(), target: target)
-            let pointerEffect = UIPointerEffect.lift(preview)
-
-            return UIPointerStyle(effect: pointerEffect, shape: nil)
+        guard let superview = window, index < buttons.count else {
+            return nil
         }
 
-        return nil
+        let pillButton = buttons[index]
+        let pillButtonFrame = stackView.convert(pillButton.frame, to: superview)
+        let target = UIPreviewTarget(container: superview, center: CGPoint(x: pillButtonFrame.midX, y: pillButtonFrame.midY))
+        let preview = UITargetedPreview(view: pillButton, parameters: UIPreviewParameters(), target: target)
+        let pointerEffect = UIPointerEffect.lift(preview)
+
+        return UIPointerStyle(effect: pointerEffect, shape: nil)
     }
 
     @available(iOS 13.4, *)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Implement pointer interaction for PillButtonBar.
Followed Apple's guidelines from the WWDC demo: https://developer.apple.com/videos/play/wwdc2020/10093/.
For group of continuous items, it is recommended to add the pointer interaction on the container view, the stack view in this case.
Then, add a pointer region for each item, PillButton in this case.
The lift style is used for the interaction style.
When a pill button is hovered, its background color needs to be slightly adjusted by being a bit darker in light mode and a bit lighter in dark mode. Otherwise, the highlight effect makes the pill button less visible.

Also included in this change: set the avatar view target preview to the window. That way, no matter in which subview the avatar view will end up, its lift effect will never get cutoff since the preview will render in the top superview, the window.

![demo](https://user-images.githubusercontent.com/4185114/92663458-37103480-f2b6-11ea-8533-254c26ab9054.gif)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/226)