### PR TITLE
[DrawerVnext] Conforming to box-shadow variant by including dual shadows from Figma

### DIFF
--- a/ios/FluentUI/Vnext/Design Token System/DrawerTokens.swift
+++ b/ios/FluentUI/Vnext/Design Token System/DrawerTokens.swift
@@ -9,19 +9,15 @@ import SwiftUI
 public class MSFDrawerTokens: MSFTokensBase, ObservableObject {
 
     @Published public var shadow1Color: Color!
-    @Published public var shadow1Opacity: Double!
     @Published public var shadow1Blur: CGFloat!
     @Published public var shadow1DepthX: CGFloat!
     @Published public var shadow1DepthY: CGFloat!
     @Published public var shadow2Color: Color!
-    @Published public var shadow2Opacity: Double!
     @Published public var shadow2Blur: CGFloat!
     @Published public var shadow2DepthX: CGFloat!
     @Published public var shadow2DepthY: CGFloat!
     @Published public var backgroundDimmedColor: Color!
     @Published public var backgroundClearColor: Color!
-    @Published public var backgroundDimmedOpacity: Double!
-    @Published public var backgroundClearOpacity: Double!
 
     public override init() {
         super.init()
@@ -38,18 +34,14 @@ public class MSFDrawerTokens: MSFTokensBase, ObservableObject {
         let appearanceProxy = theme.MSFDrawerTokens
 
         shadow1Color = Color(appearanceProxy.shadow1Color)
-        shadow1Opacity = Double(appearanceProxy.shadow1Opacity)
         shadow1Blur = appearanceProxy.shadow1Blur
         shadow1DepthX = appearanceProxy.shadow1OffsetX
         shadow1DepthY = appearanceProxy.shadow1OffsetY
         shadow2Color = Color(appearanceProxy.shadow2Color)
-        shadow2Opacity = Double(appearanceProxy.shadow2Opacity)
         shadow2Blur = appearanceProxy.shadow2Blur
         shadow2DepthX = appearanceProxy.shadow2OffsetX
         shadow2DepthY = appearanceProxy.shadow2OffsetY
         backgroundClearColor = Color(appearanceProxy.backgroundClearColor)
         backgroundDimmedColor = Color(appearanceProxy.backgroundDimmedColor)
-        backgroundDimmedOpacity = Double(appearanceProxy.backgroundDimmedOpacity)
-        backgroundClearOpacity = Double(appearanceProxy.backgroundClearOpacity)
     }
 }

--- a/ios/FluentUI/Vnext/Design Token System/DrawerTokens.swift
+++ b/ios/FluentUI/Vnext/Design Token System/DrawerTokens.swift
@@ -8,11 +8,11 @@ import SwiftUI
 /// `DrawerTokens` assist to configure drawer apperance via UIKit components.
 public class MSFDrawerTokens: MSFTokensBase, ObservableObject {
 
-    @Published public var shadowColor: Color!
-    @Published public var shadowOpacity: Double!
-    @Published public var shadowBlur: CGFloat!
-    @Published public var shadowDepthX: CGFloat!
-    @Published public var shadowDepthY: CGFloat!
+    @Published public var shadowColor: [Color]!
+    @Published public var shadowOpacity: [Double]!
+    @Published public var shadowBlur: [CGFloat]!
+    @Published public var shadowDepthX: [CGFloat]!
+    @Published public var shadowDepthY: [CGFloat]!
     @Published public var backgroundDimmedColor: Color!
     @Published public var backgroundClearColor: Color!
     @Published public var backgroundDimmedOpacity: Double!
@@ -32,11 +32,11 @@ public class MSFDrawerTokens: MSFTokensBase, ObservableObject {
     public override func updateForCurrentTheme() {
         let appearanceProxy = theme.MSFDrawerTokens
 
-        shadowColor = Color(appearanceProxy.shadowColor)
-        shadowOpacity = Double(appearanceProxy.shadowOpacity)
+        shadowColor = appearanceProxy.shadowColor.map({Color($0)})
+        shadowOpacity = appearanceProxy.shadowOpacity.map({Double($0)})
         shadowBlur = appearanceProxy.shadowBlur
-        shadowDepthX = appearanceProxy.shadowX
-        shadowDepthY = appearanceProxy.shadowY
+        shadowDepthX = appearanceProxy.shadowOffsetX
+        shadowDepthY = appearanceProxy.shadowOffsetY
         backgroundClearColor = Color(appearanceProxy.backgroundClearColor)
         backgroundDimmedColor = Color(appearanceProxy.backgroundDimmedColor)
         backgroundDimmedOpacity = Double(appearanceProxy.backgroundDimmedOpacity)

--- a/ios/FluentUI/Vnext/Design Token System/DrawerTokens.swift
+++ b/ios/FluentUI/Vnext/Design Token System/DrawerTokens.swift
@@ -8,11 +8,16 @@ import SwiftUI
 /// `DrawerTokens` assist to configure drawer apperance via UIKit components.
 public class MSFDrawerTokens: MSFTokensBase, ObservableObject {
 
-    @Published public var shadowColor: [Color]!
-    @Published public var shadowOpacity: [Double]!
-    @Published public var shadowBlur: [CGFloat]!
-    @Published public var shadowDepthX: [CGFloat]!
-    @Published public var shadowDepthY: [CGFloat]!
+    @Published public var shadow1Color: Color!
+    @Published public var shadow1Opacity: Double!
+    @Published public var shadow1Blur: CGFloat!
+    @Published public var shadow1DepthX: CGFloat!
+    @Published public var shadow1DepthY: CGFloat!
+    @Published public var shadow2Color: Color!
+    @Published public var shadow2Opacity: Double!
+    @Published public var shadow2Blur: CGFloat!
+    @Published public var shadow2DepthX: CGFloat!
+    @Published public var shadow2DepthY: CGFloat!
     @Published public var backgroundDimmedColor: Color!
     @Published public var backgroundClearColor: Color!
     @Published public var backgroundDimmedOpacity: Double!
@@ -32,11 +37,16 @@ public class MSFDrawerTokens: MSFTokensBase, ObservableObject {
     public override func updateForCurrentTheme() {
         let appearanceProxy = theme.MSFDrawerTokens
 
-        shadowColor = appearanceProxy.shadowColor.map({Color($0)})
-        shadowOpacity = appearanceProxy.shadowOpacity.map({Double($0)})
-        shadowBlur = appearanceProxy.shadowBlur
-        shadowDepthX = appearanceProxy.shadowOffsetX
-        shadowDepthY = appearanceProxy.shadowOffsetY
+        shadow1Color = Color(appearanceProxy.shadow1Color)
+        shadow1Opacity = Double(appearanceProxy.shadow1Opacity)
+        shadow1Blur = appearanceProxy.shadow1Blur
+        shadow1DepthX = appearanceProxy.shadow1OffsetX
+        shadow1DepthY = appearanceProxy.shadow1OffsetY
+        shadow2Color = Color(appearanceProxy.shadow2Color)
+        shadow2Opacity = Double(appearanceProxy.shadow2Opacity)
+        shadow2Blur = appearanceProxy.shadow2Blur
+        shadow2DepthX = appearanceProxy.shadow2OffsetX
+        shadow2DepthY = appearanceProxy.shadow2OffsetY
         backgroundClearColor = Color(appearanceProxy.backgroundClearColor)
         backgroundDimmedColor = Color(appearanceProxy.backgroundDimmedColor)
         backgroundDimmedOpacity = Double(appearanceProxy.backgroundDimmedOpacity)

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -735,6 +735,79 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Elevation
+		public var _Elevation: ElevationAppearanceProxy?
+		open func ElevationStyle() -> ElevationAppearanceProxy {
+			if let override = _Elevation { return override }
+				return ElevationAppearanceProxy(proxy: mainProxy)
+			}
+		public var Elevation: ElevationAppearanceProxy {
+			get { return self.ElevationStyle() }
+			set { _Elevation = newValue }
+		}
+		@objc(ColorsElevationAppearanceProxy) @objcMembers open class ElevationAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: highElevation 
+			public var _highElevation: UIColor?
+			open func highElevationProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _highElevation { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity60Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var highElevation: UIColor {
+				get { return self.highElevationProperty() }
+				set { _highElevation = newValue }
+			}
+
+			//MARK: highElevation1 
+			public var _highElevation1: UIColor?
+			open func highElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _highElevation1 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity24Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity48Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var highElevation1: UIColor {
+				get { return self.highElevation1Property() }
+				set { _highElevation1 = newValue }
+			}
+
+			//MARK: highElevation2 
+			public var _highElevation2: UIColor?
+			open func highElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _highElevation2 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity20Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var highElevation2: UIColor {
+				get { return self.highElevation2Property() }
+				set { _highElevation2 = newValue }
+			}
+
+			//MARK: lowElevation1 
+			public var _lowElevation1: UIColor?
+			open func lowElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _lowElevation1 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity14Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity28Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var lowElevation1: UIColor {
+				get { return self.lowElevation1Property() }
+				set { _lowElevation1 = newValue }
+			}
+
+			//MARK: lowElevation2 
+			public var _lowElevation2: UIColor?
+			open func lowElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _lowElevation2 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity12Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity20Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var lowElevation2: UIColor {
+				get { return self.lowElevation2Property() }
+				set { _lowElevation2 = newValue }
+			}
+		}
+
+
 		//MARK: - Foreground
 		public var _Foreground: ForegroundAppearanceProxy?
 		open func ForegroundStyle() -> ForegroundAppearanceProxy {
@@ -1570,6 +1643,134 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Shadow
+		public var _Shadow: ShadowAppearanceProxy?
+		open func ShadowStyle() -> ShadowAppearanceProxy {
+			if let override = _Shadow { return override }
+				return ShadowAppearanceProxy(proxy: mainProxy)
+			}
+		public var Shadow: ShadowAppearanceProxy {
+			get { return self.ShadowStyle() }
+			set { _Shadow = newValue }
+		}
+		@objc(ColorsShadowAppearanceProxy) @objcMembers open class ShadowAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: clear 
+			public var _clear: UIColor?
+			open func clearProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _clear { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+				}
+			public var clear: UIColor {
+				get { return self.clearProperty() }
+				set { _clear = newValue }
+			}
+
+			//MARK: opacity12 
+			public var _opacity12: UIColor?
+			open func opacity12Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity12 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.01)
+				}
+			public var opacity12: UIColor {
+				get { return self.opacity12Property() }
+				set { _opacity12 = newValue }
+			}
+
+			//MARK: opacity14 
+			public var _opacity14: UIColor?
+			open func opacity14Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity14 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.24)
+				}
+			public var opacity14: UIColor {
+				get { return self.opacity14Property() }
+				set { _opacity14 = newValue }
+			}
+
+			//MARK: opacity20 
+			public var _opacity20: UIColor?
+			open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity20 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.33)
+				}
+			public var opacity20: UIColor {
+				get { return self.opacity20Property() }
+				set { _opacity20 = newValue }
+			}
+
+			//MARK: opacity24 
+			public var _opacity24: UIColor?
+			open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity24 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.03)
+				}
+			public var opacity24: UIColor {
+				get { return self.opacity24Property() }
+				set { _opacity24 = newValue }
+			}
+
+			//MARK: opacity28 
+			public var _opacity28: UIColor?
+			open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity28 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.47)
+				}
+			public var opacity28: UIColor {
+				get { return self.opacity28Property() }
+				set { _opacity28 = newValue }
+			}
+
+			//MARK: opacity40 
+			public var _opacity40: UIColor?
+			open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity40 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.66)
+				}
+			public var opacity40: UIColor {
+				get { return self.opacity40Property() }
+				set { _opacity40 = newValue }
+			}
+
+			//MARK: opacity48 
+			public var _opacity48: UIColor?
+			open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity48 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.07)
+				}
+			public var opacity48: UIColor {
+				get { return self.opacity48Property() }
+				set { _opacity48 = newValue }
+			}
+
+			//MARK: opacity60 
+			public var _opacity60: UIColor?
+			open func opacity60Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity60 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.99)
+				}
+			public var opacity60: UIColor {
+				get { return self.opacity60Property() }
+				set { _opacity60 = newValue }
+			}
+
+			//MARK: opaque 
+			public var _opaque: UIColor?
+			open func opaqueProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opaque { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+				}
+			public var opaque: UIColor {
+				get { return self.opaqueProperty() }
+				set { _opaque = newValue }
+			}
+		}
+
+
 		//MARK: - Stroke
 		public var _Stroke: StrokeAppearanceProxy?
 		open func StrokeStyle() -> StrokeAppearanceProxy {
@@ -1697,77 +1898,6 @@ extension FluentUIThemeManagerTheming {
 			}
 		}
 
-	}
-	//MARK: - ElevationOpacity
-	public var _ElevationOpacity: ElevationOpacityAppearanceProxy?
-	open func ElevationOpacityStyle() -> ElevationOpacityAppearanceProxy {
-		if let override = _ElevationOpacity { return override }
-			return ElevationOpacityAppearanceProxy(proxy: { return self })
-		}
-	public var ElevationOpacity: ElevationOpacityAppearanceProxy {
-		get { return self.ElevationOpacityStyle() }
-		set { _ElevationOpacity = newValue }
-	}
-	@objc(ElevationOpacityAppearanceProxy) @objcMembers open class ElevationOpacityAppearanceProxy: NSObject {
-		public let mainProxy: () -> FluentUIStyle
-		public init(proxy: @escaping () -> FluentUIStyle) {
-			self.mainProxy = proxy
-		}
-
-		//MARK: highElevation 
-		public var _highElevation: UIColor?
-		open func highElevationProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _highElevation { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity60Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var highElevation: UIColor {
-			get { return self.highElevationProperty() }
-			set { _highElevation = newValue }
-		}
-
-		//MARK: highElevation1 
-		public var _highElevation1: UIColor?
-		open func highElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _highElevation1 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity24Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity48Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var highElevation1: UIColor {
-			get { return self.highElevation1Property() }
-			set { _highElevation1 = newValue }
-		}
-
-		//MARK: highElevation2 
-		public var _highElevation2: UIColor?
-		open func highElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _highElevation2 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity20Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var highElevation2: UIColor {
-			get { return self.highElevation2Property() }
-			set { _highElevation2 = newValue }
-		}
-
-		//MARK: lowElevation1 
-		public var _lowElevation1: UIColor?
-		open func lowElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _lowElevation1 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity14Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity28Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var lowElevation1: UIColor {
-			get { return self.lowElevation1Property() }
-			set { _lowElevation1 = newValue }
-		}
-
-		//MARK: lowElevation2 
-		public var _lowElevation2: UIColor?
-		open func lowElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _lowElevation2 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity12Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity20Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var lowElevation2: UIColor {
-			get { return self.lowElevation2Property() }
-			set { _lowElevation2 = newValue }
-		}
 	}
 	//MARK: - Icon
 	public var _Icon: IconAppearanceProxy?
@@ -3374,7 +3504,7 @@ extension FluentUIThemeManagerTheming {
 		public var _backgroundDimmedColor: UIColor?
 		open func backgroundDimmedColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _backgroundDimmedColor { return override }
-			return mainProxy().ElevationOpacity.highElevationProperty(traitCollection)
+			return mainProxy().Colors.Elevation.highElevationProperty(traitCollection)
 			}
 		public var backgroundDimmedColor: UIColor {
 			get { return self.backgroundDimmedColorProperty() }
@@ -4372,7 +4502,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4383,7 +4513,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4478,7 +4608,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4489,7 +4619,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4584,7 +4714,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4595,7 +4725,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4690,7 +4820,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4701,7 +4831,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4796,7 +4926,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4807,7 +4937,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4902,7 +5032,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4913,7 +5043,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4965,132 +5095,6 @@ extension FluentUIThemeManagerTheming {
 			}
 		}
 
-	}
-	//MARK: - ShadowOpacity
-	public var _ShadowOpacity: ShadowOpacityAppearanceProxy?
-	open func ShadowOpacityStyle() -> ShadowOpacityAppearanceProxy {
-		if let override = _ShadowOpacity { return override }
-			return ShadowOpacityAppearanceProxy(proxy: { return self })
-		}
-	public var ShadowOpacity: ShadowOpacityAppearanceProxy {
-		get { return self.ShadowOpacityStyle() }
-		set { _ShadowOpacity = newValue }
-	}
-	@objc(ShadowOpacityAppearanceProxy) @objcMembers open class ShadowOpacityAppearanceProxy: NSObject {
-		public let mainProxy: () -> FluentUIStyle
-		public init(proxy: @escaping () -> FluentUIStyle) {
-			self.mainProxy = proxy
-		}
-
-		//MARK: clear 
-		public var _clear: UIColor?
-		open func clearProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _clear { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-			}
-		public var clear: UIColor {
-			get { return self.clearProperty() }
-			set { _clear = newValue }
-		}
-
-		//MARK: opacity12 
-		public var _opacity12: UIColor?
-		open func opacity12Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity12 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.01)
-			}
-		public var opacity12: UIColor {
-			get { return self.opacity12Property() }
-			set { _opacity12 = newValue }
-		}
-
-		//MARK: opacity14 
-		public var _opacity14: UIColor?
-		open func opacity14Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity14 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.24)
-			}
-		public var opacity14: UIColor {
-			get { return self.opacity14Property() }
-			set { _opacity14 = newValue }
-		}
-
-		//MARK: opacity20 
-		public var _opacity20: UIColor?
-		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity20 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.33)
-			}
-		public var opacity20: UIColor {
-			get { return self.opacity20Property() }
-			set { _opacity20 = newValue }
-		}
-
-		//MARK: opacity24 
-		public var _opacity24: UIColor?
-		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity24 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.03)
-			}
-		public var opacity24: UIColor {
-			get { return self.opacity24Property() }
-			set { _opacity24 = newValue }
-		}
-
-		//MARK: opacity28 
-		public var _opacity28: UIColor?
-		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity28 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.47)
-			}
-		public var opacity28: UIColor {
-			get { return self.opacity28Property() }
-			set { _opacity28 = newValue }
-		}
-
-		//MARK: opacity40 
-		public var _opacity40: UIColor?
-		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity40 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.66)
-			}
-		public var opacity40: UIColor {
-			get { return self.opacity40Property() }
-			set { _opacity40 = newValue }
-		}
-
-		//MARK: opacity48 
-		public var _opacity48: UIColor?
-		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity48 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.07)
-			}
-		public var opacity48: UIColor {
-			get { return self.opacity48Property() }
-			set { _opacity48 = newValue }
-		}
-
-		//MARK: opacity60 
-		public var _opacity60: UIColor?
-		open func opacity60Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity60 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.99)
-			}
-		public var opacity60: UIColor {
-			get { return self.opacity60Property() }
-			set { _opacity60 = newValue }
-		}
-
-		//MARK: opaque 
-		public var _opaque: UIColor?
-		open func opaqueProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opaque { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-			}
-		public var opaque: UIColor {
-			get { return self.opaqueProperty() }
-			set { _opaque = newValue }
-		}
 	}
 	//MARK: - Spacing
 	public var _Spacing: SpacingAppearanceProxy?

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -3333,58 +3333,68 @@ extension FluentUIThemeManagerTheming {
 		}
 
 		//MARK: shadowBlur 
