### PR TITLE
SideTabBar account button AX label

### DIFF
--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -345,6 +345,8 @@ open class AvatarView: UIView {
 
         super.init(frame: containerView.frame)
 
+        self.accessibilityTraits = .image
+
         addSubview(containerView)
     }
 
@@ -744,7 +746,6 @@ open class AvatarView: UIView {
     // MARK: Accessibility
 
     open override var isAccessibilityElement: Bool { get { return true } set { } }
-    open override var accessibilityTraits: UIAccessibilityTraits { get { return .image } set { } }
 
     open override var accessibilityLabel: String? {
         get {

--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -345,7 +345,7 @@ open class AvatarView: UIView {
 
         super.init(frame: containerView.frame)
 
-        self.accessibilityTraits = .image
+        accessibilityTraits = .image
 
         addSubview(containerView)
     }

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -25,7 +25,13 @@ public protocol SideTabBarDelegate {
 @objc(MSFSideTabBar)
 open class SideTabBar: UIView {
     /// Delegate to handle user interactions in the side tab bar.
-    @objc public weak var delegate: SideTabBarDelegate?
+    @objc public weak var delegate: SideTabBarDelegate? {
+        didSet {
+            if let avatarView = avatarView {
+                avatarView.accessibilityTraits = delegate != nil ? .button : .image
+            }
+        }
+    }
 
     /// The avatar view that displays above the top tab bar items.
     /// The avatar view's size class should be AvatarSize.medium.
@@ -40,8 +46,11 @@ open class SideTabBar: UIView {
                 avatarView.avatarSize = .medium
                 avatarView.translatesAutoresizingMaskIntoConstraints = false
                 avatarView.overrideAccessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
-                avatarView.accessibilityTraits = .button
                 addSubview(avatarView)
+
+                if delegate != nil {
+                    avatarView.accessibilityTraits = .button
+                }
 
                 avatarView.addGestureRecognizer(avatarViewGestureRecognizer)
             }

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -39,6 +39,8 @@ open class SideTabBar: UIView {
             if let avatarView = avatarView {
                 avatarView.avatarSize = .medium
                 avatarView.translatesAutoresizingMaskIntoConstraints = false
+                avatarView.overrideAccessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
+                avatarView.accessibilityTraits = .button
                 addSubview(avatarView)
 
                 avatarView.addGestureRecognizer(avatarViewGestureRecognizer)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The SideTabBar's account button AX label is set to: "<account name> image".
In the FluentUI navigation bar, the account button's AX label is: "account profile button".
Let's be consistent and set the SideTabBar's account button label to the same value as the nav bar's account button.
Additionally, the AX trait for the button should be set to "button" instead of "image". It is fair to assume that anyone that will consume the SideTabBar will want the avatar view to be an interactive button.

### Verification

Run on device and make sure that VoiceOver announcements match expectations.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/389)