### PR TITLE
support unread dot in pill style segment control

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -140,7 +140,7 @@ class ColorDemoController: UIViewController {
     }
 
     private lazy var segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: colorProviderThemedWindowTypes.map({ return $0.name }), style: .primaryPill)
+        let segmentedControl = SegmentedControl(items: colorProviderThemedWindowTypes.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
         segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
         return segmentedControl
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -7,7 +7,12 @@ import Foundation
 import FluentUI
 
 class SegmentedControlDemoController: DemoController {
-    let segmentTitles: [String] = ["First", "Second", "Third", "Fourth"]
+    let segmentItems: [SegmentItem] = [
+        SegmentItem(title: "First"),
+        SegmentItem(title: "Second"),
+        SegmentItem(title: "Third", isUnread: true),
+        SegmentItem(title: "Fourth")
+    ]
 
     var controlLabels = [SegmentedControl: Label]() {
         didSet {
@@ -22,9 +27,38 @@ class SegmentedControlDemoController: DemoController {
         container.layoutMargins.left = 0
         container.layoutMargins.right = 0
 
+        addTitle(text: "Primary Pill")
+
+        addPillControl(items: Array(segmentItems.prefix(3)), style: .primaryPill)
+        container.addArrangedSubview(UIView())
+
+        addTitle(text: "Primary Pill with unequal buttons")
+
+        addPillControl(items: Array(segmentItems.prefix(2)), style: .primaryPill, equalSegments: false)
+        container.addArrangedSubview(UIView())
+
+        addTitle(text: "Disabled Primary Pill")
+
+        addPillControl(items: Array(segmentItems.prefix(2)), style: .primaryPill, enabled: false)
+        container.addArrangedSubview(UIView())
+
+        addTitle(text: "On Brand Pill")
+
+        addPillControl(items: Array(segmentItems.prefix(4)), style: .onBrandPill)
+        container.addArrangedSubview(UIView())
+
+        addTitle(text: "On Brand Pill with unequal buttons")
+
+        addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, equalSegments: false)
+        container.addArrangedSubview(UIView())
+
+        addTitle(text: "Disabled On Brand Pill")
+
+        addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, enabled: false)
+
         addTitle(text: "Tabs (deprecated)")
 
-        let tabsSegmentedControl = SegmentedControl(items: segmentTitles)
+        let tabsSegmentedControl = SegmentedControl(items: segmentItems, style: .tabs)
         tabsSegmentedControl.addTarget(self, action: #selector(updateLabel(forControl:)), for: .valueChanged)
         container.addArrangedSubview(tabsSegmentedControl)
         controlLabels[tabsSegmentedControl] = addDescription(text: "", textAlignment: .center)
@@ -32,47 +66,18 @@ class SegmentedControlDemoController: DemoController {
 
         addTitle(text: "Disabled Tabs (deprecated)")
 
-        let disabledTabsSegmentedControl = SegmentedControl(items: Array(segmentTitles.prefix(3)))
+        let disabledTabsSegmentedControl = SegmentedControl(items: Array(segmentItems.prefix(3)), style: .tabs)
         disabledTabsSegmentedControl.isEnabled = false
         disabledTabsSegmentedControl.selectedSegmentIndex = 1
         container.addArrangedSubview(disabledTabsSegmentedControl)
         container.addArrangedSubview(UIView())
-
-        addTitle(text: "Primary Pill")
-
-        addPillControl(items: Array(segmentTitles.prefix(3)), style: .primaryPill)
-        container.addArrangedSubview(UIView())
-
-        addTitle(text: "Primary Pill with unequal buttons")
-
-        addPillControl(items: Array(segmentTitles.prefix(2)), style: .primaryPill, equalSegments: false)
-        container.addArrangedSubview(UIView())
-
-        addTitle(text: "Disabled Primary Pill")
-
-        addPillControl(items: Array(segmentTitles.prefix(2)), style: .primaryPill, enabled: false)
-        container.addArrangedSubview(UIView())
-
-        addTitle(text: "On Brand Pill")
-
-        addPillControl(items: Array(segmentTitles.prefix(3)), style: .onBrandPill)
-        container.addArrangedSubview(UIView())
-
-        addTitle(text: "On Brand Pill with unequal buttons")
-
-        addPillControl(items: Array(segmentTitles.prefix(2)), style: .onBrandPill, equalSegments: false)
-        container.addArrangedSubview(UIView())
-
-        addTitle(text: "Disabled On Brand Pill")
-
-        addPillControl(items: Array(segmentTitles.prefix(2)), style: .onBrandPill, enabled: false)
     }
 
     @objc func updateLabel(forControl control: SegmentedControl) {
-        controlLabels[control]?.text = "\"\(segmentTitles[control.selectedSegmentIndex])\" segment is selected"
+        controlLabels[control]?.text = "\"\(segmentItems[control.selectedSegmentIndex].title)\" segment is selected"
     }
 
-    func addPillControl(items: [String], style: SegmentedControl.Style, equalSegments: Bool = true, enabled: Bool = true) {
+    func addPillControl(items: [SegmentItem], style: SegmentedControl.Style, equalSegments: Bool = true, enabled: Bool = true) {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -13,7 +13,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
     private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
 
     private let segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles, style: .primaryPill)
+        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
         segmentedControl.addTarget(self, action: #selector(updateActiveTabContent), for: .valueChanged)
         return segmentedControl
     }()

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -222,6 +222,10 @@
 		C0A0D76E233AEF6C00F432FD /* ShimmerLinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A0D76B233AEF6C00F432FD /* ShimmerLinesView.swift */; };
 		C0A0D76F233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A0D76C233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift */; };
 		C0EAAEAD2347E1DF00C7244E /* ShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */; };
+		C708B04C260A8696007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
+		C708B056260A86FA007190FA /* SegmentPillButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B055260A86FA007190FA /* SegmentPillButton.swift */; };
+		C708B05F260A8778007190FA /* SegmentPillButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B055260A86FA007190FA /* SegmentPillButton.swift */; };
+		C708B064260A87F7007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
 		C77A04B725F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04ED25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
