### PR TITLE
Set imagePosition for title-only and image-only init methods

### DIFF
--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -23,7 +23,7 @@ open class Button: NSButton {
 		accentColor: NSColor = Colors.primary
 	) {
 		let format = ButtonFormat(size: size, style: style, accentColor: accentColor)
-		self.init(title: title, format: format)
+		self.init(title: title, imagePosition: .noImage, format: format)
 	}
 
 	/// Initializes a Fluent UI Button with an image only
@@ -39,7 +39,7 @@ open class Button: NSButton {
 		accentColor: NSColor = Colors.primary
 	) {
 		let format = ButtonFormat(size: size, style: style, accentColor: accentColor)
-		self.init(image: image, format: format)
+		self.init(image: image, imagePosition: .imageOnly, format: format)
 	}
 
 	/// Initializes a Fluent UI Button with a title and image


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
Updated convenience initializers for title-only and image-only buttons to pass appropriate imagePosition values to the designated initializer, so that we don't have to rely on the automatic content-based detection in the `titleRect` and `imageRect` methods of `ButtonCell`.

### Verification
Used nuget publish script to bring changes into setupui, and tested via SetupUITestApp.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/403)