### PR TITLE
bring tabbaritemview accessibilityhint improvement to main_0.1

### DIFF
--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@، %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "اضغط ضغطاً مزدوجاً لعرض مزيد من الإجراءات";
 

--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@، %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d من %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "اضغط ضغطاً مزدوجاً لعرض مزيد من الإجراءات";

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d de %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Toqueu dues vegades per veure més accions.";

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Toqueu dues vegades per veure més accions.";
 

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Poklepáním zobrazíte další akce.";
 

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d z %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Poklepáním zobrazíte další akce.";

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d af %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dobbelttryk for at se flere handlinger";

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dobbelttryk for at se flere handlinger";
 

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Doppeltippen Sie, um weitere Aktionen anzuzeigen.";
 

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d von %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Doppeltippen Sie, um weitere Aktionen anzuzeigen.";

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d από %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Πατήστε δύο φορές για να προβάλετε περισσότερες ενέργειες";

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Πατήστε δύο φορές για να προβάλετε περισσότερες ενέργειες";
 

--- a/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Double tap to view more actions";
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Double tap to view more actions";
 

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d de %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Pulsa dos veces para ver más acciones";

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Pulsa dos veces para ver más acciones";
 

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d de %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Pulsa dos veces para ver más acciones";

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Pulsa dos veces para ver más acciones";
 

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d/%2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Näytä lisää toimintoja kaksoisnapauttamalla";

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Näytä lisää toimintoja kaksoisnapauttamalla";
 

--- a/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Appuyez deux fois pour afficher d’autres actions";
 

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d מתוך %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "הקש פעמיים כדי להציג פעולות נוספות";

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "הקש פעמיים כדי להציג פעולות נוספות";
 

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%2d में से %1d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "अधिक गतिविधियाँ देखने के लिए डबल टैप करें";

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "अधिक गतिविधियाँ देखने के लिए डबल टैप करें";
 

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dvaput dodirnite da biste pogledali dodatne akcije";
 

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d od %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dvaput dodirnite da biste pogledali dodatne akcije";

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d/%2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Koppintson ide duplán a további műveletek megtekintéséhez";

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Koppintson ide duplán a további műveletek megtekintéséhez";
 

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Ketuk dua kali untuk melihat tindakan lainnya";
 

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d dari %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Ketuk dua kali untuk melihat tindakan lainnya";

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d di %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Effettua un doppio tocco per visualizzare altre azioni";

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Effettua un doppio tocco per visualizzare altre azioni";
 

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@、 %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "ダブルタップしてその他のアクションを表示します";
 

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@、 %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "全 %2d ページ中 %1d ページ目";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "ダブルタップしてその他のアクションを表示します";

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d/%2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "더 많은 작업을 보려면 두 번 탭하세요.";

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "더 많은 작업을 보려면 두 번 탭하세요.";
 

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d daripada %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dwiketik untuk melihat lebih banyak tindakan";

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dwiketik untuk melihat lebih banyak tindakan";
 

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d av %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dobbelttrykk for å vise flere handlinger";

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dobbelttrykk for å vise flere handlinger";
 

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dubbeltikken om meer acties weer te geven";
 

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d van %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dubbeltikken om meer acties weer te geven";

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d z %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Naciśnij dwukrotnie, aby wyświetlić więcej akcji";

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Naciśnij dwukrotnie, aby wyświetlić więcej akcji";
 

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dê um toque duplo para exibir mais ações";
 

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d de %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dê um toque duplo para exibir mais ações";

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d de %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Faça duplo toque para ver mais ações";

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Faça duplo toque para ver mais ações";
 

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Atingeți de două ori pentru a vedea mai multe acțiuni";
 

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d din %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Atingeți de două ori pentru a vedea mai multe acțiuni";

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d из %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Дважды коснитесь, чтобы просмотреть другие действия";

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Дважды коснитесь, чтобы просмотреть другие действия";
 

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dvojitým ťuknutím zobrazíte ďalšie akcie";
 

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d z %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dvojitým ťuknutím zobrazíte ďalšie akcie";

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d av %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dubbeltryck för att visa fler åtgärder";

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Dubbeltryck för att visa fler åtgärder";
 

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d จาก %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "แตะสองครั้งเพื่อดูการดำเนินการเพิ่มเติม";

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "แตะสองครั้งเพื่อดูการดำเนินการเพิ่มเติม";
 

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d / %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Diğer eylemleri görüntülemek için iki kez dokunun";

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Diğer eylemleri görüntülemek için iki kez dokunun";
 

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d із %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Торкніться двічі, щоб переглянути більше дій";

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Торкніться двічі, щоб переглянути більше дій";
 

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Nhấn đúp để xem thêm hành động";
 

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d trên %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "Nhấn đúp để xem thêm hành động";

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@、%@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "双击以查看更多操作";
 

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@、%@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "第 %1d 个，共 %2d 个";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "双击以查看更多操作";

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -100,7 +100,7 @@
 "Accessibility.AvatarView.LabelFormat" = "%@，%@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
-"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+"Accessibility.TabBarItemView.Hint" = "%1d / %2d";
 
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "點兩下以檢視更多動作";

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@，%@";
 
+/* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
+"Accessibility.TabBarItemView.Hint" = "%1d of %2d";
+
 /* Accessibility hint for more actions button */
 "Accessibility.TableViewCell.MoreActions.Hint" = "點兩下以檢視更多動作";
 

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -13,7 +13,11 @@ class TabBarItemView: UIView {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected
             updateColors()
-            accessibilityTraits = isSelected ? .selected : .none
+            if isSelected {
+                accessibilityTraits.insert(.selected)
+            } else {
+                accessibilityTraits.remove(.selected)
+            }
         }
     }
 

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -40,10 +40,15 @@ open class TabBarView: UIView {
                 preconditionFailure("tab bar items can't be more than \(Constants.maxTabCount)")
             }
 
-            for item in items {
+            for (index, item) in items.enumerated() {
                 let tabBarItemView = TabBarItemView(item: item, showsTitle: showsItemTitles)
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTabBarItemTapped(_:)))
                 tabBarItemView.addGestureRecognizer(tapGesture)
+
+                // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+                if #available(iOS 14.0, *) {
+                    tabBarItemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                }
                 stackView.addArrangedSubview(tabBarItemView)
             }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

git cherry-pick 320c410, 961f5b0, a1d7b79, fbdfdac, 700ab4c, 66750e5 to bring accessibilityHint to TabbarItemView.

### Verification

test tabbarview VO accessibility and make sure index is announced.


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/554)