### PR TITLE
Fixing implementation of ThemeKey.defaultValue.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -14,27 +14,27 @@ class ThemingDemoController: DemoController {
         addTitle(text: "Default / Current window theme")
         addDescription(text: "The default theme is defined by the FluentUIStyle class. The client app can override any of its properties and associate it to a specific UIWindow instance.")
 
-        let customThemeButton = MSFButton(style: .primary,
-                                               size: .medium,
-                                               action: { [weak self] _ in
+        let overrideThemeButton = MSFButton(style: .primary,
+                                            size: .medium,
+                                            action: { [weak self] _ in
                                                 guard let strongSelf = self else {
                                                     return
                                                 }
                                                 strongSelf.didPressOverrideThemeButton()
-                                               })
-        customThemeButton.state.text = "Override theme for current window"
+                                            })
+        overrideThemeButton.state.text = "Override theme for current window"
 
-        let disabledCstomThemeButton = MSFButton(style: .secondary,
-                                                      size: .medium,
-                                                      action: { [weak self] _ in
-                                                        guard let strongSelf = self else {
-                                                            return
-                                                        }
-                                                        strongSelf.didPressResetThemeButton()
-                                                      })
-        disabledCstomThemeButton.state.text = "Reset theme for current window"
+        let resetThemeButton = MSFButton(style: .secondary,
+                                         size: .medium,
+                                         action: { [weak self] _ in
+                                            guard let strongSelf = self else {
+                                                return
+                                            }
+                                            strongSelf.didPressResetThemeButton()
+                                         })
+        resetThemeButton.state.text = "Reset theme for current window"
 
-        addRow(items: [customThemeButton.view, disabledCstomThemeButton.view], itemSpacing: 20)
+        addRow(items: [overrideThemeButton.view, resetThemeButton.view], itemSpacing: 20)
 
         let avatarAccent = MSFAvatar(style: .accent, size: .xlarge)
         avatarAccent.state.isRingVisible = true

--- a/ios/FluentUI/Vnext/Design Token System/Theming.swift
+++ b/ios/FluentUI/Vnext/Design Token System/Theming.swift
@@ -54,7 +54,9 @@ public class MSFTokensBase {
 // MARK: Theme SwiftUI Environment Value
 
 struct ThemeKey: EnvironmentKey {
-    static var defaultValue: FluentUIStyle = FluentUIThemeManager.S
+    static var defaultValue: FluentUIStyle {
+        return FluentUIThemeManager.S
+    }
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In the scenario of multiple YAML theme files, the FluentUIThemeManager.S property may change during runtime.
The ThemeKey.defaultValue previously was assigned with FluentUIThemeManager.S and no updated when it was changed.

Implementing the ThemeKey.defaultValue to always return the current value of FluentUIThemeManager.S is the correct implementation for the property.

### Verification

1. Created local scenario with 2 YAML files setting the FluentUIStyle as the base style.
2. Switched themes based on the instruction below:
 **FluentUIThemingManager.default.theme = .themeEnum**
3. Ensured the themes were property reflected on the controls.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui-apple/pull/411)