### PR TITLE
fix for voice over issue in case of passthrough drawercontroller

### DIFF
--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -77,12 +77,15 @@ class DrawerPresentationController: UIPresentationController {
         // Pass the passthrough view in touch forwarding view
         if let passThroughView = self.passThroughView {
             view.passthroughView = passThroughView
+            view.accessibilityElements = [passThroughView]
+        } else {
+            view.isAccessibilityElement = true
+            view.accessibilityLabel = "Accessibility.Dismiss.Label".localized
+            view.accessibilityHint = "Accessibility.Dismiss.Hint".localized
+            view.accessibilityTraits = .button
         }
         view.backgroundColor = .clear
-        view.isAccessibilityElement = true
-        view.accessibilityLabel = "Accessibility.Dismiss.Label".localized
-        view.accessibilityHint = "Accessibility.Dismiss.Hint".localized
-        view.accessibilityTraits = .button
+
         // Workaround for a bug in iOS: if the resizing handle happens to be in the middle of the backgroundView, VoiceOver will send touch event to it (according to the backgroundView's accessibilityActivationPoint) even though it's not parented in backgroundView or even interactable - this will prevent backgroundView from receiving touch and dismissing controller
 
         view.gestureRecognizers = [UITapGestureRecognizer(target: self, action: #selector(handleBackgroundViewTapped(_:)))]


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When we make the drawerController passthrough, Voice Over doesn't work on the underlying screen. So as a fix, added passthrough view as accessibility elements.

### Verification

1) Tap on **Show with underlying interactable content View**
2) Enable Voice over and check.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/292)