### PR TITLE
Adds override func 'becomeFirstResponder' to TableHeaderFooterView to fix selection bug

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -427,6 +427,10 @@ private class TableViewHeaderFooterTitleView: UITextView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+    override func becomeFirstResponder() -> Bool {
+        return false
+    }
+
     override var selectedTextRange: UITextRange? {
         get {
             // No need for selection, but we need to keep it selectable in order for links to work


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
#229 caused a small regression where it is possible to select text in a TableViewHeaderFooterView with a link by double tapping a word. To fix this I overrode ```becomeFirstResponder()``` in TableViewHeaderFooterView. 

![Simulator Screen Shot - iPod touch (7th generation) - 2020-10-19 at 15 35 05](https://user-images.githubusercontent.com/2467701/96518884-b16e9580-1220-11eb-9616-fb91ebb2a663.png)

### Verification
In the Demo app TableViewHeaderFooterView example VC, after this fix all the accessories that could be interacted with before the fix still allow interaction, as does the web link in the second to last case. Single tap, double tap, or holding and dragging does not select text in any of them.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/263)