### PR TITLE
when avatar is being updated for large title view, lets make sure the…

### DIFF
--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -387,9 +387,7 @@ open class AvatarView: UIView {
             updateBorder()
         }
 
-        if hasCustomBorder || hasBorder {
-            updateInnerStroke()
-        }
+        updateInnerStroke()
 
         if let fallbackImageStyle = fallbackImageStyle {
             updateImageViewWithFallbackImage(style: fallbackImageStyle)
@@ -620,12 +618,19 @@ open class AvatarView: UIView {
     }
 
     private func updateInnerStroke() {
-        imageView.layer.borderWidth = avatarSize.insideBorder
-        imageView.layer.borderColor = Colors.surfacePrimary.cgColor
-        imageView.layer.masksToBounds = true
-        initialsView.layer.borderWidth = avatarSize.insideBorder
-        initialsView.layer.borderColor = Colors.surfacePrimary.cgColor
-        initialsView.layer.masksToBounds = true
+        if hasCustomBorder || hasBorder {
+            imageView.layer.borderWidth = avatarSize.insideBorder
+            imageView.layer.borderColor = Colors.surfacePrimary.cgColor
+            imageView.layer.masksToBounds = true
+            initialsView.layer.borderWidth = avatarSize.insideBorder
+            initialsView.layer.borderColor = Colors.surfacePrimary.cgColor
+            initialsView.layer.masksToBounds = true
+        } else {
+            imageView.layer.borderWidth = 0
+            imageView.layer.borderColor = nil
+            initialsView.layer.borderWidth = 0
+            initialsView.layer.borderColor = nil
+        }
     }
 
     private func updatePresenceImage() {

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -27,7 +27,10 @@ class LargeTitleView: UIView {
     var avatar: Avatar? {
         didSet {
             updateProfileButtonVisibility()
-            [avatarView, smallMorphingAvatarView].forEach { $0?.setup(avatar: avatar) }
+            [avatarView, smallMorphingAvatarView].forEach {
+                $0?.setup(avatar: avatar)
+                $0?.layoutSubviews()
+            }
         }
     }
 


### PR DESCRIPTION
… inner stoke is recalculated to show and hide border view correctly

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/538)