### PR TITLE
NotificationView warning/danger colors update to meet accessibility standards.

### DIFF
--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/redShade10.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/redShade10.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x34",
+          "green" : "0x2F",
+          "red" : "0xBC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/redShade40.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/redShade40.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x11",
+          "green" : "0x10",
+          "red" : "0x3F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/redTint20.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/redTint20.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0x5F",
+          "red" : "0xDC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/redTint60.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/redTint60.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF6",
+          "green" : "0xF6",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowShade40.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowShade40.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x44",
+          "red" : "0x4C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowShade50.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowShade50.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x24",
+          "red" : "0x28"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowTint20.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowTint20.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3D",
+          "green" : "0xEA",
+          "red" : "0xFD"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowTint50.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/yellowTint50.colorset/Contents.json
@@ -1,0 +1,29 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD6",
+          "green" : "0xFB",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -89,8 +89,12 @@ public final class Colors: NSObject {
         case pumpkinTint40
         case purpleShade30
         case purpleTint40
+        case redShade10
         case redShade30
+        case redShade40
+        case redTint20
         case redTint40
+        case redTint60
         case royalBlueShade30
         case royalBlueTint40
         case seafoamShade30
@@ -99,6 +103,10 @@ public final class Colors: NSObject {
         case steelTint40
         case tealShade30
         case tealTint40
+        case yellowShade40
+        case yellowShade50
+        case yellowTint20
+        case yellowTint50
         case pinkRed10
         case red20
         case red10
@@ -283,10 +291,18 @@ public final class Colors: NSObject {
                 return "purpleShade30"
             case .purpleTint40:
                 return "purpleTint40"
+            case .redShade10:
+                return "redShade10"
             case .redShade30:
                 return "redShade30"
+            case .redShade40:
+                return "redShade40"
+            case .redTint20:
+                return "redTint20"
             case .redTint40:
                 return "redTint40"
+            case .redTint60:
+                return "redTint60"
             case .royalBlueShade30:
                 return "royalBlueShade30"
             case .royalBlueTint40:
@@ -303,6 +319,14 @@ public final class Colors: NSObject {
                 return "tealShade30"
             case .tealTint40:
                 return "tealTint40"
+            case .yellowShade40:
+                return "yellowShade40"
+            case .yellowShade50:
+                return "yellowShade50"
+            case .yellowTint20:
+                return "yellowTint20"
+            case .yellowTint50:
+                return "yellowTint50"
             case .pinkRed10:
                 return "pinkRed10"
             case .red20:

--- a/ios/FluentUI/Notification/NotificationView.swift
+++ b/ios/FluentUI/Notification/NotificationView.swift
@@ -73,9 +73,9 @@ open class NotificationView: UIView {
             case .neutralBar:
                 return Colors.Notification.NeutralBar.background
             case .dangerToast:
-                return UIColor(light: Colors.Palette.dangerTint40.color, dark: Colors.Palette.dangerPrimary.color)
+                return UIColor(light: Colors.Palette.redTint60.color, dark: Colors.Palette.redShade40.color)
             case .warningToast:
-                return UIColor(light: Colors.Palette.warningTint40.color, dark: Colors.Palette.warningPrimary.color)
+                return UIColor(light: Colors.Palette.yellowTint50.color, dark: Colors.Palette.yellowShade40.color)
             }
         }
         func foregroundColor(for window: UIWindow) -> UIColor {
@@ -91,9 +91,9 @@ open class NotificationView: UIView {
             case .neutralBar:
                 return Colors.Notification.NeutralBar.foreground
             case .dangerToast:
-                return UIColor(light: Colors.Palette.dangerShade20.color, dark: .black)
+                return UIColor(light: Colors.Palette.redShade10.color, dark: Colors.Palette.redTint20.color)
             case .warningToast:
-                return UIColor(light: Colors.Palette.warningShade30.color, dark: .black)
+                return UIColor(light: Colors.Palette.yellowShade50.color, dark: Colors.Palette.yellowTint20.color)
             }
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The design team updated the colors used for Warning and Danger toast scenarios for the NotificationView in order to meet accessibility standards.

Reflecting this into code.

### Verification

Validated the demo app in both dark and light modes:

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-02-17 at 1 18 11 PM](https://user-images.githubusercontent.com/68076145/108276059-146b2d00-712c-11eb-8a53-22a9be8e4068.png) | ![Screen Shot 2021-02-17 at 2 01 39 PM](https://user-images.githubusercontent.com/68076145/108276126-319ffb80-712c-11eb-9bc0-0cf84804ba47.png) |
| ![Screen Shot 2021-02-17 at 1 18 20 PM](https://user-images.githubusercontent.com/68076145/108276082-1d5bfe80-712c-11eb-8181-f93e5a7a2a1e.png) | ![Screen Shot 2021-02-17 at 2 01 48 PM](https://user-images.githubusercontent.com/68076145/108276148-3795dc80-712c-11eb-8fa0-7fa01b3f5ad9.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/441)