### PR TITLE
Fix consumption of fluentui-ios (built with Xcode 11) when building with Xcode 12

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -40,7 +40,7 @@ open class NavigationBarTopAccessoryViewAttributes: NSObject {
         self.minWidth = minWidth
         super.init()
     }
-	
+
 	public override init() {
 		self.widthMultiplier = 1.0
 		self.maxWidth = .greatestFiniteMagnitude

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -40,12 +40,18 @@ open class NavigationBarTopAccessoryViewAttributes: NSObject {
         self.minWidth = minWidth
         super.init()
     }
+	
+	public override init() {
+		self.widthMultiplier = 1.0
+		self.maxWidth = .greatestFiniteMagnitude
+		self.minWidth = .zero
+	}
 }
 
 /// Layout attributes for a navigation bar's top search bar.
 @objc(MSFNavigationBarTopSearchBarAttributes)
 open class NavigationBarTopSearchBarAttributes: NavigationBarTopAccessoryViewAttributes {
-    @objc public init() {
+    @objc public override init() {
         super.init(widthMultiplier: Constants.widthMultiplier, maxWidth: Constants.viewMaxWidth, minWidth: Constants.viewMinWidth)
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -41,11 +41,11 @@ open class NavigationBarTopAccessoryViewAttributes: NSObject {
         super.init()
     }
 
-	public override init() {
-		self.widthMultiplier = 1.0
-		self.maxWidth = .greatestFiniteMagnitude
-		self.minWidth = .zero
-	}
+    public override init() {
+        self.widthMultiplier = 1.0
+        self.maxWidth = .greatestFiniteMagnitude
+        self.minWidth = .zero
+    }
 }
 
 /// Layout attributes for a navigation bar's top search bar.

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -309,7 +309,7 @@ extension PopupMenuController: UITableViewDataSource {
         let identifier = String(describing: cellClass)
         tableView.register(cellClass, forCellReuseIdentifier: identifier)
 
-		let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! (PopupMenuItemTemplateCell & TableViewCell)
+        let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! (PopupMenuItemTemplateCell & TableViewCell)
         cell.setup(item: item)
         cell.preservesSpaceForImage = itemsHaveImages
 

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -309,7 +309,7 @@ extension PopupMenuController: UITableViewDataSource {
         let identifier = String(describing: cellClass)
         tableView.register(cellClass, forCellReuseIdentifier: identifier)
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! PopupMenuItemTemplateCell
+		let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! (PopupMenuItemTemplateCell & TableViewCell)
         cell.setup(item: item)
         cell.preservesSpaceForImage = itemsHaveImages
 

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -38,7 +38,7 @@ public protocol PopupMenuTemplateItem: AnyObject {
  You can use `UITableViewCell` conforms to this protocol for customization.
 */
 @objc(MSFPopupMenuItemTemplateCell)
-public protocol PopupMenuItemTemplateCell where Self: UITableViewCell {
+public protocol PopupMenuItemTemplateCell {
     /// `PopupMenuController` will notify that one or more items in the list contain image(s)
     @objc var preservesSpaceForImage: Bool { get set }
     /// `PopupMenuController` will notify the custom separatorColor.

--- a/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuProtocols.swift
@@ -35,7 +35,7 @@ public protocol PopupMenuTemplateItem: AnyObject {
 /**
 `PopupMenuItemTemplateCell` represents a template cell protocol inside `PopupMenuController`.
  The built-in type is `PopupMenuItemCell`.
- You can use `UITableViewCell` conforms to this protocol for customization.
+ If you are making a custom object conform to this protocol, it must be a `UITableViewCell` for the Pop Up Menu to work properly
 */
 @objc(MSFPopupMenuItemTemplateCell)
 public protocol PopupMenuItemTemplateCell {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
A new swift compiler version is used between Xcode 11 and Xcode 12. When building with Xcode 12 and trying to import the FluentUILib module, the compiler complains about a few things

**NavigationBar.swift**
NavigationBarTopSearchBarAttributes subclasses from NavigationBarTopAccessoryViewAttributes. The superclass has an init with multiple parameters whereas the subclass has an init with no parameters. The subclass does not declare its init as an override even though it is technically overriding from a few levels up in the hierarchy. Consuming the swift interface complains about that, but we can't just mark it as override because its superclass does not have that method.

Ultimately the best solution I can think of is to add a dummy init to NavigationBarTopAccessoryViewAttributes with no parameters so overriding init is defined behavior

**PopupMenuController.swift**
**PopupMenuProtocols.swift**
PopupMenuItemTemplateCell is a protocol requires conformers to be UITableViewCell. Unfortunately the generated swift-interface loses this distinction and just tries to make the protocol inherit from the class which is not ok. That syntax (public protocol Foo where Self:Bar) appears to be new and not quite settled. Let's just skip doing that for now and put the onus on usages to also specify the conformer must be a UITableViewCell. There's only one instance here

### Verification
Manual inspection before/after of swift interface and objC interfaces

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/231)