### PR TITLE
Overriding BadgeView background color to set transparent background

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -262,6 +262,13 @@ open class BadgeView: UIView {
         let labelWidth = max(minLabelWidth, min(maxLabelWidth, fittingLabelWidth))
         label.frame = CGRect(x: size.horizontalPadding, y: size.verticalPadding, width: labelWidth, height: labelHeight)
     }
+    
+    open override var backgroundColor: UIColor? {
+        didSet {
+            super.backgroundColor = .clear
+            updateBackgroundColor()
+        }
+    }
 
     open func reload() {
         label.text = dataSource?.text

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -38,6 +38,7 @@ public protocol BadgeViewDelegate {
 
 public extension Colors {
     struct Badge {
+        public static var background: UIColor = .clear
         public static var backgroundDisabled = UIColor(light: surfaceSecondary, dark: gray700)
         public static var backgroundError = UIColor(light: Palette.dangerTint40.color, dark: Palette.dangerTint30.color)
         public static var backgroundErrorSelected: UIColor = error
@@ -174,17 +175,21 @@ open class BadgeView: UIView {
 
     @objc open var isActive: Bool = true {
         didSet {
-            updateBackgroundColor()
-            updateLabelTextColor()
+            update()
             isUserInteractionEnabled = isActive
         }
     }
 
     @objc open var isSelected: Bool = false {
         didSet {
-            updateBackgroundColor()
-            updateLabelTextColor()
+            update()
             updateAccessibility()
+        }
+    }
+    
+    open var labelTextColor: UIColor? {
+        didSet {
+            update()
         }
     }
 
@@ -200,8 +205,7 @@ open class BadgeView: UIView {
 
     private var style: Style = .default {
         didSet {
-            updateBackgroundColor()
-            updateLabelTextColor()
+            update()
         }
     }
 
@@ -265,8 +269,9 @@ open class BadgeView: UIView {
     
     open override var backgroundColor: UIColor? {
         didSet {
-            super.backgroundColor = .clear
-            updateBackgroundColor()
+            if backgroundColor != oldValue {
+                update()
+            }
         }
     }
 
@@ -286,8 +291,7 @@ open class BadgeView: UIView {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateBackgroundColor()
-        updateLabelTextColor()
+        update()
     }
 
     private func updateAccessibility() {
@@ -299,16 +303,23 @@ open class BadgeView: UIView {
             accessibilityHint = "Accessibility.Select.Hint".localized
         }
     }
+    
+    private func update() {
+        updateBackgroundColor()
+        updateLabelTextColor()
+    }
 
     private func updateBackgroundColor() {
         if let window = window {
-            backgroundView.backgroundColor = backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            let color = backgroundColor ?? backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            backgroundView.backgroundColor = color
+            super.backgroundColor = Colors.Badge.background
         }
     }
 
     private func updateLabelTextColor() {
         if let window = window {
-            label.textColor = textColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            label.textColor = labelTextColor ?? textColor(for: window, style: style, selected: isSelected, enabled: isActive)
         }
     }
 


### PR DESCRIPTION

### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Override background color for base view
Set it to transparent color and update color for front view (badge view background)

### Verification

Override the background Color for badge view instance.
```swift
       badge.backgroundColor = Colors.Palette.blueMagenta30.color
```

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2020-10-30 at 12 00 00 PM](https://user-images.githubusercontent.com/63682282/97746376-77668480-1aa7-11eb-805a-2728e1a6f919.png) | ![Screen Shot 2020-10-30 at 11 59 21 AM](https://user-images.githubusercontent.com/63682282/97746464-96fdad00-1aa7-11eb-96c9-f398bf683eb0.png) |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/287)