### PR TITLE
Cherry-picking CCB changes into main_0.1 branch.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -32,6 +32,8 @@ class CommandBarDemoController: DemoController {
 
         case textStyle
 
+        case disabledText
+
         var iconImage: UIImage? {
             switch self {
             case .add:
@@ -66,7 +68,7 @@ class CommandBarDemoController: DemoController {
                 return UIImage(named: "link24Regular")
             case .keyboard:
                 return UIImage(named: "keyboardDock24Regular")
-            case .textStyle:
+            case .textStyle, .disabledText:
                 return nil
             }
         }
@@ -75,6 +77,8 @@ class CommandBarDemoController: DemoController {
             switch self {
             case .textStyle:
                 return TextStyle.body.textRepresentation
+            case .disabledText:
+                return "Search"
             default:
                 return nil
             }
@@ -84,6 +88,8 @@ class CommandBarDemoController: DemoController {
             switch self {
             case .textStyle:
                 return TextStyle.body.font
+            case .disabledText:
+                return .systemFont(ofSize: 15, weight: .regular)
             default:
                 return nil
             }
@@ -91,7 +97,7 @@ class CommandBarDemoController: DemoController {
 
         var isPersistSelection: Bool {
             switch self {
-            case .add, .mention, .calendar, .arrowUndo, .arrowRedo, .copy, .delete, .link, .keyboard, .textStyle:
+            case .add, .mention, .calendar, .arrowUndo, .arrowRedo, .copy, .delete, .link, .keyboard, .textStyle, .disabledText:
                 return false
             case .textBold, .textItalic, .textUnderline, .textStrikethrough, .checklist, .bulletList, .numberList:
                 return true
@@ -160,6 +166,9 @@ class CommandBarDemoController: DemoController {
                 .textStyle
             ],
             [
+                .disabledText
+            ],
+            [
                 .textBold,
                 .textItalic,
                 .textUnderline,
@@ -187,10 +196,11 @@ class CommandBarDemoController: DemoController {
         }
 
         itemGroups[0][1].isEnabled = false
+        itemGroups[2][0].isEnabled = false
 
         if #available(iOS 14.0, *) {
             // Copy item
-            let copyItem = itemGroups[3][0]
+            let copyItem = itemGroups[4][0]
             copyItem.menu = UIMenu(children: [UIAction(title: "Copy Image", image: UIImage(named: "copy24Regular"), handler: { _ in }),
                                               UIAction(title: "Copy Text", image: UIImage(named: "text24Regular"), handler: { _ in })])
             copyItem.showsMenuAsPrimaryAction = true
@@ -240,7 +250,7 @@ class CommandBarDemoController: DemoController {
             titleFont: command.titleFont,
             isEnabled: isEnabled,
             isSelected: isSelected,
-            itemTappedHandler: { [weak self] (item) in
+            itemTappedHandler: { [weak self] (_, item) in
                 self?.handleCommandItemTapped(command: command, item: item)
             }
         )

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -235,7 +235,7 @@ open class CommandBar: UIView {
     }
 
     @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
-        sender.item.handleTapped()
+        sender.item.handleTapped(sender)
         sender.updateState()
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -55,12 +55,12 @@ class CommandBarButton: UIButton {
         isEnabled = item.isEnabled
         isSelected = isPersistSelection && item.isSelected
 
-        if item.iconImage == nil {
-            setTitle(item.title, for: .normal)
-            if let font = item.titleFont {
-                titleLabel?.font = font
-            }
-        }
+        // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
+        let iconImage = item.iconImage
+        setImage(iconImage, for: .normal)
+        setTitle(iconImage != nil ? nil : item.title, for: .normal)
+        titleLabel?.isEnabled = isEnabled
+        titleLabel?.font = item.titleFont
     }
 
     private let isPersistSelection: Bool

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -9,7 +9,7 @@ public typealias CommandBarItemGroup = [CommandBarItem]
 
 @objc(MSFCommandBarItem)
 open class CommandBarItem: NSObject {
-    public typealias ItemTappedHandler = ((CommandBarItem) -> Void)
+    public typealias ItemTappedHandler = ((UIView, CommandBarItem) -> Void)
 
     @objc public init(
         iconImage: UIImage?,
@@ -79,11 +79,11 @@ open class CommandBarItem: NSObject {
     @available(iOS 14.0, *)
     @objc public lazy var showsMenuAsPrimaryAction: Bool = false
 
-    public static let defaultItemTappedHandler: ItemTappedHandler = { item in
+    public static let defaultItemTappedHandler: ItemTappedHandler = { _, item in
         item.isSelected.toggle()
     }
 
-    func handleTapped() {
-        itemTappedHandler(self)
+    func handleTapped(_ sender: CommandBarButton) {
+        itemTappedHandler(sender, self)
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking changes from #495 and #500 into the main_0.1 branch.

### Verification

Sanity check by building and running the iOS Demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/502)