### PR TITLE
Fix for DrawerController crash when UIView.areAnimationsEnabled is false

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -702,6 +702,7 @@ open class DrawerController: UIViewController {
             }
         }
     }
+
     private var resizingGestureRecognizer: UIPanGestureRecognizer? {
         didSet {
             if let oldRecognizer = oldValue {
@@ -950,14 +951,14 @@ open class DrawerController: UIViewController {
 
 extension DrawerController: UIViewControllerTransitioningDelegate {
     public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if presentationStyle(for: source) == .slideover {
+        if presentationStyle(for: source) == .slideover && UIView.areAnimationsEnabled {
             return DrawerTransitionAnimator(presenting: true, presentationDirection: presentationDirection(for: source.view), containerOffset: shadowOffset)
         }
         return nil
     }
 
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if let controller = dismissed.presentationController as? DrawerPresentationController {
+        if let controller = dismissed.presentationController as? DrawerPresentationController, UIView.areAnimationsEnabled {
             return DrawerTransitionAnimator(presenting: false, presentationDirection: controller.presentationDirection, containerOffset: shadowOffset)
         }
         return nil

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -54,7 +54,7 @@ public extension PillButton {
             return UIColor(light: Colors.primaryShade20(for: window), dark: Colors.surfaceQuaternary)
         }
     }
- 
+
     // MARK: selected state
 
     static func selectedBackgroundColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
@@ -85,7 +85,7 @@ public extension PillButton {
             return UIColor(light: Colors.primaryShade10(for: window), dark: normalBackgroundColor(for: window, for: style))
         }
     }
-    
+
     static func disabledTitleColor(for window: UIWindow, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

One of our client apps reported that a crash happens when the [UIView.areAnimationsEnabled](https://developer.apple.com/documentation/uikit/uiview/1622571-areanimationsenabled)is false (scenario they explicitly exercise in their XCUITests.

```
We are disabling animation for some XCUITest in AppDelegate's applications:didFinishLaunchingWithOptions: method,
[UIView setAnimationsEnabled:FALSE];
But when we present DrawerController,
[self presentViewController:filterDrawerController animated:YES completion:nil];
We get the following error because of forced unwrapping of optional,

"Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value"
in DrawerTransitionAnimator's presentWithTransitionContext method(https://github.com/microsoft/fluentui-apple/blob/d4a86fa93f3d118805ae4a7fa6d1881c37677840/ios/FluentUI/Drawer/DrawerTransitionAnimator.swift#L41)
```


The crash happens because the Drawer controller returns the DrawerTransitionAnimator regardless of that UIView static property, which causes the control to incorrectly use the code path for when animations are being used.

### Verification

[Set the property](https://developer.apple.com/documentation/uikit/uiview/1622420-setanimationsenabled) to false and ensured that all the Drawer functionality remains intact while not animating its transitions:

UIView.areAnimationsEnabled: **true**

https://user-images.githubusercontent.com/68076145/106203348-174bb100-6170-11eb-8189-f6ce5efd405b.mov


UIView.areAnimationsEnabled: **false** 

https://user-images.githubusercontent.com/68076145/106203407-2df20800-6170-11eb-8027-9d1b71b93349.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/417)