### PR TITLE
[PeoplePicker] Add a parameter to hide empty personaListView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -15,20 +15,22 @@ class PeoplePickerSampleData {
         let pickedPersonas: [Persona]
         let allowsPickedPersonasToAppearAsSuggested: Bool
         let showsSearchDirectoryButton: Bool
+        let hidePersonaListViewWhenNoSuggestedPersonas: Bool
 
-        init(description: String, numberOfLines: Int = 0, pickedPersonas: [Persona] = [], allowsPickedPersonasToAppearAsSuggested: Bool = true, showsSearchDirectoryButton: Bool = true) {
+        init(description: String, numberOfLines: Int = 0, pickedPersonas: [Persona] = [], allowsPickedPersonasToAppearAsSuggested: Bool = true, showsSearchDirectoryButton: Bool = true, hidePersonaListViewWhenNoSuggestedPersonas: Bool = false) {
             self.description = description
             self.numberOfLines = numberOfLines
             self.pickedPersonas = pickedPersonas
             self.allowsPickedPersonasToAppearAsSuggested = allowsPickedPersonasToAppearAsSuggested
             self.showsSearchDirectoryButton = showsSearchDirectoryButton
+            self.hidePersonaListViewWhenNoSuggestedPersonas = hidePersonaListViewWhenNoSuggestedPersonas
         }
     }
 
     static let variants: [Variant] = [
         Variant(description: "Standard implementation with one line of picked personas", numberOfLines: 1, pickedPersonas: [samplePersonas[0], samplePersonas[4], samplePersonas[11], samplePersonas[14]]),
         Variant(description: "Doesn't allow picked personas to appear as suggested", pickedPersonas: [samplePersonas[0], samplePersonas[9]], allowsPickedPersonasToAppearAsSuggested: false),
-        Variant(description: "Hides search directory button", pickedPersonas: [samplePersonas[13]], showsSearchDirectoryButton: false),
+        Variant(description: "Hides search directory button", pickedPersonas: [samplePersonas[13]], showsSearchDirectoryButton: false, hidePersonaListViewWhenNoSuggestedPersonas: true),
         Variant(description: "Includes callback when picking a suggested persona")
     ]
 }
@@ -59,6 +61,7 @@ class PeoplePickerDemoController: DemoController {
         peoplePicker.numberOfLines = variant.numberOfLines
         peoplePicker.allowsPickedPersonasToAppearAsSuggested = variant.allowsPickedPersonasToAppearAsSuggested
         peoplePicker.showsSearchDirectoryButton = variant.showsSearchDirectoryButton
+        peoplePicker.hidePersonaListViewWhenNoSuggestedPersonas = variant.hidePersonaListViewWhenNoSuggestedPersonas
         peoplePicker.delegate = self
         peoplePickers.append(peoplePicker)
         container.addArrangedSubview(peoplePicker)

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -92,6 +92,11 @@ open class PeoplePicker: BadgeField {
      */
     @objc open var allowsPickedPersonasToAppearAsSuggested: Bool = true
 
+	/**
+	 Set `hidePersonaListViewWhenNoSuggestedPersonas` to true to hide the personaListView when no suggested personas is available, i.e. personaListView is empty.
+	 */
+	@objc open var hidePersonaListViewWhenNoSuggestedPersonas: Bool = false
+
     @objc open weak var delegate: PeoplePickerDelegate? {
         didSet {
             badgeFieldDelegate = delegate
@@ -359,10 +364,11 @@ open class PeoplePicker: BadgeField {
     override func textFieldTextChanged() {
         super.textFieldTextChanged()
         let textFieldHasContent = !textFieldContent.isEmpty
-        isShowingPersonaSuggestions = textFieldHasContent
         if textFieldHasContent {
             getSuggestedPersonas()
         }
+        let hideEmptyPersonaListView = hidePersonaListViewWhenNoSuggestedPersonas && suggestedPersonas.isEmpty
+        isShowingPersonaSuggestions = textFieldHasContent && !hideEmptyPersonaListView
     }
 
     open override func resetTextFieldContent() {

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -93,7 +93,7 @@ open class PeoplePicker: BadgeField {
     @objc open var allowsPickedPersonasToAppearAsSuggested: Bool = true
 
 	/**
-	 Set `hidePersonaListViewWhenNoSuggestedPersonas` to true to hide the personaListView when no suggested personas is available, i.e. personaListView is empty.
+	 Set `hidePersonaListViewWhenNoSuggestedPersonas` to true to hide the personaListView when no suggested personas are available, i.e. personaListView is empty.
 	 */
 	@objc open var hidePersonaListViewWhenNoSuggestedPersonas: Bool = false
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add a parameter hidePersonaListViewWhenNoSuggestedPersonas to PeoplePicker to give the client ability to hide empty personaListView. Use this parameter in PeoplePickerDemoController to show how it works.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/41590608/113188284-b479a300-920e-11eb-8bb8-11f65f41abbe.png) | ![After](https://user-images.githubusercontent.com/41590608/113188308-bba0b100-920e-11eb-83ad-32c9f742acef.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/497)