### PR TITLE
Updating FluentUI-iOS-StaticLib.xcscheme with new static lib name.

### DIFF
--- a/ios/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUI-iOS-StaticLib.xcscheme
+++ b/ios/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUI-iOS-StaticLib.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8FD01165228A820600D25925"
-               BuildableName = "libFluentUILib.a"
+               BuildableName = "libFluentUI.a"
                BlueprintName = "FluentUILib"
                ReferencedContainer = "container:FluentUI.xcodeproj">
             </BuildableReference>
@@ -44,7 +44,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8FD01165228A820600D25925"
-            BuildableName = "libFluentUILib.a"
+            BuildableName = "libFluentUI.a"
             BlueprintName = "FluentUILib"
             ReferencedContainer = "container:FluentUI.xcodeproj">
          </BuildableReference>
@@ -60,7 +60,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8FD01165228A820600D25925"
-            BuildableName = "libFluentUILib.a"
+            BuildableName = "libFluentUI.a"
             BlueprintName = "FluentUILib"
             ReferencedContainer = "container:FluentUI.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#317 renamed the static library from libFluentUILib.a to libFluentUI.a.
This change consists of updating the xcscheme file to match that name update.

### Verification

Built and ran the Demo app and ensured the xccheme file wasn't changed any longer.
### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/319)