### PR TITLE
Date/Time Picker: Fix hour and minute accessibility values

### DIFF
--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewDataSource.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewDataSource.swift
@@ -381,7 +381,7 @@ private class DateTimePickerViewHourDataSource: DateTimePickerViewDataSource {
     }
 
     func accessibilityValue(forRowAtIndex index: Int) -> String? {
-        guard let item = itemStringRepresentation(forRowAtIndex: index) else {
+        guard let item = item(forRowAtIndex: index) as? Int else {
             assertionFailure("accessibilityValue > item not found")
             return nil
         }
@@ -445,7 +445,7 @@ private class DateTimePickerViewMinuteDataSource: DateTimePickerViewDataSource {
         }
 
         let translation = "Accessibility.DateTime.Minute.Value".localized
-        return String(format: translation, arguments: ["\(item)"])
+        return String(format: translation, arguments: [item])
     }
 
     func accessibilityLabel() -> String? {

--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>الساعة %d</string>
-        <key>one</key>
-        <string>الساعة %d</string>
-        <key>two</key>
-        <string>الساعة %d</string>
-        <key>few</key>
-        <string>الساعة %d</string>
-        <key>many</key>
-        <string>الساعة %d</string>
-        <key>other</key>
-        <string>الساعة %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d من الدقائق</string>
-        <key>one</key>
-        <string>%d من الدقائق</string>
-        <key>two</key>
-        <string>دقيقتان %d</string>
-        <key>few</key>
-        <string>%d دقائق</string>
-        <key>many</key>
-        <string>%d دقيقة</string>
-        <key>other</key>
-        <string>%d من الدقائق</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d من النتائج التي تم العثور عليها من الدليل</string>
-        <key>one</key>
-        <string>%d من النتائج تم العثور عليها من الدليل</string>
-        <key>two</key>
-        <string>نتيجتان %d من النتائج التي تم العثور عليها من الدليل</string>
-        <key>few</key>
-        <string>%d نتائج من النتائج التي تم العثور عليها من الدليل</string>
-        <key>many</key>
-        <string>%d نتيجة من النتائج التي تم العثور عليها من الدليل</string>
-        <key>other</key>
-        <string>%d من النتائج التي تم العثور عليها من الدليل</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>الساعة %d</string>
+			<key>one</key>
+			<string>الساعة %d</string>
+			<key>two</key>
+			<string>الساعة %d</string>
+			<key>few</key>
+			<string>الساعة %d</string>
+			<key>many</key>
+			<string>الساعة %d</string>
+			<key>other</key>
+			<string>الساعة %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d من الدقائق</string>
+			<key>one</key>
+			<string>%d من الدقائق</string>
+			<key>two</key>
+			<string>دقيقتان %d</string>
+			<key>few</key>
+			<string>%d دقائق</string>
+			<key>many</key>
+			<string>%d دقيقة</string>
+			<key>other</key>
+			<string>%d من الدقائق</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d من النتائج التي تم العثور عليها من الدليل</string>
+			<key>one</key>
+			<string>%d من النتائج تم العثور عليها من الدليل</string>
+			<key>two</key>
+			<string>نتيجتان %d من النتائج التي تم العثور عليها من الدليل</string>
+			<key>few</key>
+			<string>%d نتائج من النتائج التي تم العثور عليها من الدليل</string>
+			<key>many</key>
+			<string>%d نتيجة من النتائج التي تم العثور عليها من الدليل</string>
+			<key>other</key>
+			<string>%d من النتائج التي تم العثور عليها من الدليل</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d en punt</string>
-        <key>one</key>
-        <string>%d en punt</string>
-        <key>two</key>
-        <string>%d en punt</string>
-        <key>few</key>
-        <string>%d en punt</string>
-        <key>many</key>
-        <string>%d en punt</string>
-        <key>other</key>
-        <string>%d en punt</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minuts</string>
-        <key>one</key>
-        <string>%d minut</string>
-        <key>two</key>
-        <string>%d minuts</string>
-        <key>few</key>
-        <string>%d minuts</string>
-        <key>many</key>
-        <string>%d minuts</string>
-        <key>other</key>
-        <string>%d minuts</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d resultats al directori</string>
-        <key>one</key>
-        <string>%d resultat trobat al directori</string>
-        <key>two</key>
-        <string>%d resultats al directori</string>
-        <key>few</key>
-        <string>%d resultats al directori</string>
-        <key>many</key>
-        <string>%d resultats al directori</string>
-        <key>other</key>
-        <string>%d resultats al directori</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d en punt</string>
+			<key>one</key>
+			<string>%d en punt</string>
+			<key>two</key>
+			<string>%d en punt</string>
+			<key>few</key>
+			<string>%d en punt</string>
+			<key>many</key>
+			<string>%d en punt</string>
+			<key>other</key>
+			<string>%d en punt</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minuts</string>
+			<key>one</key>
+			<string>%d minut</string>
+			<key>two</key>
+			<string>%d minuts</string>
+			<key>few</key>
+			<string>%d minuts</string>
+			<key>many</key>
+			<string>%d minuts</string>
+			<key>other</key>
+			<string>%d minuts</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d resultats al directori</string>
+			<key>one</key>
+			<string>%d resultat trobat al directori</string>
+			<key>two</key>
+			<string>%d resultats al directori</string>
+			<key>few</key>
+			<string>%d resultats al directori</string>
+			<key>many</key>
+			<string>%d resultats al directori</string>
+			<key>other</key>
+			<string>%d resultats al directori</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d h</string>
-        <key>one</key>
-        <string>%d h</string>
-        <key>two</key>
-        <string>%d h</string>
-        <key>few</key>
-        <string>%d h</string>
-        <key>many</key>
-        <string>%d h</string>
-        <key>other</key>
-        <string>%d h</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d min</string>
-        <key>one</key>
-        <string>%d min</string>
-        <key>two</key>
-        <string>%d min</string>
-        <key>few</key>
-        <string>%d min</string>
-        <key>many</key>
-        <string>%d min</string>
-        <key>other</key>
-        <string>%d min</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>V adresáři se našlo %d výsledků.</string>
-        <key>one</key>
-        <string>V adresáři se našel %d výsledek.</string>
-        <key>two</key>
-        <string>V adresáři se našly %d výsledky.</string>
-        <key>few</key>
-        <string>V adresáři se našly %d výsledky.</string>
-        <key>many</key>
-        <string>V adresáři se našlo %d výsledků.</string>
-        <key>other</key>
-        <string>V adresáři se našel tento počet výsledků: %d.</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d h</string>
+			<key>one</key>
+			<string>%d h</string>
+			<key>two</key>
+			<string>%d h</string>
+			<key>few</key>
+			<string>%d h</string>
+			<key>many</key>
+			<string>%d h</string>
+			<key>other</key>
+			<string>%d h</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d min</string>
+			<key>one</key>
+			<string>%d min</string>
+			<key>two</key>
+			<string>%d min</string>
+			<key>few</key>
+			<string>%d min</string>
+			<key>many</key>
+			<string>%d min</string>
+			<key>other</key>
+			<string>%d min</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>V adresáři se našlo %d výsledků.</string>
+			<key>one</key>
+			<string>V adresáři se našel %d výsledek.</string>
+			<key>two</key>
+			<string>V adresáři se našly %d výsledky.</string>
+			<key>few</key>
+			<string>V adresáři se našly %d výsledky.</string>
+			<key>many</key>
+			<string>V adresáři se našlo %d výsledků.</string>
+			<key>other</key>
+			<string>V adresáři se našel tento počet výsledků: %d.</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Klokken %d</string>
-        <key>one</key>
-        <string>Klokken %d</string>
-        <key>two</key>
-        <string>Klokken %d</string>
-        <key>few</key>
-        <string>Klokken %d</string>
-        <key>many</key>
-        <string>Klokken %d</string>
-        <key>other</key>
-        <string>Klokken %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutter</string>
-        <key>one</key>
-        <string>%d minut</string>
-        <key>two</key>
-        <string>%d minutter</string>
-        <key>few</key>
-        <string>%d minutter</string>
-        <key>many</key>
-        <string>%d minutter</string>
-        <key>other</key>
-        <string>%d minutter</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Der blev fundet %d resultater fra mappen</string>
-        <key>one</key>
-        <string>%d resultat blev fundet fra mappen</string>
-        <key>two</key>
-        <string>Der blev fundet %d resultater fra mappen</string>
-        <key>few</key>
-        <string>Der blev fundet %d resultater fra mappen</string>
-        <key>many</key>
-        <string>Der blev fundet %d resultater fra mappen</string>
-        <key>other</key>
-        <string>Der blev fundet %d resultater fra mappen</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Klokken %d</string>
+			<key>one</key>
+			<string>Klokken %d</string>
+			<key>two</key>
+			<string>Klokken %d</string>
+			<key>few</key>
+			<string>Klokken %d</string>
+			<key>many</key>
+			<string>Klokken %d</string>
+			<key>other</key>
+			<string>Klokken %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutter</string>
+			<key>one</key>
+			<string>%d minut</string>
+			<key>two</key>
+			<string>%d minutter</string>
+			<key>few</key>
+			<string>%d minutter</string>
+			<key>many</key>
+			<string>%d minutter</string>
+			<key>other</key>
+			<string>%d minutter</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Der blev fundet %d resultater fra mappen</string>
+			<key>one</key>
+			<string>%d resultat blev fundet fra mappen</string>
+			<key>two</key>
+			<string>Der blev fundet %d resultater fra mappen</string>
+			<key>few</key>
+			<string>Der blev fundet %d resultater fra mappen</string>
+			<key>many</key>
+			<string>Der blev fundet %d resultater fra mappen</string>
+			<key>other</key>
+			<string>Der blev fundet %d resultater fra mappen</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d Uhr</string>
-        <key>one</key>
-        <string>%d Uhr</string>
-        <key>two</key>
-        <string>%d Uhr</string>
-        <key>few</key>
-        <string>%d Uhr</string>
-        <key>many</key>
-        <string>%d Uhr</string>
-        <key>other</key>
-        <string>%d Uhr</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d Minuten</string>
-        <key>one</key>
-        <string>%d Minute</string>
-        <key>two</key>
-        <string>%d Minuten</string>
-        <key>few</key>
-        <string>%d Minuten</string>
-        <key>many</key>
-        <string>%d Minuten</string>
-        <key>other</key>
-        <string>%d Minuten</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d Ergebnisse im Verzeichnis gefunden.</string>
-        <key>one</key>
-        <string>%d Ergebnis im Verzeichnis gefunden.</string>
-        <key>two</key>
-        <string>%d Ergebnisse im Verzeichnis gefunden.</string>
-        <key>few</key>
-        <string>%d Ergebnisse im Verzeichnis gefunden.</string>
-        <key>many</key>
-        <string>%d Ergebnisse im Verzeichnis gefunden.</string>
-        <key>other</key>
-        <string>%d Ergebnisse im Verzeichnis gefunden.</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d Uhr</string>
+			<key>one</key>
+			<string>%d Uhr</string>
+			<key>two</key>
+			<string>%d Uhr</string>
+			<key>few</key>
+			<string>%d Uhr</string>
+			<key>many</key>
+			<string>%d Uhr</string>
+			<key>other</key>
+			<string>%d Uhr</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d Minuten</string>
+			<key>one</key>
+			<string>%d Minute</string>
+			<key>two</key>
+			<string>%d Minuten</string>
+			<key>few</key>
+			<string>%d Minuten</string>
+			<key>many</key>
+			<string>%d Minuten</string>
+			<key>other</key>
+			<string>%d Minuten</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d Ergebnisse im Verzeichnis gefunden.</string>
+			<key>one</key>
+			<string>%d Ergebnis im Verzeichnis gefunden.</string>
+			<key>two</key>
+			<string>%d Ergebnisse im Verzeichnis gefunden.</string>
+			<key>few</key>
+			<string>%d Ergebnisse im Verzeichnis gefunden.</string>
+			<key>many</key>
+			<string>%d Ergebnisse im Verzeichnis gefunden.</string>
+			<key>other</key>
+			<string>%d Ergebnisse im Verzeichnis gefunden.</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d η ώρα</string>
-        <key>one</key>
-        <string>%d η ώρα</string>
-        <key>two</key>
-        <string>%d η ώρα</string>
-        <key>few</key>
-        <string>%d η ώρα</string>
-        <key>many</key>
-        <string>%d η ώρα</string>
-        <key>other</key>
-        <string>%d η ώρα</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d λεπτά</string>
-        <key>one</key>
-        <string>%d λεπτό</string>
-        <key>two</key>
-        <string>%d λεπτά</string>
-        <key>few</key>
-        <string>%d λεπτά</string>
-        <key>many</key>
-        <string>%d λεπτά</string>
-        <key>other</key>
-        <string>%d λεπτά</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
-        <key>one</key>
-        <string>%d αποτέλεσμα εντοπίστηκε από τον κατάλογο</string>
-        <key>two</key>
-        <string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
-        <key>few</key>
-        <string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
-        <key>many</key>
-        <string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
-        <key>other</key>
-        <string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d η ώρα</string>
+			<key>one</key>
+			<string>%d η ώρα</string>
+			<key>two</key>
+			<string>%d η ώρα</string>
+			<key>few</key>
+			<string>%d η ώρα</string>
+			<key>many</key>
+			<string>%d η ώρα</string>
+			<key>other</key>
+			<string>%d η ώρα</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d λεπτά</string>
+			<key>one</key>
+			<string>%d λεπτό</string>
+			<key>two</key>
+			<string>%d λεπτά</string>
+			<key>few</key>
+			<string>%d λεπτά</string>
+			<key>many</key>
+			<string>%d λεπτά</string>
+			<key>other</key>
+			<string>%d λεπτά</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
+			<key>one</key>
+			<string>%d αποτέλεσμα εντοπίστηκε από τον κατάλογο</string>
+			<key>two</key>
+			<string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
+			<key>few</key>
+			<string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
+			<key>many</key>
+			<string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
+			<key>other</key>
+			<string>%d αποτελέσματα εντοπίστηκαν από τον κατάλογο</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d o'clock</string>
-        <key>one</key>
-        <string>%d o'clock</string>
-        <key>two</key>
-        <string>%d o'clock</string>
-        <key>few</key>
-        <string>%d o'clock</string>
-        <key>many</key>
-        <string>%d o'clock</string>
-        <key>other</key>
-        <string>%d o'clock</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutes</string>
-        <key>one</key>
-        <string>%d minute</string>
-        <key>two</key>
-        <string>%d minutes</string>
-        <key>few</key>
-        <string>%d minutes</string>
-        <key>many</key>
-        <string>%d minutes</string>
-        <key>other</key>
-        <string>%d minutes</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d results found from directory</string>
-        <key>one</key>
-        <string>%d result found from directory</string>
-        <key>two</key>
-        <string>%d results found from directory</string>
-        <key>few</key>
-        <string>%d results found from directory</string>
-        <key>many</key>
-        <string>%d results found from directory</string>
-        <key>other</key>
-        <string>%d results found from directory</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d o&apos;clock</string>
+			<key>one</key>
+			<string>%d o&apos;clock</string>
+			<key>two</key>
+			<string>%d o&apos;clock</string>
+			<key>few</key>
+			<string>%d o&apos;clock</string>
+			<key>many</key>
+			<string>%d o&apos;clock</string>
+			<key>other</key>
+			<string>%d o&apos;clock</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutes</string>
+			<key>one</key>
+			<string>%d minute</string>
+			<key>two</key>
+			<string>%d minutes</string>
+			<key>few</key>
+			<string>%d minutes</string>
+			<key>many</key>
+			<string>%d minutes</string>
+			<key>other</key>
+			<string>%d minutes</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d results found from directory</string>
+			<key>one</key>
+			<string>%d result found from directory</string>
+			<key>two</key>
+			<string>%d results found from directory</string>
+			<key>few</key>
+			<string>%d results found from directory</string>
+			<key>many</key>
+			<string>%d results found from directory</string>
+			<key>other</key>
+			<string>%d results found from directory</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.stringsdict
@@ -6,7 +6,7 @@
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
 		<string>%#@hours@</string>
-		<key>Variable</key>
+		<key>hours</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d en punto</string>
-        <key>one</key>
-        <string>%d en punto</string>
-        <key>two</key>
-        <string>%d en punto</string>
-        <key>few</key>
-        <string>%d en punto</string>
-        <key>many</key>
-        <string>%d en punto</string>
-        <key>other</key>
-        <string>%d en punto</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutos</string>
-        <key>one</key>
-        <string>%d minuto</string>
-        <key>two</key>
-        <string>%d minutos</string>
-        <key>few</key>
-        <string>%d minutos</string>
-        <key>many</key>
-        <string>%d minutos</string>
-        <key>other</key>
-        <string>%d minutos</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Se encontraron %d resultados en el directorio</string>
-        <key>one</key>
-        <string>Se encontró %d resultado en el directorio</string>
-        <key>two</key>
-        <string>Se encontraron %d resultados en el directorio</string>
-        <key>few</key>
-        <string>Se encontraron %d resultados en el directorio</string>
-        <key>many</key>
-        <string>Se encontraron %d resultados en el directorio</string>
-        <key>other</key>
-        <string>Se encontraron %d resultados en el directorio</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d en punto</string>
+			<key>one</key>
+			<string>%d en punto</string>
+			<key>two</key>
+			<string>%d en punto</string>
+			<key>few</key>
+			<string>%d en punto</string>
+			<key>many</key>
+			<string>%d en punto</string>
+			<key>other</key>
+			<string>%d en punto</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutos</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>two</key>
+			<string>%d minutos</string>
+			<key>few</key>
+			<string>%d minutos</string>
+			<key>many</key>
+			<string>%d minutos</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Se encontraron %d resultados en el directorio</string>
+			<key>one</key>
+			<string>Se encontró %d resultado en el directorio</string>
+			<key>two</key>
+			<string>Se encontraron %d resultados en el directorio</string>
+			<key>few</key>
+			<string>Se encontraron %d resultados en el directorio</string>
+			<key>many</key>
+			<string>Se encontraron %d resultados en el directorio</string>
+			<key>other</key>
+			<string>Se encontraron %d resultados en el directorio</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d en punto</string>
-        <key>one</key>
-        <string>%d en punto</string>
-        <key>two</key>
-        <string>%d en punto</string>
-        <key>few</key>
-        <string>%d en punto</string>
-        <key>many</key>
-        <string>%d en punto</string>
-        <key>other</key>
-        <string>%d en punto</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutos</string>
-        <key>one</key>
-        <string>%d minuto</string>
-        <key>two</key>
-        <string>%d minutos</string>
-        <key>few</key>
-        <string>%d minutos</string>
-        <key>many</key>
-        <string>%d minutos</string>
-        <key>other</key>
-        <string>%d minutos</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Se han encontrado %d resultados en el directorio</string>
-        <key>one</key>
-        <string>%d resultado encontrado en el directorio</string>
-        <key>two</key>
-        <string>Se han encontrado %d resultados en el directorio</string>
-        <key>few</key>
-        <string>Se han encontrado %d resultados en el directorio</string>
-        <key>many</key>
-        <string>Se han encontrado %d resultados en el directorio</string>
-        <key>other</key>
-        <string>Se han encontrado %d resultados en el directorio</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d en punto</string>
+			<key>one</key>
+			<string>%d en punto</string>
+			<key>two</key>
+			<string>%d en punto</string>
+			<key>few</key>
+			<string>%d en punto</string>
+			<key>many</key>
+			<string>%d en punto</string>
+			<key>other</key>
+			<string>%d en punto</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutos</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>two</key>
+			<string>%d minutos</string>
+			<key>few</key>
+			<string>%d minutos</string>
+			<key>many</key>
+			<string>%d minutos</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Se han encontrado %d resultados en el directorio</string>
+			<key>one</key>
+			<string>%d resultado encontrado en el directorio</string>
+			<key>two</key>
+			<string>Se han encontrado %d resultados en el directorio</string>
+			<key>few</key>
+			<string>Se han encontrado %d resultados en el directorio</string>
+			<key>many</key>
+			<string>Se han encontrado %d resultados en el directorio</string>
+			<key>other</key>
+			<string>Se han encontrado %d resultados en el directorio</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Kello %d</string>
-        <key>one</key>
-        <string>Kello %d</string>
-        <key>two</key>
-        <string>Kello %d</string>
-        <key>few</key>
-        <string>Kello %d</string>
-        <key>many</key>
-        <string>Kello %d</string>
-        <key>other</key>
-        <string>Kello %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minuuttia</string>
-        <key>one</key>
-        <string>%d minuutti</string>
-        <key>two</key>
-        <string>%d minuuttia</string>
-        <key>few</key>
-        <string>%d minuuttia</string>
-        <key>many</key>
-        <string>%d minuuttia</string>
-        <key>other</key>
-        <string>%d minuuttia</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d tulosta löytyi hakemistosta</string>
-        <key>one</key>
-        <string>%d tulos löytyi hakemistosta</string>
-        <key>two</key>
-        <string>%d tulosta löytyi hakemistosta</string>
-        <key>few</key>
-        <string>%d tulosta löytyi hakemistosta</string>
-        <key>many</key>
-        <string>%d tulosta löytyi hakemistosta</string>
-        <key>other</key>
-        <string>%d tulosta löytyi hakemistosta</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Kello %d</string>
+			<key>one</key>
+			<string>Kello %d</string>
+			<key>two</key>
+			<string>Kello %d</string>
+			<key>few</key>
+			<string>Kello %d</string>
+			<key>many</key>
+			<string>Kello %d</string>
+			<key>other</key>
+			<string>Kello %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minuuttia</string>
+			<key>one</key>
+			<string>%d minuutti</string>
+			<key>two</key>
+			<string>%d minuuttia</string>
+			<key>few</key>
+			<string>%d minuuttia</string>
+			<key>many</key>
+			<string>%d minuuttia</string>
+			<key>other</key>
+			<string>%d minuuttia</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d tulosta löytyi hakemistosta</string>
+			<key>one</key>
+			<string>%d tulos löytyi hakemistosta</string>
+			<key>two</key>
+			<string>%d tulosta löytyi hakemistosta</string>
+			<key>few</key>
+			<string>%d tulosta löytyi hakemistosta</string>
+			<key>many</key>
+			<string>%d tulosta löytyi hakemistosta</string>
+			<key>other</key>
+			<string>%d tulosta löytyi hakemistosta</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d heures</string>
-        <key>one</key>
-        <string>%d heures</string>
-        <key>two</key>
-        <string>%d heures</string>
-        <key>few</key>
-        <string>%d heures</string>
-        <key>many</key>
-        <string>%d heures</string>
-        <key>other</key>
-        <string>%d heures</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutes</string>
-        <key>one</key>
-        <string>%d minute</string>
-        <key>two</key>
-        <string>%d minutes</string>
-        <key>few</key>
-        <string>%d minutes</string>
-        <key>many</key>
-        <string>%d minutes</string>
-        <key>other</key>
-        <string>%d minutes</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Nous avons trouvé %d résultats dans l’annuaire</string>
-        <key>one</key>
-        <string>Nous avons trouvé %d résultat dans l’annuaire</string>
-        <key>two</key>
-        <string>Nous avons trouvé %d résultats dans l’annuaire</string>
-        <key>few</key>
-        <string>Nous avons trouvé %d résultats dans l’annuaire</string>
-        <key>many</key>
-        <string>Nous avons trouvé %d résultats dans l’annuaire</string>
-        <key>other</key>
-        <string>Nous avons trouvé %d résultats dans l’annuaire</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d heures</string>
+			<key>one</key>
+			<string>%d heures</string>
+			<key>two</key>
+			<string>%d heures</string>
+			<key>few</key>
+			<string>%d heures</string>
+			<key>many</key>
+			<string>%d heures</string>
+			<key>other</key>
+			<string>%d heures</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutes</string>
+			<key>one</key>
+			<string>%d minute</string>
+			<key>two</key>
+			<string>%d minutes</string>
+			<key>few</key>
+			<string>%d minutes</string>
+			<key>many</key>
+			<string>%d minutes</string>
+			<key>other</key>
+			<string>%d minutes</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Nous avons trouvé %d résultats dans l’annuaire</string>
+			<key>one</key>
+			<string>Nous avons trouvé %d résultat dans l’annuaire</string>
+			<key>two</key>
+			<string>Nous avons trouvé %d résultats dans l’annuaire</string>
+			<key>few</key>
+			<string>Nous avons trouvé %d résultats dans l’annuaire</string>
+			<key>many</key>
+			<string>Nous avons trouvé %d résultats dans l’annuaire</string>
+			<key>other</key>
+			<string>Nous avons trouvé %d résultats dans l’annuaire</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>השעה %d</string>
-        <key>one</key>
-        <string>השעה %d</string>
-        <key>two</key>
-        <string>השעה %d</string>
-        <key>few</key>
-        <string>השעה %d</string>
-        <key>many</key>
-        <string>השעה %d</string>
-        <key>other</key>
-        <string>השעה %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d דקות</string>
-        <key>one</key>
-        <string>דקה %d</string>
-        <key>two</key>
-        <string>%d דקות</string>
-        <key>few</key>
-        <string>%d דקות</string>
-        <key>many</key>
-        <string>%d דקות</string>
-        <key>other</key>
-        <string>%d דקות</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>נמצאו %d תוצאות במדריך הכתובות</string>
-        <key>one</key>
-        <string>נמצאה תוצאה %d במדריך הכתובות</string>
-        <key>two</key>
-        <string>נמצאו %d תוצאות במדריך הכתובות</string>
-        <key>few</key>
-        <string>נמצאו %d תוצאות במדריך הכתובות</string>
-        <key>many</key>
-        <string>נמצאו %d תוצאות במדריך הכתובות</string>
-        <key>other</key>
-        <string>נמצאו %d תוצאות במדריך הכתובות</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>השעה %d</string>
+			<key>one</key>
+			<string>השעה %d</string>
+			<key>two</key>
+			<string>השעה %d</string>
+			<key>few</key>
+			<string>השעה %d</string>
+			<key>many</key>
+			<string>השעה %d</string>
+			<key>other</key>
+			<string>השעה %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d דקות</string>
+			<key>one</key>
+			<string>דקה %d</string>
+			<key>two</key>
+			<string>%d דקות</string>
+			<key>few</key>
+			<string>%d דקות</string>
+			<key>many</key>
+			<string>%d דקות</string>
+			<key>other</key>
+			<string>%d דקות</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>נמצאו %d תוצאות במדריך הכתובות</string>
+			<key>one</key>
+			<string>נמצאה תוצאה %d במדריך הכתובות</string>
+			<key>two</key>
+			<string>נמצאו %d תוצאות במדריך הכתובות</string>
+			<key>few</key>
+			<string>נמצאו %d תוצאות במדריך הכתובות</string>
+			<key>many</key>
+			<string>נמצאו %d תוצאות במדריך הכתובות</string>
+			<key>other</key>
+			<string>נמצאו %d תוצאות במדריך הכתובות</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d o'clock</string>
-        <key>one</key>
-        <string>%d o'clock</string>
-        <key>two</key>
-        <string>%d o'clock</string>
-        <key>few</key>
-        <string>%d o'clock</string>
-        <key>many</key>
-        <string>%d o'clock</string>
-        <key>other</key>
-        <string>%d o'clock</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d मिनट</string>
-        <key>one</key>
-        <string>%d मिनट</string>
-        <key>two</key>
-        <string>%d मिनट</string>
-        <key>few</key>
-        <string>%d मिनट</string>
-        <key>many</key>
-        <string>%d मिनट</string>
-        <key>other</key>
-        <string>%d मिनट</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d डायरेक्टरी से प्राप्त परिणाम</string>
-        <key>one</key>
-        <string>%d डायरेक्टरी से प्राप्त परिणाम</string>
-        <key>two</key>
-        <string>%d डायरेक्टरी से प्राप्त परिणाम</string>
-        <key>few</key>
-        <string>%d डायरेक्टरी से प्राप्त परिणाम</string>
-        <key>many</key>
-        <string>%d डायरेक्टरी से प्राप्त परिणाम</string>
-        <key>other</key>
-        <string>%d डायरेक्टरी से प्राप्त परिणाम</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d o&apos;clock</string>
+			<key>one</key>
+			<string>%d o&apos;clock</string>
+			<key>two</key>
+			<string>%d o&apos;clock</string>
+			<key>few</key>
+			<string>%d o&apos;clock</string>
+			<key>many</key>
+			<string>%d o&apos;clock</string>
+			<key>other</key>
+			<string>%d o&apos;clock</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d मिनट</string>
+			<key>one</key>
+			<string>%d मिनट</string>
+			<key>two</key>
+			<string>%d मिनट</string>
+			<key>few</key>
+			<string>%d मिनट</string>
+			<key>many</key>
+			<string>%d मिनट</string>
+			<key>other</key>
+			<string>%d मिनट</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d डायरेक्टरी से प्राप्त परिणाम</string>
+			<key>one</key>
+			<string>%d डायरेक्टरी से प्राप्त परिणाम</string>
+			<key>two</key>
+			<string>%d डायरेक्टरी से प्राप्त परिणाम</string>
+			<key>few</key>
+			<string>%d डायरेक्टरी से प्राप्त परिणाम</string>
+			<key>many</key>
+			<string>%d डायरेक्टरी से प्राप्त परिणाम</string>
+			<key>other</key>
+			<string>%d डायरेक्टरी से प्राप्त परिणाम</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d h</string>
-        <key>one</key>
-        <string>%d h</string>
-        <key>two</key>
-        <string>%d h</string>
-        <key>few</key>
-        <string>%d h</string>
-        <key>many</key>
-        <string>%d h</string>
-        <key>other</key>
-        <string>%d sati</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d min</string>
-        <key>one</key>
-        <string>%d min</string>
-        <key>two</key>
-        <string>%d min</string>
-        <key>few</key>
-        <string>%d min</string>
-        <key>many</key>
-        <string>%d min</string>
-        <key>other</key>
-        <string>%d min</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Broj rezultata pronađenih u direktoriju: %d</string>
-        <key>one</key>
-        <string>%d rezultat pronađen u direktoriju</string>
-        <key>two</key>
-        <string>Broj rezultata pronađenih u direktoriju: %d</string>
-        <key>few</key>
-        <string>Broj rezultata pronađenih u direktoriju: %d</string>
-        <key>many</key>
-        <string>Broj rezultata pronađenih u direktoriju: %d</string>
-        <key>other</key>
-        <string>Broj rezultata pronađenih u direktoriju: %d</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d h</string>
+			<key>one</key>
+			<string>%d h</string>
+			<key>two</key>
+			<string>%d h</string>
+			<key>few</key>
+			<string>%d h</string>
+			<key>many</key>
+			<string>%d h</string>
+			<key>other</key>
+			<string>%d sati</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d min</string>
+			<key>one</key>
+			<string>%d min</string>
+			<key>two</key>
+			<string>%d min</string>
+			<key>few</key>
+			<string>%d min</string>
+			<key>many</key>
+			<string>%d min</string>
+			<key>other</key>
+			<string>%d min</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Broj rezultata pronađenih u direktoriju: %d</string>
+			<key>one</key>
+			<string>%d rezultat pronađen u direktoriju</string>
+			<key>two</key>
+			<string>Broj rezultata pronađenih u direktoriju: %d</string>
+			<key>few</key>
+			<string>Broj rezultata pronađenih u direktoriju: %d</string>
+			<key>many</key>
+			<string>Broj rezultata pronađenih u direktoriju: %d</string>
+			<key>other</key>
+			<string>Broj rezultata pronađenih u direktoriju: %d</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d óra</string>
-        <key>one</key>
-        <string>%d óra</string>
-        <key>two</key>
-        <string>%d óra</string>
-        <key>few</key>
-        <string>%d óra</string>
-        <key>many</key>
-        <string>%d óra</string>
-        <key>other</key>
-        <string>%d óra</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d perc</string>
-        <key>one</key>
-        <string>%d perc</string>
-        <key>two</key>
-        <string>%d perc</string>
-        <key>few</key>
-        <string>%d perc</string>
-        <key>many</key>
-        <string>%d perc</string>
-        <key>other</key>
-        <string>%d perc</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d találat a címtárban</string>
-        <key>one</key>
-        <string>%d találat a címtárban</string>
-        <key>two</key>
-        <string>%d találat a címtárban</string>
-        <key>few</key>
-        <string>%d találat a címtárban</string>
-        <key>many</key>
-        <string>%d találat a címtárban</string>
-        <key>other</key>
-        <string>%d találat a címtárban</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d óra</string>
+			<key>one</key>
+			<string>%d óra</string>
+			<key>two</key>
+			<string>%d óra</string>
+			<key>few</key>
+			<string>%d óra</string>
+			<key>many</key>
+			<string>%d óra</string>
+			<key>other</key>
+			<string>%d óra</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d perc</string>
+			<key>one</key>
+			<string>%d perc</string>
+			<key>two</key>
+			<string>%d perc</string>
+			<key>few</key>
+			<string>%d perc</string>
+			<key>many</key>
+			<string>%d perc</string>
+			<key>other</key>
+			<string>%d perc</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d találat a címtárban</string>
+			<key>one</key>
+			<string>%d találat a címtárban</string>
+			<key>two</key>
+			<string>%d találat a címtárban</string>
+			<key>few</key>
+			<string>%d találat a címtárban</string>
+			<key>many</key>
+			<string>%d találat a címtárban</string>
+			<key>other</key>
+			<string>%d találat a címtárban</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>pukul %d</string>
-        <key>one</key>
-        <string>pukul %d</string>
-        <key>two</key>
-        <string>pukul %d</string>
-        <key>few</key>
-        <string>pukul %d</string>
-        <key>many</key>
-        <string>pukul %d</string>
-        <key>other</key>
-        <string>pukul %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d menit</string>
-        <key>one</key>
-        <string>%d menit</string>
-        <key>two</key>
-        <string>%d menit</string>
-        <key>few</key>
-        <string>%d menit</string>
-        <key>many</key>
-        <string>%d menit</string>
-        <key>other</key>
-        <string>%d menit</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d hasil ditemukan dari direktori</string>
-        <key>one</key>
-        <string>%d hasil ditemukan dari direktori</string>
-        <key>two</key>
-        <string>%d hasil ditemukan dari direktori</string>
-        <key>few</key>
-        <string>%d hasil ditemukan dari direktori</string>
-        <key>many</key>
-        <string>%d hasil ditemukan dari direktori</string>
-        <key>other</key>
-        <string>%d hasil ditemukan dari direktori</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>pukul %d</string>
+			<key>one</key>
+			<string>pukul %d</string>
+			<key>two</key>
+			<string>pukul %d</string>
+			<key>few</key>
+			<string>pukul %d</string>
+			<key>many</key>
+			<string>pukul %d</string>
+			<key>other</key>
+			<string>pukul %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d menit</string>
+			<key>one</key>
+			<string>%d menit</string>
+			<key>two</key>
+			<string>%d menit</string>
+			<key>few</key>
+			<string>%d menit</string>
+			<key>many</key>
+			<string>%d menit</string>
+			<key>other</key>
+			<string>%d menit</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d hasil ditemukan dari direktori</string>
+			<key>one</key>
+			<string>%d hasil ditemukan dari direktori</string>
+			<key>two</key>
+			<string>%d hasil ditemukan dari direktori</string>
+			<key>few</key>
+			<string>%d hasil ditemukan dari direktori</string>
+			<key>many</key>
+			<string>%d hasil ditemukan dari direktori</string>
+			<key>other</key>
+			<string>%d hasil ditemukan dari direktori</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d</string>
-        <key>one</key>
-        <string>%d</string>
-        <key>two</key>
-        <string>%d</string>
-        <key>few</key>
-        <string>%d</string>
-        <key>many</key>
-        <string>%d</string>
-        <key>other</key>
-        <string>%d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minuti</string>
-        <key>one</key>
-        <string>%d minuto</string>
-        <key>two</key>
-        <string>%d minuti</string>
-        <key>few</key>
-        <string>%d minuti</string>
-        <key>many</key>
-        <string>%d minuti</string>
-        <key>other</key>
-        <string>%d minuti</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Sono stati trovati %d risultati nella directory</string>
-        <key>one</key>
-        <string>È stato trovato %d risultato nella directory</string>
-        <key>two</key>
-        <string>Sono stati trovati %d risultati nella directory</string>
-        <key>few</key>
-        <string>Sono stati trovati %d risultati nella directory</string>
-        <key>many</key>
-        <string>Sono stati trovati %d risultati nella directory</string>
-        <key>other</key>
-        <string>Sono stati trovati %d risultati nella directory</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d</string>
+			<key>one</key>
+			<string>%d</string>
+			<key>two</key>
+			<string>%d</string>
+			<key>few</key>
+			<string>%d</string>
+			<key>many</key>
+			<string>%d</string>
+			<key>other</key>
+			<string>%d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minuti</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>two</key>
+			<string>%d minuti</string>
+			<key>few</key>
+			<string>%d minuti</string>
+			<key>many</key>
+			<string>%d minuti</string>
+			<key>other</key>
+			<string>%d minuti</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Sono stati trovati %d risultati nella directory</string>
+			<key>one</key>
+			<string>È stato trovato %d risultato nella directory</string>
+			<key>two</key>
+			<string>Sono stati trovati %d risultati nella directory</string>
+			<key>few</key>
+			<string>Sono stati trovati %d risultati nella directory</string>
+			<key>many</key>
+			<string>Sono stati trovati %d risultati nella directory</string>
+			<key>other</key>
+			<string>Sono stati trovati %d risultati nella directory</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 時</string>
-        <key>one</key>
-        <string>%d 時</string>
-        <key>two</key>
-        <string>%d 時</string>
-        <key>few</key>
-        <string>%d 時</string>
-        <key>many</key>
-        <string>%d 時</string>
-        <key>other</key>
-        <string>%d 時</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 分</string>
-        <key>one</key>
-        <string>%d 分</string>
-        <key>two</key>
-        <string>%d 分</string>
-        <key>few</key>
-        <string>%d 分</string>
-        <key>many</key>
-        <string>%d 分</string>
-        <key>other</key>
-        <string>%d 分</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 件の結果がディレクトリで見つかりました</string>
-        <key>one</key>
-        <string>%d 件の結果がディレクトリで見つかりました</string>
-        <key>two</key>
-        <string>%d 件の結果がディレクトリで見つかりました</string>
-        <key>few</key>
-        <string>%d 件の結果がディレクトリで見つかりました</string>
-        <key>many</key>
-        <string>%d 件の結果がディレクトリで見つかりました</string>
-        <key>other</key>
-        <string>%d 件の結果がディレクトリで見つかりました</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 時</string>
+			<key>one</key>
+			<string>%d 時</string>
+			<key>two</key>
+			<string>%d 時</string>
+			<key>few</key>
+			<string>%d 時</string>
+			<key>many</key>
+			<string>%d 時</string>
+			<key>other</key>
+			<string>%d 時</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 分</string>
+			<key>one</key>
+			<string>%d 分</string>
+			<key>two</key>
+			<string>%d 分</string>
+			<key>few</key>
+			<string>%d 分</string>
+			<key>many</key>
+			<string>%d 分</string>
+			<key>other</key>
+			<string>%d 分</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 件の結果がディレクトリで見つかりました</string>
+			<key>one</key>
+			<string>%d 件の結果がディレクトリで見つかりました</string>
+			<key>two</key>
+			<string>%d 件の結果がディレクトリで見つかりました</string>
+			<key>few</key>
+			<string>%d 件の結果がディレクトリで見つかりました</string>
+			<key>many</key>
+			<string>%d 件の結果がディレクトリで見つかりました</string>
+			<key>other</key>
+			<string>%d 件の結果がディレクトリで見つかりました</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d시</string>
-        <key>one</key>
-        <string>%d시</string>
-        <key>two</key>
-        <string>%d시</string>
-        <key>few</key>
-        <string>%d시</string>
-        <key>many</key>
-        <string>%d시</string>
-        <key>other</key>
-        <string>%d시</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d분</string>
-        <key>one</key>
-        <string>%d분</string>
-        <key>two</key>
-        <string>%d분</string>
-        <key>few</key>
-        <string>%d분</string>
-        <key>many</key>
-        <string>%d분</string>
-        <key>other</key>
-        <string>%d분</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>디렉터리에서 결과 %d개 발견됨</string>
-        <key>one</key>
-        <string>디렉터리에서 결과 %d개 발견됨</string>
-        <key>two</key>
-        <string>디렉터리에서 결과 %d개 발견됨</string>
-        <key>few</key>
-        <string>디렉터리에서 결과 %d개 발견됨</string>
-        <key>many</key>
-        <string>디렉터리에서 결과 %d개 발견됨</string>
-        <key>other</key>
-        <string>디렉터리에서 결과 %d개 발견됨</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d시</string>
+			<key>one</key>
+			<string>%d시</string>
+			<key>two</key>
+			<string>%d시</string>
+			<key>few</key>
+			<string>%d시</string>
+			<key>many</key>
+			<string>%d시</string>
+			<key>other</key>
+			<string>%d시</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d분</string>
+			<key>one</key>
+			<string>%d분</string>
+			<key>two</key>
+			<string>%d분</string>
+			<key>few</key>
+			<string>%d분</string>
+			<key>many</key>
+			<string>%d분</string>
+			<key>other</key>
+			<string>%d분</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>디렉터리에서 결과 %d개 발견됨</string>
+			<key>one</key>
+			<string>디렉터리에서 결과 %d개 발견됨</string>
+			<key>two</key>
+			<string>디렉터리에서 결과 %d개 발견됨</string>
+			<key>few</key>
+			<string>디렉터리에서 결과 %d개 발견됨</string>
+			<key>many</key>
+			<string>디렉터리에서 결과 %d개 발견됨</string>
+			<key>other</key>
+			<string>디렉터리에서 결과 %d개 발견됨</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Pukul %d</string>
-        <key>one</key>
-        <string>Pukul %d</string>
-        <key>two</key>
-        <string>Pukul %d</string>
-        <key>few</key>
-        <string>Pukul %d</string>
-        <key>many</key>
-        <string>Pukul %d</string>
-        <key>other</key>
-        <string>Pukul %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minit</string>
-        <key>one</key>
-        <string>%d minit</string>
-        <key>two</key>
-        <string>%d minit</string>
-        <key>few</key>
-        <string>%d minit</string>
-        <key>many</key>
-        <string>%d minit</string>
-        <key>other</key>
-        <string>%d minit</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d hasil ditemui daripada direktori</string>
-        <key>one</key>
-        <string>%d hasil ditemui daripada direktori</string>
-        <key>two</key>
-        <string>%d hasil ditemui daripada direktori</string>
-        <key>few</key>
-        <string>%d hasil ditemui daripada direktori</string>
-        <key>many</key>
-        <string>%d hasil ditemui daripada direktori</string>
-        <key>other</key>
-        <string>%d hasil ditemui daripada direktori</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Pukul %d</string>
+			<key>one</key>
+			<string>Pukul %d</string>
+			<key>two</key>
+			<string>Pukul %d</string>
+			<key>few</key>
+			<string>Pukul %d</string>
+			<key>many</key>
+			<string>Pukul %d</string>
+			<key>other</key>
+			<string>Pukul %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minit</string>
+			<key>one</key>
+			<string>%d minit</string>
+			<key>two</key>
+			<string>%d minit</string>
+			<key>few</key>
+			<string>%d minit</string>
+			<key>many</key>
+			<string>%d minit</string>
+			<key>other</key>
+			<string>%d minit</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d hasil ditemui daripada direktori</string>
+			<key>one</key>
+			<string>%d hasil ditemui daripada direktori</string>
+			<key>two</key>
+			<string>%d hasil ditemui daripada direktori</string>
+			<key>few</key>
+			<string>%d hasil ditemui daripada direktori</string>
+			<key>many</key>
+			<string>%d hasil ditemui daripada direktori</string>
+			<key>other</key>
+			<string>%d hasil ditemui daripada direktori</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>klokken %d</string>
-        <key>one</key>
-        <string>klokken %d</string>
-        <key>two</key>
-        <string>klokken %d</string>
-        <key>few</key>
-        <string>klokken %d</string>
-        <key>many</key>
-        <string>klokken %d</string>
-        <key>other</key>
-        <string>klokken %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutter</string>
-        <key>one</key>
-        <string>%d minutt</string>
-        <key>two</key>
-        <string>%d minutter</string>
-        <key>few</key>
-        <string>%d minutter</string>
-        <key>many</key>
-        <string>%d minutter</string>
-        <key>other</key>
-        <string>%d minutter</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Fant %d resultater fra katalogen</string>
-        <key>one</key>
-        <string>Fant %d resultat fra katalogen</string>
-        <key>two</key>
-        <string>Fant %d resultater fra katalogen</string>
-        <key>few</key>
-        <string>Fant %d resultater fra katalogen</string>
-        <key>many</key>
-        <string>Fant %d resultater fra katalogen</string>
-        <key>other</key>
-        <string>Fant %d resultater fra katalogen</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>klokken %d</string>
+			<key>one</key>
+			<string>klokken %d</string>
+			<key>two</key>
+			<string>klokken %d</string>
+			<key>few</key>
+			<string>klokken %d</string>
+			<key>many</key>
+			<string>klokken %d</string>
+			<key>other</key>
+			<string>klokken %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutter</string>
+			<key>one</key>
+			<string>%d minutt</string>
+			<key>two</key>
+			<string>%d minutter</string>
+			<key>few</key>
+			<string>%d minutter</string>
+			<key>many</key>
+			<string>%d minutter</string>
+			<key>other</key>
+			<string>%d minutter</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Fant %d resultater fra katalogen</string>
+			<key>one</key>
+			<string>Fant %d resultat fra katalogen</string>
+			<key>two</key>
+			<string>Fant %d resultater fra katalogen</string>
+			<key>few</key>
+			<string>Fant %d resultater fra katalogen</string>
+			<key>many</key>
+			<string>Fant %d resultater fra katalogen</string>
+			<key>other</key>
+			<string>Fant %d resultater fra katalogen</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d uur</string>
-        <key>one</key>
-        <string>%d uur</string>
-        <key>two</key>
-        <string>%d uur</string>
-        <key>few</key>
-        <string>%d uur</string>
-        <key>many</key>
-        <string>%d uur</string>
-        <key>other</key>
-        <string>%d uur</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minuten</string>
-        <key>one</key>
-        <string>%d minuut</string>
-        <key>two</key>
-        <string>%d minuten</string>
-        <key>few</key>
-        <string>%d minuten</string>
-        <key>many</key>
-        <string>%d minuten</string>
-        <key>other</key>
-        <string>%d minuten</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d resultaten gevonden in adreslijst</string>
-        <key>one</key>
-        <string>%d resultaat gevonden in adreslijst</string>
-        <key>two</key>
-        <string>%d resultaten gevonden in adreslijst</string>
-        <key>few</key>
-        <string>%d resultaten gevonden in adreslijst</string>
-        <key>many</key>
-        <string>%d resultaten gevonden in adreslijst</string>
-        <key>other</key>
-        <string>%d resultaten gevonden in adreslijst</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d uur</string>
+			<key>one</key>
+			<string>%d uur</string>
+			<key>two</key>
+			<string>%d uur</string>
+			<key>few</key>
+			<string>%d uur</string>
+			<key>many</key>
+			<string>%d uur</string>
+			<key>other</key>
+			<string>%d uur</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minuten</string>
+			<key>one</key>
+			<string>%d minuut</string>
+			<key>two</key>
+			<string>%d minuten</string>
+			<key>few</key>
+			<string>%d minuten</string>
+			<key>many</key>
+			<string>%d minuten</string>
+			<key>other</key>
+			<string>%d minuten</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d resultaten gevonden in adreslijst</string>
+			<key>one</key>
+			<string>%d resultaat gevonden in adreslijst</string>
+			<key>two</key>
+			<string>%d resultaten gevonden in adreslijst</string>
+			<key>few</key>
+			<string>%d resultaten gevonden in adreslijst</string>
+			<key>many</key>
+			<string>%d resultaten gevonden in adreslijst</string>
+			<key>other</key>
+			<string>%d resultaten gevonden in adreslijst</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d</string>
-        <key>one</key>
-        <string>%d</string>
-        <key>two</key>
-        <string>%d</string>
-        <key>few</key>
-        <string>%d</string>
-        <key>many</key>
-        <string>%d</string>
-        <key>other</key>
-        <string>%d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minut</string>
-        <key>one</key>
-        <string>%d minuta</string>
-        <key>two</key>
-        <string>%d minuty</string>
-        <key>few</key>
-        <string>%d minuty</string>
-        <key>many</key>
-        <string>%d minut</string>
-        <key>other</key>
-        <string>%d min</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Znaleziono %d wyników w katalogu</string>
-        <key>one</key>
-        <string>Wyniki znalezione w katalogu: %d</string>
-        <key>two</key>
-        <string>Znaleziono %d wyniki w katalogu</string>
-        <key>few</key>
-        <string>Znaleziono %d wyniki w katalogu</string>
-        <key>many</key>
-        <string>Znaleziono %d wyników w katalogu</string>
-        <key>other</key>
-        <string>Wyniki znalezione w katalogu: %d</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d</string>
+			<key>one</key>
+			<string>%d</string>
+			<key>two</key>
+			<string>%d</string>
+			<key>few</key>
+			<string>%d</string>
+			<key>many</key>
+			<string>%d</string>
+			<key>other</key>
+			<string>%d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minut</string>
+			<key>one</key>
+			<string>%d minuta</string>
+			<key>two</key>
+			<string>%d minuty</string>
+			<key>few</key>
+			<string>%d minuty</string>
+			<key>many</key>
+			<string>%d minut</string>
+			<key>other</key>
+			<string>%d min</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Znaleziono %d wyników w katalogu</string>
+			<key>one</key>
+			<string>Wyniki znalezione w katalogu: %d</string>
+			<key>two</key>
+			<string>Znaleziono %d wyniki w katalogu</string>
+			<key>few</key>
+			<string>Znaleziono %d wyniki w katalogu</string>
+			<key>many</key>
+			<string>Znaleziono %d wyników w katalogu</string>
+			<key>other</key>
+			<string>Wyniki znalezione w katalogu: %d</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d hora</string>
-        <key>one</key>
-        <string>%d hora</string>
-        <key>two</key>
-        <string>%d horas</string>
-        <key>few</key>
-        <string>%d horas</string>
-        <key>many</key>
-        <string>%d horas</string>
-        <key>other</key>
-        <string>%d hora(s)</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minuto</string>
-        <key>one</key>
-        <string>%d minuto</string>
-        <key>two</key>
-        <string>%d minutos</string>
-        <key>few</key>
-        <string>%d minutos</string>
-        <key>many</key>
-        <string>%d minutos</string>
-        <key>other</key>
-        <string>%d minutos</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d resultado encontrado no diretório</string>
-        <key>one</key>
-        <string>%d resultado encontrado no diretório</string>
-        <key>two</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>few</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>many</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>other</key>
-        <string>%d resultados encontrados no diretório</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d hora</string>
+			<key>one</key>
+			<string>%d hora</string>
+			<key>two</key>
+			<string>%d horas</string>
+			<key>few</key>
+			<string>%d horas</string>
+			<key>many</key>
+			<string>%d horas</string>
+			<key>other</key>
+			<string>%d hora(s)</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minuto</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>two</key>
+			<string>%d minutos</string>
+			<key>few</key>
+			<string>%d minutos</string>
+			<key>many</key>
+			<string>%d minutos</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d resultado encontrado no diretório</string>
+			<key>one</key>
+			<string>%d resultado encontrado no diretório</string>
+			<key>two</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>few</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>many</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>other</key>
+			<string>%d resultados encontrados no diretório</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d horas</string>
-        <key>one</key>
-        <string>%d hora</string>
-        <key>two</key>
-        <string>%d horas</string>
-        <key>few</key>
-        <string>%d horas</string>
-        <key>many</key>
-        <string>%d horas</string>
-        <key>other</key>
-        <string>%d horas</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minutos</string>
-        <key>one</key>
-        <string>%d minuto</string>
-        <key>two</key>
-        <string>%d minutos</string>
-        <key>few</key>
-        <string>%d minutos</string>
-        <key>many</key>
-        <string>%d minutos</string>
-        <key>other</key>
-        <string>%d minutos</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>one</key>
-        <string>%d resultado encontrado no diretório</string>
-        <key>two</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>few</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>many</key>
-        <string>%d resultados encontrados no diretório</string>
-        <key>other</key>
-        <string>%d resultados encontrados no diretório</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d horas</string>
+			<key>one</key>
+			<string>%d hora</string>
+			<key>two</key>
+			<string>%d horas</string>
+			<key>few</key>
+			<string>%d horas</string>
+			<key>many</key>
+			<string>%d horas</string>
+			<key>other</key>
+			<string>%d horas</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minutos</string>
+			<key>one</key>
+			<string>%d minuto</string>
+			<key>two</key>
+			<string>%d minutos</string>
+			<key>few</key>
+			<string>%d minutos</string>
+			<key>many</key>
+			<string>%d minutos</string>
+			<key>other</key>
+			<string>%d minutos</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>one</key>
+			<string>%d resultado encontrado no diretório</string>
+			<key>two</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>few</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>many</key>
+			<string>%d resultados encontrados no diretório</string>
+			<key>other</key>
+			<string>%d resultados encontrados no diretório</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Ora %d</string>
-        <key>one</key>
-        <string>Ora %d</string>
-        <key>two</key>
-        <string>Ora %d</string>
-        <key>few</key>
-        <string>Ora %d</string>
-        <key>many</key>
-        <string>Ora %d</string>
-        <key>other</key>
-        <string>Ora %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minute</string>
-        <key>one</key>
-        <string>%d minut</string>
-        <key>two</key>
-        <string>%d minute</string>
-        <key>few</key>
-        <string>%d minute</string>
-        <key>many</key>
-        <string>%d de minute</string>
-        <key>other</key>
-        <string>%d minute</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d rezultate găsite în director</string>
-        <key>one</key>
-        <string>%d rezultat găsit în director</string>
-        <key>two</key>
-        <string>%d rezultate găsite în director</string>
-        <key>few</key>
-        <string>%d rezultate găsite în director</string>
-        <key>many</key>
-        <string>%d de rezultate găsite în director</string>
-        <key>other</key>
-        <string>%d rezultate găsite în director</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Ora %d</string>
+			<key>one</key>
+			<string>Ora %d</string>
+			<key>two</key>
+			<string>Ora %d</string>
+			<key>few</key>
+			<string>Ora %d</string>
+			<key>many</key>
+			<string>Ora %d</string>
+			<key>other</key>
+			<string>Ora %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minute</string>
+			<key>one</key>
+			<string>%d minut</string>
+			<key>two</key>
+			<string>%d minute</string>
+			<key>few</key>
+			<string>%d minute</string>
+			<key>many</key>
+			<string>%d de minute</string>
+			<key>other</key>
+			<string>%d minute</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d rezultate găsite în director</string>
+			<key>one</key>
+			<string>%d rezultat găsit în director</string>
+			<key>two</key>
+			<string>%d rezultate găsite în director</string>
+			<key>few</key>
+			<string>%d rezultate găsite în director</string>
+			<key>many</key>
+			<string>%d de rezultate găsite în director</string>
+			<key>other</key>
+			<string>%d rezultate găsite în director</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d ч</string>
-        <key>one</key>
-        <string>%d ч</string>
-        <key>two</key>
-        <string>%d ч</string>
-        <key>few</key>
-        <string>%d ч</string>
-        <key>many</key>
-        <string>%d ч</string>
-        <key>other</key>
-        <string>%d ч</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d мин</string>
-        <key>one</key>
-        <string>%d минута</string>
-        <key>two</key>
-        <string>%d мин</string>
-        <key>few</key>
-        <string>%d мин</string>
-        <key>many</key>
-        <string>%d мин</string>
-        <key>other</key>
-        <string>%d мин</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Количество результатов поиска в каталоге: %d</string>
-        <key>one</key>
-        <string>%d результат поиска в каталоге</string>
-        <key>two</key>
-        <string>Количество результатов поиска в каталоге: %d</string>
-        <key>few</key>
-        <string>Количество результатов поиска в каталоге: %d</string>
-        <key>many</key>
-        <string>Количество результатов поиска в каталоге: %d</string>
-        <key>other</key>
-        <string>Количество результатов поиска в каталоге: %d</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d ч</string>
+			<key>one</key>
+			<string>%d ч</string>
+			<key>two</key>
+			<string>%d ч</string>
+			<key>few</key>
+			<string>%d ч</string>
+			<key>many</key>
+			<string>%d ч</string>
+			<key>other</key>
+			<string>%d ч</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d мин</string>
+			<key>one</key>
+			<string>%d минута</string>
+			<key>two</key>
+			<string>%d мин</string>
+			<key>few</key>
+			<string>%d мин</string>
+			<key>many</key>
+			<string>%d мин</string>
+			<key>other</key>
+			<string>%d мин</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Количество результатов поиска в каталоге: %d</string>
+			<key>one</key>
+			<string>%d результат поиска в каталоге</string>
+			<key>two</key>
+			<string>Количество результатов поиска в каталоге: %d</string>
+			<key>few</key>
+			<string>Количество результатов поиска в каталоге: %d</string>
+			<key>many</key>
+			<string>Количество результатов поиска в каталоге: %d</string>
+			<key>other</key>
+			<string>Количество результатов поиска в каталоге: %d</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d hod.</string>
-        <key>one</key>
-        <string>%d hod.</string>
-        <key>two</key>
-        <string>%d hod.</string>
-        <key>few</key>
-        <string>%d hod.</string>
-        <key>many</key>
-        <string>%d hod.</string>
-        <key>other</key>
-        <string>%d hod.</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d min</string>
-        <key>one</key>
-        <string>%d minúta</string>
-        <key>two</key>
-        <string>%d min</string>
-        <key>few</key>
-        <string>%d min</string>
-        <key>many</key>
-        <string>%d min</string>
-        <key>other</key>
-        <string>%d min</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Počet výsledkov nájdených v adresári: %d</string>
-        <key>one</key>
-        <string>V adresári sa našiel %d výsledok</string>
-        <key>two</key>
-        <string>Počet výsledkov nájdených v adresári: %d</string>
-        <key>few</key>
-        <string>Počet výsledkov nájdených v adresári: %d</string>
-        <key>many</key>
-        <string>Počet výsledkov nájdených v adresári: %d</string>
-        <key>other</key>
-        <string>Počet výsledkov nájdených v adresári: %d</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d hod.</string>
+			<key>one</key>
+			<string>%d hod.</string>
+			<key>two</key>
+			<string>%d hod.</string>
+			<key>few</key>
+			<string>%d hod.</string>
+			<key>many</key>
+			<string>%d hod.</string>
+			<key>other</key>
+			<string>%d hod.</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d min</string>
+			<key>one</key>
+			<string>%d minúta</string>
+			<key>two</key>
+			<string>%d min</string>
+			<key>few</key>
+			<string>%d min</string>
+			<key>many</key>
+			<string>%d min</string>
+			<key>other</key>
+			<string>%d min</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Počet výsledkov nájdených v adresári: %d</string>
+			<key>one</key>
+			<string>V adresári sa našiel %d výsledok</string>
+			<key>two</key>
+			<string>Počet výsledkov nájdených v adresári: %d</string>
+			<key>few</key>
+			<string>Počet výsledkov nájdených v adresári: %d</string>
+			<key>many</key>
+			<string>Počet výsledkov nájdených v adresári: %d</string>
+			<key>other</key>
+			<string>Počet výsledkov nájdených v adresári: %d</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Kl. %d</string>
-        <key>one</key>
-        <string>Kl. %d</string>
-        <key>two</key>
-        <string>Kl. %d</string>
-        <key>few</key>
-        <string>Kl. %d</string>
-        <key>many</key>
-        <string>Kl. %d</string>
-        <key>other</key>
-        <string>Kl. %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d minuter</string>
-        <key>one</key>
-        <string>%d minut</string>
-        <key>two</key>
-        <string>%d minuter</string>
-        <key>few</key>
-        <string>%d minuter</string>
-        <key>many</key>
-        <string>%d minuter</string>
-        <key>other</key>
-        <string>%d minuter</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d resultat hittades från katalog</string>
-        <key>one</key>
-        <string>%d resultat hittades från katalog</string>
-        <key>two</key>
-        <string>%d resultat hittades från katalog</string>
-        <key>few</key>
-        <string>%d resultat hittades från katalog</string>
-        <key>many</key>
-        <string>%d resultat hittades från katalog</string>
-        <key>other</key>
-        <string>%d resultat hittades från katalog</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Kl. %d</string>
+			<key>one</key>
+			<string>Kl. %d</string>
+			<key>two</key>
+			<string>Kl. %d</string>
+			<key>few</key>
+			<string>Kl. %d</string>
+			<key>many</key>
+			<string>Kl. %d</string>
+			<key>other</key>
+			<string>Kl. %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d minuter</string>
+			<key>one</key>
+			<string>%d minut</string>
+			<key>two</key>
+			<string>%d minuter</string>
+			<key>few</key>
+			<string>%d minuter</string>
+			<key>many</key>
+			<string>%d minuter</string>
+			<key>other</key>
+			<string>%d minuter</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d resultat hittades från katalog</string>
+			<key>one</key>
+			<string>%d resultat hittades från katalog</string>
+			<key>two</key>
+			<string>%d resultat hittades från katalog</string>
+			<key>few</key>
+			<string>%d resultat hittades från katalog</string>
+			<key>many</key>
+			<string>%d resultat hittades från katalog</string>
+			<key>other</key>
+			<string>%d resultat hittades från katalog</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d นาฬิกา</string>
-        <key>one</key>
-        <string>%d นาฬิกา</string>
-        <key>two</key>
-        <string>%d นาฬิกา</string>
-        <key>few</key>
-        <string>%d นาฬิกา</string>
-        <key>many</key>
-        <string>%d นาฬิกา</string>
-        <key>other</key>
-        <string>%d นาฬิกา</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d นาที</string>
-        <key>one</key>
-        <string>%d นาที</string>
-        <key>two</key>
-        <string>%d นาที</string>
-        <key>few</key>
-        <string>%d นาที</string>
-        <key>many</key>
-        <string>%d นาที</string>
-        <key>other</key>
-        <string>%d นาที</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
-        <key>one</key>
-        <string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
-        <key>two</key>
-        <string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
-        <key>few</key>
-        <string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
-        <key>many</key>
-        <string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
-        <key>other</key>
-        <string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d นาฬิกา</string>
+			<key>one</key>
+			<string>%d นาฬิกา</string>
+			<key>two</key>
+			<string>%d นาฬิกา</string>
+			<key>few</key>
+			<string>%d นาฬิกา</string>
+			<key>many</key>
+			<string>%d นาฬิกา</string>
+			<key>other</key>
+			<string>%d นาฬิกา</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d นาที</string>
+			<key>one</key>
+			<string>%d นาที</string>
+			<key>two</key>
+			<string>%d นาที</string>
+			<key>few</key>
+			<string>%d นาที</string>
+			<key>many</key>
+			<string>%d นาที</string>
+			<key>other</key>
+			<string>%d นาที</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
+			<key>one</key>
+			<string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
+			<key>two</key>
+			<string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
+			<key>few</key>
+			<string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
+			<key>many</key>
+			<string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
+			<key>other</key>
+			<string>พบ %d ผลลัพธ์จากไดเรกทอรี</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Saat %d</string>
-        <key>one</key>
-        <string>Saat %d</string>
-        <key>two</key>
-        <string>Saat %d</string>
-        <key>few</key>
-        <string>Saat %d</string>
-        <key>many</key>
-        <string>Saat %d</string>
-        <key>other</key>
-        <string>Saat %d</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d dakika</string>
-        <key>one</key>
-        <string>%d dakika</string>
-        <key>two</key>
-        <string>%d dakika</string>
-        <key>few</key>
-        <string>%d dakika</string>
-        <key>many</key>
-        <string>%d dakika</string>
-        <key>other</key>
-        <string>%d dakika</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Dizinde %d sonuç bulundu</string>
-        <key>one</key>
-        <string>Dizinde %d sonuç bulundu</string>
-        <key>two</key>
-        <string>Dizinde %d sonuç bulundu</string>
-        <key>few</key>
-        <string>Dizinde %d sonuç bulundu</string>
-        <key>many</key>
-        <string>Dizinde %d sonuç bulundu</string>
-        <key>other</key>
-        <string>Dizinde %d sonuç bulundu</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Saat %d</string>
+			<key>one</key>
+			<string>Saat %d</string>
+			<key>two</key>
+			<string>Saat %d</string>
+			<key>few</key>
+			<string>Saat %d</string>
+			<key>many</key>
+			<string>Saat %d</string>
+			<key>other</key>
+			<string>Saat %d</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d dakika</string>
+			<key>one</key>
+			<string>%d dakika</string>
+			<key>two</key>
+			<string>%d dakika</string>
+			<key>few</key>
+			<string>%d dakika</string>
+			<key>many</key>
+			<string>%d dakika</string>
+			<key>other</key>
+			<string>%d dakika</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Dizinde %d sonuç bulundu</string>
+			<key>one</key>
+			<string>Dizinde %d sonuç bulundu</string>
+			<key>two</key>
+			<string>Dizinde %d sonuç bulundu</string>
+			<key>few</key>
+			<string>Dizinde %d sonuç bulundu</string>
+			<key>many</key>
+			<string>Dizinde %d sonuç bulundu</string>
+			<key>other</key>
+			<string>Dizinde %d sonuç bulundu</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d год.</string>
-        <key>one</key>
-        <string>%d год.</string>
-        <key>two</key>
-        <string>%d год.</string>
-        <key>few</key>
-        <string>%d год.</string>
-        <key>many</key>
-        <string>%d год.</string>
-        <key>other</key>
-        <string>%d год.</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d хв.</string>
-        <key>one</key>
-        <string>%d хв.</string>
-        <key>two</key>
-        <string>%d хв.</string>
-        <key>few</key>
-        <string>%d хв.</string>
-        <key>many</key>
-        <string>%d хв.</string>
-        <key>other</key>
-        <string>%d хв.</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d результатів пошуку в каталозі</string>
-        <key>one</key>
-        <string>%d результат пошуку в каталозі</string>
-        <key>two</key>
-        <string>%d результати пошуку в каталозі</string>
-        <key>few</key>
-        <string>%d результати пошуку в каталозі</string>
-        <key>many</key>
-        <string>%d результатів пошуку в каталозі</string>
-        <key>other</key>
-        <string>Результатів пошуку в каталозі: %d</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d год.</string>
+			<key>one</key>
+			<string>%d год.</string>
+			<key>two</key>
+			<string>%d год.</string>
+			<key>few</key>
+			<string>%d год.</string>
+			<key>many</key>
+			<string>%d год.</string>
+			<key>other</key>
+			<string>%d год.</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d хв.</string>
+			<key>one</key>
+			<string>%d хв.</string>
+			<key>two</key>
+			<string>%d хв.</string>
+			<key>few</key>
+			<string>%d хв.</string>
+			<key>many</key>
+			<string>%d хв.</string>
+			<key>other</key>
+			<string>%d хв.</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d результатів пошуку в каталозі</string>
+			<key>one</key>
+			<string>%d результат пошуку в каталозі</string>
+			<key>two</key>
+			<string>%d результати пошуку в каталозі</string>
+			<key>few</key>
+			<string>%d результати пошуку в каталозі</string>
+			<key>many</key>
+			<string>%d результатів пошуку в каталозі</string>
+			<key>other</key>
+			<string>Результатів пошуку в каталозі: %d</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d giờ</string>
-        <key>one</key>
-        <string>%d giờ</string>
-        <key>two</key>
-        <string>%d giờ</string>
-        <key>few</key>
-        <string>%d giờ</string>
-        <key>many</key>
-        <string>%d giờ</string>
-        <key>other</key>
-        <string>%d giờ</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d phút</string>
-        <key>one</key>
-        <string>%d phút</string>
-        <key>two</key>
-        <string>%d phút</string>
-        <key>few</key>
-        <string>%d phút</string>
-        <key>many</key>
-        <string>%d phút</string>
-        <key>other</key>
-        <string>%d phút</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>Đã tìm thấy %d kết quả từ thư mục</string>
-        <key>one</key>
-        <string>Tìm thấy %d kết quả từ thư mục</string>
-        <key>two</key>
-        <string>Đã tìm thấy %d kết quả từ thư mục</string>
-        <key>few</key>
-        <string>Đã tìm thấy %d kết quả từ thư mục</string>
-        <key>many</key>
-        <string>Đã tìm thấy %d kết quả từ thư mục</string>
-        <key>other</key>
-        <string>Tìm thấy %d kết quả từ thư mục</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d giờ</string>
+			<key>one</key>
+			<string>%d giờ</string>
+			<key>two</key>
+			<string>%d giờ</string>
+			<key>few</key>
+			<string>%d giờ</string>
+			<key>many</key>
+			<string>%d giờ</string>
+			<key>other</key>
+			<string>%d giờ</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d phút</string>
+			<key>one</key>
+			<string>%d phút</string>
+			<key>two</key>
+			<string>%d phút</string>
+			<key>few</key>
+			<string>%d phút</string>
+			<key>many</key>
+			<string>%d phút</string>
+			<key>other</key>
+			<string>%d phút</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Đã tìm thấy %d kết quả từ thư mục</string>
+			<key>one</key>
+			<string>Tìm thấy %d kết quả từ thư mục</string>
+			<key>two</key>
+			<string>Đã tìm thấy %d kết quả từ thư mục</string>
+			<key>few</key>
+			<string>Đã tìm thấy %d kết quả từ thư mục</string>
+			<key>many</key>
+			<string>Đã tìm thấy %d kết quả từ thư mục</string>
+			<key>other</key>
+			<string>Tìm thấy %d kết quả từ thư mục</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 点钟</string>
-        <key>one</key>
-        <string>%d 点钟</string>
-        <key>two</key>
-        <string>%d 点钟</string>
-        <key>few</key>
-        <string>%d 点钟</string>
-        <key>many</key>
-        <string>%d 点钟</string>
-        <key>other</key>
-        <string>%d 点钟</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 分钟</string>
-        <key>one</key>
-        <string>%d 分钟</string>
-        <key>two</key>
-        <string>%d 分钟</string>
-        <key>few</key>
-        <string>%d 分钟</string>
-        <key>many</key>
-        <string>%d 分钟</string>
-        <key>other</key>
-        <string>%d 分钟</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>从目录中找到 %d 个结果</string>
-        <key>one</key>
-        <string>从目录中找到 %d 个结果</string>
-        <key>two</key>
-        <string>从目录中找到 %d 个结果</string>
-        <key>few</key>
-        <string>从目录中找到 %d 个结果</string>
-        <key>many</key>
-        <string>从目录中找到 %d 个结果</string>
-        <key>other</key>
-        <string>从目录中找到 %d 个结果</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 点钟</string>
+			<key>one</key>
+			<string>%d 点钟</string>
+			<key>two</key>
+			<string>%d 点钟</string>
+			<key>few</key>
+			<string>%d 点钟</string>
+			<key>many</key>
+			<string>%d 点钟</string>
+			<key>other</key>
+			<string>%d 点钟</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 分钟</string>
+			<key>one</key>
+			<string>%d 分钟</string>
+			<key>two</key>
+			<string>%d 分钟</string>
+			<key>few</key>
+			<string>%d 分钟</string>
+			<key>many</key>
+			<string>%d 分钟</string>
+			<key>other</key>
+			<string>%d 分钟</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>从目录中找到 %d 个结果</string>
+			<key>one</key>
+			<string>从目录中找到 %d 个结果</string>
+			<key>two</key>
+			<string>从目录中找到 %d 个结果</string>
+			<key>few</key>
+			<string>从目录中找到 %d 个结果</string>
+			<key>many</key>
+			<string>从目录中找到 %d 个结果</string>
+			<key>other</key>
+			<string>从目录中找到 %d 个结果</string>
+		</dict>
+	</dict>
+</dict>
 </plist>

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.stringsdict
@@ -1,78 +1,78 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Accessibility.DateTime.Hour.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@hours@</string>
-      <key>Variable</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 點鐘</string>
-        <key>one</key>
-        <string>%d 點鐘</string>
-        <key>two</key>
-        <string>%d 點鐘</string>
-        <key>few</key>
-        <string>%d 點鐘</string>
-        <key>many</key>
-        <string>%d 點鐘</string>
-        <key>other</key>
-        <string>%d 點鐘</string>
-      </dict>
-    </dict>
-    <key>Accessibility.DateTime.Minute.Value</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@minutes@</string>
-      <key>minutes</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>%d 分鐘</string>
-        <key>one</key>
-        <string>%d 分鐘</string>
-        <key>two</key>
-        <string>%d 分鐘</string>
-        <key>few</key>
-        <string>%d 分鐘</string>
-        <key>many</key>
-        <string>%d 分鐘</string>
-        <key>other</key>
-        <string>%d 分鐘</string>
-      </dict>
-    </dict>
-    <key>%d results found from directory</key>
-    <dict>
-      <key>NSStringLocalizedFormatKey</key>
-      <string>%#@results@</string>
-      <key>results</key>
-      <dict>
-        <key>NSStringFormatSpecTypeKey</key>
-        <string>NSStringPluralRuleType</string>
-        <key>NSStringFormatValueTypeKey</key>
-        <string>d</string>
-        <key>zero</key>
-        <string>從目錄中找到 %d 個結果</string>
-        <key>one</key>
-        <string>從目錄中找到 %d 個結果</string>
-        <key>two</key>
-        <string>從目錄中找到 %d 個結果</string>
-        <key>few</key>
-        <string>從目錄中找到 %d 個結果</string>
-        <key>many</key>
-        <string>從目錄中找到 %d 個結果</string>
-        <key>other</key>
-        <string>從目錄中找到 %d 個結果</string>
-      </dict>
-    </dict>
-  </dict>
+<dict>
+	<key>Accessibility.DateTime.Hour.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@hours@</string>
+		<key>hours</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 點鐘</string>
+			<key>one</key>
+			<string>%d 點鐘</string>
+			<key>two</key>
+			<string>%d 點鐘</string>
+			<key>few</key>
+			<string>%d 點鐘</string>
+			<key>many</key>
+			<string>%d 點鐘</string>
+			<key>other</key>
+			<string>%d 點鐘</string>
+		</dict>
+	</dict>
+	<key>Accessibility.DateTime.Minute.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@minutes@</string>
+		<key>minutes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d 分鐘</string>
+			<key>one</key>
+			<string>%d 分鐘</string>
+			<key>two</key>
+			<string>%d 分鐘</string>
+			<key>few</key>
+			<string>%d 分鐘</string>
+			<key>many</key>
+			<string>%d 分鐘</string>
+			<key>other</key>
+			<string>%d 分鐘</string>
+		</dict>
+	</dict>
+	<key>%d results found from directory</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@results@</string>
+		<key>results</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>從目錄中找到 %d 個結果</string>
+			<key>one</key>
+			<string>從目錄中找到 %d 個結果</string>
+			<key>two</key>
+			<string>從目錄中找到 %d 個結果</string>
+			<key>few</key>
+			<string>從目錄中找到 %d 個結果</string>
+			<key>many</key>
+			<string>從目錄中找到 %d 個結果</string>
+			<key>other</key>
+			<string>從目錄中找到 %d 個結果</string>
+		</dict>
+	</dict>
+</dict>
 </plist>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Bug Reference
https://dev.azure.com/microsoftdesign/fluentui-native/_workitems/edit/9568

### Description of changes
VoiceOver reads out incorrect values for the hour and minute in the date/time picker, due to two separate issues:
- Localizable.stringsdict has an error in the hour pluralization rule, where the NSStringLocalizedFormatKey is defined as `"%#@hours@"`, but the variable "hours" is undefined.  The pluralization rule is defined under the key "Variable" instead.  Because the system has no definition for the "hours" variable, it returns a localized string with that variable unsubstituted, which VO reads out directly: `"%#@hours@"`.  The fix is to rename the "Variable" key to "hours" in each language's Localizable.strings.
- The expected arguments in the localized string templates are integers (NSStringFormatValueTypeKey: d), but we supplied strings instead.  Those strings get formatted into garbage integers, which VO reads out: for example, "5032945 minutes".  The fix is to supply the expected integer arguments.

### Verification
Used test app with VoiceOver.  Tested with English and French languages.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/516)