### PR TITLE
Addressing warning for deprecated scrollIndicatorInsets.

### DIFF
--- a/ios/FluentUI/Controls/ScrollView.swift
+++ b/ios/FluentUI/Controls/ScrollView.swift
@@ -105,7 +105,8 @@ open class ScrollView: UIScrollView, ScrollableContainerView {
             let bottomInset = max(originalBottomContentInset, frame.maxY - keyboardFrame.minY)
             if contentInset.bottom != bottomInset {
                 contentInset.bottom = bottomInset
-                scrollIndicatorInsets.bottom = bottomInset
+                horizontalScrollIndicatorInsets.bottom = bottomInset
+                verticalScrollIndicatorInsets.bottom = bottomInset
 
                 if bottomInset != 0 {
                     UIView.performWithoutAnimation {


### PR DESCRIPTION

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Setting the [scrollIndicatorInsets](https://developer.apple.com/documentation/uikit/uiscrollview/1619427-scrollindicatorinsets) triggers the warning below because it's deprecated (starting on iOS 13):

`Getter for 'scrollIndicatorInsets' was deprecated in iOS 13.0: The scrollIndicatorInsets getter is deprecated, use the verticalScrollIndicatorInsets and horizontalScrollIndicatorInsets getters instead.`

The documentation is explicit that this property is just a **convenience setter for both [verticalScrollIndicatorInsets](https://developer.apple.com/documentation/uikit/uiscrollview/3198045-verticalscrollindicatorinsets) and [horizontalScrollIndicatorInsets](https://developer.apple.com/documentation/uikit/uiscrollview/3198044-horizontalscrollindicatorinsets)**, so let's just set those properties to avoid the deprecation warning:

`   open var scrollIndicatorInsets: UIEdgeInsets // use the setter only, as a convenience for setting both verticalScrollIndicatorInsets and horizontalScrollIndicatorInsets to the same value. if those properties have been set to different values, the return value of this getter (deprecated) is undefined.`

### Verification

Exercised the DrawerController scenario "Show with focusable content" stepping through the code:
 - ensured that the value of the 2 properties (verticalScrollIndicatorInsets and horizontalScrollIndicatorInsets) matched the value set on scrollIndicatorInsets before the change.
 - validated that setting the properties individually had the same effect.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/440)