### PR TITLE
Adding delegates to PeoplePicker and BadgeField to check for textFieldDidEndEditing behaviors

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -43,7 +43,7 @@ public protocol BadgeFieldDelegate: AnyObject {
      `badgeFieldShouldReturn` is called only when there's no text in the text field, otherwise `BadgeField` badges the text and doesn't call this.
      */
     @objc optional func badgeFieldShouldReturn(_ badgeField: BadgeField) -> Bool
-    /// This is called to check if we should make badges inactive on textFieldDidEndEditing
+    /// This is called to check if we should make badges inactive on textFieldDidEndEditing, default is false
     @objc optional func shouldKeepBadgesActiveOnEndEditing() -> Bool
 }
 
@@ -1126,11 +1126,7 @@ extension BadgeField: UITextFieldDelegate {
             updateLabelsVisibility()
             badgeFieldDelegate?.badgeFieldDidEndEditing?(self)
         }
-        guard let shouldKeepBadgesActiveOnEndEditing = badgeFieldDelegate?.shouldKeepBadgesActiveOnEndEditing?() else {
-            showAllBadgesForEditing = false
-            isActive = false
-            return
-        }
+        let shouldKeepBadgesActiveOnEndEditing = badgeFieldDelegate?.shouldKeepBadgesActiveOnEndEditing?() ?? false
         showAllBadgesForEditing = shouldKeepBadgesActiveOnEndEditing
         isActive = shouldKeepBadgesActiveOnEndEditing
     }

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -43,8 +43,9 @@ public protocol BadgeFieldDelegate: AnyObject {
      `badgeFieldShouldReturn` is called only when there's no text in the text field, otherwise `BadgeField` badges the text and doesn't call this.
      */
     @objc optional func badgeFieldShouldReturn(_ badgeField: BadgeField) -> Bool
-    /// This is called to check if we should make badges inactive on textFieldDidEndEditing, default is false
-    @objc optional func shouldKeepBadgesActiveOnEndEditing() -> Bool
+    /// This is called to check if we should make badges inactive on textFieldDidEndEditing.
+    /// If not implemented, the default value assumed is false.
+    @objc optional func badgeFieldShouldKeepBadgesActiveOnEndEditing(_ badgeField: BadgeField) -> Bool
 }
 
 // MARK: - BadgeField Colors
@@ -1126,7 +1127,7 @@ extension BadgeField: UITextFieldDelegate {
             updateLabelsVisibility()
             badgeFieldDelegate?.badgeFieldDidEndEditing?(self)
         }
-        let shouldKeepBadgesActiveOnEndEditing = badgeFieldDelegate?.shouldKeepBadgesActiveOnEndEditing?() ?? false
+        let shouldKeepBadgesActiveOnEndEditing = badgeFieldDelegate?.badgeFieldShouldKeepBadgesActiveOnEndEditing?(self) ?? false
         showAllBadgesForEditing = shouldKeepBadgesActiveOnEndEditing
         isActive = shouldKeepBadgesActiveOnEndEditing
     }

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -43,6 +43,8 @@ public protocol BadgeFieldDelegate: AnyObject {
      `badgeFieldShouldReturn` is called only when there's no text in the text field, otherwise `BadgeField` badges the text and doesn't call this.
      */
     @objc optional func badgeFieldShouldReturn(_ badgeField: BadgeField) -> Bool
+    /// This is called to check if we should make badges inactive on textFieldDidEndEditing
+    @objc optional func shouldKeepBadgesActiveOnEndEditing() -> Bool
 }
 
 // MARK: - BadgeField Colors
@@ -1124,8 +1126,13 @@ extension BadgeField: UITextFieldDelegate {
             updateLabelsVisibility()
             badgeFieldDelegate?.badgeFieldDidEndEditing?(self)
         }
-        showAllBadgesForEditing = false
-        isActive = false
+        guard let shouldKeepBadgesActiveOnEndEditing = badgeFieldDelegate?.shouldKeepBadgesActiveOnEndEditing?() else {
+            showAllBadgesForEditing = false
+            isActive = false
+            return
+        }
+        showAllBadgesForEditing = shouldKeepBadgesActiveOnEndEditing
+        isActive = shouldKeepBadgesActiveOnEndEditing
     }
 
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -35,6 +35,9 @@ public protocol PeoplePickerDelegate: BadgeFieldDelegate {
     // Search directory button
     /// Called when the search directory button is tapped.
     @objc optional func peoplePicker(_ peoplePicker: PeoplePicker, searchDirectoryWithCompletion completion: @escaping (_ personas: [Persona], _ success: Bool) -> Void)
+
+    /// Called to check if suggestions are to be hidden on textField endEditing
+    @objc optional func shouldKeepShowingPersonaSuggestionsOnEndEditing() -> Bool
 }
 
 // MARK: - PeoplePicker
