### PR TITLE
Updating access modifier for Avatar colors

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -324,7 +324,8 @@ open class AvatarView: NSView {
 	/// - returns: the color table entry for the given index
 	///
 	/// - note: Internal visibility exists only for unit testing
-	@objc static func getColor(for index: Int) -> ColorSet {
+	@objc(getcolorForIndex:)
+	public static func getColor(for index: Int) -> ColorSet {
 		let avatarBackgroundColors = AvatarView.avatarColors
 		return avatarBackgroundColors[index % avatarBackgroundColors.count]
 	}

--- a/macos/FluentUI/DynamicColor/DynamicColor.swift
+++ b/macos/FluentUI/DynamicColor/DynamicColor.swift
@@ -5,7 +5,8 @@
 
 import AppKit
 
-class ColorSet: NSObject {
+@objc(MSFColorSet)
+public class ColorSet: NSObject {
 	public let background: DynamicColor
 	public let foreground: DynamicColor
 
@@ -15,7 +16,8 @@ class ColorSet: NSObject {
 	}
 }
 
-class DynamicColor: NSObject {
+@objc(MSFDynamicColor)
+public class DynamicColor: NSObject {
 
 	private let light: NSColor
 	private let dark: NSColor


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS

### Description of changes

Updating Colors to allow public access for cocoaui library.
Cocoaui library consumes Avatar colors based on its index and need its foreground and background variants in different themes. 

### Verification

Sanity test for Mac test app
pod lib lint

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/478)