### PR TITLE
Adding capability to disable safe area insets in a UIHostingController.

### DIFF
--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -318,10 +318,11 @@ public struct AvatarView: View {
                       size: MSFAvatarSize = .large,
                       theme: FluentUIStyle? = nil) {
         avatarview = AvatarView(style: style,
-                                           size: size)
+                                size: size)
         hostingController = UIHostingController(rootView: AnyView(avatarview.modifyIf(theme != nil, { avatarview in
             avatarview.usingTheme(theme!)
         })))
+        hostingController.disableSafeAreaInsets()
 
         super.init()
 

--- a/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
@@ -6,6 +6,30 @@
 import UIKit
 import SwiftUI
 
+extension UIHostingController {
+    /// Disables the UIHostingController's view safe area insets by swizzling the UIView.safeAreaInsets property and returning UIEdgeInsets.zero.
+    /// This is a known issue and it's currently tracked by Radar bug FB8176223 - https://openradar.appspot.com/FB8176223
+    func disableSafeAreaInsets() {
+        guard let hostingControllerViewClass = view?.classForCoder else {
+            return
+        }
+
+        guard let safeAreaInsetsMethod = class_getInstanceMethod(hostingControllerViewClass.self,
+                                                                 #selector(getter: UIView.safeAreaInsets)) else {
+            return
+        }
+
+        let zeroSafeAreaInsetsImpl: @convention(block) (AnyObject) -> UIEdgeInsets = { (self: AnyObject!) -> UIEdgeInsets in
+            return .zero
+        }
+
+        class_replaceMethod(hostingControllerViewClass,
+                            #selector(getter: UIView.safeAreaInsets),
+                            imp_implementationWithBlock(zeroSafeAreaInsetsImpl),
+                            method_getTypeEncoding(safeAreaInsetsMethod))
+    }
+}
+
 /// This is a generic UIView wrapper to allow SwiftUI to use views from non-SwiftUI environments.
 struct UIViewAdapter: UIViewRepresentable {
 

--- a/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
@@ -19,7 +19,7 @@ extension UIHostingController {
             return
         }
 
-        let zeroSafeAreaInsetsImpl: @convention(block) (AnyObject) -> UIEdgeInsets = { (self: AnyObject!) -> UIEdgeInsets in
+        let zeroSafeAreaInsetsImpl: @convention(block) (AnyObject) -> UIEdgeInsets = { (_ self: AnyObject!) -> UIEdgeInsets in
             return .zero
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We've been experiencing bugs on the initial placement of the Avatar in certain scenarios where the main UIView being presented is affected by the safe area insets.

After investigation/debugging it was diagnosed that the UIView of the UIHostingViewController had its safe area insets changed when the view is presented or added to the view hierarchy.

Apple currently does not provide any property to allow the control of the safe area insets of the UIView provided by the UIHostingController. ([insetsLayoutMarginsFromSafeArea](https://developer.apple.com/documentation/uikit/uiview/2891101-insetslayoutmarginsfromsafearea) property of the UIView does not work).

This issue is being tracked by Apple Radar bug FB8176223:
https://openradar.appspot.com/FB8176223

The workaround for this issue at this point is swizzling into the property [safeAreaInsets](https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets) of that UIView provided by the UIHostingController and returning **UIEdgeInsets.zero** to ensure the safe area insets of the view hierarchy does not affect the UIHostingController.

### Verification

**1. Reproduced the LeftNav issue multiple times confirming that the safe area insets values were not zero:**

https://user-images.githubusercontent.com/68076145/115343069-23884e80-a160-11eb-9e4e-4d83d761098f.mov

**2. Confirmed the issue does not reproduce after the fix is applied (also checked that values of the safe area insets were all zeroed):**

https://user-images.githubusercontent.com/68076145/115343306-942f6b00-a160-11eb-8771-abae4921c1f9.mov







### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/528)