### PR TITLE
[DrawerVnext] Adding transition handler

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -119,6 +119,16 @@ class DrawerDemoController: DemoController, MSFDrawerControllerDelegate {
         drawerController?.delegate = self
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+    }
+
     @objc private func showLeftDrawerClearBackgroundButtonTapped() {
         if let drawerController = drawerController {
             drawerController.state.backgroundDimmed = false
@@ -156,12 +166,15 @@ class DrawerDemoController: DemoController, MSFDrawerControllerDelegate {
             return
         }
 
-        let isLeadingEdgeLeftToRight = view.effectiveUserInterfaceLayoutDirection == .leftToRight
+        var isleftPresentation = gesture.velocity(in: view).x > 0
+        if view.effectiveUserInterfaceLayoutDirection == .rightToLeft {
+            isleftPresentation.toggle()
+        }
 
         if let drawerController = drawerController {
             drawerController.state.backgroundDimmed = true
             drawerController.state.presentingGesture = gesture
-            drawerController.state.presentationDirection = isLeadingEdgeLeftToRight ? .right : .left
+            drawerController.state.presentationDirection = isleftPresentation ? .left : .right
             present(drawerController, animated: true, completion: nil)
         }
     }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		22010B752523CEB700FF1F10 /* ActivityViewAnimating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22010B6F2523CB2D00FF1F10 /* ActivityViewAnimating.swift */; };
 		22EABB1A2509AAD100C4BE72 /* IndeterminateProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EABB192509AAD100C4BE72 /* IndeterminateProgressBarView.swift */; };
 		22EABB1B250A196200C4BE72 /* IndeterminateProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EABB192509AAD100C4BE72 /* IndeterminateProgressBarView.swift */; };
+		3F37B51425C8DB0E007EE062 /* AnimationCompletionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF1C9325C0C066000ED4F3 /* AnimationCompletionModifier.swift */; };
 		3F4FB92D25B25843008AB7CC /* UIKit+SwiftUI_interoperability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4FB92C25B25843008AB7CC /* UIKit+SwiftUI_interoperability.swift */; };
 		3F4FB92E25B25843008AB7CC /* UIKit+SwiftUI_interoperability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4FB92C25B25843008AB7CC /* UIKit+SwiftUI_interoperability.swift */; };
 		3F4FB96125B25D51008AB7CC /* DrawerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B87AF3211E16360038C37C /* DrawerController.swift */; };
@@ -1329,6 +1330,7 @@
 				535400E525B16D7D0047DC47 /* DrawerTokens.swift in Sources */,
 				8FD0116E228A82A600D25925 /* BadgeField.swift in Sources */,
 				8FD0116F228A82A600D25925 /* BadgeStringExtractor.swift in Sources */,
+				3F37B51425C8DB0E007EE062 /* AnimationCompletionModifier.swift in Sources */,
 				8FD01170228A82A600D25925 /* BadgeView.swift in Sources */,
 				8FD01171228A82A600D25925 /* CalendarView.swift in Sources */,
 				1168630722E131CF0088B302 /* TabBarView.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		3F4FB97625B25E04008AB7CC /* Drawer+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4FB96F25B25E04008AB7CC /* Drawer+UIKit.swift */; };
 		3F4FB97725B25E04008AB7CC /* SideOverPanel+Modifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4FB97025B25E04008AB7CC /* SideOverPanel+Modifiers.swift */; };
 		3F4FB97825B25E04008AB7CC /* SideOverPanel+Modifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4FB97025B25E04008AB7CC /* SideOverPanel+Modifiers.swift */; };
+		3FDF1C9425C0C066000ED4F3 /* AnimationCompletionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF1C9325C0C066000ED4F3 /* AnimationCompletionModifier.swift */; };
 		497DC2D924185885008D86F8 /* PillButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2D724185885008D86F8 /* PillButtonBar.swift */; };
 		497DC2DA24185885008D86F8 /* PillButtonBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2D724185885008D86F8 /* PillButtonBar.swift */; };
 		497DC2DB24185885008D86F8 /* PillButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2D824185885008D86F8 /* PillButton.swift */; };
