### PR TITLE
Better Objective-C names for FluentUI Color methods

### DIFF
--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -432,7 +432,7 @@ public final class Colors: NSObject {
     @objc public static let dividerOnSecondary = UIColor(light: gray200, dark: gray700, darkElevated: gray600)
     @objc public static let dividerOnTertiary = UIColor(light: gray200, dark: gray700, darkElevated: gray600)
 
-    @objc public static func color(from palette: Palette) -> UIColor {
+	@objc(colorFromPalette:) public static func color(from palette: Palette) -> UIColor {
         return palette.color
     }
 

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -252,8 +252,8 @@ public final class Colors: NSObject {
 	/// - Parameter palette: The `Palette` enum value.
 	/// - Returns: The `NSColor` for the given `palette` value.
 	/// # Example #
-	/// `NSColor *communicationBlue = [MSFColors colorFrom:MSFColorPaletteCommunicationBlue];`
-	@objc public static func colorFrom(_ palette: Palette) -> NSColor {
+	/// `NSColor *communicationBlue = [MSFColors colorFromPalette:MSFColorPaletteCommunicationBlue];`
+	@objc(colorFromPalette:) public static func color(from palette: Palette) -> NSColor {
 		return palette.color
 	}
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes
Adopted Anand's suggestion to change the Objective-C method name from 'colorFrom:' to 'colorFromPalette:'.  Making the same change to macOS and iOS methods.

These methods don't have any current usage in devmain.

### Verification
Used nuget publish script to test with some local pending changes in devmain that adopt this method.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/372)