### PR TITLE
Origin/toddha/updatenavigationbarstyle

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -35,7 +35,7 @@ class NavigationControllerDemoController: DemoController {
 
         addTitle(text: "Top Accessory View")
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
-        
+
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))
     }
@@ -93,7 +93,7 @@ class NavigationControllerDemoController: DemoController {
     @objc func showWithTopSearchBar() {
         presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false)
     }
-    
+
     @objc func showSearchChangingStyleEverySecond() {
         presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false, updateStylePeriodically: true)
     }
@@ -135,9 +135,9 @@ class NavigationControllerDemoController: DemoController {
         content.showsTopAccessoryView = showsTopAccessory
 
         content.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
-        
+
         if updateStylePeriodically {
-            self.changeStyle(in: content.navigationItem)
+            changeStyleContinuously(in: content.navigationItem)
         }
 
         let controller = NavigationController(rootViewController: content)
@@ -164,27 +164,23 @@ class NavigationControllerDemoController: DemoController {
 
         return controller
     }
-    
-    private func changeStyle(in navigationItem: UINavigationItem) {
+
+    private func changeStyleContinuously(in navigationItem: UINavigationItem) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            var newStyle = navigationItem.navigationBarStyle
-            switch (newStyle) {
+            let newStyle: NavigationBar.Style
+            switch navigationItem.navigationBarStyle {
             case .custom:
                 newStyle = .default
-                break;
             case .default:
                 newStyle = .primary
-                break;
             case .primary:
                 newStyle = .system
-                break
             case .system:
                 newStyle = .custom
-                break
             }
-            
+
             navigationItem.navigationBarStyle = newStyle
-            self.changeStyle(in: navigationItem)
+            self.changeStyleContinuously(in: navigationItem)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -35,6 +35,9 @@ class NavigationControllerDemoController: DemoController {
 
         addTitle(text: "Top Accessory View")
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
+        
+        addTitle(text: "Change Style Periodically")
+        container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))
     }
 
     @objc func showLargeTitle() {
@@ -90,6 +93,10 @@ class NavigationControllerDemoController: DemoController {
     @objc func showWithTopSearchBar() {
         presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false)
     }
+    
+    @objc func showSearchChangingStyleEverySecond() {
+        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false, updateStylePeriodically: true)
+    }
 
     @objc func showLargeTitleWithPillSegment() {
         let segmentItems: [SegmentItem] = [
@@ -116,7 +123,8 @@ class NavigationControllerDemoController: DemoController {
                                    showsTopAccessory: Bool = false,
                                    contractNavigationBarOnScroll: Bool = true,
                                    showShadow: Bool = true,
-                                   showAvatar: Bool = true) -> NavigationController {
+                                   showAvatar: Bool = true,
+                                   updateStylePeriodically: Bool = false) -> NavigationController {
         let content = RootViewController()
         content.navigationItem.usesLargeTitle = useLargeTitle
         content.navigationItem.navigationBarStyle = style
@@ -126,8 +134,10 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTopAccessoryView = showsTopAccessory
 
-        if style == .custom {
-            content.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
+        content.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
+        
+        if updateStylePeriodically {
+            self.changeStyle(in: content.navigationItem)
         }
 
         let controller = NavigationController(rootViewController: content)
@@ -153,6 +163,29 @@ class NavigationControllerDemoController: DemoController {
         present(controller, animated: false)
 
         return controller
+    }
+    
+    private func changeStyle(in navigationItem: UINavigationItem) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            var newStyle = navigationItem.navigationBarStyle
+            switch (newStyle) {
+            case .custom:
+                newStyle = .default
+                break;
+            case .default:
+                newStyle = .primary
+                break;
+            case .primary:
+                newStyle = .system
+                break
+            case .system:
+                newStyle = .custom
+                break
+            }
+            
+            navigationItem.navigationBarStyle = newStyle
+            self.changeStyle(in: navigationItem)
+        }
     }
 
     private func createAccessoryView(with style: SearchBar.Style = .lightContent) -> SearchBar {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -241,7 +241,7 @@ open class NavigationBar: UINavigationBar {
         }
     }
 
-    private(set) var style: Style = defaultStyle
+    @objc dynamic private(set) var style: Style = defaultStyle
 
     let backgroundView = UIView() //used for coloration
     //used to cover the navigationbar during animated transitions between VCs

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -241,6 +241,7 @@ open class NavigationBar: UINavigationBar {
         }
     }
 
+    // @objc dynamic - so we can do KVO on this
     @objc dynamic private(set) var style: Style = defaultStyle
 
     let backgroundView = UIView() //used for coloration

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -47,6 +47,7 @@ class ShyHeaderController: UIViewController {
     private var accessoryViewObservation: NSKeyValueObservation?
 
     private var navigationBarCenterObservation: NSKeyValueObservation?
+    private var navigationBarStyleObservation: NSKeyValueObservation?
     private var navigationBarHeightObservation: NSKeyValueObservation?
     private var navigationBarColorObservation: NSKeyValueObservation?
 
@@ -124,11 +125,7 @@ class ShyHeaderController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if let window = view.window,
-            let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
-            shyHeaderView.navigationBarStyle = actualStyle
-            updateBackgroundColor(with: actualItem, window: window)
-        }
+        updateNavigationBarStyle()
     }
 
     // MARK: - Base Construction
@@ -216,6 +213,9 @@ class ShyHeaderController: UIViewController {
         // Observing `center` instead of `isHidden` allows us to do our changes along the system animation
         navigationBarCenterObservation = navigationController?.navigationBar.observe(\.center) { [weak self] navigationBar, _ in
             self?.shyHeaderView.navigationBarIsHidden = navigationBar.frame.maxY == 0
+        }
+        navigationBarStyleObservation = msfNavigationController?.msfNavigationBar.observe(\.style) { [weak self] _, _ in
+            self?.updateNavigationBarStyle()
         }
         navigationBarHeightObservation = msfNavigationController?.msfNavigationBar.observe(\.barHeight) { [weak self] _, _ in
             self?.updatePadding()
@@ -519,6 +519,15 @@ class ShyHeaderController: UIViewController {
         }
 
         shyHeaderView.exposure = ShyHeaderView.Exposure(withProgress: progress)
+    }
+
+    /// Updates based on the current navigation bar style.
+    private func updateNavigationBarStyle() {
+        if let window = view.window,
+            let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
+            shyHeaderView.navigationBarStyle = actualStyle
+            updateBackgroundColor(with: actualItem, window: window)
+        }
     }
 
     /// Calculates and sets the shy container's top constraint's constant value, moving the header


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Ensure that ShyHeaderView observes the navigation bar style and updates appropriately.

NavigationBar - makes the style property observable
ShyHeaderController - observes the style property on the navigation bar to update the shyHeaderView and update the background color.
NavigationControllerDemoController - adds a separate button which updates the style every 1 second.

### Verification

Added an automated test to simply update the style every 1 second and see what didn't get updated.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

https://user-images.githubusercontent.com/6126317/117485056-c987d700-af1c-11eb-8a9d-340ea4d258ad.mp4


https://user-images.githubusercontent.com/6126317/117485058-ca206d80-af1c-11eb-9194-ed423e27ad37.mp4


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/556)