### PR TITLE
[ListVnext] Replace custom LeadingView input type to UIView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
@@ -31,7 +31,7 @@ class ListVnextDemoController: DemoController {
 
         var avatar: AvatarVnext
 
-        ///AvatarView section
+        /// AvatarView section
         listSection = MSFListVnextSectionData()
         listSection.title = "AvatarView Section"
         listSection.cells = []
@@ -48,7 +48,7 @@ class ListVnextDemoController: DemoController {
         listSection.layoutType = MSFListCellVnextLayoutType.twoLines
         listData.append(listSection)
 
-        ///TableViewCell Sample Data Sections
+        /// TableViewCell Sample Data Sections
         for sectionIndex in 0...sections.count - 1 {
             section = sections[sectionIndex]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
@@ -21,6 +21,34 @@ class ListVnextDemoController: DemoController {
         var listData: [MSFListVnextSectionData] = []
         let iconStyle = MSFListIconVnextStyle.none
 
+        let samplePersonas: [PersonaData] = [
+            PersonaData(name: "Kat Larrson", email: "kat.larrson@contoso.com", subtitle: "Designer", avatarImage: UIImage(named: "avatar_kat_larsson"), color: Colors.Palette.cyanBlue10.color),
+            PersonaData(name: "Kristin Patterson", email: "kristin.patterson@contoso.com", subtitle: "Software Engineer", color: Colors.Palette.red10.color),
+            PersonaData(name: "Ashley McCarthy", avatarImage: UIImage(named: "avatar_ashley_mccarthy"), color: Colors.Palette.magenta20.color),
+            PersonaData(name: "Allan Munger", email: "allan.munger@contoso.com", subtitle: "Designer", avatarImage: UIImage(named: "avatar_allan_munger"), color: Colors.Palette.green10.color),
+            PersonaData(name: "Amanda Brady", subtitle: "Program Manager", avatarImage: UIImage(named: "avatar_amanda_brady"), color: Colors.Palette.magentaPink10.color)
+        ]
+
+        var avatar: AvatarVnext
+
+        ///AvatarView section
+        listSection = MSFListVnextSectionData()
+        listSection.title = "AvatarView Section"
+        listSection.cells = []
+        for index in 0...samplePersonas.count - 1 {
+            listCell = MSFListVnextCellData()
+            avatar = createAvatarView(size: .medium,
+                                      name: samplePersonas[index].name,
+                                      image: samplePersonas[index].avatarImage,
+                                      style: .default)
+            listCell.title = avatar.state.primaryText ?? ""
+            listCell.leadingIcon = avatar.view
+            listSection.cells.append(listCell)
+        }
+        listSection.layoutType = MSFListCellVnextLayoutType.twoLines
+        listData.append(listSection)
+
+        ///TableViewCell Sample Data Sections
         for sectionIndex in 0...sections.count - 1 {
             section = sections[sectionIndex]
 
@@ -32,7 +60,7 @@ class ListVnextDemoController: DemoController {
                 listCell = MSFListVnextCellData()
                 listCell.title = cell.text1
                 listCell.subtitle = cell.text2
-                listCell.leadingIcon = UIImage(named: cell.image)
+                listCell.leadingIcon = createCustomView(imageName: cell.image)
                 listCell.accessoryType = accessoryType(for: rowIndex)
                 listCell.onTapAction = {
                     indexPath.row = rowIndex
@@ -44,6 +72,7 @@ class ListVnextDemoController: DemoController {
             listSection.layoutType = updateLayout(subtitle: listSection.cells[0].subtitle)
             listData.append(listSection)
         }
+
         list = MSFListVnext(sections: listData, iconStyle: iconStyle)
 
         let listView = list.view
@@ -56,6 +85,32 @@ class ListVnextDemoController: DemoController {
                                      demoControllerView.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: listView.bottomAnchor),
                                      demoControllerView.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: listView.leadingAnchor),
                                      demoControllerView.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: listView.trailingAnchor)])
+    }
+
+    private func createAvatarView(size: AvatarVnextSize,
+                                  name: String? = nil,
+                                  image: UIImage? = nil,
+                                  style: AvatarVnextStyle) -> AvatarVnext {
+        let avatarView = AvatarVnext(style: style,
+                                     size: size)
+        avatarView.state.primaryText = name
+        avatarView.state.image = image
+
+        return avatarView
+    }
+
+    private func createCustomView(imageName: String, useImageAsTemplate: Bool = false) -> UIImageView? {
+        if imageName == "" {
+            return nil
+        }
+        var image = UIImage(named: imageName)
+        if useImageAsTemplate {
+            image = image?.withRenderingMode(.alwaysTemplate)
+        }
+        let customView = UIImageView(image: image)
+        customView.contentMode = .scaleAspectFit
+        customView.tintColor = Colors.Table.Cell.image
+        return customView
     }
 
     private func accessoryType(for indexPath: Int) -> MSFListAccessoryType {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
@@ -42,7 +42,7 @@ class ListVnextDemoController: DemoController {
                                       image: samplePersonas[index].avatarImage,
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
-            listCell.leadingIcon = avatar.view
+            listCell.leadingView = avatar.view
             listSection.cells.append(listCell)
         }
         listSection.layoutType = MSFListCellVnextLayoutType.twoLines
@@ -60,7 +60,7 @@ class ListVnextDemoController: DemoController {
                 listCell = MSFListVnextCellData()
                 listCell.title = cell.text1
                 listCell.subtitle = cell.text2
-                listCell.leadingIcon = createCustomView(imageName: cell.image)
+                listCell.leadingView = createCustomView(imageName: cell.image)
                 listCell.accessoryType = accessoryType(for: rowIndex)
                 listCell.onTapAction = {
                     indexPath.row = rowIndex

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -84,8 +84,8 @@
     MSFListVnextCellData *listCell3 = [[MSFListVnextCellData alloc] init];
     [listCell3 setTitle:@"SampleTitle3"];
     [listCell3 setSubtitle:@"SampleTitle3"];
-    UIImage *image = [UIImage imageNamed:@"excelIcon"];
-    [listCell3 setLeadingIcon:image];
+    UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]] ;
+    [listCell3 setLeadingView:image];
     [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
     [listCell3 setOnTapAction:^{
         [self showAlertForCellTapped:@"Sample Title3"];

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0AF14BF225A7FCE300A90572 /* UIViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */; };
+		0AF14BF325A7FCE300A90572 /* UIViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */; };
 		0BCEFADE2485FEC00088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
 		0BCEFAE1248650F10088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
 		11104BCE233ACA9500CCB232 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118D9847230BBA2300BC0B72 /* TabBarItem.swift */; };
@@ -314,6 +316,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewWrapper.swift; sourceTree = "<group>"; };
 		0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuProtocols.swift; sourceTree = "<group>"; };
 		1168630222E131CF0088B302 /* TabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemView.swift; sourceTree = "<group>"; };
 		1168630322E131CF0088B302 /* TabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -750,6 +753,7 @@
 				A5CEC16E20D98F340016922A /* Fonts.swift */,
 				537315B225438B15001FD14C /* iOS13_4_compatibility.swift */,
 				FD41C8C022DD48E60086F899 /* Operators.swift */,
+				0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1267,6 +1271,7 @@
 				53BCB0CF253A4E8D00620960 /* Obscurable.swift in Sources */,
 				53EA0F98257EC20800899357 /* AvatarViewVnext.swift in Sources */,
 				8FD0117D228A82A600D25925 /* Button.swift in Sources */,
+				0AF14BF325A7FCE300A90572 /* UIViewWrapper.swift in Sources */,
 				FD41C8BF22DD47120086F899 /* UINavigationItem+Navigation.swift in Sources */,
 				8FD0117E228A82A600D25925 /* DimmingView.swift in Sources */,
 				8FD0117F228A82A600D25925 /* DotView.swift in Sources */,
@@ -1487,6 +1492,7 @@
 				C0938E46235F66E300256251 /* ShimmerViewAppearance.swift in Sources */,
 				C0A0D76F233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift in Sources */,
 				FD256C5B2183B90B00EC9588 /* DatePickerSelectionManager.swift in Sources */,
+				0AF14BF225A7FCE300A90572 /* UIViewWrapper.swift in Sources */,
 				A5CEC23120E451D00016922A /* Button.swift in Sources */,
 				3F800564259DA182004DDB8B /* SideOverPanel+Modifiers.swift in Sources */,
 				FDF41EDB2141A23B00EC527C /* UIViewController+Extensions.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0AF14BF225A7FCE300A90572 /* UIViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */; };
