### PR TITLE
make datetimepicker to be larger text friendly

### DIFF
--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -47,6 +47,7 @@ class CalendarView: UIView {
         addSubview(weekdayHeadingView)
         addSubview(collectionView)
         addSubview(collectionViewSeparator)
+        addInteraction(UILargeContentViewerInteraction())
 
         if headerStyle == .light {
             addSubview(headingViewSeparator)

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -55,6 +55,7 @@ class CalendarViewDayCell: UICollectionViewCell {
         static let borderWidth: CGFloat = UIScreen.main.devicePixel
         static let dotDiameter: CGFloat = 4.0
         static let fadedVisualStateAlphaMultiplier: CGFloat = 0.2
+        static let maximumFontSize: CGFloat = 33.0
     }
 
     class var identifier: String { return "CalendarViewDayCell" }
@@ -93,7 +94,7 @@ class CalendarViewDayCell: UICollectionViewCell {
         selectionOverlayView.isUserInteractionEnabled = false
 
         dateLabel = UILabel(frame: .zero)
-        dateLabel.font = Fonts.body.withSize(17)
+        dateLabel.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
         dateLabel.textAlignment = .center
         dateLabel.textColor = Colors.Calendar.Day.textPrimary
         dateLabel.showsLargeContentViewer = true

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -93,9 +93,10 @@ class CalendarViewDayCell: UICollectionViewCell {
         selectionOverlayView.isUserInteractionEnabled = false
 
         dateLabel = UILabel(frame: .zero)
-        dateLabel.font = Fonts.body
+        dateLabel.font = Fonts.body.withSize(17)
         dateLabel.textAlignment = .center
         dateLabel.textColor = Colors.Calendar.Day.textPrimary
+        dateLabel.showsLargeContentViewer = true
 
         dotView = DotView()
         dotView.color = Colors.Calendar.Day.textPrimary

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -60,9 +60,10 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
 
     override init(frame: CGRect) {
         monthLabel = UILabel(frame: CGRect.zero)
-        monthLabel.font = Fonts.caption1
+        monthLabel.font = Fonts.caption1.withSize(12)
         monthLabel.textAlignment = .center
         monthLabel.textColor = Colors.Calendar.Day.textPrimary
+        monthLabel.showsLargeContentViewer = true
 
         super.init(frame: frame)
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
+import UIKit
 
 // MARK: CalendarViewDayTodayCell
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -47,8 +47,9 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
 
     private func configureFontColor() {
         if isHighlighted || isSelected {
-            dateLabel.font = Fonts.body
+            dateLabel.font = Fonts.body.withSize(17)
             dateLabel.textColor = Colors.Calendar.Day.textSelected
+            dateLabel.showsLargeContentViewer = true
         } else {
             dateLabel.font = Fonts.headline
             switch textStyle {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -47,11 +47,11 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
 
     private func configureFontColor() {
         if isHighlighted || isSelected {
-            dateLabel.font = Fonts.body.withSize(17)
+            dateLabel.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
             dateLabel.textColor = Colors.Calendar.Day.textSelected
             dateLabel.showsLargeContentViewer = true
         } else {
-            dateLabel.font = Fonts.headline
+            dateLabel.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: Fonts.headline, maximumPointSize: Constants.maximumFontSize)
             switch textStyle {
             case .primary:
                 dateLabel.textColor = Colors.Calendar.Day.textPrimary

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -94,7 +94,8 @@ class CalendarViewWeekdayHeadingView: UIView {
             let label = UILabel()
             label.textAlignment = .center
             label.text = weekdaySymbol
-            label.font = Fonts.caption1
+            label.font = Fonts.caption1.withSize(12)
+            label.showsLargeContentViewer = true
 
             switch headerStyle {
             case .light:

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -18,6 +18,8 @@ class CalendarViewWeekdayHeadingView: UIView {
             static let compactHeight: CGFloat = 26.0
             static let regularHeight: CGFloat = 48.0
         }
+        
+        static let maximumFontSize: CGFloat = 26.0
     }
 
     private var firstWeekday: Int?
@@ -94,7 +96,7 @@ class CalendarViewWeekdayHeadingView: UIView {
             let label = UILabel()
             label.textAlignment = .center
             label.text = weekdaySymbol
-            label.font = Fonts.caption1.withSize(12)
+            label.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: Fonts.caption1, maximumPointSize: Constants.maximumFontSize)
             label.showsLargeContentViewer = true
 
             switch headerStyle {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -77,6 +77,7 @@ class DateTimePickerView: UIControl {
         layer.addSublayer(gradientLayer)
         addSubview(selectionTopSeparator)
         addSubview(selectionBottomSeparator)
+        addInteraction(UILargeContentViewerInteraction())
 
         backgroundColor = Colors.DateTimePicker.background
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -18,22 +18,20 @@ public extension Colors {
 /// TableViewCell representing the cell of component view (should be used only by DateTimePickerViewComponent and not instantiated on its own)
 class DateTimePickerViewComponentCell: UITableViewCell {
     private struct Constants {
-        static let baseHeight: CGFloat = 45
-        static let verticalPadding: CGFloat = 12
+        static let baseHeight: CGFloat = 52
         static let normalTextStyle: TextStyle = .body
-        static let emphasizedTextStyle: TextStyle = .headline
+        static let fixedFontSize: CGFloat = 17
         static let normalTextColor: UIColor = Colors.DateTimePicker.text
     }
 
     static let identifier: String = "DateTimePickerViewComponentCell"
 
     class var idealHeight: CGFloat {
-        return max(Constants.verticalPadding * 2 + Constants.normalTextStyle.font.deviceLineHeight, Constants.baseHeight)
+        return Constants.baseHeight
     }
 
     var emphasized: Bool = false {
         didSet {
-            textLabel?.font = (emphasized ? Constants.emphasizedTextStyle: Constants.normalTextStyle).font
             updateTextLabelColor()
         }
     }
@@ -44,8 +42,9 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         backgroundColor = nil
 
         textLabel?.textAlignment = .center
-        textLabel?.font = Constants.normalTextStyle.font
+        textLabel?.font = Constants.normalTextStyle.font.withSize(Constants.fixedFontSize)
         textLabel?.textColor = Constants.normalTextColor
+        textLabel?.showsLargeContentViewer = true
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -18,20 +18,25 @@ public extension Colors {
 /// TableViewCell representing the cell of component view (should be used only by DateTimePickerViewComponent and not instantiated on its own)
 class DateTimePickerViewComponentCell: UITableViewCell {
     private struct Constants {
-        static let baseHeight: CGFloat = 52
-        static let normalTextStyle: TextStyle = .body
-        static let fixedFontSize: CGFloat = 17
+        static let baseHeight: CGFloat = 45
+        static let verticalPadding: CGFloat = 12
+        static let maximumFontSize: CGFloat = 33.0
         static let normalTextColor: UIColor = Colors.DateTimePicker.text
     }
 
     static let identifier: String = "DateTimePickerViewComponentCell"
 
     class var idealHeight: CGFloat {
-        return Constants.baseHeight
+        return max(Constants.verticalPadding * 2 + Fonts.body.deviceLineHeight, Constants.baseHeight)
     }
 
     var emphasized: Bool = false {
         didSet {
+            if emphasized {
+                textLabel?.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: Fonts.headline, maximumPointSize: Constants.maximumFontSize)
+            } else {
+                textLabel?.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
+            }
             updateTextLabelColor()
         }
     }
@@ -42,7 +47,7 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         backgroundColor = nil
 
         textLabel?.textAlignment = .center
-        textLabel?.font = Constants.normalTextStyle.font.withSize(Constants.fixedFontSize)
+        textLabel?.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
         textLabel?.textColor = Constants.normalTextColor
         textLabel?.showsLargeContentViewer = true
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently, datetimepicker labels just use the MSFFonts and the font sizes may get too big to fit within the calendar or datepickercomponentview. Use UIFontMetrics to limit the maximum font size of the each label and also add largecontentviewer to help users who has large text accessibility settings

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-01 at 22 26 50](https://user-images.githubusercontent.com/20715435/109608154-4a21f580-7ade-11eb-9b3a-76da2ab0e80b.png) ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-01 at 22 26 57](https://user-images.githubusercontent.com/20715435/109608167-4e4e1300-7ade-11eb-9cf8-f2171b5cc359.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-01 at 22 25 19](https://user-images.githubusercontent.com/20715435/109608202-5dcd5c00-7ade-11eb-96c3-573d3205d9c9.png) ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-01 at 22 25 30](https://user-images.githubusercontent.com/20715435/109608212-62921000-7ade-11eb-9329-66ea045c6163.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/457)