### PR TITLE
Fixing PillButton swiftlint violation warnings.

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -128,21 +128,21 @@ open class PillButton: UIButton {
             updateAppearance()
         }
     }
-    
+
     /// Set `selectedBackgroundColor` to customize background color of the pill button
     @objc open var customSelectedBackgroundColor: UIColor? {
         didSet {
             updateAppearance()
         }
     }
-    
+
     /// Set `textColor` to customize background color of the pill button
     @objc open var customTextColor: UIColor? {
         didSet {
             updateAppearance()
         }
     }
-    
+
     /// Set `selectedTextColor` to customize background color of the pill button
     @objc open var customSelectedTextColor: UIColor? {
         didSet {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -250,15 +250,15 @@ open class PillButtonBar: UIScrollView {
             if let customButtonBackgroundColor = self.customPillButtonBackgroundColor {
                 button.customBackgroundColor = customButtonBackgroundColor
             }
-            
+
             if let customSelectedButtonBackgroundColor = self.customSelectedPillButtonBackgroundColor {
                 button.customSelectedBackgroundColor = customSelectedButtonBackgroundColor
             }
-            
+
             if let customButtonTextColor = self.customPillButtonTextColor {
                 button.customTextColor = customButtonTextColor
             }
-            
+
             if let customSelectedButtonTextColor = self.customSelectedPillButtonTextColor {
                 button.customSelectedTextColor = customSelectedButtonTextColor
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Changes merged from #355 added some trailing whitespaces that caused swiftlint warnings.
Removing those.

### Verification

Ensured no swiftlint validation warnings were present in the iOS project.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/379)