### PR TITLE
Switch Xcode12-beta pipeline to use Xcode 12.2

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml
@@ -7,7 +7,7 @@ jobs:
   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
   
   steps:
-  # Select Xcode 12 beta version
+  # Select Xcode 12.2 beta version
   - template: apple-xcode-select.yml
     parameters:
       xcode_path_override: '/Applications/Xcode_12.2.app/Contents/Developer'

--- a/.ado/templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job-xcode12-beta.yml
@@ -10,7 +10,7 @@ jobs:
   # Select Xcode 12 beta version
   - template: apple-xcode-select.yml
     parameters:
-      xcode_path_override: '/Applications/Xcode_12_beta.app/Contents/Developer'
+      xcode_path_override: '/Applications/Xcode_12.2.app/Contents/Developer'
 
   # Build and zip the libraries
   - template: fluentui-apple-build-zip.yml


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

ADO has recently updated their images to account for the fact that there are 3 versions of Xcode in circulation (12.0.1, 12.1, 12.2). As such they abandoned the Xcode_12_beta naming convention in favor of being more explicit.

Since then, our beta pipeline publishes have tried to xcode-select Xcode_12_beta, failed silently (ugh) and fallen back to Xcode_12.app (12.0.1). Notably for macOS this means no Apple silicon slices were being produced

### Verification

Kicked off a manual publish adding this variable:
```
xcode_path_override : /Applications/Xcode_12.2.app
```

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/288)