### PR TITLE
Adding support for FluentUI font requirements in sGen.

### DIFF
--- a/tools/sgen/Sources/SGen/Config.swift
+++ b/tools/sgen/Sources/SGen/Config.swift
@@ -142,6 +142,7 @@ struct Config {
                 case maximumPointSize
                 case mapsTo
                 case version
+                case isScalable
             }
             
             enum Keys: String, CodingKey {
@@ -588,6 +589,8 @@ extension Config.Entry.Typography {
                                         stringValue = String(intValue)
                                     } else if let doubleValue = value.double {
                                         stringValue = String(doubleValue)
+                                    } else if let boolValue = value.bool {
+                                        stringValue = String(boolValue)
                                     } else {
                                         stringValue = value.string!
                                     }

--- a/tools/sgen/Sources/SGen/Constants.swift
+++ b/tools/sgen/Sources/SGen/Constants.swift
@@ -43,16 +43,18 @@ enum IconicWeight: String, CodingKey, CaseIterable {
 }
 
 struct TypographyInfo {
-    let defaultPointSize: String
+    let defaultPointSize: String?
     let maximumPointSize: String?
     let mapsTo: String
     let version: String?
+    let isScalable: String?
     
     init(dict: [Config.Entry.Typography.SupportedStyleKeys: String]) {
-        self.defaultPointSize = dict[.defaultPointSize]!
+        self.defaultPointSize = dict[.defaultPointSize]
         self.maximumPointSize = dict[.maximumPointSize]
         self.mapsTo = dict[.mapsTo]!
         self.version = dict[.version]
+        self.isScalable = dict[.isScalable]
     }
 }
 

--- a/tools/sgen/Sources/SGen/Generatable/RhsValue.swift
+++ b/tools/sgen/Sources/SGen/Generatable/RhsValue.swift
@@ -215,6 +215,7 @@ enum RhsValue {
                     let textStyle: String
                     let name: String?
                     let firstComponent = components.removeFirst()
+
                     if Generator.Config.typographyTextStyles.keys.contains(firstComponent) || Rhs.Font.supportedStyles.contains(firstComponent) {
                         textStyle = firstComponent
                         name = nil
@@ -222,7 +223,10 @@ enum RhsValue {
                         textStyle = components.removeFirst()
                         name = firstComponent
                     }
-                    return .font(font: Rhs.Font(name: name, textStyle: textStyle, weightAndTraits: components))
+
+                    let isScalable = (Generator.Config.typographyTextStyles[textStyle]?.isScalable ?? "true") == "true"
+
+                    return .font(font: Rhs.Font(name: name, textStyle: textStyle, weightAndTraits: components, isScalable: isScalable))
                 }
             }
         } else if let components = argumentsFromString("fluentUIColor", string: string) {
@@ -603,7 +607,7 @@ extension RhsValue: Generatable {
             let fontSize = font.fontSize != nil ? "\(font.fontSize!)" : "nil"
             let fontWeight = font.weight ?? "nil"
             let fontTraits = font.traits ?? "[]"
-            let isScalable = font.isScalableFont || font.isSystemPreferred ? "true" : "false"
+            let isScalable = font.isScalableFont
             
             return "\(prefix)\(fontClass).font(name: \(fontName), size: \(fontSize), textStyle: \(textStyle), weight: \(fontWeight), traits: \(fontTraits), traitCollection: traitCollection, isScalable: \(isScalable))"
         }

--- a/tools/sgen/Sources/SGen/Generatable/Stylesheet.swift
+++ b/tools/sgen/Sources/SGen/Generatable/Stylesheet.swift
@@ -1125,11 +1125,6 @@ private extension UIFont {
                           isScalable: isScalable)
     }
 