-		0AF14BF325A7FCE300A90572 /* UIViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */; };
+		0AF14BF225A7FCE300A90572 /* UIViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF14BF125A7FCE300A90572 /* UIViewAdapter.swift */; };
+		0AF14BF325A7FCE300A90572 /* UIViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF14BF125A7FCE300A90572 /* UIViewAdapter.swift */; };
 		0BCEFADE2485FEC00088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
 		0BCEFAE1248650F10088CEE5 /* PopupMenuProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */; };
 		11104BCE233ACA9500CCB232 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118D9847230BBA2300BC0B72 /* TabBarItem.swift */; };
@@ -316,7 +316,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewWrapper.swift; sourceTree = "<group>"; };
+		0AF14BF125A7FCE300A90572 /* UIViewAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewAdapter.swift; sourceTree = "<group>"; };
 		0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuProtocols.swift; sourceTree = "<group>"; };
 		1168630222E131CF0088B302 /* TabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemView.swift; sourceTree = "<group>"; };
 		1168630322E131CF0088B302 /* TabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -753,7 +753,7 @@
 				A5CEC16E20D98F340016922A /* Fonts.swift */,
 				537315B225438B15001FD14C /* iOS13_4_compatibility.swift */,
 				FD41C8C022DD48E60086F899 /* Operators.swift */,
