### PR TITLE
DatePicker (macOS): Fix keyboard navigation for NSPopover variant

### DIFF
--- a/macos/FluentUI/DatePicker/DatePickerView.swift
+++ b/macos/FluentUI/DatePicker/DatePickerView.swift
@@ -340,6 +340,7 @@ class DatePickerView: NSView {
 			self.monthClipView.heightAnchor.constraint(equalTo: self.calendarView.heightAnchor).isActive = true
 			self.updateSelection()
 			self.isAnimating = false
+			self.window?.recalculateKeyViewLoop()
 		})
 	}
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
To update the keyboard focus elements in the NSPopover version of the date picker, add a `recalculateKeyViewLoop()` to the completion handler of the month change animation.

Resolves #511 

### Verification
Used test app with full keyboard navigation enabled on the system.  Change has no effect on the in-window or NSMenu variant of the date picker.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/67027949/115386417-33b72280-a18e-11eb-8a50-ab48cb12cdf0.gif) | ![After](https://user-images.githubusercontent.com/67027949/115386476-4893b600-a18e-11eb-9636-85eb157f34af.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/529)