### PR TITLE
Renaming StylesheetManager to FluentUIThemeManager, updating library name in SGen.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -143,13 +143,13 @@ class ThemingDemoController: DemoController {
             colors.Brand = brandColors
             stylesheet.Colors = colors
 
-            StylesheetManager.setStylesheet(stylesheet: stylesheet, for: window)
+            FluentUIThemeManager.setStylesheet(stylesheet: stylesheet, for: window)
         }
     }
 
     func didPressResetThemeButton() {
         if let window = self.view.window {
-            StylesheetManager.removeStylesheet(for: window)
+            FluentUIThemeManager.removeStylesheet(for: window)
         }
     }
 }

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -290,7 +290,7 @@ public final class Colors: NSObject {
         brandColors.shade30 = primaryShade30(for: window)
         colors.Brand = brandColors
         stylesheet.Colors = colors
-        StylesheetManager.setStylesheet(stylesheet: stylesheet, for: window)
+        FluentUIThemeManager.setStylesheet(stylesheet: stylesheet, for: window)
     }
 
     // MARK: Primary

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -23,19 +23,19 @@ import SwiftUI
         case .none:
             break
         case .available:
-            color = StylesheetManager.S.Colors.Presence.available
+            color = FluentUIThemeManager.S.Colors.Presence.available
         case .away:
-            color = isOutOfOffice ? StylesheetManager.S.Colors.Presence.outOfOffice : StylesheetManager.S.Colors.Presence.away
+            color = isOutOfOffice ? FluentUIThemeManager.S.Colors.Presence.outOfOffice : FluentUIThemeManager.S.Colors.Presence.away
         case .busy:
-            color = StylesheetManager.S.Colors.Presence.busy
+            color = FluentUIThemeManager.S.Colors.Presence.busy
         case .blocked:
-            color = StylesheetManager.S.Colors.Presence.blocked
+            color = FluentUIThemeManager.S.Colors.Presence.blocked
         case .doNotDisturb:
-            color = StylesheetManager.S.Colors.Presence.doNotDisturb
+            color = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
         case .offline:
-            color = isOutOfOffice ? StylesheetManager.S.Colors.Presence.outOfOffice : StylesheetManager.S.Colors.Presence.offline
+            color = isOutOfOffice ? FluentUIThemeManager.S.Colors.Presence.outOfOffice : FluentUIThemeManager.S.Colors.Presence.offline
         case .unknown:
-            color = StylesheetManager.S.Colors.Presence.unknown
+            color = FluentUIThemeManager.S.Colors.Presence.unknown
         }
 
         return Color(color)

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -239,15 +239,15 @@ private extension UIFont {
 }
 
 public extension Notification.Name {
-	static let didChangeTheme = Notification.Name("Stardust.stylesheet.theme")
+	static let didChangeTheme = Notification.Name("FluentUI.stylesheet.theme")
 }
 
