### PR TITLE
MSFCenterLabelCell larger text support

### DIFF
--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -221,26 +221,6 @@ extension PersonaListView: UITableViewDataSource {
 // MARK: - PersonaListView: UITableViewDelegate
 
 extension PersonaListView: UITableViewDelegate {
-    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        guard let section = Section(rawValue: indexPath.section) else {
-            preconditionFailure("heightForRowAtIndexPath: too many sections")
-        }
-
-        switch section {
-        case .personas:
-            return UITableView.automaticDimension
-        case .searchDirectory:
-            switch searchDirectoryState {
-            case .searching:
-                return ActivityIndicatorCell.defaultHeight
-            case .displayingSearchResults:
-                return CenteredLabelCell.defaultHeight
-            case .idle:
-                return ActionsCell.defaultHeight
-            }
-        }
-    }
-
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // Deselecting row affects voice over focus, calling `deselectRowAtIndexPath` before `onPersonaSelected` would help.
         tableView.deselectRow(at: indexPath, animated: false)

--- a/ios/FluentUI/Table View/ActionsCell.swift
+++ b/ios/FluentUI/Table View/ActionsCell.swift
@@ -238,7 +238,7 @@ open class ActionsCell: UITableViewCell {
         }
 
     }
-    
+
     private struct Constants {
         static let horizontalSpacing: CGFloat = 16
         static let verticalMargin: CGFloat = 11

--- a/ios/FluentUI/Table View/ActionsCell.swift
+++ b/ios/FluentUI/Table View/ActionsCell.swift
@@ -48,12 +48,6 @@ open class ActionsCell: UITableViewCell {
         }
     }
 
-    private struct Constants {
-        static let horizontalSpacing: CGFloat = 16
-        static let verticalMargin: CGFloat = 12
-    }
-
-    public static let defaultHeight: CGFloat = 45
     public static let identifier: String = "ActionsCell"
 
     @objc public class func height(action1Title: String, action2Title: String = "", containerWidth: CGFloat) -> CGFloat {
@@ -64,7 +58,7 @@ open class ActionsCell: UITableViewCell {
         let action1TitleHeight = action1Title.preferredSize(for: actionTitleFont, width: width).height
         let action2TitleHeight = action2Title.preferredSize(for: actionTitleFont, width: width).height
 
-        return max(Constants.verticalMargin * 2 + max(action1TitleHeight, action2TitleHeight), defaultHeight)
+        return max(Constants.verticalMargin * 2 + max(action1TitleHeight, action2TitleHeight), Constants.defaultHeight)
     }
 
     @objc public class func preferredWidth(action1Title: String, action2Title: String = "") -> CGFloat {
@@ -243,5 +237,11 @@ open class ActionsCell: UITableViewCell {
             }
         }
 
+    }
+    
+    private struct Constants {
+        static let horizontalSpacing: CGFloat = 16
+        static let verticalMargin: CGFloat = 11
+        static let defaultHeight: CGFloat = 48
     }
 }

--- a/ios/FluentUI/Table View/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Table View/ActivityIndicatorCell.swift
@@ -13,7 +13,6 @@ public typealias MSActivityIndicatorCell = ActivityIndicatorCell
 @objc(MSFActivityIndicatorCell)
 open class ActivityIndicatorCell: UITableViewCell {
     public static let identifier: String = "ActivityIndicatorCell"
-    public static let defaultHeight: CGFloat = 45
 
     private let activityIndicatorView: ActivityIndicatorView = {
         let activityIndicatorView = ActivityIndicatorView(size: .small)
@@ -42,7 +41,18 @@ open class ActivityIndicatorCell: UITableViewCell {
         activityIndicatorView.startAnimating()
     }
 
+    open override var intrinsicContentSize: CGSize {
+        return sizeThatFits(CGSize(width: CGFloat.infinity, height: .infinity))
+    }
+
+    open override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let maxWidth = size.width != 0 ? size.width : .infinity
+        return CGSize(width: maxWidth, height: ActivityIndicatorCell.defaultHeight)
+    }
+
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
 
     open override func setSelected(_ selected: Bool, animated: Bool) { }
+
+    private static let defaultHeight: CGFloat = 48
 }

--- a/ios/FluentUI/Table View/CenteredLabelCell.swift
+++ b/ios/FluentUI/Table View/CenteredLabelCell.swift
@@ -13,18 +13,14 @@ public typealias MSCenteredLabelCell = CenteredLabelCell
 @objc(MSFCenteredLabelCell)
 open class CenteredLabelCell: UITableViewCell {
     public static let identifier: String = "CenteredLabelCell"
-    public static let defaultHeight: CGFloat = 45
-
-    private struct Constants {
-        static let labelFont: UIFont = Fonts.body
-        static let paddingVerticalSmall: CGFloat = 5
-    }
 
     // Public to be able to change style without wrapping every property
     public let label: UILabel = {
         let label = UILabel()
         label.backgroundColor = .clear
         label.font = Constants.labelFont
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
         return label
     }()
 
@@ -46,6 +42,19 @@ open class CenteredLabelCell: UITableViewCell {
         setNeedsLayout()
     }
 
+    open override var intrinsicContentSize: CGSize {
+        return sizeThatFits(CGSize(width: CGFloat.infinity, height: .infinity))
+    }
+
+    open override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let maxWidth = size.width != 0 ? size.width : .infinity
+
+        let labelWidthArea = maxWidth - layoutMargins.left - layoutMargins.right
+        let labelFittingSize = label.sizeThatFits(CGSize(width: labelWidthArea, height: CGFloat.greatestFiniteMagnitude))
+        let height = max(Constants.paddingVertical * 2 + ceil(labelFittingSize.height), Constants.defaultHeight)
+        return CGSize(width: maxWidth, height: height)
+    }
+
     open override func layoutSubviews() {
         super.layoutSubviews()
         let labelFittingSize = label.sizeThatFits(CGSize(width: contentView.frame.width - layoutMargins.left - layoutMargins.right, height: CGFloat.greatestFiniteMagnitude))
@@ -63,4 +72,10 @@ open class CenteredLabelCell: UITableViewCell {
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
 
     open override func setSelected(_ selected: Bool, animated: Bool) { }
+
+    private struct Constants {
+        static let labelFont: UIFont = Fonts.body
+        static let paddingVertical: CGFloat = 11
+        static let defaultHeight: CGFloat = 48
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Make sure MSFCenterLabelCell adhere to larger text size settings
Make sure CenterLabelCell, ActivityIndicatorCell and ActionsCell default height is 48 pt just like single line TableViewCell

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-23 at 17 05 01](https://user-images.githubusercontent.com/20715435/100033122-63642900-2dae-11eb-9395-b82f62a11042.png)| ![new_centercell](https://user-images.githubusercontent.com/20715435/100033639-6f9cb600-2daf-11eb-887b-cff4c006714e.png) |
|![old_personalist](https://user-images.githubusercontent.com/20715435/100033669-7e836880-2daf-11eb-9e81-e7ecd756ff8e.png)|![new_peoplepicker](https://user-images.githubusercontent.com/20715435/100033675-82af8600-2daf-11eb-8717-d6374a14795f.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/322)