### PR TITLE
Updating text calculated avatar colors background and foreground colors.

### DIFF
--- a/ios/FluentUI.Tests/AvatarTests.swift
+++ b/ios/FluentUI.Tests/AvatarTests.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+import FluentUI
+
+class AvatarTests: XCTestCase {
+
+    /// Validates that the number of colors defined for tokens textCalculatedBackgroundColors and textCalculatedForegroundColors are the same.
+    func testTextCalculatedBackgroundForegroundColorsCount() {
+        XCTAssertEqual(FluentUIThemeManager.S.MSFAvatarTokens.textCalculatedBackgroundColors.count,
+                       FluentUIThemeManager.S.MSFAvatarTokens.textCalculatedForegroundColors.count,
+                       "Text calculated background and foreground colors should provide the same number of options.")
+    }
+
+    /// Validates that the background and foreground colors for a given index in both arrays (textCalculatedBackgroundColors and textCalculatedForegroundColors tokens) match comparing:
+    ///  1. A color light mode background color with its counterpart dark mode foreground color. The color should be the same (tint40)
+    ///  2. A color light mode foreground color with its counterpart dark mode background color. The color should be the same (shade30)
+    ///
+    /// Text calculated colors are defined as the following for a given color:
+    ///  - Light mode:
+    ///    - Background: tint40
+    ///    - Foreground: shade30
+    ///  - Dark mode:
+    ///    - Background: shade30
+    ///    - Foreground: tint40
+    func testTextCalculatedBackgroundForegroundColorsMatch() {
+        let bgColors = FluentUIThemeManager.S.MSFAvatarTokens.textCalculatedBackgroundColors
+        let fgColors = FluentUIThemeManager.S.MSFAvatarTokens.textCalculatedForegroundColors
+        let lightModeTraitCollection = UITraitCollection(userInterfaceStyle: .light)
+        let darkModeTraitCollection = UITraitCollection(userInterfaceStyle: .dark)
+
+        for (index, bgColor) in bgColors.enumerated() {
+            let fgColor = fgColors[index]
+            let bgLightColor = bgColor.resolvedColor(with: lightModeTraitCollection)
+            let bgDarkColor = bgColor.resolvedColor(with: darkModeTraitCollection)
+            let fgLightColor = fgColor.resolvedColor(with: lightModeTraitCollection)
+            let fgDarkColor = fgColor.resolvedColor(with: darkModeTraitCollection)
+
+            XCTAssertEqual(bgLightColor,
+                           fgDarkColor,
+                           "Index \(index): Background color in light mode does not match Foreground color in dark mode.")
+
+            XCTAssertEqual(bgDarkColor,
+                           fgLightColor,
+                           "Index \(index): Background color in dark mode does not match Foreground color in light mode.")
+        }
+    }
+
+}

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		535401D925BB535A0047DC47 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42661412148568800E25423 /* AvatarView.swift */; };
 		5354020325BB6A750047DC47 /* ButtonLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC23020E451D00016922A /* ButtonLegacy.swift */; };
 		5354020825BB6A760047DC47 /* ButtonLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC23020E451D00016922A /* ButtonLegacy.swift */; };
+		535AD63425CA815C000F1421 /* AvatarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535AD62E25CA8156000F1421 /* AvatarTests.swift */; };
 		537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537315B225438B15001FD14C /* iOS13_4_compatibility.swift */; };
 		537315B425438B15001FD14C /* iOS13_4_compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537315B225438B15001FD14C /* iOS13_4_compatibility.swift */; };
 		53B659BA257AA50200070405 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B659B9257AA50200070405 /* Button.swift */; };
