### PR TITLE
make sure resizing handle is accessible for drawercontroller

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -682,7 +682,7 @@ open class DrawerController: UIViewController {
         return canResize && presentationDirection.isVertical
     }
     private var resizingHandleIsInteractive: Bool {
-        return resizingBehavior == .dismissOrExpand
+        return resizingBehavior == .dismissOrExpand || resizingBehavior == .expand
     }
 
     private var canResizeViaContentScrolling: Bool {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

If the resizehandle is shown for expandable or dismiss and expandable, make sure it is accessible.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| VO focus not on resize handle | ![IMG_0036](https://user-images.githubusercontent.com/20715435/115473304-59751380-a1f0-11eb-8746-a2791866d7a7.PNG) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/530)