### PR TITLE
Meet contrast ratio requirements for linked text

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -89,7 +89,7 @@ public extension Colors {
             public static var backgroundDivider: UIColor = surfaceSecondary
             public static var text: UIColor = textSecondary
             public static var textDivider: UIColor = textSecondary
-            public static var textLink: UIColor = communicationBlue
+            public static var textLink: UIColor = Palette.communicationBlueShade10.color
         }
         public static var background: UIColor = surfacePrimary
         public static var backgroundGrouped = UIColor(light: surfaceSecondary, dark: surfacePrimary)

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -89,7 +89,7 @@ public extension Colors {
             public static var backgroundDivider: UIColor = surfaceSecondary
             public static var text: UIColor = textSecondary
             public static var textDivider: UIColor = textSecondary
-            public static var textLink: UIColor = Palette.communicationBlueShade10.color
+            public static var textLink = UIColor(light: Palette.communicationBlueShade10.color, dark: communicationBlue)
         }
         public static var background: UIColor = surfacePrimary
         public static var backgroundGrouped = UIColor(light: surfaceSecondary, dark: surfacePrimary)

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -38,7 +38,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             case .regular:
                 return Colors.Table.HeaderFooter.accessoryButtonText
             case .primary:
-                return Colors.primaryShade10(for: window)
+                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.primary(for: window))
             }
         }
     }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -38,7 +38,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             case .regular:
                 return Colors.Table.HeaderFooter.accessoryButtonText
             case .primary:
-                return Colors.primary(for: window)
+                return Colors.primaryShade10(for: window)
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Contrast ratio requirements were not being met for linked text on surface secondary and surface tertiary on light mode.

### Verification

Compared color values to ensure that the ratio requirement was met.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-29 at 13 26 05](https://user-images.githubusercontent.com/22566866/97616233-4a07d100-19ea-11eb-9599-4695ebc8e844.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-29 at 13 26 50](https://user-images.githubusercontent.com/22566866/97616315-6441af00-19ea-11eb-9204-c432fac6deda.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/286)