@@ -355,6 +356,7 @@
 		5354008725B0C19C0047DC47 /* ButtonTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonTokens.swift; sourceTree = "<group>"; };
 		5354008825B0C19C0047DC47 /* DrawerTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerTokens.swift; sourceTree = "<group>"; };
 		5354008925B0C19C0047DC47 /* ListTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTokens.swift; sourceTree = "<group>"; };
+		535AD62E25CA8156000F1421 /* AvatarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarTests.swift; sourceTree = "<group>"; };
 		537315B225438B15001FD14C /* iOS13_4_compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iOS13_4_compatibility.swift; sourceTree = "<group>"; };
 		53B659B9257AA50200070405 /* Button.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		53BCB0CD253A4E8C00620960 /* Obscurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Obscurable.swift; sourceTree = "<group>"; };
@@ -814,6 +816,7 @@
 		A5CEC15E20D980B30016922A /* FluentUI.Tests */ = {
 			isa = PBXGroup;
 			children = (
+				535AD62E25CA8156000F1421 /* AvatarTests.swift */,
 				8FA3CB5A246B19EA0049E431 /* ColorTests.swift */,
 				FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */,
 				A5CEC15F20D980B30016922A /* FluentUITests.swift */,
@@ -1632,6 +1635,7 @@
 			files = (
 				A5CEC16020D980B30016922A /* FluentUITests.swift in Sources */,
 				8FA3CB5B246B19EA0049E431 /* ColorTests.swift in Sources */,
+				535AD63425CA815C000F1421 /* AvatarTests.swift in Sources */,
 				FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -103,7 +103,7 @@ public struct AvatarView: View {
         let isOutOfOffice = state.isOutOfOffice
         let initialsString: String = ((style == .overflow) ? state.primaryText ?? "" : InitialsView.initialsText(fromPrimaryText: state.primaryText,
                                                                                                                  secondaryText: state.secondaryText))
-        let shouldUseCalculatedBackgroundColor = !initialsString.isEmpty && style != .overflow
+        let shouldUseCalculatedColors = !initialsString.isEmpty && style != .overflow
 
         let ringInnerGap: CGFloat = isRingVisible ? tokens.ringInnerGap : 0
         let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
@@ -128,14 +128,18 @@ public struct AvatarView: View {
         let presenceCutoutOriginCoordinates: CGFloat = ringOuterGapSize - presenceIconFrameDiffRelativeToOuterRing - presenceIconOutlineSize
         let presenceIconFrameSideRelativeToOuterRing: CGFloat = presenceIconFrameSideRelativeToInnerRing + outerGapAndRingThicknesCombined
 
-        let foregroundColor = state.foregroundColor ?? tokens.foregroundDefaultColor!
-        let backgroundColor = state.backgroundColor ?? ( !shouldUseCalculatedBackgroundColor ?
+        let foregroundColor = state.foregroundColor ?? ( !shouldUseCalculatedColors ?
+                                                            tokens.foregroundDefaultColor! :
+                                                            InitialsView.initialsBackgroundColor(fromPrimaryText: state.primaryText,
+                                                                                                 secondaryText: state.secondaryText,
+                                                                                                 colorOptions: tokens.foregroundCalculatedColorOptions))
+        let backgroundColor = state.backgroundColor ?? ( !shouldUseCalculatedColors ?
                                                             tokens.backgroundDefaultColor! :
                                                             InitialsView.initialsBackgroundColor(fromPrimaryText: state.primaryText,
                                                                                                  secondaryText: state.secondaryText,
                                                                                                  colorOptions: tokens.backgroundCalculatedColorOptions))
         let ringGapColor = isTransparent ? Color.clear : Color(tokens.ringGapColor)
-        let ringColor = !isRingVisible ? Color.clear : Color(state.ringColor ?? ( !shouldUseCalculatedBackgroundColor ?
+        let ringColor = !isRingVisible ? Color.clear : Color(state.ringColor ?? ( !shouldUseCalculatedColors ?
                                                                                     tokens.ringDefaultColor! :
                                                                                     backgroundColor))
 
@@ -150,7 +154,7 @@ public struct AvatarView: View {
                         .foregroundColor(Color(foregroundColor)))
             :
             AnyView(Text(initialsString)
-                        .foregroundColor(Color(tokens.textColor))
+                        .foregroundColor(Color(foregroundColor))
                         .font(Font(tokens.textFont)))
 
         let bodyView = tokens.style == .group ?

--- a/ios/FluentUI/Vnext/Design Token System/AvatarTokens.swift
+++ b/ios/FluentUI/Vnext/Design Token System/AvatarTokens.swift
@@ -45,6 +45,7 @@ public class MSFAvatarTokens: MSFTokensBase, ObservableObject {
 
     @Published public var backgroundCalculatedColorOptions: [UIColor]!
     @Published public var backgroundDefaultColor: UIColor!
+    @Published public var foregroundCalculatedColorOptions: [UIColor]!
     @Published public var foregroundDefaultColor: UIColor!
     @Published public var textColor: UIColor!
 
@@ -101,7 +102,7 @@ public class MSFAvatarTokens: MSFTokensBase, ObservableObject {
         backgroundDefaultColor = appearanceProxy.backgroundDefaultColor
         backgroundCalculatedColorOptions = appearanceProxy.textCalculatedBackgroundColors
         foregroundDefaultColor = appearanceProxy.foregroundDefaultColor
-        textColor = appearanceProxy.textColor
+        foregroundCalculatedColorOptions = appearanceProxy.textCalculatedForegroundColors
 
         switch size {
         case .xsmall:

--- a/ios/FluentUI/Vnext/Design Token System/AvatarTokens.swift
+++ b/ios/FluentUI/Vnext/Design Token System/AvatarTokens.swift
@@ -47,7 +47,6 @@ public class MSFAvatarTokens: MSFTokensBase, ObservableObject {
     @Published public var backgroundDefaultColor: UIColor!
     @Published public var foregroundCalculatedColorOptions: [UIColor]!
     @Published public var foregroundDefaultColor: UIColor!
-    @Published public var textColor: UIColor!
 
     public var style: MSFAvatarStyle {
         didSet {

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -2737,42 +2737,81 @@ extension FluentUIThemeManagerTheming {
 		open func textCalculatedBackgroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _textCalculatedBackgroundColors { return override }
 			return [
-			UIColor(named: "FluentColors/cyanBlue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/red10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/magenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/green10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/magentaPink10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/cyanBlue20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/orange20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/cyan20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/orangeYellow20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/red20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/blue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/magenta10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/gray40", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/green20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/blueMagenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/pinkRed10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/gray30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/blueMagenta30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/gray20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/cyan30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/orange30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!]
+			UIColor(light: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
 		public var textCalculatedBackgroundColors: [UIColor] {
 			get { return self.textCalculatedBackgroundColorsProperty() }
 			set { _textCalculatedBackgroundColors = newValue }
 		}
 
-		//MARK: textColor 
-		public var _textColor: UIColor?
-		open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _textColor { return override }
-			return mainProxy().Colors.Foreground.neutralInvertedProperty(traitCollection)
+		//MARK: textCalculatedForegroundColors 
+		public var _textCalculatedForegroundColors: [UIColor]?
+		open func textCalculatedForegroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
+			if let override = _textCalculatedForegroundColors { return override }
+			return [
+			UIColor(light: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
-		public var textColor: UIColor {
-			get { return self.textColorProperty() }
-			set { _textColor = newValue }
+		public var textCalculatedForegroundColors: [UIColor] {
+			get { return self.textCalculatedForegroundColorsProperty() }
+			set { _textCalculatedForegroundColors = newValue }
 		}
 
 		//MARK: - textFont
@@ -4103,12 +4142,6 @@ extension FluentUIThemeManagerTheming {
 		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _ringDefaultColor { return override }
 			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
-			}
-
-		//MARK: textColor 
-		override open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _textColor { return override }
-			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
 			}
 	}
 	//MARK: - MSFPrimaryButtonTokens

--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -490,6 +490,46 @@ extension FluentUIThemeManagerTheming {
 			self.mainProxy = proxy
 		}
 
+		//MARK: - Anchor
+		public var _Anchor: AnchorAppearanceProxy?
+		open func AnchorStyle() -> AnchorAppearanceProxy {
+			if let override = _Anchor { return override }
+				return AnchorAppearanceProxy(proxy: mainProxy)
+			}
+		public var Anchor: AnchorAppearanceProxy {
+			get { return self.AnchorStyle() }
+			set { _Anchor = newValue }
+		}
+		@objc(ColorsAnchorAppearanceProxy) @objcMembers open class AnchorAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Background
 		public var _Background: BackgroundAppearanceProxy?
 		open func BackgroundStyle() -> BackgroundAppearanceProxy {
@@ -629,6 +669,86 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Beige
+		public var _Beige: BeigeAppearanceProxy?
+		open func BeigeStyle() -> BeigeAppearanceProxy {
+			if let override = _Beige { return override }
+				return BeigeAppearanceProxy(proxy: mainProxy)
+			}
+		public var Beige: BeigeAppearanceProxy {
+			get { return self.BeigeStyle() }
+			set { _Beige = newValue }
+		}
+		@objc(ColorsBeigeAppearanceProxy) @objcMembers open class BeigeAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Blue
+		public var _Blue: BlueAppearanceProxy?
+		open func BlueStyle() -> BlueAppearanceProxy {
+			if let override = _Blue { return override }
+				return BlueAppearanceProxy(proxy: mainProxy)
+			}
+		public var Blue: BlueAppearanceProxy {
+			get { return self.BlueStyle() }
+			set { _Blue = newValue }
+		}
+		@objc(ColorsBlueAppearanceProxy) @objcMembers open class BlueAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Brand
 		public var _Brand: BrandAppearanceProxy?
 		open func BrandStyle() -> BrandAppearanceProxy {
@@ -727,6 +847,246 @@ extension FluentUIThemeManagerTheming {
 			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _tint40 { return override }
 					return UIColor(light: UIColor(red: 0.9372549, green: 0.9647059, blue: 0.9882353, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.03529412, green: 0.17254902, blue: 0.2784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Brass
+		public var _Brass: BrassAppearanceProxy?
+		open func BrassStyle() -> BrassAppearanceProxy {
+			if let override = _Brass { return override }
+				return BrassAppearanceProxy(proxy: mainProxy)
+			}
+		public var Brass: BrassAppearanceProxy {
+			get { return self.BrassStyle() }
+			set { _Brass = newValue }
+		}
+		@objc(ColorsBrassAppearanceProxy) @objcMembers open class BrassAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Brown
+		public var _Brown: BrownAppearanceProxy?
+		open func BrownStyle() -> BrownAppearanceProxy {
+			if let override = _Brown { return override }
+				return BrownAppearanceProxy(proxy: mainProxy)
+			}
+		public var Brown: BrownAppearanceProxy {
+			get { return self.BrownStyle() }
+			set { _Brown = newValue }
+		}
+		@objc(ColorsBrownAppearanceProxy) @objcMembers open class BrownAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Cornflower
+		public var _Cornflower: CornflowerAppearanceProxy?
+		open func CornflowerStyle() -> CornflowerAppearanceProxy {
+			if let override = _Cornflower { return override }
+				return CornflowerAppearanceProxy(proxy: mainProxy)
+			}
+		public var Cornflower: CornflowerAppearanceProxy {
+			get { return self.CornflowerStyle() }
+			set { _Cornflower = newValue }
+		}
+		@objc(ColorsCornflowerAppearanceProxy) @objcMembers open class CornflowerAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Cranberry
+		public var _Cranberry: CranberryAppearanceProxy?
+		open func CranberryStyle() -> CranberryAppearanceProxy {
+			if let override = _Cranberry { return override }
+				return CranberryAppearanceProxy(proxy: mainProxy)
+			}
+		public var Cranberry: CranberryAppearanceProxy {
+			get { return self.CranberryStyle() }
+			set { _Cranberry = newValue }
+		}
+		@objc(ColorsCranberryAppearanceProxy) @objcMembers open class CranberryAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - DarkGreen
+		public var _DarkGreen: DarkGreenAppearanceProxy?
+		open func DarkGreenStyle() -> DarkGreenAppearanceProxy {
+			if let override = _DarkGreen { return override }
+				return DarkGreenAppearanceProxy(proxy: mainProxy)
+			}
+		public var DarkGreen: DarkGreenAppearanceProxy {
+			get { return self.DarkGreenStyle() }
+			set { _DarkGreen = newValue }
+		}
+		@objc(ColorsDarkGreenAppearanceProxy) @objcMembers open class DarkGreenAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - DarkRed
+		public var _DarkRed: DarkRedAppearanceProxy?
+		open func DarkRedStyle() -> DarkRedAppearanceProxy {
+			if let override = _DarkRed { return override }
+				return DarkRedAppearanceProxy(proxy: mainProxy)
+			}
+		public var DarkRed: DarkRedAppearanceProxy {
+			get { return self.DarkRedStyle() }
+			set { _DarkRed = newValue }
+		}
+		@objc(ColorsDarkRedAppearanceProxy) @objcMembers open class DarkRedAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0)
 				}
 			public var tint40: UIColor {
 				get { return self.tint40Property() }
@@ -943,6 +1303,406 @@ extension FluentUIThemeManagerTheming {
 			public var neutralInverted: UIColor {
 				get { return self.neutralInvertedProperty() }
 				set { _neutralInverted = newValue }
+			}
+		}
+
+
+		//MARK: - Forest
+		public var _Forest: ForestAppearanceProxy?
+		open func ForestStyle() -> ForestAppearanceProxy {
+			if let override = _Forest { return override }
+				return ForestAppearanceProxy(proxy: mainProxy)
+			}
+		public var Forest: ForestAppearanceProxy {
+			get { return self.ForestStyle() }
+			set { _Forest = newValue }
+		}
+		@objc(ColorsForestAppearanceProxy) @objcMembers open class ForestAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Gold
+		public var _Gold: GoldAppearanceProxy?
+		open func GoldStyle() -> GoldAppearanceProxy {
+			if let override = _Gold { return override }
+				return GoldAppearanceProxy(proxy: mainProxy)
+			}
+		public var Gold: GoldAppearanceProxy {
+			get { return self.GoldStyle() }
+			set { _Gold = newValue }
+		}
+		@objc(ColorsGoldAppearanceProxy) @objcMembers open class GoldAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Grape
+		public var _Grape: GrapeAppearanceProxy?
+		open func GrapeStyle() -> GrapeAppearanceProxy {
+			if let override = _Grape { return override }
+				return GrapeAppearanceProxy(proxy: mainProxy)
+			}
+		public var Grape: GrapeAppearanceProxy {
+			get { return self.GrapeStyle() }
+			set { _Grape = newValue }
+		}
+		@objc(ColorsGrapeAppearanceProxy) @objcMembers open class GrapeAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Lavender
+		public var _Lavender: LavenderAppearanceProxy?
+		open func LavenderStyle() -> LavenderAppearanceProxy {
+			if let override = _Lavender { return override }
+				return LavenderAppearanceProxy(proxy: mainProxy)
+			}
+		public var Lavender: LavenderAppearanceProxy {
+			get { return self.LavenderStyle() }
+			set { _Lavender = newValue }
+		}
+		@objc(ColorsLavenderAppearanceProxy) @objcMembers open class LavenderAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - LightTeal
+		public var _LightTeal: LightTealAppearanceProxy?
+		open func LightTealStyle() -> LightTealAppearanceProxy {
+			if let override = _LightTeal { return override }
+				return LightTealAppearanceProxy(proxy: mainProxy)
+			}
+		public var LightTeal: LightTealAppearanceProxy {
+			get { return self.LightTealStyle() }
+			set { _LightTeal = newValue }
+		}
+		@objc(ColorsLightTealAppearanceProxy) @objcMembers open class LightTealAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Lilac
+		public var _Lilac: LilacAppearanceProxy?
+		open func LilacStyle() -> LilacAppearanceProxy {
+			if let override = _Lilac { return override }
+				return LilacAppearanceProxy(proxy: mainProxy)
+			}
+		public var Lilac: LilacAppearanceProxy {
+			get { return self.LilacStyle() }
+			set { _Lilac = newValue }
+		}
+		@objc(ColorsLilacAppearanceProxy) @objcMembers open class LilacAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Magenta
+		public var _Magenta: MagentaAppearanceProxy?
+		open func MagentaStyle() -> MagentaAppearanceProxy {
+			if let override = _Magenta { return override }
+				return MagentaAppearanceProxy(proxy: mainProxy)
+			}
+		public var Magenta: MagentaAppearanceProxy {
+			get { return self.MagentaStyle() }
+			set { _Magenta = newValue }
+		}
+		@objc(ColorsMagentaAppearanceProxy) @objcMembers open class MagentaAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Marigold
+		public var _Marigold: MarigoldAppearanceProxy?
+		open func MarigoldStyle() -> MarigoldAppearanceProxy {
+			if let override = _Marigold { return override }
+				return MarigoldAppearanceProxy(proxy: mainProxy)
+			}
+		public var Marigold: MarigoldAppearanceProxy {
+			get { return self.MarigoldStyle() }
+			set { _Marigold = newValue }
+		}
+		@objc(ColorsMarigoldAppearanceProxy) @objcMembers open class MarigoldAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Mink
+		public var _Mink: MinkAppearanceProxy?
+		open func MinkStyle() -> MinkAppearanceProxy {
+			if let override = _Mink { return override }
+				return MinkAppearanceProxy(proxy: mainProxy)
+			}
+		public var Mink: MinkAppearanceProxy {
+			get { return self.MinkStyle() }
+			set { _Mink = newValue }
+		}
+		@objc(ColorsMinkAppearanceProxy) @objcMembers open class MinkAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Navy
+		public var _Navy: NavyAppearanceProxy?
+		open func NavyStyle() -> NavyAppearanceProxy {
+			if let override = _Navy { return override }
+				return NavyAppearanceProxy(proxy: mainProxy)
+			}
+		public var Navy: NavyAppearanceProxy {
+			get { return self.NavyStyle() }
+			set { _Navy = newValue }
+		}
+		@objc(ColorsNavyAppearanceProxy) @objcMembers open class NavyAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
 			}
 		}
 
@@ -1537,6 +2297,166 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Peach
+		public var _Peach: PeachAppearanceProxy?
+		open func PeachStyle() -> PeachAppearanceProxy {
+			if let override = _Peach { return override }
+				return PeachAppearanceProxy(proxy: mainProxy)
+			}
+		public var Peach: PeachAppearanceProxy {
+			get { return self.PeachStyle() }
+			set { _Peach = newValue }
+		}
+		@objc(ColorsPeachAppearanceProxy) @objcMembers open class PeachAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Pink
+		public var _Pink: PinkAppearanceProxy?
+		open func PinkStyle() -> PinkAppearanceProxy {
+			if let override = _Pink { return override }
+				return PinkAppearanceProxy(proxy: mainProxy)
+			}
+		public var Pink: PinkAppearanceProxy {
+			get { return self.PinkStyle() }
+			set { _Pink = newValue }
+		}
+		@objc(ColorsPinkAppearanceProxy) @objcMembers open class PinkAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Platinum
+		public var _Platinum: PlatinumAppearanceProxy?
+		open func PlatinumStyle() -> PlatinumAppearanceProxy {
+			if let override = _Platinum { return override }
+				return PlatinumAppearanceProxy(proxy: mainProxy)
+			}
+		public var Platinum: PlatinumAppearanceProxy {
+			get { return self.PlatinumStyle() }
+			set { _Platinum = newValue }
+		}
+		@objc(ColorsPlatinumAppearanceProxy) @objcMembers open class PlatinumAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Plum
+		public var _Plum: PlumAppearanceProxy?
+		open func PlumStyle() -> PlumAppearanceProxy {
+			if let override = _Plum { return override }
+				return PlumAppearanceProxy(proxy: mainProxy)
+			}
+		public var Plum: PlumAppearanceProxy {
+			get { return self.PlumStyle() }
+			set { _Plum = newValue }
+		}
+		@objc(ColorsPlumAppearanceProxy) @objcMembers open class PlumAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Presence
 		public var _Presence: PresenceAppearanceProxy?
 		open func PresenceStyle() -> PresenceAppearanceProxy {
@@ -1639,6 +2559,206 @@ extension FluentUIThemeManagerTheming {
 			public var unknown: UIColor {
 				get { return self.unknownProperty() }
 				set { _unknown = newValue }
+			}
+		}
+
+
+		//MARK: - Pumpkin
+		public var _Pumpkin: PumpkinAppearanceProxy?
+		open func PumpkinStyle() -> PumpkinAppearanceProxy {
+			if let override = _Pumpkin { return override }
+				return PumpkinAppearanceProxy(proxy: mainProxy)
+			}
+		public var Pumpkin: PumpkinAppearanceProxy {
+			get { return self.PumpkinStyle() }
+			set { _Pumpkin = newValue }
+		}
+		@objc(ColorsPumpkinAppearanceProxy) @objcMembers open class PumpkinAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Purple
+		public var _Purple: PurpleAppearanceProxy?
+		open func PurpleStyle() -> PurpleAppearanceProxy {
+			if let override = _Purple { return override }
+				return PurpleAppearanceProxy(proxy: mainProxy)
+			}
+		public var Purple: PurpleAppearanceProxy {
+			get { return self.PurpleStyle() }
+			set { _Purple = newValue }
+		}
+		@objc(ColorsPurpleAppearanceProxy) @objcMembers open class PurpleAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Red
+		public var _Red: RedAppearanceProxy?
+		open func RedStyle() -> RedAppearanceProxy {
+			if let override = _Red { return override }
+				return RedAppearanceProxy(proxy: mainProxy)
+			}
+		public var Red: RedAppearanceProxy {
+			get { return self.RedStyle() }
+			set { _Red = newValue }
+		}
+		@objc(ColorsRedAppearanceProxy) @objcMembers open class RedAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - RoyalBlue
+		public var _RoyalBlue: RoyalBlueAppearanceProxy?
+		open func RoyalBlueStyle() -> RoyalBlueAppearanceProxy {
+			if let override = _RoyalBlue { return override }
+				return RoyalBlueAppearanceProxy(proxy: mainProxy)
+			}
+		public var RoyalBlue: RoyalBlueAppearanceProxy {
+			get { return self.RoyalBlueStyle() }
+			set { _RoyalBlue = newValue }
+		}
+		@objc(ColorsRoyalBlueAppearanceProxy) @objcMembers open class RoyalBlueAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Seafoam
+		public var _Seafoam: SeafoamAppearanceProxy?
+		open func SeafoamStyle() -> SeafoamAppearanceProxy {
+			if let override = _Seafoam { return override }
+				return SeafoamAppearanceProxy(proxy: mainProxy)
+			}
+		public var Seafoam: SeafoamAppearanceProxy {
+			get { return self.SeafoamStyle() }
+			set { _Seafoam = newValue }
+		}
+		@objc(ColorsSeafoamAppearanceProxy) @objcMembers open class SeafoamAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
 			}
 		}
 
@@ -1771,6 +2891,46 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Steel
+		public var _Steel: SteelAppearanceProxy?
+		open func SteelStyle() -> SteelAppearanceProxy {
+			if let override = _Steel { return override }
+				return SteelAppearanceProxy(proxy: mainProxy)
+			}
+		public var Steel: SteelAppearanceProxy {
+			get { return self.SteelStyle() }
+			set { _Steel = newValue }
+		}
+		@objc(ColorsSteelAppearanceProxy) @objcMembers open class SteelAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Stroke
 		public var _Stroke: StrokeAppearanceProxy?
 		open func StrokeStyle() -> StrokeAppearanceProxy {
@@ -1895,6 +3055,46 @@ extension FluentUIThemeManagerTheming {
 			public var neutralDisabled: UIColor {
 				get { return self.neutralDisabledProperty() }
 				set { _neutralDisabled = newValue }
+			}
+		}
+
+
+		//MARK: - Teal
+		public var _Teal: TealAppearanceProxy?
+		open func TealStyle() -> TealAppearanceProxy {
+			if let override = _Teal { return override }
+				return TealAppearanceProxy(proxy: mainProxy)
+			}
+		public var Teal: TealAppearanceProxy {
+			get { return self.TealStyle() }
+			set { _Teal = newValue }
+		}
+		@objc(ColorsTealAppearanceProxy) @objcMembers open class TealAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
 			}
 		}
 
@@ -2737,36 +3937,36 @@ extension FluentUIThemeManagerTheming {
 		open func textCalculatedBackgroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _textCalculatedBackgroundColors { return override }
 			return [
-			UIColor(light: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
+			UIColor(light: mainProxy().Colors.DarkRed.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkRed.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cranberry.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cranberry.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Red.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Red.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pumpkin.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pumpkin.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Peach.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Peach.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Marigold.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Marigold.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Gold.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Gold.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brass.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brass.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brown.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brown.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Forest.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Forest.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Seafoam.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Seafoam.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.DarkGreen.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkGreen.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.LightTeal.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.LightTeal.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Teal.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Teal.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Steel.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Steel.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Blue.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Blue.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.RoyalBlue.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.RoyalBlue.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cornflower.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cornflower.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Navy.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Navy.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lavender.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lavender.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Purple.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Purple.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Grape.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Grape.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lilac.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lilac.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pink.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pink.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Magenta.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Magenta.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Plum.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Plum.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Beige.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Beige.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Mink.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Mink.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Platinum.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Platinum.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Anchor.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Anchor.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
 		public var textCalculatedBackgroundColors: [UIColor] {
 			get { return self.textCalculatedBackgroundColorsProperty() }
@@ -2778,36 +3978,36 @@ extension FluentUIThemeManagerTheming {
 		open func textCalculatedForegroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _textCalculatedForegroundColors { return override }
 			return [
-			UIColor(light: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
+			UIColor(light: mainProxy().Colors.DarkRed.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkRed.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cranberry.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cranberry.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Red.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Red.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pumpkin.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pumpkin.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Peach.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Peach.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Marigold.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Marigold.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Gold.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Gold.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brass.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brass.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brown.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brown.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Forest.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Forest.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Seafoam.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Seafoam.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.DarkGreen.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkGreen.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.LightTeal.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.LightTeal.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Teal.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Teal.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Steel.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Steel.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Blue.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Blue.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.RoyalBlue.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.RoyalBlue.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cornflower.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cornflower.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Navy.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Navy.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lavender.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lavender.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Purple.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Purple.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Grape.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Grape.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lilac.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lilac.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pink.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pink.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Magenta.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Magenta.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Plum.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Plum.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Beige.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Beige.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Mink.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Mink.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Platinum.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Platinum.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Anchor.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Anchor.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
 		public var textCalculatedForegroundColors: [UIColor] {
 			get { return self.textCalculatedForegroundColorsProperty() }

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -9,6 +9,126 @@ Colors:
     - tint30: "FluentUIColor(light: #DEECF9, dark: #043862)"
     - tint40: "FluentUIColor(light: #EFF6FC, dark: #092C47)"
 
+  DarkRed:
+    - shade30: "#420610"
+    - tint40: "#D69BA5"
+
+  Cranberry:
+    - shade30: "#6E0911"
+    - tint40: "#EDACB1"
+
+  Red:
+    - shade30: "#751D20"
+    - tint40: "#F1BBBD"
+
+  Pumpkin:
+    - shade30: "#712D09"
+    - tint40: "#EFC4AD"
+
+  Peach:
+    - shade30: "#8F4F00"
+    - tint40: "#FFDDB3"
+
+  Marigold:
+    - shade30: "#835C00"
+    - tint40: "#F9E2AE"
+
+  Gold:
+    - shade30: "#6D5700"
+    - tint40: "#EDDEA6"
+
+  Brass:
+    - shade30: "#563F06"
+    - tint40: "#E0CFA2"
+
+  Brown:
+    - shade30: "#50301A"
+    - tint40: "#DDC3B0"
+
+  Forest:
+    - shade30: "#294903"
+    - tint40: "#BDDA9B"
+
+  Seafoam:
+    - shade30: "#00723B"
+    - tint40: "#A8F0CD"
+
+  DarkGreen:
+    - shade30: "#063C06"
+    - tint40: "#9AD39A"
+
+  LightTeal:
+    - shade30: "#00656D"
+    - tint40: "#A6E8ED"
+
+  Teal:
+    - shade30: "#02494C"
+    - tint40: "#9BD9DB"
+
+  Steel:
+    - shade30: "#00333F"
+    - tint40: "#95C8D4"
+
+  Blue:
+    - shade30: "#004377"
+    - tint40: "#A9D3F2"
+
+  RoyalBlue:
+    - shade30: "#002B4F"
+    - tint40: "#9ABFDD"
+
+  Cornflower:
+    - shade30: "#2C3C85"
+    - tint40: "#C7D1FA"
+
+  Navy:
+    - shade30: "#001665"
+    - tint40: "#A3B2E9"
+
+  Lavender:
+    - shade30: "#403582"
+    - tint40: "#D2CCF8"
+
+  Purple:
+    - shade30: "#341A51"
+    - tint40: "#C6B1DE"
+
+  Grape:
+    - shade30: "#4D0D56"
+    - tint40: "#DAA7E0"
+
+  Lilac:
+    - shade30: "#63276D"
+    - tint40: "#E7BFED"
+
+  Pink:
+    - shade30: "#7F215D"
+    - tint40: "#F7C0E3"
+
+  Magenta:
+    - shade30: "#6B0042"
+    - tint40: "#ECA5D1"
+
+  Plum:
+    - shade30: "#43002C"
+    - tint40: "#D696C0"
+
+  Beige:
+    - shade30: "#454241"
+    - tint40: "#D7D5D4"
+
+  Mink:
+    - shade30: "#333231"
+    - tint40: "#CECCCB"
+
+  Platinum:
+    - shade30: "#3A4346"
+    - tint40: "#CDD5D8"
+
+  Anchor:
+    - shade30: "#1F2427"
+    - tint40: "#BCC3C7"
+
   Neutral:
     - clear: "#00000000"
     - black: "#000000"
@@ -190,66 +310,66 @@ AP_MSFAvatarTokens:
   ringThickness: [ xSmall: $Border.size.thin, small: $Border.size.thin, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   ringOuterGap: [ xSmall: $Border.size.thick, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   size: [ xSmall: 16pt, small: 24pt, medium: 32pt, large: 40pt, xlarge: 52pt, xxlarge: 72pt ]
-  textCalculatedBackgroundColors: [ "FluentUIColor(light: #D69BA5, dark: #420610)",
-                                    "FluentUIColor(light: #EDACB1, dark: #6E0911)",
-                                    "FluentUIColor(light: #F1BBBD, dark: #751D20)",
-                                    "FluentUIColor(light: #EFC4AD, dark: #712D09)",
-                                    "FluentUIColor(light: #FFDDB3, dark: #8F4F00)",
-                                    "FluentUIColor(light: #F9E2AE, dark: #835C00)",
-                                    "FluentUIColor(light: #EDDEA6, dark: #6D5700)",
-                                    "FluentUIColor(light: #E0CFA2, dark: #563F06)",
-                                    "FluentUIColor(light: #DDC3B0, dark: #50301A)",
-                                    "FluentUIColor(light: #BDDA9B, dark: #294903)",
-                                    "FluentUIColor(light: #A8F0CD, dark: #00723B)",
-                                    "FluentUIColor(light: #9AD39A, dark: #063C06)",
-                                    "FluentUIColor(light: #A6E8ED, dark: #00656D)",
-                                    "FluentUIColor(light: #9BD9DB, dark: #02494C)",
-                                    "FluentUIColor(light: #95C8D4, dark: #00333F)",
-                                    "FluentUIColor(light: #A9D3F2, dark: #004377)",
-                                    "FluentUIColor(light: #9ABFDD, dark: #002B4F)",
-                                    "FluentUIColor(light: #C7D1FA, dark: #2C3C85)",
-                                    "FluentUIColor(light: #A3B2E9, dark: #001665)",
-                                    "FluentUIColor(light: #D2CCF8, dark: #403582)",
-                                    "FluentUIColor(light: #C6B1DE, dark: #341A51)",
-                                    "FluentUIColor(light: #DAA7E0, dark: #4D0D56)",
-                                    "FluentUIColor(light: #E7BFED, dark: #63276D)",
-                                    "FluentUIColor(light: #F7C0E3, dark: #7F215D)",
-                                    "FluentUIColor(light: #ECA5D1, dark: #6B0042)",
-                                    "FluentUIColor(light: #D696C0, dark: #43002C)",
-                                    "FluentUIColor(light: #D7D5D4, dark: #454241)",
-                                    "FluentUIColor(light: #CECCCB, dark: #333231)",
-                                    "FluentUIColor(light: #CDD5D8, dark: #3A4346)",
-                                    "FluentUIColor(light: #BCC3C7, dark: #1F2427)" ]
-  textCalculatedForegroundColors: [ "FluentUIColor(light: #420610, dark: #D69BA5)",
-                                    "FluentUIColor(light: #6E0911, dark: #EDACB1)",
-                                    "FluentUIColor(light: #751D20, dark: #F1BBBD)",
-                                    "FluentUIColor(light: #712D09, dark: #EFC4AD)",
-                                    "FluentUIColor(light: #8F4F00, dark: #FFDDB3)",
-                                    "FluentUIColor(light: #835C00, dark: #F9E2AE)",
-                                    "FluentUIColor(light: #6D5700, dark: #EDDEA6)",
-                                    "FluentUIColor(light: #563F06, dark: #E0CFA2)",
-                                    "FluentUIColor(light: #50301A, dark: #DDC3B0)",
-                                    "FluentUIColor(light: #294903, dark: #BDDA9B)",
-                                    "FluentUIColor(light: #00723B, dark: #A8F0CD)",
-                                    "FluentUIColor(light: #063C06, dark: #9AD39A)",
-                                    "FluentUIColor(light: #00656D, dark: #A6E8ED)",
-                                    "FluentUIColor(light: #02494C, dark: #9BD9DB)",
-                                    "FluentUIColor(light: #00333F, dark: #95C8D4)",
-                                    "FluentUIColor(light: #004377, dark: #A9D3F2)",
-                                    "FluentUIColor(light: #002B4F, dark: #9ABFDD)",
-                                    "FluentUIColor(light: #2C3C85, dark: #C7D1FA)",
-                                    "FluentUIColor(light: #001665, dark: #A3B2E9)",
-                                    "FluentUIColor(light: #403582, dark: #D2CCF8)",
-                                    "FluentUIColor(light: #341A51, dark: #C6B1DE)",
-                                    "FluentUIColor(light: #4D0D56, dark: #DAA7E0)",
-                                    "FluentUIColor(light: #63276D, dark: #E7BFED)",
-                                    "FluentUIColor(light: #7F215D, dark: #F7C0E3)",
-                                    "FluentUIColor(light: #6B0042, dark: #ECA5D1)",
-                                    "FluentUIColor(light: #43002C, dark: #D696C0)",
-                                    "FluentUIColor(light: #454241, dark: #D7D5D4)",
-                                    "FluentUIColor(light: #333231, dark: #CECCCB)",
-                                    "FluentUIColor(light: #3A4346, dark: #CDD5D8)",
-                                    "FluentUIColor(light: #1F2427, dark: #BCC3C7)" ]
+  textCalculatedBackgroundColors: [ "FluentUIColor(light: $Colors.DarkRed.tint40, dark: $Colors.DarkRed.shade30)",
+                                    "FluentUIColor(light: $Colors.Cranberry.tint40, dark: $Colors.Cranberry.shade30)",
+                                    "FluentUIColor(light: $Colors.Red.tint40, dark: $Colors.Red.shade30)",
+                                    "FluentUIColor(light: $Colors.Pumpkin.tint40, dark: $Colors.Pumpkin.shade30)",
+                                    "FluentUIColor(light: $Colors.Peach.tint40, dark: $Colors.Peach.shade30)",
+                                    "FluentUIColor(light: $Colors.Marigold.tint40, dark: $Colors.Marigold.shade30)",
+                                    "FluentUIColor(light: $Colors.Gold.tint40, dark: $Colors.Gold.shade30)",
+                                    "FluentUIColor(light: $Colors.Brass.tint40, dark: $Colors.Brass.shade30)",
+                                    "FluentUIColor(light: $Colors.Brown.tint40, dark: $Colors.Brown.shade30)",
+                                    "FluentUIColor(light: $Colors.Forest.tint40, dark: $Colors.Forest.shade30)",
+                                    "FluentUIColor(light: $Colors.Seafoam.tint40, dark: $Colors.Seafoam.shade30)",
+                                    "FluentUIColor(light: $Colors.DarkGreen.tint40, dark: $Colors.DarkGreen.shade30)",
+                                    "FluentUIColor(light: $Colors.LightTeal.tint40, dark: $Colors.LightTeal.shade30)",
+                                    "FluentUIColor(light: $Colors.Teal.tint40, dark: $Colors.Teal.shade30)",
+                                    "FluentUIColor(light: $Colors.Steel.tint40, dark: $Colors.Steel.shade30)",
+                                    "FluentUIColor(light: $Colors.Blue.tint40, dark: $Colors.Blue.shade30)",
+                                    "FluentUIColor(light: $Colors.RoyalBlue.tint40, dark: $Colors.RoyalBlue.shade30)",
+                                    "FluentUIColor(light: $Colors.Cornflower.tint40, dark: $Colors.Cornflower.shade30)",
+                                    "FluentUIColor(light: $Colors.Navy.tint40, dark: $Colors.Navy.shade30)",
+                                    "FluentUIColor(light: $Colors.Lavender.tint40, dark: $Colors.Lavender.shade30)",
+                                    "FluentUIColor(light: $Colors.Purple.tint40, dark: $Colors.Purple.shade30)",
+                                    "FluentUIColor(light: $Colors.Grape.tint40, dark: $Colors.Grape.shade30)",
+                                    "FluentUIColor(light: $Colors.Lilac.tint40, dark: $Colors.Lilac.shade30)",
+                                    "FluentUIColor(light: $Colors.Pink.tint40, dark: $Colors.Pink.shade30)",
+                                    "FluentUIColor(light: $Colors.Magenta.tint40, dark: $Colors.Magenta.shade30)",
+                                    "FluentUIColor(light: $Colors.Plum.tint40, dark: $Colors.Plum.shade30)",
+                                    "FluentUIColor(light: $Colors.Beige.tint40, dark: $Colors.Beige.shade30)",
+                                    "FluentUIColor(light: $Colors.Mink.tint40, dark: $Colors.Mink.shade30)",
+                                    "FluentUIColor(light: $Colors.Platinum.tint40, dark: $Colors.Platinum.shade30)",
+                                    "FluentUIColor(light: $Colors.Anchor.tint40, dark: $Colors.Anchor.shade30)" ]
+  textCalculatedForegroundColors: [ "FluentUIColor(light: $Colors.DarkRed.shade30, dark: $Colors.DarkRed.tint40)",
+                                    "FluentUIColor(light: $Colors.Cranberry.shade30, dark: $Colors.Cranberry.tint40)",
+                                    "FluentUIColor(light: $Colors.Red.shade30, dark: $Colors.Red.tint40)",
+                                    "FluentUIColor(light: $Colors.Pumpkin.shade30, dark: $Colors.Pumpkin.tint40)",
+                                    "FluentUIColor(light: $Colors.Peach.shade30, dark: $Colors.Peach.tint40)",
+                                    "FluentUIColor(light: $Colors.Marigold.shade30, dark: $Colors.Marigold.tint40)",
+                                    "FluentUIColor(light: $Colors.Gold.shade30, dark: $Colors.Gold.tint40)",
+                                    "FluentUIColor(light: $Colors.Brass.shade30, dark: $Colors.Brass.tint40)",
+                                    "FluentUIColor(light: $Colors.Brown.shade30, dark: $Colors.Brown.tint40)",
+                                    "FluentUIColor(light: $Colors.Forest.shade30, dark: $Colors.Forest.tint40)",
+                                    "FluentUIColor(light: $Colors.Seafoam.shade30, dark: $Colors.Seafoam.tint40)",
+                                    "FluentUIColor(light: $Colors.DarkGreen.shade30, dark: $Colors.DarkGreen.tint40)",
+                                    "FluentUIColor(light: $Colors.LightTeal.shade30, dark: $Colors.LightTeal.tint40)",
+                                    "FluentUIColor(light: $Colors.Teal.shade30, dark: $Colors.Teal.tint40)",
+                                    "FluentUIColor(light: $Colors.Steel.shade30, dark: $Colors.Steel.tint40)",
+                                    "FluentUIColor(light: $Colors.Blue.shade30, dark: $Colors.Blue.tint40)",
+                                    "FluentUIColor(light: $Colors.RoyalBlue.shade30, dark: $Colors.RoyalBlue.tint40)",
+                                    "FluentUIColor(light: $Colors.Cornflower.shade30, dark: $Colors.Cornflower.tint40)",
+                                    "FluentUIColor(light: $Colors.Navy.shade30, dark: $Colors.Navy.tint40)",
+                                    "FluentUIColor(light: $Colors.Lavender.shade30, dark: $Colors.Lavender.tint40)",
+                                    "FluentUIColor(light: $Colors.Purple.shade30, dark: $Colors.Purple.tint40)",
+                                    "FluentUIColor(light: $Colors.Grape.shade30, dark: $Colors.Grape.tint40)",
+                                    "FluentUIColor(light: $Colors.Lilac.shade30, dark: $Colors.Lilac.tint40)",
+                                    "FluentUIColor(light: $Colors.Pink.shade30, dark: $Colors.Pink.tint40)",
+                                    "FluentUIColor(light: $Colors.Magenta.shade30, dark: $Colors.Magenta.tint40)",
+                                    "FluentUIColor(light: $Colors.Plum.shade30, dark: $Colors.Plum.tint40)",
+                                    "FluentUIColor(light: $Colors.Beige.shade30, dark: $Colors.Beige.tint40)",
+                                    "FluentUIColor(light: $Colors.Mink.shade30, dark: $Colors.Mink.tint40)",
+                                    "FluentUIColor(light: $Colors.Platinum.shade30, dark: $Colors.Platinum.tint40)",
+                                    "FluentUIColor(light: $Colors.Anchor.shade30, dark: $Colors.Anchor.tint40)" ]
   textFont: [ xSmall: "Font(9px, regular)", small: "Font(12px, regular)", medium: "Font(13px, regular)", large: "Font(15px, regular)", xlarge: "Font(20px, regular)", xxlarge: "Font(28px, medium)" ]
 
 MSFAccentAvatarTokens extends MSFAvatarTokens:

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -190,28 +190,66 @@ AP_MSFAvatarTokens:
   ringThickness: [ xSmall: $Border.size.thin, small: $Border.size.thin, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   ringOuterGap: [ xSmall: $Border.size.thick, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thicker ]
   size: [ xSmall: 16pt, small: 24pt, medium: 32pt, large: 40pt, xlarge: 52pt, xxlarge: 72pt ]
-  textCalculatedBackgroundColors: [ "NamedColor(cyanBlue10)",
-                                    "NamedColor(red10)",
-                                    "NamedColor(magenta20)",
-                                    "NamedColor(green10)",
-                                    "NamedColor(magentaPink10)",
-                                    "NamedColor(cyanBlue20)",
-                                    "NamedColor(orange20)",
-                                    "NamedColor(cyan20)",
-                                    "NamedColor(orangeYellow20)",
-                                    "NamedColor(red20)",
-                                    "NamedColor(blue10)",
-                                    "NamedColor(magenta10)",
-                                    "NamedColor(gray40)",
-                                    "NamedColor(green20)",
-                                    "NamedColor(blueMagenta20)",
-                                    "NamedColor(pinkRed10)",
-                                    "NamedColor(gray30)",
-                                    "NamedColor(blueMagenta30)",
-                                    "NamedColor(gray20)",
-                                    "NamedColor(cyan30)",
-                                    "NamedColor(orange30)" ]
-  textColor: $Colors.Foreground.neutralInverted
+  textCalculatedBackgroundColors: [ "FluentUIColor(light: #D69BA5, dark: #420610)",
+                                    "FluentUIColor(light: #EDACB1, dark: #6E0911)",
+                                    "FluentUIColor(light: #F1BBBD, dark: #751D20)",
+                                    "FluentUIColor(light: #EFC4AD, dark: #712D09)",
+                                    "FluentUIColor(light: #FFDDB3, dark: #8F4F00)",
+                                    "FluentUIColor(light: #F9E2AE, dark: #835C00)",
+                                    "FluentUIColor(light: #EDDEA6, dark: #6D5700)",
+                                    "FluentUIColor(light: #E0CFA2, dark: #563F06)",
+                                    "FluentUIColor(light: #DDC3B0, dark: #50301A)",
+                                    "FluentUIColor(light: #BDDA9B, dark: #294903)",
+                                    "FluentUIColor(light: #A8F0CD, dark: #00723B)",
+                                    "FluentUIColor(light: #9AD39A, dark: #063C06)",
+                                    "FluentUIColor(light: #A6E8ED, dark: #00656D)",
+                                    "FluentUIColor(light: #9BD9DB, dark: #02494C)",
+                                    "FluentUIColor(light: #95C8D4, dark: #00333F)",
+                                    "FluentUIColor(light: #A9D3F2, dark: #004377)",
+                                    "FluentUIColor(light: #9ABFDD, dark: #002B4F)",
+                                    "FluentUIColor(light: #C7D1FA, dark: #2C3C85)",
+                                    "FluentUIColor(light: #A3B2E9, dark: #001665)",
+                                    "FluentUIColor(light: #D2CCF8, dark: #403582)",
+                                    "FluentUIColor(light: #C6B1DE, dark: #341A51)",
+                                    "FluentUIColor(light: #DAA7E0, dark: #4D0D56)",
+                                    "FluentUIColor(light: #E7BFED, dark: #63276D)",
+                                    "FluentUIColor(light: #F7C0E3, dark: #7F215D)",
+                                    "FluentUIColor(light: #ECA5D1, dark: #6B0042)",
+                                    "FluentUIColor(light: #D696C0, dark: #43002C)",
+                                    "FluentUIColor(light: #D7D5D4, dark: #454241)",
+                                    "FluentUIColor(light: #CECCCB, dark: #333231)",
+                                    "FluentUIColor(light: #CDD5D8, dark: #3A4346)",
+                                    "FluentUIColor(light: #BCC3C7, dark: #1F2427)" ]
+  textCalculatedForegroundColors: [ "FluentUIColor(light: #420610, dark: #D69BA5)",
+                                    "FluentUIColor(light: #6E0911, dark: #EDACB1)",
+                                    "FluentUIColor(light: #751D20, dark: #F1BBBD)",
+                                    "FluentUIColor(light: #712D09, dark: #EFC4AD)",
+                                    "FluentUIColor(light: #8F4F00, dark: #FFDDB3)",
+                                    "FluentUIColor(light: #835C00, dark: #F9E2AE)",
+                                    "FluentUIColor(light: #6D5700, dark: #EDDEA6)",
+                                    "FluentUIColor(light: #563F06, dark: #E0CFA2)",
+                                    "FluentUIColor(light: #50301A, dark: #DDC3B0)",
+                                    "FluentUIColor(light: #294903, dark: #BDDA9B)",
+                                    "FluentUIColor(light: #00723B, dark: #A8F0CD)",
+                                    "FluentUIColor(light: #063C06, dark: #9AD39A)",
+                                    "FluentUIColor(light: #00656D, dark: #A6E8ED)",
+                                    "FluentUIColor(light: #02494C, dark: #9BD9DB)",
+                                    "FluentUIColor(light: #00333F, dark: #95C8D4)",
+                                    "FluentUIColor(light: #004377, dark: #A9D3F2)",
+                                    "FluentUIColor(light: #002B4F, dark: #9ABFDD)",
+                                    "FluentUIColor(light: #2C3C85, dark: #C7D1FA)",
+                                    "FluentUIColor(light: #001665, dark: #A3B2E9)",
+                                    "FluentUIColor(light: #403582, dark: #D2CCF8)",
+                                    "FluentUIColor(light: #341A51, dark: #C6B1DE)",
+                                    "FluentUIColor(light: #4D0D56, dark: #DAA7E0)",
+                                    "FluentUIColor(light: #63276D, dark: #E7BFED)",
+                                    "FluentUIColor(light: #7F215D, dark: #F7C0E3)",
+                                    "FluentUIColor(light: #6B0042, dark: #ECA5D1)",
+                                    "FluentUIColor(light: #43002C, dark: #D696C0)",
+                                    "FluentUIColor(light: #454241, dark: #D7D5D4)",
+                                    "FluentUIColor(light: #333231, dark: #CECCCB)",
+                                    "FluentUIColor(light: #3A4346, dark: #CDD5D8)",
+                                    "FluentUIColor(light: #1F2427, dark: #BCC3C7)" ]
   textFont: [ xSmall: "Font(9px, regular)", small: "Font(12px, regular)", medium: "Font(13px, regular)", large: "Font(15px, regular)", xlarge: "Font(20px, regular)", xxlarge: "Font(28px, medium)" ]
 
 MSFAccentAvatarTokens extends MSFAvatarTokens:
@@ -235,7 +273,6 @@ MSFOutlinedPrimaryAvatarTokens extends MSFAvatarTokens:
 MSFOverflowAvatarTokens extends MSFAvatarTokens:
   backgroundDefaultColor: $Colors.Background.neutral4
   foregroundDefaultColor: $Colors.Foreground.neutral3
-  textColor: $Colors.Foreground.neutral3
   ringDefaultColor: $Colors.Background.neutralDisabled
 
 AP_MSFButtonTokens:

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -2737,42 +2737,81 @@ extension FluentUIThemeManagerTheming {
 		open func textCalculatedBackgroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _textCalculatedBackgroundColors { return override }
 			return [
-			UIColor(named: "FluentColors/cyanBlue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/red10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/magenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/green10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/magentaPink10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/cyanBlue20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/orange20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/cyan20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/orangeYellow20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/red20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/blue10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/magenta10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/gray40", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/green20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/blueMagenta20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/pinkRed10", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/gray30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/blueMagenta30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/gray20", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/cyan30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!, 
-			UIColor(named: "FluentColors/orange30", in: FluentUIFramework.resourceBundle, compatibleWith: nil)!]
+			UIColor(light: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
 		public var textCalculatedBackgroundColors: [UIColor] {
 			get { return self.textCalculatedBackgroundColorsProperty() }
 			set { _textCalculatedBackgroundColors = newValue }
 		}
 
-		//MARK: textColor 
-		public var _textColor: UIColor?
-		open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _textColor { return override }
-			return mainProxy().Colors.Foreground.neutralInvertedProperty(traitCollection)
+		//MARK: textCalculatedForegroundColors 
+		public var _textCalculatedForegroundColors: [UIColor]?
+		open func textCalculatedForegroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
+			if let override = _textCalculatedForegroundColors { return override }
+			return [
+			UIColor(light: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
-		public var textColor: UIColor {
-			get { return self.textColorProperty() }
-			set { _textColor = newValue }
+		public var textCalculatedForegroundColors: [UIColor] {
+			get { return self.textCalculatedForegroundColorsProperty() }
+			set { _textCalculatedForegroundColors = newValue }
 		}
 
 		//MARK: - textFont
@@ -4103,12 +4142,6 @@ extension FluentUIThemeManagerTheming {
 		override open func ringDefaultColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 			if let override = _ringDefaultColor { return override }
 			return mainProxy().Colors.Background.neutralDisabledProperty(traitCollection)
-			}
-
-		//MARK: textColor 
-		override open func textColorProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
-			if let override = _textColor { return override }
-			return mainProxy().Colors.Foreground.neutral3Property(traitCollection)
 			}
 	}
 	//MARK: - MSFPrimaryButtonTokens

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -490,6 +490,46 @@ extension FluentUIThemeManagerTheming {
 			self.mainProxy = proxy
 		}
 
+		//MARK: - Anchor
+		public var _Anchor: AnchorAppearanceProxy?
+		open func AnchorStyle() -> AnchorAppearanceProxy {
+			if let override = _Anchor { return override }
+				return AnchorAppearanceProxy(proxy: mainProxy)
+			}
+		public var Anchor: AnchorAppearanceProxy {
+			get { return self.AnchorStyle() }
+			set { _Anchor = newValue }
+		}
+		@objc(ColorsAnchorAppearanceProxy) @objcMembers open class AnchorAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Background
 		public var _Background: BackgroundAppearanceProxy?
 		open func BackgroundStyle() -> BackgroundAppearanceProxy {
@@ -629,6 +669,86 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Beige
+		public var _Beige: BeigeAppearanceProxy?
+		open func BeigeStyle() -> BeigeAppearanceProxy {
+			if let override = _Beige { return override }
+				return BeigeAppearanceProxy(proxy: mainProxy)
+			}
+		public var Beige: BeigeAppearanceProxy {
+			get { return self.BeigeStyle() }
+			set { _Beige = newValue }
+		}
+		@objc(ColorsBeigeAppearanceProxy) @objcMembers open class BeigeAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Blue
+		public var _Blue: BlueAppearanceProxy?
+		open func BlueStyle() -> BlueAppearanceProxy {
+			if let override = _Blue { return override }
+				return BlueAppearanceProxy(proxy: mainProxy)
+			}
+		public var Blue: BlueAppearanceProxy {
+			get { return self.BlueStyle() }
+			set { _Blue = newValue }
+		}
+		@objc(ColorsBlueAppearanceProxy) @objcMembers open class BlueAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Brand
 		public var _Brand: BrandAppearanceProxy?
 		open func BrandStyle() -> BrandAppearanceProxy {
@@ -727,6 +847,246 @@ extension FluentUIThemeManagerTheming {
 			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
 				if let override = _tint40 { return override }
 					return UIColor(light: UIColor(red: 0.9372549, green: 0.9647059, blue: 0.9882353, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.03529412, green: 0.17254902, blue: 0.2784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Brass
+		public var _Brass: BrassAppearanceProxy?
+		open func BrassStyle() -> BrassAppearanceProxy {
+			if let override = _Brass { return override }
+				return BrassAppearanceProxy(proxy: mainProxy)
+			}
+		public var Brass: BrassAppearanceProxy {
+			get { return self.BrassStyle() }
+			set { _Brass = newValue }
+		}
+		@objc(ColorsBrassAppearanceProxy) @objcMembers open class BrassAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Brown
+		public var _Brown: BrownAppearanceProxy?
+		open func BrownStyle() -> BrownAppearanceProxy {
+			if let override = _Brown { return override }
+				return BrownAppearanceProxy(proxy: mainProxy)
+			}
+		public var Brown: BrownAppearanceProxy {
+			get { return self.BrownStyle() }
+			set { _Brown = newValue }
+		}
+		@objc(ColorsBrownAppearanceProxy) @objcMembers open class BrownAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Cornflower
+		public var _Cornflower: CornflowerAppearanceProxy?
+		open func CornflowerStyle() -> CornflowerAppearanceProxy {
+			if let override = _Cornflower { return override }
+				return CornflowerAppearanceProxy(proxy: mainProxy)
+			}
+		public var Cornflower: CornflowerAppearanceProxy {
+			get { return self.CornflowerStyle() }
+			set { _Cornflower = newValue }
+		}
+		@objc(ColorsCornflowerAppearanceProxy) @objcMembers open class CornflowerAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Cranberry
+		public var _Cranberry: CranberryAppearanceProxy?
+		open func CranberryStyle() -> CranberryAppearanceProxy {
+			if let override = _Cranberry { return override }
+				return CranberryAppearanceProxy(proxy: mainProxy)
+			}
+		public var Cranberry: CranberryAppearanceProxy {
+			get { return self.CranberryStyle() }
+			set { _Cranberry = newValue }
+		}
+		@objc(ColorsCranberryAppearanceProxy) @objcMembers open class CranberryAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - DarkGreen
+		public var _DarkGreen: DarkGreenAppearanceProxy?
+		open func DarkGreenStyle() -> DarkGreenAppearanceProxy {
+			if let override = _DarkGreen { return override }
+				return DarkGreenAppearanceProxy(proxy: mainProxy)
+			}
+		public var DarkGreen: DarkGreenAppearanceProxy {
+			get { return self.DarkGreenStyle() }
+			set { _DarkGreen = newValue }
+		}
+		@objc(ColorsDarkGreenAppearanceProxy) @objcMembers open class DarkGreenAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - DarkRed
+		public var _DarkRed: DarkRedAppearanceProxy?
+		open func DarkRedStyle() -> DarkRedAppearanceProxy {
+			if let override = _DarkRed { return override }
+				return DarkRedAppearanceProxy(proxy: mainProxy)
+			}
+		public var DarkRed: DarkRedAppearanceProxy {
+			get { return self.DarkRedStyle() }
+			set { _DarkRed = newValue }
+		}
+		@objc(ColorsDarkRedAppearanceProxy) @objcMembers open class DarkRedAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0)
 				}
 			public var tint40: UIColor {
 				get { return self.tint40Property() }
@@ -943,6 +1303,406 @@ extension FluentUIThemeManagerTheming {
 			public var neutralInverted: UIColor {
 				get { return self.neutralInvertedProperty() }
 				set { _neutralInverted = newValue }
+			}
+		}
+
+
+		//MARK: - Forest
+		public var _Forest: ForestAppearanceProxy?
+		open func ForestStyle() -> ForestAppearanceProxy {
+			if let override = _Forest { return override }
+				return ForestAppearanceProxy(proxy: mainProxy)
+			}
+		public var Forest: ForestAppearanceProxy {
+			get { return self.ForestStyle() }
+			set { _Forest = newValue }
+		}
+		@objc(ColorsForestAppearanceProxy) @objcMembers open class ForestAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Gold
+		public var _Gold: GoldAppearanceProxy?
+		open func GoldStyle() -> GoldAppearanceProxy {
+			if let override = _Gold { return override }
+				return GoldAppearanceProxy(proxy: mainProxy)
+			}
+		public var Gold: GoldAppearanceProxy {
+			get { return self.GoldStyle() }
+			set { _Gold = newValue }
+		}
+		@objc(ColorsGoldAppearanceProxy) @objcMembers open class GoldAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Grape
+		public var _Grape: GrapeAppearanceProxy?
+		open func GrapeStyle() -> GrapeAppearanceProxy {
+			if let override = _Grape { return override }
+				return GrapeAppearanceProxy(proxy: mainProxy)
+			}
+		public var Grape: GrapeAppearanceProxy {
+			get { return self.GrapeStyle() }
+			set { _Grape = newValue }
+		}
+		@objc(ColorsGrapeAppearanceProxy) @objcMembers open class GrapeAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Lavender
+		public var _Lavender: LavenderAppearanceProxy?
+		open func LavenderStyle() -> LavenderAppearanceProxy {
+			if let override = _Lavender { return override }
+				return LavenderAppearanceProxy(proxy: mainProxy)
+			}
+		public var Lavender: LavenderAppearanceProxy {
+			get { return self.LavenderStyle() }
+			set { _Lavender = newValue }
+		}
+		@objc(ColorsLavenderAppearanceProxy) @objcMembers open class LavenderAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - LightTeal
+		public var _LightTeal: LightTealAppearanceProxy?
+		open func LightTealStyle() -> LightTealAppearanceProxy {
+			if let override = _LightTeal { return override }
+				return LightTealAppearanceProxy(proxy: mainProxy)
+			}
+		public var LightTeal: LightTealAppearanceProxy {
+			get { return self.LightTealStyle() }
+			set { _LightTeal = newValue }
+		}
+		@objc(ColorsLightTealAppearanceProxy) @objcMembers open class LightTealAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Lilac
+		public var _Lilac: LilacAppearanceProxy?
+		open func LilacStyle() -> LilacAppearanceProxy {
+			if let override = _Lilac { return override }
+				return LilacAppearanceProxy(proxy: mainProxy)
+			}
+		public var Lilac: LilacAppearanceProxy {
+			get { return self.LilacStyle() }
+			set { _Lilac = newValue }
+		}
+		@objc(ColorsLilacAppearanceProxy) @objcMembers open class LilacAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Magenta
+		public var _Magenta: MagentaAppearanceProxy?
+		open func MagentaStyle() -> MagentaAppearanceProxy {
+			if let override = _Magenta { return override }
+				return MagentaAppearanceProxy(proxy: mainProxy)
+			}
+		public var Magenta: MagentaAppearanceProxy {
+			get { return self.MagentaStyle() }
+			set { _Magenta = newValue }
+		}
+		@objc(ColorsMagentaAppearanceProxy) @objcMembers open class MagentaAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Marigold
+		public var _Marigold: MarigoldAppearanceProxy?
+		open func MarigoldStyle() -> MarigoldAppearanceProxy {
+			if let override = _Marigold { return override }
+				return MarigoldAppearanceProxy(proxy: mainProxy)
+			}
+		public var Marigold: MarigoldAppearanceProxy {
+			get { return self.MarigoldStyle() }
+			set { _Marigold = newValue }
+		}
+		@objc(ColorsMarigoldAppearanceProxy) @objcMembers open class MarigoldAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Mink
+		public var _Mink: MinkAppearanceProxy?
+		open func MinkStyle() -> MinkAppearanceProxy {
+			if let override = _Mink { return override }
+				return MinkAppearanceProxy(proxy: mainProxy)
+			}
+		public var Mink: MinkAppearanceProxy {
+			get { return self.MinkStyle() }
+			set { _Mink = newValue }
+		}
+		@objc(ColorsMinkAppearanceProxy) @objcMembers open class MinkAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Navy
+		public var _Navy: NavyAppearanceProxy?
+		open func NavyStyle() -> NavyAppearanceProxy {
+			if let override = _Navy { return override }
+				return NavyAppearanceProxy(proxy: mainProxy)
+			}
+		public var Navy: NavyAppearanceProxy {
+			get { return self.NavyStyle() }
+			set { _Navy = newValue }
+		}
+		@objc(ColorsNavyAppearanceProxy) @objcMembers open class NavyAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
 			}
 		}
 
@@ -1537,6 +2297,166 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Peach
+		public var _Peach: PeachAppearanceProxy?
+		open func PeachStyle() -> PeachAppearanceProxy {
+			if let override = _Peach { return override }
+				return PeachAppearanceProxy(proxy: mainProxy)
+			}
+		public var Peach: PeachAppearanceProxy {
+			get { return self.PeachStyle() }
+			set { _Peach = newValue }
+		}
+		@objc(ColorsPeachAppearanceProxy) @objcMembers open class PeachAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Pink
+		public var _Pink: PinkAppearanceProxy?
+		open func PinkStyle() -> PinkAppearanceProxy {
+			if let override = _Pink { return override }
+				return PinkAppearanceProxy(proxy: mainProxy)
+			}
+		public var Pink: PinkAppearanceProxy {
+			get { return self.PinkStyle() }
+			set { _Pink = newValue }
+		}
+		@objc(ColorsPinkAppearanceProxy) @objcMembers open class PinkAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Platinum
+		public var _Platinum: PlatinumAppearanceProxy?
+		open func PlatinumStyle() -> PlatinumAppearanceProxy {
+			if let override = _Platinum { return override }
+				return PlatinumAppearanceProxy(proxy: mainProxy)
+			}
+		public var Platinum: PlatinumAppearanceProxy {
+			get { return self.PlatinumStyle() }
+			set { _Platinum = newValue }
+		}
+		@objc(ColorsPlatinumAppearanceProxy) @objcMembers open class PlatinumAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Plum
+		public var _Plum: PlumAppearanceProxy?
+		open func PlumStyle() -> PlumAppearanceProxy {
+			if let override = _Plum { return override }
+				return PlumAppearanceProxy(proxy: mainProxy)
+			}
+		public var Plum: PlumAppearanceProxy {
+			get { return self.PlumStyle() }
+			set { _Plum = newValue }
+		}
+		@objc(ColorsPlumAppearanceProxy) @objcMembers open class PlumAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Presence
 		public var _Presence: PresenceAppearanceProxy?
 		open func PresenceStyle() -> PresenceAppearanceProxy {
@@ -1639,6 +2559,206 @@ extension FluentUIThemeManagerTheming {
 			public var unknown: UIColor {
 				get { return self.unknownProperty() }
 				set { _unknown = newValue }
+			}
+		}
+
+
+		//MARK: - Pumpkin
+		public var _Pumpkin: PumpkinAppearanceProxy?
+		open func PumpkinStyle() -> PumpkinAppearanceProxy {
+			if let override = _Pumpkin { return override }
+				return PumpkinAppearanceProxy(proxy: mainProxy)
+			}
+		public var Pumpkin: PumpkinAppearanceProxy {
+			get { return self.PumpkinStyle() }
+			set { _Pumpkin = newValue }
+		}
+		@objc(ColorsPumpkinAppearanceProxy) @objcMembers open class PumpkinAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Purple
+		public var _Purple: PurpleAppearanceProxy?
+		open func PurpleStyle() -> PurpleAppearanceProxy {
+			if let override = _Purple { return override }
+				return PurpleAppearanceProxy(proxy: mainProxy)
+			}
+		public var Purple: PurpleAppearanceProxy {
+			get { return self.PurpleStyle() }
+			set { _Purple = newValue }
+		}
+		@objc(ColorsPurpleAppearanceProxy) @objcMembers open class PurpleAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Red
+		public var _Red: RedAppearanceProxy?
+		open func RedStyle() -> RedAppearanceProxy {
+			if let override = _Red { return override }
+				return RedAppearanceProxy(proxy: mainProxy)
+			}
+		public var Red: RedAppearanceProxy {
+			get { return self.RedStyle() }
+			set { _Red = newValue }
+		}
+		@objc(ColorsRedAppearanceProxy) @objcMembers open class RedAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - RoyalBlue
+		public var _RoyalBlue: RoyalBlueAppearanceProxy?
+		open func RoyalBlueStyle() -> RoyalBlueAppearanceProxy {
+			if let override = _RoyalBlue { return override }
+				return RoyalBlueAppearanceProxy(proxy: mainProxy)
+			}
+		public var RoyalBlue: RoyalBlueAppearanceProxy {
+			get { return self.RoyalBlueStyle() }
+			set { _RoyalBlue = newValue }
+		}
+		@objc(ColorsRoyalBlueAppearanceProxy) @objcMembers open class RoyalBlueAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
+		//MARK: - Seafoam
+		public var _Seafoam: SeafoamAppearanceProxy?
+		open func SeafoamStyle() -> SeafoamAppearanceProxy {
+			if let override = _Seafoam { return override }
+				return SeafoamAppearanceProxy(proxy: mainProxy)
+			}
+		public var Seafoam: SeafoamAppearanceProxy {
+			get { return self.SeafoamStyle() }
+			set { _Seafoam = newValue }
+		}
+		@objc(ColorsSeafoamAppearanceProxy) @objcMembers open class SeafoamAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
 			}
 		}
 
@@ -1771,6 +2891,46 @@ extension FluentUIThemeManagerTheming {
 		}
 
 
+		//MARK: - Steel
+		public var _Steel: SteelAppearanceProxy?
+		open func SteelStyle() -> SteelAppearanceProxy {
+			if let override = _Steel { return override }
+				return SteelAppearanceProxy(proxy: mainProxy)
+			}
+		public var Steel: SteelAppearanceProxy {
+			get { return self.SteelStyle() }
+			set { _Steel = newValue }
+		}
+		@objc(ColorsSteelAppearanceProxy) @objcMembers open class SteelAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
+			}
+		}
+
+
 		//MARK: - Stroke
 		public var _Stroke: StrokeAppearanceProxy?
 		open func StrokeStyle() -> StrokeAppearanceProxy {
@@ -1895,6 +3055,46 @@ extension FluentUIThemeManagerTheming {
 			public var neutralDisabled: UIColor {
 				get { return self.neutralDisabledProperty() }
 				set { _neutralDisabled = newValue }
+			}
+		}
+
+
+		//MARK: - Teal
+		public var _Teal: TealAppearanceProxy?
+		open func TealStyle() -> TealAppearanceProxy {
+			if let override = _Teal { return override }
+				return TealAppearanceProxy(proxy: mainProxy)
+			}
+		public var Teal: TealAppearanceProxy {
+			get { return self.TealStyle() }
+			set { _Teal = newValue }
+		}
+		@objc(ColorsTealAppearanceProxy) @objcMembers open class TealAppearanceProxy: NSObject {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			//MARK: shade30 
+			public var _shade30: UIColor?
+			open func shade30Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _shade30 { return override }
+					return UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0)
+				}
+			public var shade30: UIColor {
+				get { return self.shade30Property() }
+				set { _shade30 = newValue }
+			}
+
+			//MARK: tint40 
+			public var _tint40: UIColor?
+			open func tint40Property(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> UIColor {
+				if let override = _tint40 { return override }
+					return UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0)
+				}
+			public var tint40: UIColor {
+				get { return self.tint40Property() }
+				set { _tint40 = newValue }
 			}
 		}
 
@@ -2737,36 +3937,36 @@ extension FluentUIThemeManagerTheming {
 		open func textCalculatedBackgroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _textCalculatedBackgroundColors { return override }
 			return [
-			UIColor(light: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
+			UIColor(light: mainProxy().Colors.DarkRed.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkRed.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cranberry.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cranberry.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Red.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Red.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pumpkin.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pumpkin.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Peach.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Peach.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Marigold.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Marigold.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Gold.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Gold.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brass.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brass.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brown.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brown.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Forest.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Forest.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Seafoam.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Seafoam.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.DarkGreen.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkGreen.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.LightTeal.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.LightTeal.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Teal.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Teal.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Steel.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Steel.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Blue.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Blue.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.RoyalBlue.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.RoyalBlue.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cornflower.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cornflower.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Navy.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Navy.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lavender.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lavender.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Purple.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Purple.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Grape.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Grape.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lilac.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lilac.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pink.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pink.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Magenta.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Magenta.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Plum.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Plum.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Beige.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Beige.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Mink.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Mink.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Platinum.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Platinum.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Anchor.tint40Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Anchor.shade30Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
 		public var textCalculatedBackgroundColors: [UIColor] {
 			get { return self.textCalculatedBackgroundColorsProperty() }
@@ -2778,36 +3978,36 @@ extension FluentUIThemeManagerTheming {
 		open func textCalculatedForegroundColorsProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> [UIColor] {
 			if let override = _textCalculatedForegroundColors { return override }
 			return [
-			UIColor(light: UIColor(red: 0.25882354, green: 0.023529412, blue: 0.0627451, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.60784316, blue: 0.64705884, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.43137255, green: 0.03529412, blue: 0.06666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.6745098, blue: 0.69411767, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.45882353, green: 0.11372549, blue: 0.1254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.94509804, green: 0.73333335, blue: 0.7411765, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.44313726, green: 0.1764706, blue: 0.03529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9372549, green: 0.76862746, blue: 0.6784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.56078434, green: 0.30980393, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 1.0, green: 0.8666667, blue: 0.7019608, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.5137255, green: 0.36078432, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9764706, green: 0.8862745, blue: 0.68235296, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.42745098, green: 0.34117648, blue: 0.0, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.92941177, green: 0.87058824, blue: 0.6509804, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3372549, green: 0.24705882, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8784314, green: 0.8117647, blue: 0.63529414, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3137255, green: 0.1882353, blue: 0.101960786, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8666667, green: 0.7647059, blue: 0.6901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.16078432, green: 0.28627452, blue: 0.011764706, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7411765, green: 0.85490197, blue: 0.60784316, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.44705883, blue: 0.23137255, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.65882355, green: 0.9411765, blue: 0.8039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.023529412, green: 0.23529412, blue: 0.023529412, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.827451, blue: 0.6039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.39607844, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6509804, green: 0.9098039, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.007843138, green: 0.28627452, blue: 0.29803923, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.60784316, green: 0.8509804, blue: 0.85882354, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.2, blue: 0.24705882, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.58431375, green: 0.78431374, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.2627451, blue: 0.46666667, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6627451, green: 0.827451, blue: 0.9490196, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.16862746, blue: 0.30980393, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6039216, green: 0.7490196, blue: 0.8666667, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.17254902, green: 0.23529412, blue: 0.52156866, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.78039217, green: 0.81960785, blue: 0.98039216, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.0, green: 0.08627451, blue: 0.39607844, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.6392157, green: 0.69803923, blue: 0.9137255, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.2509804, green: 0.20784314, blue: 0.50980395, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8235294, green: 0.8, blue: 0.972549, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.20392157, green: 0.101960786, blue: 0.31764707, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7764706, green: 0.69411767, blue: 0.87058824, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3019608, green: 0.050980393, blue: 0.3372549, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.85490197, green: 0.654902, blue: 0.8784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.3882353, green: 0.15294118, blue: 0.42745098, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.90588236, green: 0.7490196, blue: 0.92941177, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.49803922, green: 0.12941177, blue: 0.3647059, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.96862745, green: 0.7529412, blue: 0.8901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.41960785, green: 0.0, blue: 0.25882354, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.9254902, green: 0.64705884, blue: 0.81960785, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.2627451, green: 0.0, blue: 0.17254902, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8392157, green: 0.5882353, blue: 0.7529412, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.27058825, green: 0.25882354, blue: 0.25490198, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.84313726, green: 0.8352941, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.2, green: 0.19607843, blue: 0.19215687, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.80784315, green: 0.8, blue: 0.79607844, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.22745098, green: 0.2627451, blue: 0.27450982, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.8039216, green: 0.8352941, blue: 0.84705883, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
-			UIColor(light: UIColor(red: 0.12156863, green: 0.14117648, blue: 0.15294118, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.7372549, green: 0.7647059, blue: 0.78039217, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
+			UIColor(light: mainProxy().Colors.DarkRed.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkRed.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cranberry.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cranberry.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Red.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Red.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pumpkin.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pumpkin.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Peach.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Peach.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Marigold.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Marigold.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Gold.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Gold.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brass.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brass.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Brown.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Brown.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Forest.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Forest.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Seafoam.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Seafoam.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.DarkGreen.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.DarkGreen.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.LightTeal.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.LightTeal.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Teal.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Teal.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Steel.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Steel.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Blue.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Blue.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.RoyalBlue.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.RoyalBlue.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Cornflower.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Cornflower.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Navy.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Navy.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lavender.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lavender.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Purple.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Purple.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Grape.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Grape.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Lilac.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Lilac.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Pink.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Pink.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Magenta.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Magenta.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Plum.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Plum.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Beige.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Beige.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Mink.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Mink.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Platinum.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Platinum.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil), 
+			UIColor(light: mainProxy().Colors.Anchor.shade30Property(traitCollection), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Anchor.tint40Property(traitCollection), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)]
 			}
 		public var textCalculatedForegroundColors: [UIColor] {
 			get { return self.textCalculatedForegroundColorsProperty() }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR resolves issue #338.
The design team released a new set of 30 colors for background and foreground colors that should be used for the Avatar.
These colors are calculated based on the primary and secondary properties:

![Screen Shot 2021-02-01 at 11 18 01 PM](https://user-images.githubusercontent.com/68076145/106565687-07233100-64e4-11eb-8c88-acd224b7d12e.png)

Since the textColor token would not be needed anymore (replaced by the foreground color), the token was also removed.

### Verification

- Verified that the avatar colors are picking up the new set of 30 colors,
- Ran a local validation generating multiple tokens with different primary text properties

| Light mode                                      | Dark mode                                     |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-02-01 at 11 16 29 PM](https://user-images.githubusercontent.com/68076145/106565958-78fb7a80-64e4-11eb-9334-b0b4389acfa6.png)| ![Screen Shot 2021-02-01 at 11 16 33 PM](https://user-images.githubusercontent.com/68076145/106565938-6f721280-64e4-11eb-8d0c-306c433efd8e.png) |
| ![Screen Shot 2021-02-01 at 11 16 43 PM](https://user-images.githubusercontent.com/68076145/106566038-9892a300-64e4-11eb-9da6-b64262b33c10.png) | ![Screen Shot 2021-02-01 at 11 16 47 PM](https://user-images.githubusercontent.com/68076145/106566065-a21c0b00-64e4-11eb-87d5-60ce9f7c4c71.png) |
| ![Screen Shot 2021-02-01 at 11 14 32 PM](https://user-images.githubusercontent.com/68076145/106566156-c677e780-64e4-11eb-9511-51aa35ed9199.png)| ![Screen Shot 2021-02-01 at 11 14 55 PM](https://user-images.githubusercontent.com/68076145/106566172-cd065f00-64e4-11eb-8bf8-0aaab6b6e9b8.png)|
| ![Screen Shot 2021-02-01 at 11 14 41 PM](https://user-images.githubusercontent.com/68076145/106566221-df809880-64e4-11eb-82c6-50f0dbee2146.png) | ![Screen Shot 2021-02-01 at 11 14 49 PM](https://user-images.githubusercontent.com/68076145/106566234-e5767980-64e4-11eb-89fb-41a00fd1837f.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/420)