### PR TITLE
Fixing updating UIView scenario of a UIViewAdapter.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -125,6 +125,7 @@ class LeftNavMenuViewController: UIViewController {
 
         let resetStatusCell = MSFListCellState()
         resetStatusCell.title = "Reset status"
+        resetStatusCell.leadingViewSize = .small
         let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
         resetStatusCell.leadingView = resetStatusImageView
@@ -134,7 +135,6 @@ class LeftNavMenuViewController: UIViewController {
         statusCellChildren.append(resetStatusCell)
 
         statusCell.title = LeftNavPresence.available.cellTitle()
-        statusCell.leadingViewSize = .small
         let statusImageView = LeftNavPresence.available.imageView()
         statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
         statusCell.leadingView = statusImageView

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -196,7 +196,6 @@
 		A5B6617323A41E2900E801DD /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B6617223A41E2900E801DD /* NotificationView.swift */; };
 		A5B6617423A41E2900E801DD /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B6617223A41E2900E801DD /* NotificationView.swift */; };
 		A5B87AF1211BD4380038C37C /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B87AF0211BD4380038C37C /* UIFont+Extension.swift */; };
-		A5B87AF6211E16370038C37C /* DrawerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B87AF3211E16360038C37C /* DrawerController.swift */; };
 		A5B87B02211E20B50038C37C /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B87B01211E20B50038C37C /* UIScreen+Extension.swift */; };
 		A5B87B04211E22B70038C37C /* DimmingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B87B03211E22B70038C37C /* DimmingView.swift */; };
 		A5B87B06211E23650038C37C /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B87B05211E23650038C37C /* UIView+Extensions.swift */; };
@@ -1489,7 +1488,6 @@
 				8FD011B8228A82A600D25925 /* PopupMenuItem.swift in Sources */,
 				8FD011B9228A82A600D25925 /* PopupMenuSection.swift in Sources */,
 				3F4FB97425B25E04008AB7CC /* SlideOverPanel.swift in Sources */,
-				A5B87AF6211E16370038C37C /* DrawerController.swift in Sources */,
 				FD41C8B622DD3EA20086F899 /* NSLayoutConstraint+Extensions.swift in Sources */,
 				8FD011BA228A82A600D25925 /* PopupMenuItemCell.swift in Sources */,
 				B4414790228F4D920040E88E /* BooleanCell.swift in Sources */,

--- a/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
@@ -16,12 +16,20 @@ public struct UIViewAdapter: UIViewRepresentable {
     }
 
     public func makeUIView(context: Context) -> UIView {
+        // Wrapping the view passed on a StackView is a workaround for a hang that occurs
+        // on iOS 13 when the view passed directly comes from a UIHostingController.view
+        // property. (e.g. using the MSFAvatar.view property).
         return UIStackView(arrangedSubviews: [makeView()])
     }
 
     public func updateUIView(_ view: UIView, context: Context) {
-        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        // This logic should be removed wnce the "wrapping in a UIStackView" workaround is removed.
+        guard let stackView = view as? UIStackView else {
+            return
+        }
+
+        stackView.removeAllSubviews()
+        stackView.addArrangedSubview(makeView())
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change fixes 3 different issues:
1. FluentUI project warning where the DrawerController.swift file was duplicated in build targets.
2. Size of icons on the presence submenu (main icons are now 24x24(medium) while the presence subitems are 16x16 (small))
3. Bug where updating the leadingView property of a cell state didn't update the UI properly

### Verification

The videos of before and after show the fix of items 2 and 3 described above:

https://user-images.githubusercontent.com/68076145/108406972-f8bd6080-71d7-11eb-9727-16add3fee566.mov 

https://user-images.githubusercontent.com/68076145/108407009-04108c00-71d8-11eb-8ae0-a12e524ee6d6.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/442)