-		public var _shadowBlur: CGFloat?
-		open func shadowBlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+		public var _shadowBlur: [CGFloat]?
+		open func shadowBlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
 			if let override = _shadowBlur { return override }
-			return mainProxy().Shadow.shadow28.blurProperty(traitCollection)
+			return [
+			mainProxy().Shadow28.shadow1.blurProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.blurProperty(traitCollection)]
 			}
-		public var shadowBlur: CGFloat {
+		public var shadowBlur: [CGFloat] {
 			get { return self.shadowBlurProperty() }
 			set { _shadowBlur = newValue }
 		}
 
 		//MARK: shadowColor 
-		public var _shadowColor: UIColor?
-		open func shadowColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+		public var _shadowColor: [UIColor]?
+		open func shadowColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _shadowColor { return override }
-			return mainProxy().Shadow.shadow28.colorProperty(traitCollection)
+			return [
+			mainProxy().Shadow28.shadow1.colorProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.colorProperty(traitCollection)]
 			}
-		public var shadowColor: UIColor {
+		public var shadowColor: [UIColor] {
 			get { return self.shadowColorProperty() }
 			set { _shadowColor = newValue }
 		}
 
-		//MARK: shadowOpacity 
-		public var _shadowOpacity: CGFloat?
-		open func shadowOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadowOpacity { return override }
-			return mainProxy().Shadow.shadow28.opacityProperty(traitCollection)
+		//MARK: shadowOffsetX 
+		public var _shadowOffsetX: [CGFloat]?
+		open func shadowOffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
+			if let override = _shadowOffsetX { return override }
+			return [
+			mainProxy().Shadow28.shadow1.xProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.xProperty(traitCollection)]
 			}
-		public var shadowOpacity: CGFloat {
+		public var shadowOffsetX: [CGFloat] {
+			get { return self.shadowOffsetXProperty() }
+			set { _shadowOffsetX = newValue }
+		}
+
+		//MARK: shadowOffsetY 
+		public var _shadowOffsetY: [CGFloat]?
+		open func shadowOffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
+			if let override = _shadowOffsetY { return override }
+			return [
+			mainProxy().Shadow28.shadow1.yProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.yProperty(traitCollection)]
+			}
+		public var shadowOffsetY: [CGFloat] {
+			get { return self.shadowOffsetYProperty() }
+			set { _shadowOffsetY = newValue }
+		}
+
+		//MARK: shadowOpacity 
+		public var _shadowOpacity: [CGFloat]?
+		open func shadowOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
+			if let override = _shadowOpacity { return override }
+			return [
+			mainProxy().Shadow28.shadow1.opacityProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.opacityProperty(traitCollection)]
+			}
+		public var shadowOpacity: [CGFloat] {
 			get { return self.shadowOpacityProperty() }
 			set { _shadowOpacity = newValue }
-		}
-
-		//MARK: shadowX 
-		public var _shadowX: CGFloat?
-		open func shadowXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadowX { return override }
-			return mainProxy().Shadow.shadow28.xProperty(traitCollection)
-			}
-		public var shadowX: CGFloat {
-			get { return self.shadowXProperty() }
-			set { _shadowX = newValue }
-		}
-
-		//MARK: shadowY 
-		public var _shadowY: CGFloat?
-		open func shadowYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadowY { return override }
-			return mainProxy().Shadow.shadow28.yProperty(traitCollection)
-			}
-		public var shadowY: CGFloat {
-			get { return self.shadowYProperty() }
-			set { _shadowY = newValue }
 		}
 	}
 	//MARK: - MSFGhostButtonTokens
@@ -4155,6 +4165,17 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity16 = newValue }
 		}
 
+		//MARK: opacity20 
+		public var _opacity20: CGFloat?
+		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity20 { return override }
+			return CGFloat(0.2)
+			}
+		public var opacity20: CGFloat {
+			get { return self.opacity20Property() }
+			set { _opacity20 = newValue }
+		}
+
 		//MARK: opacity24 
 		public var _opacity24: CGFloat?
 		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4232,33 +4253,33 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity96 = newValue }
 		}
 	}