-				0AF14BF125A7FCE300A90572 /* UIViewWrapper.swift */,
+				0AF14BF125A7FCE300A90572 /* UIViewAdapter.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1271,7 +1271,7 @@
 				53BCB0CF253A4E8D00620960 /* Obscurable.swift in Sources */,
 				53EA0F98257EC20800899357 /* AvatarViewVnext.swift in Sources */,
 				8FD0117D228A82A600D25925 /* Button.swift in Sources */,
-				0AF14BF325A7FCE300A90572 /* UIViewWrapper.swift in Sources */,
+				0AF14BF325A7FCE300A90572 /* UIViewAdapter.swift in Sources */,
 				FD41C8BF22DD47120086F899 /* UINavigationItem+Navigation.swift in Sources */,
 				8FD0117E228A82A600D25925 /* DimmingView.swift in Sources */,
 				8FD0117F228A82A600D25925 /* DotView.swift in Sources */,
@@ -1492,7 +1492,7 @@
 				C0938E46235F66E300256251 /* ShimmerViewAppearance.swift in Sources */,
 				C0A0D76F233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift in Sources */,
 				FD256C5B2183B90B00EC9588 /* DatePickerSelectionManager.swift in Sources */,
-				0AF14BF225A7FCE300A90572 /* UIViewWrapper.swift in Sources */,
+				0AF14BF225A7FCE300A90572 /* UIViewAdapter.swift in Sources */,
 				A5CEC23120E451D00016922A /* Button.swift in Sources */,
 				3F800564259DA182004DDB8B /* SideOverPanel+Modifiers.swift in Sources */,
 				FDF41EDB2141A23B00EC527C /* UIViewController+Extensions.swift in Sources */,

