### PR TITLE
Fixing swiftlint violations.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -26,23 +26,23 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         searchBar.autocorrectionType = autocorrectionType
         return searchBar
     }
-    
+
     // MARK: SearchBarDelegate
-    
+
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
     }
-    
+
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
         searchBar.placeholderText = newSearchText ?? "search"
     }
-    
+
     func searchBarDidFinishEditing(_ searchBar: SearchBar) {
     }
-    
+
     func searchBarDidCancel(_ searchBar: SearchBar) {
         searchBar.progressSpinner.stopAnimating()
     }
-    
+
     func searchBarDidRequestSearch(_ searchBar: SearchBar) {
         searchBar.progressSpinner.startAnimating()
     }

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -39,7 +39,7 @@ public protocol PeoplePickerDelegate: BadgeFieldDelegate {
     /// This is called to check if suggestions are to be hidden on textField endEditing event.
     /// If not implemented, the default value assumed is false.
     @objc optional func peoplePickerShouldKeepShowingPersonaSuggestionsOnEndEditing(_ peoplePicker: PeoplePicker) -> Bool
-	
+
     /// Called when the PersonaListView is shown.
     @objc optional func peoplePickerDidShowPersonaSuggestions(_ peoplePicker: PeoplePicker)
 


### PR DESCRIPTION

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Removing empty spaces that caused the following violation:
Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)

### Verification

No violations reported by swiftlint.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/428)