### PR TITLE
make CI run on main_0.1 and vnext_prototype branches as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      - main_0.1
+      - vnext-prototype
   pull_request:
     branches:
       - main
+      - main_0.1
+      - vnext-prototype
 
 jobs:
   xcodebuild:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,5 @@ jobs:
       run: scripts/xcode_select_current_version.sh
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
-    - script: pod lib lint
-      displayName: pod lib lint
+    - name: pod lib lint
+      run: scripts/podliblint.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,5 @@ jobs:
       run: scripts/xcode_select_current_version.sh
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
+    - script: pod lib lint
+      displayName: pod lib lint

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -77,4 +77,8 @@ else
 	echo "CI Build Succeeded"
 fi
 
+echo "Pod lib lint"
+POD_LINT_SCRIPT='scripts/podliblint.sh'
+$POD_LINT_SCRIPT
+
 exit $EXIT_CODE

--- a/scripts/podliblint.sh
+++ b/scripts/podliblint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# A simple script to lint the pod spec.
+
+pod lib lint MicrosoftFluentUI.podspec --allow-warnings


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

make CI run on main_0.1 and vnext_prototype branches as well
add "pod lib lint" in CI to check Podspec for the project

### Verification

not applicable 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/472)