### PR TITLE
remove all the unscaled fonts from MSFFonts public static variables

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -80,24 +80,16 @@ extension TextStyle {
             return "Title 2"
         case .headline:
             return "Headline"
-        case .headlineUnscaled:
-            return "Headline Unscaled"
         case .body:
             return "Body"
-        case .bodyUnscaled:
-            return "Body Unscaled"
         case .subhead:
             return "Subhead"
         case .footnote:
             return "Footnote"
-        case .footnoteUnscaled:
-            return "Footnote Unscaled"
         case .button1:
             return "Button 1"
         case .button2:
             return "Button 2"
-        case .button3:
-            return "Button 3"
         case .caption1:
             return "Caption 1"
         case .caption2:

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -142,7 +142,7 @@ open class SearchBar: UIView {
         static let clearButtonWidth: CGFloat = 8 + 16 + 8   // padding + image + padding
         static let clearButtonTrailingInset: CGFloat = 10
         static let cancelButtonLeadingInset: CGFloat = 8.0
-
+        static let fontSize: CGFloat = 17
         static let cancelButtonShowHideAnimationDuration: TimeInterval = 0.25
         static let navigationBarTransitionHidingDelay: TimeInterval = 0.5
 
@@ -203,7 +203,7 @@ open class SearchBar: UIView {
     // user interaction point
     private lazy var searchTextField: UITextField = {
         let textField = UITextField()
-        textField.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        textField.font = Fonts.body.withSize(Constants.fontSize)
         textField.delegate = self
         textField.returnKeyType = .search
         textField.enablesReturnKeyAutomatically = true
@@ -252,7 +252,7 @@ open class SearchBar: UIView {
     // hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        button.titleLabel?.font = Fonts.body.withSize(Constants.fontSize)
         button.setTitle("Common.Cancel".localized, for: .normal)
         button.addTarget(self, action: #selector(SearchBar.cancelButtonTapped(sender:)), for: .touchUpInside)
         button.alpha = 0.0

--- a/ios/FluentUI/Controls/SearchBar.swift
+++ b/ios/FluentUI/Controls/SearchBar.swift
@@ -143,9 +143,6 @@ open class SearchBar: UIView {
         static let clearButtonTrailingInset: CGFloat = 10
         static let cancelButtonLeadingInset: CGFloat = 8.0
 
-        static let searchTextFieldTextStyle: TextStyle = .bodyUnscaled
-        static let cancelButtonTextStyle: TextStyle = .bodyUnscaled
-
         static let cancelButtonShowHideAnimationDuration: TimeInterval = 0.25
         static let navigationBarTransitionHidingDelay: TimeInterval = 0.5
 
@@ -206,7 +203,7 @@ open class SearchBar: UIView {
     // user interaction point
     private lazy var searchTextField: UITextField = {
         let textField = UITextField()
-        textField.font = Constants.searchTextFieldTextStyle.font
+        textField.font = UIFont.systemFont(ofSize: 17, weight: .regular)
         textField.delegate = self
         textField.returnKeyType = .search
         textField.enablesReturnKeyAutomatically = true
@@ -255,7 +252,7 @@ open class SearchBar: UIView {
     // hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
-        button.titleLabel?.font = Constants.cancelButtonTextStyle.font
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .regular)
         button.setTitle("Common.Cancel".localized, for: .normal)
         button.addTarget(self, action: #selector(SearchBar.cancelButtonTapped(sender:)), for: .touchUpInside)
         button.alpha = 0.0

--- a/ios/FluentUI/Controls/TwoLineTitleView.swift
+++ b/ios/FluentUI/Controls/TwoLineTitleView.swift
@@ -122,10 +122,11 @@ open class TwoLineTitleView: UIView {
         return interactivePart == .title ? accessoryType : .none
     }
 
-    private lazy var titleButtonLabel: UILabel = {
-        let label = UILabel()
+    private lazy var titleButtonLabel: Label = {
+        let label = Label()
         label.lineBreakMode = .byTruncatingTail
-        label.font = Fonts.headlineUnscaled
+        label.style = .headline
+        label.maxFontSize = 17
         label.textAlignment = .center
         return label
     }()
@@ -137,12 +138,11 @@ open class TwoLineTitleView: UIView {
         return interactivePart == .subtitle ? accessoryType : .none
     }
 
-    private lazy var subtitleButtonLabel: UILabel = {
-        let label = UILabel()
+    private lazy var subtitleButtonLabel: Label = {
+        let label = Label()
         label.lineBreakMode = .byTruncatingMiddle
-        label.font = Fonts.footnoteUnscaled
-        label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.8
+        label.style = .caption1
+        label.maxFontSize = 12
         return label
     }()
 

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -67,7 +67,7 @@ public class FluentUIFramework: NSObject {
         // UIBarButtonItem
         let barButtonItem = UIBarButtonItem.appearance()
         var titleAttributes = barButtonItem.titleTextAttributes(for: .normal) ?? [:]
-        titleAttributes[.font] = Fonts.bodyUnscaled
+        titleAttributes[.font] = Fonts.body
         barButtonItem.setTitleTextAttributes(titleAttributes, for: .normal)
 
         let switchAppearance = containerTypes != nil ? UISwitch.appearance(whenContainedInInstancesOf: containerTypes!) : UISwitch.appearance()
@@ -89,7 +89,7 @@ public class FluentUIFramework: NSObject {
         }
 
         var titleAttributes = navigationBar.titleTextAttributes ?? [:]
-        titleAttributes[.font] = Fonts.headlineUnscaled
+        titleAttributes[.font] = Fonts.headline
         titleAttributes[.foregroundColor] = Colors.NavigationBar.title
         navigationBar.titleTextAttributes = titleAttributes
 

--- a/ios/FluentUI/Core/Fonts.swift
+++ b/ios/FluentUI/Core/Fonts.swift
@@ -10,31 +10,24 @@ public typealias MSFonts = Fonts
 
 @objc(MSFFonts)
 public final class Fonts: NSObject {
-    /// Bold 30pt - Does not scale automatically with Dynamic Type
-    @objc public static let largeTitle = UIFont.systemFont(ofSize: 30, weight: .bold)
-    /// Bold 26pt - Does not scale automatically with Dynamic Type
-    @objc public static let title1 = UIFont.systemFont(ofSize: 26, weight: .bold)
+    /// Bold 34pt
+    @objc public static var largeTitle: UIFont { return preferredFont(forTextStyle: .largeTitle, weight: .bold) }
+    /// Bold 28 pt
+    @objc public static var title1: UIFont { return preferredFont(forTextStyle: .title1, weight: .bold) }
     /// Semibold 22pt
     @objc public static var title2: UIFont { return preferredFont(forTextStyle: .title2, weight: .semibold) }
     /// Semibold 17pt
     @objc public static var headline: UIFont { return .preferredFont(forTextStyle: .headline) }
-    @objc public static var headlineUnscaled: UIFont { return .preferredFont(forTextStyle: .headline, compatibleWith: UITraitCollection(preferredContentSizeCategory: .large)) }
     /// Regular 17pt
     @objc public static var body: UIFont { return .preferredFont(forTextStyle: .body) }
-    @objc public static var bodyUnscaled: UIFont { return .preferredFont(forTextStyle: .body, compatibleWith: UITraitCollection(preferredContentSizeCategory: .large)) }
     /// Regular 15pt
     @objc public static var subhead: UIFont { return .preferredFont(forTextStyle: .subheadline) }
     /// Regular 13pt
     @objc public static var footnote: UIFont { return .preferredFont(forTextStyle: .footnote) }
-    @objc public static var footnoteUnscaled: UIFont { return .preferredFont(forTextStyle: .footnote, compatibleWith: UITraitCollection(preferredContentSizeCategory: .large)) }
     /// Medium 15pt
     @objc public static var button1: UIFont { return preferredFont(forTextStyle: .subheadline, weight: .medium) }
     /// Medium 13pt
     @objc public static var button2: UIFont { return preferredFont(forTextStyle: .footnote, weight: .medium) }
-    /// Medium 10pt - Does not scale automatically with Dynamic Type
-    @objc public static let button3 = UIFont.systemFont(ofSize: 10, weight: .medium)
-    /// Medium 16pt - Does not scale automatically with Dynamic Type
-    @objc public static let button4 = UIFont.systemFont(ofSize: 16, weight: .regular)
     /// Regular 12pt
     @objc public static var caption1: UIFont { return .preferredFont(forTextStyle: .caption1) }
     /// Regular 11pt
@@ -66,15 +59,11 @@ public enum TextStyle: Int, CaseIterable {
     case title1
     case title2
     case headline
-    case headlineUnscaled
     case body
-    case bodyUnscaled
     case subhead
     case footnote
-    case footnoteUnscaled
     case button1
     case button2
-    case button3
     case caption1
     case caption2
 
@@ -88,24 +77,16 @@ public enum TextStyle: Int, CaseIterable {
             return Fonts.title2
         case .headline:
             return Fonts.headline
-        case .headlineUnscaled:
-            return Fonts.headlineUnscaled
         case .body:
             return Fonts.body
-        case .bodyUnscaled:
-            return Fonts.bodyUnscaled
         case .subhead:
             return Fonts.subhead
         case .footnote:
             return Fonts.footnote
-        case .footnoteUnscaled:
-            return Fonts.footnoteUnscaled
         case .button1:
             return Fonts.button1
         case .button2:
             return Fonts.button2
-        case .button3:
-            return Fonts.button3
         case .caption1:
             return Fonts.caption1
         case .caption2:

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -19,8 +19,8 @@ class LargeTitleView: UIView {
         static let compactAvatarSize: AvatarSize = .small
         static let avatarSize: AvatarSize = .medium
 
-        static let compactTitleFont: UIFont = Fonts.title1
-        static let titleFont: UIFont = Fonts.largeTitle
+        static let compactTitleFont = UIFont.systemFont(ofSize: 26, weight: .bold)
+        static let titleFont = UIFont.systemFont(ofSize: 30, weight: .bold)
     }
 
     var avatar: Avatar? {

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -19,8 +19,8 @@ class LargeTitleView: UIView {
         static let compactAvatarSize: AvatarSize = .small
         static let avatarSize: AvatarSize = .medium
 
-        static let compactTitleFont = UIFont.systemFont(ofSize: 26, weight: .bold)
-        static let titleFont = UIFont.systemFont(ofSize: 30, weight: .bold)
+        static let compactTitleFont = Fonts.title1.withSize(26)
+        static let titleFont = Fonts.largeTitle.withSize(30)
     }
 
     var avatar: Avatar? {

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -156,7 +156,7 @@ open class PillButton: UIButton {
 
     private struct Constants {
         static let bottomInset: CGFloat = 6.0
-        static let font: UIFont = Fonts.button4
+        static let font = UIFont.systemFont(ofSize: 16, weight: .regular)
         static let horizontalInset: CGFloat = 16.0
         static let topInset: CGFloat = 6.0
     }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -227,7 +227,8 @@ class TabBarItemView: UIView {
         if isInPortraitMode {
             container.axis = .vertical
             container.spacing = Constants.spacingVertical
-            titleLabel.style = .button3
+            titleLabel.style = .button2
+            titleLabel.maxFontSize = 10
 
             if canResizeImage {
                 suggestImageSize = titleLabel.isHidden ? Constants.portraitImageSize : Constants.portraitImageWithLabelSize
@@ -235,7 +236,8 @@ class TabBarItemView: UIView {
         } else {
             container.axis = .horizontal
             container.spacing = Constants.spacingHorizontal
-            titleLabel.style = .footnoteUnscaled
+            titleLabel.style = .footnote
+            titleLabel.maxFontSize = 13
 
             if canResizeImage {
                  suggestImageSize = Constants.landscapeImageSize


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
We lived in a very confusing world for a long time which fluent textramp sometimes returns scalable fonts depending on the users accessibility setting and some are unscaled. This is really align with our intention to make our text always accessible for different OS settings. There are few controls like navigation bar or tabbar which should have fix text height because it uses large content viewer to show the "bigger" text size. This is a fairly disruptive change that I am removing all the unscalable fonts to be expose outside of sdk. Clients who wish to use fixed font should declare the font themselves rather than relying on fluent sdk.

### Verification

Tested tabbar, two line title view, large title navigation bar, search bar, pill button.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/20715435/109371871-ac1ef880-785b-11eb-8475-3ffa01b9a73e.png) | ![after](https://user-images.githubusercontent.com/20715435/109371868-a7f2db00-785b-11eb-8e69-80968b17193e.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/452)