### PR TITLE
Updating background and text avatar colors - MacOS

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -472,9 +472,8 @@ fileprivate extension Unicode.Scalar {
 }
 
 extension AvatarView {
-
-	/// the table of background colors for the initials views
-	static let avatarColors: [ColorSet] = [
+	/// Table of background and text colors for the AvatarView
+		static let avatarColors: [ColorSet] = [
 		ColorSet(background: DynamicColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color),
 				 foreground: DynamicColor(light: Colors.Palette.darkRedShade30.color, dark: Colors.Palette.darkRedTint40.color)),
 		ColorSet(background: DynamicColor(light: Colors.Palette.cranberryTint40.color, dark: Colors.Palette.cranberryShade30.color),

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -473,7 +473,7 @@ fileprivate extension Unicode.Scalar {
 
 extension AvatarView {
 	/// Table of background and text colors for the AvatarView
-		static let avatarColors: [ColorSet] = [
+	static let avatarColors: [ColorSet] = [
 		ColorSet(background: DynamicColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color),
 				 foreground: DynamicColor(light: Colors.Palette.darkRedShade30.color, dark: Colors.Palette.darkRedTint40.color)),
 		ColorSet(background: DynamicColor(light: Colors.Palette.cranberryTint40.color, dark: Colors.Palette.cranberryShade30.color),

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -312,10 +312,10 @@ open class AvatarView: NSView {
 		updateAppearance()
 	}
 
-	private func updateAppearance(_ appreance: NSAppearance = NSAppearance.current) {
+	private func updateAppearance(_ appearance: NSAppearance = NSAppearance.current) {
 		let color = AvatarView.getColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
-		avatarBackgroundColor = color.background.resolvedColor(appreance)
-		initialsFontColor = color.foreground.resolvedColor(appreance)
+		avatarBackgroundColor = color.background.resolvedColor(appearance)
+		initialsFontColor = color.foreground.resolvedColor(appearance)
 	}
 
 	/// Get the color associated with a given index

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -309,7 +309,7 @@ open class AvatarView: NSView {
 		}
 
 		initialsTextField.stringValue = AvatarView.initialsWithFallback(name: contactName, email: contactEmail)
-		updateAppearance()
+		updateAppearance(self.window?.effectiveAppearance)
 	}
 
 	private func updateAppearance(_ appearance: NSAppearance? = nil) {
@@ -325,7 +325,7 @@ open class AvatarView: NSView {
 	///
 	/// - note: Internal visibility exists only for unit testing
 	@objc static func getColor(for index: Int) -> ColorSet {
-		let avatarBackgroundColors = NSColor.avatarColors
+		let avatarBackgroundColors = AvatarView.avatarColors
 		return avatarBackgroundColors[index % avatarBackgroundColors.count]
 	}
 
@@ -471,7 +471,7 @@ fileprivate extension Unicode.Scalar {
 	static let zeroWidthSpace = Unicode.Scalar(0x200B)!
 }
 
-extension NSColor {
+extension AvatarView {
 	/// the text color of the text in the initials view
 
 	/// the table of background colors for the initials views

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -30,8 +30,8 @@ open class AvatarView: NSView {
 
 		// Prefer contactEmail to contactName for uniqueness
 		let color = AvatarView.getColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
-		avatarBackgroundColor = color.resolvedBackgroundColor()
-		initialsFontColor = color.resolvedForegroundColor()
+		avatarBackgroundColor = color.background.resolvedColor()
+		initialsFontColor = color.foreground.resolvedColor()
 		self.contactName = contactName
 		self.contactEmail = contactEmail
 		self.contactImage = contactImage
@@ -314,8 +314,8 @@ open class AvatarView: NSView {
 
 	private func updateAppearance(_ appreance: NSAppearance = NSAppearance.current) {
 		let color = AvatarView.getColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
-		avatarBackgroundColor = color.resolvedBackgroundColor(appreance)
-		initialsFontColor = color.resolvedForegroundColor(appreance)
+		avatarBackgroundColor = color.background.resolvedColor(appreance)
+		initialsFontColor = color.foreground.resolvedColor(appreance)
 	}
 
 	/// Get the color associated with a given index
@@ -324,7 +324,7 @@ open class AvatarView: NSView {
 	/// - returns: the color table entry for the given index
 	///
 	/// - note: Internal visibility exists only for unit testing
-	@objc public static func getColor(for index: Int) -> DynamicColor {
+	@objc static func getColor(for index: Int) -> ColorSet {
 		let avatarBackgroundColors = NSColor.avatarColors
 		return avatarBackgroundColors[index % avatarBackgroundColors.count]
 	}
@@ -415,17 +415,16 @@ open class AvatarView: NSView {
 
 	open override func viewWillMove(toWindow newWindow: NSWindow?) {
 		super.viewWillMove(toWindow: newWindow)
-		if let window = newWindow {
-			appearanceObserver = window.observe(\.effectiveAppearance) { [weak self] (window, value) in
-				guard let strongSelf = self else {
-					return
-				}
-				print("window \(window), value:\(value)")
 
-				strongSelf.updateAppearance(window.appearance ?? NSAppearance.current)
-			}
-		} else {
+		guard let window = newWindow else {
 			appearanceObserver = nil
+			return
+		}
+		appearanceObserver = window.observe(\.effectiveAppearance) { [weak self] (window, _) in
+			guard let strongSelf = self else {
+				return
+			}
+			strongSelf.updateAppearance(window.appearance ?? NSAppearance.current)
 		}
 	}
 }
@@ -472,41 +471,71 @@ fileprivate extension Unicode.Scalar {
 	static let zeroWidthSpace = Unicode.Scalar(0x200B)!
 }
 
-fileprivate extension NSColor {
+extension NSColor {
 	/// the text color of the text in the initials view
 
 	/// the table of background colors for the initials views
-	static let avatarColors: [DynamicColor] = [
-		DynamicColor(background: Colors.Palette.darkRedTint40.color, foreground: Colors.Palette.darkRedShade30.color),
-		DynamicColor(background: Colors.Palette.cranberryTint40.color, foreground: Colors.Palette.cranberryShade30.color),
-		DynamicColor(background: Colors.Palette.redTint40.color, foreground: Colors.Palette.redShade30.color),
-		DynamicColor(background: Colors.Palette.pumpkinTint40.color, foreground: Colors.Palette.pumpkinShade30.color),
-		DynamicColor(background: Colors.Palette.peachTint40.color, foreground: Colors.Palette.peachShade30.color),
-		DynamicColor(background: Colors.Palette.marigoldTint40.color, foreground: Colors.Palette.marigoldShade30.color),
-		DynamicColor(background: Colors.Palette.goldTint40.color, foreground: Colors.Palette.goldShade30.color),
-		DynamicColor(background: Colors.Palette.brassTint40.color, foreground: Colors.Palette.brassShade30.color),
-		DynamicColor(background: Colors.Palette.brownTint40.color, foreground: Colors.Palette.brownShade30.color),
-		DynamicColor(background: Colors.Palette.forestTint40.color, foreground: Colors.Palette.forestShade30.color),
-		DynamicColor(background: Colors.Palette.seafoamTint40.color, foreground: Colors.Palette.seafoamShade30.color),
-		DynamicColor(background: Colors.Palette.darkGreenTint40.color, foreground: Colors.Palette.darkGreenShade30.color),
-		DynamicColor(background: Colors.Palette.lightTealTint40.color, foreground: Colors.Palette.lightTealShade30.color),
-		DynamicColor(background: Colors.Palette.tealTint40.color, foreground: Colors.Palette.tealShade30.color),
-		DynamicColor(background: Colors.Palette.steelTint40.color, foreground: Colors.Palette.steelShade30.color),
-		DynamicColor(background: Colors.Palette.blueTint40.color, foreground: Colors.Palette.blueShade30.color),
-		DynamicColor(background: Colors.Palette.royalBlueTint40.color, foreground: Colors.Palette.royalBlueShade30.color),
-		DynamicColor(background: Colors.Palette.cornFlowerTint40.color, foreground: Colors.Palette.cornFlowerShade30.color),
-		DynamicColor(background: Colors.Palette.navyTint40.color, foreground: Colors.Palette.navyShade30.color),
-		DynamicColor(background: Colors.Palette.lavenderTint40.color, foreground: Colors.Palette.lavenderShade30.color),
-		DynamicColor(background: Colors.Palette.purpleTint40.color, foreground: Colors.Palette.purpleShade30.color),
-		DynamicColor(background: Colors.Palette.grapeTint40.color, foreground: Colors.Palette.grapeShade30.color),
-		DynamicColor(background: Colors.Palette.lilacTint40.color, foreground: Colors.Palette.lilacShade30.color),
-		DynamicColor(background: Colors.Palette.pinkTint40.color, foreground: Colors.Palette.pinkShade30.color),
-		DynamicColor(background: Colors.Palette.magentaTint40.color, foreground: Colors.Palette.magentaShade30.color),
-		DynamicColor(background: Colors.Palette.plumTint40.color, foreground: Colors.Palette.plumShade30.color),
-		DynamicColor(background: Colors.Palette.beigeTint40.color, foreground: Colors.Palette.beigeShade30.color),
-		DynamicColor(background: Colors.Palette.minkTint40.color, foreground: Colors.Palette.minkShade30.color),
-		DynamicColor(background: Colors.Palette.platinumTint40.color, foreground: Colors.Palette.platinumShade30.color),
-		DynamicColor(background: Colors.Palette.anchorTint40.color, foreground: Colors.Palette.anchorShade30.color)
+	static let avatarColors: [ColorSet] = [
+		ColorSet(background: DynamicColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.darkRedShade30.color, dark: Colors.Palette.darkRedTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.cranberryTint40.color, dark: Colors.Palette.cranberryShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.cranberryShade30.color, dark: Colors.Palette.cranberryTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.redTint40.color, dark: Colors.Palette.redShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.redShade30.color, dark: Colors.Palette.redTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.pumpkinTint40.color, dark: Colors.Palette.pumpkinShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.pumpkinShade30.color, dark: Colors.Palette.pumpkinTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.peachTint40.color, dark: Colors.Palette.peachShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.peachShade30.color, dark: Colors.Palette.peachTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.marigoldTint40.color, dark: Colors.Palette.marigoldShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.marigoldShade30.color, dark: Colors.Palette.marigoldTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.goldTint40.color, dark: Colors.Palette.goldShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.goldShade30.color, dark: Colors.Palette.goldTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.brassTint40.color, dark: Colors.Palette.brassShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.brassShade30.color, dark: Colors.Palette.brassTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.brownTint40.color, dark: Colors.Palette.brownShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.brownShade30.color, dark: Colors.Palette.brownTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.forestTint40.color, dark: Colors.Palette.forestShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.forestShade30.color, dark: Colors.Palette.forestTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.seafoamTint40.color, dark: Colors.Palette.seafoamShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.seafoamShade30.color, dark: Colors.Palette.seafoamTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.darkGreenTint40.color, dark: Colors.Palette.darkGreenShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.darkGreenShade30.color, dark: Colors.Palette.darkGreenTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.lightTealTint40.color, dark: Colors.Palette.lightTealShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.lightTealShade30.color, dark: Colors.Palette.lightTealTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.tealTint40.color, dark: Colors.Palette.tealShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.tealShade30.color, dark: Colors.Palette.tealTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.steelTint40.color, dark: Colors.Palette.steelShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.steelShade30.color, dark: Colors.Palette.steelTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.blueTint40.color, dark: Colors.Palette.blueShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.blueShade30.color, dark: Colors.Palette.blueTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.royalBlueTint40.color, dark: Colors.Palette.royalBlueShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.royalBlueShade30.color, dark: Colors.Palette.royalBlueTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.cornFlowerTint40.color, dark: Colors.Palette.cornFlowerShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.cornFlowerShade30.color, dark: Colors.Palette.cornFlowerTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.navyTint40.color, dark: Colors.Palette.navyShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.navyShade30.color, dark: Colors.Palette.navyTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.lavenderTint40.color, dark: Colors.Palette.lavenderShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.lavenderShade30.color, dark: Colors.Palette.lavenderTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.purpleTint40.color, dark: Colors.Palette.purpleShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.purpleShade30.color, dark: Colors.Palette.purpleTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.grapeTint40.color, dark: Colors.Palette.grapeShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.grapeShade30.color, dark: Colors.Palette.grapeTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.lilacTint40.color, dark: Colors.Palette.lilacShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.lilacShade30.color, dark: Colors.Palette.lilacTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.pinkTint40.color, dark: Colors.Palette.pinkShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.pinkShade30.color, dark: Colors.Palette.pinkTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.magentaTint40.color, dark: Colors.Palette.magentaShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.magentaShade30.color, dark: Colors.Palette.magentaTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.plumTint40.color, dark: Colors.Palette.plumShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.plumShade30.color, dark: Colors.Palette.plumTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.beigeTint40.color, dark: Colors.Palette.beigeShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.beigeShade30.color, dark: Colors.Palette.beigeTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.minkTint40.color, dark: Colors.Palette.minkShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.minkShade30.color, dark: Colors.Palette.minkTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.platinumTint40.color, dark: Colors.Palette.platinumShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.platinumShade30.color, dark: Colors.Palette.platinumTint40.color)),
+		ColorSet(background: DynamicColor(light: Colors.Palette.anchorTint40.color, dark: Colors.Palette.anchorShade30.color),
+				 foreground: DynamicColor(light: Colors.Palette.anchorShade30.color, dark: Colors.Palette.anchorTint40.color))
 	]
 }
 

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -312,7 +312,7 @@ open class AvatarView: NSView {
 		updateAppearance()
 	}
 
-	private func updateAppearance(_ appearance: NSAppearance = NSAppearance.current) {
+	private func updateAppearance(_ appearance: NSAppearance? = nil) {
 		let color = AvatarView.getColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
 		avatarBackgroundColor = color.background.resolvedColor(appearance)
 		initialsFontColor = color.foreground.resolvedColor(appearance)
@@ -424,7 +424,7 @@ open class AvatarView: NSView {
 			guard let strongSelf = self else {
 				return
 			}
-			strongSelf.updateAppearance(window.appearance ?? NSAppearance.current)
+			strongSelf.updateAppearance(window.effectiveAppearance)
 		}
 	}
 }

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -29,7 +29,9 @@ open class AvatarView: NSView {
                       contactImage: NSImage? = nil) {
 
 		// Prefer contactEmail to contactName for uniqueness
-		avatarBackgroundColor = AvatarView.backgroundColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
+		let colorSet = AvatarView.colorSet(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
+		avatarBackgroundColor = colorSet.background
+		initialsFontColor = colorSet.foreground
 		self.contactName = contactName
 		self.contactEmail = contactEmail
 		self.contactImage = contactImage
@@ -86,6 +88,18 @@ open class AvatarView: NSView {
 			}
 			needsDisplay = true
 			initialsTextField.backgroundColor = avatarBackgroundColor
+		}
+	}
+	
+	/// The initials font color of the avatar view when no image is provided.
+	/// Setting this property will override the default provided color.
+	@objc open var initialsFontColor: NSColor {
+		didSet {
+			guard oldValue != initialsFontColor else {
+				return
+			}
+			needsDisplay = true
+			initialsTextField.textColor = initialsFontColor
 		}
 	}
 
@@ -224,7 +238,7 @@ open class AvatarView: NSView {
 		textView.alignment = .center
 		textView.translatesAutoresizingMaskIntoConstraints = false
 		textView.font = font(forCircleDiameter: avatarSize)
-		textView.textColor = .initialsViewTextColor
+		textView.textColor = initialsFontColor
 		textView.drawsBackground = true
 		textView.backgroundColor = avatarBackgroundColor
 		return textView
@@ -292,7 +306,9 @@ open class AvatarView: NSView {
 		}
 
 		initialsTextField.stringValue = AvatarView.initialsWithFallback(name: contactName, email: contactEmail)
-		avatarBackgroundColor = AvatarView.backgroundColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
+		let colorSet = AvatarView.colorSet(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
+		avatarBackgroundColor = colorSet.background
+		initialsFontColor = colorSet.foreground
 	}
 
 	/// Get the color associated with a given index
@@ -301,8 +317,8 @@ open class AvatarView: NSView {
 	/// - returns: the color table entry for the given index
 	///
 	/// - note: Internal visibility exists only for unit testing
-	@objc public static func backgroundColor(for index: Int) -> NSColor {
-		let avatarBackgroundColors = NSColor.avatarBackgroundColors
+	@objc public static func colorSet(for index: Int) -> ColorSet {
+		let avatarBackgroundColors = NSColor.avatarColors
 		return avatarBackgroundColors[index % avatarBackgroundColors.count]
 	}
 
@@ -436,34 +452,69 @@ fileprivate extension Unicode.Scalar {
 
 fileprivate extension NSColor {
 	/// the text color of the text in the initials view
-	///
-	/// - note: this value doesn't change for dark mode by design as our default background color table
-	/// only provides colors designed to be used with white text, even on dark mode
-    static let initialsViewTextColor: NSColor = .white
 
 	/// the table of background colors for the initials views
-	static let avatarBackgroundColors: [NSColor] = [
-		Colors.Palette.cyanBlue10.color,
-		Colors.Palette.red10.color,
-		Colors.Palette.magenta20.color,
-		Colors.Palette.green10.color,
-		Colors.Palette.magentaPink10.color,
-		Colors.Palette.cyanBlue20.color,
-		Colors.Palette.orange20.color,
-		Colors.Palette.cyan20.color,
-		Colors.Palette.orangeYellow20.color,
-		Colors.Palette.red20.color,
-		Colors.Palette.blue10.color,
-		Colors.Palette.magenta10.color,
-		Colors.Palette.gray40.color,
-		Colors.Palette.green20.color,
-		Colors.Palette.blueMagenta20.color,
-		Colors.Palette.pinkRed10.color,
-		Colors.Palette.gray30.color,
-		Colors.Palette.blueMagenta30.color,
-		Colors.Palette.gray20.color,
-		Colors.Palette.cyan30.color,
-		Colors.Palette.orange30.color
+	static let avatarColors: [ColorSet] = [
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.darkRedShade30.color, dark: Colors.Palette.darkRedTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.cranberryTint40.color, dark: Colors.Palette.cranberryShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.cranberryShade30.color, dark: Colors.Palette.cranberryTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.redTint40.color, dark: Colors.Palette.redShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.redShade30.color, dark: Colors.Palette.redTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.pumpkinTint40.color, dark: Colors.Palette.pumpkinShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.pumpkinShade30.color, dark: Colors.Palette.pumpkinTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.peachTint40.color, dark: Colors.Palette.peachShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.peachShade30.color, dark: Colors.Palette.peachTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.marigoldTint40.color, dark: Colors.Palette.marigoldShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.marigoldShade30.color, dark: Colors.Palette.marigoldTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.goldTint40.color, dark: Colors.Palette.goldShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.goldShade30.color, dark: Colors.Palette.goldTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.brassTint40.color, dark: Colors.Palette.brassShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.brassShade30.color, dark: Colors.Palette.brassTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.brownTint40.color, dark: Colors.Palette.brownShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.brownShade30.color, dark: Colors.Palette.brownTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.forestTint40.color, dark: Colors.Palette.forestShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.forestShade30.color, dark: Colors.Palette.forestTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.seafoamTint40.color, dark: Colors.Palette.seafoamShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.seafoamShade30.color, dark: Colors.Palette.seafoamTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.darkGreenTint40.color, dark: Colors.Palette.darkGreenShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.darkGreenShade30.color, dark: Colors.Palette.darkGreenTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.lightTealTint40.color, dark: Colors.Palette.lightTealShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.lightTealShade30.color, dark: Colors.Palette.lightTealTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.tealTint40.color, dark: Colors.Palette.tealShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.tealShade30.color, dark: Colors.Palette.tealTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.steelTint40.color, dark: Colors.Palette.steelShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.steelShade30.color, dark: Colors.Palette.steelTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.blueTint40.color, dark: Colors.Palette.blueShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.blueShade30.color, dark: Colors.Palette.blueTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.royalBlueTint40.color, dark: Colors.Palette.royalBlueShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.royalBlueShade30.color, dark: Colors.Palette.royalBlueTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.cornFlowerTint40.color, dark: Colors.Palette.cornFlowerShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.cornFlowerShade30.color, dark: Colors.Palette.cornFlowerTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.navyTint40.color, dark: Colors.Palette.navyShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.navyShade30.color, dark: Colors.Palette.navyTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.lavenderTint40.color, dark: Colors.Palette.lavenderShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.lavenderShade30.color, dark: Colors.Palette.lavenderTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.purpleTint40.color, dark: Colors.Palette.purpleShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.purpleShade30.color, dark: Colors.Palette.purpleTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.grapeTint40.color, dark: Colors.Palette.grapeShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.grapeShade30.color, dark: Colors.Palette.grapeTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.lilacTint40.color, dark: Colors.Palette.lilacShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.lilacShade30.color, dark: Colors.Palette.lilacTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.pinkTint40.color, dark: Colors.Palette.pinkShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.pinkShade30.color, dark: Colors.Palette.pinkTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.magentaTint40.color, dark: Colors.Palette.magentaShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.magentaShade30.color, dark: Colors.Palette.magentaTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.plumTint40.color, dark: Colors.Palette.plumShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.plumShade30.color, dark: Colors.Palette.plumTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.beigeTint40.color, dark: Colors.Palette.beigeShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.beigeShade30.color, dark: Colors.Palette.beigeTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.minkTint40.color, dark: Colors.Palette.minkShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.minkShade30.color, dark: Colors.Palette.minkTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.platinumTint40.color, dark: Colors.Palette.platinumShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.platinumShade30.color, dark: Colors.Palette.platinumTint40.color)),
+		ColorSet(background: NSColor.getColor(light: Colors.Palette.anchorTint40.color, dark: Colors.Palette.anchorShade30.color),
+				 foreground: NSColor.getColor(light: Colors.Palette.anchorShade30.color, dark: Colors.Palette.anchorTint40.color))
 	]
 }
 
@@ -478,5 +529,28 @@ fileprivate extension CGPath {
 	/// - note: this can't be an initializer since Swift doesn't allow CF/CG types to have convenience initialer extensions
 	static func circularPath(withCircleDiameter diameter: CGFloat) -> CGPath {
 		return CGPath(ellipseIn: NSRect(x: 0, y: 0, width: diameter, height: diameter), transform: nil)
+	}
+}
+
+fileprivate extension NSColor {
+	enum InterfaceStyle: String {
+	   case dark, light
+
+		init() {
+			var type: InterfaceStyle = .light
+			let isDarkMode = NSApplication.shared.effectiveAppearance.bestMatch(from: [.darkAqua]) == .darkAqua
+			if isDarkMode {
+				type = .dark
+			}
+			self = type
+		}
+	}
+
+	static func getColor(light: NSColor, dark: NSColor) -> NSColor {
+		let currentStyle = InterfaceStyle()
+		if currentStyle == .light {
+			return light
+		}
+		return dark
 	}
 }

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -29,9 +29,9 @@ open class AvatarView: NSView {
                       contactImage: NSImage? = nil) {
 
 		// Prefer contactEmail to contactName for uniqueness
-		let colorSet = AvatarView.colorSet(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
-		avatarBackgroundColor = colorSet.background
-		initialsFontColor = colorSet.foreground
+		let color = AvatarView.getColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
+		avatarBackgroundColor = color.resolvedBackgroundColor()
+		initialsFontColor = color.resolvedForegroundColor()
 		self.contactName = contactName
 		self.contactEmail = contactEmail
 		self.contactImage = contactImage
@@ -175,6 +175,9 @@ open class AvatarView: NSView {
 	/// The layer used to mask the overall AvatarView to a circle
 	private let circleMask = CAShapeLayer()
 
+	/// The apperance observer to update colors when theme is changed
+	private var appearanceObserver: NSKeyValueObservation?
+
 	/// A property for the display style based on whether an image exists or not.
 	private var displayStyle: DisplayStyle {
 		didSet {
@@ -306,9 +309,13 @@ open class AvatarView: NSView {
 		}
 
 		initialsTextField.stringValue = AvatarView.initialsWithFallback(name: contactName, email: contactEmail)
-		let colorSet = AvatarView.colorSet(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
-		avatarBackgroundColor = colorSet.background
-		initialsFontColor = colorSet.foreground
+		updateAppearance()
+	}
+
+	private func updateAppearance(_ appreance: NSAppearance = NSAppearance.current) {
+		let color = AvatarView.getColor(for: AvatarView.colorIndex(for: contactEmail ?? contactName ?? ""))
+		avatarBackgroundColor = color.resolvedBackgroundColor(appreance)
+		initialsFontColor = color.resolvedForegroundColor(appreance)
 	}
 
 	/// Get the color associated with a given index
@@ -317,7 +324,7 @@ open class AvatarView: NSView {
 	/// - returns: the color table entry for the given index
 	///
 	/// - note: Internal visibility exists only for unit testing
-	@objc public static func colorSet(for index: Int) -> ColorSet {
+	@objc public static func getColor(for index: Int) -> DynamicColor {
 		let avatarBackgroundColors = NSColor.avatarColors
 		return avatarBackgroundColors[index % avatarBackgroundColors.count]
 	}
@@ -406,6 +413,21 @@ open class AvatarView: NSView {
 		}
 	}
 
+	open override func viewWillMove(toWindow newWindow: NSWindow?) {
+		super.viewWillMove(toWindow: newWindow)
+		if let window = newWindow {
+			appearanceObserver = window.observe(\.effectiveAppearance) { [weak self] (window, value) in
+				guard let strongSelf = self else {
+					return
+				}
+				print("window \(window), value:\(value)")
+
+				strongSelf.updateAppearance(window.appearance ?? NSAppearance.current)
+			}
+		} else {
+			appearanceObserver = nil
+		}
+	}
 }
 
 /// The various display styles of the Avatar View
@@ -454,67 +476,37 @@ fileprivate extension NSColor {
 	/// the text color of the text in the initials view
 
 	/// the table of background colors for the initials views
-	static let avatarColors: [ColorSet] = [
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.darkRedShade30.color, dark: Colors.Palette.darkRedTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.cranberryTint40.color, dark: Colors.Palette.cranberryShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.cranberryShade30.color, dark: Colors.Palette.cranberryTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.redTint40.color, dark: Colors.Palette.redShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.redShade30.color, dark: Colors.Palette.redTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.pumpkinTint40.color, dark: Colors.Palette.pumpkinShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.pumpkinShade30.color, dark: Colors.Palette.pumpkinTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.peachTint40.color, dark: Colors.Palette.peachShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.peachShade30.color, dark: Colors.Palette.peachTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.marigoldTint40.color, dark: Colors.Palette.marigoldShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.marigoldShade30.color, dark: Colors.Palette.marigoldTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.goldTint40.color, dark: Colors.Palette.goldShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.goldShade30.color, dark: Colors.Palette.goldTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.brassTint40.color, dark: Colors.Palette.brassShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.brassShade30.color, dark: Colors.Palette.brassTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.brownTint40.color, dark: Colors.Palette.brownShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.brownShade30.color, dark: Colors.Palette.brownTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.forestTint40.color, dark: Colors.Palette.forestShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.forestShade30.color, dark: Colors.Palette.forestTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.seafoamTint40.color, dark: Colors.Palette.seafoamShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.seafoamShade30.color, dark: Colors.Palette.seafoamTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.darkGreenTint40.color, dark: Colors.Palette.darkGreenShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.darkGreenShade30.color, dark: Colors.Palette.darkGreenTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.lightTealTint40.color, dark: Colors.Palette.lightTealShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.lightTealShade30.color, dark: Colors.Palette.lightTealTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.tealTint40.color, dark: Colors.Palette.tealShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.tealShade30.color, dark: Colors.Palette.tealTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.steelTint40.color, dark: Colors.Palette.steelShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.steelShade30.color, dark: Colors.Palette.steelTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.blueTint40.color, dark: Colors.Palette.blueShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.blueShade30.color, dark: Colors.Palette.blueTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.royalBlueTint40.color, dark: Colors.Palette.royalBlueShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.royalBlueShade30.color, dark: Colors.Palette.royalBlueTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.cornFlowerTint40.color, dark: Colors.Palette.cornFlowerShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.cornFlowerShade30.color, dark: Colors.Palette.cornFlowerTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.navyTint40.color, dark: Colors.Palette.navyShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.navyShade30.color, dark: Colors.Palette.navyTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.lavenderTint40.color, dark: Colors.Palette.lavenderShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.lavenderShade30.color, dark: Colors.Palette.lavenderTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.purpleTint40.color, dark: Colors.Palette.purpleShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.purpleShade30.color, dark: Colors.Palette.purpleTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.grapeTint40.color, dark: Colors.Palette.grapeShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.grapeShade30.color, dark: Colors.Palette.grapeTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.lilacTint40.color, dark: Colors.Palette.lilacShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.lilacShade30.color, dark: Colors.Palette.lilacTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.pinkTint40.color, dark: Colors.Palette.pinkShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.pinkShade30.color, dark: Colors.Palette.pinkTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.magentaTint40.color, dark: Colors.Palette.magentaShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.magentaShade30.color, dark: Colors.Palette.magentaTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.plumTint40.color, dark: Colors.Palette.plumShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.plumShade30.color, dark: Colors.Palette.plumTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.beigeTint40.color, dark: Colors.Palette.beigeShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.beigeShade30.color, dark: Colors.Palette.beigeTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.minkTint40.color, dark: Colors.Palette.minkShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.minkShade30.color, dark: Colors.Palette.minkTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.platinumTint40.color, dark: Colors.Palette.platinumShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.platinumShade30.color, dark: Colors.Palette.platinumTint40.color)),
-		ColorSet(background: NSColor.getColor(light: Colors.Palette.anchorTint40.color, dark: Colors.Palette.anchorShade30.color),
-				 foreground: NSColor.getColor(light: Colors.Palette.anchorShade30.color, dark: Colors.Palette.anchorTint40.color))
+	static let avatarColors: [DynamicColor] = [
+		DynamicColor(background: Colors.Palette.darkRedTint40.color, foreground: Colors.Palette.darkRedShade30.color),
+		DynamicColor(background: Colors.Palette.cranberryTint40.color, foreground: Colors.Palette.cranberryShade30.color),
+		DynamicColor(background: Colors.Palette.redTint40.color, foreground: Colors.Palette.redShade30.color),
+		DynamicColor(background: Colors.Palette.pumpkinTint40.color, foreground: Colors.Palette.pumpkinShade30.color),
+		DynamicColor(background: Colors.Palette.peachTint40.color, foreground: Colors.Palette.peachShade30.color),
+		DynamicColor(background: Colors.Palette.marigoldTint40.color, foreground: Colors.Palette.marigoldShade30.color),
+		DynamicColor(background: Colors.Palette.goldTint40.color, foreground: Colors.Palette.goldShade30.color),
+		DynamicColor(background: Colors.Palette.brassTint40.color, foreground: Colors.Palette.brassShade30.color),
+		DynamicColor(background: Colors.Palette.brownTint40.color, foreground: Colors.Palette.brownShade30.color),
+		DynamicColor(background: Colors.Palette.forestTint40.color, foreground: Colors.Palette.forestShade30.color),
+		DynamicColor(background: Colors.Palette.seafoamTint40.color, foreground: Colors.Palette.seafoamShade30.color),
+		DynamicColor(background: Colors.Palette.darkGreenTint40.color, foreground: Colors.Palette.darkGreenShade30.color),
+		DynamicColor(background: Colors.Palette.lightTealTint40.color, foreground: Colors.Palette.lightTealShade30.color),
+		DynamicColor(background: Colors.Palette.tealTint40.color, foreground: Colors.Palette.tealShade30.color),
+		DynamicColor(background: Colors.Palette.steelTint40.color, foreground: Colors.Palette.steelShade30.color),
+		DynamicColor(background: Colors.Palette.blueTint40.color, foreground: Colors.Palette.blueShade30.color),
+		DynamicColor(background: Colors.Palette.royalBlueTint40.color, foreground: Colors.Palette.royalBlueShade30.color),
+		DynamicColor(background: Colors.Palette.cornFlowerTint40.color, foreground: Colors.Palette.cornFlowerShade30.color),
+		DynamicColor(background: Colors.Palette.navyTint40.color, foreground: Colors.Palette.navyShade30.color),
+		DynamicColor(background: Colors.Palette.lavenderTint40.color, foreground: Colors.Palette.lavenderShade30.color),
+		DynamicColor(background: Colors.Palette.purpleTint40.color, foreground: Colors.Palette.purpleShade30.color),
+		DynamicColor(background: Colors.Palette.grapeTint40.color, foreground: Colors.Palette.grapeShade30.color),
+		DynamicColor(background: Colors.Palette.lilacTint40.color, foreground: Colors.Palette.lilacShade30.color),
+		DynamicColor(background: Colors.Palette.pinkTint40.color, foreground: Colors.Palette.pinkShade30.color),
+		DynamicColor(background: Colors.Palette.magentaTint40.color, foreground: Colors.Palette.magentaShade30.color),
+		DynamicColor(background: Colors.Palette.plumTint40.color, foreground: Colors.Palette.plumShade30.color),
+		DynamicColor(background: Colors.Palette.beigeTint40.color, foreground: Colors.Palette.beigeShade30.color),
+		DynamicColor(background: Colors.Palette.minkTint40.color, foreground: Colors.Palette.minkShade30.color),
+		DynamicColor(background: Colors.Palette.platinumTint40.color, foreground: Colors.Palette.platinumShade30.color),
+		DynamicColor(background: Colors.Palette.anchorTint40.color, foreground: Colors.Palette.anchorShade30.color)
 	]
 }
 

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -90,7 +90,7 @@ open class AvatarView: NSView {
 			initialsTextField.backgroundColor = avatarBackgroundColor
 		}
 	}
-	
+
 	/// The initials font color of the avatar view when no image is provided.
 	/// Setting this property will override the default provided color.
 	@objc open var initialsFontColor: NSColor {
@@ -529,28 +529,5 @@ fileprivate extension CGPath {
 	/// - note: this can't be an initializer since Swift doesn't allow CF/CG types to have convenience initialer extensions
 	static func circularPath(withCircleDiameter diameter: CGFloat) -> CGPath {
 		return CGPath(ellipseIn: NSRect(x: 0, y: 0, width: diameter, height: diameter), transform: nil)
-	}
-}
-
-fileprivate extension NSColor {
-	enum InterfaceStyle: String {
-	   case dark, light
-
-		init() {
-			var type: InterfaceStyle = .light
-			let isDarkMode = NSApplication.shared.effectiveAppearance.bestMatch(from: [.darkAqua]) == .darkAqua
-			if isDarkMode {
-				type = .dark
-			}
-			self = type
-		}
-	}
-
-	static func getColor(light: NSColor, dark: NSColor) -> NSColor {
-		let currentStyle = InterfaceStyle()
-		if currentStyle == .light {
-			return light
-		}
-		return dark
 	}
 }

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -309,7 +309,7 @@ open class AvatarView: NSView {
 		}
 
 		initialsTextField.stringValue = AvatarView.initialsWithFallback(name: contactName, email: contactEmail)
-		updateAppearance(self.window?.effectiveAppearance)
+		updateAppearance(window?.effectiveAppearance)
 	}
 
 	private func updateAppearance(_ appearance: NSAppearance? = nil) {

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -472,7 +472,6 @@ fileprivate extension Unicode.Scalar {
 }
 
 extension AvatarView {
-	/// the text color of the text in the initials view
 
 	/// the table of background colors for the initials views
 	static let avatarColors: [ColorSet] = [

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -456,16 +456,5 @@ public final class Colors: NSObject {
 	@objc public static var primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color
 }
 
-@objc(MSFColorSet)
-open class ColorSet: NSObject {
-	public let background: NSColor
-	public let foreground: NSColor
-
-	public init(background: NSColor, foreground: NSColor) {
-		self.background = background
-		self.foreground = foreground
-	}
-}
-
 /// Make palette enum CaseIterable for unit testing purposes
 extension Colors.Palette: CaseIterable {}

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -14,6 +14,66 @@ public final class Colors: NSObject {
 	/// colors defined in asset catalog
 	@objc(MSFColorPalette)
 	public enum Palette: Int {
+		case anchorShade30
+		case anchorTint40
+		case beigeShade30
+		case beigeTint40
+		case blueShade30
+		case blueTint40
+		case brassShade30
+		case brassTint40
+		case brownShade30
+		case brownTint40
+		case cornFlowerShade30
+		case cornFlowerTint40
+		case cranberryShade30
+		case cranberryTint40
+		case darkGreenShade30
+		case darkGreenTint40
+		case darkRedShade30
+		case darkRedTint40
+		case forestShade30
+		case forestTint40
+		case goldShade30
+		case goldTint40
+		case grapeShade30
+		case grapeTint40
+		case lavenderShade30
+		case lavenderTint40
+		case lightTealShade30
+		case lightTealTint40
+		case lilacShade30
+		case lilacTint40
+		case magentaShade30
+		case magentaTint40
+		case marigoldShade30
+		case marigoldTint40
+		case minkShade30
+		case minkTint40
+		case navyShade30
+		case navyTint40
+		case peachShade30
+		case peachTint40
+		case pinkShade30
+		case pinkTint40
+		case platinumShade30
+		case platinumTint40
+		case plumShade30
+		case plumTint40
+		case pumpkinShade30
+		case pumpkinTint40
+		case purpleShade30
+		case purpleTint40
+		case redShade30
+		case redTint40
+		case royalBlueShade30
+		case royalBlueTint40
+		case seafoamShade30
+		case seafoamTint40
+		case steelShade30
+		case steelTint40
+		case tealShade30
+		case tealTint40
 		case pinkRed10
 		case red20
 		case red10
@@ -98,6 +158,126 @@ public final class Colors: NSObject {
 
 		public var name: String {
 			switch self {
+			case .anchorShade30:
+				return "anchorShade30"
+			case .anchorTint40:
+				return "anchorTint40"
+			case .beigeShade30:
+				return "beigeShade30"
+			case .beigeTint40:
+				return "beigeTint40"
+			case .blueShade30:
+				return "blueShade30"
+			case .blueTint40:
+				return "blueTint40"
+			case .brassShade30:
+				return "brassShade30"
+			case .brassTint40:
+				return "brassTint40"
+			case .brownShade30:
+				return "brownShade30"
+			case .brownTint40:
+				return "brownTint40"
+			case .cornFlowerShade30:
+				return "cornFlowerShade30"
+			case .cornFlowerTint40:
+				return "cornFlowerTint40"
+			case .cranberryShade30:
+				return "cranberryShade30"
+			case .cranberryTint40:
+				return "cranberryTint40"
+			case .darkGreenShade30:
+				return "darkGreenShade30"
+			case .darkGreenTint40:
+				return "darkGreenTint40"
+			case .darkRedShade30:
+				return "darkRedShade30"
+			case .darkRedTint40:
+				return "darkRedTint40"
+			case .forestShade30:
+				return "forestShade30"
+			case .forestTint40:
+				return "forestTint40"
+			case .goldShade30:
+				return "goldShade30"
+			case .goldTint40:
+				return "goldTint40"
+			case .grapeShade30:
+				return "grapeShade30"
+			case .grapeTint40:
+				return "grapeTint40"
+			case .lavenderShade30:
+				return "lavenderShade30"
+			case .lavenderTint40:
+				return "lavenderTint40"
+			case .lightTealShade30:
+				return "lightTealShade30"
+			case .lightTealTint40:
+				return "lightTealTint40"
+			case .lilacShade30:
+				return "lilacShade30"
+			case .lilacTint40:
+				return "lilacTint40"
+			case .magentaShade30:
+				return "magentaShade30"
+			case .magentaTint40:
+				return "magentaTint40"
+			case .marigoldShade30:
+				return "marigoldShade30"
+			case .marigoldTint40:
+				return "marigoldTint40"
+			case .minkShade30:
+				return "minkShade30"
+			case .minkTint40:
+				return "minkTint40"
+			case .navyShade30:
+				return "navyShade30"
+			case .navyTint40:
+				return "navyTint40"
+			case .peachShade30:
+				return "peachShade30"
+			case .peachTint40:
+				return "peachTint40"
+			case .pinkShade30:
+				return "pinkShade30"
+			case .pinkTint40:
+				return "pinkTint40"
+			case .platinumShade30:
+				return "platinumShade30"
+			case .platinumTint40:
+				return "platinumTint40"
+			case .plumShade30:
+				return "plumShade30"
+			case .plumTint40:
+				return "plumTint40"
+			case .pumpkinShade30:
+				return "pumpkinShade30"
+			case .pumpkinTint40:
+				return "pumpkinTint40"
+			case .purpleShade30:
+				return "purpleShade30"
+			case .purpleTint40:
+				return "purpleTint40"
+			case .redShade30:
+				return "redShade30"
+			case .redTint40:
+				return "redTint40"
+			case .royalBlueShade30:
+				return "royalBlueShade30"
+			case .royalBlueTint40:
+				return "royalBlueTint40"
+			case .seafoamShade30:
+				return "seafoamShade30"
+			case .seafoamTint40:
+				return "seafoamTint40"
+			case .steelShade30:
+				return "steelShade30"
+			case .steelTint40:
+				return "steelTint40"
+			case .tealShade30:
+				return "tealShade30"
+			case .tealTint40:
+				return "tealTint40"
 			case .pinkRed10:
 				return "pinkRed10"
 			case .red20:
@@ -274,6 +454,17 @@ public final class Colors: NSObject {
 	@objc public static var primaryShade20: NSColor = Colors.Palette.communicationBlueShade20.color
 
 	@objc public static var primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color
+}
+
+@objc(MSFColorSet)
+open class ColorSet: NSObject {
+	public let background: NSColor
+	public let foreground: NSColor
+
+	public init(background: NSColor, foreground: NSColor) {
+		self.background = background
+		self.foreground = foreground
+	}
 }
 
 /// Make palette enum CaseIterable for unit testing purposes

--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -279,11 +279,7 @@ class CalendarDayButton: NSButton {
 						   constant: CalendarDayButton.dualModeMargin)
 
 	private var isDarkMode: Bool {
-		var isInDarkAppearance = false
-		if effectiveAppearance.bestMatch(from: [.darkAqua]) == .darkAqua {
-			isInDarkAppearance = true
-		}
-		return isInDarkAppearance
+		return InterfaceStyle() == .dark
 	}
 
 	/// Layer used to draw the selected day highlight

--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -279,7 +279,7 @@ class CalendarDayButton: NSButton {
 						   constant: CalendarDayButton.dualModeMargin)
 
 	private var isDarkMode: Bool {
-		return NSAppearance.current.isDarkMode
+		return NSApplication.shared.effectiveAppearance.isDarkMode
 	}
 
 	/// Layer used to draw the selected day highlight

--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -279,7 +279,7 @@ class CalendarDayButton: NSButton {
 						   constant: CalendarDayButton.dualModeMargin)
 
 	private var isDarkMode: Bool {
-		return InterfaceStyle() == .dark
+		return NSAppearance.current.isDarkMode
 	}
 
 	/// Layer used to draw the selected day highlight

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -6,25 +6,60 @@
 import Foundation
 import AppKit
 
-enum InterfaceStyle: String {
-   case dark, light
+private let kAppleInterfaceStyle = "AppleInterfaceStyle"
 
-	init() {
-		var type: InterfaceStyle = .light
-		let isDarkMode = NSApplication.shared.effectiveAppearance.bestMatch(from: [.darkAqua]) == .darkAqua
-		if isDarkMode {
-			type = .dark
+public extension NSAppearance {
+
+	/// Pseudo algorithm picked up from https://developer.apple.com/forums/thread/118974
+	var isDarkMode: Bool {
+		if #available(OSX 10.15, *) {
+			let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
+			if appearanceDescription.contains("dark") {
+				return true
+			}
+		} else if #available(OSX 10.14, *) {
+			if let appleInterfaceStyle = UserDefaults.standard.object(forKey: kAppleInterfaceStyle) as? String {
+				if appleInterfaceStyle.lowercased().contains("dark") {
+					return true
+				}
+			}
 		}
-		self = type
+		return false
 	}
 }
 
-public extension NSColor {
-	static func getColor(light: NSColor, dark: NSColor) -> NSColor {
-		let currentStyle = InterfaceStyle()
-		if currentStyle == .light {
-			return light
+@objc(MSFDynamicColor)
+public class DynamicColor: NSObject {
+
+	private let background: NSColor
+	private let foreground: NSColor
+
+	public init(background: NSColor, foreground: NSColor) {
+		self.background = background
+		self.foreground = foreground
+	}
+
+	/// resolves color based on theme
+	func resolvedForegroundColor(_ appearance: NSAppearance = NSAppearance.current) -> NSColor {
+		if appearance.isDarkMode {
+			return self.background
 		}
-		return dark
+		return self.foreground
+	}
+
+	/// resolves color based on theme
+	func resolvedBackgroundColor(_ appearance: NSAppearance = NSAppearance.current) -> NSColor {
+		if appearance.isDarkMode {
+			return self.foreground
+		}
+		return self.background
+	}
+
+	public override func isEqual(_ object: Any?) -> Bool {
+		let color = object as? DynamicColor
+		guard let dynamicColor = color else {
+			return false
+		}
+		return dynamicColor.background.isEqual(self.background) && dynamicColor.foreground.isEqual(self.foreground)
 	}
 }

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -11,16 +11,14 @@ public extension NSAppearance {
 
 	/// Pseudo algorithm picked up from https://developer.apple.com/forums/thread/118974
 	var isDarkMode: Bool {
-		#if DEBUG
-		     // Included for unit testing
-			if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-				if self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-					return true
-				} else {
-					return false
-				}
+		// Included for unit testing
+		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+			if self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+				return true
+			} else {
+				return false
 			}
-		#endif
+		}
 		if #available(OSX 10.15, *) {
 			let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
 			if appearanceDescription.contains("dark") {

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AppKit
+
+enum InterfaceStyle: String {
+   case dark, light
+
+	init() {
+		var type: InterfaceStyle = .light
+		let isDarkMode = NSApplication.shared.effectiveAppearance.bestMatch(from: [.darkAqua]) == .darkAqua
+		if isDarkMode {
+			type = .dark
+		}
+		self = type
+	}
+}
+
+public extension NSColor {
+	static func getColor(light: NSColor, dark: NSColor) -> NSColor {
+		let currentStyle = InterfaceStyle()
+		if currentStyle == .light {
+			return light
+		}
+		return dark
+	}
+}

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -8,22 +8,8 @@ import AppKit
 private let kAppleInterfaceStyle = "AppleInterfaceStyle"
 
 extension NSAppearance {
-
-	/// Pseudo algorithm picked up from https://developer.apple.com/forums/thread/118974
 	var isDarkMode: Bool {
-		// Included for unit testing
-		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-			return self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-		}
-		if #available(OSX 10.15, *) {
-			let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
-			return appearanceDescription.contains("dark")
-		} else if #available(OSX 10.14, *) {
-			if let appleInterfaceStyle = UserDefaults.standard.object(forKey: kAppleInterfaceStyle) as? String {
-				return appleInterfaceStyle.lowercased().contains("dark")
-			}
-		}
-		return false
+		return self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
 	}
 }
 
@@ -48,8 +34,9 @@ class DynamicColor: NSObject {
 	}
 
 	/// resolves color based on theme
-	func resolvedColor(_ appearance: NSAppearance = NSAppearance.current) -> NSColor {
-		return appearance.isDarkMode ? self.dark : self.light
+	func resolvedColor(_ appearance: NSAppearance? = nil) -> NSColor {
+		let effectiveAppearance = appearance ?? NSApplication.shared.effectiveAppearance
+		return effectiveAppearance.isDarkMode ? self.dark : self.light
 	}
 
 	public override func isEqual(_ object: Any?) -> Bool {

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -7,28 +7,20 @@ import AppKit
 
 private let kAppleInterfaceStyle = "AppleInterfaceStyle"
 
-public extension NSAppearance {
+extension NSAppearance {
 
 	/// Pseudo algorithm picked up from https://developer.apple.com/forums/thread/118974
 	var isDarkMode: Bool {
 		// Included for unit testing
 		if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-			if self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-				return true
-			} else {
-				return false
-			}
+			return self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
 		}
 		if #available(OSX 10.15, *) {
 			let appearanceDescription = NSApplication.shared.effectiveAppearance.debugDescription.lowercased()
-			if appearanceDescription.contains("dark") {
-				return true
-			}
+			return appearanceDescription.contains("dark")
 		} else if #available(OSX 10.14, *) {
 			if let appleInterfaceStyle = UserDefaults.standard.object(forKey: kAppleInterfaceStyle) as? String {
-				if appleInterfaceStyle.lowercased().contains("dark") {
-					return true
-				}
+				return appleInterfaceStyle.lowercased().contains("dark")
 			}
 		}
 		return false
@@ -61,8 +53,7 @@ class DynamicColor: NSObject {
 	}
 
 	public override func isEqual(_ object: Any?) -> Bool {
-		let color = object as? DynamicColor
-		guard let dynamicColor = color else {
+		guard let dynamicColor = object as? DynamicColor else {
 			return false
 		}
 		return dynamicColor.light.isEqual(self.light) && dynamicColor.dark.isEqual(self.dark)

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -5,8 +5,6 @@
 
 import AppKit
 
-private let kAppleInterfaceStyle = "AppleInterfaceStyle"
-
 extension NSAppearance {
 	var isDarkMode: Bool {
 		return self.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua

--- a/macos/FluentUI/Extensions/Color+Apperance.swift
+++ b/macos/FluentUI/Extensions/Color+Apperance.swift
@@ -35,8 +35,10 @@ class DynamicColor: NSObject {
 
 	/// resolves color based on theme
 	func resolvedColor(_ appearance: NSAppearance? = nil) -> NSColor {
-		let effectiveAppearance = appearance ?? NSApplication.shared.effectiveAppearance
-		return effectiveAppearance.isDarkMode ? self.dark : self.light
+		guard let appearance = appearance else {
+			return self.light
+		}
+		return appearance.isDarkMode ? self.dark : self.light
 	}
 
 	public override func isEqual(_ object: Any?) -> Bool {

--- a/macos/FluentUIUnitTest/AvatarViewTests.swift
+++ b/macos/FluentUIUnitTest/AvatarViewTests.swift
@@ -115,13 +115,16 @@ class AvatarViewTests: XCTestCase {
 		XCTAssertNil(noNameNoEmailAvatar.toolTip)
 	}
 
-	func testBackgroundColors () {
+	func testAvatarColors () {
 		// Cherry pick a few known values and test them
-		XCTAssertEqual(AvatarView.backgroundColor(for: 0), Colors.Palette.cyanBlue10.color)
-		XCTAssertEqual(AvatarView.backgroundColor(for: 2), Colors.Palette.magenta20.color)
-		XCTAssertEqual(AvatarView.backgroundColor(for: 3), Colors.Palette.green10.color)
-		XCTAssertEqual(AvatarView.backgroundColor(for: 6), Colors.Palette.orange20.color)
-		XCTAssertEqual(AvatarView.backgroundColor(for: 20), Colors.Palette.orange30.color)
+		XCTAssertTrue(AvatarView.colorSet(for: 0).background == Colors.Palette.darkRedTint40.color ||
+						AvatarView.colorSet(for: 0).background == Colors.Palette.darkRedShade30.color)
+		XCTAssertTrue(AvatarView.colorSet(for: 0).foreground == Colors.Palette.darkRedShade30.color ||
+						AvatarView.colorSet(for: 0).foreground == Colors.Palette.darkRedTint40.color)
+		XCTAssertTrue(AvatarView.colorSet(for: 29).background == Colors.Palette.anchorTint40.color ||
+						AvatarView.colorSet(for: 29).background == Colors.Palette.anchorShade30.color)
+		XCTAssertTrue(AvatarView.colorSet(for: 29).foreground == Colors.Palette.anchorShade30.color ||
+						AvatarView.colorSet(for: 29).foreground == Colors.Palette.anchorTint40.color)
 	}
 
 	func testHashAlgorithm () {

--- a/macos/FluentUIUnitTest/AvatarViewTests.swift
+++ b/macos/FluentUIUnitTest/AvatarViewTests.swift
@@ -117,14 +117,10 @@ class AvatarViewTests: XCTestCase {
 
 	func testAvatarColors () {
 		// Cherry pick a few known values and test them
-		XCTAssertTrue(AvatarView.colorSet(for: 0).background == Colors.Palette.darkRedTint40.color ||
-						AvatarView.colorSet(for: 0).background == Colors.Palette.darkRedShade30.color)
-		XCTAssertTrue(AvatarView.colorSet(for: 0).foreground == Colors.Palette.darkRedShade30.color ||
-						AvatarView.colorSet(for: 0).foreground == Colors.Palette.darkRedTint40.color)
-		XCTAssertTrue(AvatarView.colorSet(for: 29).background == Colors.Palette.anchorTint40.color ||
-						AvatarView.colorSet(for: 29).background == Colors.Palette.anchorShade30.color)
-		XCTAssertTrue(AvatarView.colorSet(for: 29).foreground == Colors.Palette.anchorShade30.color ||
-						AvatarView.colorSet(for: 29).foreground == Colors.Palette.anchorTint40.color)
+		XCTAssertEqual(AvatarView.getColor(for: 0),
+					   DynamicColor(background: Colors.Palette.darkRedTint40.color, foreground: Colors.Palette.darkRedShade30.color))
+		XCTAssertEqual(AvatarView.getColor(for: 29),
+					   DynamicColor(background: Colors.Palette.anchorTint40.color, foreground: Colors.Palette.anchorShade30.color))
 	}
 
 	func testHashAlgorithm () {

--- a/macos/FluentUIUnitTest/AvatarViewTests.swift
+++ b/macos/FluentUIUnitTest/AvatarViewTests.swift
@@ -120,7 +120,7 @@ class AvatarViewTests: XCTestCase {
 		let lightModeAppearnce = NSAppearance(named: .aqua)!
 		let darkModeAppearance = NSAppearance(named: .darkAqua)!
 
-		for (index, colorSet) in NSColor.avatarColors.enumerated() {
+		for (index, colorSet) in AvatarView.avatarColors.enumerated() {
 			let bgColor = colorSet.background
 			let fgColor = colorSet.foreground
 			let bgLightColor = bgColor.resolvedColor(lightModeAppearnce)

--- a/macos/FluentUIUnitTest/AvatarViewTests.swift
+++ b/macos/FluentUIUnitTest/AvatarViewTests.swift
@@ -116,11 +116,26 @@ class AvatarViewTests: XCTestCase {
 	}
 
 	func testAvatarColors () {
-		// Cherry pick a few known values and test them
-		XCTAssertEqual(AvatarView.getColor(for: 0),
-					   DynamicColor(background: Colors.Palette.darkRedTint40.color, foreground: Colors.Palette.darkRedShade30.color))
-		XCTAssertEqual(AvatarView.getColor(for: 29),
-					   DynamicColor(background: Colors.Palette.anchorTint40.color, foreground: Colors.Palette.anchorShade30.color))
+		// Verify if light and dark mode are interchangable
+		let lightModeAppearnce = NSAppearance(named: .aqua)!
+		let darkModeAppearance = NSAppearance(named: .darkAqua)!
+
+		for (index, colorSet) in NSColor.avatarColors.enumerated() {
+			let bgColor = colorSet.background
+			let fgColor = colorSet.foreground
+			let bgLightColor = bgColor.resolvedColor(lightModeAppearnce)
+			let bgDarkColor = bgColor.resolvedColor(darkModeAppearance)
+			let fgLightColor = fgColor.resolvedColor(lightModeAppearnce)
+			let fgDarkColor = fgColor.resolvedColor(darkModeAppearance)
+
+			XCTAssertEqual(bgLightColor,
+						   fgDarkColor,
+						   "Index \(index): Background color in light mode does not match Foreground color in dark mode.")
+
+			XCTAssertEqual(bgDarkColor,
+						   fgLightColor,
+						   "Index \(index): Background color in dark mode does not match Foreground color in light mode.")
+		}
 	}
 
 	func testHashAlgorithm () {

--- a/macos/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/macos/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2F6759B8251E4C2600210B3C /* SimpleObjCTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F6759B7251E4C2600210B3C /* SimpleObjCTest.m */; };
+		3F1B016625EDC6E200EE262E /* Color+Apperance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1B016525EDC6E200EE262E /* Color+Apperance.swift */; };
 		53BCB0DB253A72AD00620960 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0DA253A72AD00620960 /* Colors.swift */; };
 		53BCB0E2253A72E000620960 /* FluentUIResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0E1253A72E000620960 /* FluentUIResources.swift */; };
 		53BCB0ED253A75BB00620960 /* AvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0EC253A75BB00620960 /* AvatarView.swift */; };
@@ -115,6 +116,7 @@
 /* Begin PBXFileReference section */
 		2F6759B6251E4C2600210B3C /* SimpleObjCTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimpleObjCTest.h; sourceTree = "<group>"; };
 		2F6759B7251E4C2600210B3C /* SimpleObjCTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SimpleObjCTest.m; sourceTree = "<group>"; };
+		3F1B016525EDC6E200EE262E /* Color+Apperance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Apperance.swift"; sourceTree = "<group>"; };
 		53BCB0DA253A72AD00620960 /* Colors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		53BCB0E1253A72E000620960 /* FluentUIResources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentUIResources.swift; sourceTree = "<group>"; };
 		53BCB0EC253A75BB00620960 /* AvatarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
@@ -290,6 +292,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3F1B016425EDC6C400EE262E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				3F1B016525EDC6E200EE262E /* Color+Apperance.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		53BCB0D9253A724700620960 /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -421,6 +431,7 @@
 				53BCB0E9253A74FE00620960 /* Button */,
 				53BCB0D9253A724700620960 /* Core */,
 				804626C722D7909200AFA48C /* DatePicker */,
+				3F1B016425EDC6C400EE262E /* Extensions */,
 				53BCB0EA253A752400620960 /* Link */,
 				53BCB0EB253A753400620960 /* Separator */,
 				E61C96B62295E8D60006561F /* FluentUI-Info.plist */,
@@ -815,6 +826,7 @@
 				80117A7F22DCDF6F00813D59 /* CalendarView.swift in Sources */,
 				53BCB0E2253A72E000620960 /* FluentUIResources.swift in Sources */,
 				8061BF7E22EF936800F2D245 /* DatePickerView.swift in Sources */,
+				3F1B016625EDC6E200EE262E /* Color+Apperance.swift in Sources */,
 				8061BF7F22EF936800F2D245 /* DatePickerController.swift in Sources */,
 				53BCB0F4253A75CF00620960 /* Button.swift in Sources */,
 			);


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS

### Description of changes

(1/2) Fix to issue #392 . The current PR addressed color and theme changes to Avatar view.  This is extension to corresponding [PR for iOS](https://github.com/microsoft/fluentui-apple/pull/434).

This change includes two updates

1. Update primary and secondary colors with new asset catalog from previous PR for iOS
2. Update Avatar color background and foreground color to consume new set of colors

### Verification

Before (Dark Theme):
![Screen Shot 2021-03-01 at 2 14 58 PM](https://user-images.githubusercontent.com/63682282/109568126-56389380-7a9b-11eb-98f0-c0d52e442485.png)

After (Dark Theme):

![Screen Shot 2021-03-01 at 2 28 10 PM](https://user-images.githubusercontent.com/63682282/109568183-69e3fa00-7a9b-11eb-8ec6-af251ece5c0f.png)

Before (Light Theme):

![Screen Shot 2021-03-01 at 2 16 43 PM](https://user-images.githubusercontent.com/63682282/109568241-7c5e3380-7a9b-11eb-8add-73edcde48386.png)

After (Light Theme):

![Screen Shot 2021-03-01 at 2 28 51 PM](https://user-images.githubusercontent.com/63682282/109568266-84b66e80-7a9b-11eb-8da0-ed09223b221c.png)


### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/455)