### PR TITLE
Allow tooltip to grow more than 3 lines

### DIFF
--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -27,8 +27,6 @@ class TooltipView: UIView {
 
         static let paddingHorizontal: CGFloat = 13
         static let totalPaddingVertical: CGFloat = 12
-
-        static let maxLines: Int = 3
     }
 
     static let backgroundCornerRadius: CGFloat = 8
@@ -56,7 +54,7 @@ class TooltipView: UIView {
 
     private static func messageLabelSizeThatFits(_ size: CGSize, message: String) -> CGSize {
         let boundingWidth = min(Constants.maximumWidth, size.width) - 2 * Constants.paddingHorizontal
-        return message.preferredSize(for: Constants.messageLabelTextStyle.font, width: boundingWidth, numberOfLines: Constants.maxLines)
+        return message.preferredSize(for: Constants.messageLabelTextStyle.font, width: boundingWidth)
     }
 
     let positionController: TooltipPositionController
@@ -77,7 +75,7 @@ class TooltipView: UIView {
     private let messageLabel: UILabel = {
         let label = Label(style: Constants.messageLabelTextStyle)
         label.textColor = Colors.Tooltip.text
-        label.numberOfLines = Constants.maxLines
+        label.numberOfLines = 0
         return label
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

For very long message in larger text mode, tooltip currently max out at 3 lines and truncates the string.
this change lets tooltip to be multiple lines.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-23 at 16 20 45](https://user-images.githubusercontent.com/20715435/112231790-9e5b5980-8bf4-11eb-915f-c9dcc55024cc.png)| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-23 at 16 17 52](https://user-images.githubusercontent.com/20715435/112231843-b8953780-8bf4-11eb-803a-e0b63a1aa0ee.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/489)