### PR TITLE
activity indicator accessibility label

### DIFF
--- a/ios/FluentUI/Controls/ActivityIndicatorView.swift
+++ b/ios/FluentUI/Controls/ActivityIndicatorView.swift
@@ -148,6 +148,7 @@ open class ActivityIndicatorView: UIView, ActivityViewAnimating {
         layer.addSublayer(loaderLayer)
         isHidden = true
         updateView(sideSize: sideSize, strokeThickness: strokeThickness)
+        isAccessibilityElement = true
     }
 
     public required init(coder aDecoder: NSCoder) {
@@ -183,6 +184,25 @@ open class ActivityIndicatorView: UIView, ActivityViewAnimating {
 
         if hidesWhenStopped {
             isHidden = true
+        }
+    }
+
+    private var useCustomAccessibilityLabel: Bool = false
+    open override var accessibilityLabel: String? {
+        get {
+            if useCustomAccessibilityLabel {
+                return super.accessibilityLabel
+            } else {
+                if isAnimating {
+                    return "Accessibility.ActivityIndicator.Animating.label".localized
+                } else {
+                    return "Accessibility.ActivityIndicator.Stopped.label".localized
+                }
+            }
+        }
+        set {
+            super.accessibilityLabel = newValue
+            useCustomAccessibilityLabel = true
         }
     }
 

--- a/ios/FluentUI/Controls/ActivityIndicatorView.swift
+++ b/ios/FluentUI/Controls/ActivityIndicatorView.swift
@@ -83,11 +83,6 @@ open class ActivityIndicatorView: UIView, ActivityViewAnimating {
         return CGSize(width: size.sideSize, height: size.sideSize)
     }
 
-    private struct Constants {
-        static let rotationAnimationDuration: TimeInterval = 0.7
-        static let rotationAnimationKey: String = "rotationAnimation"
-    }
-
     @objc open var size: ActivityIndicatorViewSize {
         get {
             return ActivityIndicatorViewSize.allCases.first { $0.sideSize == self.sideSize } ?? .medium
@@ -111,33 +106,6 @@ open class ActivityIndicatorView: UIView, ActivityViewAnimating {
     }
     /// Don't modify this directly. Instead, call `startAnimating` and `stopAnimating`
     @objc(isAnimating) public private(set) var isAnimating: Bool = false
-
-    private var loaderLayer: CAShapeLayer = {
-        let shapeLayer = CAShapeLayer()
-        shapeLayer.contentsScale = UIScreen.main.scale
-        shapeLayer.fillColor = UIColor.clear.cgColor
-        shapeLayer.lineCap = .round
-        shapeLayer.lineJoin = .bevel
-        return shapeLayer
-    }()
-    private let loaderRotationAnimation: CABasicAnimation = {
-        let loaderRotationAnimation = CABasicAnimation(keyPath: "transform.rotation")
-
-        loaderRotationAnimation.fromValue = NSNumber(value: 0.0 as Double)
-        loaderRotationAnimation.toValue = NSNumber(value: 2 * Double.pi)
-
-        loaderRotationAnimation.duration = Constants.rotationAnimationDuration
-        loaderRotationAnimation.timingFunction = CAMediaTimingFunction(name: .linear)
-
-        loaderRotationAnimation.isRemovedOnCompletion = false
-        loaderRotationAnimation.repeatCount = .infinity
-        loaderRotationAnimation.fillMode = .forwards
-        loaderRotationAnimation.autoreverses = false
-
-        return loaderRotationAnimation
-    }()
-    private var sideSize: CGFloat = 0
-    private var strokeThickness: CGFloat = 0
 
     @objc public convenience init(size: ActivityIndicatorViewSize) {
         self.init(sideSize: size.sideSize, strokeThickness: size.strokeThickness.rawValue)
@@ -187,7 +155,6 @@ open class ActivityIndicatorView: UIView, ActivityViewAnimating {
         }
     }
 
-    private var useCustomAccessibilityLabel: Bool = false
     open override var accessibilityLabel: String? {
         get {
             if useCustomAccessibilityLabel {
@@ -241,5 +208,41 @@ open class ActivityIndicatorView: UIView, ActivityViewAnimating {
         setupLoaderLayer()
         sizeToFit()
         invalidateIntrinsicContentSize()
+    }
+
+    private let loaderRotationAnimation: CABasicAnimation = {
+        let loaderRotationAnimation = CABasicAnimation(keyPath: "transform.rotation")
+
+        loaderRotationAnimation.fromValue = NSNumber(value: 0.0 as Double)
+        loaderRotationAnimation.toValue = NSNumber(value: 2 * Double.pi)
+
+        loaderRotationAnimation.duration = Constants.rotationAnimationDuration
+        loaderRotationAnimation.timingFunction = CAMediaTimingFunction(name: .linear)
+
+        loaderRotationAnimation.isRemovedOnCompletion = false
+        loaderRotationAnimation.repeatCount = .infinity
+        loaderRotationAnimation.fillMode = .forwards
+        loaderRotationAnimation.autoreverses = false
+
+        return loaderRotationAnimation
+    }()
+
+    private var loaderLayer: CAShapeLayer = {
+        let shapeLayer = CAShapeLayer()
+        shapeLayer.contentsScale = UIScreen.main.scale
+        shapeLayer.fillColor = UIColor.clear.cgColor
+        shapeLayer.lineCap = .round
+        shapeLayer.lineJoin = .bevel
+        return shapeLayer
+    }()
+
+    private var sideSize: CGFloat = 0
+    private var strokeThickness: CGFloat = 0
+
+    private var useCustomAccessibilityLabel: Bool = false
+
+    private struct Constants {
+        static let rotationAnimationDuration: TimeInterval = 0.7
+        static let rotationAnimationKey: String = "rotationAnimation"
     }
 }

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 //
 
 // Accessibility
+"Accessibility.ActivityIndicator.Animating.label" = "In progress";
+"Accessibility.ActivityIndicator.Stopped.label" = "Progress halted";
+
 "Accessibility.Alert" = "Alert";
 "Accessibility.Dismiss.Label" = "Dismiss";
 "Accessibility.Dismiss.Hint" = "Double tap to dismiss";


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add accessibility label to Fluent activity indicator that is similar to iOS native UIActivityIndicatorView.

### Verification

VO testing with spinner in search bar, cell with activity indicator.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/280)