### PR TITLE
iOS 13 Large Title view font issue

### DIFF
--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -19,8 +19,9 @@ class LargeTitleView: UIView {
         static let compactAvatarSize: AvatarSize = .small
         static let avatarSize: AvatarSize = .medium
 
-        static let compactTitleFont = Fonts.title1.withSize(26)
-        static let titleFont = Fonts.largeTitle.withSize(30)
+        // Once we are iOS 14 minimum, we can use Fonts.largeTitle.withSize() function instead
+        static let compactTitleFont = UIFont.systemFont(ofSize: 26, weight: .bold)
+        static let titleFont = UIFont.systemFont(ofSize: 30, weight: .bold)
     }
 
     var avatar: Avatar? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Commit '99d0184' caused regression in iOS 13 which Large title view font isn't bold anymore.
It appears to be .withSize() doesn't keep the UIFont weight in iOS 13 but it does in iOS 14.
For now, directly set the UIFont with system font size with weight for large title view.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-05 at 18 18 30](https://user-images.githubusercontent.com/20715435/110191961-3d541900-7de0-11eb-9239-aab532cce400.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-05 at 14 41 54](https://user-images.githubusercontent.com/20715435/110191966-41803680-7de0-11eb-8857-e42a72126506.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/470)