### PR TITLE
Add convenience initializer for PillButtonBar to fix public API break.

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -143,7 +143,20 @@ open class PillButtonBar: UIScrollView {
     }
 
     @objc public convenience init(pillButtonStyle: PillButtonStyle = .outline) {
-        self.init(pillButtonStyle: pillButtonStyle, pillButtonBackgroundColor: nil)
+        self.init(pillButtonStyle: pillButtonStyle,
+                  pillButtonBackgroundColor: nil,
+                  selectedPillButtonBackgroundColor: nil,
+                  pillButtonTextColor: nil,
+                  selectedPillButtonTextColor: nil)
+    }
+
+    @objc public convenience init(pillButtonStyle: PillButtonStyle = .outline,
+                                  pillButtonBackgroundColor: UIColor? = nil) {
+        self.init(pillButtonStyle: pillButtonStyle,
+                  pillButtonBackgroundColor: pillButtonBackgroundColor,
+                  selectedPillButtonBackgroundColor: nil,
+                  pillButtonTextColor: nil,
+                  selectedPillButtonTextColor: nil)
     }
 
     @objc public init(pillButtonStyle: PillButtonStyle = .outline,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Change associated with #355 changed one of the initializers of the PillButtonBar which broke its public API.
This change fixes the break by reintroducing the same initializer available before (style and background color as parameters) as an additional convenience initializer. 

### Verification

Sanity tests with the FluentUI demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/386)