### PR TITLE
[AvatarVnextView] Revisiting Avatar state, styles, covering fallback scenarios and adding tokenized calculated background colors.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarVnextDemoController.swift
@@ -51,8 +51,8 @@ class AvatarVnextDemoController: DemoController {
         for size in AvatarVnextSize.allCases.reversed() {
             let phoneNumber = "+1 (425) 123 4567"
             let defaultAvatar = createAvatarView(size: size,
-                                                       name: phoneNumber,
-                                                       style: .default)
+                                                 name: phoneNumber,
+                                                 style: .default)
             avatarViews.append(defaultAvatar)
 
             let accentAvatar = createAvatarView(size: size,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarVnextDemoController.swift
@@ -7,72 +7,103 @@ import FluentUI
 import UIKit
 
 class AvatarVnextDemoController: DemoController {
-    enum BorderStyle: Int {
-    case noBorder
-    case defaultBorder
-    case colorfulBorder
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let showPresenceSettingView = createLabelAndSwitchRow(labelText: "Show presence",
-                                                              switchAction: #selector(toggleShowPresence(switchView:)),
-                                                              isOn: isShowingPresence)
 
         let backgroundSettingView = createLabelAndSwitchRow(labelText: "Use alternate background color",
                                                             switchAction: #selector(toggleAlternateBackground(switchView:)),
                                                             isOn: isUsingAlternateBackgroundColor)
-
-        let opaqueBorderSettingView = createLabelAndSwitchRow(labelText: "Use opaque borders",
-                                                            switchAction: #selector(toggleOpaqueBorders(switchView:)),
-                                                            isOn: isUsingOpaqueBorders)
-
         addRow(items: [backgroundSettingView])
+
+        let transparencySettingView = createLabelAndSwitchRow(labelText: "Do not use transparency",
+                                                              switchAction: #selector(toggleOpaqueBorders(switchView:)),
+                                                              isOn: !isTransparent)
+        addRow(items: [transparencySettingView])
+
+        let showPresenceSettingView = createLabelAndSwitchRow(labelText: "Show presence",
+                                                              switchAction: #selector(toggleShowPresence(switchView:)),
+                                                              isOn: isShowingPresence)
         addRow(items: [showPresenceSettingView])
-        addRow(items: [opaqueBorderSettingView])
 
-        createSection(withTitle: "Circle style for person",
-                      name: "Kat Larrson",
-                      image: UIImage(named: "avatar_kat_larsson")!,
-                      style: .noring)
+        let showRingsSettingView = createLabelAndSwitchRow(labelText: "Show rings",
+                                                           switchAction: #selector(toggleShowRings(switchView:)),
+                                                           isOn: isShowingRings)
+        addRow(items: [showRingsSettingView])
 
-        createSection(withTitle: "Square style for group",
-                      name: "NorthWind Traders",
-                      image: UIImage(named: "site")!,
-                      style: .group)
+        addTitle(text: "Default style")
+        for size in AvatarVnextSize.allCases.reversed() {
+            let name = "Kat Larrson"
+            let imageAvatar = createAvatarView(size: size,
+                                               name: name,
+                                               image: UIImage(named: "avatar_kat_larsson")!,
+                                               style: .default)
+            avatarViews.append(imageAvatar)
 
-        createSection(withTitle: "Circle style with border",
-                      name: "Kat Larrson",
-                      image: UIImage(named: "avatar_kat_larsson")!,
-                      style: .default,
-                      borderStyle: .defaultBorder)
+            let initialsAvatar = createAvatarView(size: size,
+                                                  name: name,
+                                                  style: .default)
+            avatarViews.append(initialsAvatar)
 
-        addTitle(text: "Fallback Images")
+            addRow(text: size.description, items: [imageAvatar.view, initialsAvatar.view], textStyle: .footnote, textWidth: 100)
+        }
+
+        addTitle(text: "Fallback (default style and accent style)")
         for size in AvatarVnextSize.allCases.reversed() {
             let phoneNumber = "+1 (425) 123 4567"
-            let fallbackImageAvatar = createAvatarView(size: size,
+            let defaultAvatar = createAvatarView(size: size,
                                                        name: phoneNumber,
-                                                       style: .noring)
-            addRow(text: size.description, items: [fallbackImageAvatar.1.view], textStyle: .footnote, textWidth: 100)
+                                                       style: .default)
+            avatarViews.append(defaultAvatar)
+
+            let accentAvatar = createAvatarView(size: size,
+                                                name: phoneNumber,
+                                                style: .accent)
+            avatarViews.append(accentAvatar)
+
+            addRow(text: size.description, items: [defaultAvatar.view, accentAvatar.view], textStyle: .footnote, textWidth: 100)
         }
 
-        addTitle(text: "Unauthenticated")
+        addTitle(text: "Fallback (outlined style and outlinedPrimary style)")
         for size in AvatarVnextSize.allCases.reversed() {
-            let unauthenticatedAvatar = createAvatarView(size: size,
-                                                         name: nil,
-                                                         style: .unauthenticated)
+            let phoneNumber = "+1 (425) 123 4567"
+            let outlinedAvatar = createAvatarView(size: size,
+                                                  name: phoneNumber,
+                                                  style: .outlined)
+            avatarViews.append(outlinedAvatar)
 
-            avatarViewsUnauthenticated.append(unauthenticatedAvatar.1)
-            addRow(text: size.description, items: [unauthenticatedAvatar.1.view], textStyle: .footnote, textWidth: 100)
+            let outlinedPrimaryAvatar = createAvatarView(size: size,
+                                                         name: phoneNumber,
+                                                         style: .outlinedPrimary)
+            avatarViews.append(outlinedPrimaryAvatar)
+
+            addRow(text: size.description, items: [outlinedAvatar.view, outlinedPrimaryAvatar.view], textStyle: .footnote, textWidth: 100)
         }
 
-        addTitle(text: "Overflow")
+        addTitle(text: "Group style")
+        for size in AvatarVnextSize.allCases.reversed() {
+            let name = "NorthWind Traders"
+            let imageAvatar = createAvatarView(size: size,
+                                               name: name,
+                                               image: UIImage(named: "site")!,
+                                               style: .group)
+            avatarViews.append(imageAvatar)
+
+            let initialsAvatar = createAvatarView(size: size,
+                                                  name: name,
+                                                  style: .group)
+            avatarViews.append(initialsAvatar)
+
+            addRow(text: size.description, items: [imageAvatar.view, initialsAvatar.view], textStyle: .footnote, textWidth: 100)
+        }
+
+        addTitle(text: "Overflow style")
         for size in AvatarVnextSize.allCases.reversed() {
             let overflowAvatar = createAvatarView(size: size,
                                                   name: "20",
                                                   style: .overflow)
-            addRow(text: size.description, items: [overflowAvatar.1.view], textStyle: .footnote, textWidth: 100)
+            avatarViews.append(overflowAvatar)
+
+            addRow(text: size.description, items: [overflowAvatar.view], textStyle: .footnote, textWidth: 100)
         }
     }
 
@@ -85,30 +116,28 @@ class AvatarVnextDemoController: DemoController {
     private var isShowingPresence: Bool = false {
         didSet {
             if oldValue != isShowingPresence {
-                for avatarView in avatarViewsWithImages {
+                for avatarView in avatarViews {
                     avatarView.state.presence = isShowingPresence ? nextPresence() : .none
-                }
-
-                for avatarView in avatarViewsWithInitials {
-                    avatarView.state.presence = isShowingPresence ? nextPresence()  : .none
                 }
             }
         }
     }
 
-    private var isUsingOpaqueBorders: Bool = false {
+    private var isShowingRings: Bool = false {
         didSet {
-            if oldValue != isUsingOpaqueBorders {
-                for avatarView in avatarViewsWithImages {
-                    avatarView.state.shouldUseOpaqueBorders = isUsingOpaqueBorders
+            if oldValue != isShowingRings {
+                for avatarView in avatarViews {
+                    avatarView.state.isRingVisible = isShowingRings
                 }
+            }
+        }
+    }
 
-                for avatarView in avatarViewsWithInitials {
-                    avatarView.state.shouldUseOpaqueBorders = isUsingOpaqueBorders
-                }
-
-                for avatarView in avatarViewsUnauthenticated {
-                    avatarView.state.shouldUseOpaqueBorders = isUsingOpaqueBorders
+    private var isTransparent: Bool = true {
+        didSet {
+            if oldValue != isTransparent {
+                for avatarView in avatarViews {
+                    avatarView.state.isTransparent = isTransparent
                 }
             }
         }
@@ -135,57 +164,34 @@ class AvatarVnextDemoController: DemoController {
         isShowingPresence = switchView.isOn
     }
 
+    @objc private func toggleShowRings(switchView: UISwitch) {
+        isShowingRings = switchView.isOn
+    }
+
     @objc private func toggleAlternateBackground(switchView: UISwitch) {
         isUsingAlternateBackgroundColor = switchView.isOn
     }
 
     @objc private func toggleOpaqueBorders(switchView: UISwitch) {
-        isUsingOpaqueBorders = switchView.isOn
+        isTransparent = !switchView.isOn
     }
 
     private func updateBackgroundColor() {
         view.backgroundColor = isUsingAlternateBackgroundColor ? UIColor(light: Colors.gray100, dark: Colors.gray600) : Colors.surfacePrimary
     }
 
-    private var avatarViewsWithImages: [AvatarVnext] = []
-    private var avatarViewsWithInitials: [AvatarVnext] = []
-    private var avatarViewsUnauthenticated: [AvatarVnext] = []
-
-    private func createSection(withTitle title: String,
-                               name: String,
-                               image: UIImage,
-                               style: AvatarVnextStyle,
-                               borderStyle: BorderStyle = .noBorder) {
-        addTitle(text: title)
-
-        for size in AvatarVnextSize.allCases.reversed() {
-            let imageAvatar = createAvatarView(size: size,
-                                               name: name,
-                                               image: image,
-                                               style: style)
-            avatarViewsWithImages.append(imageAvatar.1)
-
-            let initialsAvatar = createAvatarView(size: size,
-                                                  name: name,
-                                                  style: style)
-            avatarViewsWithInitials.append(initialsAvatar.1)
-
-            addRow(text: size.description, items: [imageAvatar.0, initialsAvatar.0], textStyle: .footnote, textWidth: 100)
-        }
-
-        container.addArrangedSubview(UIView())
-    }
+    private var avatarViews: [AvatarVnext] = []
 
     private func createAvatarView(size: AvatarVnextSize,
                                   name: String? = nil,
                                   image: UIImage? = nil,
-                                  style: AvatarVnextStyle) -> (UIView, AvatarVnext) {
+                                  style: AvatarVnextStyle) -> AvatarVnext {
         let avatarView = AvatarVnext(style: style,
                                      size: size)
         avatarView.state.primaryText = name
         avatarView.state.image = image
 
-        return (avatarView.view, avatarView)
+        return avatarView
     }
 }
 

--- a/ios/FluentUI/Generated/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Generated/FluentUIStyle.generated.swift
@@ -289,11 +289,6 @@ extension StylesheetManagerTheming {
 	case title3
 }
 
-@objc public enum style: Int, Equatable {
-	case filled = 0
-	case regular
-}
-
 }
 /// Entry point for the app stylesheet
 @objc(STRFluentUIStyle) @objcMembers public class FluentUIStyle: NSObject {
@@ -301,6 +296,30 @@ extension StylesheetManagerTheming {
 	public class func shared() -> FluentUIStyle {
 		 struct __ { static let _sharedInstance = FluentUIStyle() }
 		return __._sharedInstance
+	}
+	//MARK: - AccentAvatarTokens
+	public var _AccentAvatarTokens: AccentAvatarTokensAppearanceProxy?
+	open func AccentAvatarTokensStyle() -> AccentAvatarTokensAppearanceProxy {
+		if let override = _AccentAvatarTokens { return override }
+			return AccentAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
+		}
+	public var AccentAvatarTokens: AccentAvatarTokensAppearanceProxy {
+		get { return self.AccentAvatarTokensStyle() }
+		set { _AccentAvatarTokens = newValue }
+	}
+	@objc(AccentAvatarTokensAppearanceProxy) @objcMembers open class AccentAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
+
+		//MARK: backgroundDefaultColor 
+		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _backgroundDefaultColor { return override }
+			return mainProxy().Colors.Brand.primaryProperty(traitCollection)
+			}
+
+		//MARK: foregroundDefaultColor 
+		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _foregroundDefaultColor { return override }
+			return mainProxy().Icon.accentColorProperty(traitCollection)
+			}
 	}
 	//MARK: - AvatarTokens
 	public var _AvatarTokens: AvatarTokensAppearanceProxy?
@@ -322,7 +341,7 @@ extension StylesheetManagerTheming {
 		public var _backgroundDefaultColor: UIColor?
 		open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _backgroundDefaultColor { return override }
-			return UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0)
+			return UIColor(light: mainProxy().Colors.Neutral.whiteProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brand.primaryProperty(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 		public var backgroundDefaultColor: UIColor {
 			get { return self.backgroundDefaultColorProperty() }
@@ -417,7 +436,7 @@ extension StylesheetManagerTheming {
 		public var _foregroundDefaultColor: UIColor?
 		open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _foregroundDefaultColor { return override }
-			return UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0)
+			return UIColor(light: mainProxy().Colors.Brand.primaryProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Icon.accentColorProperty(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 		public var foregroundDefaultColor: UIColor {
 			get { return self.foregroundDefaultColorProperty() }
@@ -607,7 +626,7 @@ extension StylesheetManagerTheming {
 		public var _ringDefaultColor: UIColor?
 		open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _ringDefaultColor { return override }
-			return UIColor(red: 0.77254903, green: 0.05882353, blue: 0.12156863, alpha: 1.0)
+			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
 			}
 		public var ringDefaultColor: UIColor {
 			get { return self.ringDefaultColorProperty() }
@@ -960,6 +979,49 @@ extension StylesheetManagerTheming {
 			}
 		}
 
+
+		//MARK: textCalculatedBackgroundColors 
+		public var _textCalculatedBackgroundColors: [UIColor]?
+		open func textCalculatedBackgroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
+			if let override = _textCalculatedBackgroundColors { return override }
+			return [
+			UIColor(named: "FluentColors/cyanBlue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/red10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/magenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/green10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/magentaPink10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/cyanBlue20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/orange20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/cyan20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/orangeYellow20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/red20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/blue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/magenta10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/gray40", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/green20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/blueMagenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/pinkRed10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/gray30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/blueMagenta30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/gray20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/cyan30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/orange30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!]
+			}
+		public var textCalculatedBackgroundColors: [UIColor] {
+			get { return self.textCalculatedBackgroundColorsProperty() }
+			set { _textCalculatedBackgroundColors = newValue }
+		}
+
+		//MARK: textColor 
+		public var _textColor: UIColor?
+		open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _textColor { return override }
+			return mainProxy().Colors.Foreground.neutralInvertedProperty(traitCollection)
+			}
+		public var textColor: UIColor {
+			get { return self.textColorProperty() }
+			set { _textColor = newValue }
+		}
 
 		//MARK: - textFont
 		public var _textFont: textFontAppearanceProxy?
@@ -2538,141 +2600,6 @@ extension StylesheetManagerTheming {
 				}
 		}
 
-
-		//MARK: - GroupAvatarTokensringInnerGap
-		override open func ringInnerGapStyle() -> AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-			if let override = _ringInnerGap { return override }
-				return GroupAvatarTokensringInnerGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(GroupAvatarTokensRingInnerGapAppearanceProxy) @objcMembers open class GroupAvatarTokensringInnerGapAppearanceProxy: AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - GroupAvatarTokensringOuterGap
-		override open func ringOuterGapStyle() -> AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-			if let override = _ringOuterGap { return override }
-				return GroupAvatarTokensringOuterGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(GroupAvatarTokensRingOuterGapAppearanceProxy) @objcMembers open class GroupAvatarTokensringOuterGapAppearanceProxy: AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - GroupAvatarTokensringThickness
-		override open func ringThicknessStyle() -> AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-			if let override = _ringThickness { return override }
-				return GroupAvatarTokensringThicknessAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(GroupAvatarTokensRingThicknessAppearanceProxy) @objcMembers open class GroupAvatarTokensringThicknessAppearanceProxy: AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
 	}
 	//MARK: - Icon
 	public var _Icon: IconAppearanceProxy?
@@ -2688,6 +2615,17 @@ extension StylesheetManagerTheming {
 		public let mainProxy: () -> FluentUIStyle
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
+		}
+
+		//MARK: accentColor 
+		public var _accentColor: UIColor?
+		open func accentColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _accentColor { return override }
+			return UIColor(light: mainProxy().Colors.Neutral.whiteProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.blackProperty(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var accentColor: UIColor {
+			get { return self.accentColorProperty() }
+			set { _accentColor = newValue }
 		}
 
 		//MARK: - size
@@ -3421,159 +3359,6 @@ extension StylesheetManagerTheming {
 		}
 
 	}
-	//MARK: - NoRingAvatarTokens
-	public var _NoRingAvatarTokens: NoRingAvatarTokensAppearanceProxy?
-	open func NoRingAvatarTokensStyle() -> NoRingAvatarTokensAppearanceProxy {
-		if let override = _NoRingAvatarTokens { return override }
-			return NoRingAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
-		}
-	public var NoRingAvatarTokens: NoRingAvatarTokensAppearanceProxy {
-		get { return self.NoRingAvatarTokensStyle() }
-		set { _NoRingAvatarTokens = newValue }
-	}
-	@objc(NoRingAvatarTokensAppearanceProxy) @objcMembers open class NoRingAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
-
-		//MARK: ringDefaultColor 
-		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Neutral.clearProperty(traitCollection)
-			}
-
-		//MARK: - NoRingAvatarTokensringInnerGap
-		override open func ringInnerGapStyle() -> AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-			if let override = _ringInnerGap { return override }
-				return NoRingAvatarTokensringInnerGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(NoRingAvatarTokensRingInnerGapAppearanceProxy) @objcMembers open class NoRingAvatarTokensringInnerGapAppearanceProxy: AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - NoRingAvatarTokensringOuterGap
-		override open func ringOuterGapStyle() -> AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-			if let override = _ringOuterGap { return override }
-				return NoRingAvatarTokensringOuterGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(NoRingAvatarTokensRingOuterGapAppearanceProxy) @objcMembers open class NoRingAvatarTokensringOuterGapAppearanceProxy: AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - NoRingAvatarTokensringThickness
-		override open func ringThicknessStyle() -> AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-			if let override = _ringThickness { return override }
-				return NoRingAvatarTokensringThicknessAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(NoRingAvatarTokensRingThicknessAppearanceProxy) @objcMembers open class NoRingAvatarTokensringThicknessAppearanceProxy: AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-	}
 	//MARK: - Opacity
 	public var _Opacity: OpacityAppearanceProxy?
 	open func OpacityStyle() -> OpacityAppearanceProxy {
@@ -3689,6 +3474,54 @@ extension StylesheetManagerTheming {
 			set { _opacity96 = newValue }
 		}
 	}
+	//MARK: - OutlinedAvatarTokens
+	public var _OutlinedAvatarTokens: OutlinedAvatarTokensAppearanceProxy?
+	open func OutlinedAvatarTokensStyle() -> OutlinedAvatarTokensAppearanceProxy {
+		if let override = _OutlinedAvatarTokens { return override }
+			return OutlinedAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
+		}
+	public var OutlinedAvatarTokens: OutlinedAvatarTokensAppearanceProxy {
+		get { return self.OutlinedAvatarTokensStyle() }
+		set { _OutlinedAvatarTokens = newValue }
+	}
+	@objc(OutlinedAvatarTokensAppearanceProxy) @objcMembers open class OutlinedAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
+
+		//MARK: backgroundDefaultColor 
+		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _backgroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Neutral.grey94Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey26Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+
+		//MARK: foregroundDefaultColor 
+		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _foregroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Neutral.grey42Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+	}
+	//MARK: - OutlinedPrimaryAvatarTokens
+	public var _OutlinedPrimaryAvatarTokens: OutlinedPrimaryAvatarTokensAppearanceProxy?
+	open func OutlinedPrimaryAvatarTokensStyle() -> OutlinedPrimaryAvatarTokensAppearanceProxy {
+		if let override = _OutlinedPrimaryAvatarTokens { return override }
+			return OutlinedPrimaryAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
+		}
+	public var OutlinedPrimaryAvatarTokens: OutlinedPrimaryAvatarTokensAppearanceProxy {
+		get { return self.OutlinedPrimaryAvatarTokensStyle() }
+		set { _OutlinedPrimaryAvatarTokens = newValue }
+	}
+	@objc(OutlinedPrimaryAvatarTokensAppearanceProxy) @objcMembers open class OutlinedPrimaryAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
+
+		//MARK: backgroundDefaultColor 
+		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _backgroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Brand.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey26Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+
+		//MARK: foregroundDefaultColor 
+		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _foregroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Brand.primaryProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+	}
 	//MARK: - OverflowAvatarTokens
 	public var _OverflowAvatarTokens: OverflowAvatarTokensAppearanceProxy?
 	open func OverflowAvatarTokensStyle() -> OverflowAvatarTokensAppearanceProxy {
@@ -3713,146 +3546,11 @@ extension StylesheetManagerTheming {
 			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
 			}
 
-		//MARK: ringDefaultColor 
-		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+		//MARK: textColor 
+		override open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _textColor { return override }
+			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
 			}
-
-		//MARK: - OverflowAvatarTokensringInnerGap
-		override open func ringInnerGapStyle() -> AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-			if let override = _ringInnerGap { return override }
-				return OverflowAvatarTokensringInnerGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(OverflowAvatarTokensRingInnerGapAppearanceProxy) @objcMembers open class OverflowAvatarTokensringInnerGapAppearanceProxy: AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - OverflowAvatarTokensringOuterGap
-		override open func ringOuterGapStyle() -> AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-			if let override = _ringOuterGap { return override }
-				return OverflowAvatarTokensringOuterGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(OverflowAvatarTokensRingOuterGapAppearanceProxy) @objcMembers open class OverflowAvatarTokensringOuterGapAppearanceProxy: AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - OverflowAvatarTokensringThickness
-		override open func ringThicknessStyle() -> AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-			if let override = _ringThickness { return override }
-				return OverflowAvatarTokensringThicknessAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(OverflowAvatarTokensRingThicknessAppearanceProxy) @objcMembers open class OverflowAvatarTokensringThicknessAppearanceProxy: AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
 	}
 	//MARK: - PrimaryButtonTokens
 	public var _PrimaryButtonTokens: PrimaryButtonTokensAppearanceProxy?
@@ -4236,36 +3934,6 @@ extension StylesheetManagerTheming {
 			set { _subheadline = newValue }
 		}
 	}
-	//MARK: - UnauthenticatedAvatarTokens
-	public var _UnauthenticatedAvatarTokens: UnauthenticatedAvatarTokensAppearanceProxy?
-	open func UnauthenticatedAvatarTokensStyle() -> UnauthenticatedAvatarTokensAppearanceProxy {
-		if let override = _UnauthenticatedAvatarTokens { return override }
-			return UnauthenticatedAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
-		}
-	public var UnauthenticatedAvatarTokens: UnauthenticatedAvatarTokensAppearanceProxy {
-		get { return self.UnauthenticatedAvatarTokensStyle() }
-		set { _UnauthenticatedAvatarTokens = newValue }
-	}
-	@objc(UnauthenticatedAvatarTokensAppearanceProxy) @objcMembers open class UnauthenticatedAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
-
-		//MARK: backgroundDefaultColor 
-		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _backgroundDefaultColor { return override }
-			return mainProxy().Colors.Background.neutral4Property(traitCollection)
-			}
-
-		//MARK: foregroundDefaultColor 
-		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _foregroundDefaultColor { return override }
-			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
-			}
-
-		//MARK: ringDefaultColor 
-		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
-			}
-	}
 	//MARK: - __TextStyle
 	public var ___TextStyle: __TextStyleAppearanceProxy?
 	open func __TextStyleStyle() -> __TextStyleAppearanceProxy {
@@ -4300,14 +3968,16 @@ extension AvatarTokens: AppearaceProxyComponent {
 					return proxy
 				}
 
-				if proxy is FluentUIStyle.GroupAvatarTokensAppearanceProxy {
+				if proxy is FluentUIStyle.AccentAvatarTokensAppearanceProxy {
+					return StylesheetManager.stylesheet(FluentUIStyle.shared()).AccentAvatarTokens
+				} else if proxy is FluentUIStyle.GroupAvatarTokensAppearanceProxy {
 					return StylesheetManager.stylesheet(FluentUIStyle.shared()).GroupAvatarTokens
-				} else if proxy is FluentUIStyle.NoRingAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).NoRingAvatarTokens
+				} else if proxy is FluentUIStyle.OutlinedAvatarTokensAppearanceProxy {
+					return StylesheetManager.stylesheet(FluentUIStyle.shared()).OutlinedAvatarTokens
+				} else if proxy is FluentUIStyle.OutlinedPrimaryAvatarTokensAppearanceProxy {
+					return StylesheetManager.stylesheet(FluentUIStyle.shared()).OutlinedPrimaryAvatarTokens
 				} else if proxy is FluentUIStyle.OverflowAvatarTokensAppearanceProxy {
 					return StylesheetManager.stylesheet(FluentUIStyle.shared()).OverflowAvatarTokens
-				} else if proxy is FluentUIStyle.UnauthenticatedAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).UnauthenticatedAvatarTokens
 				}
 				return proxy
 			}