-	//MARK: - Shadow
-	public var _Shadow: ShadowAppearanceProxy?
-	open func ShadowStyle() -> ShadowAppearanceProxy {
-		if let override = _Shadow { return override }
-			return ShadowAppearanceProxy(proxy: { return self })
+	//MARK: - Shadow28
+	public var _Shadow28: Shadow28AppearanceProxy?
+	open func Shadow28Style() -> Shadow28AppearanceProxy {
+		if let override = _Shadow28 { return override }
+			return Shadow28AppearanceProxy(proxy: { return self })
 		}
-	public var Shadow: ShadowAppearanceProxy {
-		get { return self.ShadowStyle() }
-		set { _Shadow = newValue }
+	public var Shadow28: Shadow28AppearanceProxy {
+		get { return self.Shadow28Style() }
+		set { _Shadow28 = newValue }
 	}
-	@objc(ShadowAppearanceProxy) @objcMembers open class ShadowAppearanceProxy: NSObject {
+	@objc(Shadow28AppearanceProxy) @objcMembers open class Shadow28AppearanceProxy: NSObject {
 		public let mainProxy: () -> FluentUIStyle
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
 		}
 
-		//MARK: - shadow28
-		public var _shadow28: shadow28AppearanceProxy?
-		open func shadow28Style() -> shadow28AppearanceProxy {
-			if let override = _shadow28 { return override }
-				return shadow28AppearanceProxy(proxy: mainProxy)
+		//MARK: - shadow1
+		public var _shadow1: shadow1AppearanceProxy?
+		open func shadow1Style() -> shadow1AppearanceProxy {
+			if let override = _shadow1 { return override }
+				return shadow1AppearanceProxy(proxy: mainProxy)
 			}
-		public var shadow28: shadow28AppearanceProxy {
-			get { return self.shadow28Style() }
-			set { _shadow28 = newValue }
+		public var shadow1: shadow1AppearanceProxy {
+			get { return self.shadow1Style() }
+			set { _shadow1 = newValue }
 		}
-		@objc(ShadowShadow28AppearanceProxy) @objcMembers open class shadow28AppearanceProxy: NSObject {
+		@objc(Shadow28Shadow1AppearanceProxy) @objcMembers open class shadow1AppearanceProxy: NSObject {
 			public let mainProxy: () -> FluentUIStyle
 			public init(proxy: @escaping () -> FluentUIStyle) {
 				self.mainProxy = proxy
@@ -4313,6 +4334,79 @@ extension FluentUIThemeManagerTheming {
 			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
 				if let override = _y { return override }
 					return CGFloat(14.0)
+				}
+			public var y: CGFloat {
+				get { return self.yProperty() }
+				set { _y = newValue }
+			}
+		}
+
+
+		//MARK: - shadow2
+		public var _shadow2: shadow2AppearanceProxy?
+		open func shadow2Style() -> shadow2AppearanceProxy {
+			if let override = _shadow2 { return override }
+				return shadow2AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow2: shadow2AppearanceProxy {
+			get { return self.shadow2Style() }
+			set { _shadow2 = newValue }
+		}
+		@objc(Shadow28Shadow2AppearanceProxy) @objcMembers open class shadow2AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur 
+			public var _blur: CGFloat?
+			open func blurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur { return override }
+					return CGFloat(8.0)
+				}
+			public var blur: CGFloat {
+				get { return self.blurProperty() }
+				set { _blur = newValue }
+			}
+
+			//MARK: color 
+			public var _color: UIColor?
+			open func colorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color: UIColor {
+				get { return self.colorProperty() }
+				set { _color = newValue }
+			}
+
+			//MARK: opacity 
+			public var _opacity: CGFloat?
+			open func opacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity: CGFloat {
+				get { return self.opacityProperty() }
+				set { _opacity = newValue }
+			}
+
+			//MARK: x 
+			public var _x: CGFloat?
+			open func xProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x { return override }
+					return CGFloat(0.0)
+				}
+			public var x: CGFloat {
+				get { return self.xProperty() }
+				set { _x = newValue }
+			}
+
+			//MARK: y 
+			public var _y: CGFloat?
+			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y { return override }
+					return CGFloat(0.0)
 				}
 			public var y: CGFloat {
 				get { return self.yProperty() }

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -4232,6 +4232,17 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity24 = newValue }
 		}
 
+		//MARK: opacity28 
+		public var _opacity28: CGFloat?
+		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity28 { return override }
+			return CGFloat(0.28)
+			}
+		public var opacity28: CGFloat {
+			get { return self.opacity28Property() }
+			set { _opacity28 = newValue }
+		}
+
 		//MARK: opacity32 
 		public var _opacity32: CGFloat?
 		open func opacity32Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4241,6 +4252,28 @@ extension FluentUIThemeManagerTheming {
 		public var opacity32: CGFloat {
 			get { return self.opacity32Property() }
 			set { _opacity32 = newValue }
+		}
+
+		//MARK: opacity40 
+		public var _opacity40: CGFloat?
+		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity40 { return override }
+			return CGFloat(0.4)
+			}
+		public var opacity40: CGFloat {
+			get { return self.opacity40Property() }
+			set { _opacity40 = newValue }
+		}
+
+		//MARK: opacity48 
+		public var _opacity48: CGFloat?
+		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity48 { return override }
+			return CGFloat(0.48)
+			}
+		public var opacity48: CGFloat {
+			get { return self.opacity48Property() }
+			set { _opacity48 = newValue }
 		}
 
 		//MARK: opacity64 
@@ -4313,6 +4346,262 @@ extension FluentUIThemeManagerTheming {
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
 		}
+
+		//MARK: - shadow16
+		public var _shadow16: shadow16AppearanceProxy?
+		open func shadow16Style() -> shadow16AppearanceProxy {
+			if let override = _shadow16 { return override }
+				return shadow16AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow16: shadow16AppearanceProxy {
+			get { return self.shadow16Style() }
+			set { _shadow16 = newValue }
+		}
+		@objc(ShadowShadow16AppearanceProxy) @objcMembers open class shadow16AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(16.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity24Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(8.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow2
+		public var _shadow2: shadow2AppearanceProxy?
+		open func shadow2Style() -> shadow2AppearanceProxy {
+			if let override = _shadow2 { return override }
+				return shadow2AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow2: shadow2AppearanceProxy {
+			get { return self.shadow2Style() }
+			set { _shadow2 = newValue }
+		}
+		@objc(ShadowShadow2AppearanceProxy) @objcMembers open class shadow2AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(2.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(2.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity28Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(1.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
 
 		//MARK: - shadow28
 		public var _shadow28: shadow28AppearanceProxy?
@@ -4423,6 +4712,390 @@ extension FluentUIThemeManagerTheming {
 			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
 				if let override = _y1 { return override }
 					return CGFloat(14.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow4
+		public var _shadow4: shadow4AppearanceProxy?
+		open func shadow4Style() -> shadow4AppearanceProxy {
+			if let override = _shadow4 { return override }
+				return shadow4AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow4: shadow4AppearanceProxy {
+			get { return self.shadow4Style() }
+			set { _shadow4 = newValue }
+		}
+		@objc(ShadowShadow4AppearanceProxy) @objcMembers open class shadow4AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(4.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(2.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity28Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(2.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow64
+		public var _shadow64: shadow64AppearanceProxy?
+		open func shadow64Style() -> shadow64AppearanceProxy {
+			if let override = _shadow64 { return override }
+				return shadow64AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow64: shadow64AppearanceProxy {
+			get { return self.shadow64Style() }
+			set { _shadow64 = newValue }
+		}
+		@objc(ShadowShadow64AppearanceProxy) @objcMembers open class shadow64AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(64.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity48Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity40Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(32.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow8
+		public var _shadow8: shadow8AppearanceProxy?
+		open func shadow8Style() -> shadow8AppearanceProxy {
+			if let override = _shadow8 { return override }
+				return shadow8AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow8: shadow8AppearanceProxy {
+			get { return self.shadow8Style() }
+			set { _shadow8 = newValue }
+		}
+		@objc(ShadowShadow8AppearanceProxy) @objcMembers open class shadow8AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity28Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(4.0)
 				}
 			public var y1: CGFloat {
 				get { return self.y1Property() }

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -1698,6 +1698,77 @@ extension FluentUIThemeManagerTheming {
 		}
 
 	}
+	//MARK: - ElevationOpacity
+	public var _ElevationOpacity: ElevationOpacityAppearanceProxy?
+	open func ElevationOpacityStyle() -> ElevationOpacityAppearanceProxy {
+		if let override = _ElevationOpacity { return override }
+			return ElevationOpacityAppearanceProxy(proxy: { return self })
+		}
+	public var ElevationOpacity: ElevationOpacityAppearanceProxy {
+		get { return self.ElevationOpacityStyle() }
+		set { _ElevationOpacity = newValue }
+	}
+	@objc(ElevationOpacityAppearanceProxy) @objcMembers open class ElevationOpacityAppearanceProxy: NSObject {
+		public let mainProxy: () -> FluentUIStyle
+		public init(proxy: @escaping () -> FluentUIStyle) {
+			self.mainProxy = proxy
+		}
+
+		//MARK: highElevation 
+		public var _highElevation: UIColor?
+		open func highElevationProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _highElevation { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity60Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var highElevation: UIColor {
+			get { return self.highElevationProperty() }
+			set { _highElevation = newValue }
+		}
+
+		//MARK: highElevation1 
+		public var _highElevation1: UIColor?
+		open func highElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _highElevation1 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity24Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity48Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var highElevation1: UIColor {
+			get { return self.highElevation1Property() }
+			set { _highElevation1 = newValue }
+		}
+
+		//MARK: highElevation2 
+		public var _highElevation2: UIColor?
+		open func highElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _highElevation2 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity20Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var highElevation2: UIColor {
+			get { return self.highElevation2Property() }
+			set { _highElevation2 = newValue }
+		}
+
+		//MARK: lowElevation1 
+		public var _lowElevation1: UIColor?
+		open func lowElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _lowElevation1 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity14Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity28Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var lowElevation1: UIColor {
+			get { return self.lowElevation1Property() }
+			set { _lowElevation1 = newValue }
+		}
+
+		//MARK: lowElevation2 
+		public var _lowElevation2: UIColor?
+		open func lowElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _lowElevation2 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity12Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity20Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var lowElevation2: UIColor {
+			get { return self.lowElevation2Property() }
+			set { _lowElevation2 = newValue }
+		}
+	}
 	//MARK: - Icon
 	public var _Icon: IconAppearanceProxy?
 	open func IconStyle() -> IconAppearanceProxy {
@@ -3299,37 +3370,15 @@ extension FluentUIThemeManagerTheming {
 			set { _backgroundClearColor = newValue }
 		}
 
-		//MARK: backgroundClearOpacity 
-		public var _backgroundClearOpacity: CGFloat?
-		open func backgroundClearOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _backgroundClearOpacity { return override }
-			return mainProxy().Opacity.clearProperty(traitCollection)
-			}
-		public var backgroundClearOpacity: CGFloat {
-			get { return self.backgroundClearOpacityProperty() }
-			set { _backgroundClearOpacity = newValue }
-		}
-
 		//MARK: backgroundDimmedColor 
 		public var _backgroundDimmedColor: UIColor?
 		open func backgroundDimmedColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _backgroundDimmedColor { return override }
-			return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+			return mainProxy().ElevationOpacity.highElevationProperty(traitCollection)
 			}
 		public var backgroundDimmedColor: UIColor {
 			get { return self.backgroundDimmedColorProperty() }
 			set { _backgroundDimmedColor = newValue }
-		}
-
-		//MARK: backgroundDimmedOpacity 
-		public var _backgroundDimmedOpacity: CGFloat?
-		open func backgroundDimmedOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _backgroundDimmedOpacity { return override }
-			return mainProxy().Opacity.opacity64Property(traitCollection)
-			}
-		public var backgroundDimmedOpacity: CGFloat {
-			get { return self.backgroundDimmedOpacityProperty() }
-			set { _backgroundDimmedOpacity = newValue }
 		}
 
 		//MARK: shadow1Blur 
@@ -3376,17 +3425,6 @@ extension FluentUIThemeManagerTheming {
 			set { _shadow1OffsetY = newValue }
 		}
 
-		//MARK: shadow1Opacity 
-		public var _shadow1Opacity: CGFloat?
-		open func shadow1OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadow1Opacity { return override }
-			return mainProxy().Shadow.shadow28.opacity1Property(traitCollection)
-			}
-		public var shadow1Opacity: CGFloat {
-			get { return self.shadow1OpacityProperty() }
-			set { _shadow1Opacity = newValue }
-		}
-
 		//MARK: shadow2Blur 
 		public var _shadow2Blur: CGFloat?
 		open func shadow2BlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -3429,17 +3467,6 @@ extension FluentUIThemeManagerTheming {
 		public var shadow2OffsetY: CGFloat {
 			get { return self.shadow2OffsetYProperty() }
 			set { _shadow2OffsetY = newValue }
-		}
-
-		//MARK: shadow2Opacity 
-		public var _shadow2Opacity: CGFloat?
-		open func shadow2OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadow2Opacity { return override }
-			return mainProxy().Shadow.shadow28.opacity2Property(traitCollection)
-			}
-		public var shadow2Opacity: CGFloat {
-			get { return self.shadow2OpacityProperty() }
-			set { _shadow2Opacity = newValue }
 		}
 	}
 	//MARK: - MSFGhostButtonTokens
@@ -4210,17 +4237,6 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity16 = newValue }
 		}
 
-		//MARK: opacity20 
-		public var _opacity20: CGFloat?
-		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity20 { return override }
-			return CGFloat(0.2)
-			}
-		public var opacity20: CGFloat {
-			get { return self.opacity20Property() }
-			set { _opacity20 = newValue }
-		}
-
 		//MARK: opacity24 
 		public var _opacity24: CGFloat?
 		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4232,17 +4248,6 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity24 = newValue }
 		}
 
-		//MARK: opacity28 
-		public var _opacity28: CGFloat?
-		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity28 { return override }
-			return CGFloat(0.28)
-			}
-		public var opacity28: CGFloat {
-			get { return self.opacity28Property() }
-			set { _opacity28 = newValue }
-		}
-
 		//MARK: opacity32 
 		public var _opacity32: CGFloat?
 		open func opacity32Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4252,28 +4257,6 @@ extension FluentUIThemeManagerTheming {
 		public var opacity32: CGFloat {
 			get { return self.opacity32Property() }
 			set { _opacity32 = newValue }
-		}
-
-		//MARK: opacity40 
-		public var _opacity40: CGFloat?
-		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity40 { return override }
-			return CGFloat(0.4)
-			}
-		public var opacity40: CGFloat {
-			get { return self.opacity40Property() }
-			set { _opacity40 = newValue }
-		}
-
-		//MARK: opacity48 
-		public var _opacity48: CGFloat?
-		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity48 { return override }
-			return CGFloat(0.48)
-			}
-		public var opacity48: CGFloat {
-			get { return self.opacity48Property() }
-			set { _opacity48 = newValue }
 		}
 
 		//MARK: opacity64 
@@ -4389,7 +4372,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4400,33 +4383,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity24Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4517,7 +4478,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4528,33 +4489,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity28Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4645,7 +4584,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4656,33 +4595,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity24Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4773,7 +4690,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4784,33 +4701,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity28Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4901,7 +4796,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4912,33 +4807,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity48Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity40Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -5029,7 +4902,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -5040,33 +4913,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity28Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -5114,6 +4965,132 @@ extension FluentUIThemeManagerTheming {
 			}
 		}
 
+	}
+	//MARK: - ShadowOpacity
+	public var _ShadowOpacity: ShadowOpacityAppearanceProxy?
+	open func ShadowOpacityStyle() -> ShadowOpacityAppearanceProxy {
+		if let override = _ShadowOpacity { return override }
+			return ShadowOpacityAppearanceProxy(proxy: { return self })
+		}
+	public var ShadowOpacity: ShadowOpacityAppearanceProxy {
+		get { return self.ShadowOpacityStyle() }
+		set { _ShadowOpacity = newValue }
+	}
+	@objc(ShadowOpacityAppearanceProxy) @objcMembers open class ShadowOpacityAppearanceProxy: NSObject {
+		public let mainProxy: () -> FluentUIStyle
+		public init(proxy: @escaping () -> FluentUIStyle) {
+			self.mainProxy = proxy
+		}
+
+		//MARK: clear 
+		public var _clear: UIColor?
+		open func clearProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _clear { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+			}
+		public var clear: UIColor {
+			get { return self.clearProperty() }
+			set { _clear = newValue }
+		}
+
+		//MARK: opacity12 
+		public var _opacity12: UIColor?
+		open func opacity12Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity12 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.01)
+			}
+		public var opacity12: UIColor {
+			get { return self.opacity12Property() }
+			set { _opacity12 = newValue }
+		}
+
+		//MARK: opacity14 
+		public var _opacity14: UIColor?
+		open func opacity14Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity14 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.24)
+			}
+		public var opacity14: UIColor {
+			get { return self.opacity14Property() }
+			set { _opacity14 = newValue }
+		}
+
+		//MARK: opacity20 
+		public var _opacity20: UIColor?
+		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity20 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.33)
+			}
+		public var opacity20: UIColor {
+			get { return self.opacity20Property() }
+			set { _opacity20 = newValue }
+		}
+
+		//MARK: opacity24 
+		public var _opacity24: UIColor?
+		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity24 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.03)
+			}
+		public var opacity24: UIColor {
+			get { return self.opacity24Property() }
+			set { _opacity24 = newValue }
+		}
+
+		//MARK: opacity28 
+		public var _opacity28: UIColor?
+		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity28 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.47)
+			}
+		public var opacity28: UIColor {
+			get { return self.opacity28Property() }
+			set { _opacity28 = newValue }
+		}
+
+		//MARK: opacity40 
+		public var _opacity40: UIColor?
+		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity40 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.66)
+			}
+		public var opacity40: UIColor {
+			get { return self.opacity40Property() }
+			set { _opacity40 = newValue }
+		}
+
+		//MARK: opacity48 
+		public var _opacity48: UIColor?
+		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity48 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.07)
+			}
+		public var opacity48: UIColor {
+			get { return self.opacity48Property() }
+			set { _opacity48 = newValue }
+		}
+
+		//MARK: opacity60 
+		public var _opacity60: UIColor?
+		open func opacity60Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity60 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.99)
+			}
+		public var opacity60: UIColor {
+			get { return self.opacity60Property() }
+			set { _opacity60 = newValue }
+		}
+
+		//MARK: opaque 
+		public var _opaque: UIColor?
+		open func opaqueProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opaque { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+			}
+		public var opaque: UIColor {
+			get { return self.opaqueProperty() }
+			set { _opaque = newValue }
+		}
 	}
 	//MARK: - Spacing
 	public var _Spacing: SpacingAppearanceProxy?

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -3332,69 +3332,114 @@ extension FluentUIThemeManagerTheming {
 			set { _backgroundDimmedOpacity = newValue }
 		}
 
-		//MARK: shadowBlur 
-		public var _shadowBlur: [CGFloat]?
-		open func shadowBlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowBlur { return override }
-			return [
-			mainProxy().Shadow28.shadow1.blurProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.blurProperty(traitCollection)]
+		//MARK: shadow1Blur 
+		public var _shadow1Blur: CGFloat?
+		open func shadow1BlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1Blur { return override }
+			return mainProxy().Shadow.shadow28.blur1Property(traitCollection)
 			}
-		public var shadowBlur: [CGFloat] {
-			get { return self.shadowBlurProperty() }
-			set { _shadowBlur = newValue }
+		public var shadow1Blur: CGFloat {
+			get { return self.shadow1BlurProperty() }
+			set { _shadow1Blur = newValue }
 		}
 
-		//MARK: shadowColor 
-		public var _shadowColor: [UIColor]?
-		open func shadowColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
-			if let override = _shadowColor { return override }
-			return [
-			mainProxy().Shadow28.shadow1.colorProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.colorProperty(traitCollection)]
+		//MARK: shadow1Color 
+		public var _shadow1Color: UIColor?
+		open func shadow1ColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _shadow1Color { return override }
+			return mainProxy().Shadow.shadow28.color1Property(traitCollection)
 			}
-		public var shadowColor: [UIColor] {
-			get { return self.shadowColorProperty() }
-			set { _shadowColor = newValue }
+		public var shadow1Color: UIColor {
+			get { return self.shadow1ColorProperty() }
+			set { _shadow1Color = newValue }
 		}
 
-		//MARK: shadowOffsetX 
-		public var _shadowOffsetX: [CGFloat]?
-		open func shadowOffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowOffsetX { return override }
-			return [
-			mainProxy().Shadow28.shadow1.xProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.xProperty(traitCollection)]
+		//MARK: shadow1OffsetX 
+		public var _shadow1OffsetX: CGFloat?
+		open func shadow1OffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1OffsetX { return override }
+			return mainProxy().Shadow.shadow28.x1Property(traitCollection)
 			}
-		public var shadowOffsetX: [CGFloat] {
-			get { return self.shadowOffsetXProperty() }
-			set { _shadowOffsetX = newValue }
+		public var shadow1OffsetX: CGFloat {
+			get { return self.shadow1OffsetXProperty() }
+			set { _shadow1OffsetX = newValue }
 		}
 
-		//MARK: shadowOffsetY 
-		public var _shadowOffsetY: [CGFloat]?
-		open func shadowOffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowOffsetY { return override }
-			return [
-			mainProxy().Shadow28.shadow1.yProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.yProperty(traitCollection)]
+		//MARK: shadow1OffsetY 
+		public var _shadow1OffsetY: CGFloat?
+		open func shadow1OffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1OffsetY { return override }
+			return mainProxy().Shadow.shadow28.y1Property(traitCollection)
 			}
-		public var shadowOffsetY: [CGFloat] {
-			get { return self.shadowOffsetYProperty() }
-			set { _shadowOffsetY = newValue }
+		public var shadow1OffsetY: CGFloat {
+			get { return self.shadow1OffsetYProperty() }
+			set { _shadow1OffsetY = newValue }
 		}
 
-		//MARK: shadowOpacity 
-		public var _shadowOpacity: [CGFloat]?
-		open func shadowOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowOpacity { return override }
-			return [
-			mainProxy().Shadow28.shadow1.opacityProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.opacityProperty(traitCollection)]
+		//MARK: shadow1Opacity 
+		public var _shadow1Opacity: CGFloat?
+		open func shadow1OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1Opacity { return override }
+			return mainProxy().Shadow.shadow28.opacity1Property(traitCollection)
 			}
-		public var shadowOpacity: [CGFloat] {
-			get { return self.shadowOpacityProperty() }
-			set { _shadowOpacity = newValue }
+		public var shadow1Opacity: CGFloat {
+			get { return self.shadow1OpacityProperty() }
+			set { _shadow1Opacity = newValue }
+		}
+
+		//MARK: shadow2Blur 
+		public var _shadow2Blur: CGFloat?
+		open func shadow2BlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2Blur { return override }
+			return mainProxy().Shadow.shadow28.blur2Property(traitCollection)
+			}
+		public var shadow2Blur: CGFloat {
+			get { return self.shadow2BlurProperty() }
+			set { _shadow2Blur = newValue }
+		}
+
+		//MARK: shadow2Color 
+		public var _shadow2Color: UIColor?
+		open func shadow2ColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _shadow2Color { return override }
+			return mainProxy().Shadow.shadow28.color2Property(traitCollection)
+			}
+		public var shadow2Color: UIColor {
+			get { return self.shadow2ColorProperty() }
+			set { _shadow2Color = newValue }
+		}
+
+		//MARK: shadow2OffsetX 
+		public var _shadow2OffsetX: CGFloat?
+		open func shadow2OffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2OffsetX { return override }
+			return mainProxy().Shadow.shadow28.x2Property(traitCollection)
+			}
+		public var shadow2OffsetX: CGFloat {
+			get { return self.shadow2OffsetXProperty() }
+			set { _shadow2OffsetX = newValue }
+		}
+
+		//MARK: shadow2OffsetY 
+		public var _shadow2OffsetY: CGFloat?
+		open func shadow2OffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2OffsetY { return override }
+			return mainProxy().Shadow.shadow28.y2Property(traitCollection)
+			}
+		public var shadow2OffsetY: CGFloat {
+			get { return self.shadow2OffsetYProperty() }
+			set { _shadow2OffsetY = newValue }
+		}
+
+		//MARK: shadow2Opacity 
+		public var _shadow2Opacity: CGFloat?
+		open func shadow2OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2Opacity { return override }
+			return mainProxy().Shadow.shadow28.opacity2Property(traitCollection)
+			}
+		public var shadow2Opacity: CGFloat {
+			get { return self.shadow2OpacityProperty() }
+			set { _shadow2Opacity = newValue }
 		}
 	}
 	//MARK: - MSFGhostButtonTokens
@@ -4253,164 +4298,146 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity96 = newValue }
 		}
 	}
