### PR TITLE
Improving Avatar animation support.

### DIFF
--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -187,7 +187,8 @@ public struct AvatarView: View {
             :
             AnyView(Text(initialsString)
                         .foregroundColor(Color(foregroundColor))
-                        .font(Font(tokens.textFont)))
+                        .font(Font(tokens.textFont))
+                        .animation(.none))
 
         let bodyView = tokens.style == .group ?
         AnyView(avatarContent
@@ -201,40 +202,21 @@ public struct AvatarView: View {
                     .foregroundColor(ringGapColor)
                     .frame(width: ringOuterGapSize, height: ringOuterGapSize, alignment: .center)
                     .overlay(Circle()
-                                .foregroundColor(ringColor)
+                                .strokeBorder(ringColor, lineWidth: ringThickness)
                                 .frame(width: ringSize, height: ringSize, alignment: .center)
-                                .mask(circularCutoutMask(targetFrameRect: CGRect(x: 0,
-                                                                                 y: 0,
-                                                                                 width: ringSize,
-                                                                                 height: ringSize),
-                                                         cutoutFrameRect: CGRect(x: ringThickness,
-                                                                                 y: ringThickness,
-                                                                                 width: ringInnerGapSize,
-                                                                                 height: ringInnerGapSize))
-                                        .fill(style: FillStyle(eoFill: isTransparent)))
                                 .overlay(Circle()
-                                            .foregroundColor(ringGapColor)
-                                            .frame(width: ringInnerGapSize, height: ringInnerGapSize, alignment: .center)
-                                            .overlay(Circle()
-                                                        .foregroundColor(Color(backgroundColor))
-                                                        .frame(width: avatarImageSize, height: avatarImageSize, alignment: .center)
-                                                        .overlay(avatarContent
-                                                                    .frame(width: avatarImageSize * avatarImageSizeRatio, height: avatarImageSize * avatarImageSizeRatio, alignment: .center)
-                                                                    .clipShape(Circle()),
-                                                                 alignment: .center)
-                                            )
-                                )
-                             ,
+                                            .foregroundColor(Color(backgroundColor))
+                                            .frame(width: avatarImageSize, height: avatarImageSize, alignment: .center)
+                                            .overlay(avatarContent
+                                                        .frame(width: avatarImageSize * avatarImageSizeRatio, height: avatarImageSize * avatarImageSizeRatio, alignment: .center)
+                                                        .clipShape(Circle())
+                                                        .transition(.opacity),
+                                                     alignment: .center)
+                                ),
                              alignment: .center)
                     .modifyIf(shouldDisplayPresence, { thisView in
-                        thisView.mask(circularCutoutMask(targetFrameRect: CGRect(x: 0,
-                                                                                 y: 0,
-                                                                                 width: ringOuterGapSize,
-                                                                                 height: ringOuterGapSize),
-                                                         cutoutFrameRect: CGRect(x: presenceCutoutOriginCoordinates,
-                                                                                 y: presenceCutoutOriginCoordinates,
-                                                                                 width: presenceIconOutlineSize,
-                                                                                 height: presenceIconOutlineSize))
+                        thisView.mask(PresenceCutout(presenceCutoutOriginCoordinates: presenceCutoutOriginCoordinates,
+                                                     presenceIconOutlineSize: presenceIconOutlineSize)
                                         .fill(style: FillStyle(eoFill: true)))
                                 .overlay(Circle()
                                             .foregroundColor(isTransparent ? Color.clear : Color(tokens.ringGapColor))
@@ -266,19 +248,39 @@ public struct AvatarView: View {
             }
     }
 
-    private func circularCutoutMask(targetFrameRect: CGRect, cutoutFrameRect: CGRect) -> Path {
-        var cutoutFrame = Rectangle().path(in: targetFrameRect)
-        cutoutFrame.addPath(Circle().path(in: cutoutFrameRect))
-
-        return cutoutFrame
-    }
-
     public func setStyle(style: MSFAvatarStyle) {
         tokens.style = style
     }
 
     public func setSize(size: MSFAvatarSize) {
-        tokens.size = size
+        withAnimation(.linear(duration: animationDuration)) {
+            tokens.size = size
+        }
+    }
+
+    private let animationDuration: Double = 0.1
+
+    private struct PresenceCutout: Shape {
+        var presenceCutoutOriginCoordinates: CGFloat
+        var presenceIconOutlineSize: CGFloat
+
+        var animatableData: AnimatablePair<CGFloat, CGFloat> {
+            get {
+                AnimatablePair(presenceCutoutOriginCoordinates, presenceIconOutlineSize)
+            }
+
+            set {
+                presenceCutoutOriginCoordinates = newValue.first
+                presenceIconOutlineSize = newValue.second
+            }
+        }
+
+        func path(in rect: CGRect) -> Path {
+            var cutoutFrame = Rectangle().path(in: rect)
+            cutoutFrame.addPath(Circle().path(in: CGRect(x: presenceCutoutOriginCoordinates, y: presenceCutoutOriginCoordinates, width: presenceIconOutlineSize, height: presenceIconOutlineSize)))
+
+            return cutoutFrame
+        }
     }
 }
 

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -208,7 +208,9 @@ public struct AvatarView: View {
                                             .foregroundColor(Color(backgroundColor))
                                             .frame(width: avatarImageSize, height: avatarImageSize, alignment: .center)
                                             .overlay(avatarContent
-                                                        .frame(width: avatarImageSize * avatarImageSizeRatio, height: avatarImageSize * avatarImageSizeRatio, alignment: .center)
+                                                        .frame(width: avatarImageSize * avatarImageSizeRatio,
+                                                               height: avatarImageSize * avatarImageSizeRatio,
+                                                               alignment: .center)
                                                         .clipShape(Circle())
                                                         .transition(.opacity),
                                                      alignment: .center)
@@ -277,8 +279,10 @@ public struct AvatarView: View {
 
         func path(in rect: CGRect) -> Path {
             var cutoutFrame = Rectangle().path(in: rect)
-            cutoutFrame.addPath(Circle().path(in: CGRect(x: presenceCutoutOriginCoordinates, y: presenceCutoutOriginCoordinates, width: presenceIconOutlineSize, height: presenceIconOutlineSize)))
-
+            cutoutFrame.addPath(Circle().path(in: CGRect(x: presenceCutoutOriginCoordinates,
+                                                         y: presenceCutoutOriginCoordinates,
+                                                         width: presenceIconOutlineSize,
+                                                         height: presenceIconOutlineSize)))
             return cutoutFrame
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The Avatar currently does not support smooth animations in the way that it is written.
Some changes were made to simplify its implementation and support the animation of the path used for the presence cutout:

1. Switching from the cutout approach to using the strokeBorder modifier in order to create the gap between the ring and the avatar content.
2. Implementing the presence cutout as a Shape so that it provides the properties that should be animated
3. Adding animation for when the size is changed.
4. Adding a default animation duration.

On the Large Title scenario this is what the current implementation looks like when it's animated:

https://user-images.githubusercontent.com/68076145/114795527-98641e80-9d43-11eb-9dae-643e7bfe8ff8.mov

### Verification

1. Ensured that the visuals of the Avatar remain unchanged in light and dark modes.
2. Tested different variations of the avatar state while animated:
**- Image only**

https://user-images.githubusercontent.com/68076145/114795707-17f1ed80-9d44-11eb-855e-d8b2e9ca8033.mov

**- Image, ring and presence**

https://user-images.githubusercontent.com/68076145/114795738-2809cd00-9d44-11eb-99a0-fe80b5221e31.mov

- Initials, ring and presence

https://user-images.githubusercontent.com/68076145/114795763-37891600-9d44-11eb-9a20-e367b5234f68.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/517)