### PR TITLE
Address build failure for SwiftLInt in iOS project

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -1341,7 +1341,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    export LINTPATH=\"./\"\n    swiftlint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n    export LINTPATH=\"${LOCROOT}/./\"\n    swiftlint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

This is an extension to [PR for corresponding macOS](https://github.com/microsoft/fluentui-apple/pull/477) fix. 
Fix to issue #472 

SwiftLInt validation in iOS project fails because Sgen swift files does not comply with SwiftLInt rules. 

![Screen Shot 2021-03-17 at 11 05 32 AM](https://user-images.githubusercontent.com/63682282/111516050-ba508e00-8710-11eb-91f2-3f727fc04372.png)

Logs to failed build can be located [here](https://github.com/microsoft/fluentui-apple/runs/2132926631).

The fix addressed applies swiftlint on for projects under current directory (iOS project)

### Verification

A clean build against vnext branch with successful validation can be located [here](https://github.com/microsoft/fluentui-apple/pull/481/checks?check_run_id=2133095797). 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/482)