### PR TITLE
Add primary colors for Mac

### DIFF
--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -247,6 +247,40 @@ public final class Colors: NSObject {
 			}
 		}
 	}
+	
+	// MARK: Primary
+	
+	@objc public var primary: NSColor = Colors.Palette.communicationBlue.color {
+		didSet { }
+	}
+	
+	@objc public var primaryTint10: NSColor = Colors.Palette.communicationBlueTint10.color {
+		didSet { }
+	}
+	
+	@objc public var primaryTint20: NSColor = Colors.Palette.communicationBlueTint20.color {
+		didSet { }
+	}
+	
+	@objc public var primaryTint30: NSColor = Colors.Palette.communicationBlueTint30.color {
+		didSet { }
+	}
+	
+	@objc public var primaryTint40: NSColor = Colors.Palette.communicationBlueTint40.color {
+		didSet { }
+	}
+	
+	@objc public var primaryShade10: NSColor = Colors.Palette.communicationBlueShade10.color {
+		didSet { }
+	}
+	
+	@objc public var primaryShade20: NSColor = Colors.Palette.communicationBlueShade20.color {
+		didSet { }
+	}
+	
+	@objc public var primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color {
+		didSet { }
+	}
 }
 
 /// Make palette enum CaseIterable for unit testing purposes

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -250,37 +250,21 @@ public final class Colors: NSObject {
 	
 	// MARK: Primary
 	
-	@objc public var primary: NSColor = Colors.Palette.communicationBlue.color {
-		didSet { }
-	}
+	@objc public static var primary: NSColor = Colors.Palette.communicationBlue.color
 	
-	@objc public var primaryTint10: NSColor = Colors.Palette.communicationBlueTint10.color {
-		didSet { }
-	}
+	@objc public static var primaryTint10: NSColor = Colors.Palette.communicationBlueTint10.color
 	
-	@objc public var primaryTint20: NSColor = Colors.Palette.communicationBlueTint20.color {
-		didSet { }
-	}
+	@objc public static var primaryTint20: NSColor = Colors.Palette.communicationBlueTint20.color
 	
-	@objc public var primaryTint30: NSColor = Colors.Palette.communicationBlueTint30.color {
-		didSet { }
-	}
+	@objc public static var primaryTint30: NSColor = Colors.Palette.communicationBlueTint30.color
 	
-	@objc public var primaryTint40: NSColor = Colors.Palette.communicationBlueTint40.color {
-		didSet { }
-	}
+	@objc public static var primaryTint40: NSColor = Colors.Palette.communicationBlueTint40.color
 	
-	@objc public var primaryShade10: NSColor = Colors.Palette.communicationBlueShade10.color {
-		didSet { }
-	}
+	@objc public static var primaryShade10: NSColor = Colors.Palette.communicationBlueShade10.color
 	
-	@objc public var primaryShade20: NSColor = Colors.Palette.communicationBlueShade20.color {
-		didSet { }
-	}
+	@objc public static var primaryShade20: NSColor = Colors.Palette.communicationBlueShade20.color
 	
-	@objc public var primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color {
-		didSet { }
-	}
+	@objc public static var primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color
 }
 
 /// Make palette enum CaseIterable for unit testing purposes

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/Contents.json
@@ -2,5 +2,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "provides-namespace" : true
   }
 }

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryColor.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryColor.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.235",
-          "green" : "0.537",
-          "red" : "0.063"
+          "blue" : "0x3B",
+          "green" : "0x88",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryColor.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.255",
+          "green" : "0.486",
+          "red" : "0.063"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.235",
+          "green" : "0.537",
+          "red" : "0.063"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade10Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade10Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.231",
-          "green" : "0.439",
-          "red" : "0.059"
+          "blue" : "0x3A",
+          "green" : "0x6F",
+          "red" : "0x0F"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.290",
-          "green" : "0.584",
-          "red" : "0.122"
+          "blue" : "0x49",
+          "green" : "0x94",
+          "red" : "0x1F"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade10Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade10Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.231",
+          "green" : "0.439",
+          "red" : "0.059"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.290",
+          "green" : "0.584",
+          "red" : "0.122"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade20Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade20Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.196",
+          "green" : "0.373",
+          "red" : "0.047"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.376",
+          "green" : "0.651",
+          "red" : "0.216"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade20Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade20Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.196",
-          "green" : "0.373",
-          "red" : "0.047"
+          "blue" : "0x31",
+          "green" : "0x5F",
+          "red" : "0x0B"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.376",
-          "green" : "0.651",
-          "red" : "0.216"
+          "blue" : "0x5F",
+          "green" : "0xA6",
+          "red" : "0x37"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade30Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade30Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.141",
+          "green" : "0.275",
+          "red" : "0.035"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.510",
+          "green" : "0.741",
+          "red" : "0.376"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade30Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryShade30Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.141",
-          "green" : "0.275",
-          "red" : "0.035"
+          "blue" : "0x23",
+          "green" : "0x46",
+          "red" : "0x08"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.510",
-          "green" : "0.741",
-          "red" : "0.376"
+          "blue" : "0x82",
+          "green" : "0xBC",
+          "red" : "0x5F"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint10Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint10Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.318",
+          "green" : "0.553",
+          "red" : "0.129"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.216",
+          "green" : "0.475",
+          "red" : "0.059"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint10Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint10Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.318",
-          "green" : "0.553",
-          "red" : "0.129"
+          "blue" : "0x51",
+          "green" : "0x8D",
+          "red" : "0x20"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.216",
-          "green" : "0.475",
-          "red" : "0.059"
+          "blue" : "0x37",
+          "green" : "0x79",
+          "red" : "0x0F"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint20Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint20Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.494",
-          "green" : "0.694",
-          "red" : "0.333"
+          "blue" : "0x7D",
+          "green" : "0xB0",
+          "red" : "0x54"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.145",
-          "green" : "0.325",
-          "red" : "0.039"
+          "blue" : "0x24",
+          "green" : "0x52",
+          "red" : "0x09"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint20Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint20Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.494",
+          "green" : "0.694",
+          "red" : "0.333"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.145",
+          "green" : "0.325",
+          "red" : "0.039"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint30Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint30Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.725",
+          "green" : "0.847",
+          "red" : "0.627"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.071",
+          "green" : "0.161",
+          "red" : "0.020"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint30Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint30Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.725",
-          "green" : "0.847",
-          "red" : "0.627"
+          "blue" : "0xB8",
+          "green" : "0xD7",
+          "red" : "0x9F"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.071",
-          "green" : "0.161",
-          "red" : "0.020"
+          "blue" : "0x12",
+          "green" : "0x29",
+          "red" : "0x05"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint40Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint40Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.847",
+          "green" : "0.918",
+          "red" : "0.792"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.039",
+          "green" : "0.086",
+          "red" : "0.012"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint40Color.colorset/Contents.json
+++ b/macos/FluentUITestApp/Assets.xcassets/Colors/DemoPrimaryTint40Color.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.847",
-          "green" : "0.918",
-          "red" : "0.792"
+          "blue" : "0xD7",
+          "green" : "0xEA",
+          "red" : "0xC9"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.039",
-          "green" : "0.086",
-          "red" : "0.012"
+          "blue" : "0x09",
+          "green" : "0x15",
+          "red" : "0x03"
         }
       },
       "idiom" : "universal"