-	//MARK: - Shadow28
-	public var _Shadow28: Shadow28AppearanceProxy?
-	open func Shadow28Style() -> Shadow28AppearanceProxy {
-		if let override = _Shadow28 { return override }
-			return Shadow28AppearanceProxy(proxy: { return self })
+	//MARK: - Shadow
+	public var _Shadow: ShadowAppearanceProxy?
+	open func ShadowStyle() -> ShadowAppearanceProxy {
+		if let override = _Shadow { return override }
+			return ShadowAppearanceProxy(proxy: { return self })
 		}
-	public var Shadow28: Shadow28AppearanceProxy {
-		get { return self.Shadow28Style() }
-		set { _Shadow28 = newValue }
+	public var Shadow: ShadowAppearanceProxy {
+		get { return self.ShadowStyle() }
+		set { _Shadow = newValue }
 	}
-	@objc(Shadow28AppearanceProxy) @objcMembers open class Shadow28AppearanceProxy: NSObject {
+	@objc(ShadowAppearanceProxy) @objcMembers open class ShadowAppearanceProxy: NSObject {
 		public let mainProxy: () -> FluentUIStyle
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
 		}
 
-		//MARK: - shadow1
-		public var _shadow1: shadow1AppearanceProxy?
-		open func shadow1Style() -> shadow1AppearanceProxy {
-			if let override = _shadow1 { return override }
-				return shadow1AppearanceProxy(proxy: mainProxy)
+		//MARK: - shadow28
+		public var _shadow28: shadow28AppearanceProxy?
+		open func shadow28Style() -> shadow28AppearanceProxy {
+			if let override = _shadow28 { return override }
+				return shadow28AppearanceProxy(proxy: mainProxy)
 			}
-		public var shadow1: shadow1AppearanceProxy {
-			get { return self.shadow1Style() }
-			set { _shadow1 = newValue }
+		public var shadow28: shadow28AppearanceProxy {
+			get { return self.shadow28Style() }
+			set { _shadow28 = newValue }
 		}
-		@objc(Shadow28Shadow1AppearanceProxy) @objcMembers open class shadow1AppearanceProxy: NSObject {
+		@objc(ShadowShadow28AppearanceProxy) @objcMembers open class shadow28AppearanceProxy: NSObject {
 			public let mainProxy: () -> FluentUIStyle
 			public init(proxy: @escaping () -> FluentUIStyle) {
 				self.mainProxy = proxy
 			}
 
-			//MARK: blur 
-			public var _blur: CGFloat?
-			open func blurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _blur { return override }
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
 					return CGFloat(28.0)
 				}
-			public var blur: CGFloat {
-				get { return self.blurProperty() }
-				set { _blur = newValue }
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
 			}
 
-			//MARK: color 
-			public var _color: UIColor?
-			open func colorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-				if let override = _color { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
-				}
-			public var color: UIColor {
-				get { return self.colorProperty() }
-				set { _color = newValue }
-			}
-
-			//MARK: opacity 
-			public var _opacity: CGFloat?
-			open func opacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity { return override }
-					return mainProxy().Opacity.opacity24Property(traitCollection)
-				}
-			public var opacity: CGFloat {
-				get { return self.opacityProperty() }
-				set { _opacity = newValue }
-			}
-
-			//MARK: x 
-			public var _x: CGFloat?
-			open func xProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _x { return override }
-					return CGFloat(0.0)
-				}
-			public var x: CGFloat {
-				get { return self.xProperty() }
-				set { _x = newValue }
-			}
-
-			//MARK: y 
-			public var _y: CGFloat?
-			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _y { return override }
-					return CGFloat(14.0)
-				}
-			public var y: CGFloat {
-				get { return self.yProperty() }
-				set { _y = newValue }
-			}
-		}
-
-
-		//MARK: - shadow2
-		public var _shadow2: shadow2AppearanceProxy?
-		open func shadow2Style() -> shadow2AppearanceProxy {
-			if let override = _shadow2 { return override }
-				return shadow2AppearanceProxy(proxy: mainProxy)
-			}
-		public var shadow2: shadow2AppearanceProxy {
-			get { return self.shadow2Style() }
-			set { _shadow2 = newValue }
-		}
-		@objc(Shadow28Shadow2AppearanceProxy) @objcMembers open class shadow2AppearanceProxy: NSObject {
-			public let mainProxy: () -> FluentUIStyle
-			public init(proxy: @escaping () -> FluentUIStyle) {
-				self.mainProxy = proxy
-			}
-
-			//MARK: blur 
-			public var _blur: CGFloat?
-			open func blurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _blur { return override }
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
 					return CGFloat(8.0)
 				}
-			public var blur: CGFloat {
-				get { return self.blurProperty() }
-				set { _blur = newValue }
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
 			}
 
-			//MARK: color 
-			public var _color: UIColor?
-			open func colorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-				if let override = _color { return override }
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
 					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
 				}
-			public var color: UIColor {
-				get { return self.colorProperty() }
-				set { _color = newValue }
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
 			}
 
-			//MARK: opacity 
-			public var _opacity: CGFloat?
-			open func opacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity { return override }
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity24Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
 					return mainProxy().Opacity.opacity20Property(traitCollection)
 				}
-			public var opacity: CGFloat {
-				get { return self.opacityProperty() }
-				set { _opacity = newValue }
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
 			}
 
-			//MARK: x 
-			public var _x: CGFloat?
-			open func xProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _x { return override }
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
 					return CGFloat(0.0)
 				}
-			public var x: CGFloat {
-				get { return self.xProperty() }
-				set { _x = newValue }
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
 			}
 
-			//MARK: y 
-			public var _y: CGFloat?
-			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _y { return override }
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
 					return CGFloat(0.0)
 				}
