### PR TITLE
Resizing behaviour

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -20,6 +20,7 @@ class DrawerDemoController: DemoController {
         addTitle(text: "Top Drawer")
         container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showTopDrawerButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show non dismissable", action: #selector(showTopDrawerNotDismissableButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: #selector(showTopDrawerChangingResizingBehaviour)))
         container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showTopDrawerNotAnimatedButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show from custom base with width on landscape", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show respecting safe area width", action: #selector(showTopDrawerSafeAreaButtonTapped)))
@@ -38,6 +39,7 @@ class DrawerDemoController: DemoController {
         addTitle(text: "Bottom Drawer")
         container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showBottomDrawerButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show with underlying interactable content view", action: #selector(showBottomDrawerWithUnderlyingInteractableViewButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: #selector(showBottomDrawerChangingResizingBehaviour)))
         container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showBottomDrawerNotAnimatedButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show from custom base", action: #selector(showBottomDrawerCustomOffsetButtonTapped)))
 
@@ -114,7 +116,7 @@ class DrawerDemoController: DemoController {
         return controller
     }
 
-    private func actionViews(drawerHasFlexibleHeight: Bool) -> [UIView] {
+    private func actionViews(drawerHasFlexibleHeight: Bool, drawerHasToggleResizingBehaviorButton: Bool) -> [UIView] {
         let spacer = UIView()
         spacer.backgroundColor = .orange
         spacer.layer.borderWidth = 1
@@ -127,13 +129,16 @@ class DrawerDemoController: DemoController {
         }
         views.append(createButton(title: "Dismiss", action: #selector(dismissButtonTapped)))
         views.append(createButton(title: "Dismiss (no animation)", action: #selector(dismissNotAnimatedButtonTapped)))
+        if drawerHasToggleResizingBehaviorButton {
+            views.append(createButton(title: "Resizing - None", action: #selector(updateResizingBehaviourButtonTapped)))
+        }
         views.append(spacer)
         return views
     }
 
-    private func containerForActionViews(drawerHasFlexibleHeight: Bool = true) -> UIView {
+    private func containerForActionViews(drawerHasFlexibleHeight: Bool = true, drawerHasToggleResizingBehaviorButton: Bool = false) -> UIView {
         let container = DemoController.createVerticalContainer()
-        for view in actionViews(drawerHasFlexibleHeight: drawerHasFlexibleHeight) {
+        for view in actionViews(drawerHasFlexibleHeight: drawerHasFlexibleHeight, drawerHasToggleResizingBehaviorButton: drawerHasToggleResizingBehaviorButton) {
             container.addArrangedSubview(view)
         }
         return container
@@ -149,6 +154,10 @@ class DrawerDemoController: DemoController {
 
     @objc private func showTopDrawerNotDismissableButtonTapped(sender: UIButton) {
         presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), resizingBehavior: .expand)
+    }
+    
+    @objc private func showTopDrawerChangingResizingBehaviour(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(drawerHasFlexibleHeight: true, drawerHasToggleResizingBehaviorButton: true), resizingBehavior: .expand)
     }
 
     @objc private func showTopDrawerNotAnimatedButtonTapped(sender: UIButton) {
@@ -174,6 +183,10 @@ class DrawerDemoController: DemoController {
 
     @objc private func showBottomDrawerButtonTapped(sender: UIButton) {
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
+    }
+    
+    @objc private func showBottomDrawerChangingResizingBehaviour(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(drawerHasFlexibleHeight: true, drawerHasToggleResizingBehaviorButton: true), resizingBehavior: .expand)
     }
 
     @objc private func showBottomDrawerWithUnderlyingInteractableViewButtonTapped(sender: UIButton) {
@@ -288,6 +301,16 @@ class DrawerDemoController: DemoController {
 
     @objc private func dismissNotAnimatedButtonTapped() {
         dismiss(animated: false)
+    }
+    
+    @objc private func updateResizingBehaviourButtonTapped(sender: UIButton) {
+        guard let drawer = presentedViewController as? DrawerController else {
+            return
+        }
+        let isResizingBehaviourNone = drawer.resizingBehavior == .none
+       
+        drawer.resizingBehavior = isResizingBehaviourNone ? .expand : .none
+        sender.setTitle(isResizingBehaviourNone ? "Resizing - None" : "Resizing - Expand", for: .normal)
     }
 
     @objc private func changePreferredContentSizeButtonTapped() {

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -253,6 +253,11 @@ open class DrawerController: UIViewController {
             if presentationDirection.isHorizontal && resizingBehavior == .dismissOrExpand {
                 resizingBehavior = .dismiss
             }
+            
+            // If the drawer is already loaded, update the resizing handle when resizing behaviour is changed.
+            if self.isViewLoaded {
+                self.updateResizingHandleView()
+            }
         }
     }
 
@@ -490,23 +495,7 @@ open class DrawerController: UIViewController {
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if canResize {
-            if showsResizingHandle {
-                if resizingHandleView == nil {
-                    resizingHandleView = ResizingHandleView()
-                    resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
-                }
-            } else {
-                resizingHandleView = nil
-            }
-            if resizingGestureRecognizer == nil {
-                resizingGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handleResizingGesture))
-            }
-        } else {
-            resizingHandleView = nil
-            resizingGestureRecognizer = nil
-        }
-        resizingGestureRecognizer?.isEnabled = false
+        self.updateResizingHandleView()
 
         // if DrawerController is shown in UIPopoverPresentationController then we want to show different darkElevated color
         if !useCustomBackgroundColor {
@@ -675,6 +664,7 @@ open class DrawerController: UIViewController {
                 initResizingHandleView()
                 if presentationDirection == .down {
                     containerView.addArrangedSubview(newView)
+                    containerView.layoutIfNeeded()
                 } else {
                     containerView.insertArrangedSubview(newView, at: 0)
                 }
@@ -714,6 +704,26 @@ open class DrawerController: UIViewController {
             resizingHandleView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleResizingHandleViewTap)))
         }
         updateResizingHandleViewAccessibility()
+    }
+    
+    private func updateResizingHandleView() {
+        if canResize {
+           if showsResizingHandle {
+               if resizingHandleView == nil {
+                   resizingHandleView = ResizingHandleView()
+                   resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
+               }
+           } else {
+               resizingHandleView = nil
+           }
+           if resizingGestureRecognizer == nil {
+               resizingGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handleResizingGesture))
+           }
+       } else {
+           resizingHandleView = nil
+           resizingGestureRecognizer = nil
+       }
+       resizingGestureRecognizer?.isEnabled = false
     }
 
     private func updateResizingHandleViewAccessibility() {

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -667,6 +667,8 @@ open class DrawerController: UIViewController {
                 initResizingHandleView()
                 if presentationDirection == .down {
                     containerView.addArrangedSubview(newView)
+                    
+                    // Force layout the containerView to avoid unwanted animation of view addition.
                     containerView.layoutIfNeeded()
                 } else {
                     containerView.insertArrangedSubview(newView, at: 0)

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -496,6 +496,8 @@ open class DrawerController: UIViewController {
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.updateResizingHandleView()
+        
+        resizingGestureRecognizer?.isEnabled = false
 
         // if DrawerController is shown in UIPopoverPresentationController then we want to show different darkElevated color
         if !useCustomBackgroundColor {
@@ -723,7 +725,6 @@ open class DrawerController: UIViewController {
            resizingHandleView = nil
            resizingGestureRecognizer = nil
        }
-       resizingGestureRecognizer?.isEnabled = false
     }
 
     private func updateResizingHandleViewAccessibility() {

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -255,8 +255,8 @@ open class DrawerController: UIViewController {
             }
             
             // If the drawer is already loaded, update the resizing handle when resizing behaviour is changed.
-            if self.isViewLoaded {
-                self.updateResizingHandleView()
+            if isViewLoaded {
+               updateResizingHandleView()
             }
         }
     }
@@ -495,8 +495,9 @@ open class DrawerController: UIViewController {
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.updateResizingHandleView()
         
+        // Configure the resizing handle view according to resizing behaviour and disable the gesture recogniser(if any) till view actually appears
+        updateResizingHandleView()
         resizingGestureRecognizer?.isEnabled = false
 
         // if DrawerController is shown in UIPopoverPresentationController then we want to show different darkElevated color


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

DrawerController.swift 
- on changing the resizingBehaviour, we check if the drawer is loaded, and accordingly, update the resizingHandleView(as per the provided resizingBehaviour)

DrawerDemoController.swift
- Added new controls in content view to toggle resizing behaviour of a presented drawer controller
- Created new buttons with resizing controls for top and bottom drawer.

### Verification
- Tested the FluentUI.demo app manually. Ensured that, upon changing the resizing behaviour, the changes are reflected in the layout.

Tested the existing drawer controllers to ensure that no behaviour is regressed.
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Changing resizing behaviour of a presented drawer, did not update the layout to add or remove the resizingHandleView | We can see that the changes are appropriately reflected, i.e. when behaviour is changed from .none to any other enum, resizingHandleView should appear and when behaviour is changed from any to .none, the resizingHandleView should disappear|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/266)