### PR TITLE
Support attributed strings for Label Control

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -26,6 +26,11 @@ class LabelDemoController: DemoController {
 
         container.addArrangedSubview(UIView())  // spacer
 
+        addLabel(text: "Test attributed strings", style: .headline, colorStyle: .regular).textAlignment = .center
+        for colorStyle in TextColorStyle.allCases {
+            addAttributedStringLabel(text: "Test attributed strings", substring: "attributed", style: .footnote, colorStyle: colorStyle)
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
 
@@ -39,6 +44,21 @@ class LabelDemoController: DemoController {
         }
         container.addArrangedSubview(label)
         return label
+    }
+
+    @discardableResult
+    func addAttributedStringLabel(text: String, substring: String, style: TextStyle, colorStyle: TextColorStyle) -> Label {
+        let label = Label(style: style, colorStyle: colorStyle)
+        label.numberOfLines = 0
+        let range = (text as NSString).range(of: substring)
+        let attributedString = NSMutableAttributedString(string:text)
+
+        attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.red , range: range)
+        label.attributedText = attributedString
+
+        container.addArrangedSubview(label)
+        return label
+
     }
 
     @objc private func handleContentSizeCategoryDidChange() {

--- a/ios/FluentUI/Controls/Label.swift
+++ b/ios/FluentUI/Controls/Label.swift
@@ -20,7 +20,7 @@ public enum TextColorStyle: Int, CaseIterable {
     case warning
     case disabled
 
-    public func color(for window: UIWindow) -> UIColor {
+    public func color(for window: UIWindow?) -> UIColor? {
         switch self {
         case .regular:
             return Colors.textPrimary
@@ -29,7 +29,10 @@ public enum TextColorStyle: Int, CaseIterable {
         case .white:
             return .white
         case .primary:
-            return Colors.primary(for: window)
+            let primaryColor = {
+                window != nil ? Colors.primary(for: window!) : Colors.textPrimary
+            }
+            return primaryColor()
         case .error:
             return Colors.error
         case .warning:
@@ -92,7 +95,9 @@ open class Label: UILabel {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateTextColor()
+        if self.attributedText == nil {
+            updateTextColor()
+        }
     }
 
     private func initialize() {
@@ -119,10 +124,8 @@ open class Label: UILabel {
     }
 
     private func updateTextColor() {
-        if let window = window {
-            let currentTextColor = _textColor ?? colorStyle.color(for: window)
-            super.textColor = currentTextColor.current
-        }
+        let currentTextColor = _textColor ?? colorStyle.color(for: window)
+        super.textColor = currentTextColor!.current
     }
 
     @objc private func handleContentSizeCategoryDidChange() {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [] macOS

### Description of changes
This change fixes a bug in label control where attributed string text color is disregarded. When a label attributed string is set with custom UIColor, the colorStyle overrides the custom color because we set the label color after the UIWindow is loaded. The fix is to set the text color before UIWindow is loaded by making it an optional.
### Verification
Created a test case for attributed strings in the demo app.
| Before                                                                  | After                                                                 |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/67026167/92984592-48556e80-f479-11ea-88d4-bea657b572ac.png) | ![image](https://user-images.githubusercontent.com/67026167/92984652-b437d700-f479-11ea-932b-6d5ccc138b94.png) |
| ![image](https://user-images.githubusercontent.com/67026167/92984597-56a38a80-f479-11ea-9ce7-1ac555bdbc52.png) | ![image](https://user-images.githubusercontent.com/67026167/92984645-a2563400-f479-11ea-873c-32a5d5bbbe01.png)|

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/227)