### PR TITLE
update segment control button accessibility hint

### DIFF
--- a/ios/FluentUI/Controls/SegmentedControl.swift
+++ b/ios/FluentUI/Controls/SegmentedControl.swift
@@ -220,6 +220,8 @@ open class SegmentedControl: UIControl {
         if index <= selectedSegmentIndex {
             _selectedSegmentIndex += 1
         }
+
+        updateAccessibilityHints()
     }
 
     /// Remove the segment at the appropriate index. If there are only 2 segments in the control, or if no segment exists at the index, this method is ignored. If the segment is currently selected, we change the selection
@@ -248,6 +250,8 @@ open class SegmentedControl: UIControl {
         if index <= selectedSegmentIndex {
             _selectedSegmentIndex -= 1
         }
+
+        updateAccessibilityHints()
     }
 
     /// Select segment at index
@@ -368,7 +372,6 @@ open class SegmentedControl: UIControl {
         let button = SegmentedControlButton(style: style)
         button.setTitle(title, for: .normal)
         button.accessibilityLabel = title
-        button.accessibilityHint = String(format: "Accessibility.Segmented.Button.Hint".localized, title)
         button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
         return button
     }
@@ -425,6 +428,12 @@ open class SegmentedControl: UIControl {
         case .switch:
             selectionView.frame = button.frame
             selectionView.layer.cornerRadius = selectionView.frame.height / 2
+        }
+    }
+
+    private func updateAccessibilityHints() {
+        for (index, button) in buttons.enumerated() {
+            button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
         }
     }
 

--- a/ios/FluentUI/Controls/SegmentedControl.swift
+++ b/ios/FluentUI/Controls/SegmentedControl.swift
@@ -433,7 +433,7 @@ open class SegmentedControl: UIControl {
 
     private func updateAccessibilityHints() {
         for (index, button) in buttons.enumerated() {
-            button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+            button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
         }
     }
 

--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@، %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "انقر للانتقال إلى %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "اضغط ضغطاً مزدوجاً لعرض مزيد من الإجراءات";
 

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Toqueu aquí per anar a %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Toqueu dues vegades per veure més accions.";
 

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Klepnutím přejdete na %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Poklepáním zobrazíte další akce.";
 

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tryk for at gå til %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dobbelttryk for at se flere handlinger";
 

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tippen Sie, um zu \"%@\" zu wechseln.";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Doppeltippen Sie, um weitere Aktionen anzuzeigen.";
 

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Πατήστε για να μεταβείτε στο %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Πατήστε δύο φορές για να προβάλετε περισσότερες ενέργειες";
 

--- a/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tap to go to %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Double tap to view more actions";
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tap to go to %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Double tap to view more actions";
 

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Pulsa para ir a %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Pulsa dos veces para ver más acciones";
 

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Pulsa para ir a %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Pulsa dos veces para ver más acciones";
 

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Siirry kohteeseen %@ napauttamalla";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Näytä lisää toimintoja kaksoisnapauttamalla";
 

--- a/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Appuyez pour accéder à %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Appuyez deux fois pour afficher d’autres actions";
 

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "הקש כדי לעבור אל %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "הקש פעמיים כדי להציג פעולות נוספות";
 

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "%@ पर जाने के लिए टैप करें";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "अधिक गतिविधियाँ देखने के लिए डबल टैप करें";
 

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Dodirnite da biste otvorili %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dvaput dodirnite da biste pogledali dodatne akcije";
 

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Ide koppintva erre a szegmensre léphet: %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Koppintson ide duplán a további műveletek megtekintéséhez";
 

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Ketuk untuk membuka %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Ketuk dua kali untuk melihat tindakan lainnya";
 

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tocca per passare a %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Effettua un doppio tocco per visualizzare altre azioni";
 

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@、 %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "タップして %@ に移動します";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "ダブルタップしてその他のアクションを表示します";
 

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "%@(으)로 이동하려면 탭하세요.";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "더 많은 작업을 보려면 두 번 탭하세요.";
 

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Ketik untuk pergi ke %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dwiketik untuk melihat lebih banyak tindakan";
 

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Trykk for å gå til %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dobbelttrykk for å vise flere handlinger";
 

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tikken om naar %@ te gaan";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dubbeltikken om meer acties weer te geven";
 

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Naciśnij, aby przejść do: %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Naciśnij dwukrotnie, aby wyświetlić więcej akcji";
 

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Toque para ir para %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dê um toque duplo para exibir mais ações";
 

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Toque para ir para %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Faça duplo toque para ver mais ações";
 

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Atingeți pentru a accesa %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Atingeți de două ori pentru a vedea mai multe acțiuni";
 

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Нажмите здесь, чтобы перейти на %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Дважды коснитесь, чтобы просмотреть другие действия";
 

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Ťuknutím prejdete na %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dvojitým ťuknutím zobrazíte ďalšie akcie";
 

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Tryck för att gå till %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dubbeltryck för att visa fler åtgärder";
 

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "แตะเพื่อไปที่ %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "แตะสองครั้งเพื่อดูการดำเนินการเพิ่มเติม";
 

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "%@ bölümüne gitmek için dokunun";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Diğer eylemleri görüntülemek için iki kez dokunun";
 

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Торкніться, щоб перейти на %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Торкніться двічі, щоб переглянути більше дій";
 

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "Nhấn để đi tới %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Nhấn đúp để xem thêm hành động";
 

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@、%@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "点击以转到 %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "双击以查看更多操作";
 

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -99,9 +99,6 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@，%@";
 
-/* Accessibility hint for a segmented control button */
-"Accessibility.Segmented.Button.Hint" = "點選以移至 %@";
-
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "點兩下以檢視更多動作";
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We shouldn't be adding accessibility hints like "tap to go to something" in our library. 
Interacting with a button with Voiceover is technically double tap. However, we really shouldn't be customizing string to tell users how to interact with our components because depending on the assistive technology that customer is using, how he or she activates a button might be different.
Instead, lets be consistent with our pillbuttonbar control which says the index of the button out of count of all buttons (similar to our tab bar works). 

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| "Tap to go to Foo" | "1 of 4" |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/307)