### PR TITLE
Added drawer dismiss blocking capability

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -307,6 +307,18 @@ extension DrawerDemoController: UITextFieldDelegate {
 
 extension DrawerDemoController: DrawerControllerDelegate {
     func shouldDismissDrawer(_ controller: DrawerController) -> Bool {
+        DispatchQueue.main.async {
+            if self.shouldBlockDrawerDismiss {
+                let alert = UIAlertController(title: "Do you really want to dismiss the drawer?", message: nil, preferredStyle: .alert)
+                controller.present(alert, animated: true)
+                let yesAction = UIAlertAction(title: "Yes", style: .default) { _ in
+                    self.dismiss(animated: true, completion: nil)
+                }
+                let noAction = UIAlertAction(title: "No", style: .cancel)
+                alert.addAction(yesAction)
+                alert.addAction(noAction)
+            }
+        }
         return !shouldBlockDrawerDismiss
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class DrawerDemoController: DemoController {
 
-    private var shouldConfirmDrawerDismiss: Bool = false
+    private var shouldConfirmDrawerDismissal: Bool = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -180,7 +180,7 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showBottomDrawerBlockingDismissButtonTapped(sender: UIButton) {
-        shouldConfirmDrawerDismiss = true
+        shouldConfirmDrawerDismissal = true
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 
@@ -307,7 +307,7 @@ extension DrawerDemoController: UITextFieldDelegate {
 
 extension DrawerDemoController: DrawerControllerDelegate {
     func drawerControllerShouldDismissDrawer(_ controller: DrawerController) -> Bool {
-        if self.shouldConfirmDrawerDismiss {
+        if shouldConfirmDrawerDismissal {
             let alert = UIAlertController(title: "Do you really want to dismiss the drawer?", message: nil, preferredStyle: .alert)
             controller.present(alert, animated: true)
             let yesAction = UIAlertAction(title: "Yes", style: .default) { _ in
@@ -317,11 +317,11 @@ extension DrawerDemoController: DrawerControllerDelegate {
             alert.addAction(yesAction)
             alert.addAction(noAction)
         }
-        return !shouldConfirmDrawerDismiss
+        return !shouldConfirmDrawerDismissal
     }
 
     func drawerControllerDidDismiss(_ controller: DrawerController) {
         // reset the flag once drawer gets dismissed
-        shouldConfirmDrawerDismiss = false
+        shouldConfirmDrawerDismissal = false
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -9,6 +9,9 @@ import UIKit
 // MARK: DrawerDemoController
 
 class DrawerDemoController: DemoController {
+    
+    private var shouldBlockDrawerDismiss: Bool = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -39,6 +42,8 @@ class DrawerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show always as slideover, resizable", action: #selector(showBottomDrawerCustomContentControllerButtonTapped)))
 
         container.addArrangedSubview(createButton(title: "Show with focusable content", action: #selector(showBottomDrawerFocusableContentButtonTapped)))
+        
+        container.addArrangedSubview(createButton(title: "Show dismiss blocking drawer", action: #selector(showBottomDrawerBlockingDismissButtonTapped)))
 
         container.addArrangedSubview(UIView())
 
@@ -74,6 +79,7 @@ class DrawerDemoController: DemoController {
         let controller: DrawerController
         if let sourceView = sourceView {
             controller = DrawerController(sourceView: sourceView, sourceRect: sourceView.bounds.insetBy(dx: sourceView.bounds.width / 2, dy: 0), presentationOrigin: presentationOrigin, presentationDirection: presentationDirection)
+            controller.delegate = self
         } else if let barButtonItem = barButtonItem {
             controller = DrawerController(barButtonItem: barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: presentationDirection)
         } else {
@@ -171,6 +177,11 @@ class DrawerDemoController: DemoController {
     @objc private func showBottomDrawerCustomOffsetButtonTapped(sender: UIButton) {
         let rect = sender.superview!.convert(sender.frame, to: nil)
         presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews())
+    }
+    
+    @objc private func showBottomDrawerBlockingDismissButtonTapped(sender: UIButton) {
+        shouldBlockDrawerDismiss = true
+        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 
     private var contentControllerOriginalPreferredContentHeight: CGFloat = 0
@@ -291,5 +302,16 @@ extension DrawerDemoController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return false
+    }
+}
+
+extension DrawerDemoController: DrawerControllerDelegate {
+    func shouldDismissDrawer(_ controller: DrawerController) -> Bool {
+        return !shouldBlockDrawerDismiss
+    }
+    
+    func drawerControllerDidDismiss(_ controller: DrawerController) {
+        // reset the flag once drawer gets dismissed
+        shouldBlockDrawerDismiss = false
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -9,9 +9,9 @@ import UIKit
 // MARK: DrawerDemoController
 
 class DrawerDemoController: DemoController {
-    
+
     private var shouldBlockDrawerDismiss: Bool = false
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -42,7 +42,7 @@ class DrawerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show always as slideover, resizable", action: #selector(showBottomDrawerCustomContentControllerButtonTapped)))
 
         container.addArrangedSubview(createButton(title: "Show with focusable content", action: #selector(showBottomDrawerFocusableContentButtonTapped)))
-        
+
         container.addArrangedSubview(createButton(title: "Show dismiss blocking drawer", action: #selector(showBottomDrawerBlockingDismissButtonTapped)))
 
         container.addArrangedSubview(UIView())
@@ -178,7 +178,7 @@ class DrawerDemoController: DemoController {
         let rect = sender.superview!.convert(sender.frame, to: nil)
         presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews())
     }
-    
+
     @objc private func showBottomDrawerBlockingDismissButtonTapped(sender: UIButton) {
         shouldBlockDrawerDismiss = true
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
@@ -309,7 +309,7 @@ extension DrawerDemoController: DrawerControllerDelegate {
     func shouldDismissDrawer(_ controller: DrawerController) -> Bool {
         return !shouldBlockDrawerDismiss
     }
-    
+
     func drawerControllerDidDismiss(_ controller: DrawerController) {
         // reset the flag once drawer gets dismissed
         shouldBlockDrawerDismiss = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class DrawerDemoController: DemoController {
 
-    private var shouldBlockDrawerDismiss: Bool = false
+    private var shouldConfirmDrawerDismiss: Bool = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -180,7 +180,7 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showBottomDrawerBlockingDismissButtonTapped(sender: UIButton) {
-        shouldBlockDrawerDismiss = true
+        shouldConfirmDrawerDismiss = true
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 
@@ -306,24 +306,22 @@ extension DrawerDemoController: UITextFieldDelegate {
 }
 
 extension DrawerDemoController: DrawerControllerDelegate {
-    func shouldDismissDrawer(_ controller: DrawerController) -> Bool {
-        DispatchQueue.main.async {
-            if self.shouldBlockDrawerDismiss {
-                let alert = UIAlertController(title: "Do you really want to dismiss the drawer?", message: nil, preferredStyle: .alert)
-                controller.present(alert, animated: true)
-                let yesAction = UIAlertAction(title: "Yes", style: .default) { _ in
-                    self.dismiss(animated: true, completion: nil)
-                }
-                let noAction = UIAlertAction(title: "No", style: .cancel)
-                alert.addAction(yesAction)
-                alert.addAction(noAction)
+    func drawerControllerShouldDismissDrawer(_ controller: DrawerController) -> Bool {
+        if self.shouldConfirmDrawerDismiss {
+            let alert = UIAlertController(title: "Do you really want to dismiss the drawer?", message: nil, preferredStyle: .alert)
+            controller.present(alert, animated: true)
+            let yesAction = UIAlertAction(title: "Yes", style: .default) { _ in
+                self.dismiss(animated: true, completion: nil)
             }
+            let noAction = UIAlertAction(title: "No", style: .cancel)
+            alert.addAction(yesAction)
+            alert.addAction(noAction)
         }
-        return !shouldBlockDrawerDismiss
+        return !shouldConfirmDrawerDismiss
     }
 
     func drawerControllerDidDismiss(_ controller: DrawerController) {
         // reset the flag once drawer gets dismissed
-        shouldBlockDrawerDismiss = false
+        shouldConfirmDrawerDismiss = false
     }
 }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -957,6 +957,10 @@ extension DrawerController: UIPopoverPresentationControllerDelegate {
     public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
     }
+
+    public func popoverPresentationControllerShouldDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) -> Bool {
+        return delegate?.shouldDismissDrawer?(self) != false
+    }
 }
 
 // MARK: - DrawerController: UIGestureRecognizerDelegate

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -101,7 +101,7 @@ public protocol DrawerControllerDelegate: AnyObject {
     /// Called after drawer has been dismissed.
     @objc optional func drawerControllerDidDismiss(_ controller: DrawerController)
 
-    /// Called when drawer is getting dismissed when user tries to dismiss drawer by tapping in background, using resizing handle or dragging drawer to bottom. Use this method to turn off drawer dismiss.
+    /// Called when drawer is getting dismissed when user tries to dismiss drawer by tapping in background, using resizing handle or dragging drawer to bottom. Use this method to prevent the drawer from being dismissed in these scenarios.
     @objc optional func drawerControllerShouldDismissDrawer(_ controller: DrawerController) -> Bool
 }
 
@@ -975,7 +975,7 @@ extension DrawerController: UIGestureRecognizerDelegate {
 // MARK: - DrawerController: DrawerPresentationDelegate
 
 extension DrawerController: DrawerPresentationControllerDelegate {
-    func drawerPresentationControllerDismissalRequested(_ presentationControler: DrawerPresentationController, animated: Bool) {
-        dismissPresentingViewController(animated: animated)
+    func drawerPresentationControllerDismissalRequested(_ presentationControler: DrawerPresentationController) {
+        dismissPresentingViewController(animated: true)
     }
 }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -97,10 +97,10 @@ public protocol DrawerControllerDelegate: AnyObject {
 
     /// Called when drawer is being dismissed.
     @objc optional func drawerControllerWillDismiss(_ controller: DrawerController)
-    
+
     /// Called after drawer has been dismissed.
     @objc optional func drawerControllerDidDismiss(_ controller: DrawerController)
-    
+
     /**
      Called when drawer is getting dismissed when user tries to dismiss drawer by tapping in background, using resizing handle or dragging drawer to bottom.
 
@@ -970,7 +970,7 @@ extension DrawerController: UIGestureRecognizerDelegate {
 // MARK: - DrawerController: DrawerPresentationDelegate
 
 extension DrawerController: DrawerPresentationDelegate {
-    func backgroundViewTapped() {
+    func backgroundViewTapped(_ presentationControler: DrawerPresentationController) {
         if delegate?.shouldDismissDrawer?(self) != false {
             presentingViewController?.dismiss(animated: false)
         }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -777,7 +777,7 @@ open class DrawerController: UIViewController {
             guard let presentationController = presentationController as? DrawerPresentationController else {
                 preconditionFailure("DrawerController cannot handle resizing without DrawerPresentationController")
             }
-            presentationController.setExtraContentSize(0, updatingLayout: true)
+            presentationController.setExtraContentSize(0, updatingLayout: true, animated: animated)
         }
         return false
     }

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol DrawerPresentationDelegate: AnyObject {
     /// Called when background view is tapped
-    func backgroundViewTapped()
+    func backgroundViewTapped(_ presentationController: DrawerPresentationController)
 }
 
 // MARK: DrawerPresentationController
@@ -30,7 +30,7 @@ class DrawerPresentationController: UIPresentationController {
     private let presentationOrigin: CGFloat?
     private let presentationOffset: CGFloat
     private let presentationBackground: DrawerPresentationBackground
-    
+
     public weak var drawerPresentationDelegate: DrawerPresentationDelegate?
 
     init(presentedViewController: UIViewController,
@@ -72,7 +72,7 @@ class DrawerPresentationController: UIPresentationController {
         view.accessibilityTraits = .button
         // Workaround for a bug in iOS: if the resizing handle happens to be in the middle of the backgroundView, VoiceOver will send touch event to it (according to the backgroundView's accessibilityActivationPoint) even though it's not parented in backgroundView or even interactable - this will prevent backgroundView from receiving touch and dismissing controller
         view.onAccessibilityActivate = { [unowned self] in
-            self.drawerPresentationDelegate?.backgroundViewTapped()
+            self.drawerPresentationDelegate?.backgroundViewTapped(self)
         }
         return view
     }()
@@ -465,7 +465,7 @@ class DrawerPresentationController: UIPresentationController {
     // MARK: Actions
 
     @objc private func handleBackgroundViewTapped(_ recognizer: UITapGestureRecognizer) {
-        drawerPresentationDelegate?.backgroundViewTapped()
+        drawerPresentationDelegate?.backgroundViewTapped(self)
     }
 
     @objc private func handleKeyboardWillChangeFrame(notification: Notification) {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol DrawerPresentationControllerDelegate: AnyObject {
     /// Called when the user requests the dismissal of the presentingViewController
-    func drawerPresentationControllerDismissalRequested(_ presentationController: DrawerPresentationController, animated: Bool)
+    func drawerPresentationControllerDismissalRequested(_ presentationController: DrawerPresentationController)
 }
 
 // MARK: DrawerPresentationController
@@ -72,7 +72,7 @@ class DrawerPresentationController: UIPresentationController {
         view.accessibilityTraits = .button
         // Workaround for a bug in iOS: if the resizing handle happens to be in the middle of the backgroundView, VoiceOver will send touch event to it (according to the backgroundView's accessibilityActivationPoint) even though it's not parented in backgroundView or even interactable - this will prevent backgroundView from receiving touch and dismissing controller
         view.onAccessibilityActivate = { [unowned self] in
-            self.drawerPresentationControllerDelegate?.drawerPresentationControllerDismissalRequested(self, animated: true)
+            self.drawerPresentationControllerDelegate?.drawerPresentationControllerDismissalRequested(self)
         }
         return view
     }()
@@ -465,7 +465,7 @@ class DrawerPresentationController: UIPresentationController {
     // MARK: Actions
 
     @objc private func handleBackgroundViewTapped(_ recognizer: UITapGestureRecognizer) {
-        drawerPresentationControllerDelegate?.drawerPresentationControllerDismissalRequested(self, animated: true)
+        drawerPresentationControllerDelegate?.drawerPresentationControllerDismissalRequested(self)
     }
 
     @objc private func handleKeyboardWillChangeFrame(notification: Notification) {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -5,6 +5,13 @@
 
 import UIKit
 
+// MARK: - DrawerPresentationDelegate
+
+protocol DrawerPresentationDelegate: AnyObject {
+    /// Called when background view is tapped
+    func backgroundViewTapped()
+}
+
 // MARK: DrawerPresentationController
 
 class DrawerPresentationController: UIPresentationController {
@@ -23,6 +30,8 @@ class DrawerPresentationController: UIPresentationController {
     private let presentationOrigin: CGFloat?
     private let presentationOffset: CGFloat
     private let presentationBackground: DrawerPresentationBackground
+    
+    public weak var drawerPresentationDelegate: DrawerPresentationDelegate?
 
     init(presentedViewController: UIViewController,
          presentingViewController: UIViewController?,
@@ -63,7 +72,7 @@ class DrawerPresentationController: UIPresentationController {
         view.accessibilityTraits = .button
         // Workaround for a bug in iOS: if the resizing handle happens to be in the middle of the backgroundView, VoiceOver will send touch event to it (according to the backgroundView's accessibilityActivationPoint) even though it's not parented in backgroundView or even interactable - this will prevent backgroundView from receiving touch and dismissing controller
         view.onAccessibilityActivate = { [unowned self] in
-            self.presentingViewController.dismiss(animated: true)
+            self.drawerPresentationDelegate?.backgroundViewTapped()
         }
         return view
     }()
@@ -456,7 +465,7 @@ class DrawerPresentationController: UIPresentationController {
     // MARK: Actions
 
     @objc private func handleBackgroundViewTapped(_ recognizer: UITapGestureRecognizer) {
-        presentingViewController.dismiss(animated: true)
+        drawerPresentationDelegate?.backgroundViewTapped()
     }
 
     @objc private func handleKeyboardWillChangeFrame(notification: Notification) {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -7,9 +7,9 @@ import UIKit
 
 // MARK: - DrawerPresentationDelegate
 
-protocol DrawerPresentationDelegate: AnyObject {
-    /// Called when background view is tapped
-    func backgroundViewTapped(_ presentationController: DrawerPresentationController)
+protocol DrawerPresentationControllerDelegate: AnyObject {
+    /// Called when the user requests the dismissal of the presentingViewController
+    func drawerPresentationControllerDismissalRequested(_ presentationController: DrawerPresentationController, animated: Bool)
 }
 
 // MARK: DrawerPresentationController
@@ -31,7 +31,7 @@ class DrawerPresentationController: UIPresentationController {
     private let presentationOffset: CGFloat
     private let presentationBackground: DrawerPresentationBackground
 
-    public weak var drawerPresentationDelegate: DrawerPresentationDelegate?
+    public weak var drawerPresentationControllerDelegate: DrawerPresentationControllerDelegate?
 
     init(presentedViewController: UIViewController,
          presentingViewController: UIViewController?,
@@ -72,7 +72,7 @@ class DrawerPresentationController: UIPresentationController {
         view.accessibilityTraits = .button
         // Workaround for a bug in iOS: if the resizing handle happens to be in the middle of the backgroundView, VoiceOver will send touch event to it (according to the backgroundView's accessibilityActivationPoint) even though it's not parented in backgroundView or even interactable - this will prevent backgroundView from receiving touch and dismissing controller
         view.onAccessibilityActivate = { [unowned self] in
-            self.drawerPresentationDelegate?.backgroundViewTapped(self)
+            self.drawerPresentationControllerDelegate?.drawerPresentationControllerDismissalRequested(self, animated: true)
         }
         return view
     }()
@@ -465,7 +465,7 @@ class DrawerPresentationController: UIPresentationController {
     // MARK: Actions
 
     @objc private func handleBackgroundViewTapped(_ recognizer: UITapGestureRecognizer) {
-        drawerPresentationDelegate?.backgroundViewTapped(self)
+        drawerPresentationControllerDelegate?.drawerPresentationControllerDismissalRequested(self, animated: true)
     }
 
     @objc private func handleKeyboardWillChangeFrame(notification: Notification) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Providing consuming class the capability to block drawer dismiss when user clicks on background view or try to drag drawer to dismiss it.

#### DrawerPresentationController.swift
- Added delegate to notify consuming class for background view taps instead of directly dismissing. 

#### DrawerController.swift
- Added a method (`shouldDismissDrawer `) to `DrawerControllerDelegate` to ask consuming class to dismiss drawer or not.
- Handled resizing gesture to take back drawer to earlier size if `false` is returned from `shouldDismissDrawer`.
- Implemented `DrawerPresentationController` delegate for handling background view taps.

#### DrawerDemoController.swift
- Added an example for drawer with blocking dismiss.

### Verification

Tested for all top, bottom, right & left drawers.

![Screen-Recording-2020-09-23-at-2 (1)](https://user-images.githubusercontent.com/25812641/93994598-afdeb880-fdad-11ea-9bf4-ba5fe75799d1.gif) ![Screen-Recording-2020-09-23-at-2](https://user-images.githubusercontent.com/25812641/93994577-a9e8d780-fdad-11ea-9893-a8a0d6b92c57.gif)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/241)
