### PR TITLE
Add Separator thickness constant

### DIFF
--- a/ios/FluentUI/Controls/Separator.swift
+++ b/ios/FluentUI/Controls/Separator.swift
@@ -70,15 +70,20 @@ open class Separator: UIView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+    /**
+     The default thickness for the separator: one device pixel
+    */
+    @objc public static var thickness: CGFloat { return UIScreen.main.devicePixel }
+
     private func initialize(style: SeparatorStyle, orientation: SeparatorOrientation) {
         super.backgroundColor = style.color
         self.orientation = orientation
         switch orientation {
         case .horizontal:
-            frame.size.height = UIScreen.main.devicePixel
+            frame.size.height = Separator.thickness
             autoresizingMask = .flexibleWidth
         case .vertical:
-            frame.size.width = UIScreen.main.devicePixel
+            frame.size.width = Separator.thickness
             autoresizingMask = .flexibleHeight
         }
         isAccessibilityElement = false


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Add a constant that represents the default thickness of the Separator.

### Verification

Verified that the separator thickness does not change.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/329)