### PR TITLE
Update segment control examples in demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -107,6 +107,7 @@ class ColorDemoController: UIViewController {
         tableView.separatorStyle = .none
 
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, tableView])
+        stackView.setCustomSpacing(16, after: segmentedControl)
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -119,7 +120,7 @@ class ColorDemoController: UIViewController {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 16),
             stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
         ])
     }
@@ -131,7 +132,7 @@ class ColorDemoController: UIViewController {
         }
     }
     private lazy var segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: colorProviderThemedWindowTypes.map({ return $0.name }), style: .tabs)
+        let segmentedControl = SegmentedControl(items: colorProviderThemedWindowTypes.map({ return $0.name }), style: .primaryPill)
         segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
         return segmentedControl
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -106,8 +106,9 @@ class ColorDemoController: UIViewController {
         tableView.delegate = self
         tableView.separatorStyle = .none
 
-        let stackView = UIStackView(arrangedSubviews: [segmentedControl, tableView])
-        stackView.setCustomSpacing(16, after: segmentedControl)
+        let separator = Separator(style: .shadow, orientation: .horizontal)
+        let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])
+        stackView.setCustomSpacing(8, after: segmentedControl)
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -120,17 +121,24 @@ class ColorDemoController: UIViewController {
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 16),
+            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
         ])
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        navigationController?.navigationBar.shadowImage = UIImage()
         if let window = view.window {
             segmentedControl.selectedSegmentIndex = colorProviderThemedWindowTypes.firstIndex(where: { return window.isKind(of: $0.windowType) }) ?? 0
         }
     }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.shadowImage = nil
+    }
+
     private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: colorProviderThemedWindowTypes.map({ return $0.name }), style: .primaryPill)
         segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -105,6 +105,8 @@ class ColorDemoController: UIViewController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
+        tableView.allowsSelection = false
+        tableView.backgroundColor = Colors.Table.background
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])
@@ -114,15 +116,13 @@ class ColorDemoController: UIViewController {
 
         view = UIView(frame: .zero)
         view.addSubview(stackView)
-        view.backgroundColor = Colors.Table.background
-
-        let safeAreaLayoutGuide = view.safeAreaLayoutGuide
+        view.backgroundColor = Colors.NavigationBar.background
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: view.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -26,10 +26,12 @@ class TableViewHeaderFooterViewDemoController: DemoController {
 
         container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
         container.layoutMargins = .zero
+        container.spacing = 0
 
         navigationController?.navigationBar.shadowImage = UIImage()
         container.addArrangedSubview(segmentedControl)
         container.setCustomSpacing(8, after: segmentedControl)
+        container.backgroundColor = Colors.NavigationBar.background
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         container.addArrangedSubview(separator)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -25,15 +25,24 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         super.viewDidLoad()
 
         container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
-        container.layoutMargins = UIEdgeInsets(top: 16, left: 0, bottom: 0, right: 0)
-        container.spacing = 0
+        container.layoutMargins = .zero
 
+        navigationController?.navigationBar.shadowImage = UIImage()
         container.addArrangedSubview(segmentedControl)
-        container.setCustomSpacing(16, after: segmentedControl)
+        container.setCustomSpacing(8, after: segmentedControl)
+
+        let separator = Separator(style: .shadow, orientation: .horizontal)
+        container.addArrangedSubview(separator)
+
         container.addArrangedSubview(groupedTableView)
         container.addArrangedSubview(plainTableView)
 
         updateActiveTabContent()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        navigationController?.navigationBar.shadowImage = nil
     }
 
     func createTableView(style: UITableView.Style) -> UITableView {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -13,7 +13,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
     private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
 
     private let segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles)
+        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles, style: .primaryPill)
         segmentedControl.addTarget(self, action: #selector(updateActiveTabContent), for: .valueChanged)
         return segmentedControl
     }()
@@ -25,10 +25,11 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         super.viewDidLoad()
 
         container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
-        container.layoutMargins = .zero
+        container.layoutMargins = UIEdgeInsets(top: 16, left: 0, bottom: 0, right: 0)
         container.spacing = 0
 
         container.addArrangedSubview(segmentedControl)
+        container.setCustomSpacing(16, after: segmentedControl)
         container.addArrangedSubview(groupedTableView)
         container.addArrangedSubview(plainTableView)
 

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -22,6 +22,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         // TODO: Make title button width dynamic
         static let titleButtonWidth: CGFloat = 160
         static let calendarHeightStyle: CalendarViewHeightStyle = .extraTall
