### PR TITLE
Bug fix: Drawer Controller does not behave correctly when being dismissed by gesture

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -184,7 +184,7 @@ class DrawerDemoController: DemoController {
     @objc private func showBottomDrawerButtonTapped(sender: UIButton) {
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
-    
+
     @objc private func showBottomDrawerChangingResizingBehaviour(sender: UIButton) {
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(drawerHasFlexibleHeight: true, drawerHasToggleResizingBehaviorButton: true), resizingBehavior: .expand)
     }
@@ -199,7 +199,7 @@ class DrawerDemoController: DemoController {
 
     @objc private func showBottomDrawerCustomOffsetButtonTapped(sender: UIButton) {
         let rect = sender.superview!.convert(sender.frame, to: nil)
-        presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews())
+        presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 
     @objc private func showBottomDrawerBlockingDismissButtonTapped(sender: UIButton) {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -145,7 +145,7 @@ class DrawerPresentationController: UIPresentationController {
             // Horizontally presented drawers must be inside containerView in order for device rotation animation to work correctly
             if presentationDirection.isHorizontal {
                 containerView?.addSubview(presentedViewController.view)
-                presentedViewController.view.frame = frameForPresentedViewController(in: contentView.bounds)
+                presentedViewController.view.frame = frameForPresentedViewController(in: frameOfPresentedViewInContainerView)
                 focusElement = containerView
             } else {
                 focusElement = contentView
@@ -303,11 +303,7 @@ class DrawerPresentationController: UIPresentationController {
         contentView.frame = frame
 
         if let presentedView = presentedView {
-            presentedView.frame = frameForPresentedViewController(in: contentView.bounds)
-
-            if presentedView.superview == containerView {
-                presentedView.frame = frameForPresentedViewController(in: frameOfPresentedViewInContainerView)
-            }
+            presentedView.frame = frameForPresentedViewController(in: presentedView.superview == containerView ? frameOfPresentedViewInContainerView : contentView.bounds)
         }
 
         if separator.superview != nil {
@@ -446,9 +442,9 @@ class DrawerPresentationController: UIPresentationController {
                            width: bounds.size.width,
                            height: bounds.size.height)
 
-        // Moves the presented view controller (drawer) down in the content view if it's being dragged towards dismissal.
-        // In case the drawer is being expanded, the content view grows with the gesture extra content size and the
-        // drawer keeps its original offset relative to the content view.
+        // Moves the presented view controller (drawer) towards its presenting base in the content view if it's being dragged to dismissal.
+        // In case the drawer is being expanded, the content view grows with the gesture extra content size and the drawer keeps its
+        // original offset relative to the content view.
         let gestureOffset = extraContentSize < 0 && extraContentSizeEffectWhenCollapsing == .move ? extraContentSize : 0
 
         if presentationDirection.isVertical {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -437,10 +437,7 @@ class DrawerPresentationController: UIPresentationController {
     }
 
     private func frameForPresentedViewController(in bounds: CGRect) -> CGRect {
-        var frame = CGRect(x: bounds.origin.x,
-                           y: bounds.origin.y,
-                           width: bounds.size.width,
-                           height: bounds.size.height)
+        var frame = bounds
 
         // Moves the presented view controller (drawer) towards its presenting base in the content view if it's being dragged to dismissal.
         // In case the drawer is being expanded, the content view grows with the gesture extra content size and the drawer keeps its

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -126,7 +126,7 @@ class DrawerPresentationController: UIPresentationController {
         // For animated presentations presented view must be inside contentView to not slide over navigation bar/toolbar
         if presentingViewController.transitionCoordinator?.isAnimated == true {
             // Avoiding content animation due to showing of the keyboard (when presented view contains the first responder)
-            presentedViewController.view.frame = contentView.bounds
+            presentedViewController.view.frame = frameForPresentedViewController(in: contentView.bounds)
             presentedViewController.view.layoutIfNeeded()
 
             contentView.addSubview(presentedViewController.view)
@@ -145,7 +145,7 @@ class DrawerPresentationController: UIPresentationController {
             // Horizontally presented drawers must be inside containerView in order for device rotation animation to work correctly
             if presentationDirection.isHorizontal {
                 containerView?.addSubview(presentedViewController.view)
-                presentedViewController.view.frame = frameOfPresentedViewInContainerView
+                presentedViewController.view.frame = frameForPresentedViewController(in: contentView.bounds)
                 focusElement = containerView
             } else {
                 focusElement = contentView
@@ -163,7 +163,7 @@ class DrawerPresentationController: UIPresentationController {
         // For animated presentations presented view must be inside contentView to not slide over navigation bar/toolbar
         if let transitionCoordinator = presentingViewController.transitionCoordinator, transitionCoordinator.isAnimated == true {
             contentView.addSubview(presentedViewController.view)
-            presentedViewController.view.frame = contentView.bounds
+            presentedViewController.view.frame = frameForPresentedViewController(in: contentView.bounds)
 
             transitionCoordinator.animate(alongsideTransition: { _ in
                 self.backgroundView.alpha = 0.0
@@ -301,9 +301,15 @@ class DrawerPresentationController: UIPresentationController {
 
     private func setContentViewFrame(_ frame: CGRect) {
         contentView.frame = frame
-        if let presentedView = presentedView, presentedView.superview == containerView {
-            presentedView.frame = frameOfPresentedViewInContainerView
+
+        if let presentedView = presentedView {
+            presentedView.frame = frameForPresentedViewController(in: contentView.bounds)
+
+            if presentedView.superview == containerView {
+                presentedView.frame = frameForPresentedViewController(in: frameOfPresentedViewInContainerView)
+            }
         }
+
         if separator.superview != nil {
             separator.frame = frameForSeparator(in: contentView.frame, withThickness: separator.frame.height)
         }
@@ -381,9 +387,7 @@ class DrawerPresentationController: UIPresentationController {
             if presentationDirection == .up {
                 contentFrame.origin.y = contentFrame.maxY - contentSize.height
             }
-            if extraContentSize < 0 && extraContentSizeEffectWhenCollapsing == .move {
-                contentFrame.origin.y += presentationDirection == .down ? extraContentSize : -extraContentSize
-            }
+
             contentSize.height += shadowOffset
         } else {
             if actualPresentationOffset == 0 {
@@ -395,9 +399,7 @@ class DrawerPresentationController: UIPresentationController {
             if presentationDirection == .fromTrailing {
                 contentFrame.origin.x = contentFrame.maxX - contentSize.width
             }
-            if extraContentSize < 0 && extraContentSizeEffectWhenCollapsing == .move {
-                contentFrame.origin.x += presentationDirection == .fromLeading ? extraContentSize : -extraContentSize
-            }
+
             contentSize.width += shadowOffset
         }
         contentFrame.size = contentSize
@@ -438,13 +440,27 @@ class DrawerPresentationController: UIPresentationController {
         return margins
     }
 
-    private func frameForSeparator(in bounds: CGRect, withThickness thickness: CGFloat) -> CGRect {
-        var bounds = bounds
-        // Separator should stay fixed even when content view is moving - compensating for move
-        if extraContentSize < 0 && extraContentSizeEffectWhenCollapsing == .move {
-            bounds.origin.y += presentationDirection == .down ? -extraContentSize : extraContentSize
+    private func frameForPresentedViewController(in bounds: CGRect) -> CGRect {
+        var frame = CGRect(x: bounds.origin.x,
+                           y: bounds.origin.y,
+                           width: bounds.size.width,
+                           height: bounds.size.height)
+
+        // Moves the presented view controller (drawer) down in the content view if it's being dragged towards dismissal.
+        // In case the drawer is being expanded, the content view grows with the gesture extra content size and the
+        // drawer keeps its original offset relative to the content view.
+        let gestureOffset = extraContentSize < 0 && extraContentSizeEffectWhenCollapsing == .move ? extraContentSize : 0
+
+        if presentationDirection.isVertical {
+            frame.origin.y += presentationDirection == .down ? gestureOffset - shadowOffset : -gestureOffset + shadowOffset
+        } else {
+            frame.origin.x += presentationDirection == .fromLeading ? gestureOffset - shadowOffset : -gestureOffset + shadowOffset
         }
 
+        return frame
+    }
+
+    private func frameForSeparator(in bounds: CGRect, withThickness thickness: CGFloat) -> CGRect {
         return CGRect(
             x: bounds.minX,
             y: presentationDirection == .down ? bounds.minY : bounds.maxY - thickness,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When presented from a base that is not the edge of the screen, the drawer does not get dismissed in the same way as it was presented (by going under the presentation base).

This issue reproduces only when the drawer is being dragged towards dismissal. Tapping outside of the drawer dismisses it correctly.

Previously the content view that clips the drawer on the custom base dismissal was being moved when the user dragged. The change makes the drawer view itself to be moved while the content view remains in place.

### Verification

Exercised all demo controller cases and ensured no regression was introduced on both portrait and landscape modes.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![drawer_bug](https://user-images.githubusercontent.com/68076145/96827084-a3b83c00-13e9-11eb-9c87-91674d80e5ee.gif) | ![bug_drawer_fixed](https://user-images.githubusercontent.com/68076145/96827108-af0b6780-13e9-11eb-9a65-347294ff585c.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/271)