@@ -348,6 +349,7 @@
 		3F4FB96E25B25E04008AB7CC /* SlideOverPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideOverPanel.swift; sourceTree = "<group>"; };
 		3F4FB96F25B25E04008AB7CC /* Drawer+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Drawer+UIKit.swift"; sourceTree = "<group>"; };
 		3F4FB97025B25E04008AB7CC /* SideOverPanel+Modifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SideOverPanel+Modifiers.swift"; sourceTree = "<group>"; };
+		3FDF1C9325C0C066000ED4F3 /* AnimationCompletionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCompletionModifier.swift; sourceTree = "<group>"; };
 		497DC2D724185885008D86F8 /* PillButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBar.swift; sourceTree = "<group>"; };
 		497DC2D824185885008D86F8 /* PillButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButton.swift; sourceTree = "<group>"; };
 		532854F925A3DD680042C3B9 /* Theming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theming.swift; sourceTree = "<group>"; };
@@ -671,6 +673,7 @@
 			isa = PBXGroup;
 			children = (
 				3F4FB92C25B25843008AB7CC /* UIKit+SwiftUI_interoperability.swift */,
+				3FDF1C9325C0C066000ED4F3 /* AnimationCompletionModifier.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1614,6 +1617,7 @@
 				A559BB7E212B6D100055E107 /* String+Extension.swift in Sources */,
 				535401D425BB53590047DC47 /* AvatarView.swift in Sources */,
 				A5961FA5218A260500E2A506 /* PopupMenuSectionHeaderView.swift in Sources */,
+				3FDF1C9425C0C066000ED4F3 /* AnimationCompletionModifier.swift in Sources */,
 				5354008D25B0C19C0047DC47 /* ListTokens.swift in Sources */,
 				FD56FD9A2194E50D0023C7EA /* DateTimePickerController.swift in Sources */,
 				A5F3B146232B1E3700007A4F /* ScrollView.swift in Sources */,

