### PR TITLE
Fix RTL bugs in the file accessory

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -19,10 +19,17 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         scrollingContainer.addSubview(stackView)
         stackView.addArrangedSubview(settingsView)
 
+        var horizontalConstraint: NSLayoutConstraint?
+        if view.effectiveUserInterfaceLayoutDirection == .leftToRight {
+            horizontalConstraint = stackView.leadingAnchor.constraint(equalTo: scrollingContainer.leadingAnchor)
+        } else {
+            horizontalConstraint = stackView.trailingAnchor.constraint(equalTo: scrollingContainer.trailingAnchor)
+        }
+
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: scrollingContainer.topAnchor, constant: Constants.stackViewSpacing),
             stackView.bottomAnchor.constraint(equalTo: scrollingContainer.bottomAnchor, constant: -Constants.stackViewSpacing),
-            stackView.leadingAnchor.constraint(equalTo: scrollingContainer.leadingAnchor)
+            horizontalConstraint!
         ])
 
         reloadCells()

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -413,6 +413,10 @@ open class TableViewCellFileAccessoryView: UIView {
                 }
             }
 
+            if effectiveUserInterfaceLayoutDirection == .rightToLeft {
+                centerOffset = -centerOffset
+            }
+
             dateLabelCenterConstraint.constant = centerOffset
             dateLabelCenterConstraint.isActive = true
 
@@ -432,6 +436,10 @@ open class TableViewCellFileAccessoryView: UIView {
                 if isShowingDate {
                     centerOffset += actionsStackView.spacing / 2
                 }
+            }
+
+            if effectiveUserInterfaceLayoutDirection == .rightToLeft {
+                centerOffset = -centerOffset
             }
 
             sharedStatusCenterConstraint.constant = centerOffset


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

TableViewCellFileAccessoryViewDemoController has layout issues in RTL. Let's fix this by reversing the horizontal layout constraint for the content stack view.

The actionsColumnOverlap property doesn't work in RTL. We need to reverse the layout logic.

### Verification

- Test RTL and LTR.
- Make sure that TableViewCellFileAccessoryViewDemoController works in both RTL and LTR.
- Make sure that actionsColumnOverlap works in RTL and LTR with various column configurations.

Before
<img width="1065" alt="Screen Shot 2020-09-22 at 2 24 34 PM" src="https://user-images.githubusercontent.com/4185114/93939901-6c6a4880-fce0-11ea-9aae-0e157842cf78.png">

After
<img width="1065" alt="Screen Shot 2020-09-22 at 2 24 27 PM" src="https://user-images.githubusercontent.com/4185114/93939911-71c79300-fce0-11ea-8c3f-17f5ed917172.png">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/242)