### PR TITLE
Replacing MSFButton with MSFButtonVnext in the Demo app.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -38,12 +38,9 @@ class DemoController: UIViewController {
 
     var allowsContentToScroll: Bool { return true }
 
-    func createButton(title: String, action: Selector) -> MSFButton {
-        let button = MSFButton()
-        button.titleLabel?.textAlignment = .center
-        button.titleLabel?.numberOfLines = 0
-        button.setTitle(title, for: .normal)
-        button.addTarget(self, action: action, for: .touchUpInside)
+    func createButton(title: String, action: (( MSFButtonVnext) -> Void)?) -> MSFButtonVnext {
+        let button = MSFButtonVnext(style: .secondary, size: .small, action: action)
+        button.state.text = title
         return button
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupViewDemoController.swift
@@ -113,7 +113,10 @@ class AvatarGroupViewDemoController: DemoController {
         backgroundColorSwitch.addTarget(self, action: #selector(toggleAlternateBackground(switchView:)), for: .valueChanged)
 
         addRow(text: "Use alternate background color", items: [backgroundColorSwitch], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
+
+        maxAvatarButton.view.widthAnchor.constraint(equalToConstant: 50).isActive = true
         addRow(text: "Max displayed avatars", items: [UIStackView(arrangedSubviews: [maxAvatarsTextField, maxAvatarButton.view])], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
+        overflowCountButton.view.widthAnchor.constraint(equalToConstant: 50).isActive = true
         addRow(text: "Overflow count", items: [UIStackView(arrangedSubviews: [overflowCountTextField, overflowCountButton.view])], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
 
         insertLabel(text: "Avatar stack without borders")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonVnextDemoController.swift
@@ -16,27 +16,36 @@ class ButtonVnextDemoController: DemoController {
             for style in MSFButtonVnextStyle.allCases {
                 addDescription(text: "\(style.description) style:", textAlignment: .natural)
 
-                let button = MSFButtonVnext(style: style, size: size) {
-                    self.didPressButton()
-                }
+                let button = MSFButtonVnext(style: style, size: size, action: { [weak self] _ in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    strongSelf.didPressButton()
+                })
                 button.state.text = "Button"
 
-                let disabledButton = MSFButtonVnext(style: style, size: size) {
-                    self.didPressButton()
-                }
+                let disabledButton = MSFButtonVnext(style: style, size: size, action: { [weak self] _ in
+                    guard let strongSelf = self else {
+                        return
+                        
+                    }
+
+                    strongSelf.didPressButton()
+                })
                 disabledButton.state.text = "Button"
                 disabledButton.state.isDisabled = true
 
                 addRow(items: [button.view, disabledButton.view], itemSpacing: 20)
 
                 if let image = style.image {
-                    let iconButton = MSFButtonVnext(style: style, size: size) {
+                    let iconButton = MSFButtonVnext(style: style, size: size) {_ in
                         self.didPressButton()
                     }
                     iconButton.state.text = "Button"
                     iconButton.state.image = image
 
-                    let disabledIconButton = MSFButtonVnext(style: style, size: size) {
+                    let disabledIconButton = MSFButtonVnext(style: style, size: size) {_ in
                         self.didPressButton()
                     }
                     disabledIconButton.state.isDisabled = true
@@ -45,14 +54,24 @@ class ButtonVnextDemoController: DemoController {
 
                     addRow(items: [iconButton.view, disabledIconButton.view], itemSpacing: 20)
 
-                    let iconOnlyButton = MSFButtonVnext(style: style, size: size) {
-                        self.didPressButton()
-                    }
+                    let iconOnlyButton = MSFButtonVnext(style: style, size: size, action: { [weak self] _ in
+                        guard let strongSelf = self else {
+                            return
+                            
+                        }
+
+                        strongSelf.didPressButton()
+                    })
                     iconOnlyButton.state.image = image
 
-                    let disabledIconOnlyButton = MSFButtonVnext(style: style, size: size) {
-                        self.didPressButton()
-                    }
+                    let disabledIconOnlyButton = MSFButtonVnext(style: style, size: size, action: { [weak self] _ in
+                        guard let strongSelf = self else {
+                            return
+                            
+                        }
+
+                        strongSelf.didPressButton()
+                    })
                     disabledIconOnlyButton.state.isDisabled = true
                     disabledIconOnlyButton.state.image = image
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
@@ -36,16 +36,81 @@ class DateTimePickerDemoController: DemoController {
         dateLabel.adjustsFontSizeToFitWidth = true
 
         container.addArrangedSubview(dateLabel)
-        container.addArrangedSubview(createButton(title: "Show date picker", action: #selector(presentDatePicker)))
-        container.addArrangedSubview(createButton(title: "Show date time picker", action: #selector(presentDateTimePicker)))
-        container.addArrangedSubview(createButton(title: "Show date range picker (paged)", action: #selector(presentDateRangePicker)))
-        container.addArrangedSubview(createButton(title: "Show date range picker (tabbed)", action: #selector(presentTabbedDateRangePicker)))
-        container.addArrangedSubview(createButton(title: "Show date time range picker", action: #selector(presentDateTimeRangePicker)))
-        container.addArrangedSubview(createButton(title: "Show picker with custom subtitles or tabs", action: #selector(presentCustomSubtitlePicker)))
+        container.addArrangedSubview(createButton(title: "Show date picker", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dateTimePicker.present(from: strongSelf, with: .date, startDate: strongSelf.startDate ?? Date(), datePickerType: strongSelf.datePickerType)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show date time picker", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dateTimePicker.present(from: strongSelf, with: .dateTime, startDate: strongSelf.startDate ?? Date(), datePickerType: strongSelf.datePickerType)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show date range picker (paged)", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let startDate = strongSelf.startDate ?? Date()
+            let endDate = strongSelf.endDate ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? startDate
+            strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show date range picker (tabbed)", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let startDate = strongSelf.startDate ?? Date()
+            let endDate = strongSelf.endDate ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? startDate
+            strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType, dateRangePresentation: .tabbed)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show date time range picker", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let startDate = strongSelf.startDate ?? Date()
+            let endDate = strongSelf.endDate ?? Calendar.current.date(byAdding: .hour, value: 1, to: startDate) ?? startDate
+            strongSelf.dateTimePicker.present(from: strongSelf, with: .dateTimeRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show picker with custom subtitles or tabs", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let startDate = strongSelf.startDate ?? Date()
+            let endDate = strongSelf.endDate ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? startDate
+            let titles: DateTimePicker.Titles
+            if strongSelf.datePickerType == .calendar && !UIAccessibility.isVoiceOverRunning {
+                titles = .with(startSubtitle: "Assignment Date", endSubtitle: "Due Date")
+            } else {
+                titles = .with(startTab: "Assignment Date", endTab: "Due Date")
+            }
+            strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType, titles: titles)
+        }).view)
+
         container.addArrangedSubview(UIView())
         container.addArrangedSubview(createDatePickerTypeUI())
         container.addArrangedSubview(createValidationUI())
-        container.addArrangedSubview(createButton(title: "Reset selected dates", action: #selector(resetDates)))
+
+        container.addArrangedSubview(createButton(title: "Reset selected dates", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.startDate = nil
+            strongSelf.endDate = nil
+            strongSelf.dateLabel.text = "No date selected"
+        }).view)
     }
 
     func createDatePickerTypeUI() -> UIStackView {
@@ -77,50 +142,6 @@ class DateTimePickerDemoController: DemoController {
         validationRow.addArrangedSubview(validationLabel)
         validationRow.addArrangedSubview(validationSwitch)
         return validationRow
-    }
-
-    @objc func presentDatePicker() {
-        dateTimePicker.present(from: self, with: .date, startDate: startDate ?? Date(), datePickerType: datePickerType)
-    }
-
-    @objc func presentDateTimePicker() {
-        dateTimePicker.present(from: self, with: .dateTime, startDate: startDate ?? Date(), datePickerType: datePickerType)
-    }
-
-    @objc func presentDateRangePicker() {
-        let startDate = self.startDate ?? Date()
-        let endDate = self.endDate ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? startDate
-        dateTimePicker.present(from: self, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: datePickerType)
-    }
-
-    @objc func presentTabbedDateRangePicker() {
-        let startDate = self.startDate ?? Date()
-        let endDate = self.endDate ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? startDate
-        dateTimePicker.present(from: self, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: datePickerType, dateRangePresentation: .tabbed)
-    }
-
-    @objc func presentDateTimeRangePicker() {
-        let startDate = self.startDate ?? Date()
-        let endDate = self.endDate ?? Calendar.current.date(byAdding: .hour, value: 1, to: startDate) ?? startDate
-        dateTimePicker.present(from: self, with: .dateTimeRange, startDate: startDate, endDate: endDate, datePickerType: datePickerType)
-    }
-
-    @objc func presentCustomSubtitlePicker() {
-        let startDate = self.startDate ?? Date()
-        let endDate = self.endDate ?? Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? startDate
-        let titles: DateTimePicker.Titles
-        if datePickerType == .calendar && !UIAccessibility.isVoiceOverRunning {
-            titles = .with(startSubtitle: "Assignment Date", endSubtitle: "Due Date")
-        } else {
-            titles = .with(startTab: "Assignment Date", endTab: "Due Date")
-        }
-        dateTimePicker.present(from: self, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: datePickerType, titles: titles)
-    }
-
-    @objc func resetDates() {
-        startDate = nil
-        endDate = nil
-        dateLabel.text = "No date selected"
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -15,27 +15,136 @@ class DrawerDemoController: DemoController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Show", style: .plain, target: self, action: #selector(barButtonTapped))
 
         addTitle(text: "Top Drawer")
-        container.addArrangedSubview(createButton(title: "Show resizable with clear background", action: #selector(showTopDrawerButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: #selector(showTopDrawerWithMaxContentHeightTapped)))
-        container.addArrangedSubview(createButton(title: "Show non dismissable", action: #selector(showTopDrawerNotDismissableButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: #selector(showTopDrawerChangingResizingBehaviour)))
-        container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showTopDrawerNotAnimatedButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show from custom base with width on landscape", action: #selector(showTopDrawerCustomOffsetButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show respecting safe area width", action: #selector(showTopDrawerSafeAreaButtonTapped)))
+
+        container.addArrangedSubview(createButton(title: "Show resizable with clear background", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .down,
+                                     presentationBackground: .none,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     resizingBehavior: .dismissOrExpand)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .down,
+                                     contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
+                                     resizingBehavior: .expand,
+                                     maxDrawerHeight: 350)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show non dismissable", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .down,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     resizingBehavior: .expand)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .down,
+                                     contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: true,
+                                                                                     drawerHasToggleResizingBehaviorButton: true),
+                                     resizingBehavior: .expand)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show with no animation", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .down,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     animated: false)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show from custom base with width on landscape", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let buttonView = sender.view
+            let rect = buttonView.superview!.convert(buttonView.frame, to: nil)
+            strongSelf.presentDrawer(sourceView: buttonView,
+                                     presentationOrigin: rect.maxY,
+                                     presentationDirection: .down,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     customWidth: true)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show respecting safe area width", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .down,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     resizingBehavior: .dismissOrExpand,
+                                     respectSafeAreaWidth: true)
+        }).view)
 
         addTitle(text: "Left/Right Drawer")
         addRow(
             items: [
-                createButton(title: "Show from leading with clear background", action: #selector(showLeftDrawerClearBackgroundButtonTapped)),
-                createButton(title: "Show from trailing with clear background", action: #selector(showRightDrawerClearBackgroundButtonTapped))
+                createButton(title: "Show from leading with clear background", action: { [weak self] sender in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    strongSelf.presentDrawer(sourceView: sender.view,
+                                             presentationDirection: .fromLeading,
+                                             presentationBackground: .none,
+                                             contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
+                                             resizingBehavior: .dismiss)
+                }).view,
+                createButton(title: "Show from trailing with clear background", action: { [weak self] sender in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    strongSelf.presentDrawer(sourceView: sender.view,
+                                             presentationDirection: .fromTrailing,
+                                             presentationBackground: .none,
+                                             contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
+                                             resizingBehavior: .dismiss)
+                }).view
             ],
             itemSpacing: Constants.verticalSpacing,
             stretchItems: true
         )
         addRow(
             items: [
-                createButton(title: "Show from leading with dimmed background", action: #selector(showLeftDrawerDimmedBackgroundButtonTapped)),
-                createButton(title: "Show from trailing with dimmed background", action: #selector(showRightDrawerDimmedBackgroundButtonTapped))
+                createButton(title: "Show from leading with dimmed background", action: { [weak self] sender in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    strongSelf.presentDrawer(sourceView: sender.view, presentationDirection: .fromLeading, presentationBackground: .black, contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+                }).view,
+                createButton(title: "Show from trailing with dimmed background", action: { [weak self] sender in
+                    guard let strongSelf = self else {
+                        return
+                    }
+
+                    strongSelf.presentDrawer(sourceView: sender.view, presentationDirection: .fromTrailing, presentationBackground: .black, contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+                }).view
             ],
             itemSpacing: Constants.verticalSpacing,
             stretchItems: true
@@ -43,19 +152,137 @@ class DrawerDemoController: DemoController {
         addDescription(text: "Swipe from the left or right edge of the screen to reveal a drawer interactively")
 
         addTitle(text: "Bottom Drawer")
-        container.addArrangedSubview(createButton(title: "Show resizable", action: #selector(showBottomDrawerButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: #selector(showBottomDrawerWithMaxContentHeightTapped)))
-        container.addArrangedSubview(createButton(title: "Show with underlying interactable content view", action: #selector(showBottomDrawerWithUnderlyingInteractableViewButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: #selector(showBottomDrawerChangingResizingBehaviour)))
-        container.addArrangedSubview(createButton(title: "Show with no animation", action: #selector(showBottomDrawerNotAnimatedButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show from custom base", action: #selector(showBottomDrawerCustomOffsetButtonTapped)))
 
-        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with dimmed background", action: #selector(showBottomDrawerCustomContentControllerDimmedBackgroundButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with clear background", action: #selector(showBottomDrawerCustomContentControllerClearBackgroundButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show resizable", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
 
-        container.addArrangedSubview(createButton(title: "Show with focusable content", action: #selector(showBottomDrawerFocusableContentButtonTapped)))
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .up,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     resizingBehavior: .dismissOrExpand)
+        }).view)
 
-        container.addArrangedSubview(createButton(title: "Show dismiss blocking drawer", action: #selector(showBottomDrawerBlockingDismissButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .up,
+                                     contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
+                                     resizingBehavior: .dismissOrExpand,
+                                     maxDrawerHeight: 350)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show with underlying interactable content view", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.navigationController?.pushViewController(PassThroughDrawerDemoController(), animated: true)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .up,
+                                     contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: true,
+                                                                                     drawerHasToggleResizingBehaviorButton: true),
+                                     resizingBehavior: .expand)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show with no animation", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .up,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     animated: false)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show from custom base", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let buttonView = sender.view
+            let rect = buttonView.superview!.convert(buttonView.frame, to: nil)
+            strongSelf.presentDrawer(sourceView: buttonView,
+                                     presentationOrigin: rect.minY,
+                                     presentationDirection: .up,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     resizingBehavior: .dismissOrExpand)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with dimmed background", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showBottomDrawerCustomContentController(sourceView: sender.view, presentationBackground: .black)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with clear background", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showBottomDrawerCustomContentController(sourceView: sender.view, presentationBackground: .none)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show with focusable content", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let contentController = UIViewController()
+
+            let container = UIStackView()
+            container.axis = .vertical
+            container.isLayoutMarginsRelativeArrangement = true
+            container.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+            container.spacing = 10
+            container.translatesAutoresizingMaskIntoConstraints = false
+            contentController.view.addSubview(container)
+            NSLayoutConstraint.activate([container.topAnchor.constraint(equalTo: contentController.view.topAnchor),
+                                         container.heightAnchor.constraint(equalTo: contentController.view.heightAnchor),
+                                         container.leadingAnchor.constraint(equalTo: contentController.view.leadingAnchor),
+                                         container.widthAnchor.constraint(equalTo: contentController.view.widthAnchor)])
+
+            let textField = UITextField()
+            textField.text = "Some focusable content"
+            textField.delegate = self
+            container.addArrangedSubview(textField)
+
+            container.addArrangedSubview(strongSelf.hideKeyboardButton.view)
+
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .up,
+                                     permittedArrowDirections: .any,
+                                     contentController: contentController,
+                                     resizingBehavior: .dismissOrExpand,
+                                     adjustHeightForKeyboard: true)
+
+            textField.becomeFirstResponder()
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show dismiss blocking drawer", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.shouldConfirmDrawerDismissal = true
+            strongSelf.presentDrawer(sourceView: sender.view,
+                                     presentationDirection: .up,
+                                     contentView: strongSelf.containerForActionViews(),
+                                     resizingBehavior: .dismissOrExpand)
+        }).view)
 
         container.addArrangedSubview(UIView())
 
@@ -158,15 +385,57 @@ class DrawerDemoController: DemoController {
 
         var views = [UIView]()
         if drawerHasFlexibleHeight {
-            let expandButton = createButton(title: "Expand", action: #selector(expandButtonTapped))
+            let expandButton = createButton(title: "Expand", action: { [weak self] _ in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                guard let drawer = strongSelf.presentedViewController as? DrawerController else {
+                    return
+                }
+                drawer.isExpanded = !drawer.isExpanded
+            })
+
             self.expandButton = expandButton
-            views.append(createButton(title: "Change content height", action: #selector(changeContentHeightButtonTapped)))
-            views.append(expandButton)
+            views.append(createButton(title: "Change content height", action: { sender in
+                if let spacer = (sender.view.superview as? UIStackView)?.arrangedSubviews.last,
+                    let heightConstraint = spacer.constraints.first {
+                    heightConstraint.constant = heightConstraint.constant == 20 ? 100 : 20
+                }
+            }).view)
+            views.append(expandButton.view)
         }
-        views.append(createButton(title: "Dismiss", action: #selector(dismissButtonTapped)))
-        views.append(createButton(title: "Dismiss (no animation)", action: #selector(dismissNotAnimatedButtonTapped)))
+
+        views.append(createButton(title: "Dismiss", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dismiss(animated: true)
+        }).view)
+
+        views.append(createButton(title: "Dismiss (no animation)", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dismiss(animated: false)
+        }).view)
+
         if drawerHasToggleResizingBehaviorButton {
-            views.append(createButton(title: "Resizing - None", action: #selector(updateResizingBehaviourButtonTapped)))
+            views.append(createButton(title: "Resizing - None", action: { [weak self] sender in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                guard let drawer = strongSelf.presentedViewController as? DrawerController else {
+                    return
+                }
+
+                let isResizingBehaviourNone = drawer.resizingBehavior == .none
+                drawer.resizingBehavior = isResizingBehaviourNone ? .expand : .none
+                sender.state.text = isResizingBehaviourNone ? "Resizing - None" : "Resizing - Expand"
+            }).view)
         }
         views.append(spacer)
         return views
@@ -181,92 +450,10 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func barButtonTapped(sender: UIBarButtonItem) {
-        presentDrawer(barButtonItem: sender, presentationDirection: .down, permittedArrowDirections: .any, contentView: containerForActionViews())
-    }
-
-    @objc private func showTopDrawerButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, presentationBackground: .none, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
-    }
-
-    @objc private func showTopDrawerWithMaxContentHeightTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .expand, maxDrawerHeight: 350)
-    }
-
-    @objc private func showTopDrawerNotDismissableButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), resizingBehavior: .expand)
-    }
-
-    @objc private func showTopDrawerChangingResizingBehaviour(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(drawerHasFlexibleHeight: true, drawerHasToggleResizingBehaviorButton: true), resizingBehavior: .expand)
-    }
-
-    @objc private func showTopDrawerNotAnimatedButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), animated: false)
-    }
-
-    @objc private func showTopDrawerCustomOffsetButtonTapped(sender: UIButton) {
-        let rect = sender.superview!.convert(sender.frame, to: nil)
-        presentDrawer(sourceView: sender, presentationOrigin: rect.maxY, presentationDirection: .down, contentView: containerForActionViews(), customWidth: true)
-    }
-
-    @objc private func showTopDrawerSafeAreaButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .down, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand, respectSafeAreaWidth: true)
-    }
-
-    @objc private func showLeftDrawerClearBackgroundButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .fromLeading, presentationBackground: .none, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-    }
-
-    @objc private func showLeftDrawerDimmedBackgroundButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .fromLeading, presentationBackground: .black, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-    }
-
-    @objc private func showRightDrawerClearBackgroundButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .fromTrailing, presentationBackground: .none, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-    }
-
-    @objc private func showRightDrawerDimmedBackgroundButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .fromTrailing, presentationBackground: .black, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-    }
-
-    @objc private func showBottomDrawerButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
-    }
-
-    @objc private func showBottomDrawerWithMaxContentHeightTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismissOrExpand, maxDrawerHeight: 350)
-    }
-
-    @objc private func showBottomDrawerChangingResizingBehaviour(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(drawerHasFlexibleHeight: true, drawerHasToggleResizingBehaviorButton: true), resizingBehavior: .expand)
-    }
-
-    @objc private func showBottomDrawerWithUnderlyingInteractableViewButtonTapped(sender: UIButton) {
-        navigationController?.pushViewController(PassThroughDrawerDemoController(), animated: true)
-    }
-
-    @objc private func showBottomDrawerNotAnimatedButtonTapped(sender: UIButton) {
-        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), animated: false)
-    }
-
-    @objc private func showBottomDrawerCustomOffsetButtonTapped(sender: UIButton) {
-        let rect = sender.superview!.convert(sender.frame, to: nil)
-        presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
-    }
-
-    @objc private func showBottomDrawerBlockingDismissButtonTapped(sender: UIButton) {
-        shouldConfirmDrawerDismissal = true
-        presentDrawer(sourceView: sender, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
-    }
-
-    @objc private func showBottomDrawerCustomContentControllerDimmedBackgroundButtonTapped(sender: UIButton) {
-        showBottomDrawerCustomContentController(sourceView: sender,
-                                                presentationBackground: .black)
-    }
-
-    @objc private func showBottomDrawerCustomContentControllerClearBackgroundButtonTapped(sender: UIButton) {
-        showBottomDrawerCustomContentController(sourceView: sender,
-                                                presentationBackground: .none)
+        presentDrawer(barButtonItem: sender,
+                      presentationDirection: .down,
+                      permittedArrowDirections: .any,
+                      contentView: containerForActionViews())
     }
 
     @objc private func showBottomDrawerCustomContentController(sourceView: UIView,
@@ -288,34 +475,6 @@ class DrawerDemoController: DemoController {
         drawer.contentScrollView = personaListView
     }
 
-    @objc private func showBottomDrawerFocusableContentButtonTapped(sender: UIButton) {
-        let contentController = UIViewController()
-
-        let container = UIStackView()
-        container.axis = .vertical
-        container.isLayoutMarginsRelativeArrangement = true
-        container.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        container.spacing = 10
-        container.translatesAutoresizingMaskIntoConstraints = false
-        contentController.view.addSubview(container)
-        NSLayoutConstraint.activate([container.topAnchor.constraint(equalTo: contentController.view.topAnchor),
-                                     container.heightAnchor.constraint(equalTo: contentController.view.heightAnchor),
-                                     container.leadingAnchor.constraint(equalTo: contentController.view.leadingAnchor),
-                                     container.widthAnchor.constraint(equalTo: contentController.view.widthAnchor)])
-
-        let textField = UITextField()
-        textField.text = "Some focusable content"
-        textField.delegate = self
-        container.addArrangedSubview(textField)
-
-        hideKeyboardButton.addTarget(self, action: #selector(hideKeyboardButtonTapped), for: .touchUpInside)
-        container.addArrangedSubview(hideKeyboardButton)
-
-        presentDrawer(sourceView: sender, presentationDirection: .up, permittedArrowDirections: .any, contentController: contentController, resizingBehavior: .dismissOrExpand, adjustHeightForKeyboard: true)
-
-        textField.becomeFirstResponder()
-    }
-
     @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {
         guard gesture.state == .began else {
             return
@@ -323,37 +482,11 @@ class DrawerDemoController: DemoController {
 
         let leadingEdge: UIRectEdge = view.effectiveUserInterfaceLayoutDirection == .leftToRight ? .left : .right
 
-        presentDrawer(sourceView: view, presentationDirection: gesture.edges == leadingEdge ? .fromLeading : .fromTrailing, presentingGesture: gesture, contentView: containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-    }
-
-    @objc private func changeContentHeightButtonTapped(sender: UIButton) {
-        if let spacer = (sender.superview as? UIStackView)?.arrangedSubviews.last,
-            let heightConstraint = spacer.constraints.first {
-            heightConstraint.constant = heightConstraint.constant == 20 ? 100 : 20
-        }
-    }
-
-    @objc private func expandButtonTapped(sender: UIButton) {
-        guard let drawer = presentedViewController as? DrawerController else {
-            return
-        }
-        drawer.isExpanded = !drawer.isExpanded
-    }
-
-    @objc private func dismissButtonTapped() {
-        dismiss(animated: true)
-    }
-
-    @objc private func dismissNotAnimatedButtonTapped() {
-        dismiss(animated: false)
-    }
-    @objc private func updateResizingBehaviourButtonTapped(sender: UIButton) {
-        guard let drawer = presentedViewController as? DrawerController else {
-            return
-        }
-        let isResizingBehaviourNone = drawer.resizingBehavior == .none
-        drawer.resizingBehavior = isResizingBehaviourNone ? .expand : .none
-        sender.setTitle(isResizingBehaviourNone ? "Resizing - None" : "Resizing - Expand", for: .normal)
+        presentDrawer(sourceView: view,
+                      presentationDirection: gesture.edges == leadingEdge ? .fromLeading : .fromTrailing,
+                      presentingGesture: gesture,
+                      contentView: containerForActionViews(drawerHasFlexibleHeight: false),
+                      resizingBehavior: .dismiss)
     }
 
     @objc private func changePreferredContentSizeButtonTapped() {
@@ -364,21 +497,17 @@ class DrawerDemoController: DemoController {
         }
     }
 
-    @objc private func hideKeyboardButtonTapped(sender: UIButton) {
-        if let stackView = sender.superview as? UIStackView {
-            let textField = stackView.arrangedSubviews.first(where: { $0 is UITextField })
-            textField?.resignFirstResponder()
-        }
-    }
-
     private var shouldConfirmDrawerDismissal: Bool = false
-    private var expandButton: MSFButton?
+    private var expandButton: MSFButtonVnext?
 
-    private let hideKeyboardButton: MSFButton = {
-        let button = MSFButton(style: .primaryFilled)
-        button.setTitle("Hide keyboard", for: .normal)
-        button.setContentCompressionResistancePriority(.required, for: .vertical)
-        button.setContentHuggingPriority(.required, for: .vertical)
+    private let hideKeyboardButton: MSFButtonVnext = {
+        let button = MSFButtonVnext(style: .primary, size: .large) { sender in
+            if let stackView = sender.view.superview as? UIStackView {
+                let textField = stackView.arrangedSubviews.first(where: { $0 is UITextField })
+                textField?.resignFirstResponder()
+            }
+        }
+        button.state.text = "Hide keyboard"
         return button
     }()
 }
@@ -392,11 +521,11 @@ extension DrawerDemoController: UITextFieldDelegate {
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        hideKeyboardButton.isEnabled = true
+        hideKeyboardButton.state.isDisabled = false
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        hideKeyboardButton.isEnabled = false
+        hideKeyboardButton.state.isDisabled = true
     }
 }
 
@@ -421,7 +550,7 @@ extension DrawerDemoController: DrawerControllerDelegate {
     }
 
     func drawerControllerDidChangeExpandedState(_ controller: DrawerController) {
-        expandButton?.setTitle(controller.isExpanded ? collapseText : expandText, for: .normal)
+        expandButton?.state.text = controller.isExpanded ? collapseText : expandText
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -10,51 +10,82 @@ class HUDDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        container.alignment = .leading
-        let showActivityButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showActivityHUD()
+        let showActivityButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showActivityHUD()
         })
         showActivityButton.state.text = "Show activity HUD"
         container.addArrangedSubview(showActivityButton.view)
 
-        let showSuccessButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showSuccessHUD()
+        let showSuccessButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showSuccessHUD()
         })
         showSuccessButton.state.text = "Show success HUD"
         container.addArrangedSubview(showSuccessButton.view)
 
-        let showFailureButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showFailureHUD()
+        let showFailureButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showFailureHUD()
         })
         showFailureButton.state.text = "Show failure HUD"
         container.addArrangedSubview(showFailureButton.view)
 
-        let showCustomButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showCustomHUD()
+        let showCustomButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showCustomHUD()
         })
         showCustomButton.state.text = "Show custom HUD"
         container.addArrangedSubview(showCustomButton.view)
 
-        let showCustomNonBlockingButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showCustomNonBlockingHUD()
+        let showCustomNonBlockingButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showCustomNonBlockingHUD()
         })
         showCustomNonBlockingButton.state.text = "Show custom non-blocking HUD"
         container.addArrangedSubview(showCustomNonBlockingButton.view)
 
-        let showNolabelButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showNoLabelHUD()
+        let showNolabelButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showNoLabelHUD()
         })
         showNolabelButton.state.text = "Show HUD with no label"
         container.addArrangedSubview(showNolabelButton.view)
 
-        let showGestureButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showGestureHUD()
+        let showGestureButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showGestureHUD()
         })
         showGestureButton.state.text = "Show HUD with tap gesture callback"
         container.addArrangedSubview(showGestureButton.view)
 
-        let showUpdatingButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.showUpdateHUD()
+        let showUpdatingButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.showUpdateHUD()
         })
         showUpdatingButton.state.text = "Show HUD with updating caption"
         container.addArrangedSubview(showUpdatingButton.view)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -11,83 +11,138 @@ class NavigationControllerDemoController: DemoController {
         super.viewDidLoad()
 
         addTitle(text: "Large Title with Primary style")
-        container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitle)))
-        container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithShyAccessory)))
-        container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithFixedAccessory)))
-        container.addArrangedSubview(createButton(title: "Show without an avatar", action: #selector(showLargeTitleWithoutAvatar)))
+        container.addArrangedSubview(createButton(title: "Show without accessory", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         accessoryView: strongSelf.createAccessoryView(),
+                                         contractNavigationBarOnScroll: true)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         accessoryView: strongSelf.createAccessoryView(),
+                                         contractNavigationBarOnScroll: false)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show without an avatar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         style: .primary,
+                                         accessoryView: strongSelf.createAccessoryView(),
+                                         showAvatar: false)
+        }).view)
 
         addTitle(text: "Large Title with System style")
