### PR TITLE
Removing the target button reference from the ButtonStyle.

### DIFF
--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -14,16 +14,15 @@ import SwiftUI
     @objc @Published public var text: String?
 }
 
-/// ButtonStyle which configures the Button View according to its state and design tokens.
-struct MSFButtonViewButtonStyle: ButtonStyle {
-    var targetButton: MSFButtonView
+/// Body of the button adjusted for pressed or rest state
+struct ButtonBody: View {
+    @ObservedObject var tokens: MSFButtonTokens
+    @ObservedObject var state: MSFButtonState
+    var isPressed: Bool
 
-    func makeBody(configuration: Self.Configuration) -> some View {
-        let tokens = targetButton.tokens
-        let state = targetButton.state
+    var body: some View {
         let isDisabled = state.isDisabled
         let isFloatingStyle = tokens.style.isFloatingStyle
-        let isPressed = configuration.isPressed
         let shouldUsePressedShadow = isDisabled || isPressed
 
         return HStack(spacing: tokens.interspace) {
@@ -77,6 +76,18 @@ struct MSFButtonViewButtonStyle: ButtonStyle {
     }
 }
 
+/// ButtonStyle which configures the Button View according to its state and design tokens.
+struct MSFButtonViewButtonStyle: ButtonStyle {
+    @ObservedObject var tokens: MSFButtonTokens
+    @ObservedObject var state: MSFButtonState
+
+    func makeBody(configuration: Self.Configuration) -> some View {
+        ButtonBody(tokens: tokens,
+                   state: state,
+                   isPressed: configuration.isPressed)
+    }
+}
+
 /// View that represents the button
 public struct MSFButtonView: View {
     @Environment(\.theme) var theme: FluentUIStyle
@@ -95,7 +106,8 @@ public struct MSFButtonView: View {
 
     public var body: some View {
         Button(action: action, label: {})
-            .buttonStyle(MSFButtonViewButtonStyle(targetButton: self))
+            .buttonStyle(MSFButtonViewButtonStyle(tokens: tokens,
+                                                  state: state))
             .disabled(state.isDisabled)
             .frame(maxWidth: .infinity)
             .designTokens(tokens,

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -15,10 +15,10 @@ import SwiftUI
 }
 
 /// Body of the button adjusted for pressed or rest state
-struct ButtonBody: View {
+struct MSFButtonViewBody: View {
     @ObservedObject var tokens: MSFButtonTokens
     @ObservedObject var state: MSFButtonState
-    var isPressed: Bool
+    let isPressed: Bool
 
     var body: some View {
         let isDisabled = state.isDisabled
@@ -82,9 +82,9 @@ struct MSFButtonViewButtonStyle: ButtonStyle {
     @ObservedObject var state: MSFButtonState
 
     func makeBody(configuration: Self.Configuration) -> some View {
-        ButtonBody(tokens: tokens,
-                   state: state,
-                   isPressed: configuration.isPressed)
+        MSFButtonViewBody(tokens: tokens,
+                          state: state,
+                          isPressed: configuration.isPressed)
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change removes the reference of the Button View from the ButtonStyle struct that modifies the view to render its pressed state.

Previously this was the design where we could have the buttons updating when tokens were changed (theme changes) while keeping the Button code in a single place (ButtonStyle).

Creating a separate view that is used to render the button body now allows for the Button Style to keep a reference to the tokens and state objects only (which is the correct approach compared to keeping a reference to a struct).

### Verification

Ran the modified code on both iOS 14 and iOS 13 ensuring that the button behavior is not regressed:

https://user-images.githubusercontent.com/68076145/117674610-abaab400-b160-11eb-9f4c-95d4ace290a5.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/559)