### PR TITLE
Make several internal extensions public and bring back UIFontDescriptor's extensions

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -205,6 +205,8 @@
 		C0EAAEAD2347E1DF00C7244E /* ShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */; };
 		CCC18C2C2501B22F00BE830E /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2B2501B22F00BE830E /* CardView.swift */; };
 		CCC18C2D2501B22F00BE830E /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2B2501B22F00BE830E /* CardView.swift */; };
+		D41A23A625B1FB8500651182 /* UIFontDescriptor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D475255025B1C9620045252A /* UIFontDescriptor+Extension.swift */; };
+		D475255125B1C9620045252A /* UIFontDescriptor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D475255025B1C9620045252A /* UIFontDescriptor+Extension.swift */; };
 		FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */; };
 		FD0D29D62151A3D700E8655E /* CardPresenterNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0D29D52151A3D700E8655E /* CardPresenterNavigationController.swift */; };
 		FD1FAE1B2272464B00A5DBA4 /* GenericDateTimePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1FAE1A2272464B00A5DBA4 /* GenericDateTimePicker.swift */; };
@@ -399,6 +401,7 @@
 		C0A0D76C233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerLinesViewAppearance.swift; sourceTree = "<group>"; };
 		C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerView.swift; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		D475255025B1C9620045252A /* UIFontDescriptor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFontDescriptor+Extension.swift"; sourceTree = "<group>"; };
 		FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerControllerTests.swift; sourceTree = "<group>"; };
 		FD0D29D52151A3D700E8655E /* CardPresenterNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresenterNavigationController.swift; sourceTree = "<group>"; };
 		FD1FAE1A2272464B00A5DBA4 /* GenericDateTimePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericDateTimePicker.swift; sourceTree = "<group>"; };
@@ -611,6 +614,7 @@
 				A559BB7D212B6D100055E107 /* String+Extension.swift */,
 				A56CE7B522E68A7800AA77EE /* UIColor+Extensions.swift */,
 				A5B87AF0211BD4380038C37C /* UIFont+Extension.swift */,
+				D475255025B1C9620045252A /* UIFontDescriptor+Extension.swift */,
 				A5961FA6218A2E4500E2A506 /* UIImage+Extensions.swift */,
 				A5F3B148232B1F9700007A4F /* UIResponder+Extensions.swift */,
 				A5B87B01211E20B50038C37C /* UIScreen+Extension.swift */,
@@ -1268,6 +1272,7 @@
 				637F92732501637200B5B085 /* PersonaBadgeViewDataSource.swift in Sources */,
 				8FD01197228A82A600D25925 /* DateTimePickerViewComponentTableView.swift in Sources */,
 				8FD01198228A82A600D25925 /* DateTimePickerViewDataSource.swift in Sources */,
+				D41A23A625B1FB8500651182 /* UIFontDescriptor+Extension.swift in Sources */,
 				8FD01199228A82A600D25925 /* DateTimePickerViewLayout.swift in Sources */,
 				FD41C8C222DD48E60086F899 /* Operators.swift in Sources */,
 				8FD0119A228A82A600D25925 /* DrawerController.swift in Sources */,
@@ -1404,6 +1409,7 @@
 				A5237ACB21DED7030040BF27 /* ResizingHandleView.swift in Sources */,
 				B4E782C72179509A00A7DFCE /* CenteredLabelCell.swift in Sources */,
 				FD9A5C872179464F00D224D9 /* DateComponents+Extensions.swift in Sources */,
+				D475255125B1C9620045252A /* UIFontDescriptor+Extension.swift in Sources */,
 				A5B87AF7211E16370038C37C /* DrawerTransitionAnimator.swift in Sources */,
 				C0A0D76D233AEF6C00F432FD /* ShimmerAppearance.swift in Sources */,
 				FD41C8C122DD48E60086F899 /* Operators.swift in Sources */,

--- a/ios/FluentUI/Extensions/UIFont+Extension.swift
+++ b/ios/FluentUI/Extensions/UIFont+Extension.swift
@@ -5,7 +5,12 @@
 
 import UIKit
 
-extension UIFont {
+public extension UIFont {
     var deviceLineHeight: CGFloat { return UIScreen.main.roundToDevicePixels(lineHeight) }
+
     var deviceLineHeightWithLeading: CGFloat { return UIScreen.main.roundToDevicePixels(lineHeight + max(0, leading)) }
+
+    func withWeight(_ weight: UIFont.Weight) -> UIFont {
+        return UIFont(descriptor: fontDescriptor.withWeight(weight), size: pointSize)
+  }
 }

--- a/ios/FluentUI/Extensions/UIFontDescriptor+Extension.swift
+++ b/ios/FluentUI/Extensions/UIFontDescriptor+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+public extension UIFontDescriptor {
+    var traits: [UIFontDescriptor.TraitKey: Any]? {
+        return object(forKey: .traits) as? [UIFontDescriptor.TraitKey: Any]
+    }
+
+    var weight: UIFont.Weight {
+        if let weight = traits?[.weight] as? NSNumber {
+            return UIFont.Weight(CGFloat(weight.floatValue))
+        }
+        return .regular
+    }
+
+    func withWeight(_ weight: UIFont.Weight) -> UIFontDescriptor {
+        var attributes = fontAttributes
+        var traits = self.traits ?? [:]
+        traits[.weight] = NSNumber(value: Float(weight.rawValue))
+        attributes[.traits] = traits
+        return UIFontDescriptor(fontAttributes: attributes)
+    }
+}

--- a/ios/FluentUI/Extensions/UITableViewCell+Extension.swift
+++ b/ios/FluentUI/Extensions/UITableViewCell+Extension.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-extension UITableViewCell {
+public extension UITableViewCell {
     func hideSystemSeparator() {
         separatorInset = UIEdgeInsets(top: 0, left: max(UIScreen.main.bounds.width, UIScreen.main.bounds.height), bottom: 0, right: 0)
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

1. Make `UIFont` extension methods public again.
2. Make `UITableViewCell` extension method (`hideSystemSeparator()`) public again.
3. Bring back the `UIFontDescriptor` extension methods.

With these changes it would be much easier for Outlook Mobile iOS to migrate from `OfficeUIFabric`(1.1.2) to `FluentUI`. And these functionality exposed could also be used by other consumers.

### Verification

N/A

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/400)