### PR TITLE
ShimmerView Colors

### DIFF
--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -361,7 +361,7 @@ open class ShimmerView: UIView {
 public extension Colors {
     struct Shimmer {
         public static var darkGradient: UIColor = .black
-        public static var gradientCenter: UIColor = .init(light: .white, dark: gray950)
-        public static var tint: UIColor = Colors.Palette.gray400.color
+        public static var gradientCenter = UIColor(light: .white, dark: gray950)
+        public static var tint = UIColor(light: surfaceTertiary, lightHighContrast: Colors.Palette.gray400.color, dark: surfaceQuaternary, darkHighContrast: Colors.Palette.gray400.color)
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Design team feedback on making the shimmerView colors lighter again.
This is a partial undo for commit 450fd13. Taking design feedback to only have stronger color contrast on increased contrast iOS setting for shimmerView because it should be a temporary state.

### Verification
| regular | increased contrast |
| --- | --- |
|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-16 at 20 49 02](https://user-images.githubusercontent.com/20715435/102445516-7dc1a900-3fe0-11eb-9e75-089743dc3a04.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-16 at 20 44 22](https://user-images.githubusercontent.com/20715435/102445311-10157d00-3fe0-11eb-8e21-0b97937f7c1c.png)|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-16 at 20 44 33](https://user-images.githubusercontent.com/20715435/102445319-13106d80-3fe0-11eb-9c53-d11f21147688.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-16 at 20 44 28](https://user-images.githubusercontent.com/20715435/102445314-1277d700-3fe0-11eb-832a-2cff16b7296f.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/348)