--- a/macos/FluentUITestViewControllers/TestColorViewController.swift
+++ b/macos/FluentUITestViewControllers/TestColorViewController.swift
@@ -24,23 +24,22 @@ class TestColorViewController: NSViewController {
 		}
 		
 		/// Excel primary colors
-		let color = Colors.init()
-		color.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: color.primary))
-		color.primaryShade10 = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade10", color: color.primaryShade10))
-		color.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade20", color: color.primaryShade20))
-		color.primaryShade30 = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade30", color: color.primaryShade30))
-		color.primaryTint10 = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint10", color: color.primaryTint10))
-		color.primaryTint20 = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint20", color: color.primaryTint20))
-		color.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint30", color: color.primaryTint30))
-		color.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint40", color: color.primaryTint40))
+		Colors.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: Colors.primary))
+		Colors.primaryShade10 = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade10", color: Colors.primaryShade10))
+		Colors.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade20", color: Colors.primaryShade20))
+		Colors.primaryShade30 = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade30", color: Colors.primaryShade30))
+		Colors.primaryTint10 = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint10", color: Colors.primaryTint10))
+		Colors.primaryTint20 = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint20", color: Colors.primaryTint20))
+		Colors.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint30", color: Colors.primaryTint30))
+		Colors.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint40", color: Colors.primaryTint40))
 		
 		let documentView = NSView()
 		documentView.translatesAutoresizingMaskIntoConstraints = false

