### PR TITLE
Fixing stack overflow caused by didSet on selectedTextRange property.

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -428,11 +428,14 @@ private class TableViewHeaderFooterTitleView: UITextView {
     }
 
     override var selectedTextRange: UITextRange? {
-        didSet {
+        get {
             // No need for selection, but we need to keep it selectable in order for links to work
-            if selectedTextRange != nil {
-                selectedTextRange = nil
-            }
+            return nil
+        }
+
+        set {
+            // No-op because we don't want to allow this property to be set.
+            // It should always return nil which indicates there is no current selection (https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange)
         }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Commit e12eede79d585730b1d00dabce72977947c33f8a added code to override the selectedTextRange property on the TableViewHeaderFooterTitleView class in order to block selection on the UITextView. 
The UITextView still needs to be selectable to allow links to work.

    override var selectedTextRange: UITextRange? {
        didSet {
            // No need for selection, but we need to keep it selectable in order for links to work
            if selectedTextRange != nil {
                selectedTextRange = nil
            }
        }
    }

The issue is that in the case where the property is set to a non nil value, the code in didSet property observer sets the property again causing a stack overflow.

This can be fixed by overriding the property and always returning nil while making the setter a no-op.

### Verification

1. Forced the stack overflow by setting the selectedTextRange property to a non-nil value.
2. Verified the stack overflow does not reproduce after the fix is applied.
3. Validated links on the footer work as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/229)