--- a/ios/FluentUI/Core/UIViewAdapter.swift
+++ b/ios/FluentUI/Core/UIViewAdapter.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// This is a generic UIView wrapper to allow SwiftUI  to use views from non-SwiftUI environments.
-struct UIViewWrapper: UIViewRepresentable {
+struct UIViewAdapter: UIViewRepresentable {
 
     var makeView: () -> UIView
 

--- a/ios/FluentUI/Core/UIViewAdapter.swift
+++ b/ios/FluentUI/Core/UIViewAdapter.swift
@@ -6,7 +6,7 @@
 import UIKit
 import SwiftUI
 
-/// This is a generic UIView wrapper to allow SwiftUI  to use views from non-SwiftUI environments.
+/// This is a generic UIView wrapper to allow SwiftUI to use views from non-SwiftUI environments.
 struct UIViewAdapter: UIViewRepresentable {
 
     var makeView: () -> UIView

--- a/ios/FluentUI/Core/UIViewWrapper.swift
+++ b/ios/FluentUI/Core/UIViewWrapper.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+/// This is a generic UIView wrapper to allow SwiftUI  to use views from non-SwiftUI environments.
+struct UIViewWrapper: UIViewRepresentable {
+
+    var makeView: () -> UIView
+
+    init(_ makeView: @escaping @autoclosure () -> UIView) {
+        self.makeView = makeView
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        makeView()
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+    }
+}

--- a/ios/FluentUI/Table View/ListVnext.swift
+++ b/ios/FluentUI/Table View/ListVnext.swift
@@ -42,7 +42,7 @@ public enum MSFListAccessoryType: Int, CaseIterable {
 @objc(MSFListVnextCellData)
 public class MSFListVnextCellData: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
-    @objc @Published public var leadingIcon: UIView?
+    @objc @Published public var leadingView: UIView?
     @objc @Published public var title: String = ""
     @objc @Published public var subtitle: String?
     @objc @Published public var accessoryType: MSFListAccessoryType = .none
@@ -203,8 +203,8 @@ extension MSFListView {
         var body: some View {
             Button(action: cell.onTapAction ?? {}, label: {
                 HStack(spacing: 0) {
-                    if let leadingIcon = cell.leadingIcon {
-                        UIViewWrapper(leadingIcon)
+                    if let leadingView = cell.leadingView {
+                        UIViewWrapper(leadingView)
                             .frame(width: tokens.iconSize, height: tokens.iconSize)
                             .padding(.trailing, tokens.iconInterspace)
                     }

--- a/ios/FluentUI/Table View/ListVnext.swift
+++ b/ios/FluentUI/Table View/ListVnext.swift
@@ -42,7 +42,8 @@ public enum MSFListAccessoryType: Int, CaseIterable {
 @objc(MSFListVnextCellData)
 public class MSFListVnextCellData: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
-    @objc @Published public var leadingIcon: UIImage?
+//    @objc @Published public var leadingIcon: UIImage?
+    @objc @Published public var leadingIcon: UIView?
     @objc @Published public var title: String = ""
     @objc @Published public var subtitle: String?
     @objc @Published public var accessoryType: MSFListAccessoryType = .none
@@ -204,8 +205,7 @@ extension MSFListView {
             Button(action: cell.onTapAction ?? {}, label: {
                 HStack(spacing: 0) {
                     if let leadingIcon = cell.leadingIcon {
-                        Image(uiImage: leadingIcon)
-                            .resizable()
+                        UIViewWrapper(leadingIcon)
                             .frame(width: tokens.iconSize, height: tokens.iconSize)
                             .padding(.trailing, tokens.iconInterspace)
                     }
@@ -286,6 +286,25 @@ extension MSFListView {
                 }
             }
         }
+    }
+}
+
+/// Generic UIView wrapper
+struct UIViewWrapper: UIViewRepresentable {
+
+    var makeView: () -> UIView
+
+    init(_ makeView: @escaping @autoclosure () -> UIView) {
+        self.makeView = makeView
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        makeView()
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
     }
 }
 

--- a/ios/FluentUI/Table View/ListVnext.swift
+++ b/ios/FluentUI/Table View/ListVnext.swift
@@ -288,25 +288,6 @@ extension MSFListView {
     }
 }
 
-/// Generic UIView wrapper
-struct UIViewWrapper: UIViewRepresentable {
-
-    var makeView: () -> UIView
-
-    init(_ makeView: @escaping @autoclosure () -> UIView) {
-        self.makeView = makeView
-    }
-
-    func makeUIView(context: Context) -> UIView {
-        makeView()
-    }
-
-    func updateUIView(_ view: UIView, context: Context) {
-        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-    }
-}
-
 @objc(MSFListVnext)
 open class MSFListVnext: NSObject {
 

--- a/ios/FluentUI/Table View/ListVnext.swift
+++ b/ios/FluentUI/Table View/ListVnext.swift
@@ -204,7 +204,7 @@ extension MSFListView {
             Button(action: cell.onTapAction ?? {}, label: {
                 HStack(spacing: 0) {
                     if let leadingView = cell.leadingView {
-                        UIViewWrapper(leadingView)
+                        UIViewAdapter(leadingView)
                             .frame(width: tokens.iconSize, height: tokens.iconSize)
                             .padding(.trailing, tokens.iconInterspace)
                     }

--- a/ios/FluentUI/Table View/ListVnext.swift
+++ b/ios/FluentUI/Table View/ListVnext.swift
@@ -42,7 +42,6 @@ public enum MSFListAccessoryType: Int, CaseIterable {
 @objc(MSFListVnextCellData)
 public class MSFListVnextCellData: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
-//    @objc @Published public var leadingIcon: UIImage?
     @objc @Published public var leadingIcon: UIView?
     @objc @Published public var title: String = ""
     @objc @Published public var subtitle: String?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

List's custom LeadingView only accepted Images, but with this new change should be able to accept any UIView as its input. (https://github.com/microsoft/fluentui-apple/issues/365)

### Verification

Sample section was added in main List.

| Current                                       | Vnext                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-01-06 at 20 55 18](https://user-images.githubusercontent.com/22566866/103845345-80ed0980-5061-11eb-976e-1d5d7aa3effb.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-01-06 at 20 54 40](https://user-images.githubusercontent.com/22566866/103845308-6c107600-5061-11eb-87a3-60d7f52ee15b.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/378)