### PR TITLE
get rid of some warnings in swiftLint for iOS demo app

### DIFF
--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -35,14 +35,14 @@ import UIKit
 
     convenience init(light: UIColor, lightHighContrast: UIColor? = nil, lightElevated: UIColor? = nil, lightElevatedHighContrast: UIColor? = nil, dark: UIColor? = nil, darkHighContrast: UIColor? = nil, darkElevated: UIColor? = nil, darkElevatedHighContrast: UIColor? = nil) {
         self.init { traits -> UIColor in
-            let getColorForContrast = { (default: UIColor?, highContrast: UIColor?) -> UIColor? in
+            let getColorForContrast = { (_ default: UIColor?, highContrast: UIColor?) -> UIColor? in
                 if traits.accessibilityContrast == .high, let color = highContrast {
                     return color
                 }
                 return `default`
             }
 
-            let getColor = { (default: UIColor?, highContrast: UIColor?, elevated: UIColor?, elevatedHighContrast: UIColor?) -> UIColor? in
+            let getColor = { (_ default: UIColor?, highContrast: UIColor?, elevated: UIColor?, elevatedHighContrast: UIColor?) -> UIColor? in
                 if traits.userInterfaceLevel == .elevated,
                     let color = getColorForContrast(elevated, elevatedHighContrast) {
                     return color

--- a/ios/FluentUI/HUD/HUD.swift
+++ b/ios/FluentUI/HUD/HUD.swift
@@ -220,7 +220,7 @@ public class HUD: NSObject {
             presentedHUDView.transform = CGAffineTransform(scaleX: Constants.hideAnimationScale, y: Constants.hideAnimationScale)
         }
 
-        let completion = { (finished: Bool) in
+        let completion = { (_ finished: Bool) in
             guard presentedHUDView === presentedHUDView else {
                 // HUD has been shown before it finished being hidden
                 return


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

few compiler warnings because of unused params

### Verification

build and run

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/471)