### PR TITLE
add warning and danger style notification toast

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -10,6 +10,8 @@ class NotificationViewDemoController: DemoController {
         case primaryToast
         case primaryToastWithImageAndTitle
         case neutralToast
+        case dangerToast
+        case warningToast
         case primaryBar
         case primaryOutlineBar
         case neutralBar
@@ -24,6 +26,10 @@ class NotificationViewDemoController: DemoController {
                 return "Primary Toast with image and title"
             case .neutralToast:
                 return "Neutral Toast"
+            case .dangerToast:
+                return "Danger Toast"
+            case .warningToast:
+                return "Warning Toast"
             case .primaryBar:
                 return "Primary Bar"
             case .primaryOutlineBar:
@@ -34,6 +40,7 @@ class NotificationViewDemoController: DemoController {
                 return "Persistent Bar with Action"
             case .persistentBarWithCancel:
                 return "Persistent Bar with Cancel"
+
             }
         }
 
@@ -73,6 +80,10 @@ class NotificationViewDemoController: DemoController {
             view.setup(style: .primaryToast, title: "Kat's iPhoneX", message: "Listen to Emails • 7 mins", image: UIImage(named: "play-in-circle-24x24"), action: { [unowned self] in self.showMessage("`Dismiss` tapped") }, messageAction: { [unowned self] in self.showMessage("`Listen to emails` tapped") })
         case .neutralToast:
             view.setup(style: .neutralToast, message: "Some items require you to sign in to view them", actionTitle: "Sign in", action: { [unowned self] in self.showMessage("`Sign in` tapped") })
+        case .dangerToast:
+            view.setup(style: .dangerToast, message: "There was a problem, and your recent changes may not have saved", actionTitle: "Retry", action: { [unowned self] in self.showMessage("`Retry` tapped") })
+        case .warningToast:
+            view.setup(style: .warningToast, message: "Read Only")
         case .primaryBar:
             view.setup(style: .primaryBar, message: "Updating...")
         case .primaryOutlineBar:

--- a/ios/FluentUI/Notification/NotificationView.swift
+++ b/ios/FluentUI/Notification/NotificationView.swift
@@ -48,8 +48,17 @@ open class NotificationView: UIView {
         case primaryBar
         case primaryOutlineBar
         case neutralBar
+        case dangerToast
+        case warningToast
 
-        var isToast: Bool { self == .primaryToast || self == .neutralToast }
+        var isToast: Bool {
+            switch self {
+            case .primaryBar, .primaryOutlineBar, .neutralBar:
+                return false
+            case .primaryToast, .neutralToast, .dangerToast, .warningToast:
+                return true
+            }
+        }
 
         func backgroundColor(for window: UIWindow) -> UIColor {
             switch self {
@@ -63,6 +72,10 @@ open class NotificationView: UIView {
                 return Colors.Notification.PrimaryOutlineBar.background
             case .neutralBar:
                 return Colors.Notification.NeutralBar.background
+            case .dangerToast:
+                return UIColor(light: Colors.Palette.dangerTint40.color, dark: Colors.Palette.dangerPrimary.color)
+            case .warningToast:
+                return UIColor(light: Colors.Palette.warningTint40.color, dark: Colors.Palette.warningPrimary.color)
             }
         }
         func foregroundColor(for window: UIWindow) -> UIColor {
@@ -77,6 +90,10 @@ open class NotificationView: UIView {
                 return UIColor(light: Colors.primary(for: window), dark: Colors.textPrimary)
             case .neutralBar:
                 return Colors.Notification.NeutralBar.foreground
+            case .dangerToast:
+                return UIColor(light: Colors.Palette.dangerShade20.color, dark: .black)
+            case .warningToast:
+                return UIColor(light: Colors.Palette.warningShade30.color, dark: .black)
             }
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding 2 new styles for notification toast: danger and warning

### Verification

Tested on iPhone with light and dark mode

| light                                       | dark                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-02-02 at 09 49 20](https://user-images.githubusercontent.com/20715435/106641679-55641e80-653c-11eb-940c-36c8d1030e79.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-02-02 at 09 49 46](https://user-images.githubusercontent.com/20715435/106641725-63b23a80-653c-11eb-9ad5-4c4dfaa2cd6e.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/421)