### PR TITLE
Large title header needs "header" accessibility trait

### DIFF
--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -189,6 +189,7 @@ class LargeTitleView: UIView {
         contentStackView.addArrangedSubview(titleButton)
         titleButton.setTitle(nil, for: .normal)
         titleButton.titleLabel?.font = Constants.titleFont
+        titleButton.titleLabel?.accessibilityTraits = .header
         titleButton.setTitleColor(colorForStyle, for: .normal)
         titleButton.titleLabel?.textAlignment = .left
         titleButton.contentHorizontalAlignment = .left


### PR DESCRIPTION
Set the accessibility trait to header for the large title header's title.

### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Verification

Tested on device to make sure that VoiceOver announces that the header title is in fact a "heading".

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/375)