### PR TITLE
New property in the file accessory cell view for action buttons that shouldn't offset the columns

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -92,6 +92,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         static let cellPaddingThreshold: CGFloat = 768
         static let largeCellPadding: CGFloat = 16
         static let smallCellPadding: CGFloat = 8
+        static let plusMinusButtonWidth: CGFloat = 40
     }
 
     private var topAccessoryViews: [TableViewCellFileAccessoryView] = []
@@ -353,6 +354,26 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         }
     }
 
+    private var topActionsOverlap: UInt = 0 {
+        didSet {
+            if oldValue != topActionsOverlap {
+                for accessoryView in topAccessoryViews {
+                    accessoryView.actionsColumnOverlap = topActionsOverlap
+                }
+            }
+        }
+    }
+
+    private var bottomActionsOverlap: UInt = 0 {
+        didSet {
+            if oldValue != bottomActionsOverlap {
+                for accessoryView in bottomAccessoryViews {
+                    accessoryView.actionsColumnOverlap = bottomActionsOverlap
+                }
+            }
+        }
+    }
+
     private lazy var settingsView: UIView = {
         let settingsView = UIStackView(frame: .zero)
         settingsView.axis = .horizontal
@@ -362,8 +383,12 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         spacingView.widthAnchor.constraint(equalToConstant: Constants.stackViewSpacing).isActive = true
         settingsView.addArrangedSubview(spacingView)
 
-        let plusButton = createButton(title: "+", action: #selector(incrementMinimumActionsCount))
-        let minusButton = createButton(title: "-", action: #selector(decrementMinimumActionsCount))
+        let plusMinActionsButton = createPlusMinusButton(plus: true, #selector(incrementMinimumActionsCount))
+        let minusMinActionsButton = createPlusMinusButton(plus: false, #selector(decrementMinimumActionsCount))
+        let plusTopOverlapButton = createPlusMinusButton(plus: true, #selector(incrementTopActionsOverlap))
+        let minusTopOverlapButton = createPlusMinusButton(plus: false, #selector(decrementTopActionsOverlap))
+        let plusBottomOverlapButton = createPlusMinusButton(plus: true, #selector(incrementBottomActionsOverlap))
+        let minusBottomOverlapButton = createPlusMinusButton(plus: false, #selector(decrementBottomActionsOverlap))
 
         let settingViews: [UIView] = [
             createLabelAndSwitchRow(labelText: "Dynamic width", switchAction: #selector(toggleDynamicWidth(switchView:)), isOn: useDynamicWidth),
@@ -371,7 +396,9 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             createLabelAndSwitchRow(labelText: "Show date", switchAction: #selector(toggleShowDate(switchView:)), isOn: showDate),
             createButton(title: "Choose date", action: #selector(presentDatePicker)),
             createButton(title: "Choose time", action: #selector(presentTimePicker)),
-            createLabelAndViewsRow(labelText: "Minimum actions count", views: [plusButton, minusButton]),
+            createLabelAndViewsRow(labelText: "Minimum actions count", views: [plusMinActionsButton, minusMinActionsButton]),
+            createLabelAndViewsRow(labelText: "Top actions overlap", views: [plusTopOverlapButton, minusTopOverlapButton]),
+            createLabelAndViewsRow(labelText: "Bottom actions overlap", views: [plusBottomOverlapButton, minusBottomOverlapButton]),
             createLabelAndSwitchRow(labelText: "Show shared status", switchAction: #selector(toggleShowSharedStatus(switchView:)), isOn: showSharedStatus),
             createLabelAndSwitchRow(labelText: "Is document shared", switchAction: #selector(toggleAreDocumentsShared(switchView:)), isOn: areDocumentsShared),
             createLabelAndSwitchRow(labelText: "Show keep offline button", switchAction: #selector(toggleShowKeepOffline(switchView:)), isOn: showKeepOfflineAction),
@@ -397,6 +424,12 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
 
         return settingsView
     }()
+
+    private func createPlusMinusButton(plus: Bool, _ selector: Selector) -> UIButton {
+        let button = createButton(title: (plus ? "+" : "-"), action: selector)
+        button.widthAnchor.constraint(equalToConstant: Constants.plusMinusButtonWidth).isActive = true
+        return button
+    }
 
     @objc private func toggleShowDate(switchView: UISwitch) {
         showDate = switchView.isOn
@@ -487,6 +520,26 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
     @objc private func decrementMinimumActionsCount() {
         if minimumActionsCount > 0 {
             minimumActionsCount -= 1
+        }
+    }
+
+    @objc private func incrementTopActionsOverlap() {
+        topActionsOverlap += 1
+    }
+
+    @objc private func decrementTopActionsOverlap() {
+        if topActionsOverlap > 0 {
+            topActionsOverlap -= 1
+        }
+    }
+
+    @objc private func incrementBottomActionsOverlap() {
+        bottomActionsOverlap += 1
+    }
+
+    @objc private func decrementBottomActionsOverlap() {
+        if bottomActionsOverlap > 0 {
+            bottomActionsOverlap -= 1
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -41,7 +41,8 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             }
         }
 
-        accessoryViews.removeAll()
+        topAccessoryViews.removeAll()
+        bottomAccessoryViews.removeAll()
 
         var layoutConstraints: [NSLayoutConstraint] = []
 
@@ -52,9 +53,9 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
                 stackView.addArrangedSubview(cellTitle)
             }
 
-            let cell1 = createCell(title: "Document Title", subtitle: "OneDrive - Microsoft · Microsoft Teams Chat Files")
+            let cell1 = createCell(title: "Document Title", subtitle: "OneDrive - Microsoft · Microsoft Teams Chat Files", top: true)
             let cell2 = createCell(title: "This is a very long document title that keeps on going forever to test text truncation",
-                                   subtitle: "This is a very long document subtitle that keeps on going forever to test text truncation")
+                                   subtitle: "This is a very long document subtitle that keeps on going forever to test text truncation", top: false)
 
             let containerView = UIStackView(frame: .zero)
             containerView.axis = .vertical
@@ -93,7 +94,8 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         static let smallCellPadding: CGFloat = 8
     }
 
-    private var accessoryViews: [TableViewCellFileAccessoryView] = []
+    private var topAccessoryViews: [TableViewCellFileAccessoryView] = []
+    private var bottomAccessoryViews: [TableViewCellFileAccessoryView] = []
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(frame: .zero)
@@ -110,7 +112,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         return customAccessoryView
     }
 
-    private func actions() -> [FileAccessoryViewAction] {
+    private func actions(top: Bool) -> [FileAccessoryViewAction] {
         var actions: [FileAccessoryViewAction] = []
         if showOverflowAction {
             let action = FileAccessoryViewAction(title: "File actions",
@@ -157,7 +159,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             actions.append(action)
         }
 
-        if showErrorAction {
+        if showErrorAction && !(!top && !showErrorOnBottomCellAction) {
             if #available(iOS 13.0, *) {
                 let action = FileAccessoryViewAction(title: "Error",
                                                      image: UIImage(named: "ic_fluent_warning_24_regular")!,
@@ -172,34 +174,44 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
     }
 
     private func updateActions() {
-        let actionList = actions()
-        for accessoryView in accessoryViews {
-            accessoryView.actions = actionList
+        let topActionList = actions(top: true)
+        for accessoryView in topAccessoryViews {
+            accessoryView.actions = topActionList
+        }
+
+        let bottomActionList = actions(top: false)
+        for accessoryView in bottomAccessoryViews {
+            accessoryView.actions = bottomActionList
         }
     }
 
     private func updateDate() {
         let date = showDate ? self.date : nil
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             accessoryView.date = date
         }
     }
 
     private func updateSharedStatus() {
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             accessoryView.showSharedStatus = showSharedStatus
         }
     }
 
     private func updateAreDocumentsShared() {
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             accessoryView.isShared = areDocumentsShared
         }
     }
 
-    private func createCell(title: String, subtitle: String) -> TableViewCell {
+    private func createCell(title: String, subtitle: String, top: Bool) -> TableViewCell {
         let customAccessoryView = createAccessoryView()
-        accessoryViews.append(customAccessoryView)
+
+        if top {
+            topAccessoryViews.append(customAccessoryView)
+        } else {
+            bottomAccessoryViews.append(customAccessoryView)
+        }
 
         let cell = TableViewCell(frame: .zero)
         customAccessoryView.tableViewCell = cell
@@ -231,7 +243,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
     private func updateCellPadding() {
         let extraPadding = view.frame.width >= Constants.cellPaddingThreshold && useDynamicPadding ? Constants.largeCellPadding : Constants.smallCellPadding
 
-        for accessoryView in accessoryViews {
+        for accessoryView in topAccessoryViews + bottomAccessoryViews {
             if let cell = accessoryView.tableViewCell {
                 cell.paddingLeading = TableViewCell.defaultPaddingLeading + extraPadding
                 cell.paddingTrailing = TableViewCell.defaultPaddingTrailing + extraPadding
@@ -281,13 +293,19 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         }
     }
 
+    private var showErrorOnBottomCellAction: Bool = true {
+        didSet {
+            updateActions()
+        }
+    }
+
     private var showOverflowAction: Bool = true {
         didSet {
             reloadCells()
         }
     }
 
-    private var useDynamicWidth: Bool = false {
+    private var useDynamicWidth: Bool = true {
         didSet {
             reloadCells()
         }
@@ -325,6 +343,16 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         }
     }
 
+    private var minimumActionsCount: UInt = 0 {
+        didSet {
+            if oldValue != minimumActionsCount {
+                for accessoryView in topAccessoryViews + bottomAccessoryViews {
+                    accessoryView.minimumActionsCount = minimumActionsCount
+                }
+            }
+        }
+    }
+
     private lazy var settingsView: UIView = {
         let settingsView = UIStackView(frame: .zero)
         settingsView.axis = .horizontal
@@ -334,12 +362,16 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         spacingView.widthAnchor.constraint(equalToConstant: Constants.stackViewSpacing).isActive = true
         settingsView.addArrangedSubview(spacingView)
 
+        let plusButton = createButton(title: "+", action: #selector(incrementMinimumActionsCount))
+        let minusButton = createButton(title: "-", action: #selector(decrementMinimumActionsCount))
+
         let settingViews: [UIView] = [
             createLabelAndSwitchRow(labelText: "Dynamic width", switchAction: #selector(toggleDynamicWidth(switchView:)), isOn: useDynamicWidth),
             createLabelAndSwitchRow(labelText: "Dynamic padding", switchAction: #selector(toggleDynamicPadding(switchView:)), isOn: useDynamicPadding),
             createLabelAndSwitchRow(labelText: "Show date", switchAction: #selector(toggleShowDate(switchView:)), isOn: showDate),
             createButton(title: "Choose date", action: #selector(presentDatePicker)),
             createButton(title: "Choose time", action: #selector(presentTimePicker)),
+            createLabelAndViewsRow(labelText: "Minimum actions count", views: [plusButton, minusButton]),
             createLabelAndSwitchRow(labelText: "Show shared status", switchAction: #selector(toggleShowSharedStatus(switchView:)), isOn: showSharedStatus),
             createLabelAndSwitchRow(labelText: "Is document shared", switchAction: #selector(toggleAreDocumentsShared(switchView:)), isOn: areDocumentsShared),
             createLabelAndSwitchRow(labelText: "Show keep offline button", switchAction: #selector(toggleShowKeepOffline(switchView:)), isOn: showKeepOfflineAction),
@@ -348,6 +380,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
             createLabelAndSwitchRow(labelText: "Show pin button", switchAction: #selector(togglePin(switchView:)), isOn: showPinAction),
             createLabelAndSwitchRow(labelText: "Disable pin button", switchAction: #selector(togglePinButtonDisabled(switchView:)), isOn: isPinActionDisabled),
             createLabelAndSwitchRow(labelText: "Show error button", switchAction: #selector(toggleErrorButton(switchView:)), isOn: showErrorAction),
+            createLabelAndSwitchRow(labelText: "Show error button on top cell only", switchAction: #selector(toggleErrorOnBottomCellButton(switchView:)), isOn: !showErrorOnBottomCellAction),
             createLabelAndSwitchRow(labelText: "Show overflow button", switchAction: #selector(toggleOverflow(switchView:)), isOn: showOverflowAction)
         ]
 
@@ -419,6 +452,10 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         showErrorAction = switchView.isOn
     }
 
+    @objc private func toggleErrorOnBottomCellButton(switchView: UISwitch) {
+        showErrorOnBottomCellAction = !switchView.isOn
+    }
+
     @objc private func toggleOverflow(switchView: UISwitch) {
         showOverflowAction = switchView.isOn
     }
@@ -441,6 +478,16 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
 
     @objc private func handleKeepOfflineAction() {
         displayActionAlert(title: "Keep offline")
+    }
+
+    @objc private func incrementMinimumActionsCount() {
+        minimumActionsCount += 1
+    }
+
+    @objc private func decrementMinimumActionsCount() {
+        if minimumActionsCount > 0 {
+            minimumActionsCount -= 1
+        }
     }
 
     private func displayActionAlert(title: String) {

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -86,6 +86,7 @@ open class TableViewCellFileAccessoryView: UIView {
 
     /// The minimum count of actions.
     /// If there are fewer actions to display than this count, empty spaces will be reserved for those missing actions.
+    /// This property is useful to align columns between cells that display a different number of actions.
     /// Setting this value too high could result in a broken layout.
     @objc public var minimumActionsCount: UInt = 0 {
         didSet {

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -84,6 +84,17 @@ open class TableViewCellFileAccessoryView: UIView {
         }
     }
 
+    /// The minimum count of actions.
+    /// If there are fewer actions to display than this count, empty spaces will be reserved for those missing actions.
+    /// Setting this value too high could result in a broken layout.
+    @objc public var minimumActionsCount: UInt = 0 {
+        didSet {
+            if oldValue != minimumActionsCount {
+                updateLayout()
+            }
+        }
+    }
+
     @objc public weak var tableViewCell: TableViewCell? {
         didSet {
             updateLayout()
@@ -283,6 +294,25 @@ open class TableViewCellFileAccessoryView: UIView {
         for action in visibleActions.reversed() {
             let actionView = FileAccessoryViewActionView(action: action, window: currentWindow)
             actionsStackView.addArrangedSubview(actionView)
+        }
+
+        if actionsStackView.arrangedSubviews.count < minimumActionsCount {
+            let emptyActionsToAdd = Int(minimumActionsCount) - actionsStackView.arrangedSubviews.count
+            var layoutConstraints: [NSLayoutConstraint] = []
+
+            for _ in 1...emptyActionsToAdd {
+                let emptyView = UIView(frame: .zero)
+                emptyView.translatesAutoresizingMaskIntoConstraints = false
+
+                layoutConstraints.append(contentsOf: [
+                    emptyView.widthAnchor.constraint(equalToConstant: FileAccessoryViewActionView.size.width),
+                    emptyView.heightAnchor.constraint(greaterThanOrEqualToConstant: FileAccessoryViewActionView.size.height)
+                ])
+
+                actionsStackView.insertArrangedSubview(emptyView, at: 0)
+            }
+
+            NSLayoutConstraint.activate(layoutConstraints)
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -96,6 +96,20 @@ open class TableViewCellFileAccessoryView: UIView {
         }
     }
 
+    /// Number of actions that should overlap with the column that comes before the actions column.
+    /// If actionsOffsetCount > 0, this column will reduce its width but keep its content centered as if there
+    /// was no offset. This is particularily useful with actions that are displayed. Reserving an empty slot for
+    /// an action that rarely displays would cause the previous column to look uncentered. This column
+    /// would also look uncentered when the rarely displayed action is displayed. The solution is to
+    /// allow this action to overlap the space reserved for the previous column.
+    @objc public var actionsColumnOverlap: UInt = 0 {
+        didSet {
+            if oldValue != actionsColumnOverlap {
+                updateLayout()
+            }
+        }
+    }
+
     @objc public weak var tableViewCell: TableViewCell? {
         didSet {
             updateLayout()
@@ -189,8 +203,25 @@ open class TableViewCellFileAccessoryView: UIView {
         return label
     }()
 
-    private lazy var dateLabelWidth: NSLayoutConstraint = {
-        return dateLabel.widthAnchor.constraint(equalToConstant: 0)
+    private lazy var dateColumnView: UIView = {
+        let view = UIView(frame: .zero)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(dateLabel)
+
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: dateLabel.topAnchor),
+            view.bottomAnchor.constraint(equalTo: dateLabel.bottomAnchor)
+        ])
+
+        return view
+    }()
+
+    private lazy var dateColumnWidth: NSLayoutConstraint = {
+        return dateColumnView.widthAnchor.constraint(equalToConstant: 0)
+    }()
+
+    private lazy var dateLabelCenterConstraint: NSLayoutConstraint = {
+        return dateLabel.centerXAnchor.constraint(equalTo: dateColumnView.centerXAnchor)
     }()
 
     private func updateSharedStatus() {
@@ -215,27 +246,31 @@ open class TableViewCellFileAccessoryView: UIView {
         return imageView
     }()
 
+    private lazy var sharedStatusCenteredView: UIView = {
+        let view = UIView(frame: .zero)
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        return view
+    }()
+
     private lazy var sharedStatusView: UIView = {
         let containerView = UIView(frame: .zero)
         containerView.translatesAutoresizingMaskIntoConstraints = false
 
-        let view = UIView(frame: .zero)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        containerView.addSubview(view)
+        containerView.addSubview(sharedStatusCenteredView)
 
-        view.addSubview(sharedStatusImageView)
-        view.addSubview(sharedStatusLabel)
+        sharedStatusCenteredView.addSubview(sharedStatusImageView)
+        sharedStatusCenteredView.addSubview(sharedStatusLabel)
 
         NSLayoutConstraint.activate([
             sharedStatusImageView.widthAnchor.constraint(equalToConstant: Constants.sharedIconSize),
             sharedStatusImageView.heightAnchor.constraint(equalToConstant: Constants.sharedIconSize),
-            sharedStatusImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            sharedStatusImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            sharedStatusImageView.leadingAnchor.constraint(equalTo: sharedStatusCenteredView.leadingAnchor),
+            sharedStatusImageView.centerYAnchor.constraint(equalTo: sharedStatusCenteredView.centerYAnchor),
             sharedStatusLabel.leadingAnchor.constraint(equalTo: sharedStatusImageView.trailingAnchor, constant: Constants.sharedStatusSpacing),
-            sharedStatusLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            sharedStatusLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            containerView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            sharedStatusLabel.trailingAnchor.constraint(equalTo: sharedStatusCenteredView.trailingAnchor),
+            sharedStatusLabel.centerYAnchor.constraint(equalTo: sharedStatusCenteredView.centerYAnchor),
+            containerView.centerYAnchor.constraint(equalTo: sharedStatusCenteredView.centerYAnchor)
         ])
 
         return containerView
@@ -243,6 +278,10 @@ open class TableViewCellFileAccessoryView: UIView {
 
     private lazy var sharedStatusViewWidth: NSLayoutConstraint = {
         return sharedStatusView.widthAnchor.constraint(equalToConstant: 0)
+    }()
+
+    private lazy var sharedStatusCenterConstraint: NSLayoutConstraint = {
+        return sharedStatusCenteredView.centerXAnchor.constraint(equalTo: sharedStatusView.centerXAnchor)
     }()
 
     private func updateActions() {
@@ -318,7 +357,7 @@ open class TableViewCellFileAccessoryView: UIView {
     }
 
     private func updateDateLabel() {
-        let dateString = date?.displayString(short: (dateLabelWidth.constant < Constants.fullDateMinWidth)) ?? ""
+        let dateString = date?.displayString(short: (dateColumnWidth.constant < Constants.fullDateMinWidth)) ?? ""
         dateLabel.text = dateString
     }
 
@@ -357,11 +396,25 @@ open class TableViewCellFileAccessoryView: UIView {
             }
         }
 
-        dateLabel.removeFromSuperview()
+        let columnLeadingOffset = CGFloat(actionsColumnOverlap) * (FileAccessoryViewActionView.size.width + actionsStackView.spacing)
+
+        dateColumnView.removeFromSuperview()
         if isShowingDate {
-            columnStackView.insertArrangedSubview(dateLabel, at: 0)
-            dateLabelWidth.constant = columnWidth
-            dateLabelWidth.isActive = true
+            columnStackView.insertArrangedSubview(dateColumnView, at: 0)
+            dateColumnWidth.constant = columnWidth
+            dateColumnWidth.isActive = true
+
+            var centerOffset: CGFloat = 0
+            if actionsColumnOverlap > 0 {
+                centerOffset = columnLeadingOffset / 2
+
+                if isShowingSharedStatus {
+                    centerOffset -= actionsStackView.spacing / 2
+                }
+            }
+
+            dateLabelCenterConstraint.constant = centerOffset
+            dateLabelCenterConstraint.isActive = true
 
             updateDateLabel()
         }
@@ -371,10 +424,22 @@ open class TableViewCellFileAccessoryView: UIView {
             columnStackView.insertArrangedSubview(sharedStatusView, at: (isShowingDate ? 1 : 0))
             sharedStatusViewWidth.constant = columnWidth
             sharedStatusViewWidth.isActive = true
+
+            var centerOffset: CGFloat = 0
+            if actionsColumnOverlap > 0 {
+                centerOffset = columnLeadingOffset / 2
+
+                if isShowingDate {
+                    centerOffset += actionsStackView.spacing / 2
+                }
+            }
+
+            sharedStatusCenterConstraint.constant = centerOffset
+            sharedStatusCenterConstraint.isActive = true
         }
 
         if isShowingDate && isShowingSharedStatus {
-            columnStackView.setCustomSpacing(0, after: dateLabel)
+            columnStackView.setCustomSpacing(0, after: dateColumnView)
         }
 
         var height: CGFloat = FileAccessoryViewActionView.size.height


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In the file accessory table view cell, clients can specify a set of actions that will be displayed in the trailing part of the cell's view. Clients will want columns to always be aligned between cells. In some cases, there are actions that will rarely display. For example, in Office, we need an action to handle cache errors. These errors are rare. minimumActionsCount is a useful property that can be used to set the minimum count of actions per cell. In this case, we don't want to use minimumActionsCount otherwise we would have to reserve an empty space for an action that rarely shows. This will move the alignment of the columns towards the left. Instead, we want that last action to overlap the columns section. We don't actually want the UIViews to overlap but we want to create that visual effect. 
The solution: add a property that indicates how many actions should overlap the other columns. If this property is set to a value greater than 0, we will recenter the column's contents towards the right based on this property. The bounds of the columns will not change.

### Verification

- Test with large and small screen sizes to test the different spacing configurations.
- Test with only the shared column visible.
- Test with only the date column visible.
- Test with no column visible.
- Test with the shared and date columns visible.
- Test with various configurations of action buttons.
- Test with different values of this new property.
- Make sure that the columns are always aligned when the property is set correctly.

Before:
<img width="844" alt="Screen Shot 2020-09-18 at 2 40 19 PM" src="https://user-images.githubusercontent.com/4185114/93647770-15056900-f9be-11ea-85c6-aec54bfe72b0.png">
<img width="844" alt="Screen Shot 2020-09-18 at 2 40 14 PM" src="https://user-images.githubusercontent.com/4185114/93647776-18005980-f9be-11ea-83a1-6073ef3b04e1.png">
<img width="844" alt="Screen Shot 2020-09-18 at 2 40 22 PM" src="https://user-images.githubusercontent.com/4185114/93647779-19318680-f9be-11ea-9ee0-3393552d55c4.png">

After:
<img width="844" alt="Screen Shot 2020-09-18 at 2 40 01 PM" src="https://user-images.githubusercontent.com/4185114/93647788-1fbffe00-f9be-11ea-961e-75c5ae0b88bb.png">
<img width="844" alt="Screen Shot 2020-09-18 at 2 40 10 PM" src="https://user-images.githubusercontent.com/4185114/93647795-23538500-f9be-11ea-8acf-83fcd3ae1f2c.png">
<img width="844" alt="Screen Shot 2020-09-18 at 2 39 58 PM" src="https://user-images.githubusercontent.com/4185114/93647799-2484b200-f9be-11ea-86fe-ef5e90762cdc.png">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/237)