### PR TITLE
Adding conditional modifier for SwiftUI views.

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		536AEF7525F1ECA800A36206 /* ButtonLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536AEF7325F1ECA800A36206 /* ButtonLegacy.swift */; };
 		537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537315B225438B15001FD14C /* iOS13_4_compatibility.swift */; };
 		53BCB0CE253A4E8D00620960 /* Obscurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0CD253A4E8C00620960 /* Obscurable.swift */; };
+		53C61F8D2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C61F8C2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift */; };
+		53C61F8E2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C61F8C2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift */; };
 		7D0931C324AAAC9B0072458A /* SideTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0931C224AAAC8C0072458A /* SideTabBar.swift */; };
 		7D23482724D88DE600FBE057 /* AvatarGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D23482624D88DDF00FBE057 /* AvatarGroupView.swift */; };
 		7DC2FB2824C0ED1600367A55 /* TableViewCellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2FB2724C0ED1100367A55 /* TableViewCellFileAccessoryView.swift */; };
@@ -397,6 +399,7 @@
 		536AEF7325F1ECA800A36206 /* ButtonLegacy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonLegacy.swift; sourceTree = "<group>"; };
 		537315B225438B15001FD14C /* iOS13_4_compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iOS13_4_compatibility.swift; sourceTree = "<group>"; };
 		53BCB0CD253A4E8C00620960 /* Obscurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Obscurable.swift; sourceTree = "<group>"; };
+		53C61F8C2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftUI+ViewModifiers.swift"; sourceTree = "<group>"; };
 		53FC90C02567300A008A06FD /* FluentUI_common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FluentUI_common.xcconfig; sourceTree = "<group>"; };
 		53FC90F525673626008A06FD /* FluentUI_release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FluentUI_release.xcconfig; sourceTree = "<group>"; };
 		53FC90F625673626008A06FD /* FluentUI_debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FluentUI_debug.xcconfig; sourceTree = "<group>"; };
@@ -798,10 +801,11 @@
 		536AEF2925F1EC0300A36206 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				536AEF2A25F1EC0300A36206 /* FluentUIStyle.generated.swift */,
-				536AEF2B25F1EC0300A36206 /* UIKit+SwiftUI_interoperability.swift */,
-				536AEF2C25F1EC0300A36206 /* Theming.swift */,
 				536AEF2D25F1EC0300A36206 /* AnimationCompletionModifier.swift */,
+				536AEF2A25F1EC0300A36206 /* FluentUIStyle.generated.swift */,
+				53C61F8C2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift */,
+				536AEF2C25F1EC0300A36206 /* Theming.swift */,
+				536AEF2B25F1EC0300A36206 /* UIKit+SwiftUI_interoperability.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1511,6 +1515,7 @@
 				5314E1A725F01A7C0099271A /* ActionsCell.swift in Sources */,
 				5314E07B25F00F1A0099271A /* DateTimePickerViewDataSource.swift in Sources */,
 				5314E15725F016DB0099271A /* ScrollView.swift in Sources */,
+				53C61F8E2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift in Sources */,
 				5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */,
 				5314E11D25F015EA0099271A /* AvatarGroupView.swift in Sources */,
 				5314E06B25F00F100099271A /* DateTimePicker.swift in Sources */,
@@ -1677,6 +1682,7 @@
 				FDFB8AF321361C9D0046850A /* CalendarViewDayMonthYearCell.swift in Sources */,
 				A5961F9D218A254D00E2A506 /* PopupMenuController.swift in Sources */,
 				FD56FD92219123FE0023C7EA /* DateTimePickerViewComponentTableView.swift in Sources */,
