### PR TITLE
[ListVnext] Automating cell layout/height

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -95,7 +95,7 @@ class ListDemoController: DemoController {
                 listCell = MSFListCellState()
                 listCell.title = cell.text1
                 listCell.subtitle = cell.text2
-                if let subtitle = listCell.subtitle, !subtitle.isEmpty {
+                if !listCell.subtitle.isEmpty {
                     listCell.leadingViewSize = MSFListCellLeadingViewSize.large
                 }
                 listCell.titleLineLimit = section.numberOfLines
@@ -103,7 +103,6 @@ class ListDemoController: DemoController {
                 listCell.leadingView = createCustomView(imageName: cell.image)
                 listCell.trailingView = section.hasAccessory ? createCustomView(imageName: cell.image) : nil
                 listCell.accessoryType = accessoryType(for: rowIndex)
-                listCell.layoutType = updateLayout(subtitle: listCell.subtitle)
                 listCell.onTapAction = {
                     indexPath.row = rowIndex
                     indexPath.section = sectionIndex
@@ -169,14 +168,6 @@ class ListDemoController: DemoController {
             return .none
         default:
             return .none
-        }
-    }
-
-    private func updateLayout(subtitle: String?) -> MSFListCellLayoutType {
-        if let subtitle = subtitle, !subtitle.isEmpty {
-            return MSFListCellLayoutType.twoLines
-        } else {
-            return MSFListCellLayoutType.oneLine
         }
     }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -27,19 +27,20 @@ import SwiftUI
     @objc @Published public var leadingView: UIView?
     @objc @Published public var leadingViewSize: MSFListCellLeadingViewSize = .medium
     @objc @Published public var title: String = ""
-    @objc @Published public var subtitle: String?
+    @objc @Published public var subtitle: String = ""
     @objc @Published public var trailingView: UIView?
     @objc @Published public var accessoryType: MSFListAccessoryType = .none
     @objc @Published public var titleLineLimit: Int = 0
     @objc @Published public var subtitleLineLimit: Int = 0
     @objc @Published public var children: [MSFListCellState]?
     @objc @Published public var isExpanded: Bool = false
-    @objc @Published public var layoutType: MSFListCellLayoutType = .oneLine
+    @objc @Published public var layoutType: MSFListCellLayoutType = .none
     @objc public var onTapAction: (() -> Void)?
 }
 
 /// Pre-defined layout heights of cells
 @objc public enum MSFListCellLayoutType: Int, CaseIterable {
+    case none
     case oneLine
     case twoLines
     case threeLines
@@ -81,8 +82,8 @@ struct MSFListCellView: View {
                             .foregroundColor(Color(tokens.leadingTextColor))
                             .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)
                     }
-                    if let subtitle = state.subtitle, !subtitle.isEmpty {
-                        Text(subtitle)
+                    if !state.subtitle.isEmpty {
+                        Text(state.subtitle)
                             .font(Font(tokens.subtitleFont))
                             .foregroundColor(Color(tokens.subtitleColor))
                             .lineLimit(state.subtitleLineLimit == 0 ? nil : state.subtitleLineLimit)
@@ -108,7 +109,7 @@ struct MSFListCellView: View {
                 }
             }
         })
-        .buttonStyle(ListCellButtonStyle(tokens: tokens, layoutType: state.layoutType))
+        .buttonStyle(ListCellButtonStyle(tokens: tokens, state: state))
         if hasDividers {
             let padding = tokens.horizontalCellPadding + (state.leadingView != nil ? (tokens.leadingViewSize + tokens.iconInterspace) : 0)
             Divider()
@@ -128,11 +129,13 @@ struct MSFListCellView: View {
 
 struct ListCellButtonStyle: ButtonStyle {
     let tokens: MSFListCellTokens
-    let layoutType: MSFListCellLayoutType
+    let state: MSFListCellState
 
     func makeBody(configuration: Self.Configuration) -> some View {
         let height: CGFloat
-        switch layoutType {
+        switch state.layoutType {
+        case .none:
+            height = !state.subtitle.isEmpty ? tokens.cellHeightTwoLines : tokens.cellHeightOneLine
         case .oneLine:
             height = tokens.cellHeightOneLine
         case .twoLines:

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -34,13 +34,13 @@ import SwiftUI
     @objc @Published public var subtitleLineLimit: Int = 0
     @objc @Published public var children: [MSFListCellState]?
     @objc @Published public var isExpanded: Bool = false
-    @objc @Published public var layoutType: MSFListCellLayoutType = .none
+    @objc @Published public var layoutType: MSFListCellLayoutType = .automatic
     @objc public var onTapAction: (() -> Void)?
 }
 
 /// Pre-defined layout heights of cells
 @objc public enum MSFListCellLayoutType: Int, CaseIterable {
-    case none
+    case automatic
     case oneLine
     case twoLines
     case threeLines
@@ -134,7 +134,7 @@ struct ListCellButtonStyle: ButtonStyle {
     func makeBody(configuration: Self.Configuration) -> some View {
         let height: CGFloat
         switch state.layoutType {
-        case .none:
+        case .automatic:
             height = !state.subtitle.isEmpty ? tokens.cellHeightTwoLines : tokens.cellHeightOneLine
         case .oneLine:
             height = tokens.cellHeightOneLine


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cell layout is now automatically defined - presence of only a title will produce a one-line cell height, and a subtitle will produce a double-line cell height. There is still the option to override the default layout as well.

### Verification


https://user-images.githubusercontent.com/22566866/108574570-6606e980-72dd-11eb-91eb-02d795afb2c7.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/443)