### PR TITLE
modify demo app drawercontroller button titles to accurately reflect …

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -380,6 +380,9 @@ extension DrawerDemoController: DrawerControllerDelegate {
     }
 
     func drawerControllerDidChangeExpandedState(_ controller: DrawerController) {
-        expandButton?.setTitle(controller.isExpanded ? "Return to normal" : "Expand", for: .normal)
+        expandButton?.setTitle(controller.isExpanded ? collapseText : expandText, for: .normal)
     }
 }
+
+fileprivate let collapseText: String = "Return to normal"
+fileprivate let expandText: String = "Expand"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -9,9 +9,6 @@ import UIKit
 // MARK: DrawerDemoController
 
 class DrawerDemoController: DemoController {
-
-    private var shouldConfirmDrawerDismissal: Bool = false
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -86,13 +83,12 @@ class DrawerDemoController: DemoController {
         let controller: DrawerController
         if let sourceView = sourceView {
             controller = DrawerController(sourceView: sourceView, sourceRect: sourceView.bounds.insetBy(dx: sourceView.bounds.width / 2, dy: 0), presentationOrigin: presentationOrigin, presentationDirection: presentationDirection, preferredMaximumHeight: maxDrawerHeight)
-            controller.delegate = self
         } else if let barButtonItem = barButtonItem {
             controller = DrawerController(barButtonItem: barButtonItem, presentationOrigin: presentationOrigin, presentationDirection: presentationDirection, preferredMaximumHeight: maxDrawerHeight)
         } else {
             preconditionFailure("Presenting a drawer requires either a sourceView or a barButtonItem")
         }
-
+        controller.delegate = self
         controller.presentationStyle = presentationStyle
         controller.presentationOffset = presentationOffset
         controller.presentationBackground = presentationBackground
@@ -127,8 +123,10 @@ class DrawerDemoController: DemoController {
 
         var views = [UIView]()
         if drawerHasFlexibleHeight {
+            let expandButton = createButton(title: "Expand", action: #selector(expandButtonTapped))
+            self.expandButton = expandButton
             views.append(createButton(title: "Change content height", action: #selector(changeContentHeightButtonTapped)))
-            views.append(createButton(title: "Expand", action: #selector(expandButtonTapped)))
+            views.append(expandButton)
         }
         views.append(createButton(title: "Dismiss", action: #selector(dismissButtonTapped)))
         views.append(createButton(title: "Dismiss (no animation)", action: #selector(dismissNotAnimatedButtonTapped)))
@@ -269,12 +267,8 @@ class DrawerDemoController: DemoController {
         textField.delegate = self
         container.addArrangedSubview(textField)
 
-        let button = Button(style: .primaryFilled)
-        button.setTitle("Hide keyboard", for: .normal)
-        button.setContentCompressionResistancePriority(.required, for: .vertical)
-        button.setContentHuggingPriority(.required, for: .vertical)
-        button.addTarget(self, action: #selector(hideKeyboardButtonTapped), for: .touchUpInside)
-        container.addArrangedSubview(button)
+        hideKeyboardButton.addTarget(self, action: #selector(hideKeyboardButtonTapped), for: .touchUpInside)
+        container.addArrangedSubview(hideKeyboardButton)
 
         presentDrawer(sourceView: sender, presentationDirection: .up, permittedArrowDirections: .any, contentController: contentController, resizingBehavior: .dismissOrExpand, adjustHeightForKeyboard: true)
 
@@ -303,7 +297,6 @@ class DrawerDemoController: DemoController {
             return
         }
         drawer.isExpanded = !drawer.isExpanded
-        sender.setTitle(drawer.isExpanded ? "Return to normal" : "Expand", for: .normal)
     }
 
     @objc private func dismissButtonTapped() {
@@ -336,6 +329,17 @@ class DrawerDemoController: DemoController {
             textField?.resignFirstResponder()
         }
     }
+
+    private var shouldConfirmDrawerDismissal: Bool = false
+    private var expandButton: Button?
+
+    private let hideKeyboardButton: Button = {
+        let button = Button(style: .primaryFilled)
+        button.setTitle("Hide keyboard", for: .normal)
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
+        button.setContentHuggingPriority(.required, for: .vertical)
+        return button
+    }()
 }
 
 // MARK: - DrawerDemoController: UITextFieldDelegate
@@ -344,6 +348,14 @@ extension DrawerDemoController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return false
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        hideKeyboardButton.isEnabled = true
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        hideKeyboardButton.isEnabled = false
     }
 }
 
@@ -365,5 +377,9 @@ extension DrawerDemoController: DrawerControllerDelegate {
     func drawerControllerDidDismiss(_ controller: DrawerController) {
         // reset the flag once drawer gets dismissed
         shouldConfirmDrawerDismissal = false
+    }
+
+    func drawerControllerDidChangeExpandedState(_ controller: DrawerController) {
+        expandButton?.setTitle(controller.isExpanded ? "Return to normal" : "Expand", for: .normal)
     }
 }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -287,6 +287,7 @@ open class DrawerController: UIViewController {
 
             updateResizingHandleViewAccessibility()
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
+            delegate?.drawerControllerDidChangeExpandedState?(self)
         }
     }
     /**
@@ -868,7 +869,6 @@ open class DrawerController: UIViewController {
                 } else {
                     presentationController.setExtraContentSize(0, updatingLayout: false)
                     isExpanded = true
-                    delegate?.drawerControllerDidChangeExpandedState?(self)
                 }
             } else if offset <= -Constants.resizingThreshold {
                 if isExpanded {
@@ -878,7 +878,6 @@ open class DrawerController: UIViewController {
                         presentationController.setExtraContentSize(0, updatingLayout: false)
                     }
                     isExpanded = false
-                    delegate?.drawerControllerDidChangeExpandedState?(self)
                 } else {
                     dismissPresentingViewController(animated: true, isResizing: true)
                 }


### PR DESCRIPTION
…the state of the drawercontroller

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
In the demo app, when keyboard is hidden, appropriately disable "hide keyboard" button.
Also, when user changes the drawer expand state by gesture, make sure the "expand" button title is updated appropriately.

Miscellaneous:
- make sure DrawerControllerDelegate's drawerControllerDidChangeExpandedState() protocol gets called anytime drawer expanded state has changed.
- move private variables of DrawerDemoController to bottom of the file

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-28 at 00 01 54](https://user-images.githubusercontent.com/20715435/97403598-f72afe00-18b1-11eb-828b-bdeae246c9a0.png) ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-28 at 00 02 04](https://user-images.githubusercontent.com/20715435/97403601-fa25ee80-18b1-11eb-9a89-2989b2462f14.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-28 at 00 06 23](https://user-images.githubusercontent.com/20715435/97403640-0a3dce00-18b2-11eb-9c81-f791f9d3ed68.png) ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-28 at 00 06 33](https://user-images.githubusercontent.com/20715435/97403645-0ca02800-18b2-11eb-94eb-1ac13ad33151.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/284)