### PR TITLE
Fix for the Localize workflow

### DIFF
--- a/.github/workflows/localize.yml
+++ b/.github/workflows/localize.yml
@@ -26,7 +26,7 @@ jobs:
         TDBUILD_AAD_APPLICATION_CLIENT_SECRET: ${{ secrets.TDBUILD_AAD_APPLICATION_CLIENT_SECRET }}
       run: scripts/localize.sh
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v2.7.0
+      uses: peter-evans/create-pull-request@v3.5.0
       with:
         commit-message: Latest localized resource files from Touchdown Build
         title: '[Localization] Localized Resource Files'


### PR DESCRIPTION
The Localize workflow of FluentUI repo GitHub Actions is failing with the following errors reported on the "Create Pull Request" step:

**Run peter-evans/create-pull-request@v2.7.0**
```
Error: Unable to process command '::set-env name=pythonLocation,::/opt/hostedtoolcache/Python/3.9.0/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/Python/3.9.0/x64' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '::add-path::/opt/hostedtoolcache/Python/3.9.0/x64/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

The change behind this warning which was later turned into an error is described in detail on this [blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/):

### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

The description of [Release v3.4.1 of the peter-evans/create-pull-request repository](https://github.com/peter-evans/create-pull-request/releases/tag/v3.4.1) addresses this issue:
- Dependency updates (Removes the Actions runner warning about set-env deprecation)

**Updating our dependency of peter-evans/create-pull-request from v2.7.0 to v3.5.0 (latest version) fixes the problem.**

### Verification

Tested running the Workflow on a different fork to [reproduce the issue](https://github.com/rdeassis/fluentui-apple/actions/runs/368910625) and [validate it is fixed after the version update](https://github.com/rdeassis/fluentui-apple/actions/runs/368900663).

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/315)