### PR TITLE
MSFNavigationDemoController switch and label weren't position correctly

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -105,7 +105,6 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.accessoryView = accessoryView
         content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
-        content.showsTabs = !showShadow
         content.showsTopAccessoryView = showsTopAccessory
 
         if style == .custom {
@@ -184,50 +183,13 @@ extension NavigationControllerDemoController: UIGestureRecognizerDelegate {
 // MARK: - RootViewController
 
 class RootViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-    var container: UIStackView { return view as! UIStackView }
     private(set) lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
+        tableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
         return tableView
-    }()
-
-    private(set) lazy var searchProgressSpinnerSwitchView: UIView = {
-        let itemRow = UIStackView()
-        itemRow.axis = .horizontal
-        itemRow.distribution = .equalCentering
-        itemRow.alignment = .leading
-        itemRow.isLayoutMarginsRelativeArrangement = true
-        itemRow.layoutMargins = UIEdgeInsets(top: 10, left: 15, bottom: 10, right: 15)
-        itemRow.translatesAutoresizingMaskIntoConstraints = false
-
-        let searchSpinnerSwitchLabel = Label(style: .subhead, colorStyle: .regular)
-        searchSpinnerSwitchLabel.text = "Show spinner while using the search bar"
-        itemRow.addArrangedSubview(searchSpinnerSwitchLabel)
-
-        let searchSpinnerSwitch = UISwitch()
-        searchSpinnerSwitch.isOn = true
-        searchSpinnerSwitch.addTarget(self, action: #selector(shouldShowSearchSpinner(switchView:)), for: .valueChanged)
-
-        itemRow.addArrangedSubview(searchSpinnerSwitchLabel)
-        itemRow.addArrangedSubview(searchSpinnerSwitch)
-
-        let itemsContainer = UIView()
-        itemsContainer.backgroundColor = Colors.tableBackground
-        itemsContainer.addSubview(itemRow)
-        itemsContainer.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            itemsContainer.topAnchor.constraint(equalTo: itemRow.topAnchor),
-            itemsContainer.bottomAnchor.constraint(equalTo: itemRow.bottomAnchor),
-            itemsContainer.leadingAnchor.constraint(equalTo: itemRow.leadingAnchor),
-            itemsContainer.trailingAnchor.constraint(equalTo: itemRow.trailingAnchor),
-            searchSpinnerSwitchLabel.centerYAnchor.constraint(equalTo: itemsContainer.centerYAnchor),
-            searchSpinnerSwitch.centerYAnchor.constraint(equalTo: itemsContainer.centerYAnchor)
-        ])
-
-        return itemsContainer
     }()
 
     var showSearchProgressSpinner: Bool = true
@@ -235,14 +197,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     var allowsCellSelection: Bool = false {
         didSet {
             updateRightBarButtonItems()
-        }
-    }
-
-    var showsTabs: Bool = false {
-        didSet {
-            if showsTabs != oldValue {
-                segmentedControl = showsTabs ? SegmentedControl(items: ["Unread", "All"]) : nil
-            }
         }
     }
 
@@ -266,15 +220,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     private var navigationBarFrameObservation: NSKeyValueObservation?
 
-    private var segmentedControl: SegmentedControl? {
-        didSet {
-            oldValue?.removeFromSuperview()
-            if let segmentedControl = segmentedControl {
-                container.insertArrangedSubview(segmentedControl, at: 0)
-            }
-        }
-    }
-
     private let tabBarView: TabBarView = {
         let tabBarView = TabBarView()
         tabBarView.items = [
@@ -285,19 +230,12 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         return tabBarView
     }()
 
-    override func loadView() {
-        let container = UIStackView()
-        container.axis = .vertical
-        view = container
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
-        if navigationItem.accessoryView != nil {
-            container.addArrangedSubview(searchProgressSpinnerSwitchView)
-        }
 
-        container.addArrangedSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+
         updateNavigationTitle()
         updateLeftBarButtonItems()
         updateRightBarButtonItems()
@@ -306,6 +244,10 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         view.addSubview(tabBarView)
 
         let tabBarViewConstraints = [
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             tabBarView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             tabBarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tabBarView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -354,11 +296,23 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == 0 {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
+                return UITableViewCell()
+            }
+            cell.setup(title: "Show spinner while using the search bar", isOn: true)
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.shouldShowSearchSpinner(isOn: cell?.isOn ?? false)
+            }
+            return cell
+        }
+
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as? TableViewCell else {
             return UITableViewCell()
         }
         let imageView = UIImageView(image: UIImage(named: "excelIcon"))
-        cell.setup(title: "Cell #\(1 + indexPath.row)", customView: imageView, accessoryType: .disclosureIndicator)
+        cell.setup(title: "Cell #\(indexPath.row)", customView: imageView, accessoryType: .disclosureIndicator)
         cell.isInSelectionMode = isInSelectionMode
         return cell
     }
@@ -414,8 +368,8 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
     }
 
-    @objc private func shouldShowSearchSpinner(switchView: UISwitch) {
-        showSearchProgressSpinner = switchView.isOn
+    @objc private func shouldShowSearchSpinner(isOn: Bool) {
+        showSearchProgressSpinner = isOn
     }
 
     @objc private func dismissSelf() {
@@ -431,14 +385,12 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         isInSelectionMode = true
         msfNavigationController?.contractNavigationBar(animated: true)
         msfNavigationController?.allowResizeOfNavigationBarOnScroll = false
-        container.removeArrangedSubview(searchProgressSpinnerSwitchView)
     }
 
     @objc private func dismissSelectionMode() {
         isInSelectionMode = false
         msfNavigationController?.allowResizeOfNavigationBarOnScroll = true
         msfNavigationController?.expandNavigationBar(animated: true)
-        container.insertArrangedSubview(searchProgressSpinnerSwitchView, at: 0 /* index */)
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change only affects only demo app. In largest accessibility text size mode, not everything was fitting inside the screen. Update the UISwitch and label that was for search animation configuration to be part of the tableview.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-01 at 21 04 08](https://user-images.githubusercontent.com/20715435/109600752-78013d00-7ad2-11eb-891c-aeb6ff0725c7.png)| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-01 at 21 10 13](https://user-images.githubusercontent.com/20715435/109600790-9109ee00-7ad2-11eb-8903-60b32fadcf4d.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/456)