-        container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitleWithSystemStyle)))
-        container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: #selector(showLargeTitleWithSystemStyleAndNoShadow)))
-        container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithSystemStyleAndShyAccessory)))
-        container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithSystemStyleAndFixedAccessory)))
+        container.addArrangedSubview(createButton(title: "Show without accessory", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         style: .system)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         style: .system,
+                                         contractNavigationBarOnScroll: false,
+                                         showShadow: false)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         style: .system,
+                                         accessoryView: strongSelf.createAccessoryView(with: .darkContent),
+                                         contractNavigationBarOnScroll: true)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                   style: .system,
+                                   accessoryView: strongSelf.createAccessoryView(with: .darkContent),
+                                   contractNavigationBarOnScroll: false)
+        }).view)
 
         addTitle(text: "Regular Title")
-        container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showRegularTitleWithShyAccessory)))
-        container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: #selector(showRegularTitleWithFixedAccessory)))
+        container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: false,
+                                         style: .system,
+                                         accessoryView: strongSelf.createAccessoryView(with: .darkContent),
+                                         contractNavigationBarOnScroll: true)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: false,
+                                         accessoryView: strongSelf.createAccessoryView(),
+                                         contractNavigationBarOnScroll: false)
+        }).view)
 
         addTitle(text: "Size Customization")