@@ -406,6 +410,8 @@
 		C0A0D76B233AEF6C00F432FD /* ShimmerLinesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerLinesView.swift; sourceTree = "<group>"; };
 		C0A0D76C233AEF6C00F432FD /* ShimmerLinesViewAppearance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerLinesViewAppearance.swift; sourceTree = "<group>"; };
 		C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerView.swift; sourceTree = "<group>"; };
+		C708B04B260A8696007190FA /* SegmentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentItem.swift; sourceTree = "<group>"; };
+		C708B055260A86FA007190FA /* SegmentPillButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentPillButton.swift; sourceTree = "<group>"; };
 		C77A04B625F03DD1001B3EB6 /* String+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
@@ -982,6 +988,8 @@
 			isa = PBXGroup;
 			children = (
 				ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */,
+				C708B04B260A8696007190FA /* SegmentItem.swift */,
+				C708B055260A86FA007190FA /* SegmentPillButton.swift */,
 			);
 			path = SegmentedControl;
 			sourceTree = "<group>";
@@ -1380,6 +1388,7 @@
 				5314E12A25F016230099271A /* PillButton.swift in Sources */,
 				5314E01F25F00D080099271A /* Button.swift in Sources */,
 				5314E0E525F012C00099271A /* NavigationBar.swift in Sources */,
+				C708B064260A87F7007190FA /* SegmentItem.swift in Sources */,
 				5314E14325F016860099271A /* CardTransitionAnimator.swift in Sources */,
 				5314E0F825F012CB0099271A /* LargeTitleView.swift in Sources */,
 				5314E13725F016370099271A /* PopupMenuProtocols.swift in Sources */,
@@ -1388,6 +1397,7 @@
 				5314E2EC25F025710099271A /* DayOfMonth.swift in Sources */,
 				5314E0B325F010400099271A /* EasyTapButton.swift in Sources */,
 				5314E19625F019650099271A /* TabBarView.swift in Sources */,
+				C708B05F260A8778007190FA /* SegmentPillButton.swift in Sources */,
 				5314E11925F015EA0099271A /* ContactCollectionView.swift in Sources */,
 				5314E13525F016370099271A /* PopupMenuItemCell.swift in Sources */,
 				5314E2A025F024860099271A /* NSLayoutConstraint+Extensions.swift in Sources */,
