### PR TITLE
Fix for crashes while adding UIPointerInteraction instance

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -678,8 +678,8 @@
 		A5CEC16B20D98EBF0016922A /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				FD599D052134A682008845EE /* AccessibleViewDelegate.swift */,
 				FD77752A219E455A00033D58 /* AccessibilityContainerView.swift */,
+				FD599D052134A682008845EE /* AccessibleViewDelegate.swift */,
 				FDF41ED82141A02200EC527C /* CalendarConfiguration.swift */,
 				A5CEC16C20D98EE70016922A /* Colors.swift */,
 				FD777528219E3F6C00033D58 /* DayOfMonth.swift */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		497DC2DA24185885008D86F8 /* PillButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2D724185885008D86F8 /* PillButtonBar.swift */; };
 		497DC2DB24185885008D86F8 /* PillButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2D824185885008D86F8 /* PillButton.swift */; };
 		497DC2DC24185885008D86F8 /* PillButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2D824185885008D86F8 /* PillButton.swift */; };
+		537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537315B225438B15001FD14C /* iOS13_4_compatibility.swift */; };
+		537315B425438B15001FD14C /* iOS13_4_compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537315B225438B15001FD14C /* iOS13_4_compatibility.swift */; };
 		53BCB0CE253A4E8D00620960 /* Obscurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0CD253A4E8C00620960 /* Obscurable.swift */; };
 		53BCB0CF253A4E8D00620960 /* Obscurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0CD253A4E8C00620960 /* Obscurable.swift */; };
 		56DA1CD824523611008D745E /* ShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */; };
@@ -308,6 +310,7 @@
 		22EABB192509AAD100C4BE72 /* IndeterminateProgressBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarView.swift; sourceTree = "<group>"; };
 		497DC2D724185885008D86F8 /* PillButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBar.swift; sourceTree = "<group>"; };
 		497DC2D824185885008D86F8 /* PillButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButton.swift; sourceTree = "<group>"; };
+		537315B225438B15001FD14C /* iOS13_4_compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iOS13_4_compatibility.swift; sourceTree = "<group>"; };
 		53BCB0CD253A4E8C00620960 /* Obscurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Obscurable.swift; sourceTree = "<group>"; };
 		7D0931C224AAAC8C0072458A /* SideTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabBar.swift; sourceTree = "<group>"; };
 		7D23482624D88DDF00FBE057 /* AvatarGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarGroupView.swift; sourceTree = "<group>"; };
@@ -676,12 +679,13 @@
 			isa = PBXGroup;
 			children = (
 				FD599D052134A682008845EE /* AccessibleViewDelegate.swift */,
-				A5CEC16C20D98EE70016922A /* Colors.swift */,
-				A5CEC16E20D98F340016922A /* Fonts.swift */,
 				FD77752A219E455A00033D58 /* AccessibilityContainerView.swift */,
 				FDF41ED82141A02200EC527C /* CalendarConfiguration.swift */,
+				A5CEC16C20D98EE70016922A /* Colors.swift */,
 				FD777528219E3F6C00033D58 /* DayOfMonth.swift */,
 				A559BB82212B7D870055E107 /* FluentUIFramework.swift */,
+				A5CEC16E20D98F340016922A /* Fonts.swift */,
+				537315B225438B15001FD14C /* iOS13_4_compatibility.swift */,
 				FD41C8C022DD48E60086F899 /* Operators.swift */,
 			);
 			path = Core;
@@ -1203,6 +1207,7 @@
 				FD41C88522DD13230086F899 /* ContentScrollViewTraits.swift in Sources */,
 				8FD01181228A82A600D25925 /* Label.swift in Sources */,
 				8FD01182228A82A600D25925 /* ResizingHandleView.swift in Sources */,
+				537315B425438B15001FD14C /* iOS13_4_compatibility.swift in Sources */,
 				56DA1CDC24523624008D745E /* ShimmerAppearance.swift in Sources */,
 				8FD01183228A82A600D25925 /* SegmentedControl.swift in Sources */,
 				FD41C88722DD13230086F899 /* ShyHeaderController.swift in Sources */,
@@ -1338,6 +1343,7 @@
 				FD97580F2191118E00B67319 /* DateTimePickerViewComponentCell.swift in Sources */,
 				A5B6617323A41E2900E801DD /* NotificationView.swift in Sources */,
 				FD41C88622DD13230086F899 /* ShyHeaderController.swift in Sources */,
+				537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */,
 				FDFB8AF121361C9D0046850A /* CalendarViewDayMonthCell.swift in Sources */,
 				B47B58B822F8E5840078DE38 /* PeoplePicker.swift in Sources */,
 				FD41C89E22DD13230086F899 /* NavigationController.swift in Sources */,

--- a/ios/FluentUI/Core/iOS13_4_compatibility.swift
+++ b/ios/FluentUI/Core/iOS13_4_compatibility.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+// MARK: - Pointer Interaction APIs check
+
+/// Some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
+/// Checking the UIButton's isPointerInteractionEnabled property is a workaround that prevents a crash due to an
+/// exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:
+/// "uncaught ObjC exception, reason: Invalid parameter not satisfying: interaction"
+/// - Returns: true if Pointer Interaction APIs are available, otherwise false
+@available(iOS 13.4, *)
+func arePointerInteractionAPIsAvailable() -> Bool {
+    return UIButton.instancesRespond(to: Selector(("isPointerInteractionEnabled")))
+}

--- a/ios/FluentUI/Extensions/UIView+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIView+Extensions.swift
@@ -200,16 +200,3 @@ extension UIView {
         NSLayoutConstraint.contain(view: view, in: self, withInsets: insets, respectingSafeAreaInsets: respectsSafeAreaInsets)
     }
 }
