### PR TITLE
Snap sheet components to 4px grid

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -14,7 +14,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
 
     private struct Constants {
-        static let labelVerticalMarginForOneLine: CGFloat = 14
+        static let labelVerticalMarginForOneLine: CGFloat = 15
         static let accessoryImageViewOffset: CGFloat = 5
 
         static let imageViewSize: CustomViewSize = .small


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Some components do not snap to a 4px grid. This change should fix Sheets, specifically:

1. Bottom sheet

- With one-line list
- With one-line list with icons
- With header and one-line list with icons
- With description and one-line list with icons

2. Top sheet

- Default
- With one-line list

3. Floating list

- With one-line list

### Verification

Measured new components with grids and through debugging.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 19 09 25](https://user-images.githubusercontent.com/22566866/97375097-ebc2dd00-1887-11eb-9e29-f99ea422d603.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 19 08 28](https://user-images.githubusercontent.com/22566866/97375048-cc2bb480-1887-11eb-9081-746af883c3f5.png) |
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 19 06 14](https://user-images.githubusercontent.com/22566866/97374911-79ea9380-1887-11eb-85de-2f160ce5d832.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 19 07 22](https://user-images.githubusercontent.com/22566866/97374987-a3a3ba80-1887-11eb-9c37-626d307de1bd.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/277)