### PR TITLE
Restricting automatic pod publish to tags pushed to the master branch only.

### DIFF
--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   Pod-Publish:
+    if: github.event.base_ref == 'refs/heads/master'
     runs-on: macOS-10.15
     
     steps:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

We are soon starting to publish a POD for the Vnext initial releases out of the vnext-prototype branch.
Tags are going to be pushed to the vnext-prototype and manual pod publishing will be accomplished to a local cocoapods repo.

This change ensures that only tags pushed to the master branch trigger the Pod-Publish job which will publish to the main cococapod repo.

Link (GitHub community forum) for reference:
https://github.community/t/run-workflow-on-push-tag-on-specific-branch/17519

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/399)