### PR TITLE
Adding support for accessibility to the Avatar Vnext.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -106,6 +106,8 @@ class AvatarDemoController: DemoController {
             let overflowAvatar = createAvatarView(size: size,
                                                   name: "20",
                                                   style: .overflow)
+            overflowAvatar.state.accessibilityLabel = "20 more contacts"
+
             avatarViews.append(overflowAvatar)
 
             addRow(text: size.description, items: [overflowAvatar.view], textStyle: .footnote, textWidth: 100)

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -245,7 +245,7 @@ public struct AvatarView: View {
 
             let defaultAccessibilityText = state.primaryText ?? state.secondaryText ?? ""
             return (state.isOutOfOffice ?
-                        String(format: "Accessibility.AvatarView.LabelFormat".localized, defaultAccessibilityText, "Presence.OOF".localized) :
+                        String.localizedStringWithFormat("Accessibility.AvatarView.LabelFormat".localized, defaultAccessibilityText, "Presence.OOF".localized) :
                         defaultAccessibilityText)
         }()
 

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -68,7 +68,6 @@ import SwiftUI
     }
 
     public func string() -> String? {
-
         switch self {
         case .none:
             return nil
@@ -240,8 +239,8 @@ public struct AvatarView: View {
                              alignment: .topLeading))
 
         let accessibilityLabel: String = {
-            if let overridenAccessibilityLabel = state.accessibilityLabel {
-                return overridenAccessibilityLabel
+            if let overriddenAccessibilityLabel = state.accessibilityLabel {
+                return overriddenAccessibilityLabel
             }
 
             let defaultAccessibilityText = state.primaryText ?? state.secondaryText ?? ""

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -66,6 +66,28 @@ import SwiftUI
         return Image(imageName,
                      bundle: FluentUIFramework.resourceBundle)
     }
+
+    public func string() -> String? {
+
+        switch self {
+        case .none:
+            return nil
+        case .available:
+            return "Presence.Available".localized
+        case .away:
+            return "Presence.Away".localized
+        case .busy:
+            return "Presence.Busy".localized
+        case .blocked:
+            return "Presence.Blocked".localized
+        case .doNotDisturb:
+            return "Presence.DND".localized
+        case .offline:
+            return "Presence.Offline".localized
+        case .unknown:
+            return "Presence.Unknown".localized
+        }
+    }
 }
 
 /// Properties available to customize the state of the avatar
@@ -217,7 +239,22 @@ public struct AvatarView: View {
                                 AnyView(EmptyView()),
                              alignment: .topLeading))
 
+        let accessibilityLabel: String = {
+            if let overridenAccessibilityLabel = state.accessibilityLabel {
+                return overridenAccessibilityLabel
+            }
+
+            let defaultAccessibilityText = state.primaryText ?? state.secondaryText ?? ""
+            return (state.isOutOfOffice ?
+                        String(format: "Accessibility.AvatarView.LabelFormat".localized, defaultAccessibilityText, "Presence.OOF".localized) :
+                        defaultAccessibilityText)
+        }()
+
         return bodyView
+            .accessibilityElement(children: .ignore)
+            .accessibility(addTraits: .isImage)
+            .accessibility(label: Text(accessibilityLabel))
+            .accessibility(value: Text(presence.string() ?? ""))
             .onAppear {
                 // When environment values are available through the view hierarchy:
                 //  - If we get a non-default theme through the environment values,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The Vnext version of the Avatar written in SwiftUI does not have a good accessibility story.
This change fixes that by adding accessibility label and value while consolidating all of its internal components into a single accessibility item.

![Screen Shot 2021-02-26 at 11 08 12 AM](https://user-images.githubusercontent.com/68076145/109346042-ee2d4780-7825-11eb-942f-241121a1bba5.png)


### Verification

1. Ran the Accessibility inspector reading through the Avatars and ensured the values correctly announced the Avatar status.
2. Deployed the local build to the real device and navigated through the same items to validate accessibility labels, values and traits.


https://user-images.githubusercontent.com/68076145/109346293-54b26580-7826-11eb-9c7a-edcd4868fddb.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/451)