### PR TITLE
Voiceover sequence enforced for avatar view

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -84,6 +84,7 @@ class DemoController: UIViewController {
 
         items.forEach { itemRow.addArrangedSubview($0) }
         itemsContainer.addArrangedSubview(itemRow)
+        itemRow.accessibilityElements = itemRow.arrangedSubviews
         container.addArrangedSubview(itemsContainer)
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Bugfix: Focus order is not in sequential order in `AvatrViewDemoController.swift`.

Repro Steps: 

1.  Open FluentUI application.
2. Navigate to 'Avtar View' button using swipe gesture.
3. Navigate to ‘Circle style for the person’ using swipe gesture.
4.  Using right swipe navigate in forward direction and observe the issue.

 Fix: Explicitly enforce ordering of views for accessibility of stack view.

### Verification

1. Open AvatarDemoViewController and select avatar view. 
2. Swipe right after Circle style for person heading.
3. Observe the issue i.e instead of going on the Extra Extra large it is going on the image

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/294)