-        container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: #selector(showLargeTitleWithCustomizedElementSizes)))
+        container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let controller = strongSelf.presentController(withLargeTitle: true,
+                                                          accessoryView: strongSelf.createAccessoryView())
+            controller.msfNavigationBar.avatarSize = .expanded
+            controller.msfNavigationBar.titleSize = .contracted
+        }).view)
 
         addTitle(text: "Custom Navigation Bar Color")
-        container.addArrangedSubview(createButton(title: "Show with gradient navigation bar color", action: #selector(showLargeTitleWithCustomizedColor)))
+        container.addArrangedSubview(createButton(title: "Show with gradient navigation bar color", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.presentController(withLargeTitle: true,
+                                         style: .custom,
+                                         accessoryView: strongSelf.createAccessoryView())
+        }).view)
 
         addTitle(text: "Top Accessory View")
-        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
-    }
+        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
 
-    @objc func showLargeTitle() {
-        presentController(withLargeTitle: true)
-    }
-
-    @objc func showLargeTitleWithShyAccessory() {
-        presentController(withLargeTitle: true, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
-    }
-
-    @objc func showLargeTitleWithFixedAccessory() {
-        presentController(withLargeTitle: true, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
-    }
-
-    @objc func showLargeTitleWithSystemStyle() {
-        presentController(withLargeTitle: true, style: .system)
-    }
-
-    @objc func showLargeTitleWithSystemStyleAndNoShadow() {
-        presentController(withLargeTitle: true, style: .system, contractNavigationBarOnScroll: false, showShadow: false)
-    }
-
-    @objc func showLargeTitleWithSystemStyleAndShyAccessory() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
-    }
-
-    @objc func showLargeTitleWithSystemStyleAndFixedAccessory() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
-    }
-
-    @objc func showRegularTitleWithShyAccessory() {
-        presentController(withLargeTitle: false, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
-    }
-
-    @objc func showRegularTitleWithFixedAccessory() {
-        presentController(withLargeTitle: false, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
-    }
-
-    @objc func showLargeTitleWithCustomizedElementSizes() {
-        let controller = presentController(withLargeTitle: true, accessoryView: createAccessoryView())
-        controller.msfNavigationBar.avatarSize = .expanded
-        controller.msfNavigationBar.titleSize = .contracted
-    }
-
-    @objc func showLargeTitleWithCustomizedColor() {
-        presentController(withLargeTitle: true, style: .custom, accessoryView: createAccessoryView())
-    }
-
-    @objc func showLargeTitleWithoutAvatar() {
-        presentController(withLargeTitle: true, style: .primary, accessoryView: createAccessoryView(), showAvatar: false)
-    }
-
-    @objc func showWithTopSearchBar() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false)
+            strongSelf.presentController(withLargeTitle: true,
+                                         style: .system,
+                                         accessoryView: strongSelf.createAccessoryView(with: .darkContent),
+                                         showsTopAccessory: true,
+                                         contractNavigationBarOnScroll: false)
+        }).view)
     }
 
     @discardableResult

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -60,8 +60,14 @@ class NotificationViewDemoController: DemoController {
             addTitle(text: variant.displayText)
             container.addArrangedSubview(createNotificationView(forVariant: variant))
 
-            let showButton = MSFButtonVnext(style: .secondary, size: .small, action: {
-                self.createNotificationView(forVariant: variant).show(in: self.view) { $0.hide(after: variant.delayForHiding) }
+            let showButton = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                strongSelf.createNotificationView(forVariant: variant).show(in: strongSelf.view) {
+                    $0.hide(after: variant.delayForHiding)
+                }
             })
             showButton.state.text = "Show"
             container.addArrangedSubview(showButton.view)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -50,8 +50,8 @@
     [self.container addArrangedSubview:buttonVnextLabel];
 
     _testButtonVnext = [[MSFButtonVnext alloc] initWithStyle:MSFButtonVnextStyleSecondary
-                                                    size:MSFButtonVnextSizeMedium
-                                                  action:^{}];
+                                                        size:MSFButtonVnextSizeMedium
+                                                      action:^(MSFButtonVnext *sender) {}];
     [self resetVnextButton];
     [self.container addArrangedSubview:[_testButtonVnext view]];
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PassThroughDrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PassThroughDrawerDemoController.swift
@@ -92,32 +92,50 @@ class PassThroughDrawerDemoController: DemoController {
         var views = [UIView]()
         if drawerHasFlexibleHeight {
             let container = DemoController.createHorizontalContainer()
-            container.addArrangedSubview(createButton(title: "Change content height", action: #selector(changeContentHeightButtonTapped)))
-            container.addArrangedSubview(createButton(title: "Expand", action: #selector(expandButtonTapped)))
+            container.addArrangedSubview(createButton(title: "Change content height", action: { [weak self] _ in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                if let heightConstraint = strongSelf.spacer.constraints.first {
+                    heightConstraint.constant = heightConstraint.constant == 20 ? 100 : 20
+                }
+            }).view)
+
+            container.addArrangedSubview(createButton(title: "Expand", action: { [weak self] sender in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                guard let drawer = strongSelf.presentedViewController as? DrawerController else {
+                    return
+                }
+                drawer.isExpanded = !drawer.isExpanded
+                sender.state.text = drawer.isExpanded ? "Return to normal" : "Expand"
+            }).view)
             views.append(container)
         }
+
         let container = DemoController.createHorizontalContainer()
-        container.addArrangedSubview(createButton(title: "Dismiss", action: #selector(dismissButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Dismiss (no animation)", action: #selector(dismissNotAnimatedButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Dismiss", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dismiss(animated: true)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Dismiss (no animation)", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dismiss(animated: false)
+        }).view)
+
         views.append(container)
         views.append(spacer)
         return views
-    }
-
-    @objc private func expandButtonTapped(sender: UIButton) {
-        guard let drawer = presentedViewController as? DrawerController else {
-            return
-        }
-        drawer.isExpanded = !drawer.isExpanded
-        sender.setTitle(drawer.isExpanded ? "Return to normal" : "Expand", for: .normal)
-    }
-
-    @objc private func dismissButtonTapped() {
-        dismiss(animated: true)
-    }
-
-    @objc private func dismissNotAnimatedButtonTapped() {
-        dismiss(animated: false)
     }
 
     @objc private func changePreferredContentSizeButtonTapped() {
@@ -125,12 +143,6 @@ class PassThroughDrawerDemoController: DemoController {
             var size = contentController.preferredContentSize
             size.height = size.height == contentControllerOriginalPreferredContentHeight ? 500 : 400
             contentController.preferredContentSize = size
-        }
-    }
-
-    @objc private func changeContentHeightButtonTapped(sender: UIButton) {
-        if let heightConstraint = spacer.constraints.first {
-            heightConstraint.constant = heightConstraint.constant == 20 ? 100 : 20
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -35,10 +35,116 @@ class PopupMenuDemoController: DemoController {
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         ]
 
-        container.addArrangedSubview(createButton(title: "Show with sections", action: #selector(showTopMenuWithSectionsButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show with scrollable items and no icons", action: #selector(showTopMenuWithScrollableItemsButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show items with custom colors", action: #selector(showCustomColorsButtonTapped)))
-        container.addArrangedSubview(createButton(title: "Show items without dismissal after being tapped", action: #selector(showNoDismissalItemsButtonTapped)))
+        container.addArrangedSubview(createButton(title: "Show with sections", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let buttonView = sender.view
+            let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
+
+            controller.addSections([
+                PopupMenuSection(title: "Canada", items: [
+                    PopupMenuItem(imageName: "Montreal", generateSelectedImage: false, title: "Montréal", subtitle: "Québec"),
+                    PopupMenuItem(imageName: "Toronto", generateSelectedImage: false, title: "Toronto", subtitle: "Ontario"),
+                    PopupMenuItem(imageName: "Vancouver", generateSelectedImage: false, title: "Vancouver", subtitle: "British Columbia")
+                ]),
+                PopupMenuSection(title: "United States", items: [
+                    PopupMenuItem(imageName: "Las Vegas", generateSelectedImage: false, title: "Las Vegas", subtitle: "Nevada"),
+                    PopupMenuItem(imageName: "Phoenix", generateSelectedImage: false, title: "Phoenix", subtitle: "Arizona"),
+                    PopupMenuItem(imageName: "San Francisco", generateSelectedImage: false, title: "San Francisco", subtitle: "California"),
+                    PopupMenuItem(imageName: "Seattle", generateSelectedImage: false, title: "Seattle", subtitle: "Washington")
+                ])
+            ])
+
+            controller.selectedItemIndexPath = strongSelf.cityIndexPath
+            controller.onDismiss = { [unowned controller] in
+                strongSelf.cityIndexPath = controller.selectedItemIndexPath
+            }
+
+            strongSelf.present(controller, animated: true)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show with scrollable items and no icons", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let buttonView = sender.view
+            let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
+
+            let items = samplePersonas.map { PopupMenuItem(title: !$0.name.isEmpty ? $0.name : $0.email) }
+            controller.addItems(items)
+
+            strongSelf.present(controller, animated: true)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show items with custom colors", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let buttonView = sender.view
+            let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
+
+            let items = [
+                PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: strongSelf.calendarLayout == .agenda, onSelected: { strongSelf.calendarLayout = .agenda }),
+                PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: strongSelf.calendarLayout == .day, onSelected: { strongSelf.calendarLayout = .day }),
+                PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: strongSelf.calendarLayout == .threeDay, onSelected: { strongSelf.calendarLayout = .threeDay })
+            ]
+
+            let menuBackgroundColor: UIColor = .darkGray
+
+            for item in items {
+                item.titleColor = .white
+                item.titleSelectedColor = .white
+                item.imageSelectedColor = .white
+                item.accessoryCheckmarkColor = .white
+                item.backgroundColor = menuBackgroundColor
+            }
+
+            controller.addItems(items)
+
+            controller.backgroundColor = menuBackgroundColor
+            controller.resizingHandleViewBackgroundColor = menuBackgroundColor
+            controller.separatorColor = .lightGray
+
+            strongSelf.present(controller, animated: true)
+        }).view)
+
+        container.addArrangedSubview(createButton(title: "Show items without dismissal after being tapped", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            let buttonView = sender.view
+            let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
+
+            let items = [
+                PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: strongSelf.calendarLayout == .agenda, executes: .onSelectionWithoutDismissal, onSelected: { strongSelf.calendarLayout = .agenda }),
+                PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: strongSelf.calendarLayout == .day, executes: .onSelectionWithoutDismissal, onSelected: { strongSelf.calendarLayout = .day }),
+                PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: strongSelf.calendarLayout == .threeDay, executes: .onSelectionWithoutDismissal, onSelected: { strongSelf.calendarLayout = .threeDay })
+            ]
+
+            let menuBackgroundColor: UIColor = .darkGray
+
+            for item in items {
+                item.titleColor = .white
+                item.titleSelectedColor = .white
+                item.imageSelectedColor = .white
+                item.accessoryCheckmarkColor = .white
+                item.backgroundColor = menuBackgroundColor
+            }
+
+            controller.addItems(items)
+
+            controller.backgroundColor = menuBackgroundColor
+            controller.resizingHandleViewBackgroundColor = menuBackgroundColor
+            controller.separatorColor = .lightGray
+
+            strongSelf.present(controller, animated: true)
+        }).view)
+
         container.addArrangedSubview(UIView())
         addTitle(text: "Show with...")
     }