+        static let verticalPaddingFromSegmentControl: CGFloat = 4.0
     }
 
     var startDate = Date() {
@@ -157,6 +158,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
         if let segmentedControl = segmentedControl {
             view.addSubview(segmentedControl)
+            view.backgroundColor = Colors.Toolbar.background
         }
         view.addSubview(calendarView)
 
@@ -168,30 +170,34 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
         scrollToFocusDate(animated: false)
 
-        if segmentedControl == nil {
-            // Hide default bottom border of navigation bar
-            navigationController?.navigationBar.shadowImage = UIImage()
-        }
+        // Hide default bottom border of navigation bar
+        navigationController?.navigationBar.shadowImage = UIImage()
     }
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
 
-        var calendarFrame = view.bounds
+        var verticalOffset: CGFloat = 0
         if let segmentedControl = segmentedControl {
-            var frame = calendarFrame
-            frame.size.height = segmentedControl.intrinsicContentSize.height
-            calendarFrame = calendarFrame.inset(by: UIEdgeInsets(top: frame.height, left: 0, bottom: 0, right: 0))
-
-            segmentedControl.frame = frame
+            segmentedControl.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: segmentedControl.intrinsicContentSize.height)
+            verticalOffset = segmentedControl.frame.height + Constants.verticalPaddingFromSegmentControl
         }
-        calendarView.frame = calendarFrame
+
+        calendarView.frame = CGRect(x: 0, y: verticalOffset, width: view.frame.width, height: view.frame.height - verticalOffset)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if let window = view.window {
             navigationItem.rightBarButtonItem?.tintColor = UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
+        }
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if let segmentedControl = segmentedControl, previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
+            segmentedControl.style = (traitCollection.userInterfaceStyle == .dark) ? .onBrandPill : .primaryPill
         }
     }
 
