### PR TITLE
Making window provider an Environment Value.

### DIFF
--- a/ios/FluentUI/Vnext/Core/Theming.swift
+++ b/ios/FluentUI/Vnext/Core/Theming.swift
@@ -51,11 +51,17 @@ class MSFTokensBase {
     private var _theme: FluentUIStyle?
 }
 
-// MARK: Theme SwiftUI Environment Value
+// MARK: SwiftUI Environment Values
 
 struct ThemeKey: EnvironmentKey {
     static var defaultValue: FluentUIStyle {
         return FluentUIThemeManager.S
+    }
+}
+
+struct WindowProviderKey: EnvironmentKey {
+    static var defaultValue: FluentUIWindowProvider? {
+        return nil
     }
 }
 
@@ -64,10 +70,61 @@ extension EnvironmentValues {
         get { self[ThemeKey.self] }
         set { self[ThemeKey.self] = newValue }
     }
+
+    var windowProvider: FluentUIWindowProvider? {
+        get { self[WindowProviderKey.self] }
+        set { self[WindowProviderKey.self] = newValue }
+    }
 }
 
 extension View {
-    func usingTheme(_ theme: FluentUIStyle) -> some View {
+
+    /// Overrides a theme for a specific SwiftUI View and its view hierarchy.
+    /// - Parameter theme: Instance of the custom overriding theme.
+    /// - Returns: The view with its theme environment value overriden.
+    func customTheme(_ theme: FluentUIStyle) -> some View {
         environment(\.theme, theme)
+    }
+
+    /// Sets the window provider used to compute the theme associated with the SwiftUI View
+    /// based on the window that it belongs to.
+    /// - Parameter windowProvider: An instance of an class that implements the FluentUIWindowProvider protocol.
+    /// - Returns: The view with the window provider set for itself and its view hierarchy.
+    func windowProvider(_ windowProvider: FluentUIWindowProvider?) -> some View {
+        environment(\.windowProvider, windowProvider)
+    }
+
+    /// SwiftUI Views using this modifier need to define the following environment values:
+    ///  - @Environment(\.theme) var theme: FluentUIStyle
+    ///  - @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+    ///
+    /// The instances of these environment value properties will be passed to the SwiftUI view's subviews in its hierarchy.
+    ///
+    /// The logic behind the order or precedence to retrieve the correct theme to be used is:
+    ///  1. If the SwiftUI View gets a non-default theme instance through the environment value property,
+    ///    it will be used to override the theme for this View and all the sub Views in its hierarchy.
+    ///
+    ///  2. If the theme property retrieve is the default theme instance, the windowProvider will be used to
+    ///  retrieve the theme associated with the window that this View belongs to.
+    ///
+    ///  3. If the windowProvider is nil the default theme property will be used.
+    ///
+    /// - Parameters:
+    ///   - tokens: An instance of a subclass of MSFTokensBase that defines the design tokens used in that particular SwiftUI View.
+    ///   - theme: theme property (environment value) of the SwiftUI View.
+    ///   - windowProvider: windowProvider property  (environment value) of the SwiftUI View that will potentially retrieve the theme to be applied.
+    /// - Returns: The resulting View either with the computed theme applied to its design tokens.
+    func designTokens(_ tokens: MSFTokensBase,
+                      from theme: FluentUIStyle,
+                      with windowProvider: FluentUIWindowProvider?) -> some View {
+        self.onAppear {
+            tokens.windowProvider = windowProvider
+
+            if theme == ThemeKey.defaultValue {
+                tokens.updateForCurrentTheme()
+            } else {
+                tokens.theme = theme
+            }
+        }
     }
 }

--- a/ios/FluentUI/Vnext/Core/Theming.swift
+++ b/ios/FluentUI/Vnext/Core/Theming.swift
@@ -51,6 +51,25 @@ class MSFTokensBase {
     private var _theme: FluentUIStyle?
 }
 
+struct DesignTokens: ViewModifier {
+    let tokens: MSFTokensBase
+    let theme: FluentUIStyle
+    let windowProvider: FluentUIWindowProvider?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                tokens.windowProvider = windowProvider
+
+                if theme == ThemeKey.defaultValue {
+                    tokens.updateForCurrentTheme()
+                } else {
+                    tokens.theme = theme
+                }
+            }
+    }
+}
+
 // MARK: SwiftUI Environment Values
 
 struct ThemeKey: EnvironmentKey {
@@ -117,14 +136,8 @@ extension View {
     func designTokens(_ tokens: MSFTokensBase,
                       from theme: FluentUIStyle,
                       with windowProvider: FluentUIWindowProvider?) -> some View {
-        self.onAppear {
-            tokens.windowProvider = windowProvider
-
-            if theme == ThemeKey.defaultValue {
-                tokens.updateForCurrentTheme()
-            } else {
-                tokens.theme = theme
-            }
-        }
+        modifier(DesignTokens(tokens: tokens,
+                              theme: theme,
+                              windowProvider: windowProvider))
     }
 }

--- a/ios/FluentUI/Vnext/List/ListHeaderFooter.swift
+++ b/ios/FluentUI/Vnext/List/ListHeaderFooter.swift
@@ -8,13 +8,13 @@ import SwiftUI
 
 struct Header: View {
     @Environment(\.theme) var theme: FluentUIStyle
-    @ObservedObject var state: MSFListSectionState
+    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFHeaderFooterTokens
+    @ObservedObject var state: MSFListSectionState
 
-    init(state: MSFListSectionState, windowProvider: FluentUIWindowProvider?) {
+    init(state: MSFListSectionState) {
         self.state = state
-        self.tokens = MSFHeaderFooterTokens(style: state.style)
-        self.tokens.windowProvider = windowProvider
+        self.tokens = state.headerTokens
     }
 
     var body: some View {
@@ -32,17 +32,8 @@ struct Header: View {
                             trailing: tokens.trailingPadding))
         .frame(minHeight: tokens.headerHeight)
         .background(Color(state.backgroundColor ?? tokens.backgroundColor))
-        .onAppear {
-            // When environment values are available through the view hierarchy:
-            //  - If we get a non-default theme through the environment values,
-            //    we use to override the theme from this view and its hierarchy.
-            //  - Otherwise we just refresh the tokens to reflect the theme
-            //    associated with the window that this View belongs to.
-            if theme == ThemeKey.defaultValue {
-                self.tokens.updateForCurrentTheme()
-            } else {
-                self.tokens.theme = theme
-            }
-        }
+        .designTokens(tokens,
+                      from: theme,
+                      with: windowProvider)
     }
 }

--- a/ios/FluentUI/Vnext/List/ListTokens.swift
+++ b/ios/FluentUI/Vnext/List/ListTokens.swift
@@ -83,6 +83,7 @@ class MSFCellBaseTokens: MSFTokensBase, ObservableObject {
     @Published public var iconInterspace: CGFloat!
     @Published public var labelAccessoryInterspace: CGFloat!
     @Published public var labelAccessorySize: CGFloat!
+    @Published public var cellLeadingViewSize: MSFListCellLeadingViewSize!
     @Published public var leadingViewSize: CGFloat!
     @Published public var sublabelAccessorySize: CGFloat!
     @Published public var trailingItemSize: CGFloat!
@@ -93,13 +94,10 @@ class MSFCellBaseTokens: MSFTokensBase, ObservableObject {
 }
 
 class MSFListCellTokens: MSFCellBaseTokens {
-    @Published public var cellLeadingViewSize: MSFListCellLeadingViewSize!
-
     init(cellLeadingViewSize: MSFListCellLeadingViewSize = .medium) {
-        self.cellLeadingViewSize = cellLeadingViewSize
-
         super.init()
 
+        self.cellLeadingViewSize = cellLeadingViewSize
         self.themeAware = true
         updateForCurrentTheme()
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

An instance of an object that implements the FluentUIWindowProvider protocol is passed to SwiftUI controls so it can retrieve the correct theme to compute a control's tokens.

Previously this object was passed directly to the SwiftUI control by the UIKit wrapper when it is instantiated.

A problem arises when controls contain other controls and they either need to pass the window provider as a parameter, which is very error prone, or the theme override will not work for the controls in deeper levels of the view hirarchy.

This change leverage from Environment Values and makes the instance passed to a control an environment value, which means that all the views under that control's view hierarchy will use the same window provider to retrieve the correct theme.

Fixes to the List and PersonaView which were not getting the theme overrides were also fixed.

### Verification

Changed the tokens below to **$Colors.Brand.primary** YAML file locally and changed themes to ensure the color was correctly updated.
 - Avatar **ringGapColor**
 - List **borderColor**
 - List Cell **backgroundColor** (pressed state)
 - PersonaView **sublabelColor**
 - Header **textColor** (all styles)
 - Drawer **backgroundDimmedColor**: (@kubalani This scenario is not working and another work item needs to be created to address it.)

https://user-images.githubusercontent.com/68076145/116962302-754dd000-ac5a-11eb-87c5-8d5e6843a053.mov

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/551)