### PR TITLE
Add Objective-C class method for palette colors

### DIFF
--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -252,9 +252,9 @@ public final class Colors: NSObject {
 	/// - Parameter paletteValue: The `Palette` enum value.
 	/// - Returns: The `NSColor` for the given `paletteValue`.
 	/// # Example #
-	/// `NSColor *communicationBlue = [MSFColors paletteColor:MSFColorsPaletteCommunicationBlue];`
-	@objc public func paletteColor(_ paletteValue: Palette) -> NSColor {
-		return paletteValue.color
+	/// `NSColor *communicationBlue = [MSFColors paletteColor:MSFColorPaletteCommunicationBlue];`
+	@objc public static func colorFrom(_ palette: Palette) -> NSColor {
+		return palette.color
 	}
 
 	// MARK: Primary

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -249,10 +249,10 @@ public final class Colors: NSObject {
 	}
 
 	/// Allows Objective-C to get `NSColor` objects from `Palette` values.
-	/// - Parameter paletteValue: The `Palette` enum value.
-	/// - Returns: The `NSColor` for the given `paletteValue`.
+	/// - Parameter palette: The `Palette` enum value.
+	/// - Returns: The `NSColor` for the given `palette` value.
 	/// # Example #
-	/// `NSColor *communicationBlue = [MSFColors paletteColor:MSFColorPaletteCommunicationBlue];`
+	/// `NSColor *communicationBlue = [MSFColors colorFrom:MSFColorPaletteCommunicationBlue];`
 	@objc public static func colorFrom(_ palette: Palette) -> NSColor {
 		return palette.color
 	}

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -247,7 +247,16 @@ public final class Colors: NSObject {
 			}
 		}
 	}
-	
+
+	/// Allows Objective-C to get `NSColor` objects from `Palette` values.
+	/// - Parameter paletteValue: The `Palette` enum value.
+	/// - Returns: The `NSColor` for the given `paletteValue`.
+	/// # Example #
+	/// `NSColor *communicationBlue = [MSFColors paletteColor:MSFColorsPaletteCommunicationBlue];`
+	@objc public func paletteColor(_ paletteValue: Palette) -> NSColor {
+		return paletteValue.color
+	}
+
 	// MARK: Primary
 	
 	@objc public static var primary: NSColor = Colors.Palette.communicationBlue.color


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
Added an Objective-C class method to produce an NSColor object from a Palette enum value.  An iOS method with the same name already exists to produce a UIColor object from a Palette enum value.

### Verification
Used NuGet publishing script to test changes in SetupUI test app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/369)