### PR TITLE
[AvatarVnextView] Adding transparency to the inner ring gap.

### DIFF
--- a/ios/FluentUI/People Picker/AvatarViewVnext.swift
+++ b/ios/FluentUI/People Picker/AvatarViewVnext.swift
@@ -258,6 +258,7 @@ public struct AvatarVnextView: View {
         let presenceCutoutOriginCoordinates: CGFloat = ringOuterGapSize - presenceIconFrameDiffRelativeToOuterRing - presenceIconOutlineSize
         let presenceIconFrameSideRelativeToOuterRing: CGFloat = presenceIconFrameSideRelativeToInnerRing + outerGapAndRingThicknesCombined
 
+        let ringGapColor = shouldUseOpaqueBorders ? Color(tokens.ringGapColor) : Color.clear
         let ringColor = state.ringColor ?? tokens.ringDefaultColor!
         let backgroundColor = state.backgroundColor ?? tokens.backgroundDefaultColor!
         let foregroundColor = state.foregroundColor ?? tokens.foregroundDefaultColor!
@@ -287,13 +288,22 @@ public struct AvatarVnextView: View {
                 .cornerRadius(tokens.borderRadius)
         } else {
             Circle()
-                .foregroundColor(shouldUseOpaqueBorders ? Color(tokens.ringGapColor) : Color.clear)
+                .foregroundColor(ringGapColor)
                 .frame(width: ringOuterGapSize, height: ringOuterGapSize, alignment: .center)
                 .overlay(Circle()
                             .foregroundColor(Color(ringColor))
                             .frame(width: ringSize, height: ringSize, alignment: .center)
+                            .mask(circularCutoutMask(targetFrameRect: CGRect(x: 0,
+                                                                             y: 0,
+                                                                             width: ringSize,
+                                                                             height: ringSize),
+                                                     cutoutFrameRect: CGRect(x: tokens.ringThickness,
+                                                                             y: tokens.ringThickness,
+                                                                             width: ringInnerGapSize,
+                                                                             height: ringInnerGapSize))
+                                    .fill(style: FillStyle(eoFill: !shouldUseOpaqueBorders)))
                             .overlay(Circle()
-                                        .foregroundColor(Color(tokens.ringGapColor))
+                                        .foregroundColor(ringGapColor)
                                         .frame(width: ringInnerGapSize, height: ringInnerGapSize, alignment: .center)
                                         .overlay(Circle()
                                                     .foregroundColor(Color(backgroundColor))
@@ -303,9 +313,10 @@ public struct AvatarVnextView: View {
                                                                 .clipShape(Circle()),
                                                              alignment: .center)
                                         )
-                            ),
+                            )
+                         ,
                          alignment: .center)
-                .mask(presenceCutoutMask(targetFrameRect: CGRect(x: 0,
+                .mask(circularCutoutMask(targetFrameRect: CGRect(x: 0,
                                                                  y: 0,
                                                                  width: ringOuterGapSize,
                                                                  height: ringOuterGapSize),
@@ -330,7 +341,7 @@ public struct AvatarVnextView: View {
         }
     }
 
-    func presenceCutoutMask(targetFrameRect: CGRect, cutoutFrameRect: CGRect) -> Path {
+    func circularCutoutMask(targetFrameRect: CGRect, cutoutFrameRect: CGRect) -> Path {
         var cutoutFrame = Rectangle().path(in: targetFrameRect)
         cutoutFrame.addPath(Circle().path(in: cutoutFrameRect))
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The design team confirmed that the inner gap between the avatar ring and the circular image (or initials view) should follow the same transparency pattern as the ring outer gap.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![transparent_inner_ring_gap_before](https://user-images.githubusercontent.com/68076145/102176922-44116680-3e57-11eb-9cfe-4685a8e1a7e8.png) | ![transparent_inner_ring_gap_after](https://user-images.githubusercontent.com/68076145/102176943-4d023800-3e57-11eb-8220-32d6b4c5cfef.png) |

Other screenshots with variations of light/dark modes, use of opaque borders:

![Screen Shot 2020-12-14 at 9 48 24 PM](https://user-images.githubusercontent.com/68076145/102177022-82a72100-3e57-11eb-8a13-e09a107c2aa8.png)
![Screen Shot 2020-12-14 at 9 48 17 PM](https://user-images.githubusercontent.com/68076145/102177030-85097b00-3e57-11eb-99ef-4b9d95c1015c.png)
![Screen Shot 2020-12-14 at 9 48 41 PM](https://user-images.githubusercontent.com/68076145/102177035-85a21180-3e57-11eb-84be-93f34d33db08.png)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/342)