### PR TITLE
[List vNext] Creating SwiftUI property exposure for UIView properties

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -243,7 +243,7 @@ class LeftNavMenuViewController: UIViewController {
         persona.state.primaryText = "Kat Larrson"
         persona.state.secondaryText = "Designer"
         persona.state.image = UIImage(named: "avatar_kat_larsson")
-        persona.state.titleTrailingAccessoryView = chevron
+        persona.state.titleTrailingAccessoryUIView = chevron
         persona.state.backgroundColor = .systemBackground
         persona.state.onTapAction = {
             self.dismiss(animated: true, completion: {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -103,18 +103,18 @@ class ListDemoController: DemoController {
                 listCell.footnote = cell.text3
                 if !listCell.subtitle.isEmpty {
                     listCell.leadingViewSize = MSFListCellLeadingViewSize.large
-                    listCell.subtitleLeadingAccessoryView = showsLabelAccessoryView ? createCustomView(imageName: "success-12x12", imageType: "subtitle") : nil
-                    listCell.subtitleTrailingAccessoryView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-down-20x20", imageType: "subtitle") : nil
+                    listCell.subtitleLeadingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "success-12x12", imageType: "subtitle") : nil
+                    listCell.subtitleTrailingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-down-20x20", imageType: "subtitle") : nil
                 }
 
-                listCell.titleLeadingAccessoryView = showsLabelAccessoryView ? createCustomView(imageName: "ic_fluent_presence_available_16_filled", imageType: "title") : nil
-                listCell.titleTrailingAccessoryView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-right-20x20", imageType: "title") : nil
+                listCell.titleLeadingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "ic_fluent_presence_available_16_filled", imageType: "title") : nil
+                listCell.titleTrailingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-right-20x20", imageType: "title") : nil
 
                 listCell.titleLineLimit = section.numberOfLines
                 listCell.subtitleLineLimit = section.numberOfLines
                 listCell.footnoteLineLimit = section.numberOfLines
                 listCell.leadingUIView = createCustomView(imageName: cell.image)
-                listCell.trailingView = section.hasAccessory ? createCustomView(imageName: cell.image) : nil
+                listCell.trailingUIView = section.hasAccessory ? createCustomView(imageName: cell.image) : nil
                 listCell.accessoryType = accessoryType(for: rowIndex)
                 listCell.onTapAction = {
                     indexPath.row = rowIndex

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -785,8 +785,8 @@
 				536AEF2E25F1EC0300A36206 /* Button */,
 				536AEF2925F1EC0300A36206 /* Core */,
 				536AEF2225F1EC0300A36206 /* Drawer */,
-				0AA8741326001F0500D47421 /* Persona */,
 				536AEF3225F1EC0300A36206 /* List */,
+				0AA8741326001F0500D47421 /* Persona */,
 			);
 			path = Vnext;
 			sourceTree = "<group>";

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -30,7 +30,6 @@ import SwiftUI
 @objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
 
-    // SwiftUI View Properties
     @Published public var leadingView: AnyView?
     @Published public var titleLeadingAccessoryView: AnyView?
     @Published public var titleTrailingAccessoryView: AnyView?
@@ -56,60 +55,75 @@ import SwiftUI
     @objc @Published public var hasDivider: Bool = false
     @objc public var onTapAction: (() -> Void)?
 
-    // Any UIView property will set the value to a type-erased SwiftUI View
     @objc public var leadingUIView: UIView? {
         didSet {
-            if let view = self.leadingUIView {
-                self.leadingView = AnyView(UIViewAdapter(view))
+            if let view = leadingUIView {
+                leadingView = AnyView(UIViewAdapter(view))
+            } else {
+                leadingView = nil
             }
         }
     }
     @objc public var titleLeadingAccessoryUIView: UIView? {
         didSet {
-            if let view = self.titleLeadingAccessoryUIView {
-                self.titleLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            if let view = titleLeadingAccessoryUIView {
+                titleLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            } else {
+                titleLeadingAccessoryView = nil
             }
         }
     }
     @objc public var titleTrailingAccessoryUIView: UIView? {
         didSet {
-            if let view = self.titleTrailingAccessoryUIView {
-                self.titleTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            if let view = titleTrailingAccessoryUIView {
+                titleTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            } else {
+                titleTrailingAccessoryView = nil
             }
         }
     }
     @objc public var subtitleLeadingAccessoryUIView: UIView? {
         didSet {
-            if let view = self.subtitleLeadingAccessoryUIView {
-                self.subtitleLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            if let view = subtitleLeadingAccessoryUIView {
+                subtitleLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            } else {
+                subtitleLeadingAccessoryView = nil
             }
         }
     }
     @objc public var subtitleTrailingAccessoryUIView: UIView? {
         didSet {
-            if let view = self.subtitleTrailingAccessoryUIView {
-                self.subtitleTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            if let view = subtitleTrailingAccessoryUIView {
+                subtitleTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            } else {
+                subtitleTrailingAccessoryView = nil
             }
         }
     }
     @objc public var footnoteLeadingAccessoryUIView: UIView? {
         didSet {
-            if let view = self.footnoteLeadingAccessoryUIView {
-                self.footnoteLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            if let view = footnoteLeadingAccessoryUIView {
+                footnoteLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            } else {
+                footnoteLeadingAccessoryView = nil
             }
         }
     }
     @objc public var footnoteTrailingAccessoryUIView: UIView? {
         didSet {
-            if let view = self.footnoteTrailingAccessoryUIView {
-                self.footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            if let view = footnoteTrailingAccessoryUIView {
+                footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            } else {
+                footnoteTrailingAccessoryView = nil
             }
         }
     }
     @objc public var trailingUIView: UIView? {
         didSet {
-            if let view = self.trailingUIView {
-                self.trailingView = AnyView(UIViewAdapter(view))
+            if let view = trailingUIView {
+                trailingView = AnyView(UIViewAdapter(view))
+            } else {
+                trailingView = nil
             }
         }
     }

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -30,7 +30,7 @@ import SwiftUI
 @objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
 
-    //SwiftUI View Properties
+    // SwiftUI View Properties
     @Published public var leadingView: AnyView?
     @Published public var titleLeadingAccessoryView: AnyView?
     @Published public var titleTrailingAccessoryView: AnyView?

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -57,74 +57,89 @@ import SwiftUI
 
     @objc public var leadingUIView: UIView? {
         didSet {
-            if let view = leadingUIView {
-                leadingView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = leadingUIView else {
                 leadingView = nil
+                return
             }
+
+            leadingView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var titleLeadingAccessoryUIView: UIView? {
         didSet {
-            if let view = titleLeadingAccessoryUIView {
-                titleLeadingAccessoryView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = titleLeadingAccessoryUIView else {
                 titleLeadingAccessoryView = nil
+                return
             }
+
+            titleLeadingAccessoryView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var titleTrailingAccessoryUIView: UIView? {
         didSet {
-            if let view = titleTrailingAccessoryUIView {
-                titleTrailingAccessoryView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = titleTrailingAccessoryUIView else {
                 titleTrailingAccessoryView = nil
+                return
             }
+
+            titleTrailingAccessoryView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var subtitleLeadingAccessoryUIView: UIView? {
         didSet {
-            if let view = subtitleLeadingAccessoryUIView {
-                subtitleLeadingAccessoryView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = subtitleLeadingAccessoryUIView else {
                 subtitleLeadingAccessoryView = nil
+                return
             }
+
+            subtitleLeadingAccessoryView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var subtitleTrailingAccessoryUIView: UIView? {
         didSet {
-            if let view = subtitleTrailingAccessoryUIView {
-                subtitleTrailingAccessoryView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = subtitleTrailingAccessoryUIView else {
                 subtitleTrailingAccessoryView = nil
+                return
             }
+
+            subtitleTrailingAccessoryView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var footnoteLeadingAccessoryUIView: UIView? {
         didSet {
-            if let view = footnoteLeadingAccessoryUIView {
-                footnoteLeadingAccessoryView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = footnoteLeadingAccessoryUIView else {
                 footnoteLeadingAccessoryView = nil
+                return
             }
+
+            footnoteLeadingAccessoryView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var footnoteTrailingAccessoryUIView: UIView? {
         didSet {
-            if let view = footnoteTrailingAccessoryUIView {
-                footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = footnoteTrailingAccessoryUIView else {
                 footnoteTrailingAccessoryView = nil
+                return
             }
+
+            footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
         }
     }
+
     @objc public var trailingUIView: UIView? {
         didSet {
-            if let view = trailingUIView {
-                trailingView = AnyView(UIViewAdapter(view))
-            } else {
+            guard let view = trailingUIView else {
                 trailingView = nil
+                return
             }
+
+            trailingView = AnyView(UIViewAdapter(view))
         }
     }
 }

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -29,25 +29,21 @@ import SwiftUI
 ///
 @objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
+
+    //SwiftUI View Properties
     @Published public var leadingView: AnyView?
-    @objc public var leadingUIView: UIView? {
-        didSet {
-            if let view = self.leadingUIView {
-                self.leadingView = AnyView(UIViewAdapter(view))
-            }
-        }
-    }
+    @Published public var titleLeadingAccessoryView: AnyView?
+    @Published public var titleTrailingAccessoryView: AnyView?
+    @Published public var subtitleLeadingAccessoryView: AnyView?
+    @Published public var subtitleTrailingAccessoryView: AnyView?
+    @Published public var footnoteLeadingAccessoryView: AnyView?
+    @Published public var footnoteTrailingAccessoryView: AnyView?
+    @Published public var trailingView: AnyView?
+
     @objc @Published public var leadingViewSize: MSFListCellLeadingViewSize = .medium
     @objc @Published public var title: String = ""
     @objc @Published public var subtitle: String = ""
     @objc @Published public var footnote: String = ""
-    @objc @Published public var titleLeadingAccessoryView: UIView?
-    @objc @Published public var titleTrailingAccessoryView: UIView?
-    @objc @Published public var subtitleLeadingAccessoryView: UIView?
-    @objc @Published public var subtitleTrailingAccessoryView: UIView?
-    @objc @Published public var footnoteLeadingAccessoryView: UIView?
-    @objc @Published public var footnoteTrailingAccessoryView: UIView?
-    @objc @Published public var trailingView: UIView?
     @objc @Published public var accessoryType: MSFListAccessoryType = .none
     @objc @Published public var backgroundColor: UIColor?
     @objc @Published public var highlightedBackgroundColor: UIColor?
@@ -59,6 +55,64 @@ import SwiftUI
     @objc @Published public var layoutType: MSFListCellLayoutType = .automatic
     @objc @Published public var hasDivider: Bool = false
     @objc public var onTapAction: (() -> Void)?
+
+    // Any UIView property will set the value to a type-erased SwiftUI View
+    @objc public var leadingUIView: UIView? {
+        didSet {
+            if let view = self.leadingUIView {
+                self.leadingView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var titleLeadingAccessoryUIView: UIView? {
+        didSet {
+            if let view = self.titleLeadingAccessoryUIView {
+                self.titleLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var titleTrailingAccessoryUIView: UIView? {
+        didSet {
+            if let view = self.titleTrailingAccessoryUIView {
+                self.titleTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var subtitleLeadingAccessoryUIView: UIView? {
+        didSet {
+            if let view = self.subtitleLeadingAccessoryUIView {
+                self.subtitleLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var subtitleTrailingAccessoryUIView: UIView? {
+        didSet {
+            if let view = self.subtitleTrailingAccessoryUIView {
+                self.subtitleTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var footnoteLeadingAccessoryUIView: UIView? {
+        didSet {
+            if let view = self.footnoteLeadingAccessoryUIView {
+                self.footnoteLeadingAccessoryView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var footnoteTrailingAccessoryUIView: UIView? {
+        didSet {
+            if let view = self.footnoteTrailingAccessoryUIView {
+                self.footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
+    @objc public var trailingUIView: UIView? {
+        didSet {
+            if let view = self.trailingUIView {
+                self.trailingView = AnyView(UIViewAdapter(view))
+            }
+        }
+    }
 }
 
 /// Pre-defined layout heights of cells
@@ -109,7 +163,7 @@ struct MSFListCellView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 0) {
                         if let titleLeadingAccessoryView = state.titleLeadingAccessoryView {
-                            UIViewAdapter(titleLeadingAccessoryView)
+                            titleLeadingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.trailing, labelAccessoryInterspace)
                         }
@@ -120,7 +174,7 @@ struct MSFListCellView: View {
                                 .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)
                         }
                         if let titleTrailingAccessoryView = state.titleTrailingAccessoryView {
-                            UIViewAdapter(titleTrailingAccessoryView)
+                            titleTrailingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.leading, labelAccessoryInterspace)
                         }
@@ -128,7 +182,7 @@ struct MSFListCellView: View {
 
                     HStack(spacing: 0) {
                         if let subtitleLeadingAccessoryView = state.subtitleLeadingAccessoryView {
-                            UIViewAdapter(subtitleLeadingAccessoryView)
+                            subtitleLeadingAccessoryView
                                 .frame(width: sublabelAccessorySize, height: sublabelAccessorySize)
                                 .padding(.trailing, labelAccessoryInterspace)
                         }
@@ -139,7 +193,7 @@ struct MSFListCellView: View {
                                 .lineLimit(state.subtitleLineLimit == 0 ? nil : state.subtitleLineLimit)
                         }
                         if let subtitleTrailingAccessoryView = state.subtitleTrailingAccessoryView {
-                            UIViewAdapter(subtitleTrailingAccessoryView)
+                            subtitleTrailingAccessoryView
                                 .frame(width: sublabelAccessorySize, height: sublabelAccessorySize)
                                 .padding(.leading, labelAccessoryInterspace)
                         }
@@ -147,7 +201,7 @@ struct MSFListCellView: View {
 
                     HStack(spacing: 0) {
                         if let footnoteLeadingAccessoryView = state.footnoteLeadingAccessoryView {
-                            UIViewAdapter(footnoteLeadingAccessoryView)
+                            footnoteLeadingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.trailing, labelAccessoryInterspace)
                         }
@@ -158,7 +212,7 @@ struct MSFListCellView: View {
                                 .lineLimit(state.footnoteLineLimit == 0 ? nil : state.footnoteLineLimit)
                         }
                         if let footnoteTrailingAccessoryView = state.footnoteTrailingAccessoryView {
-                            UIViewAdapter(footnoteTrailingAccessoryView)
+                            footnoteTrailingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.leading, labelAccessoryInterspace)
                         }
@@ -168,7 +222,7 @@ struct MSFListCellView: View {
                 Spacer()
 
                 if let trailingView = state.trailingView {
-                    UIViewAdapter(trailingView)
+                    trailingView
                         .frame(width: tokens.trailingItemSize, height: tokens.trailingItemSize)
                         .fixedSize()
                 }

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -19,8 +19,13 @@ import SwiftUI
     var onTapAction: (() -> Void)? { get set }
 }
 
+public protocol PersonaViewState: MSFPersonaViewState {
+    var titleTrailingAccessoryView: AnyView? { get set }
+    var subtitleTrailingAccessoryView: AnyView? { get set }
+}
+
 /// Properties that make up PersonaView content
-class MSFPersonaViewStateImpl: MSFListCellState, MSFPersonaViewState {
+class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
     init(avatarState: MSFAvatarState) {
         self.avatarState = avatarState
     }

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -156,9 +156,6 @@ public struct PersonaView: View {
         state = MSFPersonaViewStateImpl(avatarState: avatar.state)
         state.leadingView = AnyView(avatar)
         state.leadingViewSize = .xlarge
-        state.titleTrailingAccessoryUIView = state.titleTrailingAccessoryUIView
-        state.subtitleTrailingAccessoryUIView = state.subtitleTrailingAccessoryUIView
-        state.onTapAction = state.onTapAction
         state.layoutType = .threeLines
     }
 

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -14,8 +14,8 @@ import SwiftUI
 /// `onTapAction` provides tap gesture for PersonaView.
 ///
 @objc public protocol MSFPersonaViewState: MSFAvatarState {
-    var titleTrailingAccessoryView: UIView? { get set }
-    var subtitleTrailingAccessoryView: UIView? { get set }
+    var titleTrailingAccessoryUIView: UIView? { get set }
+    var subtitleTrailingAccessoryUIView: UIView? { get set }
     var onTapAction: (() -> Void)? { get set }
 }
 
@@ -151,8 +151,8 @@ public struct PersonaView: View {
         state = MSFPersonaViewStateImpl(avatarState: avatar.state)
         state.leadingView = AnyView(avatar)
         state.leadingViewSize = .xlarge
-        state.titleTrailingAccessoryView = state.titleTrailingAccessoryView
-        state.subtitleTrailingAccessoryView = state.subtitleTrailingAccessoryView
+        state.titleTrailingAccessoryUIView = state.titleTrailingAccessoryUIView
+        state.subtitleTrailingAccessoryUIView = state.subtitleTrailingAccessoryUIView
         state.onTapAction = state.onTapAction
         state.layoutType = .threeLines
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Any UIView property in the List would not be accessible in a SwiftUI-only environment. This is a follow-up from #475 where the leadingView property was updated so that it can be set in SwiftUI as well.

### Verification

The PersonaView is using several of these properties:

- The leadingView is a SwiftUI View set in the PersonaView.
- The chevron is a UIView, which is then set as a SwiftUI View in the ListCell.
![Simulator Screen Shot - iPhone 11 Pro - 2021-04-26 at 15 57 23](https://user-images.githubusercontent.com/22566866/116149709-17dce080-a6a8-11eb-99b5-1c061d0550d7.png)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/541)