### PR TITLE
Adding DemoController for vNext prototype

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		114CF8B82423E10900D064AA /* ColorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114CF8B72423E10900D064AA /* ColorDemoController.swift */; };
 		22EABB182509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EABB172509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift */; };
+		3F11A4502582E70B00D3BEBC /* VXTDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F11A44F2582E70B00D3BEBC /* VXTDemoController.swift */; };
 		497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */; };
 		53B659B8257AA44F00070405 /* ButtonVnextDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B659B7257AA44F00070405 /* ButtonVnextDemoController.swift */; };
 		53B659C4257AA69E00070405 /* DrawerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DCA75D211E3A92005F4CB7 /* DrawerDemoController.swift */; };
@@ -77,6 +78,7 @@
 		114CF8B72423E10900D064AA /* ColorDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDemoController.swift; sourceTree = "<group>"; };
 		22EABB172509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
 		3D3224A9AADF58C324059464 /* Pods-FluentUI.Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FluentUI.Demo.release.xcconfig"; path = "Target Support Files/Pods-FluentUI.Demo/Pods-FluentUI.Demo.release.xcconfig"; sourceTree = "<group>"; };
+		3F11A44F2582E70B00D3BEBC /* VXTDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VXTDemoController.swift; sourceTree = "<group>"; };
 		497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarDemoController.swift; sourceTree = "<group>"; };
 		53B659B7257AA44F00070405 /* ButtonVnextDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonVnextDemoController.swift; sourceTree = "<group>"; };
 		606D7CD826903286E86B3099 /* Pods-FluentUI.Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FluentUI.Demo.debug.xcconfig"; path = "Target Support Files/Pods-FluentUI.Demo/Pods-FluentUI.Demo.debug.xcconfig"; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				E6842995247C350700A29C40 /* DemoColorThemeWindows.swift */,
 				A5DCA75F211E3B4C005F4CB7 /* DemoController.swift */,
 				A5CEC21120E436F10016922A /* DemoListViewController.swift */,
+				3F11A44F2582E70B00D3BEBC /* VXTDemoController.swift */,
 			);
 			name = Shell;
 			sourceTree = "<group>";
@@ -494,6 +497,7 @@
 				A5CEC21220E436F10016922A /* DemoListViewController.swift in Sources */,
 				B498141621E42C140077B48D /* TableViewCellDemoController.swift in Sources */,
 				FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */,
+				3F11A4502582E70B00D3BEBC /* VXTDemoController.swift in Sources */,
 				EC8EA6B02580D82A00F191CE /* ListVnextDemoController.swift in Sources */,
 				C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */,
 				C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -6,58 +6,57 @@
 import FluentUI
 import UIKit
 
-class HUDDemoController: DemoController {
+class HUDDemoController: VXTViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        container.alignment = .leading
         let showActivityButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showActivityHUD()
         })
         showActivityButton.state.text = "Show activity HUD"
-        container.addArrangedSubview(showActivityButton.view)
+        add(showActivityButton.hostingController)
 
         let showSuccessButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showSuccessHUD()
         })
         showSuccessButton.state.text = "Show success HUD"
-        container.addArrangedSubview(showSuccessButton.view)
+        add(showSuccessButton.hostingController)
 
         let showFailureButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showFailureHUD()
         })
         showFailureButton.state.text = "Show failure HUD"
-        container.addArrangedSubview(showFailureButton.view)
+        add(showFailureButton.hostingController)
 
         let showCustomButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showCustomHUD()
         })
         showCustomButton.state.text = "Show custom HUD"
-        container.addArrangedSubview(showCustomButton.view)
+        add(showCustomButton.hostingController)
 
         let showCustomNonBlockingButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showCustomNonBlockingHUD()
         })
         showCustomNonBlockingButton.state.text = "Show custom non-blocking HUD"
-        container.addArrangedSubview(showCustomNonBlockingButton.view)
+        add(showCustomNonBlockingButton.hostingController)
 
         let showNolabelButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showNoLabelHUD()
         })
         showNolabelButton.state.text = "Show HUD with no label"
-        container.addArrangedSubview(showNolabelButton.view)
+        add(showNolabelButton.hostingController)
 
         let showGestureButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showGestureHUD()
         })
         showGestureButton.state.text = "Show HUD with tap gesture callback"
-        container.addArrangedSubview(showGestureButton.view)
+        add(showGestureButton.hostingController)
 
         let showUpdatingButton = MSFButtonVnext(style: .secondary, size: .small, action: {
             self.showUpdateHUD()
         })
         showUpdatingButton.state.text = "Show HUD with updating caption"
-        container.addArrangedSubview(showUpdatingButton.view)
+        add(showUpdatingButton.hostingController)
     }
 
     @objc private func showActivityHUD() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
@@ -1,38 +1,39 @@
-  //
-  //  Copyright (c) Microsoft Corporation. All rights reserved.
-  //  Licensed under the MIT License.
-  //
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
 
-  import FluentUI
+import FluentUI
   import UIKit
 
