### PR TITLE
Link: No hover effects when disabled

### DIFF
--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -109,12 +109,27 @@ open class Link: NSButton {
 
 	private var mouseInside: Bool = false
 
+	open override var isEnabled: Bool {
+		get {
+			return super.isEnabled
+		}
+		set {
+			super.isEnabled = newValue
+			self.window?.invalidateCursorRects(for: self)
+			if !newValue {
+				mouseExited(with: NSEvent())
+			}
+		}
+	}
+
 	open override func resetCursorRects() {
-		addCursorRect(bounds, cursor: .pointingHand)
+		if isEnabled {
+			addCursorRect(bounds, cursor: .pointingHand)
+		}
 	}
 
 	private func updateTitle() {
-		let titleAttributes = (showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes
+		let titleAttributes = (isEnabled && showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes
 		self.attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
 	}
 

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -116,9 +116,7 @@ open class Link: NSButton {
 		set {
 			super.isEnabled = newValue
 			self.window?.invalidateCursorRects(for: self)
-			if !newValue {
-				mouseExited(with: NSEvent())
-			}
+			updateTitle()
 		}
 	}
 

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -7,10 +7,12 @@ import AppKit
 import FluentUI
 
 class TestLinkViewController: NSViewController {
+	let disabledLink = Link(title: "Disabled link with hover effects")
+
 	override func loadView() {
 		let url = NSURL(string: "https://github.com/microsoft/fluentui-apple")
 
-		let linkWithNoHover = Link(title: "Link", url: url)
+		let linkWithNoUnderline = Link(title: "Link", url: url)
 
 		let linkWithHover = Link(title: "Link with hover effects", url: url)
 		linkWithHover.showsUnderlineWhileMouseInside = true
@@ -27,11 +29,33 @@ class TestLinkViewController: NSViewController {
 		linkWithCustomFontAndColor.font = NSFont.systemFont(ofSize: 12.0, weight: NSFont.Weight.semibold)
 		linkWithCustomFontAndColor.contentTintColor = .textColor
 
-		let containerView = NSStackView(views: [linkWithNoHover, linkWithHover, linkWithHoverAndNoURL, linkWithOverridenTargetAction, linkWithCustomFontAndColor])
+		disabledLink.showsUnderlineWhileMouseInside = true
+		disabledLink.isEnabled = false
+		disabledLink.target = self
+		disabledLink.action = #selector(toggleLink)
+
+		let toggleDisabledLink = Link(title: "Toggle disabled link")
+		toggleDisabledLink.showsUnderlineWhileMouseInside = true
+		toggleDisabledLink.target = self
+		toggleDisabledLink.action = #selector(toggleLink)
+
+		let containerView = NSStackView(views: [
+			linkWithNoUnderline,
+			linkWithHover,
+			linkWithHoverAndNoURL,
+			linkWithOverridenTargetAction,
+			linkWithCustomFontAndColor,
+			disabledLink,
+			toggleDisabledLink
+		])
 		containerView.edgeInsets = NSEdgeInsets(top: 100, left: 100, bottom: 100, right: 100)
 		containerView.orientation = .vertical
 		containerView.distribution = .gravityAreas
 		view = containerView
+	}
+
+	@objc private func toggleLink() {
+		disabledLink.isEnabled = !disabledLink.isEnabled
 	}
 
 	@objc private func displayAlert() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
Link has confusing behavior when disabled.  It is dimmed and nothing happens when clicking it, but the underline and pointing hand hover effects still get applied.  This change removes those hover effects to signal more clearly that the user can't interact with the link.

### Verification
Added a disabled link to the test app, along with another link to enable it, and confirmed that the hover effects do not occur when the link is disabled (either initially, or programmatically later).

Also tested the scenario where the link gets disabled while the mouse is hovering over it (in this case, by having the link disable itself when clicked), ensuring that we don't end up with some hover effect that is stuck on afterward.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Link Before](https://user-images.githubusercontent.com/67027949/107597214-d7a0b280-6bce-11eb-87d0-2b22b6d302bc.gif) | ![Link After](https://user-images.githubusercontent.com/67027949/107597227-e1c2b100-6bce-11eb-86fa-7fda89b63a80.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/433)