@@ -358,9 +361,13 @@ open class PeoplePicker: BadgeField {
         isShowingPersonaSuggestions = false
     }
 
-    open override func textFieldDidEndEditing(_ textField: UITextField) {
+    public override func textFieldDidEndEditing(_ textField: UITextField) {
         super.textFieldDidEndEditing(textField)
-        isShowingPersonaSuggestions = false
+        guard let showPersonaSuggestions = delegate?.shouldKeepShowingPersonaSuggestionsOnEndEditing?() else {
+            isShowingPersonaSuggestions = false
+            return
+        }
+        isShowingPersonaSuggestions = showPersonaSuggestions
     }
 
     // MARK: Badge actions

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -358,7 +358,7 @@ open class PeoplePicker: BadgeField {
         isShowingPersonaSuggestions = false
     }
 
-    public override func textFieldDidEndEditing(_ textField: UITextField) {
+    open override func textFieldDidEndEditing(_ textField: UITextField) {
         super.textFieldDidEndEditing(textField)
         isShowingPersonaSuggestions = false
     }

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -36,8 +36,9 @@ public protocol PeoplePickerDelegate: BadgeFieldDelegate {
     /// Called when the search directory button is tapped.
     @objc optional func peoplePicker(_ peoplePicker: PeoplePicker, searchDirectoryWithCompletion completion: @escaping (_ personas: [Persona], _ success: Bool) -> Void)
 
-    /// Called to check if suggestions are to be hidden on textField endEditing, default is false
-    @objc optional func shouldKeepShowingPersonaSuggestionsOnEndEditing() -> Bool
+    /// This is called to check if suggestions are to be hidden on textField endEditing event.
+    /// If not implemented, the default value assumed is false.
+    @objc optional func peoplePickerShouldKeepShowingPersonaSuggestionsOnEndEditing(_ peoplePicker: PeoplePicker) -> Bool
 }
 
 // MARK: - PeoplePicker
@@ -363,7 +364,7 @@ open class PeoplePicker: BadgeField {
 
     public override func textFieldDidEndEditing(_ textField: UITextField) {
         super.textFieldDidEndEditing(textField)
-        isShowingPersonaSuggestions = delegate?.shouldKeepShowingPersonaSuggestionsOnEndEditing?() ?? false
+        isShowingPersonaSuggestions = delegate?.peoplePickerShouldKeepShowingPersonaSuggestionsOnEndEditing?(self) ?? false
     }
 
     // MARK: Badge actions

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -36,7 +36,7 @@ public protocol PeoplePickerDelegate: BadgeFieldDelegate {
     /// Called when the search directory button is tapped.
     @objc optional func peoplePicker(_ peoplePicker: PeoplePicker, searchDirectoryWithCompletion completion: @escaping (_ personas: [Persona], _ success: Bool) -> Void)
 
-    /// Called to check if suggestions are to be hidden on textField endEditing
+    /// Called to check if suggestions are to be hidden on textField endEditing, default is false
     @objc optional func shouldKeepShowingPersonaSuggestionsOnEndEditing() -> Bool
 }
 
@@ -363,11 +363,7 @@ open class PeoplePicker: BadgeField {
 
     public override func textFieldDidEndEditing(_ textField: UITextField) {
         super.textFieldDidEndEditing(textField)
-        guard let showPersonaSuggestions = delegate?.shouldKeepShowingPersonaSuggestionsOnEndEditing?() else {
-            isShowingPersonaSuggestions = false
-            return
-        }
-        isShowingPersonaSuggestions = showPersonaSuggestions
+        isShowingPersonaSuggestions = delegate?.shouldKeepShowingPersonaSuggestionsOnEndEditing?() ?? false
     }
 
     // MARK: Badge actions


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

textFieldDidEndEditing function's current implementation in PeoplePicker and BadgeField restricts making keyboard dismissal currently and makes badges active while resigning
This PR introduces 2 delegate methods to make a check before making badges inactive and hiding persona suggestion on endEditing in BadgeField and PeoplePicker respectively


### Verification

Tested with integration in List iOS app and by adding personaListView.keyboardDIsmissalMode to drag in PeoplePicker and testing it in PeoplePickerDemoController for demo app of FluentUI


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/240)