### PR TITLE
Replacing zero width space to empty string for VO readability

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -78,7 +78,7 @@ open class BadgeField: UIView {
         static let badgeHeight: CGFloat = 26
         static let badgeMarginHorizontal: CGFloat = 5
         static let badgeMarginVertical: CGFloat = 5
-        static let emptyTextFieldString: String = emptyString
+        static let emptyTextFieldString: String = ""
         static let dragAndDropMinimumPressDuration: TimeInterval = 0.2
         static let dragAndDropScaleAnimationDuration: TimeInterval = 0.3
         static let dragAndDropScaleFactor: CGFloat = 1.10
@@ -86,7 +86,6 @@ open class BadgeField: UIView {
         static let labelMarginRight: CGFloat = 5
         static let textStyleFont: UIFont = TextStyle.subhead.font
         static let textFieldMinWidth: CGFloat = 100
-        static let emptyString: String = ""
     }
 
     @objc open var label: String = "" {

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -78,7 +78,7 @@ open class BadgeField: UIView {
         static let badgeHeight: CGFloat = 26
         static let badgeMarginHorizontal: CGFloat = 5
         static let badgeMarginVertical: CGFloat = 5
-        static let emptyTextFieldString: String = zeroWidthSpace
+        static let emptyTextFieldString: String = emptyString
         static let dragAndDropMinimumPressDuration: TimeInterval = 0.2
         static let dragAndDropScaleAnimationDuration: TimeInterval = 0.3
         static let dragAndDropScaleFactor: CGFloat = 1.10
@@ -86,7 +86,7 @@ open class BadgeField: UIView {
         static let labelMarginRight: CGFloat = 5
         static let textStyleFont: UIFont = TextStyle.subhead.font
         static let textFieldMinWidth: CGFloat = 100
-        static let zeroWidthSpace: String = "\u{200B}"
+        static let emptyString: String = ""
     }
 
     @objc open var label: String = "" {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Fix for #256 . The Voice over reads the default value in the textfield (initialized to [zero space width](https://github.com/microsoft/fluentui-apple/blob/69c7fb74eadc33bcd13539d50bfecf1bcb5d65af/ios/FluentUI/Badge%20Field/BadgeField.swift#L89)) 

```swift
 @objc open func resetTextFieldContent() {
        textField.text = Constants.emptyTextFieldString
    }
```

Since the default is set to non empty string the voice over reads the character description instead of ignoring it. 

#### Fix

Replace unicode character with empty string.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/309)