### PR TITLE
Adding Persona View Control

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -212,7 +212,7 @@ class LeftNavMenuViewController: UIViewController {
         leftNavAvatar.state.image = UIImage(named: "avatar_kat_larsson")
 
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
-        chevron.tintColor = Colors.Table.Cell.title
+        chevron.tintColor = Colors.textPrimary
 
         let personaState = MSFPersonaCellState()
         personaState.leadingView = leftNavAvatar.view

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -80,9 +80,6 @@ class LeftNavMenuViewController: UIViewController {
         super.viewDidLoad()
 
         view = leftNavView
-        leftNavAvatar.state.presence = .available
-        leftNavAvatar.state.primaryText = "Kat Larrson"
-        leftNavAvatar.state.image = UIImage(named: "avatar_kat_larsson")
     }
 
     var menuAction: (() -> Void)?
@@ -181,6 +178,7 @@ class LeftNavMenuViewController: UIViewController {
         let orgAvatar = MSFAvatar(style: .group, size: .large)
         orgAvatar.state.primaryText = "Kat Larrson"
         microsoftAccountCell.leadingView = orgAvatar.view
+        microsoftAccountCell.leadingViewSize = .large
 
         let msaAccountCell = MSFListCellState()
         msaAccountCell.layoutType = .twoLines
@@ -189,6 +187,7 @@ class LeftNavMenuViewController: UIViewController {
         let msaAvatar = MSFAvatar(style: .group, size: .large)
         msaAvatar.state.primaryText = "kat.larrson@live.com"
         msaAccountCell.leadingView = msaAvatar.view
+        msaAccountCell.leadingViewSize = .large
 
         let addAccountCell = MSFListCellState()
         addAccountCell.title = "Add Account"
@@ -206,48 +205,29 @@ class LeftNavMenuViewController: UIViewController {
 
     private var leftNavMenuList = MSFList(sections: [])
 
-    private var leftNavAccountLabelsView: UIView {
-        let nameLabel = UILabel()
-        nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        nameLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
-        nameLabel.text = "Kat Larrson"
-
-        let titleLabel = UILabel()
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
-        titleLabel.textColor = .darkGray
-        titleLabel.text = "Designer"
-
-        let labelsStackView = UIStackView(arrangedSubviews: [nameLabel, titleLabel])
-        labelsStackView.translatesAutoresizingMaskIntoConstraints = false
-        labelsStackView.axis = .vertical
-        labelsStackView.spacing = Constant.verticalSpacing
-
-        return labelsStackView
-    }
-
     private var leftNavAccountView: UIView {
-        let avatarView = leftNavAvatar.view
-        avatarView.translatesAutoresizingMaskIntoConstraints = false
-        let labelsView = leftNavAccountLabelsView
+        leftNavAvatar.state.presence = .available
+        leftNavAvatar.state.primaryText = "Kat Larrson"
+        leftNavAvatar.state.secondaryText = "Designer"
+        leftNavAvatar.state.image = UIImage(named: "avatar_kat_larsson")
+        let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
+        chevron.tintColor = Colors.Table.Cell.title
+        let state = MSFPersonaCellState(persona: leftNavAvatar, titleTrailingAccessoryView: chevron)
+        let persona = MSFListPersona(state: state)
 
-        let chevronImageView = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
-        chevronImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        chevronImageView.translatesAutoresizingMaskIntoConstraints = false
+        let personaView = UIStackView(arrangedSubviews: [persona.view])
+
+        personaView.translatesAutoresizingMaskIntoConstraints = false
+        personaView.axis = .vertical
+        personaView.spacing = Constant.verticalSpacing
 
         let accountView = UIView()
-        accountView.addSubview(avatarView)
-        accountView.addSubview(labelsView)
-        accountView.addSubview(chevronImageView)
+        accountView.addSubview(personaView)
 
         accountView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            avatarView.leadingAnchor.constraint(equalTo: accountView.leadingAnchor, constant: Constant.margin),
-            avatarView.centerYAnchor.constraint(equalTo: accountView.centerYAnchor),
-            labelsView.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor),
-            labelsView.leadingAnchor.constraint(equalTo: avatarView.trailingAnchor, constant: Constant.margin),
-            chevronImageView.leadingAnchor.constraint(equalTo: labelsView.trailingAnchor),
-            chevronImageView.topAnchor.constraint(equalTo: labelsView.topAnchor, constant: Constant.verticalSpacing)
+            personaView.leadingAnchor.constraint(equalTo: accountView.leadingAnchor),
+            personaView.trailingAnchor.constraint(equalTo: accountView.trailingAnchor)
         ])
 
         return accountView
@@ -268,7 +248,7 @@ class LeftNavMenuViewController: UIViewController {
         contentView.addSubview(accountView)
         contentView.addSubview(menuListView)
 
-        NSLayoutConstraint.activate([accountView.heightAnchor.constraint(equalToConstant: 100),
+        NSLayoutConstraint.activate([accountView.heightAnchor.constraint(equalToConstant: 84),
                                      contentView.topAnchor.constraint(equalTo: accountView.topAnchor),
                                      contentView.leadingAnchor.constraint(equalTo: accountView.leadingAnchor),
                                      contentView.trailingAnchor.constraint(equalTo: accountView.trailingAnchor),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -210,10 +210,16 @@ class LeftNavMenuViewController: UIViewController {
         leftNavAvatar.state.primaryText = "Kat Larrson"
         leftNavAvatar.state.secondaryText = "Designer"
         leftNavAvatar.state.image = UIImage(named: "avatar_kat_larsson")
+
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
         chevron.tintColor = Colors.Table.Cell.title
-        let state = MSFPersonaCellState(persona: leftNavAvatar, titleTrailingAccessoryView: chevron)
-        let persona = MSFListPersona(state: state)
+
+        let personaState = MSFPersonaCellState()
+        personaState.leadingView = leftNavAvatar.view
+        personaState.title = leftNavAvatar.state.primaryText ?? ""
+        personaState.subtitle = leftNavAvatar.state.secondaryText ?? ""
+        personaState.titleTrailingAccessoryView = chevron
+        let persona = MSFListPersona(state: personaState)
 
         let personaView = UIStackView(arrangedSubviews: [persona.view])
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -32,7 +32,7 @@ let samplePersonas: [PersonaData] = [
     PersonaData(email: "carlos.slattery@contoso.com", subtitle: "Software Engineer"),
     PersonaData(name: "Henry Brill", subtitle: "Software Engineer", avatarImage: UIImage(named: "avatar_henry_brill")),
     PersonaData(name: "Cecil Folk", subtitle: "Program Manager", avatarImage: UIImage(named: "avatar_cecil_folk")),
-    PersonaData(name: "+1 (425) 123 4567"),
+    PersonaData(name: "+1 (425) 123 4567")
 ]
 
 let searchDirectoryPersonas: [PersonaData] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -32,7 +32,7 @@ let samplePersonas: [PersonaData] = [
     PersonaData(email: "carlos.slattery@contoso.com", subtitle: "Software Engineer"),
     PersonaData(name: "Henry Brill", subtitle: "Software Engineer", avatarImage: UIImage(named: "avatar_henry_brill")),
     PersonaData(name: "Cecil Folk", subtitle: "Program Manager", avatarImage: UIImage(named: "avatar_cecil_folk")),
-    PersonaData(name: "+1 (425) 123 4567")
+    PersonaData(name: "+1 (425) 123 4567"),
 ]
 
 let searchDirectoryPersonas: [PersonaData] = [

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -228,21 +228,10 @@ struct ListCellButtonStyle: ButtonStyle {
 
 @objc public class MSFPersonaCellState: NSObject, ObservableObject, PersonaCellProtocol {
     @objc @Published public var leadingView: UIView?
-    @objc @Published public var title: String
-    @objc @Published public var subtitle: String
-    @objc @Published public var persona: MSFAvatar?
+    @objc @Published public var title: String = ""
+    @objc @Published public var subtitle: String = ""
     @objc @Published public var titleTrailingAccessoryView: UIView?
     @objc @Published public var subtitleTrailingAccessoryView: UIView?
-
-    @objc public init(persona: MSFAvatar?,
-                      titleTrailingAccessoryView: UIView? = nil,
-                      subtitleTrailingAccessoryView: UIView? = nil) {
-        self.title = persona?.state.primaryText ?? ""
-        self.subtitle = persona?.state.secondaryText ?? ""
-        self.leadingView = persona?.view
-        self.titleTrailingAccessoryView = titleTrailingAccessoryView
-        self.subtitleTrailingAccessoryView = subtitleTrailingAccessoryView
-    }
 }
 /// UIKit wrapper that exposes the SwiftUI Persona Cell implementation
 @objc open class MSFListPersona: NSObject, FluentUIWindowProvider {

--- a/ios/FluentUI/Vnext/List/ListTokens.swift
+++ b/ios/FluentUI/Vnext/List/ListTokens.swift
@@ -6,6 +6,12 @@
 import UIKit
 import SwiftUI
 
+/// Pre-defined styles of cells
+@objc public enum MSFListCellStyle: Int, CaseIterable {
+    case normal
+    case persona
+}
+
 /// Pre-defined styles of icons
 @objc public enum MSFListCellLeadingViewSize: Int, CaseIterable {
     case small
@@ -79,6 +85,7 @@ class MSFListCellTokens: MSFTokensBase, ObservableObject {
     @Published public var labelAccessoryInterspace: CGFloat!
     @Published public var labelAccessorySize: CGFloat!
     @Published public var leadingViewSize: CGFloat!
+    @Published public var sublabelAccessorySize: CGFloat!
     @Published public var trailingItemSize: CGFloat!
 
     @Published public var footnoteFont: UIFont!
@@ -86,9 +93,11 @@ class MSFListCellTokens: MSFTokensBase, ObservableObject {
     @Published public var labelFont: UIFont!
 
     @Published public var cellLeadingViewSize: MSFListCellLeadingViewSize!
+    @Published public var style: MSFListCellStyle!
 
-    init(cellLeadingViewSize: MSFListCellLeadingViewSize) {
+    init(cellLeadingViewSize: MSFListCellLeadingViewSize, style: MSFListCellStyle) {
         self.cellLeadingViewSize = cellLeadingViewSize
+        self.style = style
 
         super.init()
 
@@ -102,15 +111,22 @@ class MSFListCellTokens: MSFTokensBase, ObservableObject {
 
     override func updateForCurrentTheme() {
         let currentTheme = theme
-        let appearanceProxy: AppearanceProxyType = currentTheme.MSFListCellTokens
+        let appearanceProxy: AppearanceProxyType
 
-        switch cellLeadingViewSize {
-        case .small:
-            leadingViewSize = appearanceProxy.leadingViewSize.small
-        case .medium, .none:
+        switch style {
+        case .normal, .none:
+            appearanceProxy = currentTheme.MSFListCellTokens
+            switch cellLeadingViewSize {
+            case .small:
+                leadingViewSize = appearanceProxy.leadingViewSize.small
+            case .medium, .none:
+                leadingViewSize = appearanceProxy.leadingViewSize.medium
+            case .large:
+                leadingViewSize = appearanceProxy.leadingViewSize.large
+            }
+        case .persona:
+            appearanceProxy = currentTheme.MSFPersonaTokens
             leadingViewSize = appearanceProxy.leadingViewSize.medium
-        case .large:
-            leadingViewSize = appearanceProxy.leadingViewSize.large
         }
 
         backgroundColor = appearanceProxy.backgroundColor.rest
@@ -132,6 +148,7 @@ class MSFListCellTokens: MSFTokensBase, ObservableObject {
         iconInterspace = appearanceProxy.iconInterspace
         labelAccessoryInterspace = appearanceProxy.labelAccessoryInterspace
         labelAccessorySize = appearanceProxy.labelAccessorySize
+        sublabelAccessorySize = appearanceProxy.sublabelAccessorySize
         trailingItemSize = appearanceProxy.trailingItemSize
 
         footnoteFont = appearanceProxy.footnoteFont

--- a/ios/FluentUI/Vnext/List/MSFListCellTokens.generated.swift
+++ b/ios/FluentUI/Vnext/List/MSFListCellTokens.generated.swift
@@ -195,6 +195,11 @@ extension FluentUIStyle {
 		}
 
 
+		// MARK: - footnoteFont 
+		open override var footnoteFont: UIFont {
+			return mainProxy().Typography.footnote
+		}
+
 		// MARK: - iconInterspace 
 		open override var iconInterspace: CGFloat {
 			return mainProxy().Spacing.small

--- a/ios/FluentUI/Vnext/List/MSFListCellTokens.generated.swift
+++ b/ios/FluentUI/Vnext/List/MSFListCellTokens.generated.swift
@@ -151,6 +151,11 @@ extension FluentUIStyle {
 		}
 
 
+		// MARK: - sublabelAccessorySize 
+		open var sublabelAccessorySize: CGFloat {
+			return mainProxy().Icon.size.xxSmall
+		}
+
 		// MARK: - sublabelColor 
 		open var sublabelColor: UIColor {
 			return mainProxy().Colors.Foreground.neutral3
@@ -171,6 +176,63 @@ extension FluentUIStyle {
 			return mainProxy().Icon.size.medium
 		}
 	}
+	// MARK: - MSFPersonaTokens
+	open var MSFPersonaTokens: MSFPersonaTokensAppearanceProxy {
+		return MSFPersonaTokensAppearanceProxy(proxy: { return self })
+	}
+	open class MSFPersonaTokensAppearanceProxy: MSFListCellTokensAppearanceProxy {
+
+		// MARK: - MSFPersonaTokenscellHeight
+		open override var cellHeight: MSFPersonaTokenscellHeightAppearanceProxy {
+			return MSFPersonaTokenscellHeightAppearanceProxy(proxy: mainProxy)
+		}
+		open class MSFPersonaTokenscellHeightAppearanceProxy: MSFListCellTokensAppearanceProxy.cellHeightAppearanceProxy {
+
+			// MARK: - twoLines 
+			open override var twoLines: CGFloat {
+				return CGFloat(84.0)
+			}
+		}
+
+
+		// MARK: - iconInterspace 
+		open override var iconInterspace: CGFloat {
+			return mainProxy().Spacing.small
+		}
+
+		// MARK: - labelAccessoryInterspace 
+		open override var labelAccessoryInterspace: CGFloat {
+			return mainProxy().Spacing.xxxSmall
+		}
+
+		// MARK: - labelAccessorySize 
+		open override var labelAccessorySize: CGFloat {
+			return mainProxy().Icon.size.xSmall
+		}
+
+		// MARK: - labelFont 
+		open override var labelFont: UIFont {
+			return mainProxy().Typography.headline
+		}
+
+		// MARK: - MSFPersonaTokensleadingViewSize
+		open override var leadingViewSize: MSFPersonaTokensleadingViewSizeAppearanceProxy {
+			return MSFPersonaTokensleadingViewSizeAppearanceProxy(proxy: mainProxy)
+		}
+		open class MSFPersonaTokensleadingViewSizeAppearanceProxy: MSFListCellTokensAppearanceProxy.leadingViewSizeAppearanceProxy {
+
+			// MARK: - medium 
+			open override var medium: CGFloat {
+				return CGFloat(52.0)
+			}
+		}
+
+
+		// MARK: - sublabelColor 
+		open override var sublabelColor: UIColor {
+			return mainProxy().Colors.Foreground.neutral1
+		}
+	}
 
 }
 fileprivate var __AppearanceProxyHandle: UInt8 = 0
@@ -185,7 +247,13 @@ extension MSFListCellTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
+					return proxy
+				}
 
+				if proxy is FluentUIStyle.MSFPersonaTokensAppearanceProxy {
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFPersonaTokens
+				}
 				return proxy
 			}
 

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -265,10 +265,20 @@ AP_MSFListCellTokens:
   labelFont: $Typography.body
   leadingViewColor: $Colors.Foreground.neutral4
   leadingViewSize: [ small: $Icon.size.xSmall, medium: $Icon.size.medium, large: $Icon.size.xxlarge ]
+  sublabelAccessorySize: $Icon.size.xxSmall
   sublabelColor: $Colors.Foreground.neutral3
   sublabelFont: $Typography.subheadline
   trailingItemForegroundColor: $Colors.Foreground.neutral3
   trailingItemSize: $Icon.size.medium
+
+MSFPersonaTokens extends MSFListCellTokens:
+  cellHeight: [ twoLines: 84pt]
+  iconInterspace: $Spacing.small
+  labelAccessoryInterspace: $Spacing.xxxSmall
+  labelAccessorySize: $Icon.size.xSmall
+  labelFont: $Typography.headline
+  leadingViewSize: [ medium: 52pt ]
+  sublabelColor: $Colors.Foreground.neutral1
 
 AP_MSFHeaderFooterTokens:
   backgroundColor: $Colors.Background.neutral1

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -273,6 +273,7 @@ AP_MSFListCellTokens:
 
 MSFPersonaTokens extends MSFListCellTokens:
   cellHeight: [ twoLines: 84pt]
+  footnoteFont: $Typography.footnote
   iconInterspace: $Spacing.small
   labelAccessoryInterspace: $Spacing.xxxSmall
   labelAccessorySize: $Icon.size.xSmall

--- a/tools/sgen/output/MSFListCellTokens.generated.swift
+++ b/tools/sgen/output/MSFListCellTokens.generated.swift
@@ -195,6 +195,11 @@ extension FluentUIStyle {
 		}
 
 
+		// MARK: - footnoteFont 
+		open override var footnoteFont: UIFont {
+			return mainProxy().Typography.footnote
+		}
+
 		// MARK: - iconInterspace 
 		open override var iconInterspace: CGFloat {
 			return mainProxy().Spacing.small

--- a/tools/sgen/output/MSFListCellTokens.generated.swift
+++ b/tools/sgen/output/MSFListCellTokens.generated.swift
@@ -151,6 +151,11 @@ extension FluentUIStyle {
 		}
 
 
+		// MARK: - sublabelAccessorySize 
+		open var sublabelAccessorySize: CGFloat {
+			return mainProxy().Icon.size.xxSmall
+		}
+
 		// MARK: - sublabelColor 
 		open var sublabelColor: UIColor {
 			return mainProxy().Colors.Foreground.neutral3
@@ -171,6 +176,63 @@ extension FluentUIStyle {
 			return mainProxy().Icon.size.medium
 		}
 	}
+	// MARK: - MSFPersonaTokens
+	open var MSFPersonaTokens: MSFPersonaTokensAppearanceProxy {
+		return MSFPersonaTokensAppearanceProxy(proxy: { return self })
+	}
+	open class MSFPersonaTokensAppearanceProxy: MSFListCellTokensAppearanceProxy {
+
+		// MARK: - MSFPersonaTokenscellHeight
+		open override var cellHeight: MSFPersonaTokenscellHeightAppearanceProxy {
+			return MSFPersonaTokenscellHeightAppearanceProxy(proxy: mainProxy)
+		}
+		open class MSFPersonaTokenscellHeightAppearanceProxy: MSFListCellTokensAppearanceProxy.cellHeightAppearanceProxy {
+
+			// MARK: - twoLines 
+			open override var twoLines: CGFloat {
+				return CGFloat(84.0)
+			}
+		}
+
+
+		// MARK: - iconInterspace 
+		open override var iconInterspace: CGFloat {
+			return mainProxy().Spacing.small
+		}
+
+		// MARK: - labelAccessoryInterspace 
+		open override var labelAccessoryInterspace: CGFloat {
+			return mainProxy().Spacing.xxxSmall
+		}
+
+		// MARK: - labelAccessorySize 
+		open override var labelAccessorySize: CGFloat {
+			return mainProxy().Icon.size.xSmall
+		}
+
+		// MARK: - labelFont 
+		open override var labelFont: UIFont {
+			return mainProxy().Typography.headline
+		}
+
+		// MARK: - MSFPersonaTokensleadingViewSize
+		open override var leadingViewSize: MSFPersonaTokensleadingViewSizeAppearanceProxy {
+			return MSFPersonaTokensleadingViewSizeAppearanceProxy(proxy: mainProxy)
+		}
+		open class MSFPersonaTokensleadingViewSizeAppearanceProxy: MSFListCellTokensAppearanceProxy.leadingViewSizeAppearanceProxy {
+
+			// MARK: - medium 
+			open override var medium: CGFloat {
+				return CGFloat(52.0)
+			}
+		}
+
+
+		// MARK: - sublabelColor 
+		open override var sublabelColor: UIColor {
+			return mainProxy().Colors.Foreground.neutral1
+		}
+	}
 
 }
 fileprivate var __AppearanceProxyHandle: UInt8 = 0
@@ -185,7 +247,13 @@ extension MSFListCellTokens: AppearaceProxyComponent {
 			if let proxy = objc_getAssociatedObject(self, &__AppearanceProxyHandle) as? AppearanceProxyType {
 				if !themeAware { return proxy }
 
+				if let proxyString = Optional(String(reflecting: type(of: proxy))), proxyString.hasPrefix("FluentUI") == false {
+					return proxy
+				}
 
+				if proxy is FluentUIStyle.MSFPersonaTokensAppearanceProxy {
+					return FluentUIThemeManager.stylesheet(FluentUIStyle.shared()).MSFPersonaTokens
+				}
 				return proxy
 			}
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding a Persona control to vNext. A Persona Cell can display an Avatar and its contents. The cell can exist as a standalone outside of a List.

### Verification

Passed pod lib lint, updated Demo Controller, & made sure control responded to state changes.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-03-10 at 19 10 19](https://user-images.githubusercontent.com/22566866/110720503-4aa04780-81d4-11eb-91f3-ab5c5a432c7a.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-03-10 at 20 49 17](https://user-images.githubusercontent.com/22566866/110728132-1d5a9600-81e2-11eb-953a-1497caeede43.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