+				53C61F8D2624E20C0079FAA8 /* SwiftUI+ViewModifiers.swift in Sources */,
 				B4E782C521793BB900A7DFCE /* ActivityIndicatorView.swift in Sources */,
 				A52648DC2316F4F9003342A0 /* BarButtonItems.swift in Sources */,
 				FD5BBE41214C6AF3008964B4 /* TwoLineTitleView.swift in Sources */,

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -311,16 +311,16 @@ public struct AvatarView: View {
     @objc public init(style: MSFAvatarStyle = .default,
                       size: MSFAvatarSize = .large,
                       theme: FluentUIStyle? = nil) {
-        self.avatarview = AvatarView(style: style,
+        avatarview = AvatarView(style: style,
                                            size: size)
-        self.hostingController = UIHostingController(rootView: AnyView(avatarview.modifyIf(theme != nil, { avatarview in
+        hostingController = UIHostingController(rootView: AnyView(avatarview.modifyIf(theme != nil, { avatarview in
             avatarview.usingTheme(theme!)
         })))
 
         super.init()
 
         avatarview.tokens.windowProvider = self
-        self.view.backgroundColor = UIColor.clear
+        view.backgroundColor = UIColor.clear
     }
 
     var window: UIWindow? {

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -135,9 +135,11 @@ public struct MSFButtonView: View {
         style: style,
         size: size)
 
-        self.hostingController = UIHostingController(rootView: theme != nil ? AnyView(buttonView.usingTheme(theme!)) : AnyView(buttonView))
+        hostingController = UIHostingController(rootView: AnyView(buttonView.modifyIf(theme != nil, { buttonView in
+            buttonView.usingTheme(theme!)
+        })))
         buttonView.tokens.windowProvider = self
-        self.view.backgroundColor = UIColor.clear
+        view.backgroundColor = UIColor.clear
     }
 
     var window: UIWindow? {

--- a/ios/FluentUI/Vnext/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Vnext/Core/SwiftUI+ViewModifiers.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+extension View {
+    /// Applies modifiers defined in a closure if a condition is met.
+    /// - Parameters:
+    ///   - condition: Condition that need to be met so that the closure is applied to the View.
+    ///   - modifications: Closure that outlines the modifiers that will be applied to the View should the condition evaluate to true.
+    /// - Returns: The resulting View either with the modifications applied (if condition is true) or in its original state (if condition is false).
+    @ViewBuilder
+    func modifyIf<Content: View>(_ condition: Bool,
+                                 _ modifications: (Self) -> Content) -> some View {
+        if condition {
+            modifications(self)
+        } else {
+            self
+        }
+    }
+}

--- a/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
+++ b/ios/FluentUI/Vnext/Drawer/Drawer+UIKit.swift
@@ -31,7 +31,9 @@ open class MSFDrawer: UIHostingController<AnyView>, FluentUIWindowProvider {
                       theme: FluentUIStyle? = nil) {
         let drawer = MSFDrawerView(content: UIViewControllerAdapter(contentViewController))
         self.drawer = drawer
-        super.init(rootView: theme != nil ? AnyView(drawer.usingTheme(theme!)) : AnyView(drawer))
+        super.init(rootView: AnyView(drawer.modifyIf(theme != nil, { drawer in
+            drawer.usingTheme(theme!)
+        })))
 
         drawer.tokens.windowProvider = self
         view.backgroundColor = .clear

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -86,7 +86,9 @@ public struct MSFListView: View {
     @objc public init(sections: [MSFListSectionState],
                       theme: FluentUIStyle? = nil) {
         listView = MSFListView(sections: sections)
-        hostingController = UIHostingController(rootView: theme != nil ? AnyView(listView.usingTheme(theme!)) : AnyView(listView))
+        hostingController = UIHostingController(rootView: AnyView(listView.modifyIf(theme != nil, { listView in
+            listView.usingTheme(theme!)
+        })))
 
         super.init()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We often find scenarios where we only want to apply a modifier if a certain condition is met.
In those cases we need to try to create a neutral fallback that would not affect the View visually but yet returns a valid visual result.
EmptyView() or clear transparent colors are usually the workaround for these scenarios.

This change introduces a custom SwiftUI modifier that applies a @ViewBuilder closure with modifiers only if a Bool parameter evaluates to true.

The Avatar implementation was changed to use it so it does not apply the presence modifiers in case the presence is set to .none.

### Verification

Built and ran the Demo app to ensure that all the visuals and behavior of the Avatar remain intact.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/515)