### PR TITLE
Expose Button properties

### DIFF
--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -25,7 +25,7 @@ open class Button: NSButton {
 	@objc public init(title: String, style: ButtonStyle = .primaryFilled) {
 		super.init(frame: .zero)
 		initialize(title: title, image: nil, style: style)
-    }
+	}
 
 	/// Initializes a Fluent UI Button with an image, setting the imagePosition to imageOnly
 	/// - Parameters:
@@ -35,7 +35,7 @@ open class Button: NSButton {
 		super.init(frame: .zero)
 		imagePosition = .imageOnly
 		initialize(title: nil, image: image, style: style)
-    }
+	}
 	
 	
 	/// Initializes a Fluent UI Button with a title,  image,  imagePosition, and style
@@ -48,14 +48,14 @@ open class Button: NSButton {
 		super.init(frame: .zero)
 		self.imagePosition = imagePosition
 		initialize(title: title, image: image, style: style)
-    }
+	}
 
 	/// Initializes a Fluent UI Button
 	/// Set style to primaryFilled as default
 	@objc public init() {
 		super.init(frame: .zero)
 		initialize(title: nil, image: nil, style: .primaryFilled)
-    }
+	}
 
 	@available(*, unavailable)
 	required public init?(coder decoder: NSCoder) {
@@ -152,7 +152,7 @@ open class Button: NSButton {
 	open override func updateLayer() {
 		if let layer = layer {
 			layer.borderWidth = Button.borderWidth
-			layer.cornerRadius = Button.cornerRadius
+			layer.cornerRadius = self.cornerRadius
 			layer.backgroundColor = layerBackgroundColor.cgColor
 			layer.borderColor = outlineColor.cgColor
 		}
@@ -201,6 +201,11 @@ open class Button: NSButton {
 	@objc public var style: ButtonStyle = .primaryFilled {
 		didSet {
 			if style != oldValue {
+				if style == .primaryFilled {
+					contentTintColor = .white
+				} else {
+					contentTintColor = primaryColor
+				}
 				needsDisplay = true
 			}
 		}
@@ -228,16 +233,15 @@ open class Button: NSButton {
 		}
 	}
 
-	private var restBackgroundColor: NSColor {
-		return fillColor
-	}
-
+	@objc public var restBackgroundColor: NSColor? = nil
+	@objc public var cornerRadius: CGFloat = 3
+	
 	private var hoverBackgroundColor: NSColor {
-		return fillColor.withSystemEffect(.rollover)
+		return restBackgroundColor?.withSystemEffect(.rollover) ?? fillColor.withSystemEffect(.rollover)
 	}
 
 	private var pressedBackgroundColor: NSColor {
-		return fillColor.withSystemEffect(.pressed)
+		return restBackgroundColor?.withSystemEffect(.pressed) ?? fillColor.withSystemEffect(.pressed)
 	}
 
 	private var layerBackgroundColor: NSColor {
@@ -247,10 +251,10 @@ open class Button: NSButton {
 			} else if mouseEntered {
 				return hoverBackgroundColor
 			} else {
-				return restBackgroundColor
+				return restBackgroundColor == nil ? fillColor : restBackgroundColor!
 			}
 		} else {
-			return disabledColor(for: fillColor)
+			return disabledColor(for: restBackgroundColor ?? fillColor)
 		}
 	}
 
@@ -454,8 +458,6 @@ open class Button: NSButton {
 
 
 	private static let borderWidth: CGFloat = 1
-
-	private static let cornerRadius: CGFloat = 3
 
 	private static let verticalEdgePadding: CGFloat = 4
 

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -41,7 +41,7 @@ open class Button: NSButton {
 	/// Initializes a Fluent UI Button with a title,  image,  imagePosition, and style
 	/// - Parameters:
 	///   - title: String displayed in the button
-	///   - image: The NSImage to diplay in the button
+	///   - image: The NSImage to display in the button
 	///   - imagePosition: The position of the image, relative to the title
 	///   - style: The ButtonStyle, defaulting to primaryFilled
 	@objc public init(title: String, image: NSImage, imagePosition: NSControl.ImagePosition, style: ButtonStyle = .primaryFilled) {
@@ -92,6 +92,7 @@ open class Button: NSButton {
 		set {}
 	}
 	
+	/// Image display in the button
 	override public var image: NSImage? {
 		willSet {
 			guard wantsLayer == true else {
@@ -100,6 +101,7 @@ open class Button: NSButton {
 		}
 	}
 	
+	/// String display in the button
 	override public var title: String {
 		willSet {
 			guard wantsLayer == true else {
@@ -174,6 +176,7 @@ open class Button: NSButton {
 		}
 	}
 	
+	/// Tint color of the button content.
 	open override var contentTintColor: NSColor? {
 		get {
 			if style == .primaryFilled {
@@ -211,6 +214,9 @@ open class Button: NSButton {
 		}
 	}
 
+	/// Background color in rest state. Hover and pressed state colors will adjust accordingly using the systemEffect.
+	@objc public var restBackgroundColor: NSColor? = nil
+	
 	private func disabledColor(for color: NSColor) -> NSColor {
 		return color.withSystemEffect(.disabled)
 	}
@@ -232,8 +238,6 @@ open class Button: NSButton {
 			return disabledColor(for: baseOutlineColor)
 		}
 	}
-
-	@objc public var restBackgroundColor: NSColor? = nil
 	
 	private var hoverBackgroundColor: NSColor {
 		return restBackgroundColor?.withSystemEffect(.rollover) ?? fillColor.withSystemEffect(.rollover)

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -215,7 +215,13 @@ open class Button: NSButton {
 	}
 
 	/// Background color in rest state. Hover and pressed state colors will adjust accordingly using the systemEffect.
-	@objc public var restBackgroundColor: NSColor? = nil
+	@objc public lazy var restBackgroundColor: NSColor  = fillColor {
+		didSet {
+			if restBackgroundColor != oldValue {
+				needsDisplay = true
+			}
+		}
+	}
 	
 	private func disabledColor(for color: NSColor) -> NSColor {
 		return color.withSystemEffect(.disabled)
@@ -240,11 +246,11 @@ open class Button: NSButton {
 	}
 	
 	private var hoverBackgroundColor: NSColor {
-		return restBackgroundColor?.withSystemEffect(.rollover) ?? fillColor.withSystemEffect(.rollover)
+		return restBackgroundColor.withSystemEffect(.rollover)
 	}
 
 	private var pressedBackgroundColor: NSColor {
-		return restBackgroundColor?.withSystemEffect(.pressed) ?? fillColor.withSystemEffect(.pressed)
+		return restBackgroundColor.withSystemEffect(.pressed)
 	}
 
 	private var layerBackgroundColor: NSColor {
@@ -254,10 +260,10 @@ open class Button: NSButton {
 			} else if mouseEntered {
 				return hoverBackgroundColor
 			} else {
-				return restBackgroundColor == nil ? fillColor : restBackgroundColor!
+				return restBackgroundColor
 			}
 		} else {
-			return disabledColor(for: restBackgroundColor ?? fillColor)
+			return disabledColor(for: restBackgroundColor)
 		}
 	}
 

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -177,7 +177,7 @@ open class Button: NSButton {
 	}
 	
 	/// Tint color of the button content.
-	open override var contentTintColor: NSColor? {
+	@objc override public var contentTintColor: NSColor? {
 		get {
 			if style == .primaryFilled {
 				return .white
@@ -467,7 +467,7 @@ open class Button: NSButton {
 
 
 	private static let borderWidth: CGFloat = 1
-	
+
 	private static let cornerRadius: CGFloat = 3
 
 	private static let verticalEdgePadding: CGFloat = 4

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -152,7 +152,7 @@ open class Button: NSButton {
 	open override func updateLayer() {
 		if let layer = layer {
 			layer.borderWidth = Button.borderWidth
-			layer.cornerRadius = self.cornerRadius
+			layer.cornerRadius = Button.cornerRadius
 			layer.backgroundColor = layerBackgroundColor.cgColor
 			layer.borderColor = outlineColor.cgColor
 		}
@@ -234,7 +234,6 @@ open class Button: NSButton {
 	}
 
 	@objc public var restBackgroundColor: NSColor? = nil
-	@objc public var cornerRadius: CGFloat = 3
 	
 	private var hoverBackgroundColor: NSColor {
 		return restBackgroundColor?.withSystemEffect(.rollover) ?? fillColor.withSystemEffect(.rollover)
@@ -458,6 +457,8 @@ open class Button: NSButton {
 
 
 	private static let borderWidth: CGFloat = 1
+	
+	private static let cornerRadius: CGFloat = 3
 
 	private static let verticalEdgePadding: CGFloat = 4
 

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -14,21 +14,35 @@ class TestButtonViewController: NSViewController {
 			NSTextField(labelWithString: "Primary Filled"),
 			NSTextField(labelWithString: "Primary Outline"),
 			NSTextField(labelWithString: "Borderless"),
+			NSTextField(labelWithString: "Custom Button"),
 		]
-
+		
+		let customButton = Button(title: "Custom Button")
+		customButton.restBackgroundColor = Colors.Palette.orangeYellow20.color
+		customButton.cornerRadius = 0
+		customButton.contentTintColor = Colors.Palette.warningPrimary.color
+		
 		let buttonsWithTitle: () -> [NSButton] = {
 			return [
 				Button(title: "FluentUI Button", style: .primaryFilled),
 				Button(title: "FluentUI Button", style: .primaryOutline),
 				Button(title: "FluentUI Button", style: .borderless),
+				customButton,
 			]
 		}
 
+		let customButtonWithImage = Button()
+		customButtonWithImage.restBackgroundColor = Colors.Palette.warningPrimary.color
+		customButtonWithImage.cornerRadius = 5
+		customButtonWithImage.image = NSImage(named: NSImage.stopProgressTemplateName)!
+		customButtonWithImage.contentTintColor = Colors.Palette.red20.color
+		
 		let buttonsWithImage: () -> [NSButton] = {
 			return [
 				Button(image: NSImage(named: NSImage.stopProgressTemplateName)!, style: .primaryFilled),
 				Button(image: NSImage(named: NSImage.stopProgressTemplateName)!, style: .primaryOutline),
 				Button(image: NSImage(named: NSImage.stopProgressTemplateName)!, style: .borderless),
+				customButtonWithImage,
 			]
 		}
 		
@@ -41,6 +55,7 @@ class TestButtonViewController: NSViewController {
 				Button(title: "Back", image: leadingArrowImage, imagePosition: .imageLeading, style: .primaryFilled),
 				Button(title: "Skip", image: trailingArrowImage, imagePosition: .imageTrailing, style: .primaryOutline),
 				Button(title: "Back", image: leadingArrowImage, imagePosition: .imageLeading, style: .borderless),
+				Button(title: "Custom Button", image: trailingArrowImage, imagePosition: .imageTrailing, style: .primaryOutline),
 			]
 		}
 		

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -97,7 +97,7 @@ class TestButtonViewController: NSViewController {
 		gridView.addColumn(with: buttonsWithImage())
 		gridView.addColumn(with: buttonsWithTitleAndImage())
 		gridView.addColumn(with: disabledButtons())
-		
+
 		let emptyCell = NSGridCell.emptyContentView
 	
 		// Insert the Row Titles as the last step

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -19,7 +19,6 @@ class TestButtonViewController: NSViewController {
 		
 		let customButton = Button(title: "Custom Button")
 		customButton.restBackgroundColor = Colors.Palette.orangeYellow20.color
-		customButton.cornerRadius = 0
 		customButton.contentTintColor = Colors.Palette.warningPrimary.color
 		
 		let buttonsWithTitle: () -> [NSButton] = {
@@ -33,7 +32,6 @@ class TestButtonViewController: NSViewController {
 
 		let customButtonWithImage = Button()
 		customButtonWithImage.restBackgroundColor = Colors.Palette.warningPrimary.color
-		customButtonWithImage.cornerRadius = 5
 		customButtonWithImage.image = NSImage(named: NSImage.stopProgressTemplateName)!
 		customButtonWithImage.contentTintColor = Colors.Palette.red20.color
 		

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -18,8 +18,8 @@ class TestButtonViewController: NSViewController {
 		]
 		
 		let customButton = Button(title: "Custom Button")
-		customButton.restBackgroundColor = Colors.Palette.orangeYellow20.color
-		customButton.contentTintColor = Colors.Palette.warningPrimary.color
+		customButton.restBackgroundColor = Colors.Palette.green20.color
+		customButton.contentTintColor = .white
 		
 		let buttonsWithTitle: () -> [NSButton] = {
 			return [
@@ -31,9 +31,9 @@ class TestButtonViewController: NSViewController {
 		}
 
 		let customButtonWithImage = Button()
-		customButtonWithImage.restBackgroundColor = Colors.Palette.warningPrimary.color
+		customButtonWithImage.restBackgroundColor = Colors.Palette.communicationBlue.color
 		customButtonWithImage.image = NSImage(named: NSImage.stopProgressTemplateName)!
-		customButtonWithImage.contentTintColor = Colors.Palette.red20.color
+		customButtonWithImage.contentTintColor = .white
 		
 		let buttonsWithImage: () -> [NSButton] = {
 			return [
@@ -47,19 +47,44 @@ class TestButtonViewController: NSViewController {
 		let leadingArrowImage = NSImage(named: TestButtonViewController.leadingArrow)!
 		let trailingArrowImage = NSImage(named: TestButtonViewController.trailingArrow)!
 		
+		let customButtonWithTitleAndImage = Button()
+		customButtonWithTitleAndImage.title = "BtnTitle+Img"
+		customButtonWithTitleAndImage.contentTintColor = .white
+		customButtonWithTitleAndImage.image = trailingArrowImage
+		customButtonWithTitleAndImage.imagePosition = .imageTrailing
+		customButtonWithTitleAndImage.restBackgroundColor = Colors.Palette.blueMagenta30.color
 		
 		let buttonsWithTitleAndImage: () -> [NSButton] = {
 			return [
 				Button(title: "Back", image: leadingArrowImage, imagePosition: .imageLeading, style: .primaryFilled),
 				Button(title: "Skip", image: trailingArrowImage, imagePosition: .imageTrailing, style: .primaryOutline),
 				Button(title: "Back", image: leadingArrowImage, imagePosition: .imageLeading, style: .borderless),
-				Button(title: "Custom Button", image: trailingArrowImage, imagePosition: .imageTrailing, style: .primaryOutline),
+				customButtonWithTitleAndImage,
 			]
 		}
 		
-		let disabledButtonsWithTitleAndImage = buttonsWithTitleAndImage().map { button -> NSButton in
-			button.isEnabled = false
-			return button
+		let customDisabledButton = Button()
+		customDisabledButton.title = "DisabledWithImg"
+		customDisabledButton.contentTintColor = .white
+		customDisabledButton.restBackgroundColor = Colors.Palette.blueMagenta30.color
+		customDisabledButton.image = leadingArrowImage
+		customDisabledButton.imagePosition = .imageLeading
+		customDisabledButton.isEnabled = false
+		
+		let disabledPrimaryFilled = Button(title: "PrimaryFilled disbaled", style: .primaryFilled)
+		let disabledPrimaryOutline = Button(title: "PrimaryOutline disabled", style: .primaryOutline)
+		let disabledBorderless = Button(title: "Borderless disabled", style: .borderless)
+		disabledPrimaryFilled.isEnabled = false
+		disabledPrimaryOutline.isEnabled = false
+		disabledBorderless.isEnabled = false
+		
+		let disabledButtons: () -> [NSButton] = {
+			return [
+				disabledPrimaryFilled,
+				disabledPrimaryOutline,
+				disabledBorderless,
+				customDisabledButton,
+			]
 		}
 
 		let gridView = NSGridView(frame: .zero)
@@ -71,8 +96,8 @@ class TestButtonViewController: NSViewController {
 		gridView.addColumn(with: buttonsWithTitle())
 		gridView.addColumn(with: buttonsWithImage())
 		gridView.addColumn(with: buttonsWithTitleAndImage())
-		gridView.addColumn(with: disabledButtonsWithTitleAndImage)
-
+		gridView.addColumn(with: disabledButtons())
+		
 		let emptyCell = NSGridCell.emptyContentView
 	
 		// Insert the Row Titles as the last step


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS

### Description of changes
Although Mac design toolkit is still work in progress, let's expose some of the fundamental properties that FluentUI React Native will need to customize. 

Let's expose:
contentTintColor - button content tint color
restBackgroundColor - button background color
cornerRadius - button corner radius

### Verification
Added customized button test cases to demo app:
![image](https://user-images.githubusercontent.com/67026167/99868255-f0c93280-2b8e-11eb-9c33-c4e9808c5b2f.png)
Tested exposed props in JS
![image](https://user-images.githubusercontent.com/67026167/99835294-68b53f80-2b32-11eb-9465-1b1f86b0aabf.png)



### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/321)