### PR TITLE
support avatarView with large content viewer in largetitle and sidetabbar

### DIFF
--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -46,7 +46,10 @@ class LargeTitleView: UIView {
 
     var avatarCustomAccessibilityLabel: String? {
         didSet {
-            [avatarView, smallMorphingAvatarView].forEach { $0?.customAccessibilityLabel = avatarCustomAccessibilityLabel }
+            [avatarView, smallMorphingAvatarView].forEach {
+                $0?.customAccessibilityLabel = avatarCustomAccessibilityLabel
+                $0?.largeContentTitle = avatarCustomAccessibilityLabel
+            }
         }
     }
 
@@ -171,6 +174,8 @@ class LargeTitleView: UIView {
         avatarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleAvatarViewTapped)))
         self.avatarView = avatarView
         contentStackView.addArrangedSubview(avatarView)
+        avatarView.showsLargeContentViewer = true
+        avatarView.largeContentTitle = avatarView.accessibilityLabel
 
         // small avatar view setup
         let smallAvatarView = ProfileView(avatarSize: Constants.compactAvatarSize, preferredFallbackImageStyle: preferredFallbackImageStyle)
@@ -178,6 +183,8 @@ class LargeTitleView: UIView {
         self.smallMorphingAvatarView = smallAvatarView
         smallAvatarView.translatesAutoresizingMaskIntoConstraints = false
         contentStackView.addSubview(smallAvatarView)
+        smallAvatarView.showsLargeContentViewer = true
+        smallAvatarView.largeContentTitle = smallAvatarView.accessibilityLabel
 
         smallAvatarView.centerXAnchor.constraint(equalTo: avatarView.centerXAnchor).isActive = true
         smallAvatarView.centerYAnchor.constraint(equalTo: avatarView.centerYAnchor).isActive = true

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -46,6 +46,8 @@ open class SideTabBar: UIView {
                 avatarView.avatarSize = .medium
                 avatarView.translatesAutoresizingMaskIntoConstraints = false
                 avatarView.overrideAccessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
+                avatarView.showsLargeContentViewer = true
+                avatarView.largeContentTitle = avatarView.overrideAccessibilityLabel
                 addSubview(avatarView)
 
                 if delegate != nil {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

SideTabbar and NavigationController both show avatarviews but it is the one subview that doesn't support large content viewer. So we are adding those support

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| none |![Simulator Screen Shot - iPhone 11 Pro Max - 2021-03-31 at 14 17 57](https://user-images.githubusercontent.com/20715435/113212762-11378680-922c-11eb-99b5-87ca411d7488.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/501)