--- a/ios/FluentUI/Generated/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Generated/FluentUIStyle.generated.swift
@@ -320,6 +320,12 @@ extension StylesheetManagerTheming {
 			if let override = _foregroundDefaultColor { return override }
 			return mainProxy().Icon.accentColorProperty(traitCollection)
 			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return mainProxy().Colors.Brand.shade10Property(traitCollection)
+			}
 	}
 	//MARK: - AvatarTokens
 	public var _AvatarTokens: AvatarTokensAppearanceProxy?
@@ -626,7 +632,7 @@ extension StylesheetManagerTheming {
 		public var _ringDefaultColor: UIColor?
 		open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
+			return mainProxy().Colors.Brand.tint10Property(traitCollection)
 			}
 		public var ringDefaultColor: UIColor {
 			get { return self.ringDefaultColorProperty() }
@@ -3497,6 +3503,12 @@ extension StylesheetManagerTheming {
 			if let override = _foregroundDefaultColor { return override }
 			return UIColor(light: mainProxy().Colors.Neutral.grey42Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
+			}
 	}
 	//MARK: - OutlinedPrimaryAvatarTokens
 	public var _OutlinedPrimaryAvatarTokens: OutlinedPrimaryAvatarTokensAppearanceProxy?
@@ -3521,6 +3533,12 @@ extension StylesheetManagerTheming {
 			if let override = _foregroundDefaultColor { return override }
 			return UIColor(light: mainProxy().Colors.Brand.primaryProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Brand.tint10Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
 	}
 	//MARK: - OverflowAvatarTokens
 	public var _OverflowAvatarTokens: OverflowAvatarTokensAppearanceProxy?
@@ -3544,6 +3562,12 @@ extension StylesheetManagerTheming {
 		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _foregroundDefaultColor { return override }
 			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
+			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
 			}
 
 		//MARK: textColor 

--- a/ios/FluentUI/People Picker/InitialsView.swift
+++ b/ios/FluentUI/People Picker/InitialsView.swift
@@ -12,7 +12,7 @@ import UIKit
  The initials are generated from a provided primary text (e.g. a name) or secondary text (e.g. an email address) and placed as a label above a colored background.
  */
 class InitialsView: UIView {
-    private static func initialsBackgroundColor(fromPrimaryText primaryText: String?, secondaryText: String?) -> UIColor {
+    static func initialsBackgroundColor(fromPrimaryText primaryText: String?, secondaryText: String?, colorOptions: [UIColor]? = nil) -> UIColor {
         // Set the color based on the primary text and secondary text
         var combined: String
         if let secondaryText = secondaryText, let primaryText = primaryText, secondaryText.count > 0 {
@@ -23,7 +23,7 @@ class InitialsView: UIView {
             combined = ""
         }
 
-        let colors = Colors.avatarBackgroundColors
+        let colors = colorOptions ?? Colors.avatarBackgroundColors
         let combinedHashable = combined as NSString
         let hashCode = Int(abs(javaHashCode(combinedHashable)))
         return colors[hashCode % colors.count]

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -121,7 +121,7 @@ Border:
 
 Icon:
   size: [ xxxSmall: 10pt, xxSmall: 12pt, xSmall: 16pt, small: 20pt, medium: 24pt, large: 28pt, xlarge: 36pt, xxlarge: 40pt, xxxlarge: 48pt ]
-  style: EnumDef(regular, filled)
+  accentColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Neutral.black)"
 
 Spacing:
   none: 0pt
@@ -148,44 +148,61 @@ Opacity:
   none: 1f
 
 AP_AvatarTokens:
-  backgroundDefaultColor: "#EDACB1"
+  backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"
   borderRadius: [ xSmall: $Border.radius.none, small: $Border.radius.none, medium: $Border.radius.none, large: $Border.radius.none, xlarge: $Border.radius.none, xxlarge: $Border.radius.none ]
-  foregroundDefaultColor: "#6E0911"
+  foregroundDefaultColor: "FluentUIColor(light: $Colors.Brand.primary, dark: $Icon.accentColor)"
   presenceIconSize: [ xSmall: 0pt, small: $Icon.size.xxxSmall, medium: $Icon.size.xxxSmall, large: $Icon.size.xxSmall, xlarge: $Icon.size.xSmall, xxlarge: $Icon.size.small ]
   presenceIconOutlineColor: $Colors.Background.neutral1
   presenceIconOutlineThickness: [ xSmall: $Border.size.none, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thick ]
-  ringDefaultColor: "#C50F1F"
+  ringDefaultColor: $Colors.Background.neutralDisabled
   ringGapColor: $Colors.Background.neutral1
   ringInnerGap: [ xSmall: $Border.size.thick, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   ringThickness: [ xSmall: $Border.size.thin, small: $Border.size.thin, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   ringOuterGap: [ xSmall: $Border.size.thick, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   size: [ xSmall: 16pt, small: 24pt, medium: 32pt, large: 40pt, xlarge: 52pt, xxlarge: 72pt ]
+  textCalculatedBackgroundColors: [ "NamedColor(cyanBlue10)", 
+                                    "NamedColor(red10)",
+                                    "NamedColor(magenta20)",
+                                    "NamedColor(green10)",
+                                    "NamedColor(magentaPink10)",
+                                    "NamedColor(cyanBlue20)",
+                                    "NamedColor(orange20)",
+                                    "NamedColor(cyan20)",
+                                    "NamedColor(orangeYellow20)",
+                                    "NamedColor(red20)",
+                                    "NamedColor(blue10)",
+                                    "NamedColor(magenta10)",
+                                    "NamedColor(gray40)",
+                                    "NamedColor(green20)",
+                                    "NamedColor(blueMagenta20)",
+                                    "NamedColor(pinkRed10)",
+                                    "NamedColor(gray30)",
+                                    "NamedColor(blueMagenta30)",
+                                    "NamedColor(gray20)",
+                                    "NamedColor(cyan30)",
+                                    "NamedColor(orange30)" ]
+  textColor: $Colors.Foreground.neutralInverted
   textFont: [ xSmall: "Font(9px, regular)", small: "Font(12px, regular)", medium: "Font(13px, regular)", large: "Font(15px, regular)", xlarge: "Font(20px, regular)", xxlarge: "Font(28px, medium)" ]
 
-NoRingAvatarTokens extends AvatarTokens:
-  ringInnerGap: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringThickness: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringOuterGap: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringDefaultColor: $Colors.Neutral.clear
+AccentAvatarTokens extends AvatarTokens:
+  backgroundDefaultColor: $Colors.Brand.primary
+  foregroundDefaultColor: $Icon.accentColor
 
-UnauthenticatedAvatarTokens extends AvatarTokens:
-  backgroundDefaultColor: $Colors.Background.neutral4
-  foregroundDefaultColor: $Colors.Foreground.neutral3
-  ringDefaultColor: $Colors.Background.neutralDisabled
+GroupAvatarTokens extends AvatarTokens:
+  borderRadius: [ xSmall: $Border.radius.small, small: $Border.radius.medium, medium: $Border.radius.medium, large: $Border.radius.large, xlarge: $Border.radius.large, xxlarge: $Border.radius.xlarge ]
+
+OutlinedAvatarTokens extends AvatarTokens:
+  backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.grey94, dark: $Colors.Neutral.grey26)"
+  foregroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.grey42, dark: $Colors.Neutral.grey78)"
+
+OutlinedPrimaryAvatarTokens extends AvatarTokens:
+  backgroundDefaultColor: "FluentUIColor(light: $Colors.Brand.tint40, dark: $Colors.Neutral.grey26)"
+  foregroundDefaultColor: "FluentUIColor(light: $Colors.Brand.primary, dark: $Colors.Neutral.grey78)"
 
 OverflowAvatarTokens extends AvatarTokens:
   backgroundDefaultColor: $Colors.Background.neutral4
   foregroundDefaultColor: $Colors.Foreground.neutral3
-  ringDefaultColor: $Colors.Neutral.clear
-  ringInnerGap: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringThickness: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringOuterGap: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-
-GroupAvatarTokens extends AvatarTokens:
-  borderRadius: [ xSmall: $Border.radius.small, small: $Border.radius.medium, medium: $Border.radius.medium, large: $Border.radius.large, xlarge: $Border.radius.large, xxlarge: $Border.radius.xlarge ]
-  ringInnerGap: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringThickness: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
-  ringOuterGap: [ xSmall: $Border.size.none, small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none, xlarge: $Border.size.none, xxlarge: $Border.size.none ]
+  textColor: $Colors.Foreground.neutral3
 
 AP_MSFButtonTokens:
   backgroundColor: [ rest: $Colors.Neutral.clear, hover: $Colors.Neutral.clear, pressed: $Colors.Neutral.clear, selected: $Colors.Neutral.clear, disabled: $Colors.Neutral.clear ]

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -154,7 +154,7 @@ AP_AvatarTokens:
   presenceIconSize: [ xSmall: 0pt, small: $Icon.size.xxxSmall, medium: $Icon.size.xxxSmall, large: $Icon.size.xxSmall, xlarge: $Icon.size.xSmall, xxlarge: $Icon.size.small ]
   presenceIconOutlineColor: $Colors.Background.neutral1
   presenceIconOutlineThickness: [ xSmall: $Border.size.none, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thick ]
-  ringDefaultColor: $Colors.Background.neutralDisabled
+  ringDefaultColor: $Colors.Brand.tint10
   ringGapColor: $Colors.Background.neutral1
   ringInnerGap: [ xSmall: $Border.size.thick, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   ringThickness: [ xSmall: $Border.size.thin, small: $Border.size.thin, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
@@ -187,6 +187,7 @@ AP_AvatarTokens:
 AccentAvatarTokens extends AvatarTokens:
   backgroundDefaultColor: $Colors.Brand.primary
   foregroundDefaultColor: $Icon.accentColor
+  ringDefaultColor: $Colors.Brand.shade10
 
 GroupAvatarTokens extends AvatarTokens:
   borderRadius: [ xSmall: $Border.radius.small, small: $Border.radius.medium, medium: $Border.radius.medium, large: $Border.radius.large, xlarge: $Border.radius.large, xxlarge: $Border.radius.xlarge ]
@@ -194,15 +195,18 @@ GroupAvatarTokens extends AvatarTokens:
 OutlinedAvatarTokens extends AvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.grey94, dark: $Colors.Neutral.grey26)"
   foregroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.grey42, dark: $Colors.Neutral.grey78)"
+  ringDefaultColor: $Colors.Background.neutralDisabled
 
 OutlinedPrimaryAvatarTokens extends AvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Brand.tint40, dark: $Colors.Neutral.grey26)"
   foregroundDefaultColor: "FluentUIColor(light: $Colors.Brand.primary, dark: $Colors.Neutral.grey78)"
+  ringDefaultColor: "FluentUIColor(light: $Colors.Brand.tint10, dark: $Colors.Neutral.grey78)"
 
 OverflowAvatarTokens extends AvatarTokens:
   backgroundDefaultColor: $Colors.Background.neutral4
   foregroundDefaultColor: $Colors.Foreground.neutral3
   textColor: $Colors.Foreground.neutral3
+  ringDefaultColor: $Colors.Background.neutralDisabled
 
 AP_MSFButtonTokens:
   backgroundColor: [ rest: $Colors.Neutral.clear, hover: $Colors.Neutral.clear, pressed: $Colors.Neutral.clear, selected: $Colors.Neutral.clear, disabled: $Colors.Neutral.clear ]

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -289,11 +289,6 @@ extension StylesheetManagerTheming {
 	case title3
 }
 
-@objc public enum style: Int, Equatable {
-	case filled = 0
-	case regular
-}
-
 }
 /// Entry point for the app stylesheet
 @objc(STRFluentUIStyle) @objcMembers public class FluentUIStyle: NSObject {
@@ -301,6 +296,30 @@ extension StylesheetManagerTheming {
 	public class func shared() -> FluentUIStyle {
 		 struct __ { static let _sharedInstance = FluentUIStyle() }
 		return __._sharedInstance
+	}
+	//MARK: - AccentAvatarTokens
+	public var _AccentAvatarTokens: AccentAvatarTokensAppearanceProxy?
+	open func AccentAvatarTokensStyle() -> AccentAvatarTokensAppearanceProxy {
+		if let override = _AccentAvatarTokens { return override }
+			return AccentAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
+		}
+	public var AccentAvatarTokens: AccentAvatarTokensAppearanceProxy {
+		get { return self.AccentAvatarTokensStyle() }
+		set { _AccentAvatarTokens = newValue }
+	}
+	@objc(AccentAvatarTokensAppearanceProxy) @objcMembers open class AccentAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
+
+		//MARK: backgroundDefaultColor 
+		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _backgroundDefaultColor { return override }
+			return mainProxy().Colors.Brand.primaryProperty(traitCollection)
+			}
+
+		//MARK: foregroundDefaultColor 
+		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _foregroundDefaultColor { return override }
+			return mainProxy().Icon.accentColorProperty(traitCollection)
+			}
 	}
 	//MARK: - AvatarTokens
 	public var _AvatarTokens: AvatarTokensAppearanceProxy?
@@ -322,7 +341,7 @@ extension StylesheetManagerTheming {
 		public var _backgroundDefaultColor: UIColor?
 		open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _backgroundDefaultColor { return override }
-			return UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0)
+			return UIColor(light: mainProxy().Colors.Neutral.whiteProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brand.primaryProperty(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 		public var backgroundDefaultColor: UIColor {
 			get { return self.backgroundDefaultColorProperty() }
@@ -417,7 +436,7 @@ extension StylesheetManagerTheming {
 		public var _foregroundDefaultColor: UIColor?
 		open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _foregroundDefaultColor { return override }
-			return UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0)
+			return UIColor(light: mainProxy().Colors.Brand.primaryProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Icon.accentColorProperty(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 		public var foregroundDefaultColor: UIColor {
 			get { return self.foregroundDefaultColorProperty() }
@@ -607,7 +626,7 @@ extension StylesheetManagerTheming {
 		public var _ringDefaultColor: UIColor?
 		open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _ringDefaultColor { return override }
-			return UIColor(red: 0.77254903, green: 0.05882353, blue: 0.12156863, alpha: 1.0)
+			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
 			}
 		public var ringDefaultColor: UIColor {
 			get { return self.ringDefaultColorProperty() }
@@ -960,6 +979,49 @@ extension StylesheetManagerTheming {
 			}
 		}
 
+
+		//MARK: textCalculatedBackgroundColors 
+		public var _textCalculatedBackgroundColors: [UIColor]?
+		open func textCalculatedBackgroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
+			if let override = _textCalculatedBackgroundColors { return override }
+			return [
+			UIColor(named: "FluentColors/cyanBlue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/red10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/magenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/green10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/magentaPink10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/cyanBlue20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/orange20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/cyan20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/orangeYellow20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/red20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/blue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/magenta10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/gray40", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/green20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/blueMagenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/pinkRed10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/gray30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/blueMagenta30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/gray20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/cyan30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
+			UIColor(named: "FluentColors/orange30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!]
+			}
+		public var textCalculatedBackgroundColors: [UIColor] {
+			get { return self.textCalculatedBackgroundColorsProperty() }
+			set { _textCalculatedBackgroundColors = newValue }
+		}
+
+		//MARK: textColor 
+		public var _textColor: UIColor?
+		open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _textColor { return override }
+			return mainProxy().Colors.Foreground.neutralInvertedProperty(traitCollection)
+			}
+		public var textColor: UIColor {
+			get { return self.textColorProperty() }
+			set { _textColor = newValue }
+		}
 
 		//MARK: - textFont
 		public var _textFont: textFontAppearanceProxy?
@@ -2538,141 +2600,6 @@ extension StylesheetManagerTheming {
 				}
 		}
 
-
-		//MARK: - GroupAvatarTokensringInnerGap
-		override open func ringInnerGapStyle() -> AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-			if let override = _ringInnerGap { return override }
-				return GroupAvatarTokensringInnerGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(GroupAvatarTokensRingInnerGapAppearanceProxy) @objcMembers open class GroupAvatarTokensringInnerGapAppearanceProxy: AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - GroupAvatarTokensringOuterGap
-		override open func ringOuterGapStyle() -> AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-			if let override = _ringOuterGap { return override }
-				return GroupAvatarTokensringOuterGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(GroupAvatarTokensRingOuterGapAppearanceProxy) @objcMembers open class GroupAvatarTokensringOuterGapAppearanceProxy: AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - GroupAvatarTokensringThickness
-		override open func ringThicknessStyle() -> AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-			if let override = _ringThickness { return override }
-				return GroupAvatarTokensringThicknessAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(GroupAvatarTokensRingThicknessAppearanceProxy) @objcMembers open class GroupAvatarTokensringThicknessAppearanceProxy: AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
 	}
 	//MARK: - Icon
 	public var _Icon: IconAppearanceProxy?
@@ -2688,6 +2615,17 @@ extension StylesheetManagerTheming {
 		public let mainProxy: () -> FluentUIStyle
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
+		}
+
+		//MARK: accentColor 
+		public var _accentColor: UIColor?
+		open func accentColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _accentColor { return override }
+			return UIColor(light: mainProxy().Colors.Neutral.whiteProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.blackProperty(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var accentColor: UIColor {
+			get { return self.accentColorProperty() }
+			set { _accentColor = newValue }
 		}
 
 		//MARK: - size
@@ -3421,159 +3359,6 @@ extension StylesheetManagerTheming {
 		}
 
 	}
-	//MARK: - NoRingAvatarTokens
-	public var _NoRingAvatarTokens: NoRingAvatarTokensAppearanceProxy?
-	open func NoRingAvatarTokensStyle() -> NoRingAvatarTokensAppearanceProxy {
-		if let override = _NoRingAvatarTokens { return override }
-			return NoRingAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
-		}
-	public var NoRingAvatarTokens: NoRingAvatarTokensAppearanceProxy {
-		get { return self.NoRingAvatarTokensStyle() }
-		set { _NoRingAvatarTokens = newValue }
-	}
-	@objc(NoRingAvatarTokensAppearanceProxy) @objcMembers open class NoRingAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
-
-		//MARK: ringDefaultColor 
-		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Neutral.clearProperty(traitCollection)
-			}
-
-		//MARK: - NoRingAvatarTokensringInnerGap
-		override open func ringInnerGapStyle() -> AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-			if let override = _ringInnerGap { return override }
-				return NoRingAvatarTokensringInnerGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(NoRingAvatarTokensRingInnerGapAppearanceProxy) @objcMembers open class NoRingAvatarTokensringInnerGapAppearanceProxy: AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - NoRingAvatarTokensringOuterGap
-		override open func ringOuterGapStyle() -> AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-			if let override = _ringOuterGap { return override }
-				return NoRingAvatarTokensringOuterGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(NoRingAvatarTokensRingOuterGapAppearanceProxy) @objcMembers open class NoRingAvatarTokensringOuterGapAppearanceProxy: AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - NoRingAvatarTokensringThickness
-		override open func ringThicknessStyle() -> AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-			if let override = _ringThickness { return override }
-				return NoRingAvatarTokensringThicknessAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(NoRingAvatarTokensRingThicknessAppearanceProxy) @objcMembers open class NoRingAvatarTokensringThicknessAppearanceProxy: AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-	}
 	//MARK: - Opacity
 	public var _Opacity: OpacityAppearanceProxy?
 	open func OpacityStyle() -> OpacityAppearanceProxy {
@@ -3689,6 +3474,54 @@ extension StylesheetManagerTheming {
 			set { _opacity96 = newValue }
 		}
 	}
+	//MARK: - OutlinedAvatarTokens
+	public var _OutlinedAvatarTokens: OutlinedAvatarTokensAppearanceProxy?
+	open func OutlinedAvatarTokensStyle() -> OutlinedAvatarTokensAppearanceProxy {
+		if let override = _OutlinedAvatarTokens { return override }
+			return OutlinedAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
+		}
+	public var OutlinedAvatarTokens: OutlinedAvatarTokensAppearanceProxy {
+		get { return self.OutlinedAvatarTokensStyle() }
+		set { _OutlinedAvatarTokens = newValue }
+	}
+	@objc(OutlinedAvatarTokensAppearanceProxy) @objcMembers open class OutlinedAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
+
+		//MARK: backgroundDefaultColor 
+		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _backgroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Neutral.grey94Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey26Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+
+		//MARK: foregroundDefaultColor 
+		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _foregroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Neutral.grey42Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+	}
+	//MARK: - OutlinedPrimaryAvatarTokens
+	public var _OutlinedPrimaryAvatarTokens: OutlinedPrimaryAvatarTokensAppearanceProxy?
+	open func OutlinedPrimaryAvatarTokensStyle() -> OutlinedPrimaryAvatarTokensAppearanceProxy {
+		if let override = _OutlinedPrimaryAvatarTokens { return override }
+			return OutlinedPrimaryAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
+		}
+	public var OutlinedPrimaryAvatarTokens: OutlinedPrimaryAvatarTokensAppearanceProxy {
+		get { return self.OutlinedPrimaryAvatarTokensStyle() }
+		set { _OutlinedPrimaryAvatarTokens = newValue }
+	}
+	@objc(OutlinedPrimaryAvatarTokensAppearanceProxy) @objcMembers open class OutlinedPrimaryAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
+
+		//MARK: backgroundDefaultColor 
+		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _backgroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Brand.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey26Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+
+		//MARK: foregroundDefaultColor 
+		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _foregroundDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Brand.primaryProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+	}
 	//MARK: - OverflowAvatarTokens
 	public var _OverflowAvatarTokens: OverflowAvatarTokensAppearanceProxy?
 	open func OverflowAvatarTokensStyle() -> OverflowAvatarTokensAppearanceProxy {
@@ -3713,146 +3546,11 @@ extension StylesheetManagerTheming {
 			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
 			}
 
-		//MARK: ringDefaultColor 
-		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+		//MARK: textColor 
+		override open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _textColor { return override }
+			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
 			}
-
-		//MARK: - OverflowAvatarTokensringInnerGap
-		override open func ringInnerGapStyle() -> AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-			if let override = _ringInnerGap { return override }
-				return OverflowAvatarTokensringInnerGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(OverflowAvatarTokensRingInnerGapAppearanceProxy) @objcMembers open class OverflowAvatarTokensringInnerGapAppearanceProxy: AvatarTokensAppearanceProxy.ringInnerGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - OverflowAvatarTokensringOuterGap
-		override open func ringOuterGapStyle() -> AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-			if let override = _ringOuterGap { return override }
-				return OverflowAvatarTokensringOuterGapAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(OverflowAvatarTokensRingOuterGapAppearanceProxy) @objcMembers open class OverflowAvatarTokensringOuterGapAppearanceProxy: AvatarTokensAppearanceProxy.ringOuterGapAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
-
-		//MARK: - OverflowAvatarTokensringThickness
-		override open func ringThicknessStyle() -> AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-			if let override = _ringThickness { return override }
-				return OverflowAvatarTokensringThicknessAppearanceProxy(proxy: mainProxy)
-			}
-		@objc(OverflowAvatarTokensRingThicknessAppearanceProxy) @objcMembers open class OverflowAvatarTokensringThicknessAppearanceProxy: AvatarTokensAppearanceProxy.ringThicknessAppearanceProxy {
-
-			//MARK: large 
-			override open func largeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _large { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: medium 
-			override open func mediumProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _medium { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: small 
-			override open func smallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _small { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xSmall 
-			override open func xSmallProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xSmall { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xlarge 
-			override open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-
-			//MARK: xxlarge 
-			override open func xxlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _xxlarge { return override }
-					return mainProxy().Border.size.noneProperty(traitCollection)
-				}
-		}
-
 	}
 	//MARK: - PrimaryButtonTokens
 	public var _PrimaryButtonTokens: PrimaryButtonTokensAppearanceProxy?
@@ -4236,36 +3934,6 @@ extension StylesheetManagerTheming {
 			set { _subheadline = newValue }
 		}
 	}
-	//MARK: - UnauthenticatedAvatarTokens
-	public var _UnauthenticatedAvatarTokens: UnauthenticatedAvatarTokensAppearanceProxy?
-	open func UnauthenticatedAvatarTokensStyle() -> UnauthenticatedAvatarTokensAppearanceProxy {
-		if let override = _UnauthenticatedAvatarTokens { return override }
-			return UnauthenticatedAvatarTokensAppearanceProxy(proxy: { return FluentUIStyle.shared() })
-		}
-	public var UnauthenticatedAvatarTokens: UnauthenticatedAvatarTokensAppearanceProxy {
-		get { return self.UnauthenticatedAvatarTokensStyle() }
-		set { _UnauthenticatedAvatarTokens = newValue }
-	}
-	@objc(UnauthenticatedAvatarTokensAppearanceProxy) @objcMembers open class UnauthenticatedAvatarTokensAppearanceProxy: AvatarTokensAppearanceProxy {
-
-		//MARK: backgroundDefaultColor 
-		override open func backgroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _backgroundDefaultColor { return override }
-			return mainProxy().Colors.Background.neutral4Property(traitCollection)
-			}
-
-		//MARK: foregroundDefaultColor 
-		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _foregroundDefaultColor { return override }
-			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
-			}
-
-		//MARK: ringDefaultColor 
-		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
-			}
-	}
 	//MARK: - __TextStyle
 	public var ___TextStyle: __TextStyleAppearanceProxy?
 	open func __TextStyleStyle() -> __TextStyleAppearanceProxy {
@@ -4300,14 +3968,16 @@ extension AvatarTokens: AppearaceProxyComponent {
 					return proxy
 				}
 
-				if proxy is FluentUIStyle.GroupAvatarTokensAppearanceProxy {
+				if proxy is FluentUIStyle.AccentAvatarTokensAppearanceProxy {
+					return StylesheetManager.stylesheet(FluentUIStyle.shared()).AccentAvatarTokens
+				} else if proxy is FluentUIStyle.GroupAvatarTokensAppearanceProxy {
 					return StylesheetManager.stylesheet(FluentUIStyle.shared()).GroupAvatarTokens
-				} else if proxy is FluentUIStyle.NoRingAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).NoRingAvatarTokens
+				} else if proxy is FluentUIStyle.OutlinedAvatarTokensAppearanceProxy {
+					return StylesheetManager.stylesheet(FluentUIStyle.shared()).OutlinedAvatarTokens
+				} else if proxy is FluentUIStyle.OutlinedPrimaryAvatarTokensAppearanceProxy {
+					return StylesheetManager.stylesheet(FluentUIStyle.shared()).OutlinedPrimaryAvatarTokens
 				} else if proxy is FluentUIStyle.OverflowAvatarTokensAppearanceProxy {
 					return StylesheetManager.stylesheet(FluentUIStyle.shared()).OverflowAvatarTokens
-				} else if proxy is FluentUIStyle.UnauthenticatedAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).UnauthenticatedAvatarTokens
 				}
 				return proxy
 			}

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -320,6 +320,12 @@ extension StylesheetManagerTheming {
 			if let override = _foregroundDefaultColor { return override }
 			return mainProxy().Icon.accentColorProperty(traitCollection)
 			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return mainProxy().Colors.Brand.shade10Property(traitCollection)
+			}
 	}
 	//MARK: - AvatarTokens
 	public var _AvatarTokens: AvatarTokensAppearanceProxy?