-
-// MARK: - Pointer Interaction APIs check
-
-extension UIView {
-    /// Some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
-    /// Checking the UIButton's isPointerInteractionEnabled property is a workaround that prevents a crash due to an
-    /// exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:
-    /// "uncaught ObjC exception, reason: Invalid parameter not satisfying: interaction"
-    /// - Returns: true if Pointer Interaction APIs are available, otherwise false
-    func arePointerInteractionAPIsAvailable() -> Bool {
-        return UIButton.instancesRespond(to: Selector(("isPointerInteractionEnabled")))
-    }
-}

--- a/ios/FluentUI/Extensions/UIView+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIView+Extensions.swift
@@ -200,3 +200,17 @@ extension UIView {
         NSLayoutConstraint.contain(view: view, in: self, withInsets: insets, respectingSafeAreaInsets: respectsSafeAreaInsets)
     }
 }
+
+// MARK: - Pointer Interaction APIs check
+
+extension UIView {
+    
+    /// Some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
+    /// Checking the UIButton's isPointerInteractionEnabled property is a workaround that prevents a crash due to an
+    /// exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:
+    /// "uncaught ObjC exception, reason: Invalid parameter not satisfying: interaction"
+    /// - Returns: true if Pointer Interaction APIs are available, otherwise false
+    func arePointerInteractionAPIsAvailable() -> Bool {
+        return UIButton.instancesRespond(to: Selector(("isPointerInteractionEnabled")))
+    }
+}

--- a/ios/FluentUI/Extensions/UIView+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIView+Extensions.swift
@@ -204,7 +204,6 @@ extension UIView {
 // MARK: - Pointer Interaction APIs check
 
 extension UIView {
-    
     /// Some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
     /// Checking the UIButton's isPointerInteractionEnabled property is a workaround that prevents a crash due to an
     /// exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:

--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -276,14 +276,17 @@ open class AvatarView: UIView {
         didSet {
             if oldValue != hasPointerInteraction {
                 if #available(iOS 13.4, *) {
-                    if hasPointerInteraction {
-                        let pointerInteraction = UIPointerInteraction(delegate: self)
-                        addInteraction(pointerInteraction)
+                    // Workaround check for beta iOS versions missing the Pointer Interactions API
+                    if arePointerInteractionAPIsAvailable() {
+                        if hasPointerInteraction {
+                            let pointerInteraction = UIPointerInteraction(delegate: self)
+                            addInteraction(pointerInteraction)
 
-                        self.pointerInteraction = pointerInteraction
-                    } else if let pointerInteraction = pointerInteraction {
-                        removeInteraction(pointerInteraction as! UIPointerInteraction)
-                        self.pointerInteraction = nil
+                            self.pointerInteraction = pointerInteraction
+                        } else if let pointerInteraction = pointerInteraction {
+                            removeInteraction(pointerInteraction as! UIPointerInteraction)
+                            self.pointerInteraction = nil
+                        }
                     }
                 }
             }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -151,8 +151,11 @@ open class PillButtonBar: UIScrollView {
         setupStackView()
 
         if #available(iOS 13.4, *) {
-            let pointerInteraction = UIPointerInteraction(delegate: self)
-            addInteraction(pointerInteraction)
+            // Workaround check for beta iOS versions missing the Pointer Interactions API
+            if arePointerInteractionAPIsAvailable() {
+                let pointerInteraction = UIPointerInteraction(delegate: self)
+                addInteraction(pointerInteraction)
+            }
         }
     }
 

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -65,11 +65,8 @@ class TabBarItemView: UIView {
         container.addSubview(badgeView)
 
         if #available(iOS 13.4, *) {
-            // Some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
-            // Checking the UIButton's isPointerInteractionEnabled property is a workaround that prevents a crash due to an
-            // exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:
-            // "uncaught ObjC exception, reason: Invalid parameter not satisfying: interaction"
-            if UIButton.instancesRespond(to: Selector(("isPointerInteractionEnabled"))) {
+            // Workaround check for beta iOS versions missing the Pointer Interactions API
+            if arePointerInteractionAPIsAvailable() {
                 let pointerInteraction = UIPointerInteraction(delegate: self)
                 addInteraction(pointerInteraction)
             }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -65,8 +65,14 @@ class TabBarItemView: UIView {
         container.addSubview(badgeView)
 
         if #available(iOS 13.4, *) {
-            let pointerInteraction = UIPointerInteraction(delegate: self)
-            addInteraction(pointerInteraction)
+            // Some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
+            // Checking the UIButton's isPointerInteractionEnabled property is a workaround that prevents a crash due to an
+            // exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:
+            // "uncaught ObjC exception, reason: Invalid parameter not satisfying: interaction"
+            if UIButton.instancesRespond(to: Selector(("isPointerInteractionEnabled"))) {
+                let pointerInteraction = UIPointerInteraction(delegate: self)
+                addInteraction(pointerInteraction)
+            }
         }
 
         isAccessibilityElement = true


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Crashes were reported for pointer interaction instances being added to views.
We found out that some beta versions of iOS 13.4 and later don't include the pointer interaction APIs.
So, we're adding a workaround by checking the UIButton's isPointerInteractionEnabled property in order prevent crashes due to an exception thrown while trying to add the UIPointerInteraction instance while running on those iOS versions:

**"uncaught ObjC exception, reason: Invalid parameter not satisfying: interaction"**

### Verification

- Ensured that the arePointerInteractionAPIsAvailable API returns false in iOS versions that don't support Pointer Interactions (iOS 12 for example)
- Exercised the controls in FluentUI that use pointer interactions to make sure the functionality is not regressed.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/272)