### PR TITLE
Hyshin/badgeview warning

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -48,7 +48,7 @@ public extension Colors {
         public static var textError: UIColor = Palette.dangerShade20.color
         public static var textErrorSelected: UIColor = textOnAccent
         public static var textWarning = UIColor(light: Palette.warningShade30.color, dark: Palette.warningPrimary.color)
-        public static var textWarningSelected = UIColor(light: Palette.warningShade30.color, dark: .black)
+        public static var textWarningSelected: UIColor = .black
     }
 }
 

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -25,8 +25,9 @@ class DrawerPresentationController: UIPresentationController {
     private let presentationBackground: DrawerPresentationBackground
 
     init(presentedViewController: UIViewController,
-         presentingViewController:UIViewController?,
-         source: UIViewController, sourceObject: Any?,
+         presentingViewController: UIViewController?,
+         source: UIViewController,
+         sourceObject: Any?,
          presentationOrigin: CGFloat?,
          presentationDirection: DrawerPresentationDirection,
          presentationOffset: CGFloat,

--- a/ios/FluentUI/Shimmer/ShimmerAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerAppearance.swift
@@ -15,27 +15,27 @@ public typealias MSShimmerAppearance = ShimmerAppearance
 @available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerAppearance)
 public class ShimmerAppearance: NSObject {
-	@objc public let alpha: CGFloat
-	@objc public let width: CGFloat
+    @objc public let alpha: CGFloat
+    @objc public let width: CGFloat
 
-	/// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
-	@objc public let angle: CGFloat
+    /// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
+    @objc public let angle: CGFloat
 
-	/// Speed of the animation, in point/seconds.
-	@objc public let speed: CGFloat
+    /// Speed of the animation, in point/seconds.
+    @objc public let speed: CGFloat
 
-	/// Delay between the end of a shimmering animation and the beginning of the next one.
-	@objc public let delay: TimeInterval
+    /// Delay between the end of a shimmering animation and the beginning of the next one.
+    @objc public let delay: TimeInterval
 
-	@objc public init(alpha: CGFloat = 0.4,
-					  width: CGFloat = 180,
-					  angle: CGFloat = -(CGFloat.pi / 45.0),
-					  speed: CGFloat = 350,
-					  delay: TimeInterval = 0.4) {
-		self.alpha = alpha
-		self.width = width
-		self.angle = angle
-		self.speed = speed
-		self.delay = delay
-	}
+    @objc public init(alpha: CGFloat = 0.4,
+                      width: CGFloat = 180,
+                      angle: CGFloat = -(CGFloat.pi / 45.0),
+                      speed: CGFloat = 350,
+                      delay: TimeInterval = 0.4) {
+        self.alpha = alpha
+        self.width = width
+        self.angle = angle
+        self.speed = speed
+        self.delay = delay
+    }
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesViewAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesViewAppearance.swift
@@ -15,27 +15,27 @@ public typealias MSShimmerLinesViewAppearance = ShimmerLinesViewAppearance
 @available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerLinesViewAppearance)
 public class ShimmerLinesViewAppearance: NSObject {
-	@objc public let lineCount: Int // use 0 if the number of lines should adapt to the available height
-	@objc public let lineHeight: CGFloat
-	@objc public let lineSpacing: CGFloat
-	@objc public let firstLineFillPercent: CGFloat
-	@objc public let lastLineFillPercent: CGFloat
+    @objc public let lineCount: Int // use 0 if the number of lines should adapt to the available height
+    @objc public let lineHeight: CGFloat
+    @objc public let lineSpacing: CGFloat
+    @objc public let firstLineFillPercent: CGFloat
+    @objc public let lastLineFillPercent: CGFloat
 
-	/// Create an apperance shimmer view apperance object
-	/// - Parameter lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-	/// - Parameter lineHeight: Height of shimmering line
-	/// - Parameter lineSpacing: Spacing between lines (if lines > 1)
-	/// - Parameter firstLineFillPercent: if two or more lines, the percent the first line should fill the available horizontal space
-	/// - Parameter lastLineFillPercent: the percent the last line should fill the available horizontal space.
-	@objc public init(lineCount: Int = 3,
-					  lineHeight: CGFloat = 11,
-					  lineSpacing: CGFloat = 11,
-					  firstLineFillPercent: CGFloat = 0.94,
-					  lastLineFillPercent: CGFloat = 0.6) {
-		self.lineCount = lineCount
-		self.lineHeight = lineHeight
-		self.lineSpacing = lineSpacing
-		self.firstLineFillPercent = firstLineFillPercent
-		self.lastLineFillPercent = lastLineFillPercent
-	}
+    /// Create an apperance shimmer view apperance object
+    /// - Parameter lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+    /// - Parameter lineHeight: Height of shimmering line
+    /// - Parameter lineSpacing: Spacing between lines (if lines > 1)
+    /// - Parameter firstLineFillPercent: if two or more lines, the percent the first line should fill the available horizontal space
+    /// - Parameter lastLineFillPercent: the percent the last line should fill the available horizontal space.
+    @objc public init(lineCount: Int = 3,
+                      lineHeight: CGFloat = 11,
+                      lineSpacing: CGFloat = 11,
+                      firstLineFillPercent: CGFloat = 0.94,
+                      lastLineFillPercent: CGFloat = 0.6) {
+        self.lineCount = lineCount
+        self.lineHeight = lineHeight
+        self.lineSpacing = lineSpacing
+        self.firstLineFillPercent = firstLineFillPercent
+        self.lastLineFillPercent = lastLineFillPercent
+    }
 }

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -134,9 +134,9 @@ open class ShimmerView: UIView {
 	/// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored
 	/// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer
 	/// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views
-	@objc public init(containerView: UIView? = nil,
-					  excludedViews: [UIView] = [],
-					  animationSynchronizer: AnimationSynchronizerProtocol? = nil) {
+    @objc public init(containerView: UIView? = nil,
+                      excludedViews: [UIView] = [],
+                      animationSynchronizer: AnimationSynchronizerProtocol? = nil) {
 		self.containerView = containerView
 		self.excludedViews = excludedViews
 		self.animationSynchronizer = animationSynchronizer

--- a/ios/FluentUI/Shimmer/ShimmerViewAppearance.swift
+++ b/ios/FluentUI/Shimmer/ShimmerViewAppearance.swift
@@ -13,27 +13,27 @@ public typealias MSShimmerViewAppearance = ShimmerViewAppearance
 @available(*, deprecated, message: "Use individual properties on ShimmerView instead")
 @objc(MSFShimmerViewAppearence)
 public class ShimmerViewAppearance: NSObject {
-	@objc public let tintColor: UIColor
-	@objc public let cornerRadius: CGFloat
-	@objc public let labelCornerRadius: CGFloat
-	@objc public let usesTextHeightForLabels: Bool
-	@objc public let labelHeight: CGFloat
+    @objc public let tintColor: UIColor
+    @objc public let cornerRadius: CGFloat
+    @objc public let labelCornerRadius: CGFloat
+    @objc public let usesTextHeightForLabels: Bool
+    @objc public let labelHeight: CGFloat
 
-	/// Create an apperance shimmer view apperance object
-	/// - Parameter tintColor: Tint color of the view.
-	/// - Parameter cornerRadius: Corner radius on each view.
-	/// - Parameter labelCornerRadius: Corner radius on each UILabel. Set to < 0 to disable and use default `cornerRadius`.
-	/// - Parameter usesTextHeightForLabels: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box. `labelHeight` will take precendence over this property.
-	/// - Parameter labelHeight: If greater than 0, a fixed height to use for all UILabels. This will take precedence over `usesTextHeightForLabels`. Set to less than 0 to disable.
-	@objc public init(tintColor: UIColor = Colors.Shimmer.tint,
-					  cornerRadius: CGFloat = 4.0,
-					  labelCornerRadius: CGFloat = 2.0,
-					  usesTextHeightForLabels: Bool = false,
-					  labelHeight: CGFloat = 11) {
-		self.tintColor = tintColor
-		self.cornerRadius = cornerRadius
-		self.labelCornerRadius = labelCornerRadius
-		self.usesTextHeightForLabels = usesTextHeightForLabels
-		self.labelHeight = labelHeight
-	}
+    /// Create an apperance shimmer view apperance object
+    /// - Parameter tintColor: Tint color of the view.
+    /// - Parameter cornerRadius: Corner radius on each view.
+    /// - Parameter labelCornerRadius: Corner radius on each UILabel. Set to < 0 to disable and use default `cornerRadius`.
+    /// - Parameter usesTextHeightForLabels: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box. `labelHeight` will take precendence over this property.
+    /// - Parameter labelHeight: If greater than 0, a fixed height to use for all UILabels. This will take precedence over `usesTextHeightForLabels`. Set to less than 0 to disable.
+    @objc public init(tintColor: UIColor = Colors.Shimmer.tint,
+                      cornerRadius: CGFloat = 4.0,
+                      labelCornerRadius: CGFloat = 2.0,
+                      usesTextHeightForLabels: Bool = false,
+                      labelHeight: CGFloat = 11) {
+        self.tintColor = tintColor
+        self.cornerRadius = cornerRadius
+        self.labelCornerRadius = labelCornerRadius
+        self.usesTextHeightForLabels = usesTextHeightForLabels
+        self.labelHeight = labelHeight
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

fix some syntax warning by other commits.
Update warning badge selected color based on latest design 

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-14 at 09 06 24](https://user-images.githubusercontent.com/20715435/93110932-cdec4080-f66a-11ea-916d-68e5de365d8c.png)| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-14 at 08 32 29](https://user-images.githubusercontent.com/20715435/93110959-d80e3f00-f66a-11ea-8481-5405912504a6.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/228)