--- a/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
+++ b/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
@@ -20,10 +20,10 @@ struct AnimationCompletionModifier: AnimatableModifier {
 
     private var completion: () -> Void
 
-    init(value: Double, completion: @escaping () -> Void) {
+    init(targetValue: Double, completion: @escaping () -> Void) {
         self.completion = completion
-        self.animatableData = value
-        valueOnCompletion = value
+        self.animatableData = targetValue
+        valueOnCompletion = targetValue
     }
 
     private func animationDidComplete() {
@@ -44,8 +44,8 @@ struct AnimationCompletionModifier: AnimatableModifier {
 
 extension View {
 
-    /// callback when animation is completed
+    /// Allows a closure to be executed upon animation completion.
     func onAnimationComplete(value: Double, completion: (() -> Void)?) -> ModifiedContent<Self, AnimationCompletionModifier> {
-        return modifier(AnimationCompletionModifier(value: value, completion: completion ?? {}))
+        return modifier(AnimationCompletionModifier(targetValue: value, completion: completion ?? {}))
     }
 }

--- a/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
+++ b/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+// MARK: - Animation Completion
+
+/// Tracks animation
+struct AnimationCompletionModifier: AnimatableModifier {
+
+    var animatableData: Double {
+        didSet {
+            animationDidComplete()
+        }
+    }
+
+    private var valueOnCompletion: Double
+
+    private var completion: () -> Void
+
+    init(value: Double, completion: @escaping () -> Void) {
+        self.completion = completion
+        self.animatableData = value
+        valueOnCompletion = value
+    }
+
+    private func animationDidComplete() {
+        guard animatableData == valueOnCompletion else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            self.completion()
+        }
+    }
+
+    func body(content: Content) -> some View {
+        /// do not modify content here, this is only for observing values during animation
+        return content
+    }
+}
+
+extension View {
+
+    // callback when animation is completed
+    func animationCompletion(value: Double, completion: (() -> Void)?) -> ModifiedContent<Self, AnimationCompletionModifier> {
+        return modifier(AnimationCompletionModifier(value: value, completion: completion ?? {}))
+    }
+}

--- a/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
+++ b/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
@@ -37,14 +37,14 @@ struct AnimationCompletionModifier: AnimatableModifier {
     }
 
     func body(content: Content) -> some View {
-        /// do not modify content here, this is only for observing values during animation
+        // do not modify content here, this is only for observing values during animation
         return content
     }
 }
 
 extension View {
 
-    // callback when animation is completed
+    /// callback when animation is completed
     func onAnimationComplete(value: Double, completion: (() -> Void)?) -> ModifiedContent<Self, AnimationCompletionModifier> {
         return modifier(AnimationCompletionModifier(value: value, completion: completion ?? {}))
     }

--- a/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
+++ b/ios/FluentUI/Vnext/Core/AnimationCompletionModifier.swift
@@ -45,7 +45,7 @@ struct AnimationCompletionModifier: AnimatableModifier {
 extension View {
 
     // callback when animation is completed
-    func animationCompletion(value: Double, completion: (() -> Void)?) -> ModifiedContent<Self, AnimationCompletionModifier> {
+    func onAnimationComplete(value: Double, completion: (() -> Void)?) -> ModifiedContent<Self, AnimationCompletionModifier> {
         return modifier(AnimationCompletionModifier(value: value, completion: completion ?? {}))
     }
 }

--- a/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
@@ -31,11 +31,6 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
         return self.drawer.state
     }
 
-    enum Constant {
-        static let linearAnimationDuration: TimeInterval = 0.25
-        static let disabledAnimationDuration: TimeInterval = 0
-    }
-
     private var drawer: MSFDrawerView<UIViewControllerAdapter>
 
     @objc public init(contentViewController: UIViewController,
@@ -93,6 +88,11 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
 // MARK: Drawer + UIViewControllerTransitioningDelegate
 
 extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning {
+
+    enum Constant {
+        static let linearAnimationDuration: TimeInterval = 0.25
+        static let disabledAnimationDuration: TimeInterval = 0
+    }
 
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return self

--- a/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
@@ -77,7 +77,7 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
     }
 
     private func dimissHostingViewIfRequired() {
-        guard drawer.state.isExpanded == false else {
+        guard !drawer.state.isExpanded else {
             return
         }
 
@@ -103,7 +103,7 @@ extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnim
     }
 
     public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        if let isAnimationAssisted = transitionContext?.isAnimated, isAnimationAssisted == true {
+        if let isAnimationAssisted = transitionContext?.isAnimated, isAnimationAssisted {
             return Constant.linearAnimationDuration
         }
         return Constant.disabledAnimationDuration
@@ -120,10 +120,10 @@ extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnim
 
         state.animationDuration = transitionDuration(using: transitionContext)
 
-//       The presentation of drawer happens in two steps
-//        1. Present the hosting view (trasnparent) without animation
-//        2. Expand drawer view with animation (depending on the client's preference)
-//        The animation is delegated to swiftUI framework instead of UIKit. The intent of overriding `UIViewControllerTransitioningDelegate` is to provide UIKit client interfaces
+        // The presentation of drawer happens in two steps
+        //     1. Present the hosting view (trasnparent) without animation
+        //     2. Expand drawer view with animation (depending on the client's preference)
+        // The animation is delegated to swiftUI framework instead of UIKit. The intent of overriding `UIViewControllerTransitioningDelegate` is to provide UIKit client interfaces
         if isPresentingDrawer {
             UIView.animate(withDuration: Constant.disabledAnimationDuration, animations: {
                 transitionContext.containerView.addSubview(drawerView)
@@ -141,15 +141,14 @@ extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnim
             state.isExpanded = false
             transitionInProgress = true
             transitionHandler = { [weak self] in
-                if let strongSelf = self {
-                    guard strongSelf.state.isExpanded == false, strongSelf.transitionInProgress == true else {
-                        // verify state after transition is completed
-                        return
-                    }
-                    drawerView.removeFromSuperview()
-                    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
-                    strongSelf.transitionInProgress = false
+                guard let strongSelf = self,
+                      !strongSelf.state.isExpanded,
+                      strongSelf.transitionInProgress else {
+                    return
                 }
+                drawerView.removeFromSuperview()
+                transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+                strongSelf.transitionInProgress = false
             }
         }
     }

--- a/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
@@ -98,7 +98,9 @@ extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnim
         return self
     }
 
-    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+    public func animationController(forPresented presented: UIViewController,
+                                    presenting: UIViewController,
+                                    source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return self
     }
 

--- a/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
@@ -6,63 +6,6 @@
 import UIKit
 import SwiftUI
 
-// MARK: Drawer + UIViewControllerTransitioningDelegate
-
-extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning {
-
-    enum Constant {
-        static let linearAnimationDuration: TimeInterval = 0.25
-        static let disabledAnimationDuration: TimeInterval = 0
-    }
-
-    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        if let isAnimationAssisted = transitionContext?.isAnimated, isAnimationAssisted == true {
-            return Constant.linearAnimationDuration
-        }
-        return Constant.disabledAnimationDuration
-    }
-
-    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-
-        let fromView = transitionContext.viewController(forKey: .from)!.view!
-        let toView = transitionContext.viewController(forKey: .to)!.view!
-
-        let isPresentingDrawer = toView == view
-
-        let drawerView = isPresentingDrawer ? toView : fromView
-
-        state.animationDuration = transitionDuration(using: transitionContext)
-
-        // Delegate animation to swiftui by changing state
-        if isPresentingDrawer {
-            transitionContext.containerView.addSubview(drawerView)
-            drawerView.frame = UIScreen.main.bounds
-            DispatchQueue.main.asyncAfter(deadline: .now() + state.animationDuration) { [weak self] in
-                if let strongSelf = self {
-                    if !strongSelf.drawer.isPresentationGestureActive {
-                        strongSelf.state.isExpanded = true
-                    }
-                }
-                transitionContext.completeTransition(true)
-            }
-        } else {
-            self.state.isExpanded = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + state.animationDuration) {
-                drawerView.removeFromSuperview()
-                transitionContext.completeTransition(true)
-            }
-        }
-    }
-
-    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return self
-    }
-
-    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return self
-    }
-}
-
 // MARK: - Drawer
 
 @objc public protocol MSFDrawerControllerDelegate: AnyObject {
@@ -88,6 +31,8 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
         return self.drawer.state
     }
 
+    private var drawer: MSFDrawerView<UIViewControllerAdapter>
+
     @objc public init(contentViewController: UIViewController,
                       theme: FluentUIStyle? = nil) {
         let drawer = MSFDrawerView(content: UIViewControllerAdapter(contentViewController))
@@ -95,11 +40,11 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
         super.init(rootView: theme != nil ? AnyView(drawer.usingTheme(theme!)) : AnyView(drawer))
 
         drawer.tokens.windowProvider = self
-        transitioningDelegate = self
         view.backgroundColor = .clear
         modalPresentationStyle = .overFullScreen
+        transitioningDelegate = self
 
-        addDelegateNotification()
+        state.didChangeState = stateChangeCompletion()
     }
 
     @objc public convenience init(contentViewController: UIViewController) {
@@ -113,19 +58,93 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
         super.init(coder: aDecoder)
     }
 
-    private var drawer: MSFDrawerView<UIViewControllerAdapter>
+    private var executeTransisitonHandler: (() -> Void)?
 
-    private func addDelegateNotification() {
-        self.drawer = self.drawer.didChangeState({ [weak self] in
+    private var transitionInProgress: Bool = false
+
+    private func stateChangeCompletion() -> ((Bool?) -> Void) {
+        return { [weak self]  _ in
             if let strongSelf = self {
-                guard let isDrawerExpanded = strongSelf.drawer.state.isExpanded else {
-                    return
-                }
-                strongSelf.delegate?.drawerDidChangeState?(state: strongSelf.state, controller: strongSelf)
-                if !isDrawerExpanded {
-                    strongSelf.dismiss(animated: true, completion: nil)
+                strongSelf.notifyStateChange()
+                strongSelf.dimissHostingViewIfRequired()
+                strongSelf.executeTransisitonHandler?()
+            }
+        }
+    }
+
+    private func notifyStateChange() {
+        guard state.isExpanded != nil else {
+            return
+        }
+        delegate?.drawerDidChangeState?(state: state, controller: self)
+    }
+
+    private func dimissHostingViewIfRequired() {
+        guard drawer.state.isExpanded == false else {
+            return
+        }
+
+        dismiss(animated: false, completion: nil)
+    }
+}
+
+// MARK: Drawer + UIViewControllerTransitioningDelegate
+
+extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning {
+
+    enum Constant {
+        static let linearAnimationDuration: TimeInterval = 0.25
+        static let disabledAnimationDuration: TimeInterval = 0
+    }
+
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return self
+    }
+
+    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return self
+    }
+
+    public func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        if let isAnimationAssisted = transitionContext?.isAnimated, isAnimationAssisted == true {
+            return Constant.linearAnimationDuration
+        }
+        return Constant.disabledAnimationDuration
+    }
+
+    public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+
+        let fromView = transitionContext.viewController(forKey: .from)!.view!
+        let toView = transitionContext.viewController(forKey: .to)!.view!
+
+        let isPresentingDrawer = toView == view
+
+        let drawerView = isPresentingDrawer ? toView : fromView
+
+        state.animationDuration = transitionDuration(using: transitionContext)
+
+        // Delegate animation to swiftui by changing state
+        if isPresentingDrawer {
+            transitionContext.containerView.addSubview(drawerView)
+            drawerView.frame = UIScreen.main.bounds
+            if !drawer.isPresentationGestureActive {
+                state.isExpanded = true
+            }
+            transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+        } else {
+            state.isExpanded = false
+            transitionInProgress = true
+            executeTransisitonHandler = { [weak self] in
+                if let strongSelf = self {
+                    guard strongSelf.state.isExpanded == false, strongSelf.transitionInProgress == true else {
+                        // verify state after transition is completed
+                        return
+                    }
+                    drawerView.removeFromSuperview()
+                    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+                    strongSelf.transitionInProgress = false
                 }
             }
-        })
+        }
     }
 }