--- a/macos/FluentUITestViewControllers/TestColorViewController.swift
+++ b/macos/FluentUITestViewControllers/TestColorViewController.swift
@@ -20,16 +20,27 @@ class TestColorViewController: NSViewController {
 		colorsStackView.alignment = .leading
 		
 		for color in Colors.Palette.allCases {
-			let colorView = ColorRectView(color: color.color)
-			let textView = NSTextField(labelWithString: color.name)
-			textView.font = .systemFont(ofSize: 18)
-			let rowStackView = NSStackView()
-			rowStackView.orientation = .horizontal
-			rowStackView.spacing = 20.0
-			rowStackView.addArrangedSubview(colorView)
-			rowStackView.addArrangedSubview(textView)
-			colorsStackView.addArrangedSubview(rowStackView)
+			colorsStackView.addArrangedSubview(createColorRowStackView(name: color.name, color: color.color))
 		}
+		
+		/// Excel primary colors
+		let color = Colors.init()
+		color.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: color.primary))
+		color.primaryShade10 = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade10", color: color.primaryShade10))
+		color.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade20", color: color.primaryShade20))
+		color.primaryShade30 = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade30", color: color.primaryShade30))
+		color.primaryTint10 = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint10", color: color.primaryTint10))
+		color.primaryTint20 = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint20", color: color.primaryTint20))
+		color.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint30", color: color.primaryTint30))
+		color.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
+		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint40", color: color.primaryTint40))
 		
 		let documentView = NSView()
 		documentView.translatesAutoresizingMaskIntoConstraints = false
@@ -47,6 +58,18 @@ class TestColorViewController: NSViewController {
 		])
 		
 		view = containerView
+	}
+
+	private func createColorRowStackView(name: String?, color: NSColor?) -> NSStackView {
+		let rowStackView = NSStackView()
+		let textView = NSTextField(labelWithString: name!)
+		let primaryColorView = ColorRectView(color: color!)
+		textView.font = .systemFont(ofSize: 18)
+		rowStackView.orientation = .horizontal
+		rowStackView.spacing = 20.0
+		rowStackView.addArrangedSubview(primaryColorView)
+		rowStackView.addArrangedSubview(textView)
+		return rowStackView
 	}
 }
 

--- a/macos/FluentUITestViewControllers/TestColorViewController.swift
+++ b/macos/FluentUITestViewControllers/TestColorViewController.swift
@@ -7,6 +7,10 @@ import AppKit
 import FluentUI
 
 class TestColorViewController: NSViewController {
+	var primaryColorsStackView = NSStackView()
+	var subviewConstraints = [NSLayoutConstraint]()
+	var toggleTextView = NSTextView(frame: NSRect(x: 0, y: 0, width: 100, height: 20))
+	
 	override func loadView() {
 		let containerView = NSView()
 		let scrollView = NSScrollView()
@@ -19,43 +23,62 @@ class TestColorViewController: NSViewController {
 		colorsStackView.orientation = .vertical
 		colorsStackView.alignment = .leading
 		
+		primaryColorsStackView.translatesAutoresizingMaskIntoConstraints = false
+		primaryColorsStackView.orientation = .vertical
+		primaryColorsStackView.alignment = .leading
+		
 		for color in Colors.Palette.allCases {
 			colorsStackView.addArrangedSubview(createColorRowStackView(name: color.name, color: color.color))
 		}
 		
-		/// Excel primary colors
-		Colors.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: Colors.primary))
-		Colors.primaryShade10 = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade10", color: Colors.primaryShade10))
-		Colors.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade20", color: Colors.primaryShade20))
-		Colors.primaryShade30 = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade30", color: Colors.primaryShade30))
-		Colors.primaryTint10 = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint10", color: Colors.primaryTint10))
-		Colors.primaryTint20 = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint20", color: Colors.primaryTint20))
-		Colors.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint30", color: Colors.primaryTint30))
-		Colors.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
-		colorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint40", color: Colors.primaryTint40))
+		loadPrimaryColors(state: NSControl.StateValue.off)
 		
 		let documentView = NSView()
 		documentView.translatesAutoresizingMaskIntoConstraints = false
 		scrollView.documentView = documentView
 		documentView.addSubview(colorsStackView)
+		documentView.addSubview(primaryColorsStackView)
 		
-		NSLayoutConstraint.activate([
+		subviewConstraints = [
 			containerView.heightAnchor.constraint(equalTo:scrollView.heightAnchor),
 			containerView.widthAnchor.constraint(equalTo:scrollView.widthAnchor),
-			
 			colorsStackView.topAnchor.constraint(equalTo: documentView.topAnchor, constant: colorRowSpacing),
 			colorsStackView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: colorRowSpacing),
 			colorsStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
-			colorsStackView.bottomAnchor.constraint(equalTo: documentView.bottomAnchor, constant: -colorRowSpacing)
-		])
+			primaryColorsStackView.topAnchor.constraint(equalTo: colorsStackView.bottomAnchor, constant: colorRowSpacing),
+			primaryColorsStackView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: colorRowSpacing),
+			primaryColorsStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor)
+		]
 		
