### PR TITLE
DatePicker (macOS): Add weekday to accessibility help

### DIFF
--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -20,7 +20,7 @@ class CalendarDayButton: NSButton {
 	///   - day: Day that should be displayed
 	init(size: CGFloat, day: CalendarDay?) {
 		self.size = size
-		self.day = day ?? CalendarDay(date: Date(), primaryLabel: "", accessibilityLabel: "", secondaryLabel: nil)
+		self.day = day ?? CalendarDay(date: Date(), primaryLabel: "", accessibilityLabel: "", accessibilityHelp: nil, secondaryLabel: nil)
 		dualMode = self.day.secondaryLabel != nil
 		upperLabel = NSTextField(labelWithString: self.day.primaryLabel)
 
@@ -65,6 +65,7 @@ class CalendarDayButton: NSButton {
 		])
 
 		setAccessibilityLabel(day?.accessibilityLabel)
+		setAccessibilityHelp(day?.accessibilityHelp)
 
 		updateViewStyle()
 	}
@@ -140,6 +141,7 @@ class CalendarDayButton: NSButton {
 			}
 
 			setAccessibilityLabel(day.accessibilityLabel)
+			setAccessibilityHelp(day.accessibilityHelp)
 			needsDisplay = true
 		}
 	}

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -172,7 +172,7 @@ struct CalendarDay {
 
 	/// String used for accessibility scenarios, like VoiceOver
 	let accessibilityLabel: String
-	
+
 	/// String with extra descriptors for accessibility scenarios.  VoiceOver
 	/// reads this string after a short delay if focus stays on an element.
 	let accessibilityHelp: String?

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -177,6 +177,8 @@ struct CalendarDay {
 	/// reads this string after a short delay if focus stays on an element.
 	let accessibilityHelp: String?
 
-	/// Secondary String representation of the day
+	/// String representation of the day on the `secondaryCalendar`, if enabled.
+	/// For example: a Chinese lunar calendar superimposed on a Gregorian
+	/// calendar allowing cross-referencing of dates between the two.
 	let secondaryLabel: String?
 }

--- a/macos/FluentUI/DatePicker/CalendarView.swift
+++ b/macos/FluentUI/DatePicker/CalendarView.swift
@@ -172,6 +172,10 @@ struct CalendarDay {
 
 	/// String used for accessibility scenarios, like VoiceOver
 	let accessibilityLabel: String
+	
+	/// String with extra descriptors for accessibility scenarios.  VoiceOver
+	/// reads this string after a short delay if focus stays on an element.
+	let accessibilityHelp: String?
 
 	/// Secondary String representation of the day
 	let secondaryLabel: String?

--- a/macos/FluentUI/DatePicker/DatePickerController.swift
+++ b/macos/FluentUI/DatePicker/DatePickerController.swift
@@ -285,6 +285,16 @@ open class DatePickerController: NSViewController {
 		return dateFormatter
 	}()
 
+	/// Formatter used to generate weekday strings used in accessibility scenarios like VoiceOver
+	private lazy var accessibilityWeekdayFormatter: DateFormatter = {
+		let dateFormatter = DateFormatter()
+		dateFormatter.calendar = calendar
+		dateFormatter.locale = calendar.locale
+		dateFormatter.setLocalizedDateFormatFromTemplate("EEEE")
+
+		return dateFormatter
+	}()
+
 	/// Formatter used to generate secondary calendar day strings
 	private var secondaryDayFormatter: DateFormatter?
 }
@@ -394,6 +404,7 @@ extension DatePickerController: DatePickerViewDataSource {
 			date: date,
 			primaryLabel: primaryDayFormatter.string(from: date),
 			accessibilityLabel: accessibilityDayFormatter.string(from: date),
+			accessibilityHelp: accessibilityWeekdayFormatter.string(from: date),
 			secondaryLabel: secondaryDayFormatter?.string(from: date))
 	}
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
When VoiceOver reads the label for a CalendarDay, it uses the locale-and-user-settings dependent `medium` format.  For a standard US locale, an example of that description is "Dec 4, 2019" (where VoiceOver pronounces "Dec" as "December").  This change adds the weekday to that description after a short pause, via the `accessibilityHelp` property.

Alternative approaches that were considered:
- Change the calendar day grid to a table, and add the weekdays as column headers.  This would be a pretty invasive and time-consuming change.
- Use the `full` date format, which (for United States locale with no customizations) includes the weekday: for example, "Tuesday, December 4, 2019".  In the US locale, VoiceOver speaks the weekday first, which isn't necessarily the first thing the user wants to hear when trying to navigate through the calendar.  The format is customizable by the user, and might be missing the weekday for some users, not to mention other locales.

### Verification
Tested using the Date Picker section of FluentUITestApp, in Engilsh (US) and French locales.

| Before | After |
|-|-|
| <img width="274" alt="Screen Shot 2021-04-15 at 3 32 24 PM" src="https://user-images.githubusercontent.com/67027949/114946319-d32b8c80-9dff-11eb-8c53-0be9d2408235.png"><img width="646" alt="Screen Shot 2021-04-15 at 3 08 48 PM" src="https://user-images.githubusercontent.com/67027949/114945999-3832b280-9dff-11eb-8fe4-4bb0219b9b45.png"><p>(short pause)</p><img width="646" alt="Screen Shot 2021-04-15 at 3 37 37 PM" src="https://user-images.githubusercontent.com/67027949/114946720-94e29d00-9e00-11eb-925b-fe32bea5b3d6.png"> | <img width="274" alt="Screen Shot 2021-04-15 at 3 32 24 PM" src="https://user-images.githubusercontent.com/67027949/114946319-d32b8c80-9dff-11eb-8c53-0be9d2408235.png"><img width="646" alt="Screen Shot 2021-04-15 at 3 08 48 PM" src="https://user-images.githubusercontent.com/67027949/114945999-3832b280-9dff-11eb-8fe4-4bb0219b9b45.png"><p>(short pause)</p><img width="646" alt="Screen Shot 2021-04-15 at 3 08 52 PM" src="https://user-images.githubusercontent.com/67027949/114946056-51d3fa00-9dff-11eb-92d9-3e42d74fa157.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/520)