### PR TITLE
Enabling Large Text accessibility support on iOS 13.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -102,6 +102,14 @@ class LeftNavMenuViewController: UIViewController {
         view = leftNavView
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
+            sizeCategory != self.traitCollection.preferredContentSizeCategory {
+            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
+        }
+    }
+
     var menuAction: (() -> Void)?
 
     private func setPresence(presence: LeftNavPresence) {
@@ -235,6 +243,8 @@ class LeftNavMenuViewController: UIViewController {
 
     private var leftNavMenuList = MSFList(sections: [])
 
+    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
+
     private lazy var leftNavAccountView: UIView = {
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
         chevron.tintColor = Colors.textPrimary
@@ -275,14 +285,17 @@ class LeftNavMenuViewController: UIViewController {
         contentView.addSubview(accountView)
         contentView.addSubview(menuListView)
 
-        NSLayoutConstraint.activate([accountView.heightAnchor.constraint(equalToConstant: 84),
-                                     contentView.topAnchor.constraint(equalTo: accountView.topAnchor),
-                                     contentView.leadingAnchor.constraint(equalTo: accountView.leadingAnchor),
-                                     contentView.trailingAnchor.constraint(equalTo: accountView.trailingAnchor),
-                                     accountView.bottomAnchor.constraint(equalTo: menuListView.topAnchor),
-                                     contentView.leadingAnchor.constraint(equalTo: menuListView.leadingAnchor),
-                                     contentView.trailingAnchor.constraint(equalTo: menuListView.trailingAnchor),
-                                     contentView.bottomAnchor.constraint(equalTo: menuListView.bottomAnchor)
+        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
+        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
+
+        NSLayoutConstraint.activate([accountViewHeightConstraint,
+                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                                     accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                                     accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                                     menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
+                                     menuListView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                                     menuListView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                                     menuListView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
 
         return contentView

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -110,9 +110,6 @@ class ListDemoController: DemoController {
                 listCell.titleLeadingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "ic_fluent_presence_available_16_filled", imageType: "title") : nil
                 listCell.titleTrailingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-right-20x20", imageType: "title") : nil
 
-                listCell.titleLineLimit = section.numberOfLines
-                listCell.subtitleLineLimit = section.numberOfLines
-                listCell.footnoteLineLimit = section.numberOfLines
                 listCell.leadingUIView = createCustomView(imageName: cell.image)
                 listCell.trailingUIView = section.hasAccessory ? createCustomView(imageName: cell.image) : nil
                 listCell.accessoryType = accessoryType(for: rowIndex)

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -37,12 +37,10 @@ struct MSFButtonViewButtonStyle: ButtonStyle {
 
             if let text = state.text {
                 Text(text)
-                    .font(isFloatingStyle ?
-                            Font(tokens.textFont) :
-                            Font.custom(tokens.textFont.familyName,
-                                        size: tokens.textFont.fontDescriptor.pointSize))
                     .fontWeight(.medium)
                     .multilineTextAlignment(.center)
+                    .scalableFont(font: tokens.textFont,
+                                  shouldScale: !isFloatingStyle)
                     .modifyIf(isFloatingStyle, { view in
                         view.frame(minHeight: tokens.textMinimumHeight)
                     })
@@ -182,7 +180,7 @@ public struct MSFButtonView: View {
         view.addInteraction(largeContentViewerInteraction)
         largeContentViewerInteraction.gestureRecognizerForExclusionRelationship.delegate = self
         view.scalesLargeContentImage = true
-        view.showsLargeContentViewer = shouldEnableLargeContentViewerForOSVersion || buttonView.tokens.style.isFloatingStyle
+        view.showsLargeContentViewer = buttonView.tokens.style.isFloatingStyle
 
         imagePropertySubscriber = buttonView.state.$image.sink { buttonImage in
             self.view.largeContentImage = buttonImage
@@ -192,14 +190,6 @@ public struct MSFButtonView: View {
             self.view.largeContentTitle = buttonText
         }
     }
-
-    private let shouldEnableLargeContentViewerForOSVersion: Bool = {
-        if #available(iOS 14.0, *) {
-            return false
-        } else {
-            return true
-        }
-    }()
 
     private var textPropertySubscriber: AnyCancellable?
 

--- a/ios/FluentUI/Vnext/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Vnext/Core/SwiftUI+ViewModifiers.swift
@@ -12,7 +12,7 @@ struct ScalableFont: ViewModifier {
 
     func body(content: Content) -> some View {
         let familyName = font.familyName
-        let size = font.pointSize
+        let size = font.fixedFont.pointSize
         let scalableFont: Font
 
             if #available(iOS 14.0, *) {

--- a/ios/FluentUI/Vnext/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Vnext/Core/SwiftUI+ViewModifiers.swift
@@ -5,6 +5,34 @@
 
 import SwiftUI
 
+struct ScalableFont: ViewModifier {
+    @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
+    let font: UIFont
+    let shouldScale: Bool
+
+    func body(content: Content) -> some View {
+        let familyName = font.familyName
+        let size = font.pointSize
+        let scalableFont: Font
+
+            if #available(iOS 14.0, *) {
+                if shouldScale {
+                    scalableFont = .custom(familyName,
+                                           size: size)
+                } else {
+                    scalableFont = .custom(familyName,
+                                           fixedSize: size)
+                }
+            } else {
+                let scaledFontSize = shouldScale ? UIFontMetrics.default.scaledValue(for: size) : size
+                scalableFont = .custom(familyName,
+                                       size: scaledFontSize)
+            }
+
+        return content.font(scalableFont)
+    }
+}
+
 extension View {
     /// Applies modifiers defined in a closure if a condition is met.
     /// - Parameters:
@@ -19,5 +47,17 @@ extension View {
         } else {
             self
         }
+    }
+
+    /// Applies a scalable SwiftUI Font type in a scalable way.
+    /// Custom fonts on iOS 13 are not scalable. This modifier works around that by adjusting to the
+    /// sizeCategory environment object and returns the SwiftUI Font in the correct size.
+    /// - Parameters:
+    ///   - font: UIFont instance of that needs to be converted into a scalable SwiftUI Font struct.
+    ///   - shouldScale: Whether the SwiftUI Font returned should be scaled or not.
+    /// - Returns: The resulting scaled Font.
+    func scalableFont(font: UIFont, shouldScale: Bool = true) -> some View {
+        modifier(ScalableFont(font: font,
+                              shouldScale: shouldScale))
     }
 }

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -206,7 +206,7 @@ struct MSFListCellView: View {
                             }
                             if hasTitle {
                                 Text(state.title)
-                                    .font(Font(tokens.labelFont))
+                                    .scalableFont(font: tokens.labelFont)
                                     .foregroundColor(Color(tokens.labelColor))
                                     .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)
                             }
@@ -225,7 +225,7 @@ struct MSFListCellView: View {
                             }
                             if !state.subtitle.isEmpty {
                                 Text(state.subtitle)
-                                    .font(Font(state.footnote.isEmpty ? tokens.footnoteFont : tokens.sublabelFont))
+                                    .scalableFont(font: state.footnote.isEmpty ? tokens.footnoteFont : tokens.sublabelFont)
                                     .foregroundColor(Color(tokens.sublabelColor))
                                     .lineLimit(state.subtitleLineLimit == 0 ? nil : state.subtitleLineLimit)
                             }
@@ -244,7 +244,7 @@ struct MSFListCellView: View {
                             }
                             if !state.footnote.isEmpty {
                                 Text(state.footnote)
-                                    .font(Font(tokens.footnoteFont))
+                                    .scalableFont(font: tokens.footnoteFont)
                                     .foregroundColor(Color(tokens.sublabelColor))
                                     .lineLimit(state.footnoteLineLimit == 0 ? nil : state.footnoteLineLimit)
                             }

--- a/ios/FluentUI/Vnext/List/ListHeaderFooter.swift
+++ b/ios/FluentUI/Vnext/List/ListHeaderFooter.swift
@@ -21,7 +21,7 @@ struct Header: View {
         HStack(spacing: 0) {
             if let title = state.title, !title.isEmpty {
                 Text(title)
-                    .font(Font(tokens.textFont))
+                    .scalableFont(font: tokens.textFont)
                     .foregroundColor(Color(tokens.textColor))
             }
             Spacer()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Custom font types in SwiftUI are not scalable on iOS 13. The app needs to be restarted so that controls using those fonts are rendered properly.
This PR adds a modifier to monitor the content size changes and update the Views that use custom fonts.
It also removes the workaround added in #540 to enable the Large Content Viewer for all buttons running on iOS 13.
It is now being applied just for the Floating Action Button style.

This fix will be applicable for the Button, List and PersonaView controls as well as future ones that need to have their content scaled in the Large Text Accessibility mode.

### Verification
 - Ran the modified code on both iOS 13 and iOS 14 validating the text scales correctly while the setting is being changed.
 - Validated the Button only shows the Large Content Viewer for the floating style buttons, while the other buttons scale the label correctly.
 - Videos below show the behavior of the controls before and after the fix.

**Before:**

https://user-images.githubusercontent.com/68076145/117224259-579c7a00-adc4-11eb-9751-2fdc412d3ef0.mov


**After:**

https://user-images.githubusercontent.com/68076145/117223760-371ff000-adc3-11eb-8133-211a11f9d701.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/553)