--- a/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
@@ -89,7 +89,7 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
 
 extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnimatedTransitioning {
 
-    enum Constant {
+    private enum  Constant {
         static let linearAnimationDuration: TimeInterval = 0.25
         static let disabledAnimationDuration: TimeInterval = 0
     }
@@ -120,21 +120,22 @@ extension MSFDrawer: UIViewControllerTransitioningDelegate, UIViewControllerAnim
 
         state.animationDuration = transitionDuration(using: transitionContext)
 
-///       The presentation of drawer happens in two steps
-///        1. Present the hosting view (trasnparent) without animation
-///        2. Expand drawer view with animation (depending on the client's preference)
-///        The animation is delegated to swiftUI framework instead of UIKit. The intent of overriding `UIViewControllerTransitioningDelegate` is to provide UIKit client interfaces
+//       The presentation of drawer happens in two steps
+//        1. Present the hosting view (trasnparent) without animation
+//        2. Expand drawer view with animation (depending on the client's preference)
+//        The animation is delegated to swiftUI framework instead of UIKit. The intent of overriding `UIViewControllerTransitioningDelegate` is to provide UIKit client interfaces
         if isPresentingDrawer {
             UIView.animate(withDuration: Constant.disabledAnimationDuration, animations: {
                 transitionContext.containerView.addSubview(drawerView)
                 drawerView.frame = UIScreen.main.bounds
             }, completion: { [weak self] _ in
-                if let strongSelf = self {
-                    if !(strongSelf.drawer.isPresentationGestureActive) {
-                        strongSelf.state.isExpanded = true
-                    }
-                    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+                guard let strongSelf = self else {
+                    return
                 }
+                if !(strongSelf.drawer.isPresentationGestureActive) {
+                    strongSelf.state.isExpanded = true
+                }
+                transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
             })
         } else {
             state.isExpanded = false

--- a/ios/FluentUI/Vnext/Drawer/Drawer.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer.swift
@@ -75,7 +75,7 @@ public struct MSFDrawerView<Content: View>: View {
         }
 
         let state = gesture.state
-        return state == .none || state == .began
+        return state == .began || state == .changed
     }
 
     public var body: some View {
@@ -92,6 +92,9 @@ public struct MSFDrawerView<Content: View>: View {
                     state.isExpanded = false
                 }
                 .transitionCompletion {
+                    guard isPresentationGestureActive == false else {
+                        return
+                    }
                     state.onStateChange?(state.isExpanded)
                 }
                 .onReceive(state.$isExpanded, perform: { value in

--- a/ios/FluentUI/Vnext/Drawer/Drawer.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer.swift
@@ -17,16 +17,12 @@ import SwiftUI
 /// `MSFDrawerState` assist to configure drawer functional properties via UIKit components.
 @objc public class MSFDrawerState: NSObject, ObservableObject {
 
-    /// A callback executed when the drawer is expanded/collapsed
-    public var onStateChange: (() -> Void)?
+    /// A callback executed after the drawer is expanded/collapsed
+    public var didChangeState: ((Bool?) -> Void)?
 
     /// Set `isExpanded` to `true` to maximize the drawer's width to fill the device screen horizontally minus the safe areas.
     /// Set to `false` to restore it to the normal size.
-    @Published public var isExpanded: Bool? {
-        didSet {
-            onStateChange?()
-        }
-    }
+    @Published public var isExpanded: Bool?
 
     @objc public var presentationDirection: MSFDrawerDirection = .left
 
@@ -95,6 +91,9 @@ public struct MSFDrawerView<Content: View>: View {
                 .performOnBackgroundTap {
                     state.isExpanded = false
                 }
+                .transitionCompletion {
+                    state.didChangeState?(state.isExpanded)
+                }
                 .onReceive(state.$isExpanded, perform: { value in
                     guard let value = value else {
                         return
@@ -142,17 +141,6 @@ public struct MSFDrawerView<Content: View>: View {
                 self.tokens.theme = theme
             }
         }
-    }
-
-    /// Custom modifier for adding a callback placeholder when drawer's state is changed
-    /// - Parameter `didChangeState`: closure executed with drawer is expanded or collapsed
-    /// - Returns: `Drawer`
-    func didChangeState(_ didChangeState: @escaping () -> Void) -> MSFDrawerView {
-        let drawerState = state
-        drawerState.onStateChange = didChangeState
-        return MSFDrawerView(content: content,
-                      state: drawerState,
-                      tokens: tokens)
     }
 
     @Environment(\.theme) var theme: FluentUIStyle

--- a/ios/FluentUI/Vnext/Drawer/Drawer.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer.swift
@@ -18,11 +18,11 @@ import SwiftUI
 @objc public class MSFDrawerState: NSObject, ObservableObject {
 
     /// A callback executed after the drawer is expanded/collapsed
-    public var didChangeState: ((Bool?) -> Void)?
+    public var onStateChange: ((Bool?) -> Void)?
 
     /// Set `isExpanded` to `true` to maximize the drawer's width to fill the device screen horizontally minus the safe areas.
     /// Set to `false` to restore it to the normal size.
-    @Published public var isExpanded: Bool?
+    @Published public var isExpanded: Bool = false
 
     @objc public var presentationDirection: MSFDrawerDirection = .left
 
@@ -92,12 +92,9 @@ public struct MSFDrawerView<Content: View>: View {
                     state.isExpanded = false
                 }
                 .transitionCompletion {
-                    state.didChangeState?(state.isExpanded)
+                    state.onStateChange?(state.isExpanded)
                 }
                 .onReceive(state.$isExpanded, perform: { value in
-                    guard let value = value else {
-                        return
-                    }
                     withAnimation(presentationAnimation) {
                         if value {
                             panelTransitionState = .expanded
@@ -233,7 +230,7 @@ struct MSFDrawerPreview: View {
                 EmptyView()
                     .navigationBarTitle(Text("Drawer Background"))
                     .navigationBarItems(leading: Button(action: {
-                        drawer.state.isExpanded?.toggle()
+                        drawer.state.isExpanded.toggle()
                     }, label: {
                         Image(systemName: "sidebar.left")
                     })).background(Color.blue)

--- a/ios/FluentUI/Vnext/Drawer/Drawer.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer.swift
@@ -92,7 +92,7 @@ public struct MSFDrawerView<Content: View>: View {
                     state.isExpanded = false
                 }
                 .transitionCompletion {
-                    guard isPresentationGestureActive == false else {
+                    guard !isPresentationGestureActive else {
                         return
                     }
                     state.onStateChange?(state.isExpanded)

--- a/ios/FluentUI/Vnext/Drawer/SideOverPanel+Modifiers.swift
+++ b/ios/FluentUI/Vnext/Drawer/SideOverPanel+Modifiers.swift
@@ -20,20 +20,6 @@ extension MSFSlideOverPanel {
                                  transitionState: $transitionState)
     }
 
-    /// Update or replace content on panel
-    /// - Parameter `drawerContent`: View to replace content
-    /// - Returns: `MSFSlideOverPanel`
-    func withContent(_ drawerContent: Content) -> MSFSlideOverPanel {
-        return MSFSlideOverPanel(percentTransition: $percentTransition,
-                                 tokens: tokens,
-                                 slideOutPanelWidth: slideOutPanelWidth,
-                                 actionOnBackgroundTap: actionOnBackgroundTap,
-                                 content: drawerContent,
-                                 backgroundDimmed: backgroundDimmed,
-                                 direction: direction,
-                                 transitionState: $transitionState)
-    }
-
     /// Add action or callback to be executed when background view is Tapped
     /// - Parameter `performOnBackgroundTap`:  defaults to no-op
     /// - Returns: `MSFSlideOverPanel`
@@ -73,6 +59,21 @@ extension MSFSlideOverPanel {
                                  content: content,
                                  backgroundDimmed: backgroundDimmed,
                                  direction: slideOutDirection,
+                                 transitionState: $transitionState)
+    }
+
+    /// Add action or callback to be executed transition is completed
+    /// - Parameter `animationCompletion`:  defaults to no-op
+    /// - Returns: `MSFSlideOverPanel`
+    func transitionCompletion(_ action: (() -> Void)?) -> MSFSlideOverPanel {
+        return MSFSlideOverPanel(percentTransition: $percentTransition,
+                                 tokens: tokens,
+                                 slideOutPanelWidth: slideOutPanelWidth,
+                                 actionOnBackgroundTap: actionOnBackgroundTap,
+                                 transitionCompletion: action,
+                                 content: content,
+                                 backgroundDimmed: backgroundDimmed,
+                                 direction: direction,
                                  transitionState: $transitionState)
     }
 }

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -38,6 +38,9 @@ struct MSFSlideOverPanel<Content: View>: View {
     /// Action executed with background transperent view is tapped
     internal var actionOnBackgroundTap: (() -> Void)?
 
+    /// Action executed with transiton state is completed
+    internal var transitionCompletion: (() -> Void)?
+
     /// Content view is visible when slide over panel is expanded
     internal var content: Content
 
@@ -68,6 +71,7 @@ struct MSFSlideOverPanel<Content: View>: View {
                         radius: tokens.shadow2Blur,
                         x: tokens.shadow2DepthX,
                         y: tokens.shadow2DepthY)
+                .animationCompletion(value: Double(resolvedContentOffset), completion: transitionCompletion)
 
             if direction == .left {
                 MSFInteractiveSpacer(defaultBackgroundColor: $tokens.backgroundClearColor)

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -71,7 +71,7 @@ struct MSFSlideOverPanel<Content: View>: View {
                         radius: tokens.shadow2Blur,
                         x: tokens.shadow2DepthX,
                         y: tokens.shadow2DepthY)
-                .animationCompletion(value: Double(resolvedContentOffset), completion: transitionCompletion)
+                .onAnimationComplete(value: Double(resolvedContentOffset), completion: transitionCompletion)
 
             if direction == .left {
                 MSFInteractiveSpacer(defaultBackgroundColor: $tokens.backgroundClearColor)


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Bug fix to issue #407 . Adding a custom handler when animation is completed. 
Since SwiftUI doesn't have a native handler an alternative that includes Animatable modifiers is used to build one.
The strategy is similar to the answer mentioned [here](https://stackoverflow.com/questions/57763709/swiftui-withanimation-completion-callback).

The caveats include adding animation in `SlidePanel` when the animation code liver is `MSFDrawerView`. Once SwiftUI adds completion blocks the custom code won't be required.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/413)