### PR TITLE
Ahbazian/pill button colors

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -83,10 +83,10 @@ class PillButtonBarDemoController: DemoController {
     }
 
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsColors: Bool = false) -> UIView {
-        let pillButtonBackgroundColor = useCustomPillsColors ? Colors.Palette.communicationBlueShade10.color : nil
-        let pillSelectedButtonBackgroundColor = useCustomPillsColors ? Colors.Palette.communicationBlueShade30.color : nil
-        let pillButtonTextColor = useCustomPillsColors ? Colors.Palette.red20.color : nil
-        let pillSelectedButtontextColor = useCustomPillsColors ? Colors.Palette.pinkRed10.color : nil
+        let pillButtonBackgroundColor = useCustomPillsColors ? Colors.textOnAccent : nil
+        let pillSelectedButtonBackgroundColor = useCustomPillsColors ? Colors.textPrimary : nil
+        let pillButtonTextColor = useCustomPillsColors ? Colors.textPrimary : nil
+        let pillSelectedButtontextColor = useCustomPillsColors ? Colors.textOnAccent : nil
 
         let bar = PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: pillButtonBackgroundColor, selectedPillButtonBackgroundColor: pillSelectedButtonBackgroundColor, pillButtonTextColor: pillButtonTextColor, selectedPillButtonTextColor: pillSelectedButtontextColor)
         bar.items = items

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -36,7 +36,7 @@ class PillButtonBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("Filled With Custom Pills Background"))
         addRow(items: [createLabelWithText("Enable/Disable pills in custom Filled Pill Bar"), disableCustomFilledSwitchView], itemSpacing: 20, centerItems: true)
-        let customBar = createBar(items: items, style: .filled, useCustomPillsBackground: true)
+        let customBar = createBar(items: items, style: .filled, useCustomPillsColors: true)
         container.addArrangedSubview(customBar)
         self.customBar = customBar
         container.addArrangedSubview(UIView())
@@ -82,8 +82,13 @@ class PillButtonBarDemoController: DemoController {
         }
     }
 
