### PR TITLE
Update Segmented Control selection animation

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -200,7 +200,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'SegmentedControl_ios' do |segmentedcontrol_ios|
     segmentedcontrol_ios.platform = :ios
-    segmentedcontrol_ios.dependency 'MicrosoftFluentUI/PillButtonBar_ios'
     segmentedcontrol_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     segmentedcontrol_ios.source_files = ["ios/FluentUI/SegmentedControl/**/*.{swift,h}"]
   end

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -154,7 +154,7 @@ open class SegmentedControl: UIControl {
 
     private struct Constants {
         static let selectionBarHeight: CGFloat = 1.5
-        static let pillHorizontalInset: CGFloat = 16
+        static let pillContainerHorizontalInset: CGFloat = 16
         static let pillButtonInsets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
         static let pillButtonCornerRadius: CGFloat = 16
     }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -416,7 +416,7 @@ open class SegmentedControl: UIControl {
                     if traitCollection.userInterfaceIdiom == .pad {
                         suggestedWidth = max(suggestedWidth / 2, 375.0)
                     } else {
-                        var insets = 2 * Constants.pillHorizontalInset
+                        var insets = 2 * Constants.pillContainerHorizontalInset
                         if let window = window {
                             insets += window.safeAreaInsets.left + window.safeAreaInsets.right
                         }
@@ -555,7 +555,7 @@ open class SegmentedControl: UIControl {
 
     private func layoutPillContainerView() {
         var frame = bounds
-        frame = frame.inset(by: UIEdgeInsets(top: 0, left: Constants.pillHorizontalInset, bottom: 0, right: Constants.pillHorizontalInset))
+        frame = frame.inset(by: UIEdgeInsets(top: 0, left: Constants.pillContainerHorizontalInset, bottom: 0, right: Constants.pillContainerHorizontalInset))
         pillContainerView.frame = frame
     }
 
@@ -574,7 +574,7 @@ open class SegmentedControl: UIControl {
             constraints.append(contentsOf: [
                 self.leadingAnchor.constraint(equalTo: pillContainerView.leadingAnchor),
                 self.trailingAnchor.constraint(equalTo: pillContainerView.trailingAnchor),
-                pillContainerView.widthAnchor.constraint(equalTo: backgroundView.widthAnchor, constant: 2 * Constants.pillHorizontalInset),
+                pillContainerView.widthAnchor.constraint(equalTo: backgroundView.widthAnchor, constant: 2 * Constants.pillContainerHorizontalInset),
 
                 pillMaskedLabelsContainerView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
                 pillMaskedLabelsContainerView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),


### PR DESCRIPTION
Changed the animation of the segmented control to use a mask layer to change the color of the text as the selection view passes a label. As part of that, removed the usage and dependency on Pill Button.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Changed the Segmented Control to use a mask layer to change the color of the labels as the selection view passes. Before, the text color would change as the user clicked on the button, but we wanted an experience more like the switch that Outlook was using for the Focused and Other switch.

### Verification
| Before | After 
---|---
| ![SegmentedControlAnimationBefore](https://user-images.githubusercontent.com/67026548/110043790-e1fd2a80-7cfc-11eb-8272-221b6ee5e7aa.gif) | ![SegmentedControlAnimationAfter](https://user-images.githubusercontent.com/67026548/110043511-5edbd480-7cfc-11eb-84b8-982704eb3ded.gif) |

Checked to see that the text color was changing with the selection view, and that the text wasn't moving while that happened.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/466)