### PR TITLE
Link custom color

### DIFF
--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -113,7 +113,7 @@ open class Link: NSButton {
 	}
 	
 	private func updateTitle() {
-		let titleAttributes = (showsUnderlineWhileMouseInside && mouseEntered) ? underlinedlinkAttributes: linkAttributes
+		let titleAttributes = (showsUnderlineWhileMouseInside && mouseEntered) ? underlinedLinkAttributes: linkAttributes
 		self.attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
 	}
 	
@@ -128,7 +128,7 @@ fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
 	.foregroundColor: NSColor.linkColor
 ]
 
-fileprivate let underlinedlinkAttributes: [NSAttributedString.Key: Any] = [
+fileprivate let underlinedLinkAttributes: [NSAttributedString.Key: Any] = [
 	.foregroundColor: NSColor.linkColor,
 	.underlineStyle: NSUnderlineStyle.single.rawValue
 ]

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -47,6 +47,7 @@ open class Link: NSButton {
 		alignment = .natural
 		isBordered = false
 		contentTintColor = .linkColor
+		setButtonType(.momentaryChange)
 		target = self
 		action = #selector(linkClicked)
 		updateTitle()
@@ -97,16 +98,6 @@ open class Link: NSButton {
 		self.trackingArea = trackingArea
 	}
 	
-	open override func mouseDown(with event: NSEvent) {
-		super.mouseDown(with: event)
-
-		// Updating the title here mitigates cases where the title disappears
-		// when the link is clicked.  This has been known to happen when the
-		// action is overridden and raises a modal dialog, as in
-		// `linkWithOverridenTargetAction` from TestLinkViewController.swift.
-		updateTitle()
-	}
-
 	open override func mouseEntered(with event: NSEvent) {
 		mouseInside = true
 		updateTitle()
@@ -135,9 +126,7 @@ open class Link: NSButton {
 	}
 }
 
-fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
-	.underlineStyle: NSUnderlineStyle()  // NSUnderlineStyleNone (no Swift equivalent)
-]
+fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [:]
 
 fileprivate let underlinedLinkAttributes: [NSAttributedString.Key: Any] = [
 	.underlineStyle: NSUnderlineStyle.single.rawValue

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -12,27 +12,20 @@ open class Link: NSButton {
 	/// Initializes a hyperlink with a title and an underlying URL that opens when clicked
 	/// - Parameters:
 	///   - title: The visible text of the link that the user sees.
-	///   - url: The URL that is opened when the link is clicked
-	@objc public init(title: String, url: NSURL) {
-		self.url = url
-		super.init(frame: .zero)
-		self.title = title
-		initialize()
+	///   - url: The URL that is opened when the link is clicked.
+	@objc public convenience init(title: String, url: NSURL) {
+		self.init(frame: .zero, title: title, url: url)
 	}
 	
 	/// Initializes a hyperlink with a title and no URL, useful if you plan to override the Target/Action
 	/// - Parameters:
 	///   - title: The visible text of the link that the user sees.
-	@objc public init(title: String) {
-		super.init(frame: .zero)
-		self.title = title
-		initialize()
+	@objc public convenience init(title: String) {
+		self.init(frame: .zero, title: title, url: nil)
 	}
 	
-	@objc public override init(frame frameRect: NSRect) {
-		super.init(frame: frameRect)
-		self.title = ""
-		initialize()
+	@objc public override convenience init(frame frameRect: NSRect) {
+		self.init(frame: frameRect, title: "", url: nil)
 	}
 	
 	@available(*, unavailable)
@@ -40,7 +33,17 @@ open class Link: NSButton {
 		preconditionFailure()
 	}
 	
-	private func initialize() {
+	/// Designated initializer.
+	/// - Parameters:
+	///   - frame: The position and size of this view in the superview's coordinate system.
+	///   - title: The visible text of the link that the user sees.
+	///   - url: The URL that is opened when the link is clicked.
+	public init(frame: NSRect = .zero, title: String = "", url: NSURL? = nil)
+	{
+		super.init(frame: frame)
+		self.title = title
+		self.url = url
+
 		alignment = .natural
 		isBordered = false
 		target = self

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -136,7 +136,7 @@ open class Link: NSButton {
 }
 
 fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
-	.underlineStyle: 0  // NSUnderlineStyleNone (no Swift equivalent)
+	.underlineStyle: NSUnderlineStyle()  // NSUnderlineStyleNone (no Swift equivalent)
 ]
 
 fileprivate let underlinedLinkAttributes: [NSAttributedString.Key: Any] = [

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -46,6 +46,7 @@ open class Link: NSButton {
 
 		alignment = .natural
 		isBordered = false
+		contentTintColor = .linkColor
 		target = self
 		action = #selector(linkClicked)
 		updateTitle()
@@ -130,11 +131,9 @@ open class Link: NSButton {
 }
 
 fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
-	.foregroundColor: NSColor.linkColor,
 	.underlineStyle: NSUnderlineStyle()
 ]
 
 fileprivate let underlinedLinkAttributes: [NSAttributedString.Key: Any] = [
-	.foregroundColor: NSColor.linkColor,
 	.underlineStyle: NSUnderlineStyle.single.rawValue
 ]

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -99,6 +99,11 @@ open class Link: NSButton {
 	
 	open override func mouseDown(with event: NSEvent) {
 		super.mouseDown(with: event)
+
+		// Updating the title here mitigates cases where the title disappears
+		// when the link is clicked.  This has been known to happen when the
+		// action is overridden and raises a modal dialog, as in
+		// `linkWithOverridenTargetAction` from TestLinkViewController.swift.
 		updateTitle()
 	}
 
@@ -131,7 +136,7 @@ open class Link: NSButton {
 }
 
 fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
-	.underlineStyle: NSUnderlineStyle()
+	.underlineStyle: 0  // NSUnderlineStyleNone (no Swift equivalent)
 ]
 
 fileprivate let underlinedLinkAttributes: [NSAttributedString.Key: Any] = [

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -96,6 +96,11 @@ open class Link: NSButton {
 		self.trackingArea = trackingArea
 	}
 	
+	open override func mouseDown(with event: NSEvent) {
+		super.mouseDown(with: event)
+		updateTitle()
+	}
+
 	open override func mouseEntered(with event: NSEvent) {
 		mouseInside = true
 		updateTitle()
@@ -125,7 +130,8 @@ open class Link: NSButton {
 }
 
 fileprivate let linkAttributes: [NSAttributedString.Key: Any] = [
-	.foregroundColor: NSColor.linkColor
+	.foregroundColor: NSColor.linkColor,
+	.underlineStyle: NSUnderlineStyle()
 ]
 
 fileprivate let underlinedLinkAttributes: [NSAttributedString.Key: Any] = [

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -97,23 +97,23 @@ open class Link: NSButton {
 	}
 	
 	open override func mouseEntered(with event: NSEvent) {
-		mouseEntered = true
+		mouseInside = true
 		updateTitle()
 	}
 
 	open override func mouseExited(with event: NSEvent) {
-		mouseEntered = false
+		mouseInside = false
 		updateTitle()
 	}
 
-	private var mouseEntered = false
+	private var mouseInside = false
 	
 	open override func resetCursorRects() {
 		addCursorRect(bounds, cursor: .pointingHand)
 	}
 	
 	private func updateTitle() {
-		let titleAttributes = (showsUnderlineWhileMouseInside && mouseEntered) ? underlinedLinkAttributes: linkAttributes
+		let titleAttributes = (showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes
 		self.attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
 	}
 	

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -23,7 +23,11 @@ class TestLinkViewController: NSViewController {
 		linkWithOverridenTargetAction.target = self
 		linkWithOverridenTargetAction.action = #selector(displayAlert)
 		
-		let containerView = NSStackView(views: [linkWithNoHover, linkWithHover, linkWithHoverAndNoURL, linkWithOverridenTargetAction])
+		let linkWithCustomFontAndColor = Link(title: "Link with custom font and color  ❯", url: url)
+		linkWithCustomFontAndColor.font = NSFont.systemFont(ofSize:12.0, weight:NSFont.Weight.semibold)
+		linkWithCustomFontAndColor.contentTintColor = .textColor
+
+		let containerView = NSStackView(views: [linkWithNoHover, linkWithHover, linkWithHoverAndNoURL, linkWithOverridenTargetAction, linkWithCustomFontAndColor])
 		containerView.edgeInsets = NSEdgeInsets(top: 100, left: 100, bottom: 100, right: 100)
 		containerView.orientation = .vertical
 		containerView.distribution = .gravityAreas

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -8,9 +8,11 @@ import FluentUI
 
 class TestLinkViewController: NSViewController {
 	override func loadView() {
-		let linkWithNoHover = Link(title: "Link", url: NSURL(string: "https://github.com/microsoft/fluentui-apple")!)
+		let url = NSURL(string: "https://github.com/microsoft/fluentui-apple")
+
+		let linkWithNoHover = Link(title: "Link", url: url)
 		
-		let linkWithHover = Link(title: "Link with hover effects", url: NSURL(string: "https://github.com/microsoft/fluentui-apple")!)
+		let linkWithHover = Link(title: "Link with hover effects", url: url)
 		linkWithHover.showsUnderlineWhileMouseInside = true
 		
 		let linkWithHoverAndNoURL = Link(title: "Link with hover effects and no URL")


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
FluentUI links have a fixed color value that is part of the `attributedTitle`, which gets clobbered by `mouseEntered` and `mouseExited` events (and therefore shouldn't be set directly).  This removes the color attribute and instead sets the `contentTintColor`, which can be overridden.  Combined with the existing `font` property, this allows us to customize the link text a bit more.

Also did some refactoring and a bugfix.

### Verification
Added a button to the test app with color and font customizations:
<img width="220" alt="Screen Shot 2021-01-05 at 14 54 57" src="https://user-images.githubusercontent.com/67027949/103709987-b3670b80-4f68-11eb-9326-e403260d62fd.png">

I also noticed an issue with the "Link with overridden Target/Action" disappearing when clicked.  This is fixed by setting the button type to `.momentaryChange` (thanks Anand):
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Disappearing Link Before](https://user-images.githubusercontent.com/67027949/103710063-f1fcc600-4f68-11eb-9698-ef4bb47ff09e.gif) | ![Disappearing Link Fixed](https://user-images.githubusercontent.com/67027949/103727025-166b9900-4f8f-11eb-9f21-c3c850a326e5.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/371)