### PR TITLE
accessibility post notification for HUD

### DIFF
--- a/ios/FluentUI/HUD/HUD.swift
+++ b/ios/FluentUI/HUD/HUD.swift
@@ -239,6 +239,7 @@ public class HUD: NSObject {
 
     @objc public func update(with caption: String) {
         presentedHUDView?.label.text = caption
+        UIAccessibility.post(notification: .layoutChanged, argument: presentedHUDView)
     }
 
     private func hostWindow(for controller: UIViewController) -> UIWindow? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When HUD updates its label, make sure VoiceOver reads out the current label.

### Verification
Step 1: Open FluentUI application.
Step 2: Navigate to 'HUD' button using swipe gesture and double tap to activate it.
Step 3: Navigate to 'Show HUD with updating caption' button and double tap to activate it and observe the message.
step 4: listen to VO annoucements

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/281)