-			public var y: CGFloat {
-				get { return self.yProperty() }
-				set { _y = newValue }
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(14.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
 			}
 		}
 

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -60,11 +60,11 @@ struct MSFSlideOverPanel<Content: View>: View {
             content
                 .frame(width: contentWidth)
                 .offset(x: resolvedContentOffset)
-                .shadow(color: shadowColor(true),
+                .shadow(color: tokens.shadow1Color,
                         radius: tokens.shadow1Blur,
                         x: tokens.shadow1DepthX,
                         y: tokens.shadow1DepthY)
-                .shadow(color: shadowColor(false),
+                .shadow(color: tokens.shadow2Color,
                         radius: tokens.shadow2Blur,
                         x: tokens.shadow2DepthX,
                         y: tokens.shadow2DepthY)
@@ -153,10 +153,6 @@ struct MSFSlideOverPanel<Content: View>: View {
             }
         }
         return minValue
-    }
-
-    private func shadowColor(_ isPrimary: Bool = true) -> Color {
-        return isPrimary ? tokens.shadow1Color : tokens.shadow2Color
     }
 }
 

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -107,7 +107,19 @@ struct MSFSlideOverPanel<Content: View>: View {
         guard backgroundDimmed else {
             return tokens.backgroundClearColor
         }
-        return tokens.backgroundDimmedColor
+
+        // animate opacity
+        var opacity: Double = 0.0
+        switch transitionState {
+        case .collapsed:
+            opacity = 0
+        case .expanded:
+            opacity = 1
+        case .inTransisiton:
+            opacity = percentTransition ?? 0
+        }
+
+        return tokens.backgroundDimmedColor.opacity(opacity)
     }
 
     private var percentTransistionOffset: CGFloat {

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -107,8 +107,7 @@ struct MSFSlideOverPanel<Content: View>: View {
         guard backgroundDimmed else {
             return tokens.backgroundClearColor
         }
-        let opacity = resolvedPanelStateValue(tokens.backgroundClearOpacity, tokens.backgroundDimmedOpacity)
-        return tokens.backgroundDimmedColor.opacity(opacity)
+        return tokens.backgroundDimmedColor
     }
 
     private var percentTransistionOffset: CGFloat {
@@ -145,9 +144,7 @@ struct MSFSlideOverPanel<Content: View>: View {
     }
 
     private func shadowColor(_ isPrimary: Bool = true) -> Color {
-        let opacity = resolvedPanelStateValue(0.0, isPrimary ? tokens.shadow1Opacity : tokens.shadow2Opacity)
-        let color: Color = isPrimary ? tokens.shadow1Color : tokens.shadow2Color
-        return color.opacity(opacity)
+        return isPrimary ? tokens.shadow1Color : tokens.shadow2Color
     }
 }
 

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -60,14 +60,14 @@ struct MSFSlideOverPanel<Content: View>: View {
             content
                 .frame(width: contentWidth)
                 .offset(x: resolvedContentOffset)
-                .shadow(color: shadowColor[0],
-                        radius: tokens.shadowBlur[0],
-                        x: tokens.shadowDepthX[0],
-                        y: tokens.shadowDepthY[0])
-                .shadow(color: shadowColor[1],
-                        radius: tokens.shadowBlur[1],
-                        x: tokens.shadowDepthX[1],
-                        y: tokens.shadowDepthY[1])
+                .shadow(color: shadowColor(true),
+                        radius: tokens.shadow1Blur,
+                        x: tokens.shadow1DepthX,
+                        y: tokens.shadow1DepthY)
+                .shadow(color: shadowColor(false),
+                        radius: tokens.shadow2Blur,
+                        x: tokens.shadow2DepthX,
+                        y: tokens.shadow2DepthY)
 
             if direction == .left {
                 MSFInteractiveSpacer(defaultBackgroundColor: $tokens.backgroundClearColor)
@@ -111,12 +111,6 @@ struct MSFSlideOverPanel<Content: View>: View {
         return tokens.backgroundDimmedColor.opacity(opacity)
     }
 
-    private var shadowColor: [Color] {
-        let opacity1 = resolvedPanelStateValue(0.0, tokens.shadowOpacity[0])
-        let opacity2 = resolvedPanelStateValue(0.0, tokens.shadowOpacity[1])
-        return [tokens.shadowColor[0].opacity(opacity1), tokens.shadowColor[1].opacity(opacity2)]
-    }
-
     private var percentTransistionOffset: CGFloat {
         // Override offset if required
         if let percentDriveTransition = percentTransition {
@@ -148,6 +142,12 @@ struct MSFSlideOverPanel<Content: View>: View {
             }
         }
         return minValue
+    }
+
+    private func shadowColor(_ isPrimary: Bool = true) -> Color {
+        let opacity = resolvedPanelStateValue(0.0, isPrimary ? tokens.shadow1Opacity : tokens.shadow2Opacity)
+        let color: Color = isPrimary ? tokens.shadow1Color : tokens.shadow2Color
+        return color.opacity(opacity)
     }
 }
 

--- a/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
+++ b/ios/FluentUI/Vnext/Drawer/SlideOverPanel.swift
@@ -60,10 +60,14 @@ struct MSFSlideOverPanel<Content: View>: View {
             content
                 .frame(width: contentWidth)
                 .offset(x: resolvedContentOffset)
-                .shadow(color: shadowColor,
-                        radius: tokens.shadowBlur,
-                        x: tokens.shadowDepthX,
-                        y: tokens.shadowDepthY)
+                .shadow(color: shadowColor[0],
+                        radius: tokens.shadowBlur[0],
+                        x: tokens.shadowDepthX[0],
+                        y: tokens.shadowDepthY[0])
+                .shadow(color: shadowColor[1],
+                        radius: tokens.shadowBlur[1],
+                        x: tokens.shadowDepthX[1],
+                        y: tokens.shadowDepthY[1])
 
             if direction == .left {
                 MSFInteractiveSpacer(defaultBackgroundColor: $tokens.backgroundClearColor)
@@ -107,9 +111,10 @@ struct MSFSlideOverPanel<Content: View>: View {
         return tokens.backgroundDimmedColor.opacity(opacity)
     }
 
-    private var shadowColor: Color {
-        let opacity = resolvedPanelStateValue(0.0, tokens.shadowOpacity)
-        return tokens.shadowColor.opacity(opacity)
+    private var shadowColor: [Color] {
+        let opacity1 = resolvedPanelStateValue(0.0, tokens.shadowOpacity[0])
+        let opacity2 = resolvedPanelStateValue(0.0, tokens.shadowOpacity[1])
+        return [tokens.shadowColor[0].opacity(opacity1), tokens.shadowColor[1].opacity(opacity2)]
     }
 
     private var percentTransistionOffset: CGFloat {

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -141,6 +141,7 @@ Spacing:
 Opacity:
   opacity8: 0.8f
   opacity16: 0.16f
+  opacity20: 0.20f
   opacity24: 0.24f
   opacity32: 0.32f
   opacity64: 0.64f
@@ -150,8 +151,9 @@ Opacity:
   none: 1f
   clear: 0.0f
 
-Shadow:
-    shadow28: [ blur: 28pt, color: $Colors.Neutral.black, opacity: $Opacity.opacity24, x: 0pt, y: 14pt ]
+Shadow28:
+    shadow1: [ blur: 28pt, color: $Colors.Neutral.black, opacity: $Opacity.opacity24, x: 0pt, y: 14pt ]
+    shadow2: [ blur: 8pt, color: $Colors.Neutral.clear, opacity: $Opacity.opacity20, x: 0pt, y: 0pt ]
 
 AP_MSFAvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"
@@ -264,8 +266,8 @@ AP_MSFDrawerTokens:
   backgroundClearOpacity: $Opacity.clear
   backgroundClearColor: $Colors.Neutral.clear
   backgroundDimmedColor: $Colors.Neutral.black
-  shadowColor: $Shadow.shadow28.color
-  shadowOpacity: $Shadow.shadow28.opacity
-  shadowBlur: $Shadow.shadow28.blur
-  shadowX: $Shadow.shadow28.x
-  shadowY: $Shadow.shadow28.y
+  shadowColor: [ $Shadow28.shadow1.color, $Shadow28.shadow2.color]
+  shadowOpacity: [ $Shadow28.shadow1.opacity, $Shadow28.shadow2.opacity]
+  shadowBlur: [ $Shadow28.shadow1.blur, $Shadow28.shadow2.blur]
+  shadowOffsetX: [ $Shadow28.shadow1.x, $Shadow28.shadow2.x]
+  shadowOffsetY: [ $Shadow28.shadow1.y, $Shadow28.shadow2.y]

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -75,6 +75,13 @@ Colors:
     - brandPressed: "FluentUIColor(light: $Colors.Brand.shade30, dark: $Colors.Brand.shade30)"
     - brandSelected: "FluentUIColor(light: $Colors.Brand.shade20, dark: $Colors.Brand.shade20)"
     - brandDisabled: "FluentUIColor(light: $Colors.Neutral.grey88, dark: $Colors.Neutral.grey84)"
+    
+  Elevation:
+    - lowElevation1: "FluentUIColor(light: $Colors.Shadow.opacity14, dark: $Colors.Shadow.opacity28)"
+    - lowElevation2: "FluentUIColor(light: $Colors.Shadow.opacity12, dark: $Colors.Shadow.opacity20)"
+    - highElevation1: "FluentUIColor(light: $Colors.Shadow.opacity24, dark: $Colors.Shadow.opacity48)"
+    - highElevation2: "FluentUIColor(light: $Colors.Shadow.opacity20, dark: $Colors.Shadow.opacity40)"
+    - highElevation: "FluentUIColor(light: $Colors.Shadow.opacity40, dark: $Colors.Shadow.opacity60)"
 
   Foreground:
     - neutral1: "FluentUIColor(light: $Colors.Neutral.grey14, lightHighContrast: $Colors.Neutral.black, dark: $Colors.Neutral.white)"
@@ -110,6 +117,18 @@ Colors:
     - brandPressed: "FluentUIColor(light: $Colors.Brand.shade30, dark: $Colors.Brand.shade30)"
     - brandSelected: "FluentUIColor(light: $Colors.Brand.shade20, dark: $Colors.Brand.shade20)"
     - brandDisabled: "FluentUIColor(light: $Colors.Neutral.grey88, dark: $Colors.Neutral.grey84)"
+    
+  Shadow:
+    - clear: "#00000000"
+    - opacity12: "#0000001F"
+    - opacity14: "#00000024"
+    - opacity20: "#00000033"
+    - opacity24: "#0000003D"
+    - opacity28: "#00000047"
+    - opacity40: "#00000066"
+    - opacity48: "#0000007A"
+    - opacity60: "#00000099"
+    - opaque: "#000000FF"
 
 Typography:
   body: "Font(body)"
@@ -150,32 +169,13 @@ Opacity:
   none: 1f
   clear: 0.0f
   
-ShadowOpacity:
-  clear: "#00000000"
-  opacity12: "#0000001F"
-  opacity14: "#00000024"
-  opacity20: "#00000033"
-  opacity24: "#0000003D"
-  opacity28: "#00000047"
-  opacity40: "#00000066"
-  opacity48: "#0000007A"
-  opacity60: "#00000099"
-  opaque: "#000000FF"
-
-ElevationOpacity:
-    lowElevation1: "FluentUIColor(light: $ShadowOpacity.opacity14, dark: $ShadowOpacity.opacity28)"
-    lowElevation2: "FluentUIColor(light: $ShadowOpacity.opacity12, dark: $ShadowOpacity.opacity20)"
-    highElevation1: "FluentUIColor(light: $ShadowOpacity.opacity24, dark: $ShadowOpacity.opacity48)"
-    highElevation2: "FluentUIColor(light: $ShadowOpacity.opacity20, dark: $ShadowOpacity.opacity40)"
-    highElevation: "FluentUIColor(light: $ShadowOpacity.opacity40, dark: $ShadowOpacity.opacity60)"
-
 Shadow:
-    shadow2: [ blur1: 2pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 1pt, blur2: 2pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
-    shadow4: [ blur1: 4pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 2pt, blur2: 2pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
-    shadow8: [ blur1: 8pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 4pt, blur2: 8pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
-    shadow16: [ blur1: 16pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 8pt, blur2: 8pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
-    shadow28: [ blur1: 28pt, color1: $ElevationOpacity.highElevation1, x1: 0pt, y1: 14pt, blur2: 8pt, color2: $ElevationOpacity.highElevation2, x2: 0pt, y2: 0pt ]
-    shadow64: [ blur1: 64pt, color1: $ElevationOpacity.highElevation1, x1: 0pt, y1: 32pt, blur2: 8pt, color2: $ElevationOpacity.highElevation2, x2: 0pt, y2: 0pt ]
+    shadow2: [ blur1: 2pt, color1: $Colors.Elevation.lowElevation1, x1: 0pt, y1: 1pt, blur2: 2pt, color2: $Colors.Elevation.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow4: [ blur1: 4pt, color1: $Colors.Elevation.lowElevation1, x1: 0pt, y1: 2pt, blur2: 2pt, color2: $Colors.Elevation.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow8: [ blur1: 8pt, color1: $Colors.Elevation.lowElevation1, x1: 0pt, y1: 4pt, blur2: 8pt, color2: $Colors.Elevation.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow16: [ blur1: 16pt, color1: $Colors.Elevation.lowElevation1, x1: 0pt, y1: 8pt, blur2: 8pt, color2: $Colors.Elevation.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow28: [ blur1: 28pt, color1: $Colors.Elevation.highElevation1, x1: 0pt, y1: 14pt, blur2: 8pt, color2: $Colors.Elevation.highElevation2, x2: 0pt, y2: 0pt ]
+    shadow64: [ blur1: 64pt, color1: $Colors.Elevation.highElevation1, x1: 0pt, y1: 32pt, blur2: 8pt, color2: $Colors.Elevation.highElevation2, x2: 0pt, y2: 0pt ]
 
 AP_MSFAvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"
@@ -285,7 +285,7 @@ MSFIconOnlyListTokens extends MSFListTokens:
 
 AP_MSFDrawerTokens:
   backgroundClearColor: $Colors.Neutral.clear
-  backgroundDimmedColor: $ElevationOpacity.highElevation
+  backgroundDimmedColor: $Colors.Elevation.highElevation
   shadow1Color: $Shadow.shadow28.color1
   shadow1Blur: $Shadow.shadow28.blur1
   shadow1OffsetX: $Shadow.shadow28.x1

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -151,9 +151,8 @@ Opacity:
   none: 1f
   clear: 0.0f
 
-Shadow28:
-    shadow1: [ blur: 28pt, color: $Colors.Neutral.black, opacity: $Opacity.opacity24, x: 0pt, y: 14pt ]
-    shadow2: [ blur: 8pt, color: $Colors.Neutral.clear, opacity: $Opacity.opacity20, x: 0pt, y: 0pt ]
+Shadow:
+    shadow28: [ blur1: 28pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity24, x1: 0pt, y1: 14pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
 
 AP_MSFAvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"
@@ -266,8 +265,13 @@ AP_MSFDrawerTokens:
   backgroundClearOpacity: $Opacity.clear
   backgroundClearColor: $Colors.Neutral.clear
   backgroundDimmedColor: $Colors.Neutral.black
-  shadowColor: [ $Shadow28.shadow1.color, $Shadow28.shadow2.color]
-  shadowOpacity: [ $Shadow28.shadow1.opacity, $Shadow28.shadow2.opacity]
-  shadowBlur: [ $Shadow28.shadow1.blur, $Shadow28.shadow2.blur]
-  shadowOffsetX: [ $Shadow28.shadow1.x, $Shadow28.shadow2.x]
-  shadowOffsetY: [ $Shadow28.shadow1.y, $Shadow28.shadow2.y]
+  shadow1Color: $Shadow.shadow28.color1
+  shadow1Opacity: $Shadow.shadow28.opacity1
+  shadow1Blur: $Shadow.shadow28.blur1
+  shadow1OffsetX: $Shadow.shadow28.x1
+  shadow1OffsetY: $Shadow.shadow28.y1
+  shadow2Color: $Shadow.shadow28.color2
+  shadow2Opacity: $Shadow.shadow28.opacity2
+  shadow2Blur: $Shadow.shadow28.blur2
+  shadow2OffsetX: $Shadow.shadow28.x2
+  shadow2OffsetY: $Shadow.shadow28.y2

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -141,26 +141,41 @@ Spacing:
 Opacity:
   opacity8: 0.8f
   opacity16: 0.16f
-  opacity20: 0.20f
   opacity24: 0.24f
-  opacity28: 0.28f
   opacity32: 0.32f
-  opacity40: 0.40f
-  opacity48: 0.48f
   opacity64: 0.64f
   opacity72: 0.72f
   opacity88: 0.88f
   opacity96: 0.96f
   none: 1f
   clear: 0.0f
+  
+ShadowOpacity:
+  clear: "#00000000"
+  opacity12: "#0000001F"
+  opacity14: "#00000024"
+  opacity20: "#00000033"
+  opacity24: "#0000003D"
+  opacity28: "#00000047"
+  opacity40: "#00000066"
+  opacity48: "#0000007A"
+  opacity60: "#00000099"
+  opaque: "#000000FF"
+
+ElevationOpacity:
+    lowElevation1: "FluentUIColor(light: $ShadowOpacity.opacity14, dark: $ShadowOpacity.opacity28)"
+    lowElevation2: "FluentUIColor(light: $ShadowOpacity.opacity12, dark: $ShadowOpacity.opacity20)"
+    highElevation1: "FluentUIColor(light: $ShadowOpacity.opacity24, dark: $ShadowOpacity.opacity48)"
+    highElevation2: "FluentUIColor(light: $ShadowOpacity.opacity20, dark: $ShadowOpacity.opacity40)"
+    highElevation: "FluentUIColor(light: $ShadowOpacity.opacity40, dark: $ShadowOpacity.opacity60)"
 
 Shadow:
-    shadow2: [ blur1: 2pt, color1: $Colors.Neutral.clear, opacity1: $Opacity.opacity28, x1: 0pt, y1: 1pt, blur2: 2pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
-    shadow4: [ blur1: 4pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity28, x1: 0pt, y1: 2pt, blur2: 2pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
-    shadow8: [ blur1: 8pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity28, x1: 0pt, y1: 4pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
-    shadow16: [ blur1: 16pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity24, x1: 0pt, y1: 8pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
-    shadow28: [ blur1: 28pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity24, x1: 0pt, y1: 14pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
-    shadow64: [ blur1: 64pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity48, x1: 0pt, y1: 32pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity40, x2: 0pt, y2: 0pt ]
+    shadow2: [ blur1: 2pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 1pt, blur2: 2pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow4: [ blur1: 4pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 2pt, blur2: 2pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow8: [ blur1: 8pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 4pt, blur2: 8pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow16: [ blur1: 16pt, color1: $ElevationOpacity.lowElevation1, x1: 0pt, y1: 8pt, blur2: 8pt, color2: $ElevationOpacity.lowElevation2, x2: 0pt, y2: 0pt ]
+    shadow28: [ blur1: 28pt, color1: $ElevationOpacity.highElevation1, x1: 0pt, y1: 14pt, blur2: 8pt, color2: $ElevationOpacity.highElevation2, x2: 0pt, y2: 0pt ]
+    shadow64: [ blur1: 64pt, color1: $ElevationOpacity.highElevation1, x1: 0pt, y1: 32pt, blur2: 8pt, color2: $ElevationOpacity.highElevation2, x2: 0pt, y2: 0pt ]
 
 AP_MSFAvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"
@@ -269,17 +284,13 @@ MSFIconOnlyListTokens extends MSFListTokens:
   iconColor: $Colors.Foreground.neutral3
 
 AP_MSFDrawerTokens:
-  backgroundDimmedOpacity: $Opacity.opacity64
-  backgroundClearOpacity: $Opacity.clear
   backgroundClearColor: $Colors.Neutral.clear
-  backgroundDimmedColor: $Colors.Neutral.black
+  backgroundDimmedColor: $ElevationOpacity.highElevation
   shadow1Color: $Shadow.shadow28.color1
-  shadow1Opacity: $Shadow.shadow28.opacity1
   shadow1Blur: $Shadow.shadow28.blur1
   shadow1OffsetX: $Shadow.shadow28.x1
   shadow1OffsetY: $Shadow.shadow28.y1
   shadow2Color: $Shadow.shadow28.color2
-  shadow2Opacity: $Shadow.shadow28.opacity2
   shadow2Blur: $Shadow.shadow28.blur2
   shadow2OffsetX: $Shadow.shadow28.x2
   shadow2OffsetY: $Shadow.shadow28.y2

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -143,7 +143,10 @@ Opacity:
   opacity16: 0.16f
   opacity20: 0.20f
   opacity24: 0.24f
+  opacity28: 0.28f
   opacity32: 0.32f
+  opacity40: 0.40f
+  opacity48: 0.48f
   opacity64: 0.64f
   opacity72: 0.72f
   opacity88: 0.88f
@@ -152,7 +155,12 @@ Opacity:
   clear: 0.0f
 
 Shadow:
+    shadow2: [ blur1: 2pt, color1: $Colors.Neutral.clear, opacity1: $Opacity.opacity28, x1: 0pt, y1: 1pt, blur2: 2pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
+    shadow4: [ blur1: 4pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity28, x1: 0pt, y1: 2pt, blur2: 2pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
+    shadow8: [ blur1: 8pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity28, x1: 0pt, y1: 4pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
+    shadow16: [ blur1: 16pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity24, x1: 0pt, y1: 8pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
     shadow28: [ blur1: 28pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity24, x1: 0pt, y1: 14pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity20, x2: 0pt, y2: 0pt ]
+    shadow64: [ blur1: 64pt, color1: $Colors.Neutral.black, opacity1: $Opacity.opacity48, x1: 0pt, y1: 32pt, blur2: 8pt, color2: $Colors.Neutral.clear, opacity2: $Opacity.opacity40, x2: 0pt, y2: 0pt ]
 
 AP_MSFAvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -735,6 +735,79 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Elevation
+		public var _Elevation: ElevationAppearanceProxy?
+		open func ElevationStyle() -> ElevationAppearanceProxy {
+			if let override = _Elevation { return override }
+				return ElevationAppearanceProxy(proxy: mainProxy)
+			}
+		public var Elevation: ElevationAppearanceProxy {
+			get { return self.ElevationStyle() }
+			set { _Elevation = newValue }
+		}
+		@objc(ColorsElevationAppearanceProxy) @objcMembers open class ElevationAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: highElevation 
+			public var _highElevation: UIColor?
+			open func highElevationProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _highElevation { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity60Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var highElevation: UIColor {
+				get { return self.highElevationProperty() }
+				set { _highElevation = newValue }
+			}
+
+			//MARK: highElevation1 
+			public var _highElevation1: UIColor?
+			open func highElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _highElevation1 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity24Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity48Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var highElevation1: UIColor {
+				get { return self.highElevation1Property() }
+				set { _highElevation1 = newValue }
+			}
+
+			//MARK: highElevation2 
+			public var _highElevation2: UIColor?
+			open func highElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _highElevation2 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity20Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var highElevation2: UIColor {
+				get { return self.highElevation2Property() }
+				set { _highElevation2 = newValue }
+			}
+
+			//MARK: lowElevation1 
+			public var _lowElevation1: UIColor?
+			open func lowElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _lowElevation1 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity14Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity28Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var lowElevation1: UIColor {
+				get { return self.lowElevation1Property() }
+				set { _lowElevation1 = newValue }
+			}
+
+			//MARK: lowElevation2 
+			public var _lowElevation2: UIColor?
+			open func lowElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _lowElevation2 { return override }
+					return UIColor(light: mainProxy().Colors.Shadow.opacity12Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Shadow.opacity20Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var lowElevation2: UIColor {
+				get { return self.lowElevation2Property() }
+				set { _lowElevation2 = newValue }
+			}
+		}
+
+
 		//MARK: - Foreground
 		public var _Foreground: ForegroundAppearanceProxy?
 		open func ForegroundStyle() -> ForegroundAppearanceProxy {
@@ -1570,6 +1643,134 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Shadow
+		public var _Shadow: ShadowAppearanceProxy?
+		open func ShadowStyle() -> ShadowAppearanceProxy {
+			if let override = _Shadow { return override }
+				return ShadowAppearanceProxy(proxy: mainProxy)
+			}
+		public var Shadow: ShadowAppearanceProxy {
+			get { return self.ShadowStyle() }
+			set { _Shadow = newValue }
+		}
+		@objc(ColorsShadowAppearanceProxy) @objcMembers open class ShadowAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: clear 
+			public var _clear: UIColor?
+			open func clearProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _clear { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+				}
+			public var clear: UIColor {
+				get { return self.clearProperty() }
+				set { _clear = newValue }
+			}
+
+			//MARK: opacity12 
+			public var _opacity12: UIColor?
+			open func opacity12Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity12 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.01)
+				}
+			public var opacity12: UIColor {
+				get { return self.opacity12Property() }
+				set { _opacity12 = newValue }
+			}
+
+			//MARK: opacity14 
+			public var _opacity14: UIColor?
+			open func opacity14Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity14 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.24)
+				}
+			public var opacity14: UIColor {
+				get { return self.opacity14Property() }
+				set { _opacity14 = newValue }
+			}
+
+			//MARK: opacity20 
+			public var _opacity20: UIColor?
+			open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity20 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.33)
+				}
+			public var opacity20: UIColor {
+				get { return self.opacity20Property() }
+				set { _opacity20 = newValue }
+			}
+
+			//MARK: opacity24 
+			public var _opacity24: UIColor?
+			open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity24 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.03)
+				}
+			public var opacity24: UIColor {
+				get { return self.opacity24Property() }
+				set { _opacity24 = newValue }
+			}
+
+			//MARK: opacity28 
+			public var _opacity28: UIColor?
+			open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity28 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.47)
+				}
+			public var opacity28: UIColor {
+				get { return self.opacity28Property() }
+				set { _opacity28 = newValue }
+			}
+
+			//MARK: opacity40 
+			public var _opacity40: UIColor?
+			open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity40 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.66)
+				}
+			public var opacity40: UIColor {
+				get { return self.opacity40Property() }
+				set { _opacity40 = newValue }
+			}
+
+			//MARK: opacity48 
+			public var _opacity48: UIColor?
+			open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity48 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.07)
+				}
+			public var opacity48: UIColor {
+				get { return self.opacity48Property() }
+				set { _opacity48 = newValue }
+			}
+
+			//MARK: opacity60 
+			public var _opacity60: UIColor?
+			open func opacity60Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opacity60 { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.99)
+				}
+			public var opacity60: UIColor {
+				get { return self.opacity60Property() }
+				set { _opacity60 = newValue }
+			}
+
+			//MARK: opaque 
+			public var _opaque: UIColor?
+			open func opaqueProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _opaque { return override }
+					return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+				}
+			public var opaque: UIColor {
+				get { return self.opaqueProperty() }
+				set { _opaque = newValue }
+			}
+		}
+
+
 		//MARK: - Stroke
 		public var _Stroke: StrokeAppearanceProxy?
 		open func StrokeStyle() -> StrokeAppearanceProxy {
@@ -1697,77 +1898,6 @@ extension FluentUIThemeManagerTheming {
 			}
 		}
 
-	}
-	//MARK: - ElevationOpacity
-	public var _ElevationOpacity: ElevationOpacityAppearanceProxy?
-	open func ElevationOpacityStyle() -> ElevationOpacityAppearanceProxy {
-		if let override = _ElevationOpacity { return override }
-			return ElevationOpacityAppearanceProxy(proxy: { return self })
-		}
-	public var ElevationOpacity: ElevationOpacityAppearanceProxy {
-		get { return self.ElevationOpacityStyle() }
-		set { _ElevationOpacity = newValue }
-	}
-	@objc(ElevationOpacityAppearanceProxy) @objcMembers open class ElevationOpacityAppearanceProxy: NSObject {
-		public let mainProxy: () -> FluentUIStyle
-		public init(proxy: @escaping () -> FluentUIStyle) {
-			self.mainProxy = proxy
-		}
-
-		//MARK: highElevation 
-		public var _highElevation: UIColor?
-		open func highElevationProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _highElevation { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity60Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var highElevation: UIColor {
-			get { return self.highElevationProperty() }
-			set { _highElevation = newValue }
-		}
-
-		//MARK: highElevation1 
-		public var _highElevation1: UIColor?
-		open func highElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _highElevation1 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity24Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity48Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var highElevation1: UIColor {
-			get { return self.highElevation1Property() }
-			set { _highElevation1 = newValue }
-		}
-
-		//MARK: highElevation2 
-		public var _highElevation2: UIColor?
-		open func highElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _highElevation2 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity20Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var highElevation2: UIColor {
-			get { return self.highElevation2Property() }
-			set { _highElevation2 = newValue }
-		}
-
-		//MARK: lowElevation1 
-		public var _lowElevation1: UIColor?
-		open func lowElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _lowElevation1 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity14Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity28Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var lowElevation1: UIColor {
-			get { return self.lowElevation1Property() }
-			set { _lowElevation1 = newValue }
-		}
-
-		//MARK: lowElevation2 
-		public var _lowElevation2: UIColor?
-		open func lowElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _lowElevation2 { return override }
-			return UIColor(light: mainProxy().ShadowOpacity.opacity12Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity20Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-			}
-		public var lowElevation2: UIColor {
-			get { return self.lowElevation2Property() }
-			set { _lowElevation2 = newValue }
-		}
 	}
 	//MARK: - Icon
 	public var _Icon: IconAppearanceProxy?
@@ -3374,7 +3504,7 @@ extension FluentUIThemeManagerTheming {
 		public var _backgroundDimmedColor: UIColor?
 		open func backgroundDimmedColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _backgroundDimmedColor { return override }
-			return mainProxy().ElevationOpacity.highElevationProperty(traitCollection)
+			return mainProxy().Colors.Elevation.highElevationProperty(traitCollection)
 			}
 		public var backgroundDimmedColor: UIColor {
 			get { return self.backgroundDimmedColorProperty() }
@@ -4372,7 +4502,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4383,7 +4513,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4478,7 +4608,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4489,7 +4619,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4584,7 +4714,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4595,7 +4725,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4690,7 +4820,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4701,7 +4831,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4796,7 +4926,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4807,7 +4937,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4902,7 +5032,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4913,7 +5043,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
+					return mainProxy().Colors.Elevation.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
@@ -4965,132 +5095,6 @@ extension FluentUIThemeManagerTheming {
 			}
 		}
 
-	}
-	//MARK: - ShadowOpacity
-	public var _ShadowOpacity: ShadowOpacityAppearanceProxy?
-	open func ShadowOpacityStyle() -> ShadowOpacityAppearanceProxy {
-		if let override = _ShadowOpacity { return override }
-			return ShadowOpacityAppearanceProxy(proxy: { return self })
-		}
-	public var ShadowOpacity: ShadowOpacityAppearanceProxy {
-		get { return self.ShadowOpacityStyle() }
-		set { _ShadowOpacity = newValue }
-	}
-	@objc(ShadowOpacityAppearanceProxy) @objcMembers open class ShadowOpacityAppearanceProxy: NSObject {
-		public let mainProxy: () -> FluentUIStyle
-		public init(proxy: @escaping () -> FluentUIStyle) {
-			self.mainProxy = proxy
-		}
-
-		//MARK: clear 
-		public var _clear: UIColor?
-		open func clearProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _clear { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-			}
-		public var clear: UIColor {
-			get { return self.clearProperty() }
-			set { _clear = newValue }
-		}
-
-		//MARK: opacity12 
-		public var _opacity12: UIColor?
-		open func opacity12Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity12 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.01)
-			}
-		public var opacity12: UIColor {
-			get { return self.opacity12Property() }
-			set { _opacity12 = newValue }
-		}
-
-		//MARK: opacity14 
-		public var _opacity14: UIColor?
-		open func opacity14Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity14 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.24)
-			}
-		public var opacity14: UIColor {
-			get { return self.opacity14Property() }
-			set { _opacity14 = newValue }
-		}
-
-		//MARK: opacity20 
-		public var _opacity20: UIColor?
-		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity20 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.33)
-			}
-		public var opacity20: UIColor {
-			get { return self.opacity20Property() }
-			set { _opacity20 = newValue }
-		}
-
-		//MARK: opacity24 
-		public var _opacity24: UIColor?
-		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity24 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.03)
-			}
-		public var opacity24: UIColor {
-			get { return self.opacity24Property() }
-			set { _opacity24 = newValue }
-		}
-
-		//MARK: opacity28 
-		public var _opacity28: UIColor?
-		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity28 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.47)
-			}
-		public var opacity28: UIColor {
-			get { return self.opacity28Property() }
-			set { _opacity28 = newValue }
-		}
-
-		//MARK: opacity40 
-		public var _opacity40: UIColor?
-		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity40 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.66)
-			}
-		public var opacity40: UIColor {
-			get { return self.opacity40Property() }
-			set { _opacity40 = newValue }
-		}
-
-		//MARK: opacity48 
-		public var _opacity48: UIColor?
-		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity48 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.07)
-			}
-		public var opacity48: UIColor {
-			get { return self.opacity48Property() }
-			set { _opacity48 = newValue }
-		}
-
-		//MARK: opacity60 
-		public var _opacity60: UIColor?
-		open func opacity60Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opacity60 { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.99)
-			}
-		public var opacity60: UIColor {
-			get { return self.opacity60Property() }
-			set { _opacity60 = newValue }
-		}
-
-		//MARK: opaque 
-		public var _opaque: UIColor?
-		open func opaqueProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _opaque { return override }
-			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-			}
-		public var opaque: UIColor {
-			get { return self.opaqueProperty() }
-			set { _opaque = newValue }
-		}
 	}
 	//MARK: - Spacing
 	public var _Spacing: SpacingAppearanceProxy?

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -3333,58 +3333,68 @@ extension FluentUIThemeManagerTheming {
 		}
 
 		//MARK: shadowBlur 
