### PR TITLE
[PeoplePicker] Add delegate methods to notify client that PersonaListView is shown or hidden

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -96,4 +96,8 @@ extension PeoplePickerDemoController: PeoplePickerDelegate {
             completion(personas, true)
         }
     }
+
+    func peoplePickerDidHidePersonaSuggestions(_ peoplePicker: PeoplePicker) {
+        UIAccessibility.post(notification: .screenChanged, argument: peoplePicker.badges.last)
+    }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -98,6 +98,6 @@ extension PeoplePickerDemoController: PeoplePickerDelegate {
     }
 
     func peoplePickerDidHidePersonaSuggestions(_ peoplePicker: PeoplePicker) {
-        UIAccessibility.post(notification: .screenChanged, argument: peoplePicker.badges.last)
+        UIAccessibility.post(notification: .layoutChanged, argument: peoplePicker.badges.last)
     }
 }

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -39,6 +39,12 @@ public protocol PeoplePickerDelegate: BadgeFieldDelegate {
     /// This is called to check if suggestions are to be hidden on textField endEditing event.
     /// If not implemented, the default value assumed is false.
     @objc optional func peoplePickerShouldKeepShowingPersonaSuggestionsOnEndEditing(_ peoplePicker: PeoplePicker) -> Bool
+	
+    /// Called when the PersonaListView is shown.
+    @objc optional func peoplePickerDidShowPersonaSuggestions(_ peoplePicker: PeoplePicker)
+
+    /// Called when the PersonaListView is hidden.
+    @objc optional func peoplePickerDidHidePersonaSuggestions(_ peoplePicker: PeoplePicker)
 }
 
 // MARK: - PeoplePicker
@@ -192,13 +198,14 @@ open class PeoplePicker: BadgeField {
         }
 
         personaListView.searchDirectoryState = .idle
-
+        delegate?.peoplePickerDidShowPersonaSuggestions?(self)
         setNeedsLayout()
     }
 
     /// Hides personaSuggestionsView
     @objc open func hidePersonaSuggestions() {
         personaSuggestionsView.removeFromSuperview()
+        delegate?.peoplePickerDidHidePersonaSuggestions?(self)
         containingViewBoundsObservation = nil
     }
 

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -198,15 +198,16 @@ open class PeoplePicker: BadgeField {
         }
 
         personaListView.searchDirectoryState = .idle
-        delegate?.peoplePickerDidShowPersonaSuggestions?(self)
         setNeedsLayout()
+        layoutIfNeeded()
+        delegate?.peoplePickerDidShowPersonaSuggestions?(self)
     }
 
     /// Hides personaSuggestionsView
     @objc open func hidePersonaSuggestions() {
         personaSuggestionsView.removeFromSuperview()
-        delegate?.peoplePickerDidHidePersonaSuggestions?(self)
         containingViewBoundsObservation = nil
+        delegate?.peoplePickerDidHidePersonaSuggestions?(self)
     }
 
     private func layoutPersonaSuggestions() {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

- PeoplePicker.swift: Adding two delegate methods peoplePickerDidShowPersonaSuggestions and peoplePickerDidHidePersonaSuggestions to notify client that the PersonaListView is shown/hidden.
- PeoplePickerDemoController.swift: Implement delegate method peoplePickerDidHidePersonaSuggestions to move the VoiceOver focus to the last added persona after the PersonaListView gets dismissed.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Before the change, when voice over is enabled, selecting a contact from PersonaListView would dismiss the list but highlight the voice over focus on the view below wherever user touches.  | After the change, selecting a contact would dismiss the list and VoiceOver focus would land on the last added person |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ X ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/425)