### PR TITLE
Add an option to set minimum number of actions in file accessory view

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -41,7 +41,8 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             }
         }
 
-        accessoryViews.removeAll()
+        topAccessoryViews.removeAll()
+        bottomAccessoryViews.removeAll()
 
         var layoutConstraints: [NSLayoutConstraint] = []
 
@@ -52,9 +53,9 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
                 stackView.addArrangedSubview(cellTitle)
             }
 
-            let cell1 = createCell(title: "Document Title", subtitle: "OneDrive - Microsoft · Microsoft Teams Chat Files")
+            let cell1 = createCell(title: "Document Title", subtitle: "OneDrive - Microsoft · Microsoft Teams Chat Files", top: true)
             let cell2 = createCell(title: "This is a very long document title that keeps on going forever to test text truncation",
-                                   subtitle: "This is a very long document subtitle that keeps on going forever to test text truncation")
+                                   subtitle: "This is a very long document subtitle that keeps on going forever to test text truncation", top: false)
 
             let containerView = UIStackView(frame: .zero)
             containerView.axis = .vertical
@@ -93,7 +94,8 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         static let smallCellPadding: CGFloat = 8
     }
 
-    private var accessoryViews: [TableViewCellFileAccessoryView] = []
+    private var topAccessoryViews: [TableViewCellFileAccessoryView] = []
+    private var bottomAccessoryViews: [TableViewCellFileAccessoryView] = []
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(frame: .zero)
@@ -110,7 +112,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         return customAccessoryView
     }
 
