### PR TITLE
Consolidate PillButton styles

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -19,37 +19,37 @@ class PillButtonBarDemoController: DemoController {
                                           PillButtonBarItem(title: "Actions"),
                                           PillButtonBarItem(title: "More")]
 
-        let disableFilledSwitchView = UISwitch()
-        disableFilledSwitchView.isOn = true
-        disableFilledSwitchView.addTarget(self, action: #selector(toggleFilledPills(switchView:)), for: .valueChanged)
+        let disableOnBrandSwitchView = UISwitch()
+        disableOnBrandSwitchView.isOn = true
+        disableOnBrandSwitchView.addTarget(self, action: #selector(toggleOnBrandPills(switchView:)), for: .valueChanged)
 
-        container.addArrangedSubview(createLabelWithText("Filled"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in Filled Pill Bar"), disableFilledSwitchView], itemSpacing: 20, centerItems: true)
-        let filledBar = createBar(items: items, style: .filled)
-        container.addArrangedSubview(filledBar)
-        self.filledBar = filledBar
+        container.addArrangedSubview(createLabelWithText("onBrand"))
+        addRow(items: [createLabelWithText("Enable/Disable pills in onBrand Pill Bar"), disableOnBrandSwitchView], itemSpacing: 20, centerItems: true)
+        let onBrandBar = createBar(items: items, style: .onBrand)
+        container.addArrangedSubview(onBrandBar)
+        self.onBrandBar = onBrandBar
         container.addArrangedSubview(UIView())
 
-        let disableCustomFilledSwitchView = UISwitch()
-        disableCustomFilledSwitchView.isOn = true
-        disableCustomFilledSwitchView.addTarget(self, action: #selector(toggleCustomFilledPills(switchView:)), for: .valueChanged)
+        let disableCustomOnBrandSwitchView = UISwitch()
+        disableCustomOnBrandSwitchView.isOn = true
+        disableCustomOnBrandSwitchView.addTarget(self, action: #selector(toggleCustomOnBrandPills(switchView:)), for: .valueChanged)
 
-        container.addArrangedSubview(createLabelWithText("Filled With Custom Pills Background"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in custom Filled Pill Bar"), disableCustomFilledSwitchView], itemSpacing: 20, centerItems: true)
-        let customBar = createBar(items: items, style: .filled, useCustomPillsColors: true)
+        container.addArrangedSubview(createLabelWithText("onBrand With Custom Pills Background"))
+        addRow(items: [createLabelWithText("Enable/Disable pills in custom onBrand Pill Bar"), disableCustomOnBrandSwitchView], itemSpacing: 20, centerItems: true)
+        let customBar = createBar(items: items, style: .onBrand, useCustomPillsColors: true)
         container.addArrangedSubview(customBar)
         self.customBar = customBar
         container.addArrangedSubview(UIView())
 
-        let disableOutlinedSwitchView = UISwitch()
-        disableOutlinedSwitchView.isOn = true
-        disableOutlinedSwitchView.addTarget(self, action: #selector(toggleOutlinedPills(switchView:)), for: .valueChanged)
+        let disablePrimarySwitchView = UISwitch()
+        disablePrimarySwitchView.isOn = true
+        disablePrimarySwitchView.addTarget(self, action: #selector(togglePrimaryPills(switchView:)), for: .valueChanged)
 
-        container.addArrangedSubview(createLabelWithText("Outline"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in Outline Pill bar"), disableOutlinedSwitchView], itemSpacing: 20, centerItems: true)
-        let outlineBar = createBar(items: items)
-        container.addArrangedSubview(outlineBar)
-        self.outlineBar = outlineBar
+        container.addArrangedSubview(createLabelWithText("Primary"))
+        addRow(items: [createLabelWithText("Enable/Disable pills in Primary Pill bar"), disablePrimarySwitchView], itemSpacing: 20, centerItems: true)
+        let primaryBar = createBar(items: items)
+        container.addArrangedSubview(primaryBar)
+        self.primaryBar = primaryBar
         container.addArrangedSubview(UIView())
 
         // When inserting longer button "Templates" instead of shorter "Other" button as the fourth button, compact layouts (most iPhones)
@@ -77,12 +77,12 @@ class PillButtonBarDemoController: DemoController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if let window = view.window {
-            filledBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
+            onBrandBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
             customBar?.backgroundColor = UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
         }
     }
 
-    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .outline, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsColors: Bool = false) -> UIView {
+    func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .primary, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsColors: Bool = false) -> UIView {
         let pillButtonBackgroundColor = useCustomPillsColors ? Colors.textOnAccent : nil
         let pillSelectedButtonBackgroundColor = useCustomPillsColors ? Colors.textPrimary : nil
         let pillButtonTextColor = useCustomPillsColors ? Colors.textPrimary : nil
@@ -99,7 +99,7 @@ class PillButtonBarDemoController: DemoController {
         }
 
         let backgroundView = UIView()
-        if style == .outline {
+        if style == .primary {
             backgroundView.backgroundColor = Colors.Navigation.System.background
         }
 
@@ -144,26 +144,26 @@ class PillButtonBarDemoController: DemoController {
         }
     }
 
-    @objc private func toggleFilledPills(switchView: UISwitch) {
-        let pillBar = self.filledBar?.subviews[0] as! PillButtonBar
+    @objc private func toggleOnBrandPills(switchView: UISwitch) {
+        let pillBar = self.onBrandBar?.subviews[0] as! PillButtonBar
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
-    @objc private func toggleCustomFilledPills(switchView: UISwitch) {
+    @objc private func toggleCustomOnBrandPills(switchView: UISwitch) {
         let pillBar = self.customBar?.subviews[0] as! PillButtonBar
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
-    @objc private func toggleOutlinedPills(switchView: UISwitch) {
-        let pillBar = self.outlineBar?.subviews[0] as! PillButtonBar
+    @objc private func togglePrimaryPills(switchView: UISwitch) {
+        let pillBar = self.primaryBar?.subviews[0] as! PillButtonBar
         togglePills(pillBar: pillBar, enable: switchView.isOn)
     }
 
-    private var filledBar: UIView?
+    private var onBrandBar: UIView?
 
     private var customBar: UIView?
 
-    private var outlineBar: UIView?
+    private var primaryBar: UIView?
 }
 
 // MARK: - PillButtonBarDemoController: PillButtonBarDelegate

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		7DC2FB2924C0ED1700367A55 /* TableViewCellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2FB2724C0ED1100367A55 /* TableViewCellFileAccessoryView.swift */; };
 		7DC2FB2D24D209E800367A55 /* Presence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2FB2C24D209E300367A55 /* Presence.swift */; };
 		7DC2FB2E24D209E800367A55 /* Presence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2FB2C24D209E300367A55 /* Presence.swift */; };
+		86AF4F7525AFC746005D4253 /* PillButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */; };
 		8A01C86F248FFC5300C971F3 /* ContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A01C86E248FFC5300C971F3 /* ContactView.swift */; };
 		8ACE4D3524E31ADA00B9D0EB /* ContactCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF03E1B24B6BDBD00E6E2A2 /* ContactCollectionViewCell.swift */; };
 		8ACE4D3624E31B1C00B9D0EB /* ContactCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF03E1924B6BD4700E6E2A2 /* ContactCollectionView.swift */; };
@@ -323,6 +324,7 @@
 		7D23482624D88DDF00FBE057 /* AvatarGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarGroupView.swift; sourceTree = "<group>"; };
 		7DC2FB2724C0ED1100367A55 /* TableViewCellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCellFileAccessoryView.swift; sourceTree = "<group>"; };
 		7DC2FB2C24D209E300367A55 /* Presence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presence.swift; sourceTree = "<group>"; };
+		86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtonStyle.swift; sourceTree = "<group>"; };
 		8A01C86E248FFC5300C971F3 /* ContactView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactView.swift; sourceTree = "<group>"; };
 		8AF03E1924B6BD4700E6E2A2 /* ContactCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCollectionView.swift; sourceTree = "<group>"; };
 		8AF03E1B24B6BDBD00E6E2A2 /* ContactCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 			children = (
 				497DC2D824185885008D86F8 /* PillButton.swift */,
 				497DC2D724185885008D86F8 /* PillButtonBar.swift */,
+				86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */,
 			);
 			path = "Pill Button Bar";
 			sourceTree = "<group>";
@@ -1433,6 +1436,7 @@
 				C0A0D76F233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift in Sources */,
 				FD256C5B2183B90B00EC9588 /* DatePickerSelectionManager.swift in Sources */,
 				A5CEC23120E451D00016922A /* Button.swift in Sources */,
+				86AF4F7525AFC746005D4253 /* PillButtonStyle.swift in Sources */,
 				FDF41EDB2141A23B00EC527C /* UIViewController+Extensions.swift in Sources */,
 				FD56FD95219131430023C7EA /* DateTimePickerView.swift in Sources */,
 				FDA1AF8C21484625001AE720 /* BlurringView.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		7DC2FB2D24D209E800367A55 /* Presence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2FB2C24D209E300367A55 /* Presence.swift */; };
 		7DC2FB2E24D209E800367A55 /* Presence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2FB2C24D209E300367A55 /* Presence.swift */; };
 		86AF4F7525AFC746005D4253 /* PillButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */; };
+		86AF4F8225B0F85A005D4253 /* PillButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */; };
 		8A01C86F248FFC5300C971F3 /* ContactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A01C86E248FFC5300C971F3 /* ContactView.swift */; };
 		8ACE4D3524E31ADA00B9D0EB /* ContactCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF03E1B24B6BDBD00E6E2A2 /* ContactCollectionViewCell.swift */; };
 		8ACE4D3624E31B1C00B9D0EB /* ContactCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF03E1924B6BD4700E6E2A2 /* ContactCollectionView.swift */; };