-		public var _shadowBlur: CGFloat?
-		open func shadowBlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+		public var _shadowBlur: [CGFloat]?
+		open func shadowBlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
 			if let override = _shadowBlur { return override }
-			return mainProxy().Shadow.shadow28.blurProperty(traitCollection)
+			return [
+			mainProxy().Shadow28.shadow1.blurProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.blurProperty(traitCollection)]
 			}
-		public var shadowBlur: CGFloat {
+		public var shadowBlur: [CGFloat] {
 			get { return self.shadowBlurProperty() }
 			set { _shadowBlur = newValue }
 		}
 
 		//MARK: shadowColor 
-		public var _shadowColor: UIColor?
-		open func shadowColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+		public var _shadowColor: [UIColor]?
+		open func shadowColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _shadowColor { return override }
-			return mainProxy().Shadow.shadow28.colorProperty(traitCollection)
+			return [
+			mainProxy().Shadow28.shadow1.colorProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.colorProperty(traitCollection)]
 			}
-		public var shadowColor: UIColor {
+		public var shadowColor: [UIColor] {
 			get { return self.shadowColorProperty() }
 			set { _shadowColor = newValue }
 		}
 
-		//MARK: shadowOpacity 
-		public var _shadowOpacity: CGFloat?
-		open func shadowOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadowOpacity { return override }
-			return mainProxy().Shadow.shadow28.opacityProperty(traitCollection)
+		//MARK: shadowOffsetX 
+		public var _shadowOffsetX: [CGFloat]?
+		open func shadowOffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
+			if let override = _shadowOffsetX { return override }
+			return [
+			mainProxy().Shadow28.shadow1.xProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.xProperty(traitCollection)]
 			}
-		public var shadowOpacity: CGFloat {
+		public var shadowOffsetX: [CGFloat] {
+			get { return self.shadowOffsetXProperty() }
+			set { _shadowOffsetX = newValue }
+		}
+
+		//MARK: shadowOffsetY 
+		public var _shadowOffsetY: [CGFloat]?
+		open func shadowOffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
+			if let override = _shadowOffsetY { return override }
+			return [
+			mainProxy().Shadow28.shadow1.yProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.yProperty(traitCollection)]
+			}
+		public var shadowOffsetY: [CGFloat] {
+			get { return self.shadowOffsetYProperty() }
+			set { _shadowOffsetY = newValue }
+		}
+
+		//MARK: shadowOpacity 
+		public var _shadowOpacity: [CGFloat]?
+		open func shadowOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
+			if let override = _shadowOpacity { return override }
+			return [
+			mainProxy().Shadow28.shadow1.opacityProperty(traitCollection), 
+			mainProxy().Shadow28.shadow2.opacityProperty(traitCollection)]
+			}
+		public var shadowOpacity: [CGFloat] {
 			get { return self.shadowOpacityProperty() }
 			set { _shadowOpacity = newValue }
-		}
-
-		//MARK: shadowX 
-		public var _shadowX: CGFloat?
-		open func shadowXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadowX { return override }
-			return mainProxy().Shadow.shadow28.xProperty(traitCollection)
-			}
-		public var shadowX: CGFloat {
-			get { return self.shadowXProperty() }
-			set { _shadowX = newValue }
-		}
-
-		//MARK: shadowY 
-		public var _shadowY: CGFloat?
-		open func shadowYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadowY { return override }
-			return mainProxy().Shadow.shadow28.yProperty(traitCollection)
-			}
-		public var shadowY: CGFloat {
-			get { return self.shadowYProperty() }
-			set { _shadowY = newValue }
 		}
 	}
 	//MARK: - MSFGhostButtonTokens
@@ -4155,6 +4165,17 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity16 = newValue }
 		}
 
+		//MARK: opacity20 
+		public var _opacity20: CGFloat?
+		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity20 { return override }
+			return CGFloat(0.2)
+			}
+		public var opacity20: CGFloat {
+			get { return self.opacity20Property() }
+			set { _opacity20 = newValue }
+		}
+
 		//MARK: opacity24 
 		public var _opacity24: CGFloat?
 		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4232,33 +4253,33 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity96 = newValue }
 		}
 	}
