### PR TITLE
Removing the 'Vnext' suffix from MSFList and associated types.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -10,7 +10,7 @@ let demos: [(title: String, controllerClass: UIViewController.Type)] = [
     ("Avatar (Vnext)", AvatarDemoController.self),
     ("Button (Vnext)", ButtonDemoController.self),
     ("Drawer (Vnext)", DrawerDemoController.self),
-    ("List (Vnext)", ListVnextDemoController.self),
+    ("List (Vnext)", ListDemoController.self),
     ("Theming (vNext)", ThemingDemoController.self),
     ("ActivityIndicatorView", ActivityIndicatorViewDemoController.self),
     ("AvatarGroupView", AvatarGroupViewDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -11,7 +11,7 @@ let demos: [(title: String, controllerClass: UIViewController.Type)] = [
     ("Button (Vnext)", ButtonDemoController.self),
     ("Drawer (Vnext)", DrawerDemoController.self),
     ("List (Vnext)", ListDemoController.self),
-    ("Theming (vNext)", ThemingDemoController.self),
+    ("Theming (Vnext)", ThemingDemoController.self),
     ("ActivityIndicatorView", ActivityIndicatorViewDemoController.self),
     ("AvatarGroupView", AvatarGroupViewDemoController.self),
     ("AvatarView", AvatarLegacyViewDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListVnextDemoController.swift
@@ -6,7 +6,7 @@
 import FluentUI
 import UIKit
 
-class ListVnextDemoController: DemoController {
+class ListDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -15,11 +15,11 @@ class ListVnextDemoController: DemoController {
         var cell: TableViewCellSampleData.Item
         var indexPath = IndexPath(row: 0, section: 0)
 
-        var list: MSFListVnext
-        var listCell: MSFListVnextCellData
-        var listSection: MSFListVnextSectionData
-        var listData: [MSFListVnextSectionData] = []
-        let iconStyle = MSFListIconVnextStyle.none
+        var list: MSFList
+        var listCell: MSFListCellData
+        var listSection: MSFListSectionData
+        var listData: [MSFListSectionData] = []
+        let iconStyle = MSFListIconStyle.none
 
         let samplePersonas: [PersonaData] = [
             PersonaData(name: "Kat Larrson", email: "kat.larrson@contoso.com", subtitle: "Designer", avatarImage: UIImage(named: "avatar_kat_larsson"), color: Colors.Palette.cyanBlue10.color),
@@ -32,18 +32,18 @@ class ListVnextDemoController: DemoController {
         var avatar: MSFAvatar
 
         /// AvatarView section
-        listSection = MSFListVnextSectionData()
+        listSection = MSFListSectionData()
         listSection.title = "AvatarView Section"
         listSection.cells = []
         for index in 0...samplePersonas.count - 1 {
-            listCell = MSFListVnextCellData()
+            listCell = MSFListCellData()
             avatar = createAvatarView(size: .medium,
                                       name: samplePersonas[index].name,
                                       image: samplePersonas[index].avatarImage,
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
             listCell.leadingView = avatar.view
-            listCell.layoutType = MSFListCellVnextLayoutType.twoLines
+            listCell.layoutType = MSFListCellLayoutType.twoLines
             listSection.cells.append(listCell)
         }
         listData.append(listSection)
@@ -52,12 +52,12 @@ class ListVnextDemoController: DemoController {
         for sectionIndex in 0...sections.count - 1 {
             section = sections[sectionIndex]
 
-            listSection = MSFListVnextSectionData()
+            listSection = MSFListSectionData()
             listSection.title = section.title
             listSection.cells = []
             for rowIndex in 0...TableViewCellSampleData.numberOfItemsInSection - 1 {
                 cell = section.item
-                listCell = MSFListVnextCellData()
+                listCell = MSFListCellData()
                 listCell.title = cell.text1
                 listCell.subtitle = cell.text2
                 listCell.leadingView = createCustomView(imageName: cell.image)
@@ -73,7 +73,7 @@ class ListVnextDemoController: DemoController {
             listData.append(listSection)
         }
 
-        list = MSFListVnext(sections: listData, iconStyle: iconStyle)
+        list = MSFList(sections: listData, iconStyle: iconStyle)
 
         let listView = list.view
         listView.translatesAutoresizingMaskIntoConstraints = false
@@ -130,11 +130,11 @@ class ListVnextDemoController: DemoController {
         }
     }
 
-    private func updateLayout(subtitle: String?) -> MSFListCellVnextLayoutType {
+    private func updateLayout(subtitle: String?) -> MSFListCellLayoutType {
         if let subtitle = subtitle, !subtitle.isEmpty {
-            return MSFListCellVnextLayoutType.twoLines
+            return MSFListCellLayoutType.twoLines
         } else {
-            return MSFListCellVnextLayoutType.oneLine
+            return MSFListCellLayoutType.oneLine
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -68,36 +68,36 @@
     [listVnextLabel setText:@"List (vNext)"];
     [self.container addArrangedSubview:listVnextLabel];
     
-    MSFListVnextCellData *listCell1 = [[MSFListVnextCellData alloc] init];
+    MSFListCellData *listCell1 = [[MSFListCellData alloc] init];
     [listCell1 setTitle:@"SampleTitle1"];
     [listCell1 setOnTapAction:^{
         [self showAlertForCellTapped:@"SampleTitle1"];
     }];
 
-    MSFListVnextCellData *listCell2 = [[MSFListVnextCellData alloc] init];
+    MSFListCellData *listCell2 = [[MSFListCellData alloc] init];
     [listCell2 setTitle:@"SampleTitle2"];
     [listCell2 setSubtitle:@"SampleTitle2"];
-    [listCell2 setLayoutType:MSFListCellVnextLayoutTypeTwoLines];
+    [listCell2 setLayoutType:MSFListCellLayoutTypeTwoLines];
     [listCell2 setOnTapAction:^{
         [self showAlertForCellTapped:@"SampleTitle2"];
     }];
 
-    MSFListVnextCellData *listCell3 = [[MSFListVnextCellData alloc] init];
+    MSFListCellData *listCell3 = [[MSFListCellData alloc] init];
     [listCell3 setTitle:@"SampleTitle3"];
     [listCell3 setSubtitle:@"SampleTitle3"];
     UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]] ;
     [listCell3 setLeadingView:image];
     [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
-    [listCell3 setLayoutType:MSFListCellVnextLayoutTypeTwoLines];
+    [listCell3 setLayoutType:MSFListCellLayoutTypeTwoLines];
     [listCell3 setOnTapAction:^{
         [self showAlertForCellTapped:@"Sample Title3"];
     }];
 
-    MSFListVnextSectionData *section = [[MSFListVnextSectionData alloc] init];
+    MSFListSectionData *section = [[MSFListSectionData alloc] init];
     [section setCells:@[listCell1, listCell2, listCell3]];
     NSArray *sections = @[section];
 
-    MSFListVnext *list = [[MSFListVnext alloc] initWithSections:sections iconStyle:MSFListIconVnextStyleNone];
+    MSFList *list = [[MSFList alloc] initWithSections:sections iconStyle:MSFListIconStyleNone];
 
     UIView *listView = [list view];
     listView.translatesAutoresizingMaskIntoConstraints = false;

--- a/ios/FluentUI/Vnext/Design Token System/ListTokens.swift
+++ b/ios/FluentUI/Vnext/Design Token System/ListTokens.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Pre-defined styles of icons
-@objc public enum MSFListIconVnextStyle: Int, CaseIterable {
+@objc public enum MSFListIconStyle: Int, CaseIterable {
     case none
     case iconOnly
     case large
@@ -59,9 +59,9 @@ public class MSFListTokens: MSFTokensBase, ObservableObject {
     @Published public var subtitleFont: UIFont!
     @Published public var textFont: UIFont!
 
-    var iconStyle: MSFListIconVnextStyle!
+    var iconStyle: MSFListIconStyle!
 
-    public init(iconStyle: MSFListIconVnextStyle) {
+    public init(iconStyle: MSFListIconStyle) {
         self.iconStyle = iconStyle
 
         super.init()
@@ -78,7 +78,7 @@ public class MSFListTokens: MSFTokensBase, ObservableObject {
         let currentTheme = theme
         let appearanceProxy: AppearanceProxyType
 
-        if iconStyle == MSFListIconVnextStyle.iconOnly {
+        if iconStyle == MSFListIconStyle.iconOnly {
             appearanceProxy = currentTheme.MSFIconOnlyListTokens
         } else {
             appearanceProxy = currentTheme.MSFListTokens

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Properties that make up cell content
-@objc public class MSFListVnextCellData: NSObject, ObservableObject, Identifiable {
+@objc public class MSFListCellData: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
     @objc @Published public var leadingView: UIView?
     @objc @Published public var title: String = ""
@@ -15,25 +15,25 @@ import SwiftUI
     @objc @Published public var accessoryType: MSFListAccessoryType = .none
     @objc @Published public var titleLineLimit: Int = 1
     @objc @Published public var subtitleLineLimit: Int = 1
-    @objc @Published public var layoutType: MSFListCellVnextLayoutType = .oneLine
+    @objc @Published public var layoutType: MSFListCellLayoutType = .oneLine
     @objc public var onTapAction: (() -> Void)?
 }
 
 /// Properties that make up section content
-@objc public class MSFListVnextSectionData: NSObject, ObservableObject, Identifiable {
+@objc public class MSFListSectionData: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
-    @objc @Published public var cells: [MSFListVnextCellData] = []
+    @objc @Published public var cells: [MSFListCellData] = []
     @objc @Published public var title: String?
     @objc @Published public var hasBorder: Bool = false
 }
 
 /// Properties that make up list content
-@objc public class MSFListVnextState: NSObject, ObservableObject {
-    @objc @Published public var sections: [MSFListVnextSectionData] = []
+@objc public class MSFListState: NSObject, ObservableObject {
+    @objc @Published public var sections: [MSFListSectionData] = []
 }
 
 /// Pre-defined layout heights of cells
-@objc public enum MSFListCellVnextLayoutType: Int, CaseIterable {
+@objc public enum MSFListCellLayoutType: Int, CaseIterable {
     case oneLine
     case twoLines
     case threeLines
@@ -41,12 +41,12 @@ import SwiftUI
 
 public struct MSFListView: View {
     @Environment(\.theme) var theme: FluentUIStyle
-    @ObservedObject var state: MSFListVnextState
+    @ObservedObject var state: MSFListState
     @ObservedObject var tokens: MSFListTokens
 
-    public init(sections: [MSFListVnextSectionData],
-                iconStyle: MSFListIconVnextStyle) {
-        self.state = MSFListVnextState()
+    public init(sections: [MSFListSectionData],
+                iconStyle: MSFListIconStyle) {
+        self.state = MSFListState()
         self.tokens = MSFListTokens(iconStyle: iconStyle)
         self.state.sections = sections
     }
@@ -103,10 +103,10 @@ public struct MSFListView: View {
 extension MSFListView {
     /// View for List Cells
     struct MSFListCellView: View {
-        var cell: MSFListVnextCellData
+        var cell: MSFListCellData
         @ObservedObject var tokens: MSFListTokens
 
-        init(cell: MSFListVnextCellData, tokens: MSFListTokens) {
+        init(cell: MSFListCellData, tokens: MSFListTokens) {
             self.cell = cell
             self.tokens = tokens
         }
@@ -155,7 +155,7 @@ extension MSFListView {
 
     struct ListCellButtonStyle: ButtonStyle {
         let tokens: MSFListTokens
-        let layoutType: MSFListCellVnextLayoutType
+        let layoutType: MSFListCellLayoutType
 
         func makeBody(configuration: Self.Configuration) -> some View {
             let height: CGFloat
@@ -200,10 +200,10 @@ extension MSFListView {
     }
 }
 
-@objc open class MSFListVnext: NSObject, FluentUIWindowProvider {
+@objc open class MSFList: NSObject, FluentUIWindowProvider {
 
-    @objc public init(sections: [MSFListVnextSectionData],
-                      iconStyle: MSFListIconVnextStyle,
+    @objc public init(sections: [MSFListSectionData],
+                      iconStyle: MSFListIconStyle,
                       theme: FluentUIStyle? = nil) {
         listView = MSFListView(sections: sections,
                                iconStyle: iconStyle)
@@ -215,8 +215,8 @@ extension MSFListView {
         view.backgroundColor = UIColor.clear
     }
 
-    @objc public convenience init(sections: [MSFListVnextSectionData],
-                                  iconStyle: MSFListIconVnextStyle) {
+    @objc public convenience init(sections: [MSFListSectionData],
+                                  iconStyle: MSFListIconStyle) {
         self.init(sections: sections,
                   iconStyle: iconStyle,
                   theme: nil)
@@ -226,7 +226,7 @@ extension MSFListView {
         return hostingController.view
     }
 
-    @objc open var state: MSFListVnextState {
+    @objc open var state: MSFListState {
         return listView.state
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Before making the Vnext types available for client apps, we need to remove the 'Vnext' suffix from the type names.
This change renames the List Vnext and associated types to remove that suffix.

### Verification

Built and ran the demo app to ensure the MSFList is intact.
Ran pod lib lint to ensure the Vnext podspec remains valid.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/409)