### PR TITLE
unwrap optionals safely

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -76,7 +76,7 @@ class DemoController: UIViewController {
         itemRow.alignment = .center
         itemRow.spacing = itemSpacing
 
-        if text != "" {
+        if !text.isEmpty {
             let label = Label(style: textStyle, colorStyle: .regular)
             label.text = text
             label.widthAnchor.constraint(equalToConstant: textWidth).isActive = true

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -37,8 +37,8 @@ class DemoListViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        guard let title = FluentUIFramework.bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String else { 
+
+        guard let title = FluentUIFramework.bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String else {
             return assertionFailure("CFBundleExecutable is nil")
         }
         let titleView = TwoLineTitleView()

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -9,11 +9,11 @@ import FluentUI
 class DemoListViewController: UITableViewController {
 
     static func addDemoListTo(window: UIWindow, pushing viewController: UIViewController?) {
-        if let colorProvider = window as? ColorProviding {
+        if let colorProvider = window as? ColorProviding, let primaryColor = colorProvider.primaryColor(for: window) {
             Colors.setProvider(provider: colorProvider, for: window)
-            FluentUIFramework.initializeAppearance(with: colorProvider.primaryColor(for: window)!, whenContainedInInstancesOf: [type(of: window)])
+            FluentUIFramework.initializeAppearance(with: primaryColor, whenContainedInInstancesOf: [type(of: window)])
         } else {
-            FluentUIFramework.initializeAppearance()
+            FluentUIFramework.initializeAppearance(with: Colors.primary(for: window))
         }
 
         let demoListViewController = DemoListViewController(nibName: nil, bundle: nil)
@@ -37,9 +37,13 @@ class DemoListViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        guard let title = FluentUIFramework.bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as? String else { 
+            return assertionFailure("CFBundleExecutable is nil")
+        }
         let titleView = TwoLineTitleView()
         titleView.setup(
-            title: FluentUIFramework.bundle.object(forInfoDictionaryKey: "CFBundleExecutable") as! String,
+            title: title,
             subtitle: FluentUIFramework.bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         )
         navigationItem.titleView = titleView
@@ -75,7 +79,9 @@ class DemoListViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath) as! TableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath) as? TableViewCell else {
+            return UITableViewCell()
+        }
         cell.setup(title: demos[indexPath.row].title, accessoryType: .disclosureIndicator)
         cell.titleNumberOfLinesForLargerDynamicType = 2
         return cell

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -139,16 +139,16 @@ class ColorDemoController: UIViewController {
     @objc private func segmentedControlValueChanged(sender: Any) {
         if let segmentedControl = sender as? SegmentedControl {
             let windowType = colorProviderThemedWindowTypes[segmentedControl.selectedSegmentIndex].windowType
-            let colorThemeHost: ColorThemeHosting
+            let colorThemeHost: ColorThemeHosting?
             if #available(iOS 13, *) {
-                colorThemeHost = view.window?.windowScene?.delegate as! ColorThemeHosting
+                colorThemeHost = view.window?.windowScene?.delegate as? ColorThemeHosting
             } else {
-                colorThemeHost = UIApplication.shared.delegate as! ColorThemeHosting
+                colorThemeHost = UIApplication.shared.delegate as? ColorThemeHosting
             }
 
             if let navigationController = navigationController {
                 navigationController.popViewController(animated: false)
-                colorThemeHost.updateToWindowWith(type: windowType, pushing: self)
+                colorThemeHost?.updateToWindowWith(type: windowType, pushing: self)
             }
         }
     }
@@ -162,9 +162,9 @@ class ColorDemoController: UIViewController {
 
 extension ColorDemoController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let section = sections[section]
-        header.setup(style: .header, title: section.text)
+        header?.setup(style: .header, title: section.text)
         return header
     }
 }
@@ -181,7 +181,9 @@ extension ColorDemoController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as! TableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
+            return UITableViewCell()
+        }
 
         let section = sections[indexPath.section]
         let colorView = section.colorViews[indexPath.row]

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -205,7 +205,7 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showTopDrawerCustomOffsetButtonTapped(sender: UIButton) {
-        let rect = sender.superview!.convert(sender.frame, to: nil)
+        guard let rect = sender.superview?.convert(sender.frame, to: nil) else { return }
         presentDrawer(sourceView: sender, presentationOrigin: rect.maxY, presentationDirection: .down, contentView: containerForActionViews(), customWidth: true)
     }
 
@@ -250,7 +250,7 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showBottomDrawerCustomOffsetButtonTapped(sender: UIButton) {
-        let rect = sender.superview!.convert(sender.frame, to: nil)
+        guard let rect = sender.superview?.convert(sender.frame, to: nil) else { return }
         presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -205,7 +205,9 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showTopDrawerCustomOffsetButtonTapped(sender: UIButton) {
-        guard let rect = sender.superview?.convert(sender.frame, to: nil) else { return }
+        guard let rect = sender.superview?.convert(sender.frame, to: nil) else {
+            return
+        }
         presentDrawer(sourceView: sender, presentationOrigin: rect.maxY, presentationDirection: .down, contentView: containerForActionViews(), customWidth: true)
     }
 
@@ -250,7 +252,9 @@ class DrawerDemoController: DemoController {
     }
 
     @objc private func showBottomDrawerCustomOffsetButtonTapped(sender: UIButton) {
-        guard let rect = sender.superview?.convert(sender.frame, to: nil) else { return }
+        guard let rect = sender.superview?.convert(sender.frame, to: nil) else {
+            return
+        }
         presentDrawer(sourceView: sender, presentationOrigin: rect.minY, presentationDirection: .up, contentView: containerForActionViews(), resizingBehavior: .dismissOrExpand)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -120,8 +120,7 @@ class NavigationControllerDemoController: DemoController {
             content.allowsCellSelection = true
         }
 
-        if accessoryView != nil {
-            let searchBarView = accessoryView as! SearchBar
+        if let searchBarView = accessoryView as? SearchBar {
             searchBarView.delegate = content
         }
 
@@ -337,14 +336,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         if showsTopAccessoryView {
             let showTopAccessoryView = view.frame.size.width >= Constants.topAccessoryViewWidthThreshold
 
-            if showTopAccessoryView && navigationItem.accessoryView != nil {
-                let accessoryView = navigationItem.accessoryView as! SearchBar
+            if let accessoryView = navigationItem.accessoryView as? SearchBar, showTopAccessoryView {
                 accessoryView.hidesNavigationBarDuringSearch = false
-
                 navigationItem.accessoryView = nil
                 navigationItem.topAccessoryView = accessoryView
-            } else if !showTopAccessoryView && navigationItem.topAccessoryView != nil {
-                let accessoryView = navigationItem.topAccessoryView as! SearchBar
+            } else if let accessoryView = navigationItem.topAccessoryView as? SearchBar, !showTopAccessoryView {
                 accessoryView.hidesNavigationBarDuringSearch = true
 
                 navigationItem.topAccessoryView = nil
@@ -358,7 +354,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as! TableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as? TableViewCell else {
+            return UITableViewCell()
+        }
         let imageView = UIImageView(image: UIImage(named: "excelIcon"))
         cell.setup(title: "Cell #\(1 + indexPath.row)", customView: imageView, accessoryType: .disclosureIndicator)
         cell.isInSelectionMode = isInSelectionMode
@@ -484,7 +482,9 @@ class ChildViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as! TableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as? TableViewCell else {
+            return UITableViewCell()
+        }
         cell.setup(title: "Child Cell #\(1 + indexPath.row)")
         return cell
     }
@@ -540,7 +540,9 @@ class ModalViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as! TableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as? TableViewCell else {
+            return UITableViewCell()
+        }
         cell.setup(title: "Child Cell #\(1 + indexPath.row)")
         cell.backgroundColor = isGrouped ? Colors.Table.Cell.backgroundGrouped : Colors.Table.Cell.background
         cell.topSeparatorType = isGrouped && indexPath.row == 0 ? .full : .none
@@ -552,8 +554,8 @@ class ModalViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
-        header.setup(style: .header, title: "Section Header")
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
+        header?.setup(style: .header, title: "Section Header")
         return header
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -63,7 +63,9 @@ extension OtherCellsDemoController: UITableViewDataSource {
         }
 
         if section.title == "BooleanCell" {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
+                return UITableViewCell()
+            }
             cell.setup(title: item.text1, customView: TableViewSampleData.createCustomView(imageName: item.image, useImageAsTemplate: true), isOn: indexPath.row == 0)
             cell.onValueChanged = { [unowned self, unowned cell] in
                 self.showAlertForSwitchTapped(isOn: cell.isOn)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -48,19 +48,22 @@ extension OtherCellsDemoController: UITableViewDataSource {
         let item = section.items[indexPath.row]
 
         if section.title == "ActionsCell" {
-            let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier) as! ActionsCell
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier) as? ActionsCell else {
+                return UITableViewCell()
+            }
             cell.setup(action1Title: item.text1, action2Title: item.text2, action2Type: .destructive)
             let isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
             cell.bottomSeparatorType = isLastInSection ? .full : .inset
             return cell
         }
 
-        if section.title == "ActivityIndicatorCell" {
-            return tableView.dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier) as! ActivityIndicatorCell
+        if let cell = tableView.dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier) as? ActivityIndicatorCell,
+           section.title == "ActivityIndicatorCell" {
+            return cell
         }
 
         if section.title == "BooleanCell" {
-            let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as! BooleanCell
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else { return UITableViewCell() }
             cell.setup(title: item.text1, customView: TableViewSampleData.createCustomView(imageName: item.image, useImageAsTemplate: true), isOn: indexPath.row == 0)
             cell.onValueChanged = { [unowned self, unowned cell] in
                 self.showAlertForSwitchTapped(isOn: cell.isOn)
@@ -69,7 +72,9 @@ extension OtherCellsDemoController: UITableViewDataSource {
         }
 
         if section.title == "CenteredLabelCell" {
-            let cell = tableView.dequeueReusableCell(withIdentifier: CenteredLabelCell.identifier) as! CenteredLabelCell
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: CenteredLabelCell.identifier) as? CenteredLabelCell else {
+                return UITableViewCell()
+            }
             cell.setup(text: item.text1)
             return cell
         }
@@ -90,9 +95,9 @@ extension OtherCellsDemoController: UITableViewDataSource {
 
 extension OtherCellsDemoController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let section = sections[section]
-        header.setup(style: section.headerStyle, title: section.title)
+        header?.setup(style: section.headerStyle, title: section.title)
         return header
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -145,18 +145,21 @@ class PillButtonBarDemoController: DemoController {
     }
 
     @objc private func toggleOnBrandPills(switchView: UISwitch) {
-        let pillBar = self.onBrandBar?.subviews[0] as! PillButtonBar
-        togglePills(pillBar: pillBar, enable: switchView.isOn)
+        if let pillBar = self.onBrandBar?.subviews.first as? PillButtonBar {
+            togglePills(pillBar: pillBar, enable: switchView.isOn)
+        }
     }
 
     @objc private func toggleCustomOnBrandPills(switchView: UISwitch) {
-        let pillBar = self.customBar?.subviews[0] as! PillButtonBar
-        togglePills(pillBar: pillBar, enable: switchView.isOn)
+        if let pillBar = self.customBar?.subviews.first as? PillButtonBar {
+            togglePills(pillBar: pillBar, enable: switchView.isOn)
+        }
     }
 
     @objc private func togglePrimaryPills(switchView: UISwitch) {
-        let pillBar = self.primaryBar?.subviews[0] as! PillButtonBar
-        togglePills(pillBar: pillBar, enable: switchView.isOn)
+        if let pillBar = self.primaryBar?.subviews.first as? PillButtonBar {
+            togglePills(pillBar: pillBar, enable: switchView.isOn)
+        }
     }
 
     private var onBrandBar: UIView?

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -175,10 +175,10 @@ class SideTabBarDemoController: DemoController {
 
     private func showAvatarView(_ show: Bool) {
         var avatarView: AvatarView?
-        if show {
+        if let image = UIImage(named: "avatar_kat_larsson"), show {
             avatarView = AvatarView(avatarSize: .medium, withBorder: false, style: .circle, preferredFallbackImageStyle: .onAccentFilled)
-            avatarView!.setup(primaryText: "Kat Larson", secondaryText: "", image: UIImage(named: "avatar_kat_larsson")!)
-            avatarView!.hasPointerInteraction = true
+            avatarView?.setup(primaryText: "Kat Larson", secondaryText: "", image: image)
+            avatarView?.hasPointerInteraction = true
         }
 
         sideTabBar.avatarView = avatarView
@@ -239,13 +239,13 @@ extension SideTabBarDemoController: SideTabBarDelegate {
         let alert = UIAlertController(title: "\(item.title) was selected", message: nil, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default)
         alert.addAction(action)
-        contentViewController!.present(alert, animated: true)
+        contentViewController?.present(alert, animated: true)
     }
 
     func sideTabBar(_ sideTabBar: SideTabBar, didActivate avatarView: AvatarView) {
         let alert = UIAlertController(title: "Avatar view was tapped", message: nil, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default)
         alert.addAction(action)
-        contentViewController!.present(alert, animated: true)
+        contentViewController?.present(alert, animated: true)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -115,9 +115,11 @@ extension TableViewCellDemoController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
+            return UITableViewCell()
+        }
         let section = sections[indexPath.section]
         let item = section.item
-        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as! TableViewCell
         cell.setup(
             title: item.text1,
             subtitle: item.text2,
@@ -160,9 +162,9 @@ extension TableViewCellDemoController: UITableViewDataSource {
 
 extension TableViewCellDemoController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let section = sections[section]
-        header.setup(style: section.headerStyle, title: section.title)
+        header?.setup(style: section.headerStyle, title: section.title)
         return header
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift
@@ -23,7 +23,7 @@ class TableViewCellShimmerDemoController: TableViewCellDemoController {
         let section = sections[indexPath.section]
         let item = section.item
 
-        guard let cell = super.tableView(tableView, cellForRowAt: indexPath) as? TableViewCell else { 
+        guard let cell = super.tableView(tableView, cellForRowAt: indexPath) as? TableViewCell else {
             return UITableViewCell()
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift
@@ -23,7 +23,9 @@ class TableViewCellShimmerDemoController: TableViewCellDemoController {
         let section = sections[indexPath.section]
         let item = section.item
 
-        let cell = super.tableView(tableView, cellForRowAt: indexPath) as! TableViewCell
+        guard let cell = super.tableView(tableView, cellForRowAt: indexPath) as? TableViewCell else { 
+            return UITableViewCell()
+        }
 
         // fill with spaces representing the text that would go in each cell
         // double the character count because spaces take up much less horizontal space than

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -64,7 +64,9 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as! TableViewCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
+            return UITableViewCell()
+        }
         cell.setup(title: TableViewHeaderFooterSampleData.itemTitle)
         var isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
         if tableView.style == .grouped {
@@ -88,22 +90,22 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let index = section
         let section = tableView.style == .grouped ? groupedSections[section] : plainSections[section]
-        if section.hasHandler {
+        if let header = header, section.hasHandler {
             header.onHeaderViewTapped = { [weak self] in self?.forHeaderTapped(header: header, section: index) }
         }
 
         if section.hasCustomAccessoryView {
-            header.setup(style: section.headerStyle, title: section.title, accessoryView: createCustomAccessoryView(), leadingView: section.hasCustomLeadingView ? createCustomLeadingView(section: index) : nil)
+            header?.setup(style: section.headerStyle, title: section.title, accessoryView: createCustomAccessoryView(), leadingView: section.hasCustomLeadingView ? createCustomLeadingView(section: index) : nil)
         } else {
-            header.setup(style: section.headerStyle, title: section.title, accessoryButtonTitle: section.hasAccessory ? "See More" : "", leadingView: section.hasCustomLeadingView ? createCustomLeadingView(section: index) : nil)
+            header?.setup(style: section.headerStyle, title: section.title, accessoryButtonTitle: section.hasAccessory ? "See More" : "", leadingView: section.hasCustomLeadingView ? createCustomLeadingView(section: index) : nil)
         }
 
-        header.titleNumberOfLines = section.numberOfLines
-        header.accessoryButtonStyle = section.accessoryButtonStyle
-        header.onAccessoryButtonTapped = { [unowned self] in self.showAlertForAccessoryTapped(title: section.title) }
+        header?.titleNumberOfLines = section.numberOfLines
+        header?.accessoryButtonStyle = section.accessoryButtonStyle
+        header?.onAccessoryButtonTapped = { [weak self] in self?.showAlertForAccessoryTapped(title: section.title) }
 
         return header
     }
@@ -122,23 +124,23 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if tableView.style == .grouped && groupedSections[section].hasFooter {
-            let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as! TableViewHeaderFooterView
+            let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
             let section = groupedSections[section]
             if section.footerLinkText.isEmpty {
-                footer.setup(style: .footer, title: section.footerText)
+                footer?.setup(style: .footer, title: section.footerText)
             } else {
                 let title = NSMutableAttributedString(string: section.footerText)
                 let range = (title.string as NSString).range(of: section.footerLinkText)
                 if range.location != -1 {
                     title.addAttribute(.link, value: "https://github.com/microsoft/fluentui-apple", range: range)
                 }
-                footer.setup(style: .footer, attributedTitle: title)
+                footer?.setup(style: .footer, attributedTitle: title)
 
                 if section.hasCustomLinkHandler {
-                    footer.delegate = self
+                    footer?.delegate = self
                 }
             }
-            footer.titleNumberOfLines = section.numberOfLines
+            footer?.titleNumberOfLines = section.numberOfLines
             return footer
         }
         return nil

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -705,7 +705,7 @@ open class BadgeField: UIView {
     // MARK: Text field
 
     @objc open var textFieldContent: String {
-        return textField.text!.trimmed()
+        return textField.text?.trimmed() ?? ""
     }
 
     @objc open func resetTextFieldContent() {
@@ -869,7 +869,7 @@ open class BadgeField: UIView {
             return
         }
 
-        let draggedBadge = gesture.view as! BadgeView
+        guard let draggedBadge = gesture.view as? BadgeView else { return }
         switch gesture.state {
         case .began:
             // Already dragging another badge: cancel this new gesture
@@ -931,7 +931,7 @@ open class BadgeField: UIView {
         // Dragging window becomes front window
         draggingWindow.isHidden = false
         // Move dragged badge to main window
-        draggedBadge!.frame = convert(draggedBadge!.frame, to: containingWindow)
+        draggedBadge?.frame = convert(draggedBadge!.frame, to: containingWindow)
         draggingWindow.addSubview(draggedBadge!)
         // Animate scale
         UIView.animate(withDuration: Constants.dragAndDropScaleAnimationDuration) {

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -869,7 +869,9 @@ open class BadgeField: UIView {
             return
         }
 
-        guard let draggedBadge = gesture.view as? BadgeView else { return }
+        guard let draggedBadge = gesture.view as? BadgeView else {
+            return
+        }
         switch gesture.state {
         case .began:
             // Already dragging another badge: cancel this new gesture

--- a/ios/FluentUI/Calendar/CalendarViewDataSource.swift
+++ b/ios/FluentUI/Calendar/CalendarViewDataSource.swift
@@ -174,30 +174,40 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
         // Setup cell
         if dayStartDate.compare(calendar.startOfDay(for: calendarConfiguration.referenceStartDate)) == .orderedAscending {
             // Before reference start date
-            let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as! CalendarViewDayCell
+            guard let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as? CalendarViewDayCell else {
+                return UICollectionViewCell()
+            }
             dayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: "", indicatorLevel: 0)
             return dayCell
         }
 
         if dayStartDate == todayDate {
-            let dayTodayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayTodayCell.identifier, for: indexPath) as! CalendarViewDayTodayCell
+            guard let dayTodayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayTodayCell.identifier, for: indexPath) as? CalendarViewDayTodayCell else {
+                return UICollectionViewCell()
+            }
             dayTodayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
             return dayTodayCell
         }
 
         if dayStartDateComponents.day == 1 {
             if dayStartDateComponents.year != todayDateComponents.year {
-                let dayMonthYearCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthYearCell.identifier, for: indexPath) as! CalendarViewDayMonthYearCell
+                guard let dayMonthYearCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthYearCell.identifier, for: indexPath) as? CalendarViewDayMonthYearCell else {
+                    return UICollectionViewCell()
+                }
                 dayMonthYearCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, yearLabelText: yearLabelText, indicatorLevel: indicatorLevel)
                 return dayMonthYearCell
             } else {
-                let dayMonthCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthCell.identifier, for: indexPath) as! CalendarViewDayMonthCell
+                guard let dayMonthCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthCell.identifier, for: indexPath) as? CalendarViewDayMonthCell else {
+                    return UICollectionViewCell()
+                }
                 dayMonthCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
                 return dayMonthCell
             }
         }
 
-        let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as! CalendarViewDayCell
+        guard let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as? CalendarViewDayCell else {
+            return UICollectionViewCell()
+        }
         dayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
         return dayCell
     }
@@ -223,7 +233,9 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
             monthLabelText = String.dateString(from: firstDayStartDateOfWeek, compactness: .longMonthNameFullYear)
         }
 
-        let monthBannerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CalendarViewMonthBannerView.reuseIdentifier, for: indexPath) as! CalendarViewMonthBannerView
+        guard let monthBannerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CalendarViewMonthBannerView.reuseIdentifier, for: indexPath) as? CalendarViewMonthBannerView else {
+            return UICollectionViewCell()
+        }
         monthBannerView.setup(monthLabelText: monthLabelText)
 
         // Keep weak reference

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -299,17 +299,21 @@ private class SelectionOverlayView: UIView {
             circleView = DotView()
         }
 
-        setupView(circleView!)
-        circleView!.color = activeColor
+        if let circleView = circleView {
+            setupView(circleView)
+            circleView.color = activeColor
+        }
     }
 
     private func setupSquareView() {
         if squareView == nil {
             squareView = UIView()
         }
-
-        setupView(squareView!)
-        squareView!.backgroundColor = activeColor
+    
+        if let squareView = squareView {
+            setupView(squareView)
+            squareView.backgroundColor = activeColor
+        }
     }
 
     private func setupView(_ view: UIView) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -309,7 +309,7 @@ private class SelectionOverlayView: UIView {
         if squareView == nil {
             squareView = UIView()
         }
-    
+
         if let squareView = squareView {
             setupView(squareView)
             squareView.backgroundColor = activeColor

--- a/ios/FluentUI/Controls/ScrollView.swift
+++ b/ios/FluentUI/Controls/ScrollView.swift
@@ -94,21 +94,23 @@ open class ScrollView: UIScrollView, ScrollableContainerView {
         guard let container = superview else {
             return
         }
+        
+        if let userInfo = notification.userInfo,
+           var keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            keyboardFrame = container.convert(keyboardFrame, from: nil)
 
-        var keyboardFrame = (notification.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
-        keyboardFrame = container.convert(keyboardFrame, from: nil)
+            if originalBottomContentInset == nil {
+                originalBottomContentInset = contentInset.bottom
+            }
+            let bottomInset = max(originalBottomContentInset, frame.maxY - keyboardFrame.minY)
+            if contentInset.bottom != bottomInset {
+                contentInset.bottom = bottomInset
+                scrollIndicatorInsets.bottom = bottomInset
 
-        if originalBottomContentInset == nil {
-            originalBottomContentInset = contentInset.bottom
-        }
-        let bottomInset = max(originalBottomContentInset, frame.maxY - keyboardFrame.minY)
-        if contentInset.bottom != bottomInset {
-            contentInset.bottom = bottomInset
-            scrollIndicatorInsets.bottom = bottomInset
-
-            if bottomInset != 0 {
-                UIView.performWithoutAnimation {
-                    makeFirstResponderVisible()
+                if bottomInset != 0 {
+                    UIView.performWithoutAnimation {
+                        makeFirstResponderVisible()
+                    }
                 }
             }
         }

--- a/ios/FluentUI/Controls/ScrollView.swift
+++ b/ios/FluentUI/Controls/ScrollView.swift
@@ -94,7 +94,7 @@ open class ScrollView: UIScrollView, ScrollableContainerView {
         guard let container = superview else {
             return
         }
-        
+
         if let userInfo = notification.userInfo,
            var keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
             keyboardFrame = container.convert(keyboardFrame, from: nil)

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -238,7 +238,7 @@ open class SearchBar: UIView {
             // Workaround check for beta iOS versions missing the Pointer Interactions API
             if arePointerInteractionAPIsAvailable() {
                 clearButton.isPointerInteractionEnabled = true
-                clearButton.pointerStyleProvider = { button, effect, shape in
+                clearButton.pointerStyleProvider = { button, effect, _ in
                     let preview = UITargetedPreview(view: button)
                     return UIPointerStyle(effect: .lift(preview))
                 }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponent.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponent.swift
@@ -117,7 +117,7 @@ extension DateTimePickerViewComponent: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = dataSource.itemStringRepresentation(forRowAtIndex: indexPath.row)
-        let cell = tableView.dequeueReusableCell(withIdentifier: DateTimePickerViewComponentCell.identifier) as! DateTimePickerViewComponentCell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: DateTimePickerViewComponentCell.identifier) as? DateTimePickerViewComponentCell else { return UITableViewCell() }
 
         cell.textLabel?.text = item
         if indexPath.row == self.tableView.middleIndexPath?.row {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponent.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponent.swift
@@ -117,8 +117,9 @@ extension DateTimePickerViewComponent: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let item = dataSource.itemStringRepresentation(forRowAtIndex: indexPath.row)
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: DateTimePickerViewComponentCell.identifier) as? DateTimePickerViewComponentCell else { return UITableViewCell() }
-
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: DateTimePickerViewComponentCell.identifier) as? DateTimePickerViewComponentCell else {
+            return UITableViewCell()
+        }
         cell.textLabel?.text = item
         if indexPath.row == self.tableView.middleIndexPath?.row {
             previousSelectedIndexPath = indexPath

--- a/ios/FluentUI/People Picker/AvatarView.swift
+++ b/ios/FluentUI/People Picker/AvatarView.swift
@@ -293,8 +293,8 @@ open class AvatarView: UIView {
                             addInteraction(pointerInteraction)
 
                             self.pointerInteraction = pointerInteraction
-                        } else if let pointerInteraction = pointerInteraction {
-                            removeInteraction(pointerInteraction as! UIPointerInteraction)
+                        } else if let pointerInteraction = pointerInteraction as? UIPointerInteraction {
+                            removeInteraction(pointerInteraction)
                             self.pointerInteraction = nil
                         }
                     }
@@ -635,21 +635,21 @@ open class AvatarView: UIView {
                 presenceBorderView = UIView(frame: .zero)
 
                 let presenceBorderColor = UIColor(named: "presenceBorder", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!
-                presenceBorderView!.backgroundColor = presenceBorderColor
+                presenceBorderView?.backgroundColor = presenceBorderColor
 
                 addSubview(presenceBorderView!)
                 addSubview(presenceImageView!)
             }
 
-            presenceBorderView!.isHidden = !useOpaquePresenceBorder
+            presenceBorderView?.isHidden = !useOpaquePresenceBorder
 
             let image = presence.image(size: avatarSize.presenceSize)
             if let image = image {
-                presenceImageView!.image = image
+                presenceImageView?.image = image
             }
         } else if presenceImageView != nil {
-            presenceImageView!.removeFromSuperview()
-            presenceBorderView!.removeFromSuperview()
+            presenceImageView?.removeFromSuperview()
+            presenceBorderView?.removeFromSuperview()
             presenceImageView = nil
             presenceBorderView = nil
         }

--- a/ios/FluentUI/People Picker/ContactCollectionView.swift
+++ b/ios/FluentUI/People Picker/ContactCollectionView.swift
@@ -176,7 +176,7 @@ extension ContactCollectionView: UICollectionViewDataSource {
     }
 
     @objc public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ContactCollectionViewCell.identifier, for: indexPath) as? ContactCollectionViewCell else { 
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ContactCollectionViewCell.identifier, for: indexPath) as? ContactCollectionViewCell else {
             return UICollectionViewCell()
         }
         cell.setup(contact: personas[indexPath.item], size: size.contactViewSize)

--- a/ios/FluentUI/People Picker/ContactCollectionView.swift
+++ b/ios/FluentUI/People Picker/ContactCollectionView.swift
@@ -88,8 +88,8 @@ open class ContactCollectionView: UICollectionView {
     open weak var contactCollectionViewDelegate: ContactCollectionViewDelegate? {
         didSet {
             if oldValue == nil && contactCollectionViewDelegate != nil {
-                let cells = visibleCells as! [ContactCollectionViewCell]
-                for cell in cells {
+                let cells = visibleCells as? [ContactCollectionViewCell]
+                for cell in cells ?? [] {
                     cell.contactView?.contactViewDelegate = self
                 }
             }
@@ -176,11 +176,13 @@ extension ContactCollectionView: UICollectionViewDataSource {
     }
 
     @objc public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ContactCollectionViewCell.identifier, for: indexPath) as! ContactCollectionViewCell
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ContactCollectionViewCell.identifier, for: indexPath) as? ContactCollectionViewCell else { 
+            return UICollectionViewCell()
+        }
         cell.setup(contact: personas[indexPath.item], size: size.contactViewSize)
 
         if contactCollectionViewDelegate != nil {
-            cell.contactView!.contactViewDelegate = self
+            cell.contactView?.contactViewDelegate = self
         }
 
         contactViewToIndexMap[cell.contactView!] = indexPath.item

--- a/ios/FluentUI/People Picker/ContactCollectionViewCell.swift
+++ b/ios/FluentUI/People Picker/ContactCollectionViewCell.swift
@@ -25,10 +25,10 @@ class ContactCollectionViewCell: UICollectionViewCell {
             contactView = ContactView(identifier: identifier, size: size)
         }
 
-        contactView!.translatesAutoresizingMaskIntoConstraints = false
+        contactView?.translatesAutoresizingMaskIntoConstraints = false
 
         if let avatarImage = persona.avatarImage {
-            contactView!.avatarImage = avatarImage
+            contactView?.avatarImage = avatarImage
         }
 
         contentView.addSubview(contactView!)

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -350,7 +350,7 @@ open class PeoplePicker: BadgeField {
 
     override func textFieldTextChanged() {
         super.textFieldTextChanged()
-        let textFieldHasContent = textFieldContent != ""
+        let textFieldHasContent = !textFieldContent.isEmpty
         isShowingPersonaSuggestions = textFieldHasContent
         if textFieldHasContent {
             getSuggestedPersonas()

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -189,7 +189,7 @@ extension PersonaListView: UITableViewDataSource {
 
         switch section {
         case .personas:
-            let cell = dequeueReusableCell(withIdentifier: PersonaCell.identifier, for: indexPath) as! PersonaCell
+            guard let cell = dequeueReusableCell(withIdentifier: PersonaCell.identifier, for: indexPath) as? PersonaCell else { return UITableViewCell() }
             let persona = personaList[indexPath.row]
             cell.setup(persona: persona, accessoryType: accessoryType)
             cell.backgroundColor = .clear
@@ -198,16 +198,22 @@ extension PersonaListView: UITableViewDataSource {
         case .searchDirectory:
             switch searchDirectoryState {
             case .searching:
-                let cell = dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier, for: indexPath) as! ActivityIndicatorCell
+                guard let cell = dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier, for: indexPath) as? ActivityIndicatorCell else {
+                    return UITableViewCell()
+                }
                 cell.hideSystemSeparator()
                 return cell
             case .displayingSearchResults:
-                let cell = dequeueReusableCell(withIdentifier: CenteredLabelCell.identifier, for: indexPath) as! CenteredLabelCell
+                guard let cell = dequeueReusableCell(withIdentifier: CenteredLabelCell.identifier, for: indexPath) as? CenteredLabelCell else {
+                    return UITableViewCell()
+                }
                 cell.setup(text: searchResultText)
                 cell.hideSystemSeparator()
                 return cell
             case .idle:
-                let cell = dequeueReusableCell(withIdentifier: ActionsCell.identifier, for: indexPath) as! ActionsCell
+                guard let cell = dequeueReusableCell(withIdentifier: ActionsCell.identifier, for: indexPath) as? ActionsCell else {
+                    return UITableViewCell()
+                }
                 cell.setup(action1Title: "MSPersonaListView.SearchDirectory".localized)
                 cell.action1Button.addTarget(self, action: #selector(searchDirectoryButtonTapped), for: .touchUpInside)
                 cell.accessibilityTraits = .button

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -189,7 +189,9 @@ extension PersonaListView: UITableViewDataSource {
 
         switch section {
         case .personas:
-            guard let cell = dequeueReusableCell(withIdentifier: PersonaCell.identifier, for: indexPath) as? PersonaCell else { return UITableViewCell() }
+            guard let cell = dequeueReusableCell(withIdentifier: PersonaCell.identifier, for: indexPath) as? PersonaCell else {
+                return UITableViewCell()
+            }
             let persona = personaList[indexPath.row]
             cell.setup(persona: persona, accessoryType: accessoryType)
             cell.backgroundColor = .clear

--- a/ios/FluentUI/People Picker/Presence.swift
+++ b/ios/FluentUI/People Picker/Presence.swift
@@ -72,10 +72,12 @@ public enum Presence: Int, CaseIterable {
         }
 
         var image: UIImage?
-        if let imageName = imageName {
-            image = UIImage.staticImageNamed(imageName)!.image(withPrimaryColor: color!)
+        if let imageName = imageName,
+           let staticImageNamed = UIImage.staticImageNamed(imageName),
+           let color = color {
+            image = staticImageNamed.image(withPrimaryColor: color)
         }
-
+        
         return image
     }
 

--- a/ios/FluentUI/People Picker/Presence.swift
+++ b/ios/FluentUI/People Picker/Presence.swift
@@ -77,7 +77,7 @@ public enum Presence: Int, CaseIterable {
            let color = color {
             image = staticImageNamed.image(withPrimaryColor: color)
         }
-        
+
         return image
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -518,8 +518,7 @@ extension PillButtonBar: UIPointerInteractionDelegate {
 
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
-        guard let index = region.identifier as? Int else { return nil }
-        guard let superview = window, index < buttons.count else {
+        guard let superview = window, let index = region.identifier as? Int, index < buttons.count else {
             return nil
         }
 
@@ -534,7 +533,9 @@ extension PillButtonBar: UIPointerInteractionDelegate {
 
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, willEnter region: UIPointerRegion, animator: UIPointerInteractionAnimating) {
-        guard let index = region.identifier as? Int else { return }
+        guard let index = region.identifier as? Int else {
+            return
+        }
         if let window = window, customPillButtonBackgroundColor == nil, index < buttons.count {
             let pillButton = buttons[index]
             if !pillButton.isSelected {
@@ -545,7 +546,9 @@ extension PillButtonBar: UIPointerInteractionDelegate {
 
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, willExit region: UIPointerRegion, animator: UIPointerInteractionAnimating) {
-        guard let index = region.identifier as? Int else { return }
+        guard let index = region.identifier as? Int else {
+            return
+        }
         if customPillButtonBackgroundColor == nil && index < buttons.count {
             let pillButton = buttons[index]
             pillButton.customBackgroundColor = nil

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -518,7 +518,7 @@ extension PillButtonBar: UIPointerInteractionDelegate {
 
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
-        let index = region.identifier as! Int
+        guard let index = region.identifier as? Int else { return nil }
         guard let superview = window, index < buttons.count else {
             return nil
         }
@@ -534,7 +534,7 @@ extension PillButtonBar: UIPointerInteractionDelegate {
 
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, willEnter region: UIPointerRegion, animator: UIPointerInteractionAnimating) {
-        let index = region.identifier as! Int
+        guard let index = region.identifier as? Int else { return }
         if let window = window, customPillButtonBackgroundColor == nil, index < buttons.count {
             let pillButton = buttons[index]
             if !pillButton.isSelected {
@@ -545,7 +545,7 @@ extension PillButtonBar: UIPointerInteractionDelegate {
 
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, willExit region: UIPointerRegion, animator: UIPointerInteractionAnimating) {
-        let index = region.identifier as! Int
+        guard let index = region.identifier as? Int else { return }
         if customPillButtonBackgroundColor == nil && index < buttons.count {
             let pillButton = buttons[index]
             pillButton.customBackgroundColor = nil

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -309,7 +309,9 @@ extension PopupMenuController: UITableViewDataSource {
         let identifier = String(describing: cellClass)
         tableView.register(cellClass, forCellReuseIdentifier: identifier)
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as! (PopupMenuItemTemplateCell & TableViewCell)
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier) as? (PopupMenuItemTemplateCell & TableViewCell) else {
+            return UITableViewCell()
+        }
         cell.setup(item: item)
         cell.preservesSpaceForImage = itemsHaveImages
 
@@ -341,8 +343,8 @@ extension PopupMenuController: UITableViewDelegate {
         if !PopupMenuSectionHeaderView.isHeaderVisible(for: section) {
             return nil
         }
-        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: PopupMenuSectionHeaderView.identifier) as! PopupMenuSectionHeaderView
-        headerView.setup(section: section)
+        let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: PopupMenuSectionHeaderView.identifier) as? PopupMenuSectionHeaderView
+        headerView?.setup(section: section)
         return headerView
     }
 

--- a/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Table View/TableViewCellFileAccessoryView.swift
@@ -226,7 +226,7 @@ open class TableViewCellFileAccessoryView: UIView {
 
     private func updateSharedStatus() {
         let imageName = isShared ? "ic_fluent_people_24_regular" : "ic_fluent_person_24_regular"
-        sharedStatusImageView.image = UIImage.staticImageNamed(imageName)!.image(withPrimaryColor: Colors.gray500)
+        sharedStatusImageView.image = UIImage.staticImageNamed(imageName)?.image(withPrimaryColor: Colors.gray500)
         sharedStatusLabel.text = isShared ? "Common.Shared".localized : "Common.OnlyMe".localized
     }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -376,7 +376,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             titleView.isAccessibilityElement = true
         }
 
-        accessoryButton = accessoryButtonTitle != "" ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
+        accessoryButton = !accessoryButtonTitle.isEmpty ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
         self.leadingView = leadingView
 
         self.style = style


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
This PR changes the way of optionals unwrapping and unwraps them safely. Force unwrapping is not safe and might lead to crashes.

**_Question_**
In this code base `unowned self` in closures is used in most places.  Even though `unowned` has better performance than `weak`, it should be only used when we are sure that the reference always refers to an instance that has not been deallocated. I understand that if `self` is `nil` inside closure, something has gone wrong, however wouldn't it be safer to use `weak`? What do you think? I am happy to improve this if needed 😄 

**Testing**
This PR only improves optional unwrapping and doesn't change UI or any other logic. So the demo app as well as all components should work as before.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/418)