@@ -1300,6 +1301,7 @@
 				7D23482824D88DE700FBE057 /* AvatarGroupView.swift in Sources */,
 				8FD011B0228A82A600D25925 /* HUD.swift in Sources */,
 				8ACE4D3824E31B4700B9D0EB /* ContactView.swift in Sources */,
+				86AF4F8225B0F85A005D4253 /* PillButtonStyle.swift in Sources */,
 				8FD011B1228A82A600D25925 /* HUDView.swift in Sources */,
 				8FD011B2228A82A600D25925 /* AvatarView.swift in Sources */,
 				A5F3B147232B1E3700007A4F /* ScrollView.swift in Sources */,

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -14,33 +14,6 @@ public typealias MSPillButton = PillButton
 @objc(MSFPillButton)
 open class PillButton: UIButton {
 
-    @objc public static let cornerRadius: CGFloat = 16.0
-
-    @objc public let pillBarItem: PillButtonBarItem
-
-    @objc public let style: PillButtonStyle
-
-    public override var isSelected: Bool {
-        didSet {
-            updateAppearance()
-            updateAccessibilityTraits()
-        }
-    }
-
-    public override var isEnabled: Bool {
-        didSet {
-            updateAppearance()
-            updateAccessibilityTraits()
-        }
-    }
-
-    public override var isHighlighted: Bool {
-        didSet {
-            updateAppearance()
-            updateAccessibilityTraits()
-        }
-    }
-
     /// Set `backgroundColor` to customize background color of the pill button
     @objc open var customBackgroundColor: UIColor? {
         didSet {
@@ -69,6 +42,11 @@ open class PillButton: UIButton {
         }
     }
 
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateAppearance()
+    }
+
     @objc public init(pillBarItem: PillButtonBarItem, style: PillButtonStyle = .primary) {
         self.pillBarItem = pillBarItem
         self.style = style
@@ -76,13 +54,34 @@ open class PillButton: UIButton {
         setupView()
     }
 
+    @objc public static let cornerRadius: CGFloat = 16.0
+
+    @objc public let pillBarItem: PillButtonBarItem
+
+    @objc public let style: PillButtonStyle
+
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateAppearance()
+    public override var isSelected: Bool {
+        didSet {
+            updateAppearance()
+            updateAccessibilityTraits()
+        }
+    }
+
+    public override var isEnabled: Bool {
+        didSet {
+            updateAppearance()
+            updateAccessibilityTraits()
+        }
+    }
+
+    public override var isHighlighted: Bool {
+        didSet {
+            updateAppearance()
+        }
     }
 
     private func setupView() {

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -5,89 +5,6 @@
 
 import UIKit
 
-// MARK: - PillButtonStyle
-
-@available(*, deprecated, renamed: "PillButtonStyle")
-public typealias MSPillButtonStyle = PillButtonStyle
-
-@objc(MSFPillButtonStyle)
-public enum PillButtonStyle: Int {
-    case outline
-    case filled
-
-    func backgroundColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return PillButton.outlineStyleBackgroundColor
-        case .filled:
-            return UIColor(light: Colors.primaryShade10(for: window), dark: PillButton.outlineStyleBackgroundColor)
-        }
-    }
-
-    func selectedBackgroundColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return UIColor(light: Colors.primary(for: window), dark: Colors.surfaceQuaternary)
-        case .filled:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        }
-    }
-
-    func hoverBackgroundColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return Colors.surfaceQuaternary
-        case .filled:
-            return UIColor(light: Colors.primaryShade20(for: window), dark: Colors.surfaceQuaternary)
-        }
-    }
-
-    var titleColor: UIColor {
-        switch self {
-        case .outline:
-            return PillButton.outlineStyleTitleColor
-        case .filled:
-            return PillButton.filledStyleTitleColor
-        }
-    }
-
-    func selectedTitleColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return PillButton.outlineStyleTitleSelectedColor
-        case .filled:
-            return UIColor(light: Colors.primary(for: window), dark: PillButton.outlineStyleTitleSelectedColor)
-        }
-    }
-
-    func disabledTitleColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return Colors.textDisabled
-        case .filled:
-            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
-        }
-    }
-
-    func selectedDisabledBackgroundColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return Colors.surfaceQuaternary
-        case .filled:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        }
-    }
-
-    func selectedDisabledTitleColor(for window: UIWindow) -> UIColor {
-        switch self {
-        case .outline:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
-        case .filled:
-            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
-        }
-    }
-}
-
 // MARK: PillButton
 
 @available(*, deprecated, renamed: "PillButton")
