### PR TITLE
Avatar border colors now show color

### DIFF
--- a/ios/FluentUI/Avatar/AvatarGroupView.swift
+++ b/ios/FluentUI/Avatar/AvatarGroupView.swift
@@ -41,7 +41,7 @@ open class AvatarGroupView: UIView {
         }
     }
 
-    /// Set to true to generate border colors from InitialView ColorSet
+    /// Set to true to generate border colors from InitialView ColorSet excluding the Overflow AvatarView
     @objc open var shouldGenerateBorderColor: Bool = false {
         didSet {
             if oldValue != shouldGenerateBorderColor {

--- a/ios/FluentUI/Avatar/AvatarGroupView.swift
+++ b/ios/FluentUI/Avatar/AvatarGroupView.swift
@@ -41,6 +41,15 @@ open class AvatarGroupView: UIView {
         }
     }
 
+    /// Set to true to generate border colors from InitialView ColorSet
+    @objc open var shouldGenerateBorderColor: Bool = false {
+        didSet {
+            if oldValue != shouldGenerateBorderColor {
+                updateAvatars()
+            }
+        }
+    }
+
     /// Maximum count of avatars that can be displayed in the avatar group view.
     /// If the avatars array contains more avatars than this limit, an overflow UI will be displayed with the overflow count.
     /// The overflow UI is an avatar view with a "+" sign and the overflow count.
@@ -119,6 +128,7 @@ open class AvatarGroupView: UIView {
 
         for avatar in avatars.prefix(Int(maxDisplayedAvatars)) {
             let avatarView = AvatarView(avatarSize: avatarSize, withBorder: showBorders, style: .circle)
+            avatarView.shouldGenerateBorderColor = shouldGenerateBorderColor
             avatarView.setup(avatar: avatar)
 
             constraints.append(contentsOf: insert(avatarView: avatarView, previousAvatarView: previousAvatarView))

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -258,7 +258,7 @@ open class AvatarView: UIView {
         }
     }
 
-    /// When true, the border color will be calculated using InitialView's ColorSet
+    /// When true, the border color will be calculated using InitialView's ColorSet excluding the Overflow AvatarView
     @objc open var shouldGenerateBorderColor: Bool = false {
         didSet {
             if oldValue != shouldGenerateBorderColor {

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -730,7 +730,6 @@ open class AvatarView: UIView {
             if let window = window {
                 imageView.backgroundColor = style.backgroundColor(for: window)
                 imageView.tintColor = style.imageColor(for: window)
-                borderColor = style == AvatarFallbackImageStyle.primaryFilled ? style.imageColor(for: window) : style.backgroundColor(for: window)
             }
 
             fallbackImageStyle = style

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -257,13 +257,13 @@ open class AvatarView: UIView {
             }
         }
     }
-    
+
     @objc open var shouldCalculateRingColor: Bool = false {
         didSet {
             updateBorderColor()
         }
     }
-    
+
     @objc open var borderColor: UIColor? {
         didSet {
             if hasBorder && !hasCustomBorder {

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -444,10 +444,11 @@ open class AvatarView: UIView {
         self.secondaryText = secondaryText
         self.presence = presence
         self.fallbackImageStyle = nil
+        setupInitialsView(convertTextToInitials: convertTextToInitials)
         if let image = image {
             setupWithImage(image)
         } else if !convertTextToInitials || isInitialsAvailable() {
-            setupWithInitialsView(convertTextToInitials: convertTextToInitials)
+            showInitialsView()
         } else {
             updateImageViewWithFallbackImage(style: preferredFallbackImageStyle)
         }
@@ -532,19 +533,24 @@ open class AvatarView: UIView {
         }
     }
 
-    private func setupWithInitialsView(convertTextToInitials: Bool) {
+    private func setupInitialsView(convertTextToInitials: Bool) {
         if convertTextToInitials {
             initialsView.setup(primaryText: primaryText, secondaryText: secondaryText)
         } else {
             initialsView.setup(initialsText: primaryText ?? secondaryText)
         }
 
-        initialsView.isHidden = false
-        imageView.isHidden = true
+        showInitialsView()
 
         if let initialsViewBackgroundColor = initialsView.backgroundColor {
             avatarBackgroundColor = initialsViewBackgroundColor
+            borderColor = initialsViewBackgroundColor
         }
+    }
+
+    private func showInitialsView() {
+        initialsView.isHidden = false
+        imageView.isHidden = true
     }
 
     private func setupWithImage(_ image: UIImage, animated: Bool = false) {

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -257,7 +257,13 @@ open class AvatarView: UIView {
             }
         }
     }
-
+    
+    @objc open var shouldCalculateRingColor: Bool = false {
+        didSet {
+            updateBorderColor()
+        }
+    }
+    
     @objc open var borderColor: UIColor? {
         didSet {
             if hasBorder && !hasCustomBorder {
@@ -444,11 +450,10 @@ open class AvatarView: UIView {
         self.secondaryText = secondaryText
         self.presence = presence
         self.fallbackImageStyle = nil
-        setupInitialsView(convertTextToInitials: convertTextToInitials)
         if let image = image {
             setupWithImage(image)
         } else if !convertTextToInitials || isInitialsAvailable() {
-            showInitialsView()
+            setupWithInitialsView(convertTextToInitials: convertTextToInitials)
         } else {
             updateImageViewWithFallbackImage(style: preferredFallbackImageStyle)
         }
@@ -533,23 +538,19 @@ open class AvatarView: UIView {
         }
     }
 
-    private func setupInitialsView(convertTextToInitials: Bool) {
+    private func setupWithInitialsView(convertTextToInitials: Bool) {
         if convertTextToInitials {
             initialsView.setup(primaryText: primaryText, secondaryText: secondaryText)
         } else {
             initialsView.setup(initialsText: primaryText ?? secondaryText)
         }
 
-        showInitialsView()
+        initialsView.isHidden = false
+        imageView.isHidden = true
 
         if let initialsViewBackgroundColor = initialsView.backgroundColor {
             avatarBackgroundColor = initialsViewBackgroundColor
         }
-    }
-
-    private func showInitialsView() {
-        initialsView.isHidden = false
-        imageView.isHidden = true
     }
 
     private func setupWithImage(_ image: UIImage, animated: Bool = false) {
@@ -594,7 +595,8 @@ open class AvatarView: UIView {
         if let borderColor = borderColor {
             borderView.layer.borderColor = borderColor.cgColor
         } else {
-            borderView.layer.borderColor = Colors.Avatar.border.cgColor
+            borderView.layer.borderColor = shouldCalculateRingColor ?
+                InitialsView.initialsColorSet(fromPrimaryText: primaryText, secondaryText: secondaryText).background.cgColor : Colors.Avatar.border.cgColor
         }
     }
 

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -258,9 +258,12 @@ open class AvatarView: UIView {
         }
     }
 
-    @objc open var shouldCalculateRingColor: Bool = false {
+    /// When true, the border color will be calculated using InitialView's ColorSet
+    @objc open var shouldGenerateBorderColor: Bool = false {
         didSet {
-            updateBorderColor()
+            if oldValue != shouldGenerateBorderColor {
+                updateBorderColor()
+            }
         }
     }
 
@@ -595,7 +598,7 @@ open class AvatarView: UIView {
         if let borderColor = borderColor {
             borderView.layer.borderColor = borderColor.cgColor
         } else {
-            borderView.layer.borderColor = shouldCalculateRingColor ?
+            borderView.layer.borderColor = shouldGenerateBorderColor ?
                 InitialsView.initialsColorSet(fromPrimaryText: primaryText, secondaryText: secondaryText).background.cgColor : Colors.Avatar.border.cgColor
         }
     }

--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -544,7 +544,6 @@ open class AvatarView: UIView {
 
         if let initialsViewBackgroundColor = initialsView.backgroundColor {
             avatarBackgroundColor = initialsViewBackgroundColor
-            borderColor = initialsViewBackgroundColor
         }
     }
 
@@ -729,6 +728,7 @@ open class AvatarView: UIView {
             if let window = window {
                 imageView.backgroundColor = style.backgroundColor(for: window)
                 imageView.tintColor = style.imageColor(for: window)
+                borderColor = style == AvatarFallbackImageStyle.primaryFilled ? style.imageColor(for: window) : style.backgroundColor(for: window)
             }
 
             fallbackImageStyle = style

--- a/ios/FluentUI/Avatar/InitialsView.swift
+++ b/ios/FluentUI/Avatar/InitialsView.swift
@@ -88,7 +88,7 @@ public extension Colors {
  The initials are generated from a provided primary text (e.g. a name) or secondary text (e.g. an email address) and placed as a label above a colored background.
  */
 class InitialsView: UIView {
-    private static func initialsColorSet(fromPrimaryText primaryText: String?, secondaryText: String?) -> ColorSet {
+    static func initialsColorSet(fromPrimaryText primaryText: String?, secondaryText: String?) -> ColorSet {
         // Set the color based on the primary text and secondary text
         var combined: String
         if let secondaryText = secondaryText, let primaryText = primaryText, secondaryText.count > 0 {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Avatar border colors disappeared with #434. They are now back with the updated Color Set.

### Verification: (color tests not checked in)

| Default setting | Enabling border color generation: | Color inputs from PersonaData (should override default color): |
|-----|-----|-----|
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-28 at 16 40 45](https://user-images.githubusercontent.com/22566866/116476192-7d63d500-a840-11eb-84fb-d276e765545e.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-28 at 16 35 39](https://user-images.githubusercontent.com/22566866/116475985-31189500-a840-11eb-983c-dc508c0330b9.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-16 at 17 57 51](https://user-images.githubusercontent.com/22566866/115091484-43f4a680-9edd-11eb-9da8-d44cd6f64b95.png) |

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-16 at 17 55 33](https://user-images.githubusercontent.com/22566866/115091373-f1b38580-9edc-11eb-9e05-d81e85afd281.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-16 at 17 53 35](https://user-images.githubusercontent.com/22566866/115091266-ab5e2680-9edc-11eb-822a-cccc17681cf7.png) |
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-16 at 17 55 04](https://user-images.githubusercontent.com/22566866/115091340-e06a7900-9edc-11eb-8f9b-9a1204cfaf49.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-16 at 17 53 47](https://user-images.githubusercontent.com/22566866/115091293-bc0e9c80-9edc-11eb-806c-93985c73b7dd.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/522)