### PR TITLE
Prevent text label from being displayed outside of the TabBarItemView

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -145,6 +145,7 @@ open class SideTabBar: UIView {
         static let bottomItemSize: CGFloat = 24
         static let badgeTopSectionPadding: CGFloat = 2
         static let badgeBottomSectionPadding: CGFloat = 4
+        static let numberOfTitleLines = 2
     }
 
     private var layoutConstraints: [NSLayoutConstraint] = []
@@ -230,6 +231,7 @@ open class SideTabBar: UIView {
             tabBarItemView.translatesAutoresizingMaskIntoConstraints = false
             tabBarItemView.alwaysShowTitleBelowImage = true
             tabBarItemView.maxBadgeWidth = Constants.viewWidth / 2 - badgePadding
+            tabBarItemView.numberOfTitleLines = Constants.numberOfTitleLines
 
             if itemView(with: item, in: section) != nil && section == .top && item == selectedTopItem {
                 tabBarItemView.isSelected = true
@@ -240,8 +242,6 @@ open class SideTabBar: UIView {
             tabBarItemView.addGestureRecognizer(tapGesture)
             stackView.addArrangedSubview(tabBarItemView)
         }
-
-        NSLayoutConstraint.activate(constraints)
 
         if section == .top && !didRestoreSelection {
             selectedTopItem = allItems.first

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -34,6 +34,15 @@ class TabBarItemView: UIView {
                 updateLayout()
             }
         }
+	}
+
+    /// The number of lines for the item's title label.
+    var numberOfTitleLines: Int = 1 {
+        didSet {
+            if oldValue != numberOfTitleLines {
+                titleLabel.numberOfLines = numberOfTitleLines
+            }
+        }
     }
 
     init(item: TabBarItem, showsTitle: Bool, canResizeImage: Bool = true) {
@@ -70,8 +79,11 @@ class TabBarItemView: UIView {
             scalesLargeContentImage = true
         }
 
-        NSLayoutConstraint.activate([container.centerXAnchor.constraint(equalTo: centerXAnchor),
-                                     container.centerYAnchor.constraint(equalTo: centerYAnchor)])
+        NSLayoutConstraint.activate([
+			container.centerXAnchor.constraint(equalTo: centerXAnchor),
+			container.centerYAnchor.constraint(equalTo: centerYAnchor),
+			container.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor)
+		])
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(badgeValueDidChange),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

TabBarItemView does not constrain its label to its bounds.
If the item's title is long enough, it will be displayed outside of the view's bounds.

We can fix this by limiting the TabBarItemView's content stack view width to its view width.
Additionally, for the SideTabBar, we want the title to be displayed on 2 lines if it doesn't fit on one line, since SideTabBar has less vertical space than TabBarView. We can achieve this by adding a property in TabBarItemView that allows us to modify the number of lines for the title label.

### Verification

- Test on iPhone and iPad.
- Tested iPad compact and regular. 
- Tested size class transitions. Rotation and iPad split-view.
- Tested in SideTabBar and TabBarView.

Before:
<img width="1458" alt="Screen Shot 2020-10-19 at 2 49 22 PM" src="https://user-images.githubusercontent.com/4185114/96515948-0dceb680-121b-11eb-8211-34f6d0e4ddb8.png">
<img width="1458" alt="Screen Shot 2020-10-19 at 2 49 35 PM" src="https://user-images.githubusercontent.com/4185114/96515955-11623d80-121b-11eb-9f24-dc7b971ca2de.png">

After:
<img width="1458" alt="Screen Shot 2020-10-19 at 2 44 54 PM" src="https://user-images.githubusercontent.com/4185114/96515965-1626f180-121b-11eb-981a-737bd3770b81.png">
<img width="1458" alt="Screen Shot 2020-10-19 at 2 45 14 PM" src="https://user-images.githubusercontent.com/4185114/96515967-16bf8800-121b-11eb-9d50-3d3b45def152.png">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/262)