@@ -211,7 +217,8 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     private func initSegmentedControl() {
         let titles = [customStartTabTitle ?? "MSDateTimePicker.StartDate".localized,
                       customEndTabTitle ?? "MSDateTimePicker.EndDate".localized]
-        segmentedControl = SegmentedControl(items: titles, style: .onBrandPill)
+        segmentedControl = SegmentedControl(items: titles,
+                                            style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
         segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 
@@ -476,9 +483,13 @@ extension DatePickerController: CalendarViewStyleDataSource {
 
 extension DatePickerController: CardPresentable {
     func idealSize() -> CGSize {
+        var extraHeight: CGFloat = 0
+        if let segmentedControlHeight = segmentedControl?.frame.height {
+            extraHeight = segmentedControlHeight + Constants.verticalPaddingFromSegmentControl
+        }
         return CGSize(
             width: Constants.idealWidth,
-            height: calendarView.height(for: Constants.calendarHeightStyle, in: view.bounds) + (segmentedControl?.frame.height ?? 0)
+            height: calendarView.height(for: Constants.calendarHeightStyle, in: view.bounds) + extraHeight
         )
     }
 }

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -211,7 +211,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     private func initSegmentedControl() {
         let titles = [customStartTabTitle ?? "MSDateTimePicker.StartDate".localized,
                       customEndTabTitle ?? "MSDateTimePicker.EndDate".localized]
-        segmentedControl = SegmentedControl(items: titles)
+        segmentedControl = SegmentedControl(items: titles, style: .onBrandPill)
         segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -20,6 +20,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
         static let idealRowCount: Int = 7
         static let idealWidth: CGFloat = 320
         static let titleButtonWidth: CGFloat = 160
+        static let verticalPaddingFromSegmentControl: CGFloat = 4.0
     }
 
     var startDate: Date {
@@ -115,6 +116,9 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
 
         if let segmentedControl = segmentedControl {
             view.addSubview(segmentedControl)
+            // Hide default bottom border of navigation bar
+            navigationController?.navigationBar.shadowImage = UIImage()
+            view.backgroundColor = Colors.Toolbar.background
         }
         view.addSubview(dateTimePickerView)
         initNavigationBar()
@@ -122,10 +126,12 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
 
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
+        var verticalOffset: CGFloat = 0
         if let segmentedControl = segmentedControl {
             segmentedControl.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: segmentedControl.intrinsicContentSize.height)
+            verticalOffset = segmentedControl.frame.height + Constants.verticalPaddingFromSegmentControl
         }
-        let verticalOffset = segmentedControl?.frame.height ?? 0
+
         dateTimePickerView.frame = CGRect(x: 0, y: verticalOffset, width: view.frame.width, height: view.frame.height - verticalOffset)
     }
 
@@ -150,7 +156,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             titles = [customStartTabTitle ?? "MSDateTimePicker.StartDate".localized,
                       customEndTabTitle ?? "MSDateTimePicker.EndDate".localized]
         }
-        segmentedControl = SegmentedControl(items: titles, style: .onBrandPill)
+        segmentedControl = SegmentedControl(items: titles, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
         segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 
@@ -208,9 +214,13 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
 
 extension DateTimePickerController: CardPresentable {
     func idealSize() -> CGSize {
+        var extraHeight: CGFloat = 0
+        if let segmentedControlHeight = segmentedControl?.frame.height {
+            extraHeight = segmentedControlHeight + Constants.verticalPaddingFromSegmentControl
+        }
         return CGSize(
             width: Constants.idealWidth,
-            height: DateTimePickerViewLayout.height(forRowCount: Constants.idealRowCount) + (segmentedControl?.frame.height ?? 0)
+            height: DateTimePickerViewLayout.height(forRowCount: Constants.idealRowCount) + extraHeight
         )
     }
 }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -150,7 +150,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             titles = [customStartTabTitle ?? "MSDateTimePicker.StartDate".localized,
                       customEndTabTitle ?? "MSDateTimePicker.EndDate".localized]
         }
-        segmentedControl = SegmentedControl(items: titles)
+        segmentedControl = SegmentedControl(items: titles, style: .onBrandPill)
         segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: DateTimePicker Colors
 public extension Colors {
   struct DateTimePicker {
-      public static var background: UIColor = Calendar.background
+    public static var background = UIColor(light: surfacePrimary, dark: gray900)
       public static var text: UIColor = textSecondary
   }
 }
@@ -44,7 +44,7 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
-        backgroundColor = nil
+        backgroundColor = Colors.DateTimePicker.background
 
         textLabel?.textAlignment = .center
         textLabel?.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -171,6 +171,7 @@ open class SegmentedControl: UIControl {
     @objc public var isAnimated: Bool = true
     @objc public var numberOfSegments: Int { return items.count }
     @objc public var shouldSetEqualWidthForSegments: Bool = true
+    public var shouldUseWindowWidth: Bool = true
     @objc public var selectedSegmentIndex: Int {
         get { return _selectedSegmentIndex }
         set { selectSegment(at: newValue, animated: false) }
@@ -409,17 +410,14 @@ open class SegmentedControl: UIControl {
                 case .primaryPill, .onBrandPill:
                     var suggestedWidth = frame.width
 
-                    if let windowWidth = window?.frame.width {
+                    if shouldUseWindowWidth, let windowWidth = window?.safeAreaLayoutGuide.layoutFrame.width {
                         suggestedWidth = windowWidth
                     }
                     // for iPad regular full width pill styles might look too wide
                     if traitCollection.userInterfaceIdiom == .pad {
                         suggestedWidth = max(suggestedWidth / 2, 375.0)
                     } else {
-                        var insets = 2 * Constants.pillContainerHorizontalInset
-                        if let window = window {
-                            insets += window.safeAreaInsets.left + window.safeAreaInsets.right
-                        }
+                        let insets = 2 * Constants.pillContainerHorizontalInset
                         suggestedWidth -= insets
                     }
                     suggestedWidth = ceil(suggestedWidth)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -24,7 +24,7 @@ public extension Colors {
         }
 
         struct OnBrandPill {
-            static let background = PrimaryPill.background
+            static let background: UIColor = PrimaryPill.background
             static let backgroundDisabled: UIColor = PrimaryPill.backgroundDisabled
             static let segmentText = UIColor(light: textOnAccent, dark: textPrimary)
             static let selection = UIColor(light: surfacePrimary, dark: surfaceQuaternary)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -17,15 +17,15 @@ public extension Colors {
         }
 
         struct PrimaryPill {
-            static let background = UIColor(light: surfaceTertiary, dark: surfaceSecondary)
+            static let background = UIColor(light: surfaceTertiary, dark: gray950)
             static let backgroundDisabled: UIColor = background
             static let segmentText = UIColor(light: textSecondary, dark: textPrimary)
             static let selectionDisabled: UIColor = surfaceQuaternary
         }
 
         struct OnBrandPill {
-            static let background = UIColor(light: surfaceTertiary, dark: surfaceSecondary)
-            static let backgroundDisabled: UIColor = background
+            static let background = PrimaryPill.background
+            static let backgroundDisabled: UIColor = PrimaryPill.backgroundDisabled
             static let segmentText = UIColor(light: textOnAccent, dark: textPrimary)
             static let selection = UIColor(light: surfacePrimary, dark: surfaceQuaternary)
             static let selectionDisabled = UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
@@ -183,7 +183,11 @@ open class SegmentedControl: UIControl {
     private var customSelectedSegmentedControlButtonTextColor: UIColor?
 
     private var items = [String]()
-    private let style: Style
+    internal var style: Style {
+        didSet {
+            updateWindowSpecificColors()
+        }
+    }
 
     // Hierarchy for pill styles:
     //
@@ -422,7 +426,7 @@ open class SegmentedControl: UIControl {
             bottomSeparator.frame = CGRect(x: 0, y: frame.height - bottomSeparator.frame.height, width: frame.width, height: bottomSeparator.frame.height)
         }
 
-        flipSubviewsForRTL()        
+        flipSubviewsForRTL()
         layoutSelectionView()
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Now that we have the Fluent Design recommended pill style segment control update all the instance of segment control to use pill style.
- while updating the datetimepicker, I've discovered the bug that pill segment will always try to take the full window width rather than within the contained view. Update the sizeToFit calculation and constraints of the pillcontainerview so that segment control can layout correctly.
- Pill style background color can't be surfaceSecondary in dark mode because surfaceSecondary has different dark elevated color. Rather we should just define as gray950.
- Extend the SegmentControl "style" property to be changeable based on light/dark mode for datetimepicker.
- For Demo app, Color and TableViewHeaderFooterView pages are now updated to use pill style.
- Fix dark mode background color bug in DateTimePickerView.

### Verification

Tested on iPhone and iPad

| Before                                       | After light                                      | After Dark |
|----------------------------------------------|--------------------------------------------|-------------------------------------------|
| ![before_color](https://user-images.githubusercontent.com/20715435/111021979-c8a35080-8384-11eb-88a0-5115f87b3aee.png) | ![light_color](https://user-images.githubusercontent.com/20715435/111022043-1fa92580-8385-11eb-975e-dd1cedc14342.png)|![dark_color](https://user-images.githubusercontent.com/20715435/111022109-a958f300-8385-11eb-9944-0643253dd0a8.png)|
| ![before_datepicker](https://user-images.githubusercontent.com/20715435/111021989-d062f500-8384-11eb-85bd-dde04ff66ad6.png) | ![light_datepicker](https://user-images.githubusercontent.com/20715435/111022052-35b6e600-8385-11eb-87a2-2ee74d221a2f.png) |![dark_datepicker](https://user-images.githubusercontent.com/20715435/111022113-b1189780-8385-11eb-9aa7-0623afce0d6f.png)|
| ![before_headerfooter](https://user-images.githubusercontent.com/20715435/111022034-0d2eec00-8385-11eb-8dfc-7c4cabc73915.png) | ![light_headerfooter](https://user-images.githubusercontent.com/20715435/111022055-3d768a80-8385-11eb-9d08-6e30b19fbcce.png)|![dark_headerfooter](https://user-images.githubusercontent.com/20715435/111022122-c097e080-8385-11eb-98bc-4412d1481772.png)|
| ![before_segment](https://user-images.githubusercontent.com/20715435/111022007-e670b580-8384-11eb-9651-2c1857cdde8a.png)| ![light_segment](https://user-images.githubusercontent.com/20715435/111022061-48311f80-8385-11eb-9dac-179fba30350f.png) |![dark_segment](https://user-images.githubusercontent.com/20715435/111022130-ca214880-8385-11eb-92c4-37e6956698db.png)|
|![before_timepicker](https://user-images.githubusercontent.com/20715435/111022012-f4bed180-8384-11eb-8c07-eb40630647a3.png)| ![light_timepicker](https://user-images.githubusercontent.com/20715435/111022064-4d8e6a00-8385-11eb-9829-49ee03274d82.png) |![dark_timepicker](https://user-images.githubusercontent.com/20715435/111022139-d2798380-8385-11eb-9bbc-b2fe2d781340.png)|



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/480)