### PR TITLE
Link: Add correct focus ring

### DIFF
--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -126,6 +126,15 @@ open class Link: NSButton {
 		}
 	}
 
+	private let cornerRadius: CGFloat = 2
+
+	open override func drawFocusRingMask() {
+		// Ensure we draw the focus ring around the entire link bounds
+		// rather than just around the image if the link contains one.
+		let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius)
+		path.fill()
+	}
+
 	private func updateTitle() {
 		let titleAttributes = (isEnabled && showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes
 		self.attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -9,6 +9,50 @@ import AppKit
 @objc(MSFLink)
 open class Link: NSButton {
 
+	/// The text displayed on the control, stylized to look like a hyperlink
+	open override var title: String {
+		didSet {
+			guard oldValue != title else {
+				return
+			}
+			updateTitle()
+		}
+	}
+
+	open override func mouseEntered(with event: NSEvent) {
+		mouseInside = true
+		updateTitle()
+	}
+
+	open override func mouseExited(with event: NSEvent) {
+		mouseInside = false
+		updateTitle()
+	}
+
+	open override var isEnabled: Bool {
+		get {
+			return super.isEnabled
+		}
+		set {
+			super.isEnabled = newValue
+			self.window?.invalidateCursorRects(for: self)
+			updateTitle()
+		}
+	}
+
+	open override func resetCursorRects() {
+		if isEnabled {
+			addCursorRect(bounds, cursor: .pointingHand)
+		}
+	}
+
+	open override func drawFocusRingMask() {
+		// Ensure we draw the focus ring around the entire link bounds
+		// rather than just around the image if the link contains one.
+		let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius)
+		path.fill()
+	}
+
 	/// Initializes a hyperlink with a title and an underlying URL that opens when clicked
 	/// - Parameters:
 	///   - title: The visible text of the link that the user sees.
@@ -64,18 +108,6 @@ open class Link: NSButton {
 		}
 	}
 
-	/// The text displayed on the control, stylized to look like a hyperlink
-	open override var title: String {
-		didSet {
-			guard oldValue != title else {
-				return
-			}
-			updateTitle()
-		}
-	}
-
-	private var trackingArea: NSTrackingArea?
-
 	public override func updateTrackingAreas() {
 		super.updateTrackingAreas()
 
@@ -97,43 +129,11 @@ open class Link: NSButton {
 		self.trackingArea = trackingArea
 	}
 
-	open override func mouseEntered(with event: NSEvent) {
-		mouseInside = true
-		updateTitle()
-	}
-
-	open override func mouseExited(with event: NSEvent) {
-		mouseInside = false
-		updateTitle()
-	}
+	private var trackingArea: NSTrackingArea?
 
 	private var mouseInside: Bool = false
 
-	open override var isEnabled: Bool {
-		get {
-			return super.isEnabled
-		}
-		set {
-			super.isEnabled = newValue
-			self.window?.invalidateCursorRects(for: self)
-			updateTitle()
-		}
-	}
-
-	open override func resetCursorRects() {
-		if isEnabled {
-			addCursorRect(bounds, cursor: .pointingHand)
-		}
-	}
-
 	private let cornerRadius: CGFloat = 2
-
-	open override func drawFocusRingMask() {
-		// Ensure we draw the focus ring around the entire link bounds
-		// rather than just around the image if the link contains one.
-		let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius)
-		path.fill()
-	}
 
 	private func updateTitle() {
 		let titleAttributes = (isEnabled && showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -25,9 +25,11 @@ class TestLinkViewController: NSViewController {
 		linkWithOverridenTargetAction.target = self
 		linkWithOverridenTargetAction.action = #selector(displayAlert)
 
-		let linkWithCustomFontAndColor = Link(title: "Link with custom font and color  ❯", url: url)
-		linkWithCustomFontAndColor.font = NSFont.systemFont(ofSize: 12.0, weight: NSFont.Weight.semibold)
-		linkWithCustomFontAndColor.contentTintColor = .textColor
+		let customLink = Link(title: "Link with custom font, color and image", url: url)
+		customLink.font = NSFont.systemFont(ofSize: 12.0, weight: NSFont.Weight.semibold)
+		customLink.contentTintColor = .textColor
+		customLink.image = NSImage(named: NSImage.goRightTemplateName)!
+		customLink.imagePosition = .imageLeading
 
 		disabledLink.showsUnderlineWhileMouseInside = true
 		disabledLink.isEnabled = false
@@ -44,7 +46,7 @@ class TestLinkViewController: NSViewController {
 			linkWithHover,
 			linkWithHoverAndNoURL,
 			linkWithOverridenTargetAction,
-			linkWithCustomFontAndColor,
+			customLink,
 			disabledLink,
 			toggleDisabledLink
 		])

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -29,7 +29,7 @@ class TestLinkViewController: NSViewController {
 		customLink.font = NSFont.systemFont(ofSize: 12.0, weight: NSFont.Weight.semibold)
 		customLink.contentTintColor = .textColor
 		customLink.image = NSImage(named: NSImage.goRightTemplateName)!
-		customLink.imagePosition = .imageLeading
+		customLink.imagePosition = .imageTrailing
 
 		disabledLink.showsUnderlineWhileMouseInside = true
 		disabledLink.isEnabled = false


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
The default focus ring for Link has similar issues to that for Button, where the ring hugs the text tightly by default, or if the control contains an image, surrounds that instead.

This change ensures the ring surrounds the entire control, and adds a small corner radius to improve the look.

### Verification
Added an image to a link in the test app, and used full keyboard navigation to check the focus ring appearance.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Link Before](https://user-images.githubusercontent.com/67027949/107655142-1e76c280-6c38-11eb-92b4-1a5df63ac923.gif) | ![Link After](https://user-images.githubusercontent.com/67027949/107655161-246ca380-6c38-11eb-81bb-07ecb781d365.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/435)