### PR TITLE
Add support for legacy colors for backward compatibility

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -339,8 +339,8 @@ open class AvatarView: NSView {
 	@objc(getLegacyBackgroundColorForIndex:)
 	@available(*, deprecated, message: "Use getColorForIndex instead")
 	public static func getLegacyColor(for index: Int) -> NSColor {
-		let avatarBackgroundColors = AvatarView.legacyAvatarViewBackgroundColor
-		return avatarBackgroundColors[index % avatarBackgroundColors.count]
+		let legacyAvatarBackgroundColors = AvatarView.legacyAvatarViewBackgroundColor
+		return legacyAvatarBackgroundColors[index % legacyAvatarBackgroundColors.count]
 	}
 
 	/// the font size in the initials view will be scaled to this fraction of the avatarSize passed in

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -324,9 +324,22 @@ open class AvatarView: NSView {
 	/// - returns: the color table entry for the given index
 	///
 	/// - note: Internal visibility exists only for unit testing
-	@objc(getcolorForIndex:)
+	@objc(getColorForIndex:)
 	public static func getColor(for index: Int) -> ColorSet {
 		let avatarBackgroundColors = AvatarView.avatarColors
+		return avatarBackgroundColors[index % avatarBackgroundColors.count]
+	}
+
+	/// Get the legacy color associated with a given index
+	/// - parameter index: the index into the color table
+	///
+	/// - returns: the color table entry for the given index
+	///
+	/// - note: Internal visibility exists only for unit testing
+	@objc(getLegacyBackgroundColorForIndex:)
+	@available(*, deprecated, message: "Use getColorForIndex instead")
+	public static func getLegacyColor(for index: Int) -> NSColor {
+		let avatarBackgroundColors = AvatarView.legacyAvatarViewBackgroundColor
 		return avatarBackgroundColors[index % avatarBackgroundColors.count]
 	}
 
@@ -474,6 +487,31 @@ fileprivate extension Unicode.Scalar {
 }
 
 extension AvatarView {
+
+	static let legacyAvatarViewBackgroundColor: [NSColor] = [
+		Colors.Palette.cyanBlue10.color,
+		Colors.Palette.red10.color,
+		Colors.Palette.magenta20.color,
+		Colors.Palette.green10.color,
+		Colors.Palette.magentaPink10.color,
+		Colors.Palette.cyanBlue20.color,
+		Colors.Palette.orange20.color,
+		Colors.Palette.cyan20.color,
+		Colors.Palette.orangeYellow20.color,
+		Colors.Palette.red20.color,
+		Colors.Palette.blue10.color,
+		Colors.Palette.magenta10.color,
+		Colors.Palette.gray40.color,
+		Colors.Palette.green20.color,
+		Colors.Palette.blueMagenta20.color,
+		Colors.Palette.pinkRed10.color,
+		Colors.Palette.gray30.color,
+		Colors.Palette.blueMagenta30.color,
+		Colors.Palette.gray20.color,
+		Colors.Palette.cyan30.color,
+		Colors.Palette.orange30.color
+	]
+
 	/// Table of background and text colors for the AvatarView
 	static let avatarColors: [ColorSet] = [
 		ColorSet(background: DynamicColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color),

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -335,7 +335,7 @@ open class AvatarView: NSView {
 	///
 	/// - returns: the color table entry for the given index
 	///
-	/// - note: Internal visibility exists only for unit testing
+	/// - note: API method avaiable for legacy support only, This will be removed in future release
 	@objc(getLegacyBackgroundColorForIndex:)
 	@available(*, deprecated, message: "Use getColorForIndex instead")
 	public static func getLegacyColor(for index: Int) -> NSColor {

--- a/macos/FluentUI/DynamicColor/DynamicColor.swift
+++ b/macos/FluentUI/DynamicColor/DynamicColor.swift
@@ -7,8 +7,8 @@ import AppKit
 
 @objc(MSFColorSet)
 public class ColorSet: NSObject {
-	public let background: DynamicColor
-	public let foreground: DynamicColor
+	@objc public let background: DynamicColor
+	@objc public let foreground: DynamicColor
 
 	public init(background: DynamicColor, foreground: DynamicColor) {
 		self.background = background
@@ -19,8 +19,8 @@ public class ColorSet: NSObject {
 @objc(MSFDynamicColor)
 public class DynamicColor: NSObject {
 
-	private let light: NSColor
-	private let dark: NSColor
+	@objc public let light: NSColor
+	@objc public let dark: NSColor
 
 	public init(light: NSColor, dark: NSColor) {
 		self.light = light
@@ -28,7 +28,7 @@ public class DynamicColor: NSObject {
 	}
 
 	/// resolves color based on theme
-	func resolvedColor(_ appearance: NSAppearance? = nil) -> NSColor {
+	@objc func resolvedColor(_ appearance: NSAppearance? = nil) -> NSColor {
 		guard let appearance = appearance else {
 			return self.light
 		}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [X] macOS

### Description of changes

Reviving legacy colors from pull request #455 . Outlook team needs legacy color for backward compatibility. 
LPC (Live persona card) scenarios are currently dependent of using legacy colors. 
LPC uses browser based avatar colors that needs to be in sync with outlook native colors for the newer and outlook legacy version. 

![Screen Shot 2021-03-17 at 3 50 43 PM](https://user-images.githubusercontent.com/63682282/111554942-8d1dd300-8744-11eb-878c-69d883f94d86.png)

Outlook team will prioritize using FURN for LPC. Adding support to retrieve legacy colors till then. 

Additionally exposing `ColorSet` and `DynamicColor` API that would allow CocoaUI team to consume new colors when outlook scenarios are resolved. 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/484)