@@ -626,7 +632,7 @@ extension StylesheetManagerTheming {
 		public var _ringDefaultColor: UIColor?
 		open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _ringDefaultColor { return override }
-			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
+			return mainProxy().Colors.Brand.tint10Property(traitCollection)
 			}
 		public var ringDefaultColor: UIColor {
 			get { return self.ringDefaultColorProperty() }
@@ -3497,6 +3503,12 @@ extension StylesheetManagerTheming {
 			if let override = _foregroundDefaultColor { return override }
 			return UIColor(light: mainProxy().Colors.Neutral.grey42Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
+			}
 	}
 	//MARK: - OutlinedPrimaryAvatarTokens
 	public var _OutlinedPrimaryAvatarTokens: OutlinedPrimaryAvatarTokensAppearanceProxy?
@@ -3521,6 +3533,12 @@ extension StylesheetManagerTheming {
 			if let override = _foregroundDefaultColor { return override }
 			return UIColor(light: mainProxy().Colors.Brand.primaryProperty(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return UIColor(light: mainProxy().Colors.Brand.tint10Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Neutral.grey78Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
 	}
 	//MARK: - OverflowAvatarTokens
 	public var _OverflowAvatarTokens: OverflowAvatarTokensAppearanceProxy?
@@ -3544,6 +3562,12 @@ extension StylesheetManagerTheming {
 		override open func foregroundDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _foregroundDefaultColor { return override }
 			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
+			}
+
+		//MARK: ringDefaultColor 
+		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _ringDefaultColor { return override }
+			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
 			}
 
 		//MARK: textColor 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

1. These changes revisit the Avatar styles and resolves issue #340.
We now have parity with the current Avatar implementation in terms of fallback scenarios (where the user information is not provided or the initials can't be calculated such as in phone number only scenario).

2. NoRing is not a style anymore. It's part of the state of the avatar where a flag can be set to display the ring.

3. The styles and sizes can now be set/updated after the Avatar has been initialized. Updating any of those properties will trigger SwiftUI to refresh the views.

4. The foundation is also laid for issue #338. We are currently using the same calculated color options as the current Avatar, but they are tokenized and only need to be updated to the new 30 variations of colors once the design team has them ready.

### Verification

Ran variations of the Demo app as well as setting states of show/hide ring, custom ring and background colors.
Light and dark mode variations.

|                                       |                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2020-12-16 at 10 17 28 AM](https://user-images.githubusercontent.com/68076145/102391620-d0707600-3f8a-11eb-98fd-6e4f6f8a702e.png) | ![Screen Shot 2020-12-16 at 10 18 02 AM](https://user-images.githubusercontent.com/68076145/102391653-db2b0b00-3f8a-11eb-9200-337b6d7fe2b1.png) |
| ![Screen Shot 2020-12-16 at 10 12 13 AM](https://user-images.githubusercontent.com/68076145/102391724-f4cc5280-3f8a-11eb-9eb9-b19c84a7cc57.png) | ![Screen Shot 2020-12-16 at 10 12 22 AM](https://user-images.githubusercontent.com/68076145/102391754-fe55ba80-3f8a-11eb-9a2a-75ee57a68406.png) |
| ![Screen Shot 2020-12-16 at 3 29 10 PM](https://user-images.githubusercontent.com/68076145/102420751-ab462c80-3fb7-11eb-8254-6fb620f64154.png) | ![Screen Shot 2020-12-16 at 3 29 25 PM](https://user-images.githubusercontent.com/68076145/102420776-b6995800-3fb7-11eb-8508-913cf6dca1db.png) |
| ![Screen Shot 2020-12-16 at 3 29 16 PM](https://user-images.githubusercontent.com/68076145/102420795-c0bb5680-3fb7-11eb-9cf9-c168faa10278.png) | ![Screen Shot 2020-12-16 at 3 29 32 PM](https://user-images.githubusercontent.com/68076145/102420810-c87afb00-3fb7-11eb-9ddf-52972f60b791.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/346)