-    private func actions() -> [FileAccessoryViewAction] {
+    private func actions(top: Bool) -> [FileAccessoryViewAction] {
         var actions: [FileAccessoryViewAction] = []
         if showOverflowAction {
             let action = FileAccessoryViewAction(title: "File actions",
@@ -157,7 +159,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             actions.append(action)
         }
 
-        if showErrorAction {
+        if showErrorAction && !(!top && !showErrorOnBottomCellAction) {
             if #available(iOS 13.0, *) {
                 let action = FileAccessoryViewAction(title: "Error",
                                                      image: UIImage(named: "ic_fluent_warning_24_regular")!,
@@ -172,34 +174,44 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
     }
 
     private func updateActions() {
-        let actionList = actions()
-        for accessoryView in accessoryViews {
-            accessoryView.actions = actionList
+        let topActionList = actions(top: true)
+        for accessoryView in topAccessoryViews {
+            accessoryView.actions = topActionList
+        }
+
+        let bottomActionList = actions(top: false)
+        for accessoryView in bottomAccessoryViews {
+            accessoryView.actions = bottomActionList
         }
     }
 
     private func updateDate() {
         let date = showDate ? self.date : nil
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             accessoryView.date = date
         }
     }
 
     private func updateSharedStatus() {
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             accessoryView.showSharedStatus = showSharedStatus
         }
     }
 
     private func updateAreDocumentsShared() {
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             accessoryView.isShared = areDocumentsShared
         }
     }
 
-    private func createCell(title: String, subtitle: String) -> TableViewCell {
+    private func createCell(title: String, subtitle: String, top: Bool) -> TableViewCell {
         let customAccessoryView = createAccessoryView()
-        accessoryViews.append(customAccessoryView)
+
+        if top {
+            topAccessoryViews.append(customAccessoryView)
+        } else {
+            bottomAccessoryViews.append(customAccessoryView)
+        }
 
         let cell = TableViewCell(frame: .zero)
         customAccessoryView.tableViewCell = cell
@@ -231,7 +243,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
     private func updateCellPadding() {
         let extraPadding = view.frame.width >= Constants.cellPaddingThreshold && useDynamicPadding ? Constants.largeCellPadding : Constants.smallCellPadding
 
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             if let cell = accessoryView.tableViewCell {
                 cell.paddingLeading = TableViewCell.defaultPaddingLeading + extraPadding
                 cell.paddingTrailing = TableViewCell.defaultPaddingTrailing + extraPadding
@@ -281,13 +293,19 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         }
     }
 
+    private var showErrorOnBottomCellAction: Bool = true {
+        didSet {
+            updateActions()
+        }
+    }
+
     private var showOverflowAction: Bool = true {
         didSet {
             reloadCells()
         }
     }
 
-    private var useDynamicWidth: Bool = false {
+    private var useDynamicWidth: Bool = true {
         didSet {
             reloadCells()
         }
@@ -325,6 +343,16 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         }
     }
 
+    private var minimumActionsCount: UInt = 0 {
+        didSet {
+            if oldValue != minimumActionsCount {
+                for accessoryView in topAccessoryViews + bottomAccessoryViews {
+                    accessoryView.minimumActionsCount = minimumActionsCount
+                }
+            }
+        }
+    }
+
     private lazy var settingsView: UIView = {
         let settingsView = UIStackView(frame: .zero)
         settingsView.axis = .horizontal
@@ -334,12 +362,16 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         spacingView.widthAnchor.constraint(equalToConstant: Constants.stackViewSpacing).isActive = true
         settingsView.addArrangedSubview(spacingView)
 
+        let plusButton = createButton(title: "+", action: #selector(incrementMinimumActionsCount))
+        let minusButton = createButton(title: "-", action: #selector(decrementMinimumActionsCount))
+
         let settingViews: [UIView] = [
             createLabelAndSwitchRow(labelText: "Dynamic width", switchAction: #selector(toggleDynamicWidth(switchView:)), isOn: useDynamicWidth),
             createLabelAndSwitchRow(labelText: "Dynamic padding", switchAction: #selector(toggleDynamicPadding(switchView:)), isOn: useDynamicPadding),
             createLabelAndSwitchRow(labelText: "Show date", switchAction: #selector(toggleShowDate(switchView:)), isOn: showDate),
             createButton(title: "Choose date", action: #selector(presentDatePicker)),
             createButton(title: "Choose time", action: #selector(presentTimePicker)),
+            createLabelAndViewsRow(labelText: "Minimum actions count", views: [plusButton, minusButton]),
             createLabelAndSwitchRow(labelText: "Show shared status", switchAction: #selector(toggleShowSharedStatus(switchView:)), isOn: showSharedStatus),
             createLabelAndSwitchRow(labelText: "Is document shared", switchAction: #selector(toggleAreDocumentsShared(switchView:)), isOn: areDocumentsShared),
             createLabelAndSwitchRow(labelText: "Show keep offline button", switchAction: #selector(toggleShowKeepOffline(switchView:)), isOn: showKeepOfflineAction),
@@ -348,6 +380,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             createLabelAndSwitchRow(labelText: "Show pin button", switchAction: #selector(togglePin(switchView:)), isOn: showPinAction),
             createLabelAndSwitchRow(labelText: "Disable pin button", switchAction: #selector(togglePinButtonDisabled(switchView:)), isOn: isPinActionDisabled),
             createLabelAndSwitchRow(labelText: "Show error button", switchAction: #selector(toggleErrorButton(switchView:)), isOn: showErrorAction),
+            createLabelAndSwitchRow(labelText: "Show error button on top cell only", switchAction: #selector(toggleErrorOnBottomCellButton(switchView:)), isOn: !showErrorOnBottomCellAction),
             createLabelAndSwitchRow(labelText: "Show overflow button", switchAction: #selector(toggleOverflow(switchView:)), isOn: showOverflowAction)
         ]
 
@@ -419,6 +452,10 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         showErrorAction = switchView.isOn
     }
 
+    @objc private func toggleErrorOnBottomCellButton(switchView: UISwitch) {
+        showErrorOnBottomCellAction = !switchView.isOn
+    }
+
     @objc private func toggleOverflow(switchView: UISwitch) {
         showOverflowAction = switchView.isOn
     }
@@ -441,6 +478,16 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
 
     @objc private func handleKeepOfflineAction() {
         displayActionAlert(title: "Keep offline")
+    }
+
+    @objc private func incrementMinimumActionsCount() {
+        minimumActionsCount += 1
+    }
+
+    @objc private func decrementMinimumActionsCount() {
+        if minimumActionsCount > 0 {
+            minimumActionsCount -= 1
+        }
     }
 
     private func displayActionAlert(title: String) {

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -86,6 +86,7 @@ open class TableViewCellFileAccessoryView: UIView {
 
     /// The minimum count of actions.
     /// If there are fewer actions to display than this count, empty spaces will be reserved for those missing actions.
+    /// This property is useful to align columns between cells that display a different number of actions.
     /// Setting this value too high could result in a broken layout.
     @objc public var minimumActionsCount: UInt = 0 {
         didSet {

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -84,6 +84,17 @@ open class TableViewCellFileAccessoryView: UIView {
         }
     }
 
+    /// The minimum count of actions.
+    /// If there are fewer actions to display than this count, empty spaces will be reserved for those missing actions.
+    /// Setting this value too high could result in a broken layout.
+    @objc public var minimumActionsCount: UInt = 0 {
+        didSet {
+            if oldValue != minimumActionsCount {
+                updateLayout()
+            }
+        }
+    }
+
     @objc public weak var tableViewCell: TableViewCell? {
         didSet {
             updateLayout()
@@ -283,6 +294,25 @@ open class TableViewCellFileAccessoryView: UIView {
         for action in visibleActions.reversed() {
             let actionView = FileAccessoryViewActionView(action: action, window: currentWindow)
             actionsStackView.addArrangedSubview(actionView)
+        }
+
+        if actionsStackView.arrangedSubviews.count < minimumActionsCount {
+            let emptyActionsToAdd = Int(minimumActionsCount) - actionsStackView.arrangedSubviews.count
+            var layoutConstraints: [NSLayoutConstraint] = []
+
+            for _ in 1...emptyActionsToAdd {
+                let emptyView = UIView(frame: .zero)
+                emptyView.translatesAutoresizingMaskIntoConstraints = false
+
+                layoutConstraints.append(contentsOf: [
+                    emptyView.widthAnchor.constraint(equalToConstant: FileAccessoryViewActionView.size.width),
+                    emptyView.heightAnchor.constraint(greaterThanOrEqualToConstant: FileAccessoryViewActionView.size.height)
+                ])
+
+                actionsStackView.insertArrangedSubview(emptyView, at: 0)
+            }
+
+            NSLayoutConstraint.activate(layoutConstraints)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add an option to set minimum number of actions in file accessory view.
This will allow columns to be aligned when the number of actions can vary between rows.
Added some options in the demo controller to test this change.

After:
<img width="844" alt="Screen Shot 2020-09-17 at 2 20 10 PM" src="https://user-images.githubusercontent.com/4185114/93529918-97742700-f8f1-11ea-8090-8effee984919.png">

Before:
<img width="844" alt="Screen Shot 2020-09-17 at 2 20 12 PM" src="https://user-images.githubusercontent.com/4185114/93529931-9c38db00-f8f1-11ea-9f21-21373a3eacae.png">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/234)