### PR TITLE
DrawerPresentationController should reflect DrawerController properties.

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -381,11 +381,22 @@ open class DrawerController: UIViewController {
 
     @objc public weak var delegate: DrawerControllerDelegate?
 
+    let presentationOrigin: CGFloat?
+    let presentationDirection: DrawerPresentationDirection
+    let preferredMaximumExpansionHeight: CGFloat
+
+    var sourceObject: Any? {
+        return sourceView ?? barButtonItem
+    }
+
+    /// Shadow is required if background is transparent
+    var shadowOffset: CGFloat {
+        return presentationBackground == .none ? Constants.shadowOffset : 0
+    }
+
     private let sourceView: UIView?
     private let sourceRect: CGRect?
     private let barButtonItem: UIBarButtonItem?
-    private let presentationOrigin: CGFloat?
-    private let presentationDirection: DrawerPresentationDirection
 
     private var isPreferredContentSizeBeingChangedInternally: Bool = false
     private var normalDrawerHeight: CGFloat = 0
@@ -396,21 +407,18 @@ open class DrawerController: UIViewController {
         view.axis = .vertical
         return view
     }()
+
     private var containerViewBottomConstraint: NSLayoutConstraint? {
         didSet {
             updateContainerViewBottomConstraint()
         }
     }
-    /// Shadow is required if background is transparent
-    private var shadowOffset: CGFloat {
-        return presentationBackground == .none ? Constants.shadowOffset : 0
-    }
+    
     private var containerViewCenterObservation: NSKeyValueObservation?
 
     private var useCustomBackgroundColor: Bool = false
     /// for iPad split mode, navigation bar has a different dark elevated color, and if it is a `.down` presentation style, match `Colors.NavigationBar.background` elevated color
     private var useNavigationBarBackgroundColor: Bool = false
-    private let preferredMaximumExpansionHeight: CGFloat
 
     /**
      Initializes `DrawerController` to be presented as a popover from `sourceRect` in `sourceView` on iPad and as a slideover on iPhone/iPad.
@@ -969,17 +977,8 @@ extension DrawerController: UIViewControllerTransitioningDelegate {
             let drawerPresentationController = DrawerPresentationController(presentedViewController: presented,
                                                 presentingViewController: presenting,
                                                 source: source,
-                                                sourceObject: sourceView ?? barButtonItem,
-                                                presentationOrigin: presentationOrigin,
                                                 presentationDirection: direction,
-                                                presentationOffset: presentationOffset,
-                                                presentationBackground: presentationBackground,
-                                                adjustHeightForKeyboard: adjustsHeightForKeyboard,
-                                                shouldUseWindowFullWidthInLandscape: shouldUseWindowFullWidthInLandscape,
-                                                shouldRespectSafeAreaForWindowFullWidth: shouldRespectSafeAreaForWindowFullWidth,
-                                                passThroughView: passThroughView,
-                                                shadowOffset: shadowOffset,
-                                                maximumPresentationHeight: preferredMaximumExpansionHeight)
+                                                adjustHeightForKeyboard: adjustsHeightForKeyboard)
             drawerPresentationController.drawerPresentationControllerDelegate = self
             return drawerPresentationController
         case .popover:


### PR DESCRIPTION
The DrawerPresentationController is not exposed externally and is created by the DrawerController.
Some DrawerController properties outlining presentation traits are duplicated into DrawerPresentationController and passed on the initializer.

The issue is that if the calling code changes one of these DrawerController after it has created the DrawerPresentationController, they are not updated in the DrawerPresentationController instance.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The suggested fix to move these properties to the DrawerPresentationControllerDelegate so that they're retrieved directly from the DrawerController when they are needed in the DrawerPresentationController logic.

### Verification

Ran the Drawer controller scenarios on the Demo App on iPad, iPhone (with and without notch) and stepped through the debugger ensuring that the properties were correctly retrieved from the DrawerController instance.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/310)