-    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsBackground: Bool = false) -> UIView {
-        let bar = PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: useCustomPillsBackground ? Colors.Palette.communicationBlueShade30.color : nil)
+    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsColors: Bool = false) -> UIView {
+        let pillButtonBackgroundColor = useCustomPillsColors ? Colors.Palette.communicationBlueShade10.color : nil
+        let pillSelectedButtonBackgroundColor = useCustomPillsColors ? Colors.Palette.communicationBlueShade30.color : nil
+        let pillButtonTextColor = useCustomPillsColors ? Colors.Palette.red20.color : nil
+        let pillSelectedButtontextColor = useCustomPillsColors ? Colors.Palette.pinkRed10.color : nil
+
+        let bar = PillButtonBar(pillButtonStyle: style, pillButtonBackgroundColor: pillButtonBackgroundColor, selectedPillButtonBackgroundColor: pillSelectedButtonBackgroundColor, pillButtonTextColor: pillButtonTextColor, selectedPillButtonTextColor: pillSelectedButtontextColor)
         bar.items = items
         _ = bar.selectItem(atIndex: 0)
         bar.barDelegate = self

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -203,34 +203,17 @@ open class PillButton: UIButton {
         if let window = window {
             if isSelected {
                 if isEnabled {
-                    if let customSelectedBackgroundColor = customSelectedBackgroundColor {
-                        backgroundColor = customSelectedBackgroundColor
-                    } else {
-                        backgroundColor = style.selectedBackgroundColor(for: window)
-                    }
-                    
-                    if let customSelectedTextColor = customSelectedTextColor {
-                        setTitleColor(customSelectedTextColor, for: .normal)
-                    } else {
-                        setTitleColor(style.selectedTitleColor(for: window), for: .normal)
-                    }
+                    backgroundColor = customSelectedBackgroundColor ?? style.selectedBackgroundColor(for: window)
+                    setTitleColor(customSelectedTextColor ?? style.selectedTitleColor(for: window), for: .normal)
                 } else {
                     backgroundColor = style.selectedDisabledBackgroundColor(for: window)
                     setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
                 }
             } else {
-                if let customBackgroundColor = customBackgroundColor {
-                    backgroundColor = customBackgroundColor
-                } else {
-                    backgroundColor = style.backgroundColor(for: window)
-                }
+                backgroundColor = customBackgroundColor ?? style.backgroundColor(for: window)
 
                 if isEnabled {
-                    if let customTextColor = customTextColor {
-                        setTitleColor(customTextColor, for: .normal)
-                    } else {
-                        setTitleColor(style.titleColor, for: .normal)
-                    }
+                    setTitleColor(customTextColor ?? style.titleColor, for: .normal)
                 } else {
                     setTitleColor(style.disabledTitleColor(for: window), for: .disabled)
                 }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -128,6 +128,27 @@ open class PillButton: UIButton {
             updateAppearance()
         }
     }
+    
+    /// Set `selectedBackgroundColor` to customize background color of the pill button
+    @objc open var customSelectedBackgroundColor: UIColor? {
+        didSet {
+            updateAppearance()
+        }
+    }
+    
+    /// Set `textColor` to customize background color of the pill button
+    @objc open var customTextColor: UIColor? {
+        didSet {
+            updateAppearance()
+        }
+    }
+    
+    /// Set `selectedTextColor` to customize background color of the pill button
+    @objc open var customSelectedTextColor: UIColor? {
+        didSet {
+            updateAppearance()
+        }
+    }
 
     @objc public init(pillBarItem: PillButtonBarItem, style: PillButtonStyle = .outline) {
         self.pillBarItem = pillBarItem
@@ -182,8 +203,17 @@ open class PillButton: UIButton {
         if let window = window {
             if isSelected {
                 if isEnabled {
-                    backgroundColor = style.selectedBackgroundColor(for: window)
-                    setTitleColor(style.selectedTitleColor(for: window), for: .normal)
+                    if let customSelectedBackgroundColor = customSelectedBackgroundColor {
+                        backgroundColor = customSelectedBackgroundColor
+                    } else {
+                        backgroundColor = style.selectedBackgroundColor(for: window)
+                    }
+                    
+                    if let customSelectedTextColor = customSelectedTextColor {
+                        setTitleColor(customSelectedTextColor, for: .normal)
+                    } else {
+                        setTitleColor(style.selectedTitleColor(for: window), for: .normal)
+                    }
                 } else {
                     backgroundColor = style.selectedDisabledBackgroundColor(for: window)
                     setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
@@ -196,7 +226,11 @@ open class PillButton: UIButton {
                 }
 
                 if isEnabled {
-                    setTitleColor(style.titleColor, for: .normal)
+                    if let customTextColor = customTextColor {
+                        setTitleColor(customTextColor, for: .normal)
+                    } else {
+                        setTitleColor(style.titleColor, for: .normal)
+                    }
                 } else {
                     setTitleColor(style.disabledTitleColor(for: window), for: .disabled)
                 }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -149,6 +149,9 @@ open class PillButtonBar: UIScrollView {
     @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil, selectedPillButtonBackgroundColor: UIColor? = nil, pillButtonTextColor: UIColor? = nil, selectedPillButtonTextColor: UIColor? = nil) {
         self.pillButtonStyle = pillButtonStyle
         self.customPillButtonBackgroundColor = pillButtonBackgroundColor
+        self.customSelectedPillButtonBackgroundColor = selectedPillButtonBackgroundColor
+        self.customPillButtonTextColor = pillButtonTextColor
+        self.customSelectedPillButtonTextColor = selectedPillButtonTextColor
         super.init(frame: .zero)
         setupScrollView()
         setupStackView()

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -146,7 +146,11 @@ open class PillButtonBar: UIScrollView {
         self.init(pillButtonStyle: pillButtonStyle, pillButtonBackgroundColor: nil)
     }
 
-    @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil, selectedPillButtonBackgroundColor: UIColor? = nil, pillButtonTextColor: UIColor? = nil, selectedPillButtonTextColor: UIColor? = nil) {
+    @objc public init(pillButtonStyle: PillButtonStyle = .outline,
+                      pillButtonBackgroundColor: UIColor? = nil,
+                      selectedPillButtonBackgroundColor: UIColor? = nil,
+                      pillButtonTextColor: UIColor? = nil,
+                      selectedPillButtonTextColor: UIColor? = nil) {
         self.pillButtonStyle = pillButtonStyle
         self.customPillButtonBackgroundColor = pillButtonBackgroundColor
         self.customSelectedPillButtonBackgroundColor = selectedPillButtonBackgroundColor

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -116,6 +116,9 @@ open class PillButtonBar: UIScrollView {
     }()
 
     private var customPillButtonBackgroundColor: UIColor?
+    private var customSelectedPillButtonBackgroundColor: UIColor?
+    private var customPillButtonTextColor: UIColor?
+    private var customSelectedPillButtonTextColor: UIColor?
 
     private var leadingConstraint: NSLayoutConstraint?
 
@@ -143,7 +146,7 @@ open class PillButtonBar: UIScrollView {
         self.init(pillButtonStyle: pillButtonStyle, pillButtonBackgroundColor: nil)
     }
 
-    @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil) {
+    @objc public init(pillButtonStyle: PillButtonStyle = .outline, pillButtonBackgroundColor: UIColor? = nil, selectedPillButtonBackgroundColor: UIColor? = nil, pillButtonTextColor: UIColor? = nil, selectedPillButtonTextColor: UIColor? = nil) {
         self.pillButtonStyle = pillButtonStyle
         self.customPillButtonBackgroundColor = pillButtonBackgroundColor
         super.init(frame: .zero)
@@ -239,6 +242,18 @@ open class PillButtonBar: UIScrollView {
             button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
             if let customButtonBackgroundColor = self.customPillButtonBackgroundColor {
                 button.customBackgroundColor = customButtonBackgroundColor
+            }
+            
+            if let customSelectedButtonBackgroundColor = self.customSelectedPillButtonBackgroundColor {
+                button.customSelectedBackgroundColor = customSelectedButtonBackgroundColor
+            }
+            
+            if let customButtonTextColor = self.customPillButtonTextColor {
+                button.customTextColor = customButtonTextColor
+            }
+            
+            if let customSelectedButtonTextColor = self.customSelectedPillButtonTextColor {
+                button.customSelectedTextColor = customSelectedButtonTextColor
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Making the pill button color customizable 

### Verification

By using this new ability in the demo app and creating pill bar with custom colors

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Can't customize the colors of the pill button (just the background can be customized) | Can customize the colors of the pill button (background, selected background, text, selected text) ![Simulator Screen Shot - iPod touch (7th generation) - 2021-01-07 at 14 30 10](https://user-images.githubusercontent.com/64224417/103892853-f524bd00-50f4-11eb-86f4-959e91063817.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/355)