### PR TITLE
Disable ShimmerView animation if OS has "reduce motion" accessibility…

### DIFF
--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -141,6 +141,11 @@ open class ShimmerView: UIView {
 		self.excludedViews = excludedViews
 		self.animationSynchronizer = animationSynchronizer
 		super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(syncAnimation),
+                                               name: UIAccessibility.reduceMotionStatusDidChangeNotification,
+                                               object: nil)
 	}
 
 	required public init?(coder: NSCoder) {
@@ -249,11 +254,17 @@ open class ShimmerView: UIView {
 
 	/// Update the shimmer animation
 	func updateShimmeringAnimation() {
+        shimmeringLayer.removeAnimation(forKey: "shimmering")
+
+        // For usability/accessibility reasons, the animation is not added if the user
+        // has the "reduce motion" enabled on the device.
+        guard !UIAccessibility.isReduceMotionEnabled else {
+            return
+        }
+
 		if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
 			animationSynchronizer.referenceLayer = shimmeringLayer
 		}
-
-		shimmeringLayer.removeAnimation(forKey: "shimmering")
 
 		let animation = CABasicAnimation(keyPath: "locations")
 


### PR DESCRIPTION
… setting turned ON.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The design team requested that for usability reasons, the ShimmerView should not animate when the OS "reduce motion" accessibility setting is turned on.

### Verification

Validated the animation is being executed when the setting is disabled and the shimmer is static when it's turned on:

![Screen Shot 2020-09-22 at 9 07 13 PM](https://user-images.githubusercontent.com/68076145/93965883-0994a380-fd18-11ea-8d58-e2ac774ebe02.png)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/243)