-	//MARK: - Shadow
-	public var _Shadow: ShadowAppearanceProxy?
-	open func ShadowStyle() -> ShadowAppearanceProxy {
-		if let override = _Shadow { return override }
-			return ShadowAppearanceProxy(proxy: { return self })
+	//MARK: - Shadow28
+	public var _Shadow28: Shadow28AppearanceProxy?
+	open func Shadow28Style() -> Shadow28AppearanceProxy {
+		if let override = _Shadow28 { return override }
+			return Shadow28AppearanceProxy(proxy: { return self })
 		}
-	public var Shadow: ShadowAppearanceProxy {
-		get { return self.ShadowStyle() }
-		set { _Shadow = newValue }
+	public var Shadow28: Shadow28AppearanceProxy {
+		get { return self.Shadow28Style() }
+		set { _Shadow28 = newValue }
 	}
-	@objc(ShadowAppearanceProxy) @objcMembers open class ShadowAppearanceProxy: NSObject {
+	@objc(Shadow28AppearanceProxy) @objcMembers open class Shadow28AppearanceProxy: NSObject {
 		public let mainProxy: () -> FluentUIStyle
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
 		}
 
-		//MARK: - shadow28
-		public var _shadow28: shadow28AppearanceProxy?
-		open func shadow28Style() -> shadow28AppearanceProxy {
-			if let override = _shadow28 { return override }
-				return shadow28AppearanceProxy(proxy: mainProxy)
+		//MARK: - shadow1
+		public var _shadow1: shadow1AppearanceProxy?
+		open func shadow1Style() -> shadow1AppearanceProxy {
+			if let override = _shadow1 { return override }
+				return shadow1AppearanceProxy(proxy: mainProxy)
 			}
-		public var shadow28: shadow28AppearanceProxy {
-			get { return self.shadow28Style() }
-			set { _shadow28 = newValue }
+		public var shadow1: shadow1AppearanceProxy {
+			get { return self.shadow1Style() }
+			set { _shadow1 = newValue }
 		}
-		@objc(ShadowShadow28AppearanceProxy) @objcMembers open class shadow28AppearanceProxy: NSObject {
+		@objc(Shadow28Shadow1AppearanceProxy) @objcMembers open class shadow1AppearanceProxy: NSObject {
 			public let mainProxy: () -> FluentUIStyle
 			public init(proxy: @escaping () -> FluentUIStyle) {
 				self.mainProxy = proxy
@@ -4313,6 +4334,79 @@ extension FluentUIThemeManagerTheming {
 			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
 				if let override = _y { return override }
 					return CGFloat(14.0)
+				}
+			public var y: CGFloat {
+				get { return self.yProperty() }
+				set { _y = newValue }
+			}
+		}
+
+
+		//MARK: - shadow2
+		public var _shadow2: shadow2AppearanceProxy?
+		open func shadow2Style() -> shadow2AppearanceProxy {
+			if let override = _shadow2 { return override }
+				return shadow2AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow2: shadow2AppearanceProxy {
+			get { return self.shadow2Style() }
+			set { _shadow2 = newValue }
+		}
+		@objc(Shadow28Shadow2AppearanceProxy) @objcMembers open class shadow2AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur 
+			public var _blur: CGFloat?
+			open func blurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur { return override }
+					return CGFloat(8.0)
+				}
+			public var blur: CGFloat {
+				get { return self.blurProperty() }
+				set { _blur = newValue }
+			}
+
+			//MARK: color 
+			public var _color: UIColor?
+			open func colorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color: UIColor {
+				get { return self.colorProperty() }
+				set { _color = newValue }
+			}
+
+			//MARK: opacity 
+			public var _opacity: CGFloat?
+			open func opacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity: CGFloat {
+				get { return self.opacityProperty() }
+				set { _opacity = newValue }
+			}
+
+			//MARK: x 
+			public var _x: CGFloat?
+			open func xProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x { return override }
+					return CGFloat(0.0)
+				}
+			public var x: CGFloat {
+				get { return self.xProperty() }
+				set { _x = newValue }
+			}
+
+			//MARK: y 
+			public var _y: CGFloat?
+			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y { return override }
+					return CGFloat(0.0)
 				}
 			public var y: CGFloat {
 				get { return self.yProperty() }

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -4232,6 +4232,17 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity24 = newValue }
 		}
 
+		//MARK: opacity28 
+		public var _opacity28: CGFloat?
+		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity28 { return override }
+			return CGFloat(0.28)
+			}
+		public var opacity28: CGFloat {
+			get { return self.opacity28Property() }
+			set { _opacity28 = newValue }
+		}
+
 		//MARK: opacity32 
 		public var _opacity32: CGFloat?
 		open func opacity32Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4241,6 +4252,28 @@ extension FluentUIThemeManagerTheming {
 		public var opacity32: CGFloat {
 			get { return self.opacity32Property() }
 			set { _opacity32 = newValue }
+		}
+
+		//MARK: opacity40 
+		public var _opacity40: CGFloat?
+		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity40 { return override }
+			return CGFloat(0.4)
+			}
+		public var opacity40: CGFloat {
+			get { return self.opacity40Property() }
+			set { _opacity40 = newValue }
+		}
+
+		//MARK: opacity48 
+		public var _opacity48: CGFloat?
+		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _opacity48 { return override }
+			return CGFloat(0.48)
+			}
+		public var opacity48: CGFloat {
+			get { return self.opacity48Property() }
+			set { _opacity48 = newValue }
 		}
 
 		//MARK: opacity64 
@@ -4313,6 +4346,262 @@ extension FluentUIThemeManagerTheming {
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
 		}
+
+		//MARK: - shadow16
+		public var _shadow16: shadow16AppearanceProxy?
+		open func shadow16Style() -> shadow16AppearanceProxy {
+			if let override = _shadow16 { return override }
+				return shadow16AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow16: shadow16AppearanceProxy {
+			get { return self.shadow16Style() }
+			set { _shadow16 = newValue }
+		}
+		@objc(ShadowShadow16AppearanceProxy) @objcMembers open class shadow16AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(16.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity24Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(8.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow2
+		public var _shadow2: shadow2AppearanceProxy?
+		open func shadow2Style() -> shadow2AppearanceProxy {
+			if let override = _shadow2 { return override }
+				return shadow2AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow2: shadow2AppearanceProxy {
+			get { return self.shadow2Style() }
+			set { _shadow2 = newValue }
+		}
+		@objc(ShadowShadow2AppearanceProxy) @objcMembers open class shadow2AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(2.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(2.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity28Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(1.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
 
 		//MARK: - shadow28
 		public var _shadow28: shadow28AppearanceProxy?
@@ -4423,6 +4712,390 @@ extension FluentUIThemeManagerTheming {
 			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
 				if let override = _y1 { return override }
 					return CGFloat(14.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow4
+		public var _shadow4: shadow4AppearanceProxy?
+		open func shadow4Style() -> shadow4AppearanceProxy {
+			if let override = _shadow4 { return override }
+				return shadow4AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow4: shadow4AppearanceProxy {
+			get { return self.shadow4Style() }
+			set { _shadow4 = newValue }
+		}
+		@objc(ShadowShadow4AppearanceProxy) @objcMembers open class shadow4AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(4.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(2.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity28Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(2.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow64
+		public var _shadow64: shadow64AppearanceProxy?
+		open func shadow64Style() -> shadow64AppearanceProxy {
+			if let override = _shadow64 { return override }
+				return shadow64AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow64: shadow64AppearanceProxy {
+			get { return self.shadow64Style() }
+			set { _shadow64 = newValue }
+		}
+		@objc(ShadowShadow64AppearanceProxy) @objcMembers open class shadow64AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(64.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity48Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity40Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(32.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
+			}
+		}
+
+
+		//MARK: - shadow8
+		public var _shadow8: shadow8AppearanceProxy?
+		open func shadow8Style() -> shadow8AppearanceProxy {
+			if let override = _shadow8 { return override }
+				return shadow8AppearanceProxy(proxy: mainProxy)
+			}
+		public var shadow8: shadow8AppearanceProxy {
+			get { return self.shadow8Style() }
+			set { _shadow8 = newValue }
+		}
+		@objc(ShadowShadow8AppearanceProxy) @objcMembers open class shadow8AppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
+			}
+
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
+					return CGFloat(8.0)
+				}
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
+			}
+
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
+					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+				}
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
+			}
+
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity28Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
+					return mainProxy().Opacity.opacity20Property(traitCollection)
+				}
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
+			}
+
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
+					return CGFloat(0.0)
+				}
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
+			}
+
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
+					return CGFloat(0.0)
+				}
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(4.0)
 				}
 			public var y1: CGFloat {
 				get { return self.y1Property() }

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -1698,6 +1698,77 @@ extension FluentUIThemeManagerTheming {
 		}
 
 	}
+	//MARK: - ElevationOpacity
+	public var _ElevationOpacity: ElevationOpacityAppearanceProxy?
+	open func ElevationOpacityStyle() -> ElevationOpacityAppearanceProxy {
+		if let override = _ElevationOpacity { return override }
+			return ElevationOpacityAppearanceProxy(proxy: { return self })
+		}
+	public var ElevationOpacity: ElevationOpacityAppearanceProxy {
+		get { return self.ElevationOpacityStyle() }
+		set { _ElevationOpacity = newValue }
+	}
+	@objc(ElevationOpacityAppearanceProxy) @objcMembers open class ElevationOpacityAppearanceProxy: NSObject {
+		public let mainProxy: () -> FluentUIStyle
+		public init(proxy: @escaping () -> FluentUIStyle) {
+			self.mainProxy = proxy
+		}
+
+		//MARK: highElevation 
+		public var _highElevation: UIColor?
+		open func highElevationProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _highElevation { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity60Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var highElevation: UIColor {
+			get { return self.highElevationProperty() }
+			set { _highElevation = newValue }
+		}
+
+		//MARK: highElevation1 
+		public var _highElevation1: UIColor?
+		open func highElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _highElevation1 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity24Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity48Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var highElevation1: UIColor {
+			get { return self.highElevation1Property() }
+			set { _highElevation1 = newValue }
+		}
+
+		//MARK: highElevation2 
+		public var _highElevation2: UIColor?
+		open func highElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _highElevation2 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity20Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var highElevation2: UIColor {
+			get { return self.highElevation2Property() }
+			set { _highElevation2 = newValue }
+		}
+
+		//MARK: lowElevation1 
+		public var _lowElevation1: UIColor?
+		open func lowElevation1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _lowElevation1 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity14Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity28Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var lowElevation1: UIColor {
+			get { return self.lowElevation1Property() }
+			set { _lowElevation1 = newValue }
+		}
+
+		//MARK: lowElevation2 
+		public var _lowElevation2: UIColor?
+		open func lowElevation2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _lowElevation2 { return override }
+			return UIColor(light: mainProxy().ShadowOpacity.opacity12Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().ShadowOpacity.opacity20Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+			}
+		public var lowElevation2: UIColor {
+			get { return self.lowElevation2Property() }
+			set { _lowElevation2 = newValue }
+		}
+	}
 	//MARK: - Icon
 	public var _Icon: IconAppearanceProxy?
 	open func IconStyle() -> IconAppearanceProxy {
@@ -3299,37 +3370,15 @@ extension FluentUIThemeManagerTheming {
 			set { _backgroundClearColor = newValue }
 		}
 
-		//MARK: backgroundClearOpacity 
-		public var _backgroundClearOpacity: CGFloat?
-		open func backgroundClearOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _backgroundClearOpacity { return override }
-			return mainProxy().Opacity.clearProperty(traitCollection)
-			}
-		public var backgroundClearOpacity: CGFloat {
-			get { return self.backgroundClearOpacityProperty() }
-			set { _backgroundClearOpacity = newValue }
-		}
-
 		//MARK: backgroundDimmedColor 
 		public var _backgroundDimmedColor: UIColor?
 		open func backgroundDimmedColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _backgroundDimmedColor { return override }
-			return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+			return mainProxy().ElevationOpacity.highElevationProperty(traitCollection)
 			}
 		public var backgroundDimmedColor: UIColor {
 			get { return self.backgroundDimmedColorProperty() }
 			set { _backgroundDimmedColor = newValue }
-		}
-
-		//MARK: backgroundDimmedOpacity 
-		public var _backgroundDimmedOpacity: CGFloat?
-		open func backgroundDimmedOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _backgroundDimmedOpacity { return override }
-			return mainProxy().Opacity.opacity64Property(traitCollection)
-			}
-		public var backgroundDimmedOpacity: CGFloat {
-			get { return self.backgroundDimmedOpacityProperty() }
-			set { _backgroundDimmedOpacity = newValue }
 		}
 
 		//MARK: shadow1Blur 
@@ -3376,17 +3425,6 @@ extension FluentUIThemeManagerTheming {
 			set { _shadow1OffsetY = newValue }
 		}
 
-		//MARK: shadow1Opacity 
-		public var _shadow1Opacity: CGFloat?
-		open func shadow1OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadow1Opacity { return override }
-			return mainProxy().Shadow.shadow28.opacity1Property(traitCollection)
-			}
-		public var shadow1Opacity: CGFloat {
-			get { return self.shadow1OpacityProperty() }
-			set { _shadow1Opacity = newValue }
-		}
-
 		//MARK: shadow2Blur 
 		public var _shadow2Blur: CGFloat?
 		open func shadow2BlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -3429,17 +3467,6 @@ extension FluentUIThemeManagerTheming {
 		public var shadow2OffsetY: CGFloat {
 			get { return self.shadow2OffsetYProperty() }
 			set { _shadow2OffsetY = newValue }
-		}
-
-		//MARK: shadow2Opacity 
-		public var _shadow2Opacity: CGFloat?
-		open func shadow2OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _shadow2Opacity { return override }
-			return mainProxy().Shadow.shadow28.opacity2Property(traitCollection)
-			}
-		public var shadow2Opacity: CGFloat {
-			get { return self.shadow2OpacityProperty() }
-			set { _shadow2Opacity = newValue }
 		}
 	}
 	//MARK: - MSFGhostButtonTokens
@@ -4210,17 +4237,6 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity16 = newValue }
 		}
 
-		//MARK: opacity20 
-		public var _opacity20: CGFloat?
-		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity20 { return override }
-			return CGFloat(0.2)
-			}
-		public var opacity20: CGFloat {
-			get { return self.opacity20Property() }
-			set { _opacity20 = newValue }
-		}
-
 		//MARK: opacity24 
 		public var _opacity24: CGFloat?
 		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4232,17 +4248,6 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity24 = newValue }
 		}
 
-		//MARK: opacity28 
-		public var _opacity28: CGFloat?
-		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity28 { return override }
-			return CGFloat(0.28)
-			}
-		public var opacity28: CGFloat {
-			get { return self.opacity28Property() }
-			set { _opacity28 = newValue }
-		}
-
 		//MARK: opacity32 
 		public var _opacity32: CGFloat?
 		open func opacity32Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
@@ -4252,28 +4257,6 @@ extension FluentUIThemeManagerTheming {
 		public var opacity32: CGFloat {
 			get { return self.opacity32Property() }
 			set { _opacity32 = newValue }
-		}
-
-		//MARK: opacity40 
-		public var _opacity40: CGFloat?
-		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity40 { return override }
-			return CGFloat(0.4)
-			}
-		public var opacity40: CGFloat {
-			get { return self.opacity40Property() }
-			set { _opacity40 = newValue }
-		}
-
-		//MARK: opacity48 
-		public var _opacity48: CGFloat?
-		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-			if let override = _opacity48 { return override }
-			return CGFloat(0.48)
-			}
-		public var opacity48: CGFloat {
-			get { return self.opacity48Property() }
-			set { _opacity48 = newValue }
 		}
 
 		//MARK: opacity64 
@@ -4389,7 +4372,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4400,33 +4383,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity24Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4517,7 +4478,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4528,33 +4489,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity28Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4645,7 +4584,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4656,33 +4595,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity24Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4773,7 +4690,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4784,33 +4701,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity28Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -4901,7 +4796,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -4912,33 +4807,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.highElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity48Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity40Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -5029,7 +4902,7 @@ extension FluentUIThemeManagerTheming {
 			public var _color1: UIColor?
 			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color1 { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation1Property(traitCollection)
 				}
 			public var color1: UIColor {
 				get { return self.color1Property() }
@@ -5040,33 +4913,11 @@ extension FluentUIThemeManagerTheming {
 			public var _color2: UIColor?
 			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _color2 { return override }
-					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
+					return mainProxy().ElevationOpacity.lowElevation2Property(traitCollection)
 				}
 			public var color2: UIColor {
 				get { return self.color2Property() }
 				set { _color2 = newValue }
-			}
-
-			//MARK: opacity1 
-			public var _opacity1: CGFloat?
-			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity1 { return override }
-					return mainProxy().Opacity.opacity28Property(traitCollection)
-				}
-			public var opacity1: CGFloat {
-				get { return self.opacity1Property() }
-				set { _opacity1 = newValue }
-			}
-
-			//MARK: opacity2 
-			public var _opacity2: CGFloat?
-			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity2 { return override }
-					return mainProxy().Opacity.opacity20Property(traitCollection)
-				}
-			public var opacity2: CGFloat {
-				get { return self.opacity2Property() }
-				set { _opacity2 = newValue }
 			}
 
 			//MARK: x1 
@@ -5114,6 +4965,132 @@ extension FluentUIThemeManagerTheming {
 			}
 		}
 
+	}
+	//MARK: - ShadowOpacity
+	public var _ShadowOpacity: ShadowOpacityAppearanceProxy?
+	open func ShadowOpacityStyle() -> ShadowOpacityAppearanceProxy {
+		if let override = _ShadowOpacity { return override }
+			return ShadowOpacityAppearanceProxy(proxy: { return self })
+		}
+	public var ShadowOpacity: ShadowOpacityAppearanceProxy {
+		get { return self.ShadowOpacityStyle() }
+		set { _ShadowOpacity = newValue }
+	}
+	@objc(ShadowOpacityAppearanceProxy) @objcMembers open class ShadowOpacityAppearanceProxy: NSObject {
+		public let mainProxy: () -> FluentUIStyle
+		public init(proxy: @escaping () -> FluentUIStyle) {
+			self.mainProxy = proxy
+		}
+
+		//MARK: clear 
+		public var _clear: UIColor?
+		open func clearProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _clear { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+			}
+		public var clear: UIColor {
+			get { return self.clearProperty() }
+			set { _clear = newValue }
+		}
+
+		//MARK: opacity12 
+		public var _opacity12: UIColor?
+		open func opacity12Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity12 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.01)
+			}
+		public var opacity12: UIColor {
+			get { return self.opacity12Property() }
+			set { _opacity12 = newValue }
+		}
+
+		//MARK: opacity14 
+		public var _opacity14: UIColor?
+		open func opacity14Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity14 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.24)
+			}
+		public var opacity14: UIColor {
+			get { return self.opacity14Property() }
+			set { _opacity14 = newValue }
+		}
+
+		//MARK: opacity20 
+		public var _opacity20: UIColor?
+		open func opacity20Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity20 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.33)
+			}
+		public var opacity20: UIColor {
+			get { return self.opacity20Property() }
+			set { _opacity20 = newValue }
+		}
+
+		//MARK: opacity24 
+		public var _opacity24: UIColor?
+		open func opacity24Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity24 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.03)
+			}
+		public var opacity24: UIColor {
+			get { return self.opacity24Property() }
+			set { _opacity24 = newValue }
+		}
+
+		//MARK: opacity28 
+		public var _opacity28: UIColor?
+		open func opacity28Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity28 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.47)
+			}
+		public var opacity28: UIColor {
+			get { return self.opacity28Property() }
+			set { _opacity28 = newValue }
+		}
+
+		//MARK: opacity40 
+		public var _opacity40: UIColor?
+		open func opacity40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity40 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.66)
+			}
+		public var opacity40: UIColor {
+			get { return self.opacity40Property() }
+			set { _opacity40 = newValue }
+		}
+
+		//MARK: opacity48 
+		public var _opacity48: UIColor?
+		open func opacity48Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity48 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.07)
+			}
+		public var opacity48: UIColor {
+			get { return self.opacity48Property() }
+			set { _opacity48 = newValue }
+		}
+
+		//MARK: opacity60 
+		public var _opacity60: UIColor?
+		open func opacity60Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opacity60 { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.99)
+			}
+		public var opacity60: UIColor {
+			get { return self.opacity60Property() }
+			set { _opacity60 = newValue }
+		}
+
+		//MARK: opaque 
+		public var _opaque: UIColor?
+		open func opaqueProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _opaque { return override }
+			return UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+			}
+		public var opaque: UIColor {
+			get { return self.opaqueProperty() }
+			set { _opaque = newValue }
+		}
 	}
 	//MARK: - Spacing
 	public var _Spacing: SpacingAppearanceProxy?

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -3332,69 +3332,114 @@ extension FluentUIThemeManagerTheming {
 			set { _backgroundDimmedOpacity = newValue }
 		}
 
