### PR TITLE
Update CI and publishing to work on new default branch named "main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
 jobs:
   xcodebuild:

--- a/.github/workflows/localize.yml
+++ b/.github/workflows/localize.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
     paths:
       - '**.strings'
       - '**.stringsdict'

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Pod-Publish:
-    if: github.event.base_ref == 'refs/heads/master'
+    if: github.event.base_ref == 'refs/heads/main'
     runs-on: macOS-10.15
     
     steps:

--- a/scripts/generate_build_number.sh
+++ b/scripts/generate_build_number.sh
@@ -8,7 +8,7 @@ if [ -n "$BUILD_NUMBER_SUFFIX_OVERRIDE" ]; then
     # Allow someone calling us to provide an override to always add a suffix to a given build number by providing an env variable
     ADJUSTED_BUILD_NUMBER_SUFFIX_OVERRIDE="${BUILD_NUMBER_SUFFIX_OVERRIDE//[^a-z0-9A-Z]/}"
     BUILD_VERSION_SUFFIX="-$ADJUSTED_BUILD_NUMBER_SUFFIX_OVERRIDE"
-elif [ -n "$BUILD_SOURCEBRANCHNAME" ] && [ "$BUILD_SOURCEBRANCHNAME" != "master" ]; then 
+elif [ -n "$BUILD_SOURCEBRANCHNAME" ] && [ "$BUILD_SOURCEBRANCHNAME" != "main" ]; then 
     # Otherwise append the branch name unless we're the main branch for this repo
     ADJUSTED_SOURCEBRANCHNAME="${BUILD_SOURCEBRANCHNAME//[^a-z0-9A-Z]/}"
     BUILD_VERSION_SUFFIX="-$ADJUSTED_SOURCEBRANCHNAME"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes
Update our CI and CD to support "main" as well as "master". This will allow a seamless transition when renaming the default branch. This is the first step of Issue #343.

Note that the publishing steps for simplicity only reference "main", not "master". This means that there will be a small gap of time where publishing won't work as expected once this PR has been merged but before the rename has been executed. The intention is to keep this gap as small as possible, under an hour if everything goes as planned.

### Verification
CI/CD changes aren't trivial to test in progress, especially since the main branch doesn't exist yet, but part of this work will be making a followup PR to update all the remaining references to the master branch targeting the new main branch. At that time we'll confirm that all the pipelines are working as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/429)