### PR TITLE
button outline border colors should meet color contrast ratio

### DIFF
--- a/ios/FluentUI/Controls/Button.swift
+++ b/ios/FluentUI/Controls/Button.swift
@@ -313,11 +313,11 @@ open class Button: UIButton {
     }
 
     private func highlightedTitleAndImageColor(for window: UIWindow) -> UIColor {
-        return style == .primaryFilled ? normalTitleAndImageColor(for: window) : Colors.primaryTint20(for: window)
+        return style == .primaryFilled ? Colors.Button.titleWithFilledBackground : Colors.primaryTint20(for: window)
     }
 
     private func disabledTitleAndImageColor(for window: UIWindow) -> UIColor {
-        return style == .primaryFilled ? normalTitleAndImageColor(for: window) : Colors.primaryTint20(for: window)
+        return style == .primaryFilled ? Colors.Button.titleWithFilledBackground : Colors.Button.titleDisabled
     }
 
     private var normalImageTintColor: UIColor?

--- a/ios/FluentUI/Controls/Button.swift
+++ b/ios/FluentUI/Controls/Button.swift
@@ -397,7 +397,7 @@ open class Button: UIButton {
             } else if !isEnabled {
                 borderColor = Colors.Button.borderDisabled
             } else {
-                borderColor = Colors.primaryTint20(for: window)
+                borderColor = Colors.primary(for: window)
             }
             layer.borderColor = borderColor.cgColor
         }

--- a/ios/FluentUI/Controls/Button.swift
+++ b/ios/FluentUI/Controls/Button.swift
@@ -397,7 +397,7 @@ open class Button: UIButton {
             } else if !isEnabled {
                 borderColor = Colors.Button.borderDisabled
             } else {
-                borderColor = Colors.primary(for: window)
+                borderColor = Colors.primaryTint10(for: window)
             }
             layer.borderColor = borderColor.cgColor
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Matching to Fluent UI Web buttons which outline border colors are app primary colors
fix regression from commit a64b9c8 that button title  had incorrect disable color.
### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 23 13 55](https://user-images.githubusercontent.com/20715435/97401247-b29d6380-18ad-11eb-8355-7d7698f4c6c1.png)|![Simulator Screen Shot - iPhone 11 Pro - 2020-11-03 at 09 47 02](https://user-images.githubusercontent.com/20715435/98022043-f3b7db00-1db9-11eb-90e0-09d22c2de196.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/279)