+		if #available(OSX 10.15, *) {
+			let switchButton = NSSwitch(frame: CGRect(x: 1, y: 1, width: 100, height: 50))
+			switchButton.target = self
+			switchButton.action = #selector(toggleClicked)
+			toggleTextView.string = "Default"
+			toggleTextView.font = .systemFont(ofSize: 20)
+			toggleTextView.isEditable = false
+			toggleTextView.isSelectable = false
+			toggleTextView.backgroundColor = .clear
+			
+			let toggleStackView = NSStackView()
+			toggleStackView.translatesAutoresizingMaskIntoConstraints = false
+			toggleStackView.orientation = .horizontal
+			toggleStackView.spacing = 20.0
+			toggleStackView.addArrangedSubview(switchButton)
+			toggleStackView.addArrangedSubview(toggleTextView)
+			documentView.addSubview(toggleStackView)
+			
+			subviewConstraints.append(contentsOf: [
+				toggleStackView.topAnchor.constraint(equalTo: primaryColorsStackView.bottomAnchor, constant: colorRowSpacing),
+				toggleStackView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: colorRowSpacing),
+				toggleStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor, constant: colorRowSpacing),
+				toggleStackView.bottomAnchor.constraint(equalTo: documentView.bottomAnchor, constant: -colorRowSpacing)
+			])
+		} else {
+			subviewConstraints.append(primaryColorsStackView.bottomAnchor.constraint(equalTo: documentView.bottomAnchor, constant: -colorRowSpacing))
+		}
+		
+		NSLayoutConstraint.activate(subviewConstraints)
 		view = containerView
 	}
 
@@ -69,6 +92,47 @@ class TestColorViewController: NSViewController {
 		rowStackView.addArrangedSubview(primaryColorView)
 		rowStackView.addArrangedSubview(textView)
 		return rowStackView
+	}
+	
+	@available(OSX 10.15, *)
+	@objc private func toggleClicked(button: NSSwitch?) {
+		primaryColorsStackView.subviews.removeAll()
+		loadPrimaryColors(state: button?.state ?? NSControl.StateValue.off)
+	}
+	
+	private func loadPrimaryColors(state: NSControl.StateValue) {
+		if (state == NSControl.StateValue.on) {
+			Colors.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
+			Colors.primaryShade10 = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
+			Colors.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
+			Colors.primaryShade30 = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
+			Colors.primaryTint10 = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
+			Colors.primaryTint20 = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
+			Colors.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
+			Colors.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
+			toggleTextView.string = "Green"
+		}
+		else {
+			Colors.primary = Colors.Palette.communicationBlue.color
+			Colors.primaryShade10 = Colors.Palette.communicationBlueShade10.color
+			Colors.primaryShade20 = Colors.Palette.communicationBlueShade20.color
+			Colors.primaryShade30 = Colors.Palette.communicationBlueShade30.color
+			Colors.primaryTint10 = Colors.Palette.communicationBlueTint10.color
+			Colors.primaryTint20 = Colors.Palette.communicationBlueTint20.color
+			Colors.primaryTint30 = Colors.Palette.communicationBlueTint30.color
+			Colors.primaryTint40 = Colors.Palette.communicationBlueTint40.color
+			toggleTextView.string = "Default"
+		}
+		
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: Colors.primary))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade10", color: Colors.primaryShade10))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade20", color: Colors.primaryShade20))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryShade30", color: Colors.primaryShade30))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint10", color: Colors.primaryTint10))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint20", color: Colors.primaryTint20))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint30", color: Colors.primaryTint30))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint40", color: Colors.primaryTint40))
+		NSLayoutConstraint.activate(subviewConstraints)
 	}
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS

### Description of changes
Added primary color properties to Colors. I also added the demo colors from iOS to the Mac test app.

### Verification
![light](https://user-images.githubusercontent.com/67026167/99547271-5944c380-2985-11eb-85f5-55358bd7de68.gif)
![dark](https://user-images.githubusercontent.com/67026167/99547284-5e097780-2985-11eb-8bfb-c6f92c55195e.gif)



### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/312)