### PR TITLE
update demo app tableviewheaderfooterview custom accessoryview color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -111,7 +111,7 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
     private func createCustomAccessoryView() -> UIView {
         let button = UIButton(type: .system)
         button.setTitle("Custom Accessory", for: .normal)
-        button.setTitleColor(.green, for: .normal)
+        button.setTitleColor(Colors.error, for: .normal)
         return button
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Demo app's example custom accessoryView button for TableViewHeaderFooterView didn't meet 4.5:1 contrast ratio.
Let's change it to different color.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 23 50 24](https://user-images.githubusercontent.com/20715435/97402506-e6798880-18af-11eb-89ba-06a3dc61dfdc.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-27 at 23 51 23](https://user-images.githubusercontent.com/20715435/97402524-eaa5a600-18af-11eb-836d-35f1c636019a.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/282)