### PR TITLE
Fixing presence size for ExtraLarge avatar.

### DIFF
--- a/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Vnext/Design Token System/FluentUIStyle.generated.swift
@@ -2354,7 +2354,7 @@ extension FluentUIThemeManagerTheming {
 			public var _xlarge: CGFloat?
 			open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
 				if let override = _xlarge { return override }
-					return mainProxy().Icon.size.xSmallProperty(traitCollection)
+					return mainProxy().Icon.size.xxSmallProperty(traitCollection)
 				}
 			public var xlarge: CGFloat {
 				get { return self.xlargeProperty() }

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -181,7 +181,7 @@ AP_MSFAvatarTokens:
   backgroundDefaultColor: "FluentUIColor(light: $Colors.Neutral.white, dark: $Colors.Brand.primary)"
   borderRadius: [ xSmall: $Border.radius.none, small: $Border.radius.none, medium: $Border.radius.none, large: $Border.radius.none, xlarge: $Border.radius.none, xxlarge: $Border.radius.none ]
   foregroundDefaultColor: "FluentUIColor(light: $Colors.Brand.primary, dark: $Icon.accentColor)"
-  presenceIconSize: [ xSmall: 0pt, small: $Icon.size.xxxSmall, medium: $Icon.size.xxxSmall, large: $Icon.size.xxSmall, xlarge: $Icon.size.xSmall, xxlarge: $Icon.size.small ]
+  presenceIconSize: [ xSmall: 0pt, small: $Icon.size.xxxSmall, medium: $Icon.size.xxxSmall, large: $Icon.size.xxSmall, xlarge: $Icon.size.xxSmall, xxlarge: $Icon.size.small ]
   presenceIconOutlineColor: $Colors.Background.neutral1
   presenceIconOutlineThickness: [ xSmall: $Border.size.none, small: $Border.size.thick, medium: $Border.size.thick, large: $Border.size.thick, xlarge: $Border.size.thick, xxlarge: $Border.size.thick ]
   ringDefaultColor: $Colors.Brand.tint10

--- a/tools/sgen/output/FluentUIStyle.generated.swift
+++ b/tools/sgen/output/FluentUIStyle.generated.swift
@@ -2354,7 +2354,7 @@ extension FluentUIThemeManagerTheming {
 			public var _xlarge: CGFloat?
 			open func xlargeProperty(_ traitCollection: UITraitCollection? = UIScreen.main.traitCollection) -> CGFloat {
 				if let override = _xlarge { return override }
-					return mainProxy().Icon.size.xSmallProperty(traitCollection)
+					return mainProxy().Icon.size.xxSmallProperty(traitCollection)
 				}
 			public var xlarge: CGFloat {
 				get { return self.xlargeProperty() }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The design token definition for the presence size in the ExtraLarge Avatar is incorrect.
It should be 12 and is currently set to 16.

### Verification

Screenshots of the Avatar demo controller before and after the fix.
Notice the presence size on the **ExtraLarge** avatar size row.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![avatar_presencesize_bug](https://user-images.githubusercontent.com/68076145/106687798-b8c46f80-6581-11eb-9781-bd0a63b321b6.png) | ![avatar_presencesize_fixed](https://user-images.githubusercontent.com/68076145/106687679-7ac74b80-6581-11eb-87dc-0b5524504646.png) |
| ![avatar_presencesize_bug2](https://user-images.githubusercontent.com/68076145/106687886-ddb8e280-6581-11eb-89f2-5dc917797d09.png) | ![avatar_presencesize_fixed2](https://user-images.githubusercontent.com/68076145/106687697-8286f000-6581-11eb-8b0c-fb8e5ff50db2.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/422)