### PR TITLE
Update links to new default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,9 @@ name: CI
 on: 
   push:
     branches:
-      - master
       - main
   pull_request:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/localize.yml
+++ b/.github/workflows/localize.yml
@@ -3,7 +3,6 @@ name: Localize
 on: 
   push:
     branches:
-      - master
       - main
     paths:
       - '**.strings'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Fluent UI Apple
 Fluent UI Apple contains native UIKit and AppKit controls aligned with [Microsoft's Fluent UI design system](https://www.microsoft.com/design/fluent/#/). 
 
-![Build Status](https://github.com/microsoft/fluentui-apple/workflows/CI/badge.svg?branch=master)
+![Build Status](https://github.com/microsoft/fluentui-apple/workflows/CI/badge.svg?branch=main)
 ![Localization Status](https://github.com/microsoft/fluentui-apple/workflows/Localize/badge.svg)
 ![CocoaPod Publishing](https://github.com/microsoft/fluentui-apple/workflows/Pod-Publish/badge.svg)
-[![Build Status](https://dev.azure.com/microsoftdesign/fluentui-native/_apis/build/status/microsoft.fluentui-apple?branchName=master)](https://dev.azure.com/microsoftdesign/fluentui-native/_build/latest?definitionId=144&branchName=master)
+[![Build Status](https://dev.azure.com/microsoftdesign/fluentui-native/_apis/build/status/microsoft.fluentui-apple?branchName=main)](https://dev.azure.com/microsoftdesign/fluentui-native/_build/latest?definitionId=144&branchName=main)
 ![License](https://img.shields.io/github/license/Microsoft/fluentui-apple)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/MicrosoftFluentUI)](https://cocoapods.org/pods/MicrosoftFluentUI)

--- a/macos/docs/Controls/AvatarView.md
+++ b/macos/docs/Controls/AvatarView.md
@@ -38,6 +38,6 @@ AvatarView(avatarSize: size,
 ### Control Name
 `AvatarView` in Swift, `MSFAvatarView` in Objective-C
 ### Source Code
-[AvatarView.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/AvatarView.swift)
+[AvatarView.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/AvatarView/AvatarView.swift)
 ### Sample Code
-[TestAvatarViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestAvatarViewController.swift)
+[TestAvatarViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestAvatarViewController.swift)

--- a/macos/docs/Controls/AvatarView.md
+++ b/macos/docs/Controls/AvatarView.md
@@ -38,6 +38,6 @@ AvatarView(avatarSize: size,
 ### Control Name
 `AvatarView` in Swift, `MSFAvatarView` in Objective-C
 ### Source Code
-[AvatarView.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/AvatarView.swift)
+[AvatarView.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/AvatarView.swift)
 ### Sample Code
-[TestAvatarViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestAvatarViewController.swift)
+[TestAvatarViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestAvatarViewController.swift)

--- a/macos/docs/Controls/Button.md
+++ b/macos/docs/Controls/Button.md
@@ -75,6 +75,6 @@ let buttonWithImage = Button(image: NSImage(named: NSImage.addTemplateName)!)
 ### Control Name
 `Button` in Swift, `MSFButton` in Objective-C
 ### Source Code
-[Button.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/Button.swift)
+[Button.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Button.swift)
 ### Sample Code
-[TestButtonViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestButtonViewController.swift)
+[TestButtonViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestButtonViewController.swift)

--- a/macos/docs/Controls/Button.md
+++ b/macos/docs/Controls/Button.md
@@ -75,6 +75,6 @@ let buttonWithImage = Button(image: NSImage(named: NSImage.addTemplateName)!)
 ### Control Name
 `Button` in Swift, `MSFButton` in Objective-C
 ### Source Code
-[Button.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Button.swift)
+[Button.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Button/Button.swift)
 ### Sample Code
-[TestButtonViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestButtonViewController.swift)
+[TestButtonViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestButtonViewController.swift)

--- a/macos/docs/Controls/DatePicker.md
+++ b/macos/docs/Controls/DatePicker.md
@@ -74,6 +74,6 @@ controller.hasTextField = false
 ### Control Name
 `DatePickerController` in Swift, `MSFDatePickerController` in Objective-C
 ### Source Code
-[DatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/DatePicker/DatePickerController.swift)
+[DatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/DatePicker/DatePickerController.swift)
 ### Sample Code
-[TestDatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestDatePickerController.swift)
+[TestDatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestDatePickerController.swift)

--- a/macos/docs/Controls/DatePicker.md
+++ b/macos/docs/Controls/DatePicker.md
@@ -76,4 +76,4 @@ controller.hasTextField = false
 ### Source Code
 [DatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/DatePicker/DatePickerController.swift)
 ### Sample Code
-[TestDatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestDatePickerController.swift)
+[TestDatePickerController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestDatePickerController.swift)

--- a/macos/docs/Controls/Link.md
+++ b/macos/docs/Controls/Link.md
@@ -52,6 +52,6 @@ link.action = #selector(displayAlert)
 ### Control Name
 `Link` in Swift, `MSFLink` in Objective-C
 ### Source Code
-[Link.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Link.swift)
+[Link.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Link/Link.swift)
 ### Sample Code
-[TestLinkViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestLinkViewController.swift)
+[TestLinkViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestLinkViewController.swift)

--- a/macos/docs/Controls/Link.md
+++ b/macos/docs/Controls/Link.md
@@ -52,6 +52,6 @@ link.action = #selector(displayAlert)
 ### Control Name
 `Link` in Swift, `MSFLink` in Objective-C
 ### Source Code
-[Link.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/Link.swift)
+[Link.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Link.swift)
 ### Sample Code
-[TestLinkViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestLinkViewController.swift)
+[TestLinkViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestLinkViewController.swift)

--- a/macos/docs/Controls/Separator.md
+++ b/macos/docs/Controls/Separator.md
@@ -24,6 +24,6 @@ let horizontalSeparator = Separator(orientation: .horizontal)
 ### Control Name
 `Separator` in Swift, `MSFSeparator` in Objective-C
 ### Source Code
-[Separator.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Separator.swift)
+[Separator.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Separator/Separator.swift)
 ### Sample Code
-[TestSeparatorViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestSeparatorViewController.swift)
+[TestSeparatorViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestViewControllers/TestSeparatorViewController.swift)

--- a/macos/docs/Controls/Separator.md
+++ b/macos/docs/Controls/Separator.md
@@ -24,6 +24,6 @@ let horizontalSeparator = Separator(orientation: .horizontal)
 ### Control Name
 `Separator` in Swift, `MSFSeparator` in Objective-C
 ### Source Code
-[Separator.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUI/Separator.swift)
+[Separator.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUI/Separator.swift)
 ### Sample Code
-[TestSeparatorViewController.swift](https://github.com/microsoft/fluentui-apple/blob/master/macos/FluentUITestApp/TestSeparatorViewController.swift)
+[TestSeparatorViewController.swift](https://github.com/microsoft/fluentui-apple/blob/main/macos/FluentUITestApp/TestSeparatorViewController.swift)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes
Update some links to point to the new default branch name. This cleanup is relevant to #343.

Note this won't go in until after #429 is merged and the default branch is renamed.

### Verification
View the readme and verify the badges display as expected. Click on the links and ensure they resolve as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/430)