### PR TITLE
Add Obj-C support to tableCellBackgroundSelected color

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -99,6 +99,7 @@ public extension Colors {
     @objc static var tableBackgroundGrouped: UIColor { return Table.backgroundGrouped }
     @objc static var tableCellBackground: UIColor { return Table.Cell.background }
     @objc static var tableCellBackgroundGrouped: UIColor { return Table.Cell.backgroundGrouped }
+    @objc static var tableCellBackgroundSelected: UIColor { return Table.Cell.backgroundSelected }
     @objc static var tableCellImage: UIColor { return Table.Cell.image }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Add Obj-C support to table cell's selected background color.

### Verification
-Verified that the added tableCellBackgroundSelected public Obj-C variable is available in the generated FluentUI-Swift.h file.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/550)