@@ -1521,6 +1531,7 @@
 				FD41C88422DD13230086F899 /* ContentScrollViewTraits.swift in Sources */,
 				FD97580F2191118E00B67319 /* DateTimePickerViewComponentCell.swift in Sources */,
 				A5B6617323A41E2900E801DD /* NotificationView.swift in Sources */,
+				C708B04C260A8696007190FA /* SegmentItem.swift in Sources */,
 				FD41C88622DD13230086F899 /* ShyHeaderController.swift in Sources */,
 				537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */,
 				FDFB8AF121361C9D0046850A /* CalendarViewDayMonthCell.swift in Sources */,
@@ -1538,6 +1549,7 @@
 				FD41C89422DD13230086F899 /* LargeTitleView.swift in Sources */,
 				C0938E44235E8ED500256251 /* AnimationSynchronizer.swift in Sources */,
 				B483323521DEA8D70022B4CC /* HUD.swift in Sources */,
+				C708B056260A86FA007190FA /* SegmentPillButton.swift in Sources */,
 				A5B87B06211E23650038C37C /* UIView+Extensions.swift in Sources */,
 				7D0931C324AAAC9B0072458A /* SideTabBar.swift in Sources */,
 				A5961FA7218A2E4500E2A506 /* UIImage+Extensions.swift in Sources */,

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -215,9 +215,9 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func initSegmentedControl() {
-        let titles = [customStartTabTitle ?? "MSDateTimePicker.StartDate".localized,
-                      customEndTabTitle ?? "MSDateTimePicker.EndDate".localized]
-        segmentedControl = SegmentedControl(items: titles,
+        let items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
+                     SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
+        segmentedControl = SegmentedControl(items: items,
                                             style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
         segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -148,15 +148,15 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func initSegmentedControl(includesTime: Bool) {
-        let titles: [String]
+        let items: [SegmentItem]
         if includesTime {
-            titles = [customStartTabTitle ?? "MSDateTimePicker.StartTime".localized,
-                      customEndTabTitle ?? "MSDateTimePicker.EndTime".localized]
+            items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartTime".localized),
+                     SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndTime".localized)]
         } else {
-            titles = [customStartTabTitle ?? "MSDateTimePicker.StartDate".localized,
-                      customEndTabTitle ?? "MSDateTimePicker.EndDate".localized]
+            items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
+                     SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         }
-        segmentedControl = SegmentedControl(items: titles, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
+        segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
         segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+import Foundation
+
+/// Used for SegmentedControl array of views
+@objc(MSFSegmentItem)
+public class SegmentItem: NSObject {
+    public let title: String
+
+    /// This value will determine whether or not to show dot next to the pill button label
+    public var isUnread: Bool {
+       didSet {
+           if oldValue != isUnread {
+               NotificationCenter.default.post(name: SegmentItem.isUnreadValueDidChangeNotification, object: self)
+           }
+       }
+   }
+
+    @objc public init(title: String, isUnread: Bool = false) {
+        self.title = title
+        self.isUnread = isUnread
+        super.init()
+    }
+
+    /// Notification sent when item's `isUnread` value changes.
+    static let isUnreadValueDidChangeNotification = NSNotification.Name(rawValue: "SegmentItemisUnreadValueDidChangeNotification")
+}

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -87,7 +87,7 @@ class SegmentPillButton: UIButton {
 
     private struct Constants {
         static let fontSize: CGFloat = 16
-        static let unreadDotOffset = CGPoint(x: 4, y: 3)
+        static let unreadDotOffset = CGPoint(x: 6, y: 3)
         static let unreadDotSize: CGFloat = 6
         static let insets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
     }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -1,0 +1,94 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+import UIKit
+
+class SegmentPillButton: UIButton {
+    var isUnreadDotVisible: Bool = false {
+        didSet {
+            if oldValue != isUnreadDotVisible {
+                if isUnreadDotVisible {
+                    self.layer.addSublayer(unreadDotLayer)
+                } else {
+                    unreadDotLayer.removeFromSuperlayer()
+                }
+            }
+        }
+    }
+
+    var unreadDotColor: UIColor = Colors.gray100
+
+    override var isSelected: Bool {
+        didSet {
+            if oldValue != isSelected && isSelected == true {
+                item.isUnread = false
+                updateUnreadDot()
+            }
+        }
+    }
+
+    init(withItem item: SegmentItem) {
+        self.item = item
+        super.init(frame: .zero)
+
+        self.contentEdgeInsets = Constants.insets
+
+        let title = item.title
+        self.setTitle(title, for: .normal)
+        self.accessibilityLabel = title
+        self.largeContentTitle = title
+        self.showsLargeContentViewer = true
+        self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(isUnreadValueDidChange),
+                                               name: SegmentItem.isUnreadValueDidChangeNotification,
+                                               object: item)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateUnreadDot()
+    }
+
+    private let item: SegmentItem
+
+    private let unreadDotLayer: CALayer = {
+        let unreadDotLayer = CALayer()
+        unreadDotLayer.bounds.size = CGSize(width: Constants.unreadDotSize, height: Constants.unreadDotSize)
+        unreadDotLayer.cornerRadius = Constants.unreadDotSize / 2
+        return unreadDotLayer
+    }()
+
+    @objc private func isUnreadValueDidChange() {
+        isUnreadDotVisible = item.isUnread
+        setNeedsLayout()
+    }
+
+    private func updateUnreadDot() {
+        isUnreadDotVisible = item.isUnread
+        if isUnreadDotVisible {
+            let anchor = self.titleLabel?.frame ?? .zero
+            let xPos: CGFloat
+            if effectiveUserInterfaceLayoutDirection == .leftToRight {
+                xPos = anchor.maxX + Constants.unreadDotOffset.x
+            } else {
+                xPos = anchor.minX - Constants.unreadDotOffset.x - Constants.unreadDotSize
+            }
+            unreadDotLayer.frame.origin = CGPoint(x: xPos, y: anchor.minY + Constants.unreadDotOffset.y)
+            unreadDotLayer.backgroundColor = unreadDotColor.cgColor
+        }
+    }
+
+    private struct Constants {
+        static let fontSize: CGFloat = 16
+        static let unreadDotOffset = CGPoint(x: 4, y: 3)
+        static let unreadDotSize: CGFloat = 6
+        static let insets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
+    }
+}

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -136,7 +136,7 @@ open class SegmentedControl: UIControl {
         func segmentUnreadDotColor(for window: UIWindow) -> UIColor {
             switch self {
             case .primaryPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.textPrimary)
+                return UIColor(light: Colors.primary(for: window), dark: Colors.gray100)
             case .tabs, .onBrandPill:
                 return Colors.SegmentedControl.OnBrandPill.segmentText
             }
@@ -651,7 +651,7 @@ open class SegmentedControl: UIControl {
                     }
 
                     if let switchButton = button as? SegmentPillButton {
-                        switchButton.unreadDotColor = style.segmentUnreadDotColor(for: window)
+                        switchButton.unreadDotColor = isEnabled ? style.segmentUnreadDotColor(for: window) : style.segmentTextColorDisabled(for: window)
                     }
                 }
             }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -37,13 +37,24 @@ public extension Colors {
 @objc(MSFSegmentItem)
 public class SegmentItem: NSObject {
     public var title: String
-    public var isUnread: Bool
+    
+    /// This value will determine whether or not to show dot next to the pill button label
+    public var isUnread: Bool{
+       didSet {
+           if oldValue != isUnread {
+               NotificationCenter.default.post(name: SegmentItem.isUnreadValueDidChangeNotification, object: self)
+           }
+       }
+   }
 
     @objc public init(title: String, isUnread: Bool = false) {
         self.title = title
         self.isUnread = isUnread
         super.init()
     }
+
+    /// Notification sent when item's `isUnread` value changes.
+    static let isUnreadValueDidChangeNotification = NSNotification.Name(rawValue: "SegmentItemisUnreadValueDidChangeNotification")
 }
 
 // MARK: SegmentedControl
@@ -748,6 +759,11 @@ private class SegmentedPillButton: UIButton {
         self.largeContentTitle = title
         self.showsLargeContentViewer = true
         self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(isUnreadValueDidChange),
+                                               name: SegmentItem.isUnreadValueDidChangeNotification,
+                                               object: item)
     }
 
     required init?(coder: NSCoder) {
@@ -767,6 +783,11 @@ private class SegmentedPillButton: UIButton {
         unreadDotLayer.cornerRadius = Constants.unreadDotSize / 2
         return unreadDotLayer
     }()
+
+    @objc private func isUnreadValueDidChange() {
+        isUnreadDotVisible = item.isUnread
+        setNeedsLayout()
+    }
 
     private func updateUnreadDot() {
         isUnreadDotVisible = item.isUnread

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -33,6 +33,19 @@ public extension Colors {
     }
 }
 
+/// Used for SegmentedControl array of views
+@objc(MSFSegmentItem)
+public class SegmentItem: NSObject {
+    public var title: String
+    public var isUnread: Bool
+
+    @objc public init(title: String, isUnread: Bool = false) {
+        self.title = title
+        self.isUnread = isUnread
+        super.init()
+    }
+}
+
 // MARK: SegmentedControl
 @available(*, deprecated, renamed: "SegmentedControl")
 public typealias MSSegmentedControl = SegmentedControl
@@ -142,15 +155,6 @@ open class SegmentedControl: UIControl {
             }
         }
 
-        var segmentTextFont: UIFont {
-            switch self {
-            case .tabs:
-                return TextStyle.subhead.font
-            case .primaryPill, .onBrandPill:
-                return UIFont.systemFont(ofSize: 16)
-            }
-        }
-
         var selectionChangeAnimationDuration: TimeInterval {
             switch self {
             case .tabs:
@@ -164,7 +168,6 @@ open class SegmentedControl: UIControl {
     private struct Constants {
         static let selectionBarHeight: CGFloat = 1.5
         static let pillContainerHorizontalInset: CGFloat = 16
-        static let pillButtonInsets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
         static let pillButtonCornerRadius: CGFloat = 16
     }
 
@@ -191,7 +194,7 @@ open class SegmentedControl: UIControl {
     private var customSegmentedControlButtonTextColor: UIColor?
     private var customSelectedSegmentedControlButtonTextColor: UIColor?
 
-    private var items = [String]()
+    private var items = [SegmentItem]()
     internal var style: Style {
         didSet {
             updateWindowSpecificColors()
@@ -243,9 +246,9 @@ open class SegmentedControl: UIControl {
 
     /// Initializes a segmented control with the specified titles.
     ///
-    /// - Parameter items: An array of title strings representing the segments for this control.
+    /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
-    @objc public convenience init(items: [String], style: Style = .tabs) {
+    @objc public convenience init(items: [SegmentItem], style: Style = .primaryPill) {
         self.init(items: items,
                   style: style,
                   customSegmentedControlBackgroundColor: nil,
@@ -256,14 +259,14 @@ open class SegmentedControl: UIControl {
 
     /// Initializes a segmented control with the specified titles, style, and colors (colors are for pill styles only).
     ///
-    /// - Parameter items: An array of title strings representing the segments for this control.
+    /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
     /// - Parameter customSegmentedControlBackgroundColor: UIColor to use as the background color
     /// - Parameter customSegmentedControlSelectedButtonBackgroundColor: UIColor to use as the selected button background color
     /// - Parameter customSegmentedControlButtonTextColor: UIColor to use as the unselected button text color
     /// - Parameter customSelectedSegmentedControlButtonTextColor: UIColor to use as the selected button text color
-    @objc public init(items: [String],
-                      style: Style = .tabs,
+    @objc public init(items: [SegmentItem],
+                      style: Style = .primaryPill,
                       customSegmentedControlBackgroundColor: UIColor? = nil,
                       customSegmentedControlSelectedButtonBackgroundColor: UIColor? = nil,
                       customSegmentedControlButtonTextColor: UIColor? = nil,
@@ -279,7 +282,7 @@ open class SegmentedControl: UIControl {
         switch style {
         case .tabs:
             addSubview(backgroundView)
-            addButtons(titles: items)
+            addButtons(items: items)
             // Separator must be over buttons and selection view on top of everything
             addSubview(bottomSeparator)
             addSubview(selectionView)
@@ -291,7 +294,7 @@ open class SegmentedControl: UIControl {
             pillMaskedLabelsContainerView.mask = selectionView
             pillMaskedLabelsContainerView.isUserInteractionEnabled = false
             pillContainerView.addSubview(pillMaskedLabelsContainerView)
-            addButtons(titles: items)
+            addButtons(items: items)
             // We need to add pillMaskedLabelsContainerView to the container view
             // before the buttons in order to activate the label constraints, but
             // we want pillMaskedLabelsContainerView to show above the buttons.
@@ -310,19 +313,19 @@ open class SegmentedControl: UIControl {
     /// Insert new segment at index with the specified title. If a segment exists at that index, it will be inserted before and will therefore take its index.
     ///
     /// - Parameters:
-    ///   - title: The title of the newly created segment
+    ///   - item: The item of the newly created segment
     ///   - index: The index at which to insert the newly created segment
-    @objc open func insertSegment(withTitle title: String, at index: Int) {
-        items.insert(title, at: index)
+    @objc open func insertSegment(_ item: SegmentItem, at index: Int) {
+        items.insert(item, at: index)
 
         let button: UIButton
         // TODO: Add option for animated addition?
         switch style {
         case .tabs:
-            button = createTabButton(withTitle: title)
+            button = createTabButton(withItem: item)
             addSubview(button)
         case .primaryPill, .onBrandPill:
-            button = createSwitchButton(withTitle: title)
+            button = createPillButton(withItem: item)
             pillContainerView.addSubview(button)
             addMaskedPillLabel(over: button, at: index)
         }
@@ -509,42 +512,37 @@ open class SegmentedControl: UIControl {
         return buttons[index] as UIView
     }
 
-    private func addButtons(titles: [String]) {
+    private func addButtons(items: [SegmentItem]) {
         // Create buttons
-        for (index, title) in titles.enumerated() {
-            insertSegment(withTitle: title, at: index)
+        for (index, item) in items.enumerated() {
+            insertSegment(item, at: index)
         }
 
         // Select first button
-        if !titles.isEmpty {
+        if !items.isEmpty {
             selectSegment(at: 0, animated: false)
         }
     }
 
-    private func createTabButton(withTitle title: String) -> SegmentedControlButton {
+    private func createTabButton(withItem item: SegmentItem) -> SegmentedControlButton {
         let button = SegmentedControlButton()
+        let title = item.title
         button.setTitle(title, for: .normal)
         button.accessibilityLabel = title
         button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
         return button
     }
 
-    private func createSwitchButton(withTitle title: String) -> UIButton {
-        let button = SegmentedSwitchButton()
-        button.setTitle(title, for: .normal)
-        button.accessibilityLabel = title
-        button.largeContentTitle = title
-        button.showsLargeContentViewer = true
-        button.titleLabel?.font = style.segmentTextFont
+    private func createPillButton(withItem item: SegmentItem) -> UIButton {
+        let button = SegmentedPillButton(withItem: item)
         button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
-        button.contentEdgeInsets = Constants.pillButtonInsets
         return button
     }
 
     private func addMaskedPillLabel(over button: UIButton, at index: Int) {
         let maskedLabel = UILabel()
         maskedLabel.text = button.currentTitle
-        maskedLabel.font = style.segmentTextFont
+        maskedLabel.font = button.titleLabel?.font
         maskedLabel.translatesAutoresizingMaskIntoConstraints = false
         pillMaskedLabelsContainerView.addSubview(maskedLabel)
         pillMaskedLabels.insert(maskedLabel, at: index)
@@ -665,7 +663,7 @@ open class SegmentedControl: UIControl {
                             button.setTitleColor(style.segmentTextColorDisabled(for: window), for: .normal)
                     }
 
-                    if let switchButton = button as? SegmentedSwitchButton {
+                    if let switchButton = button as? SegmentedPillButton {
                         switchButton.unreadDotColor = style.segmentUnreadDotColor(for: window)
                     }
                 }
@@ -710,15 +708,15 @@ private class SegmentedControlButton: UIButton {
     }
 
     @objc private func updateFont() {
-        titleLabel?.font = SegmentedControl.Style.tabs.segmentTextFont
+        titleLabel?.font = TextStyle.subhead.font
     }
 }
 
-private class SegmentedSwitchButton: UIButton {
-    var isUnread: Bool = false {
+private class SegmentedPillButton: UIButton {
+    var isUnreadDotVisible: Bool = false {
         didSet {
-            if oldValue != isUnread {
-                if isUnread {
+            if oldValue != isUnreadDotVisible {
+                if isUnreadDotVisible {
                     self.layer.addSublayer(unreadDotLayer)
                 } else {
                     unreadDotLayer.removeFromSuperlayer()
@@ -732,15 +730,36 @@ private class SegmentedSwitchButton: UIButton {
     override var isSelected: Bool {
         didSet {
             if oldValue != isSelected && isSelected == true {
-                isUnread = false
+                item.isUnread = false
+                updateUnreadDot()
             }
         }
+    }
+
+    init(withItem item: SegmentItem) {
+        self.item = item
+        super.init(frame: .zero)
+
+        self.contentEdgeInsets = Constants.insets
+
+        let title = item.title
+        self.setTitle(title, for: .normal)
+        self.accessibilityLabel = title
+        self.largeContentTitle = title
+        self.showsLargeContentViewer = true
+        self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
         updateUnreadDot()
     }
+
+    private let item: SegmentItem
 
     private let unreadDotLayer: CALayer = {
         let unreadDotLayer = CALayer()
@@ -750,7 +769,8 @@ private class SegmentedSwitchButton: UIButton {
     }()
 
     private func updateUnreadDot() {
-        if isUnread {
+        isUnreadDotVisible = item.isUnread
+        if isUnreadDotVisible {
             let anchor = self.titleLabel?.frame ?? .zero
             let xPos: CGFloat
             if effectiveUserInterfaceLayoutDirection == .leftToRight {
@@ -764,7 +784,9 @@ private class SegmentedSwitchButton: UIButton {
     }
 
     private struct Constants {
+        static let fontSize: CGFloat = 16
         static let unreadDotOffset = CGPoint(x: 4, y: 3)
         static let unreadDotSize: CGFloat = 6
+        static let insets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -36,10 +36,10 @@ public extension Colors {
 /// Used for SegmentedControl array of views
 @objc(MSFSegmentItem)
 public class SegmentItem: NSObject {
-    public var title: String
-    
+    public let title: String
+
     /// This value will determine whether or not to show dot next to the pill button label
-    public var isUnread: Bool{
+    public var isUnread: Bool {
        didSet {
            if oldValue != isUnread {
                NotificationCenter.default.post(name: SegmentItem.isUnreadValueDidChangeNotification, object: self)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Breaking change included:
- Default style is no longer `.tab` and it is now `.primaryPill` style
- Initializing SegmentedControl doesn't take an array of String anymore and it takes array of SegmentItems
- SegmentItems have title and boolean flag for whether or not show unread dot in the button
- SegmentControl will listen to unread boolean flag value change and update the view accordingly

miscellaneous:
break a part SegmentedControl.swift file into SegmentItem.swift & SegmentPillButton.swift

### Verification
Light & Dark, RTL and LTR languages

|mode | light                                 | dark                                      |
|---------------------------------------------|----------------------------------------------|-------------------------------------------|
|before| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-23 at 13 47 48](https://user-images.githubusercontent.com/20715435/112216186-719c4780-8bde-11eb-813c-139c2792012a.png) |  ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-23 at 13 48 04](https://user-images.githubusercontent.com/20715435/112216217-795bec00-8bde-11eb-9308-be9e48ace2dc.png)|
|After| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-23 at 13 34 47](https://user-images.githubusercontent.com/20715435/112215732-f20e7880-8bdd-11eb-9688-0b3f61f26fa2.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-23 at 13 35 20](https://user-images.githubusercontent.com/20715435/112215703-e91da700-8bdd-11eb-9d97-ac4261bce17d.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/487)