### PR TITLE
Support button action

### DIFF
--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -88,6 +88,7 @@ open class Button: NSButton {
 		isBordered = false
 		wantsLayer = true
 		layer?.contentsScale = window?.backingScaleFactor ?? 1.0
+		setButtonType(.momentaryChange)
 
 		if let cell = cell as? ButtonCell {
 			// The Button properties `contentTintColorDisabled`,
@@ -183,47 +184,10 @@ open class Button: NSButton {
 		}
 	}
 
-	private var trackingArea: NSTrackingArea?
-	
-	override public func updateTrackingAreas() {
-		super.updateTrackingAreas()
-
-		if let trackingArea = trackingArea {
-			removeTrackingArea(trackingArea)
-			self.trackingArea = nil
-		}
-
-		let opts: NSTrackingArea.Options = [.mouseEnteredAndExited, .activeAlways]
-		let trackingArea = NSTrackingArea(rect: bounds, options: opts, owner: self, userInfo: nil)
-		addTrackingArea(trackingArea)
-		self.trackingArea = trackingArea
-	}
-
 	open override func mouseDown(with event: NSEvent) {
-		var pressed = true
-		var nextEvent:NSEvent
-		var mouseInRect = true
-
 		mouseDown = true
-		while (pressed) {
-			nextEvent = (self.window?.nextEvent(matching: NSEvent.EventTypeMask(rawValue: NSEvent.EventTypeMask.RawValue(NX_LMOUSEUPMASK | NX_MOUSEEXITEDMASK | NX_MOUSEENTEREDMASK))))!
-			
-			switch nextEvent.type {
-			case NSEvent.EventType.leftMouseUp:
-				/// send action if cursor is inside the button
-				if mouseInRect {
-					self.sendAction(action, to: target)
-				}
-				pressed = false
-				mouseDown = false
-			case NSEvent.EventType.mouseExited:
-				mouseInRect = false
-			case NSEvent.EventType.mouseEntered:
-				mouseInRect = true
-			default: // ignore other events
-				break
-			}
-		}
+		super.mouseDown(with: event)
+		mouseDown = false
 	}
 
 	open override var isEnabled: Bool {

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -183,16 +183,47 @@ open class Button: NSButton {
 		}
 	}
 
-	open override func mouseDown(with event: NSEvent) {
-		mouseDown = true
-		super.mouseDown(with: event)
-		/// mouseUp doesn't register when super.mouseDown is called
-		self.mouseUp(with: event)
+	private var trackingArea: NSTrackingArea?
+	
+	override public func updateTrackingAreas() {
+		super.updateTrackingAreas()
+
+		if let trackingArea = trackingArea {
+			removeTrackingArea(trackingArea)
+			self.trackingArea = nil
+		}
+
+		let opts: NSTrackingArea.Options = [.mouseEnteredAndExited, .activeAlways]
+		let trackingArea = NSTrackingArea(rect: bounds, options: opts, owner: self, userInfo: nil)
+		addTrackingArea(trackingArea)
+		self.trackingArea = trackingArea
 	}
 
-	open override func mouseUp(with event: NSEvent) {
-		mouseDown = false
-		super.mouseUp(with: event)
+	open override func mouseDown(with event: NSEvent) {
+		var pressed = true
+		var nextEvent:NSEvent
+		var mouseInRect = true
+
+		mouseDown = true
+		while (pressed) {
+			nextEvent = (self.window?.nextEvent(matching: NSEvent.EventTypeMask(rawValue: NSEvent.EventTypeMask.RawValue(NX_LMOUSEUPMASK | NX_MOUSEEXITEDMASK | NX_MOUSEENTEREDMASK))))!
+			
+			switch nextEvent.type {
+			case NSEvent.EventType.leftMouseUp:
+				/// send action if cursor is inside the button
+				if mouseInRect {
+					self.sendAction(action, to: target)
+				}
+				pressed = false
+				mouseDown = false
+			case NSEvent.EventType.mouseExited:
+				mouseInRect = false
+			case NSEvent.EventType.mouseEntered:
+				mouseInRect = true
+			default: // ignore other events
+				break
+			}
+		}
 	}
 
 	open override var isEnabled: Bool {

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -185,11 +185,14 @@ open class Button: NSButton {
 
 	open override func mouseDown(with event: NSEvent) {
 		mouseDown = true
+		super.mouseDown(with: event)
+		/// mouseUp doesn't register when super.mouseDown is called
+		self.mouseUp(with: event)
 	}
 
 	open override func mouseUp(with event: NSEvent) {
-		_ = target?.perform(action, with: event)
 		mouseDown = false
+		super.mouseUp(with: event)
 	}
 
 	open override var isEnabled: Bool {

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -188,6 +188,7 @@ open class Button: NSButton {
 	}
 
 	open override func mouseUp(with event: NSEvent) {
+		_ = target?.perform(action, with: event)
 		mouseDown = false
 	}
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS

### Description of changes
In the current button implementation, we override the mouse events to customize the mouse down behavior. Since we are not calling the super class, we need to manually trigger the target action.

### Verification
In the test app, ensured the button action is executed (mouse & keyboard), and the mouse events are fired. 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/354)