### PR TITLE
Fixing swiftlint warnings.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -421,9 +421,6 @@ extension DrawerDemoController: DrawerControllerDelegate {
     }
 
     func drawerControllerDidChangeExpandedState(_ controller: DrawerController) {
-        expandButton?.setTitle(controller.isExpanded ? collapseText : expandText, for: .normal)
+        expandButton?.setTitle(controller.isExpanded ? "Return to normal" : "Expand", for: .normal)
     }
 }
-
-fileprivate let collapseText: String = "Return to normal"
-fileprivate let expandText: String = "Expand"

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -417,7 +417,7 @@ open class DrawerController: UIViewController {
             updateContainerViewBottomConstraint()
         }
     }
-    
+
     private var containerViewCenterObservation: NSKeyValueObservation?
 
     private var useCustomBackgroundColor: Bool = false

--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -616,7 +616,7 @@ open class AvatarView: UIView {
 
         borderView.backgroundColor = UIColor(patternImage: image)
     }
-    
+
     private func updateInnerStroke() {
         imageView.layer.borderWidth = avatarSize.insideBorder
         imageView.layer.borderColor = Colors.surfacePrimary.cgColor
@@ -802,7 +802,7 @@ class OverflowAvatarView: AvatarView {
 
     private let hasBorder: Bool
     private let borderView: UIView
-    
+
     private func updateColors() {
         initialsView.setFontColor(UIColor(light: Colors.gray500, dark: Colors.gray100))
         initialsView.setBackgroundColor(UIColor(light: Colors.gray50, dark: Colors.gray600))

--- a/ios/FluentUI/People Picker/InitialsView.swift
+++ b/ios/FluentUI/People Picker/InitialsView.swift
@@ -117,7 +117,7 @@ class InitialsView: UIView {
         /// `adjustsFontSizeToFitWidth` will not adjust unless text is on or exceeds the containing bounds.
         static let borderAdjustment: CGFloat = 2.5
     }
-    
+
     // MARK: Setup
 
     /// Sets up in the initialsView by displaying initials from a provided primary text or secondary text


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixing some minor issues with swiftlint warnings.

### Verification

Ensured swiftlint warnings are gone.
DrawerController resizable scenario still shows "Expand" and "Return to normal" correctly. 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/374)