### PR TITLE
Adding button accessibility trait even when the cell is selected.

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1367,11 +1367,6 @@ open class TableViewCell: UITableViewCell {
     }
 
     private func initAccessibilityForAccessoryType() {
-        if _accessoryType == .disclosureIndicator || _accessoryType == .detailButton {
-            accessibilityTraits.insert(.button)
-        } else {
-            accessibilityTraits.remove(.button)
-        }
         if _accessoryType == .checkmark || isSelected {
             accessibilityTraits.insert(.selected)
         } else {
@@ -1380,6 +1375,8 @@ open class TableViewCell: UITableViewCell {
     }
 
     private func updateAccessibility() {
+        accessibilityTraits.insert(.button)
+
         if isEnabled {
             accessibilityTraits.remove(.notEnabled)
         } else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The PopupMenuController is currently failing to set the button accessibility trait for items that are selected.
Previously, the only scenario where it would be set is when the accessory type was set to disclosure or detail button.

### Verification

Ensured all the PopupMenuController cells have the button accessibility trait even if they're disabled or selected.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-02-08 at 9 10 00 AM](https://user-images.githubusercontent.com/68076145/107270289-9c03be00-69ff-11eb-9ba0-77cfe043d6aa.png) | ![Screen Shot 2021-02-08 at 9 28 33 AM](https://user-images.githubusercontent.com/68076145/107270315-a3c36280-69ff-11eb-8ea9-85aeccbca95f.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/426)