### PR TITLE
hide initialsView or Image based on displayStyle of AvatarView

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -338,7 +338,7 @@ open class AvatarView: NSView {
 		} else {
 			toolTip = nil
 			setAccessibilityLabel(nil)
-			if hasImage {
+			if !hasImage {
 				setAccessibilityElement(false)
 				setAccessibilityRole(.unknown)
 			}

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -107,14 +107,8 @@ open class AvatarView: NSView {
 
 			contactImageView.image = contactImage
 
-			// Update our display style
-			if contactImage == nil {
-				displayStyle = .initials
-			} else {
-				displayStyle = .image
-				setAccessibilityRole(.image)
-				setAccessibilityElement(true)
-			}
+			// Update our display style and content
+			updateAvatarViewContents()
 		}
 	}
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

In case when client team reuses the avatarView, based on the displayStyle hide the subview behind the currentView.
When contactImage was translucent, it may show the initials view behind the current view.

Also, it doesn't make sense just because it doesn't have tooltip text the avatar view isn't accessible. Keep the accessibilityrole to .image if there is a contact image.

### Verification

not part of the change but programmatically update the avatarView public properties after it has rendered

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Screen Shot 2021-04-27 at 5 00 08 PM](https://user-images.githubusercontent.com/20715435/116326780-1aa80600-a77a-11eb-958c-83bbc709e540.png)|![Screen Shot 2021-04-27 at 4 58 55 PM](https://user-images.githubusercontent.com/20715435/116326802-30b5c680-a77a-11eb-879e-f7456c24c4ed.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/547)