### PR TITLE
add disable accessibility trait when badge view is disabled.

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -177,6 +177,11 @@ open class BadgeView: UIView {
             updateBackgroundColor()
             updateLabelTextColor()
             isUserInteractionEnabled = isActive
+            if isActive {
+                accessibilityTraits.remove(.notEnabled)
+            } else {
+                accessibilityTraits.insert(.notEnabled)
+            }
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When BageView isActive is false, lets add "notEnable" accessibility trait so that VoiceOver will say "dimmed"

### Verification

Tested in demoapp badgeview scenarios.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/283)