### PR TITLE
Revert back to using macOS 10.15 images for CI and publish

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: fluentui_apple_publish_nuget
   pool:
-    vmImage: 'macos-11.0'
+    vmImage: 'macos-10.15'
   displayName: FluentUI Apple Publish NuGet
   timeoutInMinutes: 60 # how long to run the job before automatically cancelling
   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   xcodebuild:
-    runs-on: macos-11.0
+    runs-on: macos-10.15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Pod-Publish:
-    runs-on: macOS-11.0
+    runs-on: macOS-10.15
     
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Commit #349 deleted a beta pipeline and also tried to switch to running ci and publish on macOS 11.0. This worked for CI which uses GitHub Actions, but not for a private publish step running on Azure Pipelines where 11.0 is still not supported. My bad...

Revert that portion of the change.

### Verification
Will monitor CI and publish

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/351)