### PR TITLE
Rename iOS Static Library from "FluentUILib" to "FluentUI"

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 		8AF03E1B24B6BDBD00E6E2A2 /* ContactCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCollectionViewCell.swift; sourceTree = "<group>"; };
 		8AF03E1D24B6BDFB00E6E2A2 /* ContactCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCollectionViewLayout.swift; sourceTree = "<group>"; };
 		8FA3CB5A246B19EA0049E431 /* ColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
-		8FD01166228A820600D25925 /* libFluentUILib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFluentUILib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8FD01166228A820600D25925 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -630,7 +630,7 @@
 				A5CEC15120D980B20016922A /* FluentUI.framework */,
 				A5CEC15A20D980B30016922A /* FluentUITests.xctest */,
 				A5DA88FC226FAA01000A8EA8 /* FluentUIResources-ios.bundle */,
-				8FD01166228A820600D25925 /* libFluentUILib.a */,
+				8FD01166228A820600D25925 /* libFluentUI.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -986,7 +986,7 @@
 			);
 			name = FluentUILib;
 			productName = OfficeUIFabricStaticLib;
-			productReference = 8FD01166228A820600D25925 /* libFluentUILib.a */;
+			productReference = 8FD01166228A820600D25925 /* libFluentUI.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		A5CEC15020D980B20016922A /* FluentUI */ = {
@@ -1571,7 +1571,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = FluentUI;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1583,7 +1583,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = FluentUI;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1595,7 +1595,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = FluentUI;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/scripts/prepare_for_nuget_pack.sh
+++ b/scripts/prepare_for_nuget_pack.sh
@@ -36,7 +36,7 @@ make_dir_if_necessary "$NUGET_OUTPUT_INCLUDE_DIR_IOS_FLUENTUI"
 # Pick the release simulator header since the device target has some arm64 specific ifdefs while the simulator version works on all platforms.
 # Rename the FluentUILib-Swift.h to FluentUI-Swift.h for consistency with Framework consumption
 echo "Copy iOS generated Swift header to include dir"
-rsync -a "DerivedData/Build/Intermediates.noindex/FluentUI.build/Release-iphonesimulator/FluentUILib.build/DerivedSources/FluentUILib-Swift.h" "$NUGET_OUTPUT_INCLUDE_DIR_IOS_FLUENTUI/FluentUI-Swift.h"
+rsync -a "DerivedData/Build/Intermediates.noindex/FluentUI.build/Release-iphonesimulator/FluentUILib.build/DerivedSources/FluentUI-Swift.h" "$NUGET_OUTPUT_INCLUDE_DIR_IOS_FLUENTUI/FluentUI-Swift.h"
 
 # cd into the products directory to make copying all the output easier
 cd $PRODUCTS_DIR
@@ -52,26 +52,26 @@ rsync -a Release/FluentUI.framework/ nuget/Ship-macosx/FluentUI.framework/
 
 make_dir_if_necessary "nuget/Debug-iphoneos"
 echo "Copy Debug-iphoneos build output into nuget folder"
-rsync -a Debug-iphoneos/libFluentUILib.a nuget/Debug-iphoneos/
-rsync -a Debug-iphoneos/FluentUILib.swiftmodule/ nuget/Debug-iphoneos/FluentUILib.swiftmodule/
+rsync -a Debug-iphoneos/libFluentUI.a nuget/Debug-iphoneos/
+rsync -a Debug-iphoneos/FluentUI.swiftmodule/ nuget/Debug-iphoneos/FluentUI.swiftmodule/
 rsync -a Debug-iphoneos/FluentUIResources-ios.bundle/ nuget/Debug-iphoneos/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Ship-iphoneos"
 echo "Copy Ship-iphoneos build output into nuget folder"
-rsync -a Release-iphoneos/libFluentUILib.a nuget/Ship-iphoneos/
-rsync -a Release-iphoneos/FluentUILib.swiftmodule/ nuget/Ship-iphoneos/FluentUILib.swiftmodule/
+rsync -a Release-iphoneos/libFluentUI.a nuget/Ship-iphoneos/
+rsync -a Release-iphoneos/FluentUI.swiftmodule/ nuget/Ship-iphoneos/FluentUI.swiftmodule/
 rsync -a Release-iphoneos/FluentUIResources-ios.bundle/ nuget/Ship-iphoneos/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Debug-iphonesimulator"
 echo "Copy Debug-iphonesimulator build output into nuget folder"
-rsync -a Debug-iphonesimulator/libFluentUILib.a nuget/Debug-iphonesimulator/
-rsync -a Debug-iphonesimulator/FluentUILib.swiftmodule/ nuget/Debug-iphonesimulator/FluentUILib.swiftmodule/
+rsync -a Debug-iphonesimulator/libFluentUI.a nuget/Debug-iphonesimulator/
+rsync -a Debug-iphonesimulator/FluentUI.swiftmodule/ nuget/Debug-iphonesimulator/FluentUI.swiftmodule/
 rsync -a Debug-iphonesimulator/FluentUIResources-ios.bundle/ nuget/Debug-iphonesimulator/FluentUIResources-ios.bundle/
 
 make_dir_if_necessary "nuget/Ship-iphonesimulator"
 echo "Copy Ship-iphonesimulator build output into nuget folder"
-rsync -a Release-iphonesimulator/libFluentUILib.a nuget/Ship-iphonesimulator/
-rsync -a Release-iphonesimulator/FluentUILib.swiftmodule/ nuget/Ship-iphonesimulator/FluentUILib.swiftmodule/
+rsync -a Release-iphonesimulator/libFluentUI.a nuget/Ship-iphonesimulator/
+rsync -a Release-iphonesimulator/FluentUI.swiftmodule/ nuget/Ship-iphonesimulator/FluentUI.swiftmodule/
 rsync -a Release-iphonesimulator/FluentUIResources-ios.bundle/ nuget/Ship-iphonesimulator/FluentUIResources-ios.bundle/
 
 # cd into our nuget folder to finally zip up our build output


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This is to close #306 

Our iOS static library and framework had different names, which meant the compiled products had different symbols, which prevented interop if another library (like FluentUI React Native) was expecting symbols the framework provided, but got symbols the static library provided.

Renaming the Product in xcode to "FluentUI" explicitly solves this.
Let's also update our CI pipeline to still properly find the compiled libraries and pack appropriately.

Note: This is a breaking change, as every `import FluentUILib` must now be a `import FluentUI`

### Verification

Locally created the static libraries and copied them into my office enlistment. Made sure that office compiled and ran for the scenario I was testing

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/317)