### PR TITLE
Add Obj-C support to CenteredLabelCell setup function

### DIFF
--- a/ios/FluentUI/Table View/CenteredLabelCell.swift
+++ b/ios/FluentUI/Table View/CenteredLabelCell.swift
@@ -37,7 +37,7 @@ open class CenteredLabelCell: UITableViewCell {
     /// Set up the cell with text to be displayed in the centered label
     ///
     /// - Parameter text: The text to be displayed
-    open func setup(text: String) {
+    @objc open func setup(text: String) {
         label.text = text
         setNeedsLayout()
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add Obj-C support to CenteredLabelCell's setup function

### Verification

Verified that the generated FluentUI-Swift.h contains CenteredLabelCell setup function

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/393)