### PR TITLE
[ListVnext] Move cell layout (height) definition to the cell

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
@@ -43,9 +43,9 @@ class ListVnextDemoController: DemoController {
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
             listCell.leadingView = avatar.view
+            listCell.layoutType = MSFListCellVnextLayoutType.twoLines
             listSection.cells.append(listCell)
         }
-        listSection.layoutType = MSFListCellVnextLayoutType.twoLines
         listData.append(listSection)
 
         /// TableViewCell Sample Data Sections
@@ -62,6 +62,7 @@ class ListVnextDemoController: DemoController {
                 listCell.subtitle = cell.text2
                 listCell.leadingView = createCustomView(imageName: cell.image)
                 listCell.accessoryType = accessoryType(for: rowIndex)
+                listCell.layoutType = updateLayout(subtitle: listCell.subtitle)
                 listCell.onTapAction = {
                     indexPath.row = rowIndex
                     indexPath.section = sectionIndex
@@ -69,7 +70,6 @@ class ListVnextDemoController: DemoController {
                 }
                 listSection.cells.append(listCell)
             }
-            listSection.layoutType = updateLayout(subtitle: listSection.cells[0].subtitle)
             listData.append(listSection)
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -77,6 +77,7 @@
     MSFListVnextCellData *listCell2 = [[MSFListVnextCellData alloc] init];
     [listCell2 setTitle:@"SampleTitle2"];
     [listCell2 setSubtitle:@"SampleTitle2"];
+    [listCell2 setLayoutType:MSFListCellVnextLayoutTypeTwoLines];
     [listCell2 setOnTapAction:^{
         [self showAlertForCellTapped:@"SampleTitle2"];
     }];
@@ -87,12 +88,12 @@
     UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]] ;
     [listCell3 setLeadingView:image];
     [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
+    [listCell3 setLayoutType:MSFListCellVnextLayoutTypeTwoLines];
     [listCell3 setOnTapAction:^{
         [self showAlertForCellTapped:@"Sample Title3"];
     }];
 
     MSFListVnextSectionData *section = [[MSFListVnextSectionData alloc] init];
-    [section setLayoutType:MSFListCellVnextLayoutTypeTwoLines];
     [section setCells:@[listCell1, listCell2, listCell3]];
     NSArray *sections = @[section];
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -15,6 +15,7 @@ import SwiftUI
     @objc @Published public var accessoryType: MSFListAccessoryType = .none
     @objc @Published public var titleLineLimit: Int = 1
     @objc @Published public var subtitleLineLimit: Int = 1
+    @objc @Published public var layoutType: MSFListCellVnextLayoutType = .oneLine
     @objc public var onTapAction: (() -> Void)?
 }
 
@@ -24,7 +25,6 @@ import SwiftUI
     @objc @Published public var cells: [MSFListVnextCellData] = []
     @objc @Published public var title: String?
     @objc @Published public var hasBorder: Bool = false
-    @objc @Published public var layoutType: MSFListCellVnextLayoutType = .oneLine
 }
 
 /// Properties that make up list content
@@ -77,7 +77,6 @@ public struct MSFListView: View {
 
                 ForEach(section.cells, id: \.self) { cell in
                     MSFListCellView(cell: cell,
-                                    layoutType: section.layoutType,
                                     tokens: tokens)
                         .border(section.hasBorder ? Color(tokens.borderColor) : Color.clear, width: section.hasBorder ? tokens.borderSize : 0)
                         .frame(maxWidth: .infinity)
@@ -105,12 +104,10 @@ extension MSFListView {
     /// View for List Cells
     struct MSFListCellView: View {
         var cell: MSFListVnextCellData
-        var layoutType: MSFListCellVnextLayoutType
         @ObservedObject var tokens: MSFListTokens
 
-        init(cell: MSFListVnextCellData, layoutType: MSFListCellVnextLayoutType, tokens: MSFListTokens) {
+        init(cell: MSFListVnextCellData, tokens: MSFListTokens) {
             self.cell = cell
-            self.layoutType = layoutType
             self.tokens = tokens
         }
 
@@ -152,7 +149,7 @@ extension MSFListView {
                     }
                 }
             })
-            .buttonStyle(ListCellButtonStyle(tokens: tokens, layoutType: layoutType))
+            .buttonStyle(ListCellButtonStyle(tokens: tokens, layoutType: cell.layoutType))
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cell layout was originally defined in a List Section. This responsibility is being moved to the cell so that there is more precise customization options.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/401)