@@ -94,96 +200,6 @@ class PopupMenuDemoController: DemoController {
             PopupMenuItem(title: "Week (no icon)", isSelected: calendarLayout == .week, onSelected: { self.calendarLayout = .week }),
             PopupMenuItem(image: UIImage(named: "month-view-24x24"), title: "Month", isSelected: calendarLayout == .month, onSelected: { self.calendarLayout = .month })
         ])
-
-        present(controller, animated: true)
-    }
-
-    @objc private func showTopMenuWithSectionsButtonTapped(sender: UIButton) {
-        let controller = PopupMenuController(sourceView: sender, sourceRect: sender.bounds, presentationDirection: .down)
-
-        controller.addSections([
-            PopupMenuSection(title: "Canada", items: [
-                PopupMenuItem(imageName: "Montreal", generateSelectedImage: false, title: "Montréal", subtitle: "Québec"),
-                PopupMenuItem(imageName: "Toronto", generateSelectedImage: false, title: "Toronto", subtitle: "Ontario"),
-                PopupMenuItem(imageName: "Vancouver", generateSelectedImage: false, title: "Vancouver", subtitle: "British Columbia")
-            ]),
-            PopupMenuSection(title: "United States", items: [
-                PopupMenuItem(imageName: "Las Vegas", generateSelectedImage: false, title: "Las Vegas", subtitle: "Nevada"),
-                PopupMenuItem(imageName: "Phoenix", generateSelectedImage: false, title: "Phoenix", subtitle: "Arizona"),
-                PopupMenuItem(imageName: "San Francisco", generateSelectedImage: false, title: "San Francisco", subtitle: "California"),
-                PopupMenuItem(imageName: "Seattle", generateSelectedImage: false, title: "Seattle", subtitle: "Washington")
-            ])
-        ])
-
-        controller.selectedItemIndexPath = cityIndexPath
-        controller.onDismiss = { [unowned controller] in
-            self.cityIndexPath = controller.selectedItemIndexPath
-        }
-
-        present(controller, animated: true)
-    }
-
-    @objc private func showTopMenuWithScrollableItemsButtonTapped(sender: UIButton) {
-        let controller = PopupMenuController(sourceView: sender, sourceRect: sender.bounds, presentationDirection: .down)
-
-        let items = samplePersonas.map { PopupMenuItem(title: !$0.name.isEmpty ? $0.name : $0.email) }
-        controller.addItems(items)
-
-        present(controller, animated: true)
-    }
-
-    @objc private func showCustomColorsButtonTapped(sender: UIButton) {
-        let controller = PopupMenuController(sourceView: sender, sourceRect: sender.bounds, presentationDirection: .down)
-
-        let items = [
-            PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: calendarLayout == .agenda, onSelected: { self.calendarLayout = .agenda }),
-            PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: calendarLayout == .day, onSelected: { self.calendarLayout = .day }),
-            PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: calendarLayout == .threeDay, onSelected: { self.calendarLayout = .threeDay })
-        ]
-
-        let menuBackgroundColor: UIColor = .darkGray
-
-        for item in items {
-            item.titleColor = .white
-            item.titleSelectedColor = .white
-            item.imageSelectedColor = .white
-            item.accessoryCheckmarkColor = .white
-            item.backgroundColor = menuBackgroundColor
-        }
-
-        controller.addItems(items)
-
-        controller.backgroundColor = menuBackgroundColor
-        controller.resizingHandleViewBackgroundColor = menuBackgroundColor
-        controller.separatorColor = .lightGray
-
-        present(controller, animated: true)
-    }
-
-    @objc private func showNoDismissalItemsButtonTapped(sender: UIButton) {
-        let controller = PopupMenuController(sourceView: sender, sourceRect: sender.bounds, presentationDirection: .down)
-
-        let items = [
-            PopupMenuItem(image: UIImage(named: "agenda-24x24"), title: "Agenda", isSelected: calendarLayout == .agenda, executes: .onSelectionWithoutDismissal, onSelected: { self.calendarLayout = .agenda }),
-            PopupMenuItem(image: UIImage(named: "day-view-24x24"), title: "Day", isSelected: calendarLayout == .day, executes: .onSelectionWithoutDismissal, onSelected: { self.calendarLayout = .day }),
-            PopupMenuItem(image: UIImage(named: "3-day-view-24x24"), title: "3-Day", isEnabled: false, isSelected: calendarLayout == .threeDay, executes: .onSelectionWithoutDismissal, onSelected: { self.calendarLayout = .threeDay })
-        ]
-
-        let menuBackgroundColor: UIColor = .darkGray
-
-        for item in items {
-            item.titleColor = .white
-            item.titleSelectedColor = .white
-            item.imageSelectedColor = .white
-            item.accessoryCheckmarkColor = .white
-            item.backgroundColor = menuBackgroundColor
-        }
-
-        controller.addItems(items)
-
-        controller.backgroundColor = menuBackgroundColor
-        controller.resizingHandleViewBackgroundColor = menuBackgroundColor
-        controller.separatorColor = .lightGray
 
         present(controller, animated: true)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -41,12 +41,24 @@ class SideTabBarDemoController: DemoController {
         }
     }
 
