### PR TITLE
Fixing build pipeline failure caused by the swiftlint lint path.

### DIFF
--- a/macos/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/macos/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -803,7 +803,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    export LINTPATH=\"../\"\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    export LINTPATH=\"${LOCROOT}/../\"\n    swiftlint --config ../../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

**Issue:**
After the CI checks were added to the vnext-prototype branch (#472) an issue with the lint path in the Mac build was exposed
where the swiftlint path linted was the entire root folder instead of the /macos folder.

Because the /tools/sgen has .swift files that fail the swiftlint validation, the script phase fails and the entire pipeline job fails as a consequence.

By running the pipeline manually we could notice that from the logs. (links of those manually triggered jobs linked below)
- https://dev.azure.com/microsoftdesign/fluentui-native/_build/results?buildId=12522&view=logs&j=0fa1658d-7ef3-53c3-5be9-84125ae0021f&t=e9c07ef3-9efe-5e16-61a9-99fbe520817e
- https://dev.azure.com/microsoftdesign/fluentui-native/_build/results?buildId=12476&view=logs&j=0fa1658d-7ef3-53c3-5be9-84125ae0021f&t=e9c07ef3-9efe-5e16-61a9-99fbe520817e&l=4008

**Fix:**
The fix for the issue is to ensure the lint path variable set on the RunScript phase of the Xcode project that runs swiftlint is using the environment variable **LOCROOT** which points to the specific ./macos/xcode folder of the build environment.

Interestingly enough the issue couldn't be reproduced locally by running the xcodebuild command that is run by the pipeline:
`xcodebuild -sdk macosx -configuration Debug -project ./macos/xcode/FluentUI.xcodeproj -scheme FluentUI-macOS build -verbose `

### Verification

1. Ran manual jobs from a branch with the changes on this PR and ensured that the jobs are now passing while the files being linted are just the ones inside ./macos folder and the entire pipeline succeeds:
- https://dev.azure.com/microsoftdesign/fluentui-native/_build/results?buildId=12536&view=results

2. Built the project locally ensuring the linting happens only on the correct folders:
![Screen Shot 2021-03-12 at 11 46 51 AM](https://user-images.githubusercontent.com/68076145/110990911-d0cda280-8328-11eb-97ca-1bb3b4b17171.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/477)