### PR TITLE
hideInsideGapForBorder property in macOS avatarView

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -168,6 +168,17 @@ open class AvatarView: NSView {
 		}
 	}
 
+	/// Set to true to not have inside gap between content of the avatarView to its border
+	@objc public var hideInsideGapForBorder: Bool = false {
+		didSet {
+			guard oldValue != hideInsideGapForBorder else {
+				return
+			}
+
+			updateHeight()
+		}
+	}
+
 	/// The width constraint giving this view its size
 	private var widthConstraint: NSLayoutConstraint?
 
@@ -291,8 +302,8 @@ open class AvatarView: NSView {
 
 		// Replace all existing subviews with the proper ones, ensuring the correct z-ordering
 		subviews = [
-			borderView,
-			contentView
+			contentView,
+			borderView
 		]
 
 		let diameter = diameterForContentCircle()
@@ -364,7 +375,9 @@ open class AvatarView: NSView {
 	}
 
 	private func diameterForContentCircle() -> CGFloat {
-		return hasBorder ? avatarSize - (AvatarView.borderWidth * 2) - (AvatarView.contentInset * 2) : avatarSize
+		// When showing the border but there isn't inside gap between contentView and the borderView,
+		// making the content circle exactly the size of avatarSize - (AvatarView.borderWidth * 2) may cause pixel gaps in the cicle edges
+		return hasBorder && !hideInsideGapForBorder ? avatarSize - (AvatarView.borderWidth * 2) - (AvatarView.contentInset * 2) : avatarSize
 	}
 
 	/// Get the ColorSet associated with a given index


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Similar to commit cacd3d88 on iOS, create a new public property `hideInsideGapForBorder` to hide gap between contentView and borderView

before border view was behind contentView. this can cause weird pixel gaps when we want to draw borderView circle mask adjacent to contentView. When hideInsideGapForBorder is true, make the contentView draw edge to edge of the avatarView and draw the borderView on top

### Verification

no direct changes in test app

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Screen Shot 2021-04-28 at 12 11 21 PM](https://user-images.githubusercontent.com/20715435/116459593-e0427580-a81a-11eb-88b0-88d5ffe4f3bd.png)|  ![Screen Shot 2021-04-28 at 12 09 24 PM](https://user-images.githubusercontent.com/20715435/116459510-c143e380-a81a-11eb-941b-0956c6454ba8.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/549)