### PR TITLE
Adding iPad Pointer Interaction support to the Avatar.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -10,6 +10,11 @@ class AvatarDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let enablePointerInteractionSettingView = createLabelAndSwitchRow(labelText: "Enable iPad pointer interaction",
+                                                                          switchAction: #selector(toggleEnablePointerInteraction(switchView:)),
+                                                                          isOn: isPointerInteractionEnabled)
+        addRow(items: [enablePointerInteractionSettingView])
+
         let backgroundSettingView = createLabelAndSwitchRow(labelText: "Use alternate background color",
                                                             switchAction: #selector(toggleAlternateBackground(switchView:)),
                                                             isOn: isUsingAlternateBackgroundColor)
@@ -120,6 +125,16 @@ class AvatarDemoController: DemoController {
         }
     }
 
+    private var isPointerInteractionEnabled: Bool = false {
+        didSet {
+            if oldValue != isPointerInteractionEnabled {
+                for avatarView in avatarViews {
+                    avatarView.state.hasPointerInteraction = isPointerInteractionEnabled
+                }
+            }
+        }
+    }
+
     private var isShowingPresence: Bool = false {
         didSet {
             if oldValue != isShowingPresence {
@@ -175,6 +190,10 @@ class AvatarDemoController: DemoController {
         }
 
         return presence!
+    }
+
+    @objc private func toggleEnablePointerInteraction(switchView: UISwitch) {
+        isPointerInteractionEnabled = switchView.isOn
     }
 
     @objc private func toggleShowPresence(switchView: UISwitch) {

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -206,7 +206,6 @@ public struct AvatarView: View {
                         .frame(width: tokens.avatarSize, height: tokens.avatarSize, alignment: .center)
                         .contentShape(RoundedRectangle(cornerRadius: tokens.borderRadius))
                         .clipShape(RoundedRectangle(cornerRadius: tokens.borderRadius))
-                        .cornerRadius(tokens.borderRadius)
             } else {
                 Circle()
                     .foregroundColor(ringGapColor)
@@ -244,9 +243,7 @@ public struct AvatarView: View {
                                                 .frame(width: presenceIconFrameSideRelativeToOuterRing, height: presenceIconFrameSideRelativeToOuterRing, alignment: .bottomTrailing)
                                         ,
                                              alignment: .topLeading)
-                                .frame(width: overallFrameSide,
-                                       height: overallFrameSide,
-                                       alignment: .topLeading)
+                                .frame(width: overallFrameSide, height: overallFrameSide, alignment: .topLeading)
                     })
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- Adds iPad Pointer interaction support to the Avatar which is disabled by default.
- Optimizes the SwiftUI code by removing AnyView() calls where possible.

### Verification

1. Verified behavior on both iOS 13.7 and iOS 14.4.
2. Exercised Avatar properties (rings, transparency and presence status)

**iOS 14.4**

https://user-images.githubusercontent.com/68076145/115325133-f330b800-a13f-11eb-8975-bd78d4ab1472.mov

**iOS 13.7**

https://user-images.githubusercontent.com/68076145/115325191-06dc1e80-a140-11eb-8fc5-10e3a1365b13.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/527)