### PR TITLE
Fixing "Do not disturb" color.

### DIFF
--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -262,7 +262,7 @@ public final class Colors: NSObject {
             case .presenceBusy:
                 return "presenceBusy"
             case .presenceDnd:
-                return "presenceOffline"
+                return "presenceDnd"
             case .presenceOffline:
                 return "presenceOffline"
             case .presenceOof:

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -237,7 +237,7 @@ public final class Colors: NSObject {
 			case .presenceBusy:
 				return "presenceBusy"
 			case .presenceDnd:
-				return "presenceOffline"
+				return "presenceDnd"
 			case .presenceOffline:
 				return "presenceOffline"
 			case .presenceOof:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

Fixing incorrect string representation of the "Do not disturb" enum.
This also impacts the color returned by the presence enumeration.

### Verification

**iOS**
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ios_before](https://user-images.githubusercontent.com/68076145/101544445-8e2bb100-395a-11eb-8c31-8183886e3302.png) | ![ios_after](https://user-images.githubusercontent.com/68076145/101544468-95eb5580-395a-11eb-9e78-b51110df727b.png) |

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![macos_before](https://user-images.githubusercontent.com/68076145/101544500-a4d20800-395a-11eb-931b-36ec895c6e4e.png) | ![macos_after](https://user-images.githubusercontent.com/68076145/101544518-ac91ac80-395a-11eb-904b-8b7fbdab4d27.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/332)