### PR TITLE
[sGen code generator] Adding support for FluentUI asset catalog colors.

### DIFF
--- a/tools/sgen/Sources/SGen/Generatable/RhsValue.swift
+++ b/tools/sgen/Sources/SGen/Generatable/RhsValue.swift
@@ -41,6 +41,9 @@ enum RhsValue {
     /// A font value.
     case font(font: Rhs.Font)
     
+    /// A named color in an asset catalog.
+    case namedColor(namedColor: Rhs.NamedColor)
+    
     /// A color value.
     case color(color: Rhs.Color)
     
@@ -219,6 +222,10 @@ enum RhsValue {
                     return .font(font: Rhs.Font(name: name, textStyle: textStyle, weightAndTraits: components))
                 }
             }
+        } else if let components = argumentsFromString("namedColor", string: string) {
+            assert(components.count == 1, "Not a valid named color. Format: NamedColor(\"AssetCatalogColorName\")")
+            return .namedColor(namedColor: Rhs.NamedColor(name: (components[0])))
+            
         } else if let components = argumentsFromString("color", string: string) {
             assert(components.count == 1, "Not a valid color. Format: \"#rrggbb\" or \"#rrggbbaa\"")
             return .color(color: Rhs.Color(rgba: "#\(components[0])"))
@@ -383,6 +390,7 @@ enum RhsValue {
         case .float(_): return "CGFloat"
         case .boolean(_): return "Bool"
         case .font(font: let font): return font.isSymbolFont ? "String" : "UIFont"
+        case .namedColor(_): return "UIColor"
         case .color(_): return "UIColor"
         case .image(_): return "UIImage"
         case .enumDef(let type, _): return type
@@ -436,6 +444,9 @@ extension RhsValue: Generatable {
             
         case .font(let font):
             return generateFont(prefix, font: font)
+            
+        case .namedColor(let namedColor):
+            return generateNamedColor(prefix, namedColor: namedColor)
             
         case .color(let color):
             return generateColor(prefix, color: color)
@@ -543,6 +554,13 @@ extension RhsValue: Generatable {
             
             return "\(prefix)\(fontClass).font(name: \(fontName), size: \(fontSize), textStyle: \(textStyle), weight: \(fontWeight), traits: \(fontTraits), traitCollection: traitCollection, isScalable: \(isScalable))"
         }
+    }
+    
+    func generateNamedColor(_ prefix: String, namedColor: Rhs.NamedColor) -> String {
+        let colorClass = "UIColor"
+        return
+            "\(prefix)\(colorClass)"
+                + "(named: \"FluentColors/\(namedColor.colorName ?? "")\", in: FluentUIFramework.resourceBundle, compatibleWith: nil)"
     }
     
     func generateColor(_ prefix: String, color: Rhs.Color) -> String {

--- a/tools/sgen/Sources/SGen/Generatable/RhsValue.swift
+++ b/tools/sgen/Sources/SGen/Generatable/RhsValue.swift
@@ -560,7 +560,7 @@ extension RhsValue: Generatable {
         let colorClass = "UIColor"
         return
             "\(prefix)\(colorClass)"
-                + "(named: \"FluentColors/\(namedColor.colorName ?? "")\", in: FluentUIFramework.resourceBundle, compatibleWith: nil)"
+                + "(named: \"FluentColors/\(namedColor.colorName ?? "")\", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!"
     }
     
     func generateColor(_ prefix: String, color: Rhs.Color) -> String {

--- a/tools/sgen/Sources/SGen/Rhs.swift
+++ b/tools/sgen/Sources/SGen/Rhs.swift
@@ -19,6 +19,14 @@ struct Rhs {
         case missingHashMarkAsPrefix, unableToScanHexValue, mismatchedHexStringLength
     }
     
+    class NamedColor {
+        let colorName: String?
+        
+        init(name: String? = nil) {
+            self.colorName = name
+        }
+    }
+    
     class Color {
         
         let red: Float

--- a/tools/sgen/sgenTests/Inputs/GenericStyle.yml
+++ b/tools/sgen/sgenTests/Inputs/GenericStyle.yml
@@ -2,7 +2,7 @@ import: [GenericStyleIcon.yml]
 
 Color:
   test: "#ffffff"
-  namedColorTest: NamedColor("colorFromAssetCatalog")
+  namedColorTest: NamedColor(colorFromAssetCatalog)
 
 AP_EmptyListView:
   color: [normal: $Color.test]

--- a/tools/sgen/sgenTests/Inputs/GenericStyle.yml
+++ b/tools/sgen/sgenTests/Inputs/GenericStyle.yml
@@ -2,6 +2,7 @@ import: [GenericStyleIcon.yml]
 
 Color:
   test: "#ffffff"
+  namedColorTest: NamedColor("colorFromAssetCatalog")
 
 AP_EmptyListView:
   color: [normal: $Color.test]


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Adding support for FluentUI asset catalog colors in the YAML language (borderColor on the example below).
Currently colors can only be expressed with a hex literal value (like the backgroundColor on the example below).

AP_ButtonVNext:
  borderColor: **NamedColor(communicationBlue)**
  backgroundColor: "#00FF00"

### Verification

Generated swift files from a YAML with the new NamedColor construct and built the generated file.

```
		//MARK: borderColor 
		public var _borderColor: UIColor?
		open func borderColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
			if let override = _borderColor { return override }
			return UIColor(named: "FluentColors/communicationBlue", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!
			}
		public var borderColor: UIColor {
			get { return self.borderColorProperty() }
			set { _borderColor = newValue }
		}
```

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/255)