-		//MARK: shadowBlur 
-		public var _shadowBlur: [CGFloat]?
-		open func shadowBlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowBlur { return override }
-			return [
-			mainProxy().Shadow28.shadow1.blurProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.blurProperty(traitCollection)]
+		//MARK: shadow1Blur 
+		public var _shadow1Blur: CGFloat?
+		open func shadow1BlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1Blur { return override }
+			return mainProxy().Shadow.shadow28.blur1Property(traitCollection)
 			}
-		public var shadowBlur: [CGFloat] {
-			get { return self.shadowBlurProperty() }
-			set { _shadowBlur = newValue }
+		public var shadow1Blur: CGFloat {
+			get { return self.shadow1BlurProperty() }
+			set { _shadow1Blur = newValue }
 		}
 
-		//MARK: shadowColor 
-		public var _shadowColor: [UIColor]?
-		open func shadowColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
-			if let override = _shadowColor { return override }
-			return [
-			mainProxy().Shadow28.shadow1.colorProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.colorProperty(traitCollection)]
+		//MARK: shadow1Color 
+		public var _shadow1Color: UIColor?
+		open func shadow1ColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _shadow1Color { return override }
+			return mainProxy().Shadow.shadow28.color1Property(traitCollection)
 			}
-		public var shadowColor: [UIColor] {
-			get { return self.shadowColorProperty() }
-			set { _shadowColor = newValue }
+		public var shadow1Color: UIColor {
+			get { return self.shadow1ColorProperty() }
+			set { _shadow1Color = newValue }
 		}
 
-		//MARK: shadowOffsetX 
-		public var _shadowOffsetX: [CGFloat]?
-		open func shadowOffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowOffsetX { return override }
-			return [
-			mainProxy().Shadow28.shadow1.xProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.xProperty(traitCollection)]
+		//MARK: shadow1OffsetX 
+		public var _shadow1OffsetX: CGFloat?
+		open func shadow1OffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1OffsetX { return override }
+			return mainProxy().Shadow.shadow28.x1Property(traitCollection)
 			}
-		public var shadowOffsetX: [CGFloat] {
-			get { return self.shadowOffsetXProperty() }
-			set { _shadowOffsetX = newValue }
+		public var shadow1OffsetX: CGFloat {
+			get { return self.shadow1OffsetXProperty() }
+			set { _shadow1OffsetX = newValue }
 		}
 
-		//MARK: shadowOffsetY 
-		public var _shadowOffsetY: [CGFloat]?
-		open func shadowOffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowOffsetY { return override }
-			return [
-			mainProxy().Shadow28.shadow1.yProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.yProperty(traitCollection)]
+		//MARK: shadow1OffsetY 
+		public var _shadow1OffsetY: CGFloat?
+		open func shadow1OffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1OffsetY { return override }
+			return mainProxy().Shadow.shadow28.y1Property(traitCollection)
 			}
-		public var shadowOffsetY: [CGFloat] {
-			get { return self.shadowOffsetYProperty() }
-			set { _shadowOffsetY = newValue }
+		public var shadow1OffsetY: CGFloat {
+			get { return self.shadow1OffsetYProperty() }
+			set { _shadow1OffsetY = newValue }
 		}
 
-		//MARK: shadowOpacity 
-		public var _shadowOpacity: [CGFloat]?
-		open func shadowOpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [CGFloat] {
-			if let override = _shadowOpacity { return override }
-			return [
-			mainProxy().Shadow28.shadow1.opacityProperty(traitCollection), 
-			mainProxy().Shadow28.shadow2.opacityProperty(traitCollection)]
+		//MARK: shadow1Opacity 
+		public var _shadow1Opacity: CGFloat?
+		open func shadow1OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow1Opacity { return override }
+			return mainProxy().Shadow.shadow28.opacity1Property(traitCollection)
 			}
-		public var shadowOpacity: [CGFloat] {
-			get { return self.shadowOpacityProperty() }
-			set { _shadowOpacity = newValue }
+		public var shadow1Opacity: CGFloat {
+			get { return self.shadow1OpacityProperty() }
+			set { _shadow1Opacity = newValue }
+		}
+
+		//MARK: shadow2Blur 
+		public var _shadow2Blur: CGFloat?
+		open func shadow2BlurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2Blur { return override }
+			return mainProxy().Shadow.shadow28.blur2Property(traitCollection)
+			}
+		public var shadow2Blur: CGFloat {
+			get { return self.shadow2BlurProperty() }
+			set { _shadow2Blur = newValue }
+		}
+
+		//MARK: shadow2Color 
+		public var _shadow2Color: UIColor?
+		open func shadow2ColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+			if let override = _shadow2Color { return override }
+			return mainProxy().Shadow.shadow28.color2Property(traitCollection)
+			}
+		public var shadow2Color: UIColor {
+			get { return self.shadow2ColorProperty() }
+			set { _shadow2Color = newValue }
+		}
+
+		//MARK: shadow2OffsetX 
+		public var _shadow2OffsetX: CGFloat?
+		open func shadow2OffsetXProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2OffsetX { return override }
+			return mainProxy().Shadow.shadow28.x2Property(traitCollection)
+			}
+		public var shadow2OffsetX: CGFloat {
+			get { return self.shadow2OffsetXProperty() }
+			set { _shadow2OffsetX = newValue }
+		}
+
+		//MARK: shadow2OffsetY 
+		public var _shadow2OffsetY: CGFloat?
+		open func shadow2OffsetYProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2OffsetY { return override }
+			return mainProxy().Shadow.shadow28.y2Property(traitCollection)
+			}
+		public var shadow2OffsetY: CGFloat {
+			get { return self.shadow2OffsetYProperty() }
+			set { _shadow2OffsetY = newValue }
+		}
+
+		//MARK: shadow2Opacity 
+		public var _shadow2Opacity: CGFloat?
+		open func shadow2OpacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+			if let override = _shadow2Opacity { return override }
+			return mainProxy().Shadow.shadow28.opacity2Property(traitCollection)
+			}
+		public var shadow2Opacity: CGFloat {
+			get { return self.shadow2OpacityProperty() }
+			set { _shadow2Opacity = newValue }
 		}
 	}
 	//MARK: - MSFGhostButtonTokens
@@ -4253,164 +4298,146 @@ extension FluentUIThemeManagerTheming {
 			set { _opacity96 = newValue }
 		}
 	}
-	//MARK: - Shadow28
-	public var _Shadow28: Shadow28AppearanceProxy?
-	open func Shadow28Style() -> Shadow28AppearanceProxy {
-		if let override = _Shadow28 { return override }
-			return Shadow28AppearanceProxy(proxy: { return self })
+	//MARK: - Shadow
+	public var _Shadow: ShadowAppearanceProxy?
+	open func ShadowStyle() -> ShadowAppearanceProxy {
+		if let override = _Shadow { return override }
+			return ShadowAppearanceProxy(proxy: { return self })
 		}
-	public var Shadow28: Shadow28AppearanceProxy {
-		get { return self.Shadow28Style() }
-		set { _Shadow28 = newValue }
+	public var Shadow: ShadowAppearanceProxy {
+		get { return self.ShadowStyle() }
+		set { _Shadow = newValue }
 	}
-	@objc(Shadow28AppearanceProxy) @objcMembers open class Shadow28AppearanceProxy: NSObject {
+	@objc(ShadowAppearanceProxy) @objcMembers open class ShadowAppearanceProxy: NSObject {
 		public let mainProxy: () -> FluentUIStyle
 		public init(proxy: @escaping () -> FluentUIStyle) {
 			self.mainProxy = proxy
 		}
 
-		//MARK: - shadow1
-		public var _shadow1: shadow1AppearanceProxy?
-		open func shadow1Style() -> shadow1AppearanceProxy {
-			if let override = _shadow1 { return override }
-				return shadow1AppearanceProxy(proxy: mainProxy)
+		//MARK: - shadow28
+		public var _shadow28: shadow28AppearanceProxy?
+		open func shadow28Style() -> shadow28AppearanceProxy {
+			if let override = _shadow28 { return override }
+				return shadow28AppearanceProxy(proxy: mainProxy)
 			}
-		public var shadow1: shadow1AppearanceProxy {
-			get { return self.shadow1Style() }
-			set { _shadow1 = newValue }
+		public var shadow28: shadow28AppearanceProxy {
+			get { return self.shadow28Style() }
+			set { _shadow28 = newValue }
 		}
-		@objc(Shadow28Shadow1AppearanceProxy) @objcMembers open class shadow1AppearanceProxy: NSObject {
+		@objc(ShadowShadow28AppearanceProxy) @objcMembers open class shadow28AppearanceProxy: NSObject {
 			public let mainProxy: () -> FluentUIStyle
 			public init(proxy: @escaping () -> FluentUIStyle) {
 				self.mainProxy = proxy
 			}
 
-			//MARK: blur 
-			public var _blur: CGFloat?
-			open func blurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _blur { return override }
+			//MARK: blur1 
+			public var _blur1: CGFloat?
+			open func blur1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur1 { return override }
 					return CGFloat(28.0)
 				}
-			public var blur: CGFloat {
-				get { return self.blurProperty() }
-				set { _blur = newValue }
+			public var blur1: CGFloat {
+				get { return self.blur1Property() }
+				set { _blur1 = newValue }
 			}
 
-			//MARK: color 
-			public var _color: UIColor?
-			open func colorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-				if let override = _color { return override }
-					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
-				}
-			public var color: UIColor {
-				get { return self.colorProperty() }
-				set { _color = newValue }
-			}
-
-			//MARK: opacity 
-			public var _opacity: CGFloat?
-			open func opacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity { return override }
-					return mainProxy().Opacity.opacity24Property(traitCollection)
-				}
-			public var opacity: CGFloat {
-				get { return self.opacityProperty() }
-				set { _opacity = newValue }
-			}
-
-			//MARK: x 
-			public var _x: CGFloat?
-			open func xProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _x { return override }
-					return CGFloat(0.0)
-				}
-			public var x: CGFloat {
-				get { return self.xProperty() }
-				set { _x = newValue }
-			}
-
-			//MARK: y 
-			public var _y: CGFloat?
-			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _y { return override }
-					return CGFloat(14.0)
-				}
-			public var y: CGFloat {
-				get { return self.yProperty() }
-				set { _y = newValue }
-			}
-		}
-
-
-		//MARK: - shadow2
-		public var _shadow2: shadow2AppearanceProxy?
-		open func shadow2Style() -> shadow2AppearanceProxy {
-			if let override = _shadow2 { return override }
-				return shadow2AppearanceProxy(proxy: mainProxy)
-			}
-		public var shadow2: shadow2AppearanceProxy {
-			get { return self.shadow2Style() }
-			set { _shadow2 = newValue }
-		}
-		@objc(Shadow28Shadow2AppearanceProxy) @objcMembers open class shadow2AppearanceProxy: NSObject {
-			public let mainProxy: () -> FluentUIStyle
-			public init(proxy: @escaping () -> FluentUIStyle) {
-				self.mainProxy = proxy
-			}
-
-			//MARK: blur 
-			public var _blur: CGFloat?
-			open func blurProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _blur { return override }
+			//MARK: blur2 
+			public var _blur2: CGFloat?
+			open func blur2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _blur2 { return override }
 					return CGFloat(8.0)
 				}
-			public var blur: CGFloat {
-				get { return self.blurProperty() }
-				set { _blur = newValue }
+			public var blur2: CGFloat {
+				get { return self.blur2Property() }
+				set { _blur2 = newValue }
 			}
 
-			//MARK: color 
-			public var _color: UIColor?
-			open func colorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-				if let override = _color { return override }
+			//MARK: color1 
+			public var _color1: UIColor?
+			open func color1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color1 { return override }
+					return mainProxy().Colors.Neutral.blackProperty(traitCollection)
+				}
+			public var color1: UIColor {
+				get { return self.color1Property() }
+				set { _color1 = newValue }
+			}
+
+			//MARK: color2 
+			public var _color2: UIColor?
+			open func color2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _color2 { return override }
 					return mainProxy().Colors.Neutral.clearProperty(traitCollection)
 				}
-			public var color: UIColor {
-				get { return self.colorProperty() }
-				set { _color = newValue }
+			public var color2: UIColor {
+				get { return self.color2Property() }
+				set { _color2 = newValue }
 			}
 
-			//MARK: opacity 
-			public var _opacity: CGFloat?
-			open func opacityProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _opacity { return override }
+			//MARK: opacity1 
+			public var _opacity1: CGFloat?
+			open func opacity1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity1 { return override }
+					return mainProxy().Opacity.opacity24Property(traitCollection)
+				}
+			public var opacity1: CGFloat {
+				get { return self.opacity1Property() }
+				set { _opacity1 = newValue }
+			}
+
+			//MARK: opacity2 
+			public var _opacity2: CGFloat?
+			open func opacity2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _opacity2 { return override }
 					return mainProxy().Opacity.opacity20Property(traitCollection)
 				}
-			public var opacity: CGFloat {
-				get { return self.opacityProperty() }
-				set { _opacity = newValue }
+			public var opacity2: CGFloat {
+				get { return self.opacity2Property() }
+				set { _opacity2 = newValue }
 			}
 
-			//MARK: x 
-			public var _x: CGFloat?
-			open func xProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _x { return override }
+			//MARK: x1 
+			public var _x1: CGFloat?
+			open func x1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x1 { return override }
 					return CGFloat(0.0)
 				}
-			public var x: CGFloat {
-				get { return self.xProperty() }
-				set { _x = newValue }
+			public var x1: CGFloat {
+				get { return self.x1Property() }
+				set { _x1 = newValue }
 			}
 
-			//MARK: y 
-			public var _y: CGFloat?
-			open func yProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
-				if let override = _y { return override }
+			//MARK: x2 
+			public var _x2: CGFloat?
+			open func x2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _x2 { return override }
 					return CGFloat(0.0)
 				}
-			public var y: CGFloat {
-				get { return self.yProperty() }
-				set { _y = newValue }
+			public var x2: CGFloat {
+				get { return self.x2Property() }
+				set { _x2 = newValue }
+			}
+
+			//MARK: y1 
+			public var _y1: CGFloat?
+			open func y1Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y1 { return override }
+					return CGFloat(14.0)
+				}
+			public var y1: CGFloat {
+				get { return self.y1Property() }
+				set { _y1 = newValue }
+			}
+
+			//MARK: y2 
+			public var _y2: CGFloat?
+			open func y2Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
+				if let override = _y2 { return override }
+					return CGFloat(0.0)
+				}
+			public var y2: CGFloat {
+				get { return self.y2Property() }
+				set { _y2 = newValue }
 			}
 		}
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Bugfix to issue #358 

Adding design token for Shadow28 variant. Figma files conform to CSS [box-shadow](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) method that allows to add multiple shadows to a component. 

The current changes apply dual shadows as opposed to one (marked in red). The illustrate the effect of combined shadow effect I have added a different color. 

**First Shadow**
![Screen Shot 2021-01-28 at 11 06 45 AM](https://user-images.githubusercontent.com/63682282/106186861-b4e7b600-6159-11eb-8ca9-715d5873c79c.png)
**Second Shadow**
![Screen Shot 2021-01-28 at 11 08 56 AM](https://user-images.githubusercontent.com/63682282/106186863-b6b17980-6159-11eb-9a44-bd61370aa90f.png)

**Combined Shadow**
![Screen Shot 2021-01-28 at 11 06 05 AM](https://user-images.githubusercontent.com/63682282/106186856-b31df280-6159-11eb-80cc-9eb6f3456e49.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/414)