-    convenience init?(name: String, scalable: Bool) {
-        self.init(name: name, size: 4)
-        self.isScalable = scalable
-    }
-
     var isScalable: Bool {
         get { return objc_getAssociatedObject(self, &scalableHandle) as? Bool ?? false }
         set { objc_setAssociatedObject(self, &scalableHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }

--- a/tools/sgen/Sources/SGen/Generatable/Stylesheet.swift
+++ b/tools/sgen/Sources/SGen/Generatable/Stylesheet.swift
@@ -1089,7 +1089,7 @@ private class FluentUIFontCache: NSObject {
 
 \(visibility) var scalableHandle: UInt8 = 0
 
-public extension UIFont {
+private extension UIFont {
     private static var cache = FluentUIFontCache()
 
 """

--- a/tools/sgen/Sources/SGen/Rhs.swift
+++ b/tools/sgen/Sources/SGen/Rhs.swift
@@ -188,13 +188,10 @@ struct Rhs {
         var fontSize: Float?
         var fontStyle: String?
         var isSymbolFont: Bool = false
+        var isScalableFont: Bool = false
         
         var isSystemPreferred: Bool {
             return fontName?.contains("PreferredSystem") ?? false
-        }
-        
-        var isScalableFont: Bool {
-            return fontStyle != nil
         }
         
         var isSystemFont: Bool {
@@ -202,17 +199,21 @@ struct Rhs {
         }
         
         var systemTextStyle: String? {
-            if isScalableFont == false { return nil }
-            
-            let style = fontStyle!
+            guard let style = fontStyle else {
+                return nil
+            }
+
             assert(Rhs.Font.supportedStyles.contains(style),
                    "\(style) is not a valid system font style. Allowed styles: \(Rhs.Font.supportedStyles)")
-            
+
             return "UIFont.TextStyle.\(style)"
         }
         
         var textStyle: String? {
-            guard let fontStyle = fontStyle, isScalableFont else { return nil }
+            guard let fontStyle = fontStyle else {
+                return nil
+            }
+
             return "\(FontTextStyle)." + fontStyle
         }
         
@@ -241,11 +242,12 @@ struct Rhs {
             self.isSymbolFont = true
         }
         
-        init(name: String? = nil, size: Float? = nil, textStyle: String? = nil, weightAndTraits: [String]? = nil) {
+        init(name: String? = nil, size: Float? = nil, textStyle: String? = nil, weightAndTraits: [String]? = nil, isScalable: Bool = false) {
             self.fontName = name
             self.fontTraits = traits
             self.fontSize = size
             self.fontStyle = textStyle
+            self.isScalableFont = isScalable
          
             if let weightAndTraits = weightAndTraits {
                 if weightAndTraits.count == 2 {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

This is about modifying the generation of **StardustFontResponsibleCache** output to support FluentUI's font enumerations.

It'll be renamed to **FluentUIFontCache** and modifications will be made in the following aspects:

 1. Add support for UIFont.Style based unscaled fonts:

 2. Bring the functionality of loading custom fonts to FluentUI (leveraging the StardustFontResponsibleCache and the Design Token System functionality).

 3. Refactor code to be swift lint compatible and drop support for earlier versions of iOS (< iOS 11 in this case).

Items #1 and #2 will be accomplished through leveraging from the Config YAML.
A new typography style property **isScalable** will be added to flag whether a given style should scale fonts.
Custom font loading is already supported by the symbolsFont section of the Config file.

Below is a sample of the config YAML file that will define the styles that match the current Font extension constants in FluentUI:

```
symbolsFont:
  dir: ./Resources/
  names:
    - { light: TeamsAssetsUNI-Light, regular: TeamsAssetsUNI-Regular }
typography:
  styles:
    - largeTitle: { defaultPointSize: 34, maximumPointSize: 38, mapsTo: largeTitle }
    - title1: { defaultPointSize: 28, maximumPointSize: 32, mapsTo: title1 }
    - title2: { defaultPointSize: 22, maximumPointSize: 26, mapsTo: title2 }
    - title3: { defaultPointSize: 20, maximumPointSize: 24, mapsTo: title3 }
    - headline: { defaultPointSize: 17, maximumPointSize: 21, mapsTo: headline }
    - headlineUnscaled: { defaultPointSize: 17, maximumPointSize: 21, mapsTo: headline, isScalable: false }
    - body: { defaultPointSize: 17, maximumPointSize: 21, mapsTo: body }
    - bodyUnscaled: { defaultPointSize: 17, maximumPointSize: 21, mapsTo: body, isScalable: false }
    - callout: { defaultPointSize: 16, maximumPointSize: 20, mapsTo: callout }
    - subheadline: { defaultPointSize: 15, maximumPointSize: 19, mapsTo: subheadline }
    - footnote: { defaultPointSize: 13, maximumPointSize: 17, mapsTo: footnote }
    - footnoteUnscaled: { defaultPointSize: 13, maximumPointSize: 17, mapsTo: footnote, isScalable: false }
    - caption1: { defaultPointSize: 12, maximumPointSize: 16, mapsTo: caption1 }
    - caption2: { defaultPointSize: 11, maximumPointSize: 15, mapsTo: caption2 }

```
### Verification

Ran the Generator with the changes on this PR and validated the output compiles, passes swift lint validation.
Below is the relevant output generated by the config snipped above:

```
/// Your view should conform to 'AppearaceProxyComponent'.
public protocol AppearaceProxyComponent: class {
    associatedtype ApperanceProxyType
    var appearanceProxy: ApperanceProxyType { get }
    var themeAware: Bool { get set }
    func didChangeAppearanceProxy()
}

public extension AppearaceProxyComponent {
    func initAppearanceProxy(themeAware: Bool = true) {
        self.themeAware = themeAware
        didChangeAppearanceProxy()
    }
}

public extension S.IconicFontStyle {
    var name: String {
        switch self {
        case .light:
            return StylesheetManager.S.__SymbolFont.lightFontName
        case .regular:
            return StylesheetManager.S.__SymbolFont.regularFontName
        }
    }
}

private extension S.FontTextStyle {
    var style: UIFont.TextStyle? {
        switch self {
        case .body:
            return .body
        case .bodyUnscaled:
            return .body
        case .callout:
            return .callout
        case .caption1:
            return .caption1
        case .caption2:
            return .caption2
        case .footnote:
            return .footnote
        case .footnoteUnscaled:
            return .footnote
        case .headline:
            return .headline
        case .headlineUnscaled:
            return .headline
        case .largeTitle:
            return .largeTitle
        case .subheadline:
            return .subheadline
        case .title1:
            return .title1
        case .title2:
            return .title2
        case .title3:
            return .title3
        }
    }

    var defaultPointSize: CGFloat? {
        switch self {
        case .body:
            return 17
        case .bodyUnscaled:
            return 17
        case .callout:
            return 16
        case .caption1:
            return 12
        case .caption2:
            return 11
        case .footnote:
            return 13
        case .footnoteUnscaled:
            return 13
        case .headline:
            return 17
        case .headlineUnscaled:
            return 17
        case .largeTitle:
            return 34
        case .subheadline:
            return 15
        case .title1:
            return 28
        case .title2:
            return 22
        case .title3:
            return 20
        }
    }

    var maximumPointSize: CGFloat? {
        switch self {
        case .body:
            return 21
        case .bodyUnscaled:
            return 21
        case .callout:
            return 20
        case .caption1:
            return 16
        case .caption2:
            return 15
        case .footnote:
            return 17
        case .footnoteUnscaled:
            return 17
        case .headline:
            return 21
        case .headlineUnscaled:
            return 21
        case .largeTitle:
            return 38
        case .subheadline:
            return 19
        case .title1:
            return 32
        case .title2:
            return 26
        case .title3:
            return 24
        }
    }
}

private let defaultSizes: [UIFont.TextStyle: CGFloat] = {
    var sizes: [UIFont.TextStyle: CGFloat] = [.body: 17,
                                              .callout: 16,
                                              .caption2: 11,
                                              .caption1: 12,
                                              .footnote: 13,
                                              .headline: 17,
                                              .largeTitle: 34,
                                              .subheadline: 15,
                                              .title3: 20,
                                              .title2: 22,
                                              .title1: 28]
    return sizes
}()

private class FluentUIFontCache: NSObject {
    private lazy var cache = [UIFont.FontType: UIFont]()

    override init() {
        super.init()
        NotificationCenter.default.addObserver(self,
                                               selector: #selector(handleApplicationDidReceiveMemoryWarning),
                                               name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
    }

    @objc private func handleApplicationDidReceiveMemoryWarning() {
        cache.removeAll()
    }

    func font(name: String? = nil,
              size: CGFloat? = nil,
              textStyle: S.FontTextStyle? = nil,
              weight: UIFont.Weight? = nil,
              traits: UIFontDescriptor.SymbolicTraits,
              traitCollection: UITraitCollection? = nil,
              isScalable: Bool = true) -> UIFont {
        let key = UIFont.FontType(name: name,
                                  size: size,
                                  textStyle: textStyle,
                                  weight: weight,
                                  traits: traits,
                                  traitCollection: traitCollection,
                                  isScalable: isScalable)
        if let font = cache[key] {
            return font
        }

        var font: UIFont!
        var isAlreadyScalable = false
        let fontSize = size ?? textStyle?.defaultPointSize

        if let name = name, let size = fontSize, let customFontWithSpecificSize = UIFont(name: name, size: size) {
            font = customFontWithSpecificSize
        } else if let size = fontSize {
            if let weight = weight {
                font = UIFont.systemFont(ofSize: size, weight: weight)
            } else {
                font = UIFont.systemFont(ofSize: size)
            }
        } else if let nativeTextStyle = textStyle?.style {
            isAlreadyScalable = isScalable && textStyle?.maximumPointSize == nil
            font = UIFont.preferredFont(forTextStyle: nativeTextStyle,
                                        compatibleWith: isScalable ? traitCollection : UITraitCollection(preferredContentSizeCategory: .large))
        }

        guard font != nil else {
            fatalError("Failed to load the font.")
        }

        if !traits.isEmpty {
            font = font.with(traits: traits)
        }

        if isScalable && !isAlreadyScalable {
            if let nativeTextStyle = textStyle?.style {
                if let maximumPointSize = textStyle?.maximumPointSize {
                    font = UIFontMetrics(forTextStyle: nativeTextStyle).scaledFont(for: font, maximumPointSize: maximumPointSize, compatibleWith: traitCollection)
                } else {
                    font = UIFontMetrics(forTextStyle: nativeTextStyle).scaledFont(for: font, compatibleWith: traitCollection)
                }
            } else {
                font = UIFontMetrics.default.scaledFont(for: font, compatibleWith: traitCollection)
            }
        }

        font.isScalable = isScalable
        font.fontType = key
        cache[key] = font
        return font
    }
}

private var fontTypeHandle: UInt8 = 0

private extension UIFont {
    struct FontType: Hashable {
        let name: String?
        let size: CGFloat?
        let textStyle: S.FontTextStyle?
        let weight: UIFont.Weight?
        let traits: UIFontDescriptor.SymbolicTraits
        let traitCollection: UITraitCollection?
        let isScalable: Bool
        func hash(into hasher: inout Hasher) {
            hasher.combine(name)
            hasher.combine(size)
            hasher.combine(textStyle)
            hasher.combine(weight)
            hasher.combine(traits.rawValue)
            hasher.combine(traitCollection)
            hasher.combine(isScalable)
        }
    }

    var fontType: FontType? {
        get { return objc_getAssociatedObject(self, &fontTypeHandle) as? FontType }
        set { objc_setAssociatedObject(self, &fontTypeHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
    }
}

private var scalableHandle: UInt8 = 0

private extension UIFont {
    private static var cache = FluentUIFontCache()
    convenience init?(style: S.IconicFontStyle, size: CGFloat) {
        self.init(name: style.name, size: size)
    }
    func with(traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
        let descriptor = fontDescriptor.withSymbolicTraits(traits)
        return UIFont(descriptor: descriptor!, size: 0)
    }

    class func font(name: String? = nil,
                    size: CGFloat? = nil,
                    textStyle: S.FontTextStyle? = nil,
                    weight: UIFont.Weight? = nil,
                    traits: UIFontDescriptor.SymbolicTraits,
                    traitCollection: UITraitCollection? = nil,
                    isScalable: Bool = true) -> UIFont {
        return cache.font(name: name,
                          size: size,
                          textStyle: textStyle,
                          weight: weight,
                          traits: traits,
                          traitCollection: traitCollection,
                          isScalable: isScalable)
    }

    var isScalable: Bool {
        get { return objc_getAssociatedObject(self, &scalableHandle) as? Bool ?? false }
        set { objc_setAssociatedObject(self, &scalableHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
    }

    var textStyle: UIFont.TextStyle? {
        return fontDescriptor.fontAttributes[.textStyle] as? UIFont.TextStyle
    }

    var fixedFont: UIFont {
        if isScalable == false {
            return self
        }

        if let fontType = fontType {
            return UIFont.font(name: fontType.name, size: fontType.size, textStyle: fontType.textStyle, weight: fontType.weight, traits: fontType.traits, traitCollection: fontType.traitCollection, isScalable: false)
        }

        guard let textStyle = textStyle, let defaultSize = defaultSizes[textStyle] else {
            return self
        }

        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
        return UIFont(descriptor: fontDescriptor, size: defaultSize)
    }
}
```

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/265)