### PR TITLE
Updating Xcode version to 12.5.

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: fluentui_apple_publish_nuget
   pool:
-    vmImage: 'macos-10.15'
+    vmImage: 'macos-11.0'
   displayName: FluentUI Apple Publish NuGet
   timeoutInMinutes: 60 # how long to run the job before automatically cancelling
   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   validation:
-    runs-on: macos-10.15
+    runs-on: macos-11.0
     strategy:
       fail-fast: true
     steps:
@@ -26,7 +26,7 @@ jobs:
     - name: validation
       run: scripts/validation.sh
   xcodebuild:
-    runs-on: macos-10.15
+    runs-on: macos-11.0
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Switch to current version of Xcode
+      run: scripts/xcode_select_current_version.sh
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Pod-Publish:
     if: github.event.base_ref == 'refs/heads/main'
-    runs-on: macOS-10.15
+    runs-on: macOS-11.0
     
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fluent UI Apple contains native UIKit and AppKit controls aligned with [Microsof
 #### Requirements
 
 - iOS 13+ or macOS 10.14+
-- Xcode 11+
+- Xcode 12.5+
 - Swift 5.0+
 
 #### Using Carthage

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_12.2.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_12.5.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Xcode 12.5 is available in the GitHub images now.
This change updates the pipelines to use it according to the environment info listed on the links below:

- https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md
- https://github.com/actions/virtual-environments

### Verification

Local build using Big Sur (11.3.1) with Xcode 12.5.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/560)