@@ -97,11 +14,6 @@ public typealias MSPillButton = PillButton
 @objc(MSFPillButton)
 open class PillButton: UIButton {
 
-    /// These PillButton constants  are public so that clients can use these colors and cornerRadius to customize their own views containing PillButtons
-    @objc public static let outlineStyleBackgroundColor = UIColor(light: Colors.surfaceTertiary, dark: Colors.surfaceSecondary)
-    @objc public static let outlineStyleTitleColor = UIColor(light: Colors.textSecondary, dark: Colors.textPrimary)
-    @objc public static let outlineStyleTitleSelectedColor = UIColor(light: Colors.textOnAccent, dark: Colors.textDominant)
-    @objc public static let filledStyleTitleColor = UIColor(light: Colors.textOnAccent, dark: outlineStyleTitleColor)
     @objc public static let cornerRadius: CGFloat = 16.0
 
     @objc public let pillBarItem: PillButtonBarItem
@@ -116,6 +28,13 @@ open class PillButton: UIButton {
     }
 
     public override var isEnabled: Bool {
+        didSet {
+            updateAppearance()
+            updateAccessibilityTraits()
+        }
+    }
+
+    public override var isHighlighted: Bool {
         didSet {
             updateAppearance()
             updateAccessibilityTraits()
@@ -150,7 +69,7 @@ open class PillButton: UIButton {
         }
     }
 
-    @objc public init(pillBarItem: PillButtonBarItem, style: PillButtonStyle = .outline) {
+    @objc public init(pillBarItem: PillButtonBarItem, style: PillButtonStyle = .primary) {
         self.pillBarItem = pillBarItem
         self.style = style
         super.init(frame: .zero)
@@ -203,19 +122,36 @@ open class PillButton: UIButton {
         if let window = window {
             if isSelected {
                 if isEnabled {
-                    backgroundColor = customSelectedBackgroundColor ?? style.selectedBackgroundColor(for: window)
-                    setTitleColor(customSelectedTextColor ?? style.selectedTitleColor(for: window), for: .normal)
+                    if let customSelectedBackgroundColor = customSelectedBackgroundColor {
+                        backgroundColor = customSelectedBackgroundColor
+                    } else {
+                        backgroundColor = isHighlighted
+                            ? PillButton.selectedHighlightedBackgroundColor(for: window, for: style)
+                            : PillButton.selectedBackgroundColor(for: window, for: style)
+                    }
+
+                    setTitleColor(customSelectedTextColor ?? PillButton.selectedTitleColor(for: window, for: style), for: .normal)
+                    setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: window, for: style), for: .highlighted)
                 } else {
-                    backgroundColor = style.selectedDisabledBackgroundColor(for: window)
-                    setTitleColor(style.selectedDisabledTitleColor(for: window), for: .normal)
+                    backgroundColor = PillButton.selectedDisabledBackgroundColor(for: window, for: style)
+                    setTitleColor(PillButton.selectedDisabledTitleColor(for: window, for: style), for: .normal)
                 }
             } else {
-                backgroundColor = customBackgroundColor ?? style.backgroundColor(for: window)
+                if let customBackgroundColor = customBackgroundColor {
+                    backgroundColor = customBackgroundColor
+                } else {
+                    backgroundColor = isEnabled
+                        ? (isHighlighted
+                            ? PillButton.highlightedBackgroundColor(for: window, for: style)
+                            : PillButton.normalBackgroundColor(for: window, for: style))
+                        : PillButton.disabledBackgroundColor(for: window, for: style)
+                }
 
                 if isEnabled {
-                    setTitleColor(customTextColor ?? style.titleColor, for: .normal)
+                    setTitleColor(customTextColor ?? PillButton.titleColor(for: style), for: .normal)
+                    setTitleColor(customTextColor ?? PillButton.highlightedTitleColor(for: window, for: style), for: .highlighted)
                 } else {
-                    setTitleColor(style.disabledTitleColor(for: window), for: .disabled)
+                    setTitleColor(PillButton.disabledTitleColor(for: window, for: style), for: .disabled)
                 }
             }
         }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -142,7 +142,7 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
-    @objc public convenience init(pillButtonStyle: PillButtonStyle = .outline) {
+    @objc public convenience init(pillButtonStyle: PillButtonStyle = .primary) {
         self.init(pillButtonStyle: pillButtonStyle,
                   pillButtonBackgroundColor: nil,
                   selectedPillButtonBackgroundColor: nil,
@@ -150,7 +150,7 @@ open class PillButtonBar: UIScrollView {
                   selectedPillButtonTextColor: nil)
     }
 
-    @objc public convenience init(pillButtonStyle: PillButtonStyle = .outline,
+    @objc public convenience init(pillButtonStyle: PillButtonStyle = .primary,
                                   pillButtonBackgroundColor: UIColor? = nil) {
         self.init(pillButtonStyle: pillButtonStyle,
                   pillButtonBackgroundColor: pillButtonBackgroundColor,
@@ -159,7 +159,7 @@ open class PillButtonBar: UIScrollView {
                   selectedPillButtonTextColor: nil)
     }
 
-    @objc public init(pillButtonStyle: PillButtonStyle = .outline,
+    @objc public init(pillButtonStyle: PillButtonStyle = .primary,
                       pillButtonBackgroundColor: UIColor? = nil,
                       selectedPillButtonBackgroundColor: UIColor? = nil,
                       pillButtonTextColor: UIColor? = nil,
@@ -538,7 +538,7 @@ extension PillButtonBar: UIPointerInteractionDelegate {
         if let window = window, customPillButtonBackgroundColor == nil, index < buttons.count {
             let pillButton = buttons[index]
             if !pillButton.isSelected {
-                pillButton.customBackgroundColor = pillButton.style.hoverBackgroundColor(for: window)
+                pillButton.customBackgroundColor = PillButton.hoverBackgroundColor(for: window, for: pillButton.style)
             }
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -12,8 +12,12 @@ public typealias MSPillButtonStyle = PillButtonStyle
 
 @objc(MSFPillButtonStyle)
 public enum PillButtonStyle: Int {
-    case onBrand
+    /// primary: the default style of PillButton; use this style in conjunction with a neutral or white background.
     case primary
+
+    /// onBrand: use this style in conjunction with branded background where the background features
+    /// a prominent brand color in light mode and a muted gray in dark mode.
+    case onBrand
 }
 
 // MARK: PillButton colors
@@ -26,29 +30,28 @@ public extension PillButton {
     static func normalBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         let defaultColor = UIColor(light: Colors.surfaceTertiary, dark: Colors.surfaceSecondary)
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primaryShade10(for: window), dark: defaultColor)
         case .primary:
             return defaultColor
+        case .onBrand:
+            return UIColor(light: Colors.primaryShade10(for: window), dark: defaultColor)
         }
     }
 
     static func titleColor(for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.textOnAccent, dark: Colors.textPrimary)
         case .primary:
             return UIColor(light: Colors.textSecondary, dark: Colors.textPrimary)
-
+        case .onBrand:
+            return UIColor(light: Colors.textOnAccent, dark: Colors.textPrimary)
         }
     }
 
     static func hoverBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primaryShade20(for: window), dark: Colors.surfaceQuaternary)
         case .primary:
             return Colors.surfaceQuaternary
+        case .onBrand:
+            return UIColor(light: Colors.primaryShade20(for: window), dark: Colors.surfaceQuaternary)
         }
     }
  
@@ -56,19 +59,19 @@ public extension PillButton {
 
     static func selectedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         case .primary:
             return Colors.primary(for: window)
+        case .onBrand:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
 
     static func selectedTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
         case .primary:
             return Colors.textOnAccent
+        case .onBrand:
+            return UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
         }
     }
 
@@ -76,19 +79,19 @@ public extension PillButton {
 
     static func disabledBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primaryShade10(for: window), dark: normalBackgroundColor(for: window, for: style))
         case .primary:
             return normalBackgroundColor(for: window, for: style)
+        case .onBrand:
+            return UIColor(light: Colors.primaryShade10(for: window), dark: normalBackgroundColor(for: window, for: style))
         }
     }
     
     static func disabledTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
         case .primary:
             return Colors.textDisabled
+        case .onBrand:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
         }
     }
 
