### PR TITLE
Button: Add correct focus ring

### DIFF
--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -211,6 +211,13 @@ open class Button: NSButton {
 		return true
 	}
 
+	open override func drawFocusRingMask() {
+		// Ensure we draw the focus ring around the entire button bounds
+		// rather than just around the image or title.
+		let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius)
+		path.fill()
+	}
+
 	open override func viewDidChangeBackingProperties() {
 		super.viewDidChangeBackingProperties()
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
The keyboard focus ring for Buttons hugs the image/text in the Button, which is within the button frame.  This change adds the drawFocusRingMask method to make the focus ring hug the button frame itself.

### Verification
Turned on full keyboard navigation and navigated through Buttons in the test app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/67027949/107565249-53333d00-6b98-11eb-8709-ad18d14566a9.gif) | ![After](https://user-images.githubusercontent.com/67027949/107565267-59291e00-6b98-11eb-9244-9848dfaa799c.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/431)