### PR TITLE
Fix style errors

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -90,10 +90,10 @@ Pod::Spec.new do |s|
   end
   
   s.subspec 'SegmentedControl_ios' do |segmentedcontrol_ios|
-  	segmentedcontrol_ios.platform = :ios
-  	segmentedcontrol_ios.dependency 'MicrosoftFluentUI/Controls_ios'
-  	segmentedcontrol_ios.dependency 'MicrosoftFluentUI/PillButtonBar_ios'
-  	segmentedcontrol_ios.source_files = ["ios/FluentUI/SegmentedControl/**/*.{swift,h}"]
+    segmentedcontrol_ios.platform = :ios
+    segmentedcontrol_ios.dependency 'MicrosoftFluentUI/Controls_ios'
+    segmentedcontrol_ios.dependency 'MicrosoftFluentUI/PillButtonBar_ios'
+    segmentedcontrol_ios.source_files = ["ios/FluentUI/SegmentedControl/**/*.{swift,h}"]
   end
 
   s.subspec 'Shimmer_ios' do |shimmer_ios|

--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -88,7 +88,7 @@ Pod::Spec.new do |s|
     presenters_ios.dependency 'MicrosoftFluentUI/Controls_ios'
     presenters_ios.source_files = ["ios/FluentUI/Presenters/**/*.{swift,h}"]
   end
-  
+
   s.subspec 'SegmentedControl_ios' do |segmentedcontrol_ios|
     segmentedcontrol_ios.platform = :ios
     segmentedcontrol_ios.dependency 'MicrosoftFluentUI/Controls_ios'

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -18,7 +18,7 @@ class CalendarViewWeekdayHeadingView: UIView {
             static let compactHeight: CGFloat = 26.0
             static let regularHeight: CGFloat = 48.0
         }
-        
+
         static let maximumFontSize: CGFloat = 26.0
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -446,7 +446,7 @@ open class SegmentedControl: UIControl {
     }
 
     /// Used to retrieve the view from the segment at the specified index
-    @objc open func segmentView(at index: Int) -> UIView? {
+    open func segmentView(at index: Int) -> UIView? {
         guard index <= buttons.count else {
             return nil
         }


### PR DESCRIPTION
I accidently added some tabs to the podspec, and there were trailing spaces in CalendarViewWeekdayHeadingView.swift

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixed some white space style issues in podspec and CalendarViewWeekdayHeadingView.swift

### Verification

swiftlint no longer giving warnings for podspec and CalendarViewWeekdayHeadinfView.swift

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/460)