### PR TITLE
Expose public variable for AvatarView to hide border ring gap

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
@@ -23,7 +23,7 @@ class AvatarViewDemoController: DemoController {
         let backgroundSettingView = createLabelAndSwitchRow(labelText: "Use alternate background color",
                                                             switchAction: #selector(toggleAlternateBackground(switchView:)),
                                                             isOn: isUsingAlternateBackgroundColor)
-        
+
         let hideInsideGapForBorderSettingView = createLabelAndSwitchRow(labelText: "Hide inside gap for border ring",
                                                             switchAction: #selector(toggleHideInsideGap(switchView:)),
                                                             isOn: isHidingInsideGapForBorder)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
@@ -23,10 +23,15 @@ class AvatarViewDemoController: DemoController {
         let backgroundSettingView = createLabelAndSwitchRow(labelText: "Use alternate background color",
                                                             switchAction: #selector(toggleAlternateBackground(switchView:)),
                                                             isOn: isUsingAlternateBackgroundColor)
+        
+        let hideInsideGapForBorderSettingView = createLabelAndSwitchRow(labelText: "Hide inside gap for border ring",
+                                                            switchAction: #selector(toggleHideInsideGap(switchView:)),
+                                                            isOn: isHidingInsideGapForBorder)
 
         addRow(items: [backgroundSettingView])
         addRow(items: [showPresenceSettingView])
         addRow(items: [opaquePresenceBorderSettingView])
+        addRow(items: [hideInsideGapForBorderSettingView])
 
         createSection(withTitle: "Circle style for person",
                       name: "Kat Larrson",
@@ -80,6 +85,20 @@ class AvatarViewDemoController: DemoController {
         }
     }
 
+    private var isHidingInsideGapForBorder: Bool = false {
+        didSet {
+            if oldValue != isHidingInsideGapForBorder {
+                for avatarView in avatarViewsWithImages {
+                    avatarView.hideInsideGapForBorder = isHidingInsideGapForBorder
+                }
+
+                for avatarView in avatarViewsWithInitials {
+                    avatarView.hideInsideGapForBorder = isHidingInsideGapForBorder
+                }
+            }
+        }
+    }
+
     private var isShowingPresence: Bool = false {
         didSet {
             if oldValue != isShowingPresence {
@@ -130,6 +149,10 @@ class AvatarViewDemoController: DemoController {
 
     @objc private func toggleAlternateBackground(switchView: UISwitch) {
         isUsingAlternateBackgroundColor = switchView.isOn
+    }
+
+    @objc private func toggleHideInsideGap(switchView: UISwitch) {
+        isHidingInsideGapForBorder = switchView.isOn
     }
 
     private func updateBackgroundColor() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift
@@ -211,9 +211,7 @@ class AvatarViewDemoController: DemoController {
         colorfulGradient.colors = gradientColors
         colorfulGradient.startPoint = CGPoint(x: 0.5, y: 0.5)
         colorfulGradient.endPoint = CGPoint(x: 0.5, y: 0)
-        if #available(iOS 12.0, *) {
-            colorfulGradient.type = .conic
-        }
+        colorfulGradient.type = .conic
 
         var customBorderImage: UIImage?
         UIGraphicsBeginImageContext(size)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -454,9 +454,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         colorfulGradient.colors = gradientColors
         colorfulGradient.startPoint = CGPoint(x: 0.5, y: 0.5)
         colorfulGradient.endPoint = CGPoint(x: 0.5, y: 0)
-        if #available(iOS 12.0, *) {
-            colorfulGradient.type = .conic
-        }
+        colorfulGradient.type = .conic
 
         var customBorderImage: UIImage?
         UIGraphicsBeginImageContext(size)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -132,7 +132,7 @@ class NavigationControllerDemoController: DemoController {
 
         let controller = NavigationController(rootViewController: content)
         if showAvatar {
-            controller.msfNavigationBar.avatar = PersonaData(name: "Kat Larrson", avatarImage: UIImage(named: "avatar_kat_larsson"))
+            controller.msfNavigationBar.avatar = content.personaData
             controller.msfNavigationBar.onAvatarTapped = handleAvatarTapped
         } else {
             content.allowsCellSelection = true
@@ -220,6 +220,12 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     var showsTopAccessoryView: Bool = false
+
+    var personaData: PersonaData = {
+        let personaData = PersonaData(name: "Kat Larrson", avatarImage: UIImage(named: "avatar_kat_larsson"))
+        personaData.hideInsideGapForBorder = true
+        return personaData
+    }()
 
     private var isInSelectionMode: Bool = false {
         didSet {
@@ -327,6 +333,18 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             return cell
         }
 
+        if indexPath.row == 1 {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
+                return UITableViewCell()
+            }
+            cell.setup(title: "Show rainbow ring on avatar", isOn: false)
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.shouldShowRainbowRing(isOn: cell?.isOn ?? false)
+            }
+            return cell
+        }
+
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as? TableViewCell else {
             return UITableViewCell()
         }
@@ -391,6 +409,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         showSearchProgressSpinner = isOn
     }
 
+    @objc private func shouldShowRainbowRing(isOn: Bool) {
+        personaData.customBorderImage = isOn ? RootViewController.colorfulImageForFrame() : nil
+        msfNavigationController?.msfNavigationBar.avatar = personaData
+    }
+
     @objc private func dismissSelf() {
         dismiss(animated: false)
     }
@@ -410,6 +433,38 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         isInSelectionMode = false
         msfNavigationController?.allowResizeOfNavigationBarOnScroll = true
         msfNavigationController?.expandNavigationBar(animated: true)
+    }
+
+    private static func colorfulImageForFrame() -> UIImage? {
+        let gradientColors = [
+            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor,
+            UIColor(red: 0.18, green: 0.45, blue: 0.96, alpha: 1).cgColor,
+            UIColor(red: 0.36, green: 0.80, blue: 0.98, alpha: 1).cgColor,
+            UIColor(red: 0.45, green: 0.72, blue: 0.22, alpha: 1).cgColor,
+            UIColor(red: 0.97, green: 0.78, blue: 0.27, alpha: 1).cgColor,
+            UIColor(red: 0.94, green: 0.52, blue: 0.20, alpha: 1).cgColor,
+            UIColor(red: 0.92, green: 0.26, blue: 0.16, alpha: 1).cgColor,
+            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor]
+
+        let colorfulGradient = CAGradientLayer()
+        let size = CGSize(width: 76, height: 76)
+        colorfulGradient.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+        colorfulGradient.colors = gradientColors
+        colorfulGradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        colorfulGradient.endPoint = CGPoint(x: 0.5, y: 0)
+        if #available(iOS 12.0, *) {
+            colorfulGradient.type = .conic
+        }
+
+        var customBorderImage: UIImage?
+        UIGraphicsBeginImageContext(size)
+        if let context = UIGraphicsGetCurrentContext() {
+            colorfulGradient.render(in: context)
+            customBorderImage = UIGraphicsGetImageFromCurrentImageContext()
+        }
+        UIGraphicsEndImageContext()
+
+        return customBorderImage
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -212,6 +212,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }()
 
     var showSearchProgressSpinner: Bool = true
+    var showRainbowRingForAvatar: Bool = false
 
     var allowsCellSelection: Bool = false {
         didSet {
@@ -325,7 +326,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
-            cell.setup(title: "Show spinner while using the search bar", isOn: true)
+            cell.setup(title: "Show spinner while using the search bar", isOn: showSearchProgressSpinner)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowSearchSpinner(isOn: cell?.isOn ?? false)
@@ -337,7 +338,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
-            cell.setup(title: "Show rainbow ring on avatar", isOn: false)
+            cell.setup(title: "Show rainbow ring on avatar", isOn: showRainbowRingForAvatar)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowRainbowRing(isOn: cell?.isOn ?? false)
@@ -412,6 +413,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     @objc private func shouldShowRainbowRing(isOn: Bool) {
         personaData.customBorderImage = isOn ? RootViewController.colorfulImageForFrame() : nil
         msfNavigationController?.msfNavigationBar.avatar = personaData
+        showRainbowRingForAvatar = isOn
     }
 
     @objc private func dismissSelf() {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -27,6 +27,8 @@ public protocol Avatar {
 
     /// The presence state
     var presence: Presence { get }
+
+    var hideInsideGapForBorder: Bool { get }
 }
 
 // MARK: - AvatarData
@@ -45,6 +47,8 @@ open class AvatarData: NSObject, Avatar {
     @objc public var color: UIColor?
 
     @objc public var presence: Presence
+
+    @objc public var hideInsideGapForBorder: Bool = false
 
     @objc public init(primaryText: String = "", secondaryText: String = "", image: UIImage? = nil, presence: Presence = .none, color: UIColor? = nil) {
         self.primaryText = primaryText

--- a/ios/FluentUI/Avatar/Persona.swift
+++ b/ios/FluentUI/Avatar/Persona.swift
@@ -37,6 +37,7 @@ open class PersonaData: NSObject, Persona {
 
     /// An image that can be used as a frame (outer wide border) for the avatar view
     @objc public var customBorderImage: UIImage?
+    @objc public var hideInsideGapForBorder: Bool = false
 
     /// The color associated to this persona.
     @objc public var color: UIColor?

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -29,7 +29,6 @@ class LargeTitleView: UIView {
             updateProfileButtonVisibility()
             [avatarView, smallMorphingAvatarView].forEach {
                 $0?.setup(avatar: avatar)
-                $0?.layoutSubviews()
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently, AvatarView' border is drawn with some gap from initialsView/imageView.
This change exposes a new public variable to hide this gap and also make sure LargeTitleView can take advantage of this new boolean variable.

updates on demo app:
- add a switch in avatarView to show and hide the gap
- add a switch in NavigationController to show and hide rainbow ring in avatar

### Verification
| Avatar                                       | LargeTitleView                                      |
|----------------------------------------------|--------------------------------------------|
|https://user-images.githubusercontent.com/20715435/116173140-e45a8000-a6c0-11eb-861c-b3bc698097a9.mov| https://user-images.githubusercontent.com/20715435/116173261-1bc92c80-a6c1-11eb-8ebf-716b5c5ed00c.mov|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-04-26 at 18 07 54](https://user-images.githubusercontent.com/20715435/116173362-49ae7100-a6c1-11eb-8a60-e68b1eadb37c.png) |![Simulator Screen Shot - iPhone 11 Pro Max - 2021-04-26 at 18 56 57](https://user-images.githubusercontent.com/20715435/116173323-38fdfb00-a6c1-11eb-9906-339df4db8ac9.png)|


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/542)