-protocol StylesheetManagerTheming {
+protocol FluentUIThemeManagerTheming {
 	static func defaultTheme() -> FluentUIStyle
 	func themeInit()
 }
 
-extension StylesheetManagerTheming {
+extension FluentUIThemeManagerTheming {
 	static func defaultTheme() -> FluentUIStyle {
 		return FluentUIStyle.shared()
 	}
@@ -256,7 +256,7 @@ extension StylesheetManagerTheming {
 	}
 }
 
-@objcMembers public class StylesheetManager: NSObject, StylesheetManagerTheming {
+@objcMembers public class FluentUIThemeManager: NSObject, FluentUIThemeManagerTheming {
 
     private static var stylesheetsMap = NSMapTable<UIWindow, FluentUIStyle>(keyOptions: .weakMemory, valueOptions: .strongMemory)
 
@@ -278,7 +278,7 @@ extension StylesheetManagerTheming {
         return defaultTheme()
     }
 
-    public static let `default` = StylesheetManager()
+    public static let `default` = FluentUIThemeManager()
     public static var S: FluentUIStyle {
         return defaultTheme()
     }
@@ -4548,25 +4548,25 @@ extension MSFAvatarTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
-				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("Stardust") == false {
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
 					return proxy
 				}
 
 				if proxy is FluentUIStyle.MSFAccentAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFAccentAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFAccentAvatarTokens
 				} else if proxy is FluentUIStyle.MSFGroupAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFGroupAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFGroupAvatarTokens
 				} else if proxy is FluentUIStyle.MSFOutlinedAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedAvatarTokens
 				} else if proxy is FluentUIStyle.MSFOutlinedPrimaryAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedPrimaryAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedPrimaryAvatarTokens
 				} else if proxy is FluentUIStyle.MSFOverflowAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFOverflowAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFOverflowAvatarTokens
 				}
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFAvatarTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFAvatarTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -4610,21 +4610,21 @@ extension MSFButtonTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
-				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("Stardust") == false {
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
 					return proxy
 				}
 
 				if proxy is FluentUIStyle.MSFGhostButtonTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFGhostButtonTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFGhostButtonTokens
 				} else if proxy is FluentUIStyle.MSFPrimaryButtonTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFPrimaryButtonTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFPrimaryButtonTokens
 				} else if proxy is FluentUIStyle.MSFSecondaryButtonTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFSecondaryButtonTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFSecondaryButtonTokens
 				}
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFButtonTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFButtonTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -4672,7 +4672,7 @@ extension MSFDrawerTokens: AppearaceProxyComponent {
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFDrawerTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFDrawerTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -4716,17 +4716,17 @@ extension MSFListTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
-				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("Stardust") == false {
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
 					return proxy
 				}
 
 				if proxy is FluentUIStyle.MSFIconOnlyListTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFIconOnlyListTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFIconOnlyListTokens
 				}
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFListTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFListTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/ios/FluentUI/Vnext/Design Token System/Theming.swift
+++ b/ios/FluentUI/Vnext/Design Token System/Theming.swift
@@ -30,7 +30,7 @@ public class MSFTokensBase {
             if let overridenTheme = _theme {
                 theme = overridenTheme
             } else if  let window = windowProvider?.window,
-                    let windowTheme = StylesheetManager.stylesheet(for: window) {
+                    let windowTheme = FluentUIThemeManager.stylesheet(for: window) {
                 theme = windowTheme
             }
 
@@ -54,7 +54,7 @@ public class MSFTokensBase {
 // MARK: Theme SwiftUI Environment Value
 
 struct ThemeKey: EnvironmentKey {
-    static var defaultValue: FluentUIStyle = StylesheetManager.S
+    static var defaultValue: FluentUIStyle = FluentUIThemeManager.S
 }
 
 extension EnvironmentValues {

--- a/tools/sgen/Sources/SGen/Constants.swift
+++ b/tools/sgen/Sources/SGen/Constants.swift
@@ -15,10 +15,10 @@ let FontTextStyleSectionName = "__TextStyle"
 let TypographyStyle = "Typography"
 let SymbolNamePlaceholder = "-"
 let NamespaceEnums = "S"
-let LibraryName = "Stardust"
+let LibraryName = "FluentUI"
 let IconNameKey = "name"
 let IconEnum = "IconSymbol"
-let StylesheetManagerName = "StylesheetManager"
+let StylesheetManagerName = "FluentUIThemeManager"
 let EnumCaseNone = "none"
 
 enum IconSupportedKeys: String, CodingKey {

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -239,15 +239,15 @@ private extension UIFont {
 }
 
 public extension Notification.Name {
-	static let didChangeTheme = Notification.Name("Stardust.stylesheet.theme")
+	static let didChangeTheme = Notification.Name("FluentUI.stylesheet.theme")
 }
 
-protocol StylesheetManagerTheming {
+protocol FluentUIThemeManagerTheming {
 	static func defaultTheme() -> FluentUIStyle
 	func themeInit()
 }
 
-extension StylesheetManagerTheming {
+extension FluentUIThemeManagerTheming {
 	static func defaultTheme() -> FluentUIStyle {
 		return FluentUIStyle.shared()
 	}
@@ -256,7 +256,7 @@ extension StylesheetManagerTheming {
 	}
 }
 
-@objcMembers public class StylesheetManager: NSObject, StylesheetManagerTheming {
+@objcMembers public class FluentUIThemeManager: NSObject, FluentUIThemeManagerTheming {
 
     private static var stylesheetsMap = NSMapTable<UIWindow, FluentUIStyle>(keyOptions: .weakMemory, valueOptions: .strongMemory)
 
@@ -278,7 +278,7 @@ extension StylesheetManagerTheming {
         return defaultTheme()
     }
 
-    public static let `default` = StylesheetManager()
+    public static let `default` = FluentUIThemeManager()
     public static var S: FluentUIStyle {
         return defaultTheme()
     }
@@ -4548,25 +4548,25 @@ extension MSFAvatarTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
-				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("Stardust") == false {
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
 					return proxy
 				}
 
 				if proxy is FluentUIStyle.MSFAccentAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFAccentAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFAccentAvatarTokens
 				} else if proxy is FluentUIStyle.MSFGroupAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFGroupAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFGroupAvatarTokens
 				} else if proxy is FluentUIStyle.MSFOutlinedAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedAvatarTokens
 				} else if proxy is FluentUIStyle.MSFOutlinedPrimaryAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedPrimaryAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFOutlinedPrimaryAvatarTokens
 				} else if proxy is FluentUIStyle.MSFOverflowAvatarTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFOverflowAvatarTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFOverflowAvatarTokens
 				}
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFAvatarTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFAvatarTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -4610,21 +4610,21 @@ extension MSFButtonTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
-				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("Stardust") == false {
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
 					return proxy
 				}
 
 				if proxy is FluentUIStyle.MSFGhostButtonTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFGhostButtonTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFGhostButtonTokens
 				} else if proxy is FluentUIStyle.MSFPrimaryButtonTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFPrimaryButtonTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFPrimaryButtonTokens
 				} else if proxy is FluentUIStyle.MSFSecondaryButtonTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFSecondaryButtonTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFSecondaryButtonTokens
 				}
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFButtonTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFButtonTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -4672,7 +4672,7 @@ extension MSFDrawerTokens: AppearaceProxyComponent {
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFDrawerTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFDrawerTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -4716,17 +4716,17 @@ extension MSFListTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
-				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("Stardust") == false {
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
 					return proxy
 				}
 
 				if proxy is FluentUIStyle.MSFIconOnlyListTokensAppearanceProxy {
-					return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFIconOnlyListTokens
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFIconOnlyListTokens
 				}
 				return proxy
 			}
 
-			return StylesheetManager.stylesheet(FluentUIStyle.shared()).MSFListTokens
+			return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFListTokens
 		}
 		set {
 			objc_setAssociatedObject(self, &__AppearanceProxyHandle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change update the naming of classes and notifications in the generated code.
We're renaming StylesheetManager to FluentUIThemeManager and updating the library name from Stardust to FluentUI.

### Verification

Built and ran the Demo app exercising theming scenarios.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/410)