-  class ListVnextDemoController: DemoController {
-      override func viewDidLoad() {
-          super.viewDidLoad()
-          container.alignment = .leading
-          let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
-          var section: TableViewCellSampleData.Section
-          var cell: TableViewCellSampleData.Item
-          let numSections = sections.count - 1
+  class ListVnextDemoController: VXTViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-          var list: MSFListVnext
-          var listItem: MSFListItem
-          var listItems: [MSFListItem]
-          let style = MSFListAccessoryVnextStyle.iconOnly
-          let size = MSFListAccessoryVnextSize.icon
+        let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
+        var section: TableViewCellSampleData.Section
+        var cell: TableViewCellSampleData.Item
+        let numSections = sections.count - 1
 
-          for count in 0...numSections {
-              section = sections[count]
-              cell = section.item
-              listItem = MSFListItem()
-              listItem.title = cell.text1
-              listItem.subtitle = cell.text2
-              listItem.leadingView = cell.image
-              listItems = [listItem, listItem, listItem, listItem, listItem]
-              list = MSFListVnext(cells: listItems, style: style, size: size)
-              addRow(items: [list.view])
-          }
+        var list: MSFListVnext?
+        var listItem: MSFListItem
+        var listItems: [MSFListItem]
+        let style = MSFListAccessoryVnextStyle.iconOnly
+        let size = MSFListAccessoryVnextSize.icon
 
-          container.addArrangedSubview(UIView())
-      }
+        for count in 0...numSections {
+            section = sections[count]
+            cell = section.item
+            listItem = MSFListItem()
+            listItem.title = cell.text1
+            listItem.subtitle = cell.text2
+            listItem.leadingView = cell.image
+            listItems = [listItem, listItem, listItem, listItem, listItem]
+            list = MSFListVnext(cells: listItems, style: style, size: size)
+
+            if let controller = list?.hostingController {
+                add(controller)
+            }
+        }
+    }
   }

--- a/ios/FluentUI.Demo/FluentUI.Demo/VXTDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/VXTDemoController.swift
@@ -1,0 +1,91 @@
+//
+//  VXTDemoController.swift
+//  FluentUI.Demo
+//
+//  Created by Kunal Balani on 12/10/20.
+//  Copyright © 2020 Microsoft Corporation. All rights reserved.
+//
+
+import UIKit
+
+class VXTViewController: UIViewController {
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(scrollView)
+
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fillEqually
+        stackView.spacing = 20
+        scrollView.addSubview(stackView)
+
+        updateConstraints()
+        view.backgroundColor = Colors.surfacePrimary
+    }
+
+    private func updateConstraints() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+
+            stackView.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.heightAnchor),
+            stackView.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor)
+        ])
+    }
+}
+
+extension VXTViewController {
+
+    func add(_ child: UIViewController) {
+        addChild(child)
+        stackView.addArrangedSubview(child.view)
+        child.didMove(toParent: self)
+    }
+
+    func remove(_ child: UIViewController) {
+        guard child.parent != nil else {
+            return
+        }
+
+        child.willMove(toParent: nil)
+        stackView.removeArrangedSubview(child.view)
+        child.view.removeFromSuperview()
+        child.removeFromParent()
+    }
+}
+
+// Copy/Paste from DemoController
+extension VXTViewController {
+    func showMessage(_ message: String, autoDismiss: Bool = true, completion: (() -> Void)? = nil) {
+        let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+        present(alert, animated: true)
+
+        if autoDismiss {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                self.dismiss(animated: true)
+            }
+        } else {
+            let okAction = UIAlertAction(title: "OK", style: .default) { _ in
+                self.dismiss(animated: true, completion: completion)
+            }
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+            alert.addAction(okAction)
+            alert.addAction(cancelAction)
+        }
+
+    }
+}

--- a/ios/FluentUI/Controls/ButtonVnext.swift
+++ b/ios/FluentUI/Controls/ButtonVnext.swift
@@ -148,6 +148,7 @@ public struct MSFButtonViewButtonStyle: ButtonStyle {
                 }
         }
         .padding(tokens.padding)
+        .frame(maxWidth: .infinity)
         .foregroundColor(Color(isDisabled ? tokens.disabledTitleColor :
                                 (isPressed ? tokens.highlightedTitleColor : tokens.titleColor)))
                     .background((tokens.borderSize > 0) ?
@@ -180,7 +181,7 @@ public struct MSFButtonView: View {
         Button(action: action, label: {})
             .buttonStyle(MSFButtonViewButtonStyle(targetButton: self))
             .disabled(state.isDisabled)
-            .fixedSize()
+            .frame(maxWidth: .infinity)
     }
 }
 
@@ -188,7 +189,7 @@ public struct MSFButtonView: View {
 /// UIKit wrapper that exposes the SwiftUI Button implementation
 open class MSFButtonVnext: NSObject {
 
-    private var hostingController: UIHostingController<MSFButtonView>
+    public var hostingController: UIHostingController<MSFButtonView>
 
     @objc open var view: UIView {
         return hostingController.view

--- a/ios/FluentUI/Table View/ListVnext.swift
+++ b/ios/FluentUI/Table View/ListVnext.swift
@@ -125,15 +125,13 @@
                   Spacer()
               }
           }
-          //Frame modifier is a temporary fix for constraint issue. This should be removed in the future.
-          .frame(width: 400, height: 250, alignment: .center)
       }
   }
 
   @objc(MSFListVnext)
   open class MSFListVnext: NSObject {
 
-      private var hostingController: UIHostingController<MSFListView>
+      public var hostingController: UIHostingController<MSFListView>
 
       @objc open var view: UIView {
           return hostingController.view


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Since UIHostingViewControllers need containment API to add/remove subview the existing `DemoController` doesn't respect content size API while adding on top of `UIStackView`. 

A new DemoController base class is added that adds `UIViewController` instead of `UIView` and shields the complexity of containment API's.

More about APIs can be found [here](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/ImplementingaContainerViewController.html)

> ```objective-c
>  - (void) displayContentController: (UIViewController*) content {
>    [self addChildViewController:content];
>    content.view.frame = [self frameForContentController];
>    [self.view addSubview:self.currentClientView];
>    [content didMoveToParentViewController:self];
> }
> ```

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [X] Device rotation

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/337)