### PR TITLE
Fix for DrawerController regression: content bottom is clipped due to incorrect height and offset calculations

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -18,7 +18,7 @@ class DrawerDemoController: DemoController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Show", style: .plain, target: self, action: #selector(barButtonTapped))
 
         addTitle(text: "Top Drawer")
-        container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showTopDrawerButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show resizable with clear background", action: #selector(showTopDrawerButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: #selector(showTopDrawerWithMaxContentHeightTapped)))
         container.addArrangedSubview(createButton(title: "Show non dismissable", action: #selector(showTopDrawerNotDismissableButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: #selector(showTopDrawerChangingResizingBehaviour)))
@@ -29,8 +29,16 @@ class DrawerDemoController: DemoController {
         addTitle(text: "Left/Right Drawer")
         addRow(
             items: [
-                createButton(title: "Show from leading", action: #selector(showLeftDrawerButtonTapped)),
-                createButton(title: "Show from trailing", action: #selector(showRightDrawerButtonTapped))
+                createButton(title: "Show from leading with clear background", action: #selector(showLeftDrawerClearBackgroundButtonTapped)),
+                createButton(title: "Show from trailing with clear background", action: #selector(showRightDrawerClearBackgroundButtonTapped))
+            ],
+            itemSpacing: Constants.verticalSpacing,
+            stretchItems: true
+        )
+        addRow(
+            items: [
+                createButton(title: "Show from leading with dimmed background", action: #selector(showLeftDrawerDimmedBackgroundButtonTapped)),
+                createButton(title: "Show from trailing with dimmed background", action: #selector(showRightDrawerDimmedBackgroundButtonTapped))
             ],
             itemSpacing: Constants.verticalSpacing,
             stretchItems: true
@@ -45,7 +53,8 @@ class DrawerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showBottomDrawerNotAnimatedButtonTapped)))
         container.addArrangedSubview(createButton(title: "Show from custom base", action: #selector(showBottomDrawerCustomOffsetButtonTapped)))
 
-        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable", action: #selector(showBottomDrawerCustomContentControllerButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with dimmed background", action: #selector(showBottomDrawerCustomContentControllerDimmedBackgroundButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with clear background", action: #selector(showBottomDrawerCustomContentControllerClearBackgroundButtonTapped)))
 
         container.addArrangedSubview(createButton(title: "Show with focusable content", action: #selector(showBottomDrawerFocusableContentButtonTapped)))
 
@@ -119,6 +128,32 @@ class DrawerDemoController: DemoController {
         return controller
     }
 
+    private var contentControllerOriginalPreferredContentHeight: CGFloat = 0
+
+    @objc private func customContentNavigationController(content: UIView) -> UINavigationController {
+        let controller = UIViewController()
+        controller.title = "Resizable slideover drawer"
+        controller.toolbarItems = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            UIBarButtonItem(title: "Change preferredContentSize", style: .plain, target: self, action: #selector(changePreferredContentSizeButtonTapped)),
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        ]
+
+        controller.view.addSubview(content)
+        content.frame = controller.view.bounds
+        content.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        content.backgroundColor = Colors.NavigationBar.background
+
+        let contentController = UINavigationController(rootViewController: controller)
+        contentController.navigationBar.barTintColor = Colors.NavigationBar.background
+        contentController.toolbar.barTintColor = Colors.Toolbar.background
+        contentController.isToolbarHidden = false
+        contentController.preferredContentSize = CGSize(width: 400, height: 400)
+        contentControllerOriginalPreferredContentHeight = contentController.preferredContentSize.height
+
+        return contentController
+    }
+
     private func actionViews(drawerHasFlexibleHeight: Bool, drawerHasToggleResizingBehaviorButton: Bool) -> [UIView] {
         let spacer = UIView()
         spacer.backgroundColor = .orange
@@ -152,7 +187,7 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showTopDrawerButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
+        presentDrawer(sourceView: sender, presentationDirection: .down, presentationBackground: .none, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 
     @objc private func showTopDrawerWithMaxContentHeightTapped(sender: UIButton) {
@@ -180,12 +215,20 @@ class DrawerDemoController: DemoController {
         presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand, respectSafeAreaWidth: true)
     }
 
-    @objc private func showLeftDrawerButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .fromLeading, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+    @objc private func showLeftDrawerClearBackgroundButtonTapped(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .fromLeading, presentationBackground: .none, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
     }
 
-    @objc private func showRightDrawerButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .fromTrailing, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+    @objc private func showLeftDrawerDimmedBackgroundButtonTapped(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .fromLeading, presentationBackground: .black, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+    }
+
+    @objc private func showRightDrawerClearBackgroundButtonTapped(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .fromTrailing, presentationBackground: .none, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+    }
+
+    @objc private func showRightDrawerDimmedBackgroundButtonTapped(sender: UIButton) {
+        presentDrawer(sourceView: sender, presentationDirection: .fromTrailing, presentationBackground: .black, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
     }
 
     @objc private func showBottomDrawerButtonTapped(sender: UIButton) {
@@ -218,32 +261,30 @@ class DrawerDemoController: DemoController {
         presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 
-    private var contentControllerOriginalPreferredContentHeight: CGFloat = 0
+    @objc private func showBottomDrawerCustomContentControllerDimmedBackgroundButtonTapped(sender: UIButton) {
+        showBottomDrawerCustomContentController(sourceView: sender,
+                                                presentationBackground: .black)
+    }
 
-    @objc private func showBottomDrawerCustomContentControllerButtonTapped(sender: UIButton) {
-        let controller = UIViewController()
-        controller.title = "Resizable slideover drawer"
-        controller.toolbarItems = [
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-            UIBarButtonItem(title: "Change preferredContentSize", style: .plain, target: self, action: #selector(changePreferredContentSizeButtonTapped)),
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        ]
+    @objc private func showBottomDrawerCustomContentControllerClearBackgroundButtonTapped(sender: UIButton) {
+        showBottomDrawerCustomContentController(sourceView: sender,
+                                                presentationBackground: .none)
+    }
 
+    @objc private func showBottomDrawerCustomContentController(sourceView: UIView,
+                                                               presentationBackground: DrawerPresentationBackground) {
         let personaListView = PersonaListView()
         personaListView.personaList = samplePersonas
-        controller.view.addSubview(personaListView)
-        personaListView.frame = controller.view.bounds
-        personaListView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        personaListView.backgroundColor = Colors.NavigationBar.background
 
-        let contentController = UINavigationController(rootViewController: controller)
-        contentController.navigationBar.barTintColor = Colors.NavigationBar.background
-        contentController.toolbar.barTintColor = Colors.Toolbar.background
-        contentController.isToolbarHidden = false
-        contentController.preferredContentSize = CGSize(width: 400, height: 400)
-        contentControllerOriginalPreferredContentHeight = contentController.preferredContentSize.height
+        let contentController = customContentNavigationController(content: personaListView)
 
-        let drawer = presentDrawer(sourceView: sender, presentationDirection: .up, presentationStyle: .slideover, presentationOffset: 20, presentationBackground: .black, contentController: contentController, resizingBehavior: .dismissOrExpand)
+        let drawer = presentDrawer(sourceView: sourceView,
+                                   presentationDirection: .up,
+                                   presentationStyle: .slideover,
+                                   presentationOffset: 20,
+                                   presentationBackground: presentationBackground,
+                                   contentController: contentController,
+                                   resizingBehavior: .dismissOrExpand)
 
         drawer.resizingHandleViewBackgroundColor = Colors.NavigationBar.background
         drawer.contentScrollView = personaListView

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -149,7 +149,7 @@ class DrawerPresentationController: UIPresentationController {
             // Horizontally presented drawers must be inside containerView in order for device rotation animation to work correctly
             if presentationDirection.isHorizontal {
                 containerView?.addSubview(presentedViewController.view)
-                presentedViewController.view.frame = frameForPresentedViewController(in: frameOfPresentedViewInContainerView)
+                presentedViewController.view.frame = frameForPresentedViewController(in: contentView.bounds)
                 focusElement = containerView
             } else {
                 focusElement = contentView
@@ -307,7 +307,7 @@ class DrawerPresentationController: UIPresentationController {
         contentView.frame = frame
 
         if let presentedView = presentedView {
-            presentedView.frame = frameForPresentedViewController(in: presentedView.superview == containerView ? frameOfPresentedViewInContainerView : contentView.bounds)
+            presentedView.frame = frameForPresentedViewController(in: presentedView.superview == containerView ? contentView.frame : contentView.bounds)
         }
 
         if separator.superview != nil {
@@ -375,33 +375,33 @@ class DrawerPresentationController: UIPresentationController {
                 (traitCollection.horizontalSizeClass == .compact && !landscapeMode) {
                 contentSize.width = contentFrame.width
             }
+
             if actualPresentationOffset == 0 && (presentationDirection == .down || keyboardHeight == 0) {
                 contentSize.height += safeAreaPresentationOffset
             }
+
             contentSize.height = min(contentSize.height, contentFrame.height)
             if extraContentSize >= 0 || extraContentSizeEffectWhenCollapsing == .resize {
                 let maxContentSize = preferredMaximumPresentationSize != -1 ? preferredMaximumPresentationSize : contentFrame.height
                 contentSize.height = min(contentSize.height + extraContentSize, maxContentSize)
             }
 
+            contentSize.height += shadowOffset
+
             contentFrame.origin.x += (contentFrame.width - contentSize.width) / 2
             if presentationDirection == .up {
                 contentFrame.origin.y = contentFrame.maxY - contentSize.height
             }
-
-            contentSize.height += shadowOffset
         } else {
             if actualPresentationOffset == 0 {
                 contentSize.width += safeAreaPresentationOffset
             }
-            contentSize.width = min(contentSize.width, contentFrame.width)
+            contentSize.width = min(contentSize.width, contentFrame.width) + shadowOffset
             contentSize.height = contentFrame.height
 
             if presentationDirection == .fromTrailing {
                 contentFrame.origin.x = contentFrame.maxX - contentSize.width
             }
-
-            contentSize.width += shadowOffset
         }
         contentFrame.size = contentSize
 
@@ -450,9 +450,11 @@ class DrawerPresentationController: UIPresentationController {
         let gestureOffset = extraContentSize < 0 && extraContentSizeEffectWhenCollapsing == .move ? extraContentSize : 0
 
         if presentationDirection.isVertical {
-            frame.origin.y += presentationDirection == .down ? gestureOffset - shadowOffset : -gestureOffset + shadowOffset
+            frame.origin.y += presentationDirection == .down ? gestureOffset : -gestureOffset + shadowOffset
+            frame.size.height -= shadowOffset
         } else {
-            frame.origin.x += presentationDirection == .fromLeading ? gestureOffset - shadowOffset : -gestureOffset + shadowOffset
+            frame.origin.x += presentationDirection == .fromLeading ? gestureOffset : -gestureOffset + shadowOffset
+            frame.size.width -= shadowOffset
         }
 
         return frame


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This is a fix for issue #289:

One of the consuming apps reported a regression when presenting the drawer controller from a custom base with the **presentationBackground** set to **.none**.

The content being presented is clipped on the bottom preventing the whole rounded corner from being fully displayed.

The regression was also reproduced in the Demo App.

This is caused by the shadow offset introduced by #194.
The shadow offset is added to the height of the content view in order to create space for presented view controller's shadow.
The height of the presented view controller is defined based on the height of its container (the content view controller) and should be subtracted by the offset when the content view controller's height is increased to accommodate the shadow.

The subtraction is not happening and the origin points (**x** for trailing presentation direction and **y** for up presentation direction) are not considering the correct height when calculated.

### Verification

Tested iOS 12 and 14 on both iPad and iPhone (notched and regular).
Exercised all scenarios of the demo app and ensured the offsets and animations work correctly.
Added new demo scenarios to the app in order to exercise those.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![repro_demo_app](https://user-images.githubusercontent.com/68076145/97953213-abb29d00-1d54-11eb-9232-dca0e41bb904.png) | ![Screen Shot 2020-11-02 at 10 06 33 PM](https://user-images.githubusercontent.com/68076145/97954185-af93ee80-1d57-11eb-8fd2-70c3999982aa.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/291)