### PR TITLE
add objc support for getting navigationbar background color

### DIFF
--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -22,6 +22,9 @@ public extension Colors {
         public static var background: UIColor = NavigationBar.background
         public static var tint: UIColor = NavigationBar.tint
     }
+
+    // Objective-C support
+    @objc static var navigationBarBackground: UIColor { return NavigationBar.background }
 }
 
 // MARK: - FluentUIFramework


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

add objc support for getting navigationbar background color

### Verification

build and check fluentui-swift.h file.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/273)