### PR TITLE
make VO say "heading" for title label in demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -61,6 +61,7 @@ class DemoController: UIViewController {
         let titleLabel = Label(style: .headline)
         titleLabel.text = text
         titleLabel.textAlignment = .center
+        titleLabel.accessibilityTraits.insert(.header)
         container.addArrangedSubview(titleLabel)
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
make VO say "heading" for title label in demo app


### Verification
Turn on VoiceOver
navigate to "AvatarView" demo

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| "Circle style for person" | "Circle style for person, heading" |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/314)