### PR TITLE
add separator to BadgeFieldDemoController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
@@ -33,9 +33,11 @@ class BadgeFieldDemoController: DemoController {
 
         addDescription(text: "Badge field with limited number of lines")
         container.addArrangedSubview(badgeField1)
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(UIView())
         addDescription(text: "Badge field with unlimited number of lines")
         container.addArrangedSubview(badgeField2)
+        container.addArrangedSubview(Separator())
     }
 
     private func setupBadgeField(label: String, dataSources: [BadgeViewDataSource]) -> BadgeField {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Similar to people picker demo, add separators around badge field so that demo app user have better context

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-04-27 at 09 20 42](https://user-images.githubusercontent.com/20715435/116277155-0e9c5400-a73a-11eb-8c9a-4d74ed682e22.png) |![Simulator Screen Shot - iPhone 11 Pro Max - 2021-04-27 at 09 03 13](https://user-images.githubusercontent.com/20715435/116276698-9b92dd80-a739-11eb-8994-fb6f8709156e.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/544)