-    private lazy var incrementBadgeButton: MSFButton = {
-        return createButton(title: "+", action: #selector(incrementBadgeNumbers))
+    private lazy var incrementBadgeButton: MSFButtonVnext = {
+        return createButton(title: "+", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.modifyBadgeNumbers(increment: 1)
+        })
     }()
 
-    private lazy var decrementBadgeButton: MSFButton = {
-        return createButton(title: "-", action: #selector(decrementBadgeNumbers))
+    private lazy var decrementBadgeButton: MSFButtonVnext = {
+        return createButton(title: "-", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.modifyBadgeNumbers(increment: -1)
+        })
     }()
 
     private func presentSideTabBar() {
@@ -117,17 +129,21 @@ class SideTabBarDemoController: DemoController {
         useHigherBadgeNumbersView.translatesAutoresizingMaskIntoConstraints = false
         optionsStackView.addArrangedSubview(useHigherBadgeNumbersView)
 
-        let modifyBadgeNumbersView = createLabelAndViewsRow(labelText: "Modify badge numbers", views: [incrementBadgeButton, decrementBadgeButton])
+        let badgeNumberButtonsStackView = UIStackView(arrangedSubviews: [incrementBadgeButton.view, decrementBadgeButton.view])
+        badgeNumberButtonsStackView.spacing = 20
+        let modifyBadgeNumbersView = createLabelAndViewsRow(labelText: "Modify badge numbers", views: [badgeNumberButtonsStackView])
         modifyBadgeNumbersView.translatesAutoresizingMaskIntoConstraints = false
         optionsStackView.addArrangedSubview(modifyBadgeNumbersView)
 
-        let button = MSFButton()
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.titleLabel?.textAlignment = .center
-        button.titleLabel?.numberOfLines = 0
-        button.setTitle("Dismiss", for: .normal)
-        button.addTarget(self, action: #selector(dismissSideTabBar), for: .touchUpInside)
-        optionsStackView.addArrangedSubview(button)
+        optionsStackView.addArrangedSubview(createButton(title: "Dismiss", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.dismiss(animated: false) {
+                strongSelf.navigationController?.popViewController(animated: true)
+            }
+        }).view)
 
         NSLayoutConstraint.activate([
             sideTabBar.leadingAnchor.constraint(equalTo: contentViewController.view.leadingAnchor),
@@ -145,12 +161,6 @@ class SideTabBarDemoController: DemoController {
 
         updateBadgeNumbers()
         updateBadgeButtons()
-    }
-
-    @objc private func dismissSideTabBar() {
-        dismiss(animated: false) {
-            self.navigationController?.popViewController(animated: true)
-        }
     }
 
     @objc private func toggleAvatarView(switchView: UISwitch) {
@@ -199,8 +209,8 @@ class SideTabBarDemoController: DemoController {
     }
 
     private func updateBadgeButtons() {
-        incrementBadgeButton.isEnabled = showBadgeNumbers
-        decrementBadgeButton.isEnabled = showBadgeNumbers
+        incrementBadgeButton.state.isDisabled = !showBadgeNumbers
+        decrementBadgeButton.state.isDisabled = !showBadgeNumbers
     }
 
     private func modifyBadgeNumbers(increment: Int) {
@@ -221,14 +231,6 @@ class SideTabBarDemoController: DemoController {
         }
 
         updateBadgeNumbers()
-    }
-
-    @objc private func incrementBadgeNumbers() {
-        modifyBadgeNumbers(increment: 1)
-    }
-
-    @objc private func decrementBadgeNumbers() {
-        modifyBadgeNumbers(increment: -1)
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -10,8 +10,8 @@ class TabBarViewDemoController: DemoController {
     private enum Constants {
         static let initialBadgeNumbers: [UInt] = [5, 50, 250]
         static let initialHigherBadgeNumbers: [UInt] = [1250, 25505, 3050528]
-        static let switchSettingTextWidth: CGFloat = 180
-        static let buttonSettingTextWidth: CGFloat = 150
+        static let switchSettingTextWidth: CGFloat = 200
+        static let buttonSettingTextWidth: CGFloat = 170
     }
 
     private var tabBarView: TabBarView?
@@ -25,8 +25,12 @@ class TabBarViewDemoController: DemoController {
     private let useHigherBadgeNumbersSwitch = UISwitch()
 
     private lazy var incrementBadgeButton: MSFButtonVnext = {
-        let button = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.incrementBadgeNumbers()
+        let button = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.incrementBadgeNumbers()
         })
         button.state.text = "+"
 
@@ -34,8 +38,12 @@ class TabBarViewDemoController: DemoController {
     }()
 
     private lazy var decrementBadgeButton: MSFButtonVnext = {
-        let button = MSFButtonVnext(style: .secondary, size: .small, action: {
-            self.decrementBadgeNumbers()
+        let button = MSFButtonVnext(style: .secondary, size: .small, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.decrementBadgeNumbers()
         })
         button.state.text = "-"
 
@@ -57,7 +65,9 @@ class TabBarViewDemoController: DemoController {
         addRow(text: "Use higher badge numbers", items: [useHigherBadgeNumbersSwitch], textWidth: Constants.switchSettingTextWidth)
         useHigherBadgeNumbersSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
 
-        addRow(text: "Modify badge numbers", items: [incrementBadgeButton.view, decrementBadgeButton.view], textWidth: Constants.buttonSettingTextWidth)
+        let buttonsStackView = UIStackView(arrangedSubviews: [incrementBadgeButton.view, decrementBadgeButton.view])
+        buttonsStackView.spacing = 20
+        addRow(text: "Modify badge numbers", items: [buttonsStackView], textWidth: Constants.buttonSettingTextWidth)
 
         setupTabBarView()
         updateBadgeButtons()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -390,22 +390,84 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         spacingView.widthAnchor.constraint(equalToConstant: Constants.stackViewSpacing).isActive = true
         settingsView.addArrangedSubview(spacingView)
 
-        let plusMinActionsButton = createPlusMinusButton(plus: true, #selector(incrementMinimumActionsCount))
-        let minusMinActionsButton = createPlusMinusButton(plus: false, #selector(decrementMinimumActionsCount))
-        let plusTopOverlapButton = createPlusMinusButton(plus: true, #selector(incrementTopActionsOverlap))
-        let minusTopOverlapButton = createPlusMinusButton(plus: false, #selector(decrementTopActionsOverlap))
-        let plusBottomOverlapButton = createPlusMinusButton(plus: true, #selector(incrementBottomActionsOverlap))
-        let minusBottomOverlapButton = createPlusMinusButton(plus: false, #selector(decrementBottomActionsOverlap))
+        let plusMinActionsButton = createPlusMinusButton(plus: true, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.minimumActionsCount += 1
+        })
+        let minusMinActionsButton = createPlusMinusButton(plus: false, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            if strongSelf.minimumActionsCount > 0 {
+                strongSelf.minimumActionsCount -= 1
+            }
+        })
+        let actionsButtonsStackView = UIStackView(arrangedSubviews: [plusMinActionsButton, minusMinActionsButton])
+        actionsButtonsStackView.spacing = 10
+
+        let plusTopOverlapButton = createPlusMinusButton(plus: true, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.topActionsOverlap += 1
+        })
+        let minusTopOverlapButton = createPlusMinusButton(plus: false, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            if strongSelf.topActionsOverlap > 0 {
+                strongSelf.topActionsOverlap -= 1
+            }
+        })
+        let topOverlapButtonsStackView = UIStackView(arrangedSubviews: [plusTopOverlapButton, minusTopOverlapButton])
+        topOverlapButtonsStackView.spacing = 10
+
+        let plusBottomOverlapButton = createPlusMinusButton(plus: true, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.bottomActionsOverlap += 1
+        })
+        let minusBottomOverlapButton = createPlusMinusButton(plus: false, action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            if strongSelf.bottomActionsOverlap > 0 {
+                strongSelf.bottomActionsOverlap -= 1
+            }
+        })
+        let bottomOverlapButtonsStackView = UIStackView(arrangedSubviews: [plusBottomOverlapButton, minusBottomOverlapButton])
+        bottomOverlapButtonsStackView.spacing = 10
 
         let settingViews: [UIView] = [
             createLabelAndSwitchRow(labelText: "Dynamic width", switchAction: #selector(toggleDynamicWidth(switchView:)), isOn: useDynamicWidth),
             createLabelAndSwitchRow(labelText: "Dynamic padding", switchAction: #selector(toggleDynamicPadding(switchView:)), isOn: useDynamicPadding),
             createLabelAndSwitchRow(labelText: "Show date", switchAction: #selector(toggleShowDate(switchView:)), isOn: showDate),
-            createButton(title: "Choose date", action: #selector(presentDatePicker)),
-            createButton(title: "Choose time", action: #selector(presentTimePicker)),
-            createLabelAndViewsRow(labelText: "Minimum actions count", views: [plusMinActionsButton, minusMinActionsButton]),
-            createLabelAndViewsRow(labelText: "Top actions overlap", views: [plusTopOverlapButton, minusTopOverlapButton]),
-            createLabelAndViewsRow(labelText: "Bottom actions overlap", views: [plusBottomOverlapButton, minusBottomOverlapButton]),
+            createButton(title: "Choose date", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+                strongSelf.dateTimePicker.present(from: strongSelf, with: .date, startDate: Date(), endDate: nil, datePickerType: .components)
+            }).view,
+            createButton(title: "Choose time", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+                strongSelf.dateTimePicker.present(from: strongSelf, with: .dateTime, startDate: Date(), endDate: nil, datePickerType: .components)
+            }).view,
+            createLabelAndViewsRow(labelText: "Minimum actions count", views: [actionsButtonsStackView]),
+            createLabelAndViewsRow(labelText: "Top actions overlap", views: [topOverlapButtonsStackView]),
+            createLabelAndViewsRow(labelText: "Bottom actions overlap", views: [bottomOverlapButtonsStackView]),
             createLabelAndSwitchRow(labelText: "Show shared status", switchAction: #selector(toggleShowSharedStatus(switchView:)), isOn: showSharedStatus),
             createLabelAndSwitchRow(labelText: "Is document shared", switchAction: #selector(toggleAreDocumentsShared(switchView:)), isOn: areDocumentsShared),
             createLabelAndSwitchRow(labelText: "Show keep offline button", switchAction: #selector(toggleShowKeepOffline(switchView:)), isOn: showKeepOfflineAction),
@@ -432,8 +494,8 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
         return settingsView
     }()
 
-    private func createPlusMinusButton(plus: Bool, _ selector: Selector) -> UIButton {
-        let button = createButton(title: (plus ? "+" : "-"), action: selector)
+    private func createPlusMinusButton(plus: Bool, action: ((_ sender: MSFButtonVnext) -> Void)?) -> UIView {
+        let button = createButton(title: (plus ? "+" : "-"), action: action).view
         button.widthAnchor.constraint(equalToConstant: Constants.plusMinusButtonWidth).isActive = true
         return button
     }
@@ -443,14 +505,6 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
     }
 
     private let dateTimePicker = DateTimePicker()
-
-    @objc func presentDatePicker() {
-        dateTimePicker.present(from: self, with: .date, startDate: Date(), endDate: nil, datePickerType: .components)
-    }
-
-    @objc func presentTimePicker() {
-        dateTimePicker.present(from: self, with: .dateTime, startDate: Date(), endDate: nil, datePickerType: .components)
-    }
 
     @objc private func toggleDynamicWidth(switchView: UISwitch) {
         useDynamicWidth = switchView.isOn
@@ -518,36 +572,6 @@ class TableViewCellFileAccessoryViewDemoController: DemoController {
 
     @objc private func handleKeepOfflineAction() {
         displayActionAlert(title: "Keep offline")
-    }
-
-    @objc private func incrementMinimumActionsCount() {
-        minimumActionsCount += 1
-    }
-
-    @objc private func decrementMinimumActionsCount() {
-        if minimumActionsCount > 0 {
-            minimumActionsCount -= 1
-        }
-    }
-
-    @objc private func incrementTopActionsOverlap() {
-        topActionsOverlap += 1
-    }
-
-    @objc private func decrementTopActionsOverlap() {
-        if topActionsOverlap > 0 {
-            topActionsOverlap -= 1
-        }
-    }
-
-    @objc private func incrementBottomActionsOverlap() {
-        bottomActionsOverlap += 1
-    }
-
-    @objc private func decrementBottomActionsOverlap() {
-        if bottomActionsOverlap > 0 {
-            bottomActionsOverlap -= 1
-        }
     }
 
     private func displayActionAlert(title: String) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
@@ -19,10 +19,22 @@ class TooltipDemoController: DemoController {
         navigationItem.titleView = titleView
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Show on title", style: .plain, target: self, action: #selector(showTitleTooltip))
 
-        container.addArrangedSubview(createButton(title: "Show single-line tooltip below", action: #selector(showSingleTooltipBelow)))
-        container.addArrangedSubview(createButton(title: "Show double-line tooltip above", action: #selector(showDoubleTooltipAbove)))
-        container.addArrangedSubview(createButton(title: "Show with tap on tooltip dismissal", action: #selector(showTooltipWithTapOnTooltipDismissal)))
-        container.addArrangedSubview(createButton(title: "Show with tap on tooltip or anchor dismissal", action: #selector(showTooltipWithTapOnTooltipOrAnchorDismissal)))
+        container.addArrangedSubview(createButton(title: "Show single-line tooltip below", action: { sender in
+            Tooltip.shared.show(with: "This is pointing up.", for: sender.view, preferredArrowDirection: .up)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show double-line tooltip above", action: { sender in
+            Tooltip.shared.show(with: "This is a very long message, and this is also pointing down.", for: sender.view)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show with tap on tooltip dismissal", action: { sender in
+            Tooltip.shared.show(with: "Tap on this tooltip to dismiss.", for: sender.view, preferredArrowDirection: .up, dismissOn: .tapOnTooltip)
+        }).view)
+        container.addArrangedSubview(createButton(title: "Show with tap on tooltip or anchor dismissal", action: { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+
+            Tooltip.shared.show(with: "Tap on this tooltip or this title button to dismiss.", for: strongSelf.titleView, dismissOn: .tapOnTooltipOrAnchor)
+        }).view)
         container.addArrangedSubview(createLeftRightButtons())
 
         edgeCaseStackView = createEdgeCaseButtons()
@@ -39,16 +51,16 @@ class TooltipDemoController: DemoController {
         container.distribution = .fillEqually
         container.spacing = 16.0
 
-        let leftButton = createButton(title: "Show tooltip\n(with arrow left)", action: #selector(showTooltipLeftArrow))
-        leftButton.titleLabel?.textAlignment = .center
-        leftButton.titleLabel?.lineBreakMode = .byWordWrapping
+        let leftButton = createButton(title: "Show tooltip\n(with arrow left)", action: { sender in
+            Tooltip.shared.show(with: "This is pointing left.", for: sender.view, preferredArrowDirection: .left)
+        })
 
-        let rightButton = createButton(title: "Show tooltip\n(with arrow right)", action: #selector(showTooltipRightArrow))
-        rightButton.titleLabel?.textAlignment = .center
-        rightButton.titleLabel?.lineBreakMode = .byWordWrapping
+        let rightButton = createButton(title: "Show tooltip\n(with arrow right)", action: { sender in
+            Tooltip.shared.show(with: "This is pointing right.", for: sender.view, preferredArrowDirection: .right)
+        })
 
-        container.addArrangedSubview(leftButton)
-        container.addArrangedSubview(rightButton)
+        container.addArrangedSubview(leftButton.view)
+        container.addArrangedSubview(rightButton.view)
         return container
     }
 
@@ -58,10 +70,46 @@ class TooltipDemoController: DemoController {
         container.distribution = .equalSpacing
         container.alignment = .fill
 
-        let topleftButton = createButton(title: "", action: #selector(showTopLeftOffsetTooltip))
-        let topRightButton = createButton(title: "", action: #selector(showTopRightOffsetTooltip))
-        let bottomLeftButton = createButton(title: "", action: #selector(showBottomLeftOffsetTooltip))
-        let bottomRightButton = createButton(title: "", action: #selector(showBottomRightOffsetTooltip))
+        let topleftButton = createButton(title: " ", action: { sender in
+            Tooltip.shared.show(with: "This is an offset tooltip.", for: sender.view, preferredArrowDirection: .up)
+        }).view
+
+        let topRightButton = createButton(title: "", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            guard let window = strongSelf.view.window else {
+                return
+            }
+
+            let edgeCaseStackView = strongSelf.edgeCaseStackView!
+            var margins = Tooltip.defaultScreenMargins
+            margins.top = edgeCaseStackView.convert(edgeCaseStackView.bounds, to: window).minY - window.safeAreaInsets.top
+            margins.left = window.frame.inset(by: window.safeAreaInsets).midX
+            Tooltip.shared.show(with: "This is a very long, offset message.", for: sender.view, preferredArrowDirection: .right, screenMargins: margins)
+        }).view
+
+        let bottomLeftButton = createButton(title: "", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            guard let window = strongSelf.view.window else {
+                return
+            }
+            var margins = Tooltip.defaultScreenMargins
+            margins.right = window.frame.inset(by: window.safeAreaInsets).midX
+            Tooltip.shared.show(with: "This is a very long, offset message.", for: sender.view, preferredArrowDirection: .left, screenMargins: margins)
+        }).view
+
+        let bottomRightButton = createButton(title: "", action: { [weak self] sender in
+            guard let strongSelf = self else {
+                return
+            }
+
+            Tooltip.shared.show(with: "This is an offset tooltip.", for: sender.view)
+        }).view
 
         for button in [topleftButton, topRightButton, bottomLeftButton, bottomRightButton] {
             button.widthAnchor.constraint(equalToConstant: 32.0).isActive = true
@@ -93,57 +141,6 @@ class TooltipDemoController: DemoController {
 
     @objc func showTitleTooltip(sender: UIBarButtonItem) {
         Tooltip.shared.show(with: "This is a title-based tooltip.", for: titleView, preferredArrowDirection: .up)
-    }
-
-    @objc func showSingleTooltipBelow(sender: MSFButton) {
-        Tooltip.shared.show(with: "This is pointing up.", for: sender, preferredArrowDirection: .up)
-    }
-
-    @objc func showDoubleTooltipAbove(sender: MSFButton) {
-        Tooltip.shared.show(with: "This is a very long message, and this is also pointing down.", for: sender)
-    }
-
-    @objc func showTooltipWithTapOnTooltipDismissal(sender: MSFButton) {
-        Tooltip.shared.show(with: "Tap on this tooltip to dismiss.", for: sender, preferredArrowDirection: .up, dismissOn: .tapOnTooltip)
-    }
-
-    @objc func showTooltipWithTapOnTooltipOrAnchorDismissal(sender: MSFButton) {
-        Tooltip.shared.show(with: "Tap on this tooltip or this title button to dismiss.", for: titleView, dismissOn: .tapOnTooltipOrAnchor)
-    }
-
-    @objc func showTooltipLeftArrow(sender: MSFButton) {
-        Tooltip.shared.show(with: "This is pointing left.", for: sender, preferredArrowDirection: .left)
-    }
-
-    @objc func showTooltipRightArrow(sender: MSFButton) {
-        Tooltip.shared.show(with: "This is pointing right.", for: sender, preferredArrowDirection: .right)
-    }
-
-    @objc func showTopLeftOffsetTooltip(sender: MSFButton) {
-        Tooltip.shared.show(with: "This is an offset tooltip.", for: sender, preferredArrowDirection: .up)
-    }
-
-    @objc func showTopRightOffsetTooltip(sender: MSFButton) {
-        guard let window = view.window else {
-            return
-        }
-        var margins = Tooltip.defaultScreenMargins
-        margins.top = edgeCaseStackView.convert(edgeCaseStackView.bounds, to: window).minY - window.safeAreaInsets.top
-        margins.left = window.frame.inset(by: window.safeAreaInsets).midX
-        Tooltip.shared.show(with: "This is a very long, offset message.", for: sender, preferredArrowDirection: .right, screenMargins: margins)
-    }
-
-    @objc func showBottomLeftOffsetTooltip(sender: MSFButton) {
-        guard let window = view.window else {
-            return
-        }
-        var margins = Tooltip.defaultScreenMargins
-        margins.right = window.frame.inset(by: window.safeAreaInsets).midX
-        Tooltip.shared.show(with: "This is a very long, offset message.", for: sender, preferredArrowDirection: .left, screenMargins: margins)
-    }
-
-    @objc func showBottomRightOffsetTooltip(sender: MSFButton) {
-        Tooltip.shared.show(with: "This is an offset tooltip.", for: sender)
     }
 }
 

--- a/ios/FluentUI/Controls/ButtonVnext.swift
+++ b/ios/FluentUI/Controls/ButtonVnext.swift
@@ -145,20 +145,23 @@ public struct MSFButtonViewButtonStyle: ButtonStyle {
                     Text(text)
                         .font(Font(tokens.textFont))
                         .fontWeight(.medium)
+                        .multilineTextAlignment(.center)
                 }
         }
         .padding(tokens.padding)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundColor(Color(isDisabled ? tokens.disabledTitleColor :
                                 (isPressed ? tokens.highlightedTitleColor : tokens.titleColor)))
                     .background((tokens.borderSize > 0) ?
                         AnyView(RoundedRectangle(cornerRadius: tokens.borderRadius)
-                            .strokeBorder(lineWidth: tokens.borderSize, antialiased: false)
-                            .foregroundColor(Color(isDisabled ? tokens.disabledBorderColor :
-                                                    (isPressed ? tokens.highlightedBorderColor : tokens.borderColor))))
+                                    .strokeBorder(lineWidth: tokens.borderSize, antialiased: false)
+                                    .foregroundColor(Color(isDisabled ? tokens.disabledBorderColor :
+                                                            (isPressed ? tokens.highlightedBorderColor : tokens.borderColor)))
+                                    .contentShape(Rectangle()))
                                     :
                         AnyView(RoundedRectangle(cornerRadius: tokens.borderRadius)
-                            .fill(Color(isDisabled ? tokens.disabledBackgroundColor :
-                                            (isPressed ? tokens.highlightedBackgroundColor : tokens.backgroundColor)))))
+                                    .fill(Color(isDisabled ? tokens.disabledBackgroundColor :
+                                                    (isPressed ? tokens.highlightedBackgroundColor : tokens.backgroundColor)))))
     }
 }
 
@@ -180,7 +183,7 @@ public struct MSFButtonView: View {
         Button(action: action, label: {})
             .buttonStyle(MSFButtonViewButtonStyle(targetButton: self))
             .disabled(state.isDisabled)
-            .fixedSize()
+            .frame(maxWidth: .infinity)
     }
 }
 
@@ -188,7 +191,9 @@ public struct MSFButtonView: View {
 /// UIKit wrapper that exposes the SwiftUI Button implementation
 open class MSFButtonVnext: NSObject {
 
-    private var hostingController: UIHostingController<MSFButtonView>
+    private var hostingController: UIHostingController<MSFButtonView>!
+
+    @objc open var action: ((_ sender: MSFButtonVnext) -> Void)?
 
     @objc open var view: UIView {
         return hostingController.view
@@ -200,11 +205,20 @@ open class MSFButtonVnext: NSObject {
 
     @objc public init(style: MSFButtonVnextStyle = .secondary,
                       size: MSFButtonVnextSize = .large,
-                      action: @escaping () -> Void) {
-        self.hostingController = UIHostingController(rootView: MSFButtonView(action: action,
-                                                                             style: style,
-                                                                             size: size))
+                      action: ((_ sender: MSFButtonVnext) -> Void)?) {
         super.init()
+        initialize(style: style, size: size, action: action)
+    }
+
+    private func initialize(style: MSFButtonVnextStyle = .secondary,
+                            size: MSFButtonVnextSize = .large,
+                            action: ((_ sender: MSFButtonVnext) -> Void)?) {
+        self.action = action
+        self.hostingController = UIHostingController(rootView: MSFButtonView(action: {
+            self.action?(self)
+        },
+        style: style,
+        size: size))
         self.view.backgroundColor = UIColor.clear
     }
 }

--- a/ios/FluentUI/Controls/ButtonVnext.swift
+++ b/ios/FluentUI/Controls/ButtonVnext.swift
@@ -146,6 +146,7 @@ public struct MSFButtonViewButtonStyle: ButtonStyle {
                         .font(Font(tokens.textFont))
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
+                        .fixedSize()
                 }
         }
         .padding(tokens.padding)

--- a/ios/FluentUI/Controls/ButtonVnext.swift
+++ b/ios/FluentUI/Controls/ButtonVnext.swift
@@ -146,7 +146,6 @@ public struct MSFButtonViewButtonStyle: ButtonStyle {
                         .font(Font(tokens.textFont))
                         .fontWeight(.medium)
                         .multilineTextAlignment(.center)
-                        .fixedSize()
                 }
         }
         .padding(tokens.padding)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change replaces the usage of the MSFButton (subclass of UIButton) with the new MSFButtonVnext (SwiftUI implementation).

As outlined in #330, there were some issues with the MSFButtonVnext view (UIView from its hosting controller) when layout constraints were applied to it.

1. The layout constraints issue has been resolved and the new button view can also be used with layout constraints.

2. The action closure implementation of the button now provides the sender parameter which allows the calling code to access the object instance that triggered the action.

3. The demo app usage of the button was updated to capture a weak reference of self on the closure an avoid reference cycles with the pattern below:

```
action: { [weak self] sender in
            guard let strongSelf = self else {
                return
            }
            ...
}
```

### Verification

|                                        |                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2020-12-14 at 9 17 31 AM](https://user-images.githubusercontent.com/68076145/102113348-c9f8c780-3ded-11eb-8a2e-412374f871bd.png) | ![Screen Shot 2020-12-14 at 9 17 54 AM](https://user-images.githubusercontent.com/68076145/102113397-d41ac600-3ded-11eb-83f1-07106d99e8a2.png) |
| ![Screen Shot 2020-12-14 at 9 18 27 AM](https://user-images.githubusercontent.com/68076145/102113475-ebf24a00-3ded-11eb-9798-d286663fb799.png) | ![Screen Shot 2020-12-14 at 9 18 56 AM](https://user-images.githubusercontent.com/68076145/102113492-f3195800-3ded-11eb-8a41-8bf833225ebb.png) |
| ![Screen Shot 2020-12-14 at 9 19 35 AM](https://user-images.githubusercontent.com/68076145/102113549-03c9ce00-3dee-11eb-8797-538375a98070.png) | ![Screen Shot 2020-12-14 at 9 20 00 AM](https://user-images.githubusercontent.com/68076145/102113569-0b897280-3dee-11eb-935c-e45c9e09c917.png) |
| ![Screen Shot 2020-12-14 at 9 20 18 AM](https://user-images.githubusercontent.com/68076145/102113596-12b08080-3dee-11eb-9e7b-7ed5eeafd45a.png) | ![Screen Shot 2020-12-14 at 9 20 37 AM](https://user-images.githubusercontent.com/68076145/102113624-193ef800-3dee-11eb-98e1-728ad4e78b54.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/341)