### PR TITLE
Update CommandBarButton.swift

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -56,9 +56,9 @@ class CommandBarButton: UIButton {
         isSelected = isPersistSelection && item.isSelected
 
         // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
-        let iconImage: UIImage? = item.iconImage
+        let iconImage = item.iconImage
         setImage(iconImage, for: .normal)
-        setTitle(((iconImage != nil) ? nil : item.title), for: .normal)
+        setTitle(iconImage != nil ? nil : item.title, for: .normal)
         titleLabel?.isEnabled = isEnabled
         titleLabel?.font = item.titleFont
     }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -55,12 +55,12 @@ class CommandBarButton: UIButton {
         isEnabled = item.isEnabled
         isSelected = isPersistSelection && item.isSelected
 
-        if item.iconImage == nil {
-            setTitle(item.title, for: .normal)
-            if let font = item.titleFont {
-                titleLabel?.font = font
-            }
-        }
+        // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
+        let iconImage: UIImage? = item.iconImage
+        setImage(iconImage, for: .normal)
+        setTitle(((iconImage != nil) ? nil : item.title), for: .normal)
+        titleLabel?.isEnabled = isEnabled
+        titleLabel?.font = item.titleFont
     }
 
     private let isPersistSelection: Bool


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This fixes two related issues with updating command button state:
- when a command button with label is disabled, the label font color is incorrect because the isEnabled property of the button's label is not appropriately set; the property should always match the button enabled state
- when the state of a command has changed, it may update the icon to display, or may change between a label and icon; the current code does not cater for this, and the logic should be updated to always show the current icon if there is one, or else show the label

### Verification

Verified in local test client which supports these scenarios:
- label color is correct for both enabled/disabled state
- command button updates to correctly display the current icon or text (where there is no icon)

| Before                                       
|----------------------------------------------|
| Enabled and Disabled State |
![enabled-and-disabled](https://user-images.githubusercontent.com/52223389/113069515-62387380-9175-11eb-8934-74766e84be8e.png)

| After                                      
|----------------------------------------------|
| Disabled State (enabled state is unchanged) | 
![disabled-state](https://user-images.githubusercontent.com/52223389/113069534-69f81800-9175-11eb-8fce-9dbcb443c237.png)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/495)