### PR TITLE
add accessibilityHint for tabbaritemview for iOS 14

### DIFF
--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -99,8 +99,8 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
-/* Accessibility hint for TabBarItemView to indicate its index relative to total number of items */
-"Accessibility.TabBarItemView.Hint" = "%d of %d";
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Double tap to view more actions";

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView to indicate its index relative to total number of items */
+"Accessibility.TabBarItemView.Hint" = "%d of %d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Double tap to view more actions";
 

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -233,12 +233,17 @@ open class SideTabBar: UIView {
         let showItemTitles = section == .top ? showTopItemTitles : showBottomItemTitles
         var didRestoreSelection = false
 
-        for item in allItems {
+        for (index, item) in allItems.enumerated() {
             let tabBarItemView = TabBarItemView(item: item, showsTitle: showItemTitles, canResizeImage: false)
             tabBarItemView.translatesAutoresizingMaskIntoConstraints = false
             tabBarItemView.alwaysShowTitleBelowImage = true
             tabBarItemView.maxBadgeWidth = Constants.viewWidth / 2 - badgePadding
             tabBarItemView.numberOfTitleLines = Constants.numberOfTitleLines
+
+            // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+            if #available(iOS 14.0, *) {
+                tabBarItemView.accessibilityHint = String(format: "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+            }
 
             if itemView(with: item, in: section) != nil && section == .top && item == selectedTopItem {
                 tabBarItemView.isSelected = true

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -280,7 +280,7 @@ open class SideTabBar: UIView {
 
                 for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
                     let accessibilityIndex = index + 1 + previousSectionCount
-                    itemView.accessibilityHint = String(format: "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+                    itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
                 }
                 previousSectionCount += currentStackView.arrangedSubviews.count
             }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -13,7 +13,11 @@ class TabBarItemView: UIView {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected
             updateColors()
-            accessibilityTraits = isSelected ? .selected : .none
+            if isSelected {
+                accessibilityTraits.insert(.selected)
+            } else {
+                accessibilityTraits.remove(.selected)
+            }
         }
     }
 

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -40,10 +40,11 @@ open class TabBarView: UIView {
                 preconditionFailure("tab bar items can't be more than \(Constants.maxTabCount)")
             }
 
-            for item in items {
+            for (index, item) in items.enumerated() {
                 let tabBarItemView = TabBarItemView(item: item, showsTitle: showsItemTitles)
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTabBarItemTapped(_:)))
                 tabBarItemView.addGestureRecognizer(tapGesture)
+                tabBarItemView.accessibilityHint = String(format: "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
                 stackView.addArrangedSubview(tabBarItemView)
             }
 

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -44,7 +44,11 @@ open class TabBarView: UIView {
                 let tabBarItemView = TabBarItemView(item: item, showsTitle: showsItemTitles)
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTabBarItemTapped(_:)))
                 tabBarItemView.addGestureRecognizer(tapGesture)
-                tabBarItemView.accessibilityHint = String(format: "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+
+                // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+                if #available(iOS 14.0, *) {
+                    tabBarItemView.accessibilityHint = String(format: "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                }
                 stackView.addArrangedSubview(tabBarItemView)
             }
 

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -47,7 +47,7 @@ open class TabBarView: UIView {
 
                 // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
                 if #available(iOS 14.0, *) {
-                    tabBarItemView.accessibilityHint = String(format: "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                    tabBarItemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
                 }
                 stackView.addArrangedSubview(tabBarItemView)
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
We would like VoiceOver to read out "Home, 1 of 3, selected" when the VO focus is on a tabbar. However, right now it just says "Home, selected" in iOS 14 device.

This change is a partial revert of commit `1e17860` : it appears to be that .tabbar accessibilityTraits no longer automatically append index of the subview in iOS 14. 
This change further improves sideTabBar experience so that voiceover focus order would be vertical navigation within the sidetabbar before it goes to other views. Also, VoiceOver will announce the index of the tabbaritemview.

### Verification
iPad and iPhone device testing for sideTabBar and tabBar scenarios

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/488)