### PR TITLE
Fixing height for badgefield when there is text and keyboard is hidden

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -453,7 +453,7 @@ open class BadgeField: UIView {
             calculateBadgeFrame(badge: badge, badgeIndex: index, lineIndex: &lineIndex, left: &left, topMargin: 0, boundingWidth: bounds.width)
         }
 
-        let isFirstResponderOrHasTextFieldContent = isFirstResponder || (!isFirstResponder && !textFieldContent.isEmpty)
+        let isFirstResponderOrHasTextFieldContent = isFirstResponder || !textFieldContent.isEmpty
 
         if isEditable && isFirstResponderOrHasTextFieldContent && left + Constants.textFieldMinWidth > boundingWidth {
             lineIndex += 1

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -453,7 +453,9 @@ open class BadgeField: UIView {
             calculateBadgeFrame(badge: badge, badgeIndex: index, lineIndex: &lineIndex, left: &left, topMargin: 0, boundingWidth: bounds.width)
         }
 
-        if isEditable && isFirstResponder && left + Constants.textFieldMinWidth > boundingWidth {
+        let isFirstResponderOrHasTextFieldContent = isFirstResponder || (!isFirstResponder && !textFieldContent.isEmpty)
+
+        if isEditable && isFirstResponderOrHasTextFieldContent && left + Constants.textFieldMinWidth > boundingWidth {
             lineIndex += 1
         }
         let textFieldSize = textField.sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

On keyboard hide in badge field, if there is text in textField, that is ignored and view frame height is calculated without it. Fixing it as list app uses keyboard hide on scroll and the height of UI view gets distorted because of this.

### Verification

Texted in FluentUI using demo

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ezgif com-video-to-gif-4](https://user-images.githubusercontent.com/67058720/96140529-a9131380-0f1d-11eb-8b43-836b3bf996f7.gif)| ![ezgif com-video-to-gif-5](https://user-images.githubusercontent.com/67058720/96140574-b6c89900-0f1d-11eb-801b-b691291d198b.gif)
 |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/260)