### PR TITLE
Allow customization to badge background color and label field.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -14,6 +14,7 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Error badge", style: .error)
         addBadgeSection(title: "Warning badge", style: .warning)
         addBadgeSection(title: "Disabled badge", style: .default, isEnabled: false)
+        addBadgeSection(title: "Custom badge", style: .default, overrideColor: true)
     }
 
     func createBadge(text: String, style: BadgeView.Style, size: BadgeView.Size, isEnabled: Bool) -> BadgeView {
@@ -23,10 +24,14 @@ class BadgeViewDemoController: DemoController {
         return badge
     }
 
-    func addBadgeSection(title: String, style: BadgeView.Style, isEnabled: Bool = true) {
+    func addBadgeSection(title: String, style: BadgeView.Style, isEnabled: Bool = true, overrideColor: Bool = false) {
         addTitle(text: title)
         for size in BadgeView.Size.allCases.reversed() {
             let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
+            if overrideColor {
+                badge.backgroundColor = Colors.Palette.blueMagenta20.color
+                badge.labelTextColor = Colors.Palette.gray50.color
+            }
             addRow(text: size.description, items: [badge])
         }
         container.addArrangedSubview(UIView())

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -30,7 +30,6 @@ class BadgeViewDemoController: DemoController {
         for size in BadgeView.Size.allCases.reversed() {
             let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
             if overrideColor {
-                
                 if !isEnabled {
                     badge.disabledBackgroundColor = Colors.Palette.gray100.color
                     badge.disabledLabelTextColor = Colors.Palette.gray600.color
@@ -40,7 +39,6 @@ class BadgeViewDemoController: DemoController {
                     badge.labelTextColor = Colors.Palette.gray50.color
                     badge.selectedLabelTextColor = Colors.Palette.gray100.color
                 }
-                
             }
             addRow(text: size.description, items: [badge])
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -30,14 +30,14 @@ class BadgeViewDemoController: DemoController {
         for size in BadgeView.Size.allCases.reversed() {
             let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
             if overrideColor {
-                if !isEnabled {
-                    badge.disabledBackgroundColor = Colors.Palette.gray100.color
-                    badge.disabledLabelTextColor = Colors.Palette.gray600.color
-                } else {
+                if isEnabled {
                     badge.backgroundColor = Colors.Palette.blueMagenta20.color
                     badge.selectedBackgroundColor = Colors.Palette.cyanBlue20.color
                     badge.labelTextColor = Colors.Palette.gray50.color
                     badge.selectedLabelTextColor = Colors.Palette.gray100.color
+                } else {
+                    badge.disabledBackgroundColor = Colors.Palette.gray100.color
+                    badge.disabledLabelTextColor = Colors.Palette.gray600.color
                 }
             }
             addRow(text: size.description, items: [badge])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -15,6 +15,7 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Warning badge", style: .warning)
         addBadgeSection(title: "Disabled badge", style: .default, isEnabled: false)
         addBadgeSection(title: "Custom badge", style: .default, overrideColor: true)
+        addBadgeSection(title: "Custom disabled badge", style: .default, isEnabled: false, overrideColor: true)
     }
 
     func createBadge(text: String, style: BadgeView.Style, size: BadgeView.Size, isEnabled: Bool) -> BadgeView {
@@ -29,10 +30,17 @@ class BadgeViewDemoController: DemoController {
         for size in BadgeView.Size.allCases.reversed() {
             let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
             if overrideColor {
-                badge.backgroundColor = Colors.Palette.blueMagenta20.color
-                badge.selectedBackgroundColor = Colors.Palette.cyanBlue20.color
-                badge.labelTextColor = Colors.Palette.gray50.color
-                badge.disabledBackgroundColor = Colors.Palette.gray100.color
+                
+                if !isEnabled {
+                    badge.disabledBackgroundColor = Colors.Palette.gray100.color
+                    badge.disabledLabelTextColor = Colors.Palette.gray600.color
+                } else {
+                    badge.backgroundColor = Colors.Palette.blueMagenta20.color
+                    badge.selectedBackgroundColor = Colors.Palette.cyanBlue20.color
+                    badge.labelTextColor = Colors.Palette.gray50.color
+                    badge.selectedLabelTextColor = Colors.Palette.gray100.color
+                }
+                
             }
             addRow(text: size.description, items: [badge])
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -30,9 +30,9 @@ class BadgeViewDemoController: DemoController {
             let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
             if overrideColor {
                 badge.backgroundColor = Colors.Palette.blueMagenta20.color
-                badge.backgroundSelectedColor = Colors.Palette.cyanBlue20.color
+                badge.selectedBackgroundColor = Colors.Palette.cyanBlue20.color
                 badge.labelTextColor = Colors.Palette.gray50.color
-                badge.labelSelectedTextColor = Colors.Palette.gray100.color
+                badge.disabledBackgroundColor = Colors.Palette.gray100.color
             }
             addRow(text: size.description, items: [badge])
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -30,7 +30,9 @@ class BadgeViewDemoController: DemoController {
             let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
             if overrideColor {
                 badge.backgroundColor = Colors.Palette.blueMagenta20.color
+                badge.backgroundSelectedColor = Colors.Palette.cyanBlue20.color
                 badge.labelTextColor = Colors.Palette.gray50.color
+                badge.labelSelectedTextColor = Colors.Palette.gray100.color
             }
             addRow(text: size.description, items: [badge])
         }

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -177,6 +177,11 @@ open class BadgeView: UIView {
         didSet {
             updateColors()
             isUserInteractionEnabled = isActive
+            if isActive {
+                accessibilityTraits.remove(.notEnabled)
+            } else {
+                accessibilityTraits.insert(.notEnabled)
+            }
         }
     }
 

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -38,6 +38,7 @@ public protocol BadgeViewDelegate {
 
 public extension Colors {
     struct Badge {
+        public static var background: UIColor = .clear
         public static var backgroundDisabled = UIColor(light: surfaceSecondary, dark: gray700)
         public static var backgroundError = UIColor(light: Palette.dangerTint40.color, dark: Palette.dangerTint30.color)
         public static var backgroundErrorSelected: UIColor = error
@@ -174,22 +175,23 @@ open class BadgeView: UIView {
 
     @objc open var isActive: Bool = true {
         didSet {
-            updateBackgroundColor()
-            updateLabelTextColor()
+            updateColors()
             isUserInteractionEnabled = isActive
-            if isActive {
-                accessibilityTraits.remove(.notEnabled)
-            } else {
-                accessibilityTraits.insert(.notEnabled)
-            }
         }
     }
 
     @objc open var isSelected: Bool = false {
         didSet {
-            updateBackgroundColor()
-            updateLabelTextColor()
+            updateColors()
             updateAccessibility()
+        }
+    }
+    
+    open var labelTextColor: UIColor? {
+        didSet {
+            if labelTextColor != oldValue {
+                updateColors()
+            }
         }
     }
 
@@ -205,8 +207,7 @@ open class BadgeView: UIView {
 
     private var style: Style = .default {
         didSet {
-            updateBackgroundColor()
-            updateLabelTextColor()
+            updateColors()
         }
     }
 
@@ -267,6 +268,14 @@ open class BadgeView: UIView {
         let labelWidth = max(minLabelWidth, min(maxLabelWidth, fittingLabelWidth))
         label.frame = CGRect(x: size.horizontalPadding, y: size.verticalPadding, width: labelWidth, height: labelHeight)
     }
+    
+    open override var backgroundColor: UIColor? {
+        didSet {
+            if backgroundColor != oldValue {
+                updateColors()
+            }
+        }
+    }
 
     open func reload() {
         label.text = dataSource?.text
@@ -284,8 +293,7 @@ open class BadgeView: UIView {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateBackgroundColor()
-        updateLabelTextColor()
+        updateColors()
     }
 
     private func updateAccessibility() {
@@ -297,16 +305,22 @@ open class BadgeView: UIView {
             accessibilityHint = "Accessibility.Select.Hint".localized
         }
     }
+    
+    private func updateColors() {
+        updateBackgroundColor()
+        updateLabelTextColor()
+    }
 
     private func updateBackgroundColor() {
         if let window = window {
-            backgroundView.backgroundColor = backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            backgroundView.backgroundColor = backgroundColor ?? backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            super.backgroundColor = Colors.Badge.background
         }
     }
 
     private func updateLabelTextColor() {
         if let window = window {
-            label.textColor = textColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            label.textColor = labelTextColor ?? textColor(for: window, style: style, selected: isSelected, enabled: isActive)
         }
     }
 

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -199,7 +199,7 @@ open class BadgeView: UIView {
             if let customDisabledLabelTextColor = _disabledLabelTextColor {
                 return customDisabledLabelTextColor
             }
-            return style == .default ? Colors.Badge.textDisabled : (isActive ? self.selectedLabelTextColor : self.labelTextColor)
+            return style == .default ? Colors.Badge.textDisabled : (isSelected ? self.selectedLabelTextColor : self.labelTextColor)
         }
         set {
             if disabledBackgroundColor != newValue {
@@ -270,7 +270,7 @@ open class BadgeView: UIView {
                 return customDisabledBackgroundColor
             }
             
-            return style == .default ? Colors.Badge.backgroundDisabled : (isActive ? self.selectedBackgroundColor : self.backgroundColor)
+            return style == .default ? Colors.Badge.backgroundDisabled : (isSelected ? self.selectedBackgroundColor : self.backgroundColor)
         }
         set {
             if disabledBackgroundColor != newValue {

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -194,6 +194,22 @@ open class BadgeView: UIView {
             }
         }
     }
+    
+    open var labelSelectedTextColor: UIColor? {
+        didSet {
+            if labelSelectedTextColor != oldValue {
+                updateColors()
+            }
+        }
+    }
+    
+    open var backgroundSelectedColor: UIColor? {
+        didSet {
+            if backgroundSelectedColor != oldValue {
+                updateColors()
+            }
+        }
+    }
 
     @objc open var minWidth: CGFloat = Constants.defaultMinWidth {
         didSet {
@@ -313,14 +329,16 @@ open class BadgeView: UIView {
 
     private func updateBackgroundColor() {
         if let window = window {
-            backgroundView.backgroundColor = backgroundColor ?? backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            let customColor = isSelected ? backgroundSelectedColor : backgroundColor
+            backgroundView.backgroundColor = customColor ?? backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
             super.backgroundColor = Colors.Badge.background
         }
     }
 
     private func updateLabelTextColor() {
         if let window = window {
-            label.textColor = labelTextColor ?? textColor(for: window, style: style, selected: isSelected, enabled: isActive)
+            let customColor = isSelected ? labelSelectedTextColor : labelTextColor
+            label.textColor = customColor ?? textColor(for: window, style: style, selected: isSelected, enabled: isActive)
         }
     }
 

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -141,23 +141,22 @@ open class BadgeView: UIView {
             updateAccessibility()
         }
     }
-    
+
     private var _labelTextColor: UIColor?
     open var labelTextColor: UIColor? {
         get {
             if let customLabelTextColor = _labelTextColor {
                 return customLabelTextColor
             }
-            
             switch style {
-                case .default:
-                    if let window = window {
-                        return Colors.primary(for: window)
-                    }
-                case .warning:
-                    return Colors.Badge.textWarning
-                case .error:
-                    return Colors.Badge.textError
+            case .default:
+                if let window = window {
+                    return Colors.primary(for: window)
+                }
+            case .warning:
+                return Colors.Badge.textWarning
+            case .error:
+                return Colors.Badge.textError
             }
             return nil
         }
@@ -168,21 +167,21 @@ open class BadgeView: UIView {
             }
         }
     }
-    
+
     private var _selectedLabelTextColor: UIColor?
     open var selectedLabelTextColor: UIColor {
         get {
             if let customSelectedLabelTextColor = _selectedLabelTextColor {
                 return customSelectedLabelTextColor
             }
-            
+
             switch style {
-                case .default:
-                    return Colors.Badge.textSelected
-                case .warning:
-                    return Colors.Badge.textWarningSelected
-                case .error:
-                    return Colors.Badge.textErrorSelected
+            case .default:
+                return Colors.Badge.textSelected
+            case .warning:
+                return Colors.Badge.textWarningSelected
+            case .error:
+                return Colors.Badge.textErrorSelected
             }
         }
         set {
@@ -192,7 +191,7 @@ open class BadgeView: UIView {
             }
         }
     }
-    
+
     private var _disabledLabelTextColor: UIColor?
     open var disabledLabelTextColor: UIColor? {
         get {
@@ -208,23 +207,22 @@ open class BadgeView: UIView {
             }
         }
     }
-    
+
     private var _backgroundColor: UIColor?
     open override var backgroundColor: UIColor? {
         get {
             if let customBackgroundColor = _backgroundColor {
                 return customBackgroundColor
             }
-            
             switch style {
-                case .default:
-                    if let window = window {
-                        return Colors.primaryTint40(for: window)
-                    }
-                case .warning:
-                    return Colors.Badge.backgroundWarning
-                case .error:
-                    return Colors.Badge.backgroundError
+            case .default:
+                if let window = window {
+                    return Colors.primaryTint40(for: window)
+                }
+            case .warning:
+                return Colors.Badge.backgroundWarning
+            case .error:
+                return Colors.Badge.backgroundError
             }
             return nil
         }
@@ -235,23 +233,22 @@ open class BadgeView: UIView {
             }
         }
     }
-    
+
     private var _selectedBackgroundColor: UIColor?
     open var selectedBackgroundColor: UIColor? {
         get {
             if let customSelectedBackgroundColor = _selectedBackgroundColor {
                 return customSelectedBackgroundColor
             }
-            
             switch style {
-                case .default:
-                    if let window = window {
-                        return Colors.primary(for: window)
-                    }
-                case .warning:
-                    return Colors.Badge.backgroundWarningSelected
-                case .error:
-                    return Colors.Badge.backgroundErrorSelected
+            case .default:
+                if let window = window {
+                    return Colors.primary(for: window)
+                }
+            case .warning:
+                return Colors.Badge.backgroundWarningSelected
+            case .error:
+                return Colors.Badge.backgroundErrorSelected
             }
             return nil
         }
@@ -262,14 +259,13 @@ open class BadgeView: UIView {
             }
         }
     }
-    
+
     private var _disabledBackgroundColor: UIColor?
     open var disabledBackgroundColor: UIColor? {
         get {
             if let customDisabledBackgroundColor = _disabledBackgroundColor {
                 return customDisabledBackgroundColor
             }
-            
             return style == .default ? Colors.Badge.backgroundDisabled : (isSelected ? self.selectedBackgroundColor : self.backgroundColor)
         }
         set {
@@ -382,7 +378,7 @@ open class BadgeView: UIView {
             accessibilityHint = "Accessibility.Select.Hint".localized
         }
     }
-    
+
     private func updateColors() {
         updateBackgroundColor()
         updateLabelTextColor()

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -115,56 +115,6 @@ open class BadgeView: UIView {
         static let backgroundCornerRadius: CGFloat = 3
     }
 
-    private func backgroundColor(for window: UIWindow, style: Style, selected: Bool, enabled: Bool) -> UIColor {
-        switch style {
-        case .default:
-            if !enabled {
-                return Colors.Badge.backgroundDisabled
-            } else if selected {
-                return Colors.primary(for: window)
-            } else {
-                return Colors.primaryTint40(for: window)
-            }
-        case .warning:
-            if selected {
-                return Colors.Badge.backgroundWarningSelected
-            } else {
-                return Colors.Badge.backgroundWarning
-            }
-        case .error:
-            if selected {
-                return Colors.Badge.backgroundErrorSelected
-            } else {
-                return Colors.Badge.backgroundError
-            }
-        }
-    }
-
-    private func textColor(for window: UIWindow, style: Style, selected: Bool, enabled: Bool) -> UIColor {
-        switch style {
-        case .default:
-            if !enabled {
-                return Colors.Badge.textDisabled
-            } else if selected {
-                return Colors.Badge.textSelected
-            } else {
-                return Colors.primary(for: window)
-            }
-        case .warning:
-            if selected {
-                return Colors.Badge.textWarningSelected
-            } else {
-                return Colors.Badge.textWarning
-            }
-        case .error:
-            if selected {
-                return Colors.Badge.textErrorSelected
-            } else {
-                return Colors.Badge.textError
-            }
-        }
-    }
-
     @objc open var dataSource: BadgeViewDataSource? {
         didSet {
             reload()
@@ -192,41 +142,139 @@ open class BadgeView: UIView {
         }
     }
     
+    private var _labelTextColor: UIColor?
     open var labelTextColor: UIColor? {
-        didSet {
-            if labelTextColor != oldValue {
+        get {
+            if let customLabelTextColor = _labelTextColor {
+                return customLabelTextColor
+            }
+            
+            switch style {
+                case .default:
+                    if let window = window {
+                        return Colors.primary(for: window)
+                    }
+                case .warning:
+                    return Colors.Badge.textWarning
+                case .error:
+                    return Colors.Badge.textError
+            }
+            return nil
+        }
+        set {
+            if labelTextColor != newValue {
+                _labelTextColor = newValue
                 updateColors()
             }
         }
     }
     
-    open var selectedLabelTextColor: UIColor? {
-        didSet {
-            if selectedLabelTextColor != oldValue {
+    private var _selectedLabelTextColor: UIColor?
+    open var selectedLabelTextColor: UIColor {
+        get {
+            if let customSelectedLabelTextColor = _selectedLabelTextColor {
+                return customSelectedLabelTextColor
+            }
+            
+            switch style {
+                case .default:
+                    return Colors.Badge.textSelected
+                case .warning:
+                    return Colors.Badge.textWarningSelected
+                case .error:
+                    return Colors.Badge.textErrorSelected
+            }
+        }
+        set {
+            if selectedLabelTextColor != newValue {
+                _selectedLabelTextColor = newValue
                 updateColors()
             }
         }
     }
     
-    open var selectedBackgroundColor: UIColor? {
-        didSet {
-            if selectedBackgroundColor != oldValue {
-                updateColors()
-            }
-        }
-    }
-    
-    open var disabledBackgroundColor: UIColor? {
-        didSet {
-            if disabledBackgroundColor != oldValue {
-                updateColors()
-            }
-        }
-    }
-    
+    private var _disabledLabelTextColor: UIColor?
     open var disabledLabelTextColor: UIColor? {
-        didSet {
-            if disabledBackgroundColor != oldValue {
+        get {
+            if let customDisabledLabelTextColor = _disabledLabelTextColor {
+                return customDisabledLabelTextColor
+            }
+            return style == .default ? Colors.Badge.textDisabled : (isActive ? self.selectedLabelTextColor : self.labelTextColor)
+        }
+        set {
+            if disabledBackgroundColor != newValue {
+                _disabledLabelTextColor = newValue
+                updateColors()
+            }
+        }
+    }
+    
+    private var _backgroundColor: UIColor?
+    open override var backgroundColor: UIColor? {
+        get {
+            if let customBackgroundColor = _backgroundColor {
+                return customBackgroundColor
+            }
+            
+            switch style {
+                case .default:
+                    if let window = window {
+                        return Colors.primaryTint40(for: window)
+                    }
+                case .warning:
+                    return Colors.Badge.backgroundWarning
+                case .error:
+                    return Colors.Badge.backgroundError
+            }
+            return nil
+        }
+        set {
+            if backgroundColor != newValue {
+                _backgroundColor = newValue
+                updateColors()
+            }
+        }
+    }
+    
+    private var _selectedBackgroundColor: UIColor?
+    open var selectedBackgroundColor: UIColor? {
+        get {
+            if let customSelectedBackgroundColor = _selectedBackgroundColor {
+                return customSelectedBackgroundColor
+            }
+            
+            switch style {
+                case .default:
+                    if let window = window {
+                        return Colors.primary(for: window)
+                    }
+                case .warning:
+                    return Colors.Badge.backgroundWarningSelected
+                case .error:
+                    return Colors.Badge.backgroundErrorSelected
+            }
+            return nil
+        }
+        set {
+            if selectedBackgroundColor != newValue {
+                _selectedBackgroundColor = newValue
+                updateColors()
+            }
+        }
+    }
+    
+    private var _disabledBackgroundColor: UIColor?
+    open var disabledBackgroundColor: UIColor? {
+        get {
+            if let customDisabledBackgroundColor = _disabledBackgroundColor {
+                return customDisabledBackgroundColor
+            }
+            
+            return style == .default ? Colors.Badge.backgroundDisabled : (isActive ? self.selectedBackgroundColor : self.backgroundColor)
+        }
+        set {
+            if disabledBackgroundColor != newValue {
+                _disabledBackgroundColor = newValue
                 updateColors()
             }
         }
@@ -305,14 +353,6 @@ open class BadgeView: UIView {
         let labelWidth = max(minLabelWidth, min(maxLabelWidth, fittingLabelWidth))
         label.frame = CGRect(x: size.horizontalPadding, y: size.verticalPadding, width: labelWidth, height: labelHeight)
     }
-    
-    open override var backgroundColor: UIColor? {
-        didSet {
-            if backgroundColor != oldValue {
-                updateColors()
-            }
-        }
-    }
 
     open func reload() {
         label.text = dataSource?.text
@@ -349,18 +389,12 @@ open class BadgeView: UIView {
     }
 
     private func updateBackgroundColor() {
-        if let window = window {
-            let customColor = isActive ? (isSelected ? selectedBackgroundColor : backgroundColor) : disabledBackgroundColor
-            backgroundView.backgroundColor = customColor ?? backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
-            super.backgroundColor = Colors.Badge.background
-        }
+        backgroundView.backgroundColor = isActive ? (isSelected ? selectedBackgroundColor : backgroundColor) : disabledBackgroundColor
+        super.backgroundColor = Colors.Badge.background
     }
 
     private func updateLabelTextColor() {
-        if let window = window {
-            let customColor = isActive ? (isSelected ? selectedLabelTextColor : labelTextColor) : disabledLabelTextColor
-            label.textColor = customColor ?? textColor(for: window, style: style, selected: isSelected, enabled: isActive)
-        }
+        label.textColor = isActive ? (isSelected ? selectedLabelTextColor : labelTextColor) : disabledLabelTextColor
     }
 
     @objc private func badgeTapped() {

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -200,17 +200,33 @@ open class BadgeView: UIView {
         }
     }
     
-    open var labelSelectedTextColor: UIColor? {
+    open var selectedLabelTextColor: UIColor? {
         didSet {
-            if labelSelectedTextColor != oldValue {
+            if selectedLabelTextColor != oldValue {
                 updateColors()
             }
         }
     }
     
-    open var backgroundSelectedColor: UIColor? {
+    open var selectedBackgroundColor: UIColor? {
         didSet {
-            if backgroundSelectedColor != oldValue {
+            if selectedBackgroundColor != oldValue {
+                updateColors()
+            }
+        }
+    }
+    
+    open var disabledBackgroundColor: UIColor? {
+        didSet {
+            if disabledBackgroundColor != oldValue {
+                updateColors()
+            }
+        }
+    }
+    
+    open var disabledLabelTextColor: UIColor? {
+        didSet {
+            if disabledBackgroundColor != oldValue {
                 updateColors()
             }
         }
@@ -334,7 +350,7 @@ open class BadgeView: UIView {
 
     private func updateBackgroundColor() {
         if let window = window {
-            let customColor = isSelected ? backgroundSelectedColor : backgroundColor
+            let customColor = isActive ? (isSelected ? selectedBackgroundColor : backgroundColor) : disabledBackgroundColor
             backgroundView.backgroundColor = customColor ?? backgroundColor(for: window, style: style, selected: isSelected, enabled: isActive)
             super.backgroundColor = Colors.Badge.background
         }
@@ -342,7 +358,7 @@ open class BadgeView: UIView {
 
     private func updateLabelTextColor() {
         if let window = window {
-            let customColor = isSelected ? labelSelectedTextColor : labelTextColor
+            let customColor = isActive ? (isSelected ? selectedLabelTextColor : labelTextColor) : disabledLabelTextColor
             label.textColor = customColor ?? textColor(for: window, style: style, selected: isSelected, enabled: isActive)
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes
This is a fix for enhancement issue #80 . 

Allow client to customize the appearance (background color and text color) of badge view on a per instance basis. 
Currently the values are pre-set based on style. 
Client can set optionally both colors (defaults to initialized style if not provided) in selected/unselected modes. 

### Verification

Override the background Color for badge view instance.
```swift
       badge.backgroundColor = Colors.Palette.blueMagenta30.color
```

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2020-10-30 at 12 00 00 PM](https://user-images.githubusercontent.com/63682282/97746376-77668480-1aa7-11eb-805a-2728e1a6f919.png) | ![Screen Shot 2020-11-02 at 11 53 29 AM](https://user-images.githubusercontent.com/63682282/97912757-1981a900-1d02-11eb-8cb3-6d14accdac40.png) |

Allow to set custom background Color & text color for badge view instance.
```swift
       badge.backgroundColor = Colors.Palette.blueMagenta30.color
       badge.backgroundSelectedColor = Colors.Palette.cyanBlue20.color
       badge.labelTextColor = Colors.Palette.gray50.color
       badge.labelSelectedTextColor = Colors.Palette.gray100.color
```

Updated `BadgeViewDemoController`

![Screen Shot 2020-11-11 at 12 53 23 PM](https://user-images.githubusercontent.com/63682282/98863466-47ab6b00-241d-11eb-8908-c42f621300c9.png)


### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/287)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/290)