### PR TITLE
[BadgeView] Don't set accessibilityHint to nil when setting isActive

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -176,7 +176,6 @@ open class BadgeView: UIView {
         didSet {
             updateBackgroundColor()
             updateLabelTextColor()
-            accessibilityHint = nil
             isUserInteractionEnabled = isActive
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

The accessibilityHint of the badgeView is set to nil when setting isActive. This makes the accessibilityHint actually not working. Delete this line so that accessibilityHint stays as it is set in updateAccessibility().

### Verification

Tested on an iPhone device with VoiceOver enabled. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| When tapping on a badgeView, it says "<Badge text>, Button." | When tapping on a badgeView, it says "<Badge text>, Button, Double tap to select"  |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/238)