### PR TITLE
Added accessibility for constrained badges

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -816,7 +816,13 @@ open class BadgeField: UIView {
         if isIntroductionLabelAccessible() {
             elementsCount += 1
         }
-        elementsCount += badges.count
+        
+        if shouldUseConstrainedBadges {
+            elementsCount += constrainedBadges.count
+        } else {
+            elementsCount += badges.count
+        }
+        // texfield for adding additional badges
         elementsCount += 1
         return elementsCount
     }
@@ -826,8 +832,10 @@ open class BadgeField: UIView {
             return labelView
         }
         let offsetIndex = isIntroductionLabelAccessible() ? index - 1 : index
-        if offsetIndex < badges.count {
-            return badges[offsetIndex]
+        
+        let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
+        if offsetIndex < activeBadges.count {
+            return activeBadges[offsetIndex]
         }
         return textField
     }
@@ -836,7 +844,9 @@ open class BadgeField: UIView {
         if element as? UILabel == labelView {
             return 0
         }
-        if let badge = element as? BadgeView, let index = badges.firstIndex(of: badge) {
+        
+        let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
+        if let badge = element as? BadgeView, let index = activeBadges.firstIndex(of: badge) {
             return isIntroductionLabelAccessible() ? index + 1 : index
         }
         return accessibilityElementCount() - 1

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -816,13 +816,10 @@ open class BadgeField: UIView {
         if isIntroductionLabelAccessible() {
             elementsCount += 1
         }
-        
-        if shouldUseConstrainedBadges {
-            elementsCount += constrainedBadges.count
-        } else {
-            elementsCount += badges.count
-        }
-        // texfield for adding additional badges
+
+        elementsCount += shouldUseConstrainedBadges ? constrainedBadges.count : badges.count
+
+        // counting the trailing text field used to add more badges
         elementsCount += 1
         return elementsCount
     }
@@ -832,7 +829,7 @@ open class BadgeField: UIView {
             return labelView
         }
         let offsetIndex = isIntroductionLabelAccessible() ? index - 1 : index
-        
+
         let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
         if offsetIndex < activeBadges.count {
             return activeBadges[offsetIndex]
@@ -844,7 +841,7 @@ open class BadgeField: UIView {
         if element as? UILabel == labelView {
             return 0
         }
-        
+
         let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
         if let badge = element as? BadgeView, let index = activeBadges.firstIndex(of: badge) {
             return isIntroductionLabelAccessible() ? index + 1 : index


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Voice over doesn't work for constrained badges. 
'+5' button is not accessible through the swipe gesture and while navigating using right swipe screen reader does convey the information about the hidden element.

Repro Steps:

Step 1: Open FluentUI application.
Step 2: Navigate to 'BadgeField' button using swipe gesture.
Step 3: Navigate to '+4' button and observe the issue.

### Fix: 
Handle constrained badges accessibility elements by reading values from appropriate elements array.
 
### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/305)