### PR TITLE
Fix for crashes in ShyHeaderController.

### DIFF
--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -72,27 +72,31 @@ class ShyHeaderController: UIViewController {
 
         super.init(nibName: nil, bundle: nil)
 
-        shyHeaderView.maxHeightChanged = { [unowned self] in
-            self.updatePadding()
+        shyHeaderView.maxHeightChanged = { [weak self] in
+            self?.updatePadding()
         }
 
         loadViewIfNeeded()
         addChildController(contentViewController, containingViewIn: contentContainerView)
         contentViewController.view.fitIntoSuperview(usingConstraints: true)
 
-        contentScrollViewObservation = contentViewController.navigationItem.observe(\.contentScrollView, options: [.new]) { [unowned self] (_, change) in
+        contentScrollViewObservation = contentViewController.navigationItem.observe(\.contentScrollView, options: [.new]) { [weak self] (_, change) in
+            guard let strongSelf = self else {
+                return
+            }
+
             if let newValue = change.newValue {
-                self.contentScrollView = newValue
+                strongSelf.contentScrollView = newValue
             } else {
-                self.contentScrollView = nil
+                strongSelf.contentScrollView = nil
             }
         }
         defer {
             contentScrollView = contentViewController.navigationItem.contentScrollView
         }
 
-        accessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.accessoryView) { [unowned self] item, _ in
-            self.shyHeaderView.accessoryView = item.accessoryView
+        accessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.accessoryView) { [weak self] item, _ in
+            self?.shyHeaderView.accessoryView = item.accessoryView
         }
     }
 
@@ -208,11 +212,11 @@ class ShyHeaderController: UIViewController {
     private func setupNotificationObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(handleAccessoryExpansionRequested), name: .accessoryExpansionRequested, object: nil)
         // Observing `center` instead of `isHidden` allows us to do our changes along the system animation
-        navigationBarCenterObservation = navigationController?.navigationBar.observe(\.center) { [unowned self] navigationBar, _ in
-            self.shyHeaderView.navigationBarIsHidden = navigationBar.frame.maxY == 0
+        navigationBarCenterObservation = navigationController?.navigationBar.observe(\.center) { [weak self] navigationBar, _ in
+            self?.shyHeaderView.navigationBarIsHidden = navigationBar.frame.maxY == 0
         }
-        navigationBarHeightObservation = msfNavigationController?.msfNavigationBar.observe(\.barHeight) { [unowned self] _, _ in
-            self.updatePadding()
+        navigationBarHeightObservation = msfNavigationController?.msfNavigationBar.observe(\.barHeight) { [weak self] _, _ in
+            self?.updatePadding()
         }
     }
 
@@ -258,8 +262,8 @@ class ShyHeaderController: UIViewController {
         view.backgroundColor = color
         paddingView.backgroundColor = color
 
-        navigationBarColorObservation = item.observe(\.customNavigationBarColor) { [unowned self] item, _ in
-            self.updateBackgroundColor(with: item, window: window)
+        navigationBarColorObservation = item.observe(\.customNavigationBarColor) { [weak self] item, _ in
+            self?.updateBackgroundColor(with: item, window: window)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The ShyHeaderController uses [unowned weak] in handlers of events triggered by views it owns references to.
While this prevents the retain cycle between the closures and the view controller's references to these views, the views might still be in the view hierarchy (which keeps them in memory) while the view controller itself is already reclaimed.

In this case using unowned will cause the self references to crash if those closures are executed.
The fix for that situation is using weak references where self is an optional and does cause the retain cycle and can be checked for nil before the reference is used. 

### Verification

Sanity validation by running the navigation bar examples in the demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/244)