@@ -96,19 +99,19 @@ public extension PillButton {
 
     static func selectedDisabledBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         case .primary:
             return Colors.surfaceQuaternary
+        case .onBrand:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
         }
     }
 
     static func selectedDisabledTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
         case .primary:
             return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
+        case .onBrand:
+            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
         }
     }
 
@@ -126,19 +129,19 @@ public extension PillButton {
 
     static func selectedHighlightedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.surfaceSecondary, dark: Colors.gray700)
         case .primary:
             return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.primaryTint20(for: window))
+        case .onBrand:
+            return UIColor(light: Colors.surfaceSecondary, dark: Colors.gray700)
         }
     }
 
     static func selectedHighlightedTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
-        case .onBrand:
-            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDominant)
         case .primary:
             return selectedTitleColor(for: window, for: style)
+        case .onBrand:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDominant)
         }
     }
 }

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -1,0 +1,143 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+// MARK: - PillButtonStyle
+
+@available(*, deprecated, renamed: "PillButtonStyle")
+public typealias MSPillButtonStyle = PillButtonStyle
+
+@objc(MSFPillButtonStyle)
+public enum PillButtonStyle: Int {
+    case onBrand
+    case primary
+}
+
+// MARK: PillButton colors
+
+public extension PillButton {
+
+    // MARK: normal state
+
+    @objc(normalBackgroundColorForWindow:ForStyle:)
+    static func normalBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        let defaultColor = UIColor(light: Colors.surfaceTertiary, dark: Colors.surfaceSecondary)
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primaryShade10(for: window), dark: defaultColor)
+        case .primary:
+            return defaultColor
+        }
+    }
+
+    static func titleColor(for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.textOnAccent, dark: Colors.textPrimary)
+        case .primary:
+            return UIColor(light: Colors.textSecondary, dark: Colors.textPrimary)
+
+        }
+    }
+
+    static func hoverBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primaryShade20(for: window), dark: Colors.surfaceQuaternary)
+        case .primary:
+            return Colors.surfaceQuaternary
+        }
+    }
+ 
+    // MARK: selected state
+
+    static func selectedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
+        case .primary:
+            return Colors.primary(for: window)
+        }
+    }
+
+    static func selectedTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
+        case .primary:
+            return Colors.textOnAccent
+        }
+    }
+
+    // MARK: disabled state
+
+    static func disabledBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primaryShade10(for: window), dark: normalBackgroundColor(for: window, for: style))
+        case .primary:
+            return normalBackgroundColor(for: window, for: style)
+        }
+    }
+    
+    static func disabledTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
+        case .primary:
+            return Colors.textDisabled
+        }
+    }
+
+    // MARK: selected disabled state
+
+    static func selectedDisabledBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
+        case .primary:
+            return Colors.surfaceQuaternary
+        }
+    }
+
+    static func selectedDisabledTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
+        case .primary:
+            return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
+        }
+    }
+
+    // MARK: highlighted state
+
+    static func highlightedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        return disabledBackgroundColor(for: window, for: style)
+    }
+
+    static func highlightedTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        return UIColor(light: disabledTitleColor(for: window, for: style), dark: Colors.textSecondary)
+    }
+
+    // MARK: selected highlighted state
+    static func selectedHighlightedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.surfaceSecondary, dark: Colors.gray700)
+        case .primary:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.primaryTint20(for: window))
+        }
+    }
+
+    static func selectedHighlightedTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
+        switch style {
+        case .onBrand:
+            return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDominant)
+        case .primary:
+            return selectedTitleColor(for: window, for: style)
+        }
+    }
+}

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -123,6 +123,7 @@ public extension PillButton {
     }
 
     // MARK: selected highlighted state
+
     static func selectedHighlightedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .onBrand:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add: PillButtonStyle.swift
- Renamed "filled" style to "onBrand" and "outline" style to "primary".
- Moved PillButton style and color implementations from PillButtonStyle enum to PillButton extension for clarity.
- Added background and title colors for highlighted state.
- Changed primary active background color in dark mode from a gray to primary color for window.

PillButton.swift
- Update button appearance when "isHighlighted" is updated
- Removed color constants
- Reordered file contents based on access level.
- Renamed usages of "filled" to "onBrand" and "outline" to "primary"

PillButtonBar.swift
- Renamed usages of "filled" to "onBrand" and "outline" to "primary"

PillButtonBarDemoController.swift
- Renamed usages of "filled" to "onBrand" and "outline" to "primary"

### Verification
Verified that the PillButtonBar adopts the expected title and background colors in both light and dark mode.

Before:

<img width="638" alt="ConsolidatePillButtonColorsBefore" src="https://user-images.githubusercontent.com/8619051/104653864-17c45200-5670-11eb-99ee-cd51171d24fe.png">

<img width="636" alt="ConsolidatePillButtonColorsBefore_dark" src="https://user-images.githubusercontent.com/8619051/104653863-17c45200-5670-11eb-8abe-64b827ef0178.png">

After:

https://user-images.githubusercontent.com/8619051/104648884-ac2ab680-5668-11eb-93eb-ecf34c790c23.mov


https://user-images.githubusercontent.com/8619051/104653834-0e3aea00-5670-11eb-8431-e88fe99f3bc7.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/397)