### PR TITLE
Adding MSFView in List Vnext component

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -116,7 +116,7 @@ class LeftNavMenuViewController: UIViewController {
         self.persona.state.presence = presence.avatarPresence()
         self.statusCell.isExpanded = false
         self.statusCell.title = presence.cellTitle()
-        self.statusCell.leadingUIView = presence.imageView()
+        self.statusCell.leadingView = MSFView(presence.imageView())
     }
 
     private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
@@ -139,7 +139,7 @@ class LeftNavMenuViewController: UIViewController {
             let statusCellChild = MSFListCellState()
             statusCellChild.leadingViewSize = .small
             statusCellChild.title = presence.cellTitle()
-            statusCellChild.leadingUIView = presence.imageView()
+            statusCellChild.leadingView = MSFView(presence.imageView())
             statusCellChild.backgroundColor = .systemBackground
             statusCellChild.onTapAction = {
                 self.setPresence(presence: presence)
@@ -154,7 +154,7 @@ class LeftNavMenuViewController: UIViewController {
         resetStatusCell.backgroundColor = .systemBackground
         let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        resetStatusCell.leadingUIView = resetStatusImageView
+        resetStatusCell.leadingView = MSFView(resetStatusImageView)
         resetStatusCell.onTapAction = {
             self.setPresence(presence: .available)
         }
@@ -164,7 +164,7 @@ class LeftNavMenuViewController: UIViewController {
         statusCell.backgroundColor = .systemBackground
         let statusImageView = LeftNavPresence.available.imageView()
         statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-        statusCell.leadingUIView = statusImageView
+        statusCell.leadingView = MSFView(statusImageView)
         statusCell.children = statusCellChildren
 
         let statusMessageCell = MSFListCellState()
@@ -172,7 +172,7 @@ class LeftNavMenuViewController: UIViewController {
         statusMessageCell.title = "Set Status Message"
         let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
         statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        statusMessageCell.leadingUIView = statusMessageImageView
+        statusMessageCell.leadingView = MSFView(statusMessageImageView)
         statusMessageCell.onTapAction = defaultMenuAction
 
         let notificationsCell = MSFListCellState()
@@ -182,7 +182,7 @@ class LeftNavMenuViewController: UIViewController {
         notificationsCell.layoutType = .twoLines
         let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
         notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        notificationsCell.leadingUIView = notificationsImageView
+        notificationsCell.leadingView = MSFView(notificationsImageView)
         notificationsCell.onTapAction = defaultMenuAction
 
         let settingsCell = MSFListCellState()
@@ -190,7 +190,7 @@ class LeftNavMenuViewController: UIViewController {
         settingsCell.title = "Settings"
         let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
         settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        settingsCell.leadingUIView = settingsImageView
+        settingsCell.leadingView = MSFView(settingsImageView)
         settingsCell.onTapAction = defaultMenuAction
 
         let whatsNewCell = MSFListCellState()
@@ -198,7 +198,7 @@ class LeftNavMenuViewController: UIViewController {
         whatsNewCell.title = "What's new"
         let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
         whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        whatsNewCell.leadingUIView = whatsNewImageView
+        whatsNewCell.leadingView = MSFView(whatsNewImageView)
         whatsNewCell.onTapAction = defaultMenuAction
 
         let menuSection = MSFListSectionState()
@@ -212,7 +212,7 @@ class LeftNavMenuViewController: UIViewController {
         microsoftAccountCell.accessoryType = .checkmark
         let orgAvatar = MSFAvatar(style: .group, size: .large)
         orgAvatar.state.primaryText = "Kat Larrson"
-        microsoftAccountCell.leadingUIView = orgAvatar.view
+        microsoftAccountCell.leadingView = MSFView(orgAvatar.view)
         microsoftAccountCell.leadingViewSize = .large
 
         let msaAccountCell = MSFListCellState()
@@ -222,7 +222,7 @@ class LeftNavMenuViewController: UIViewController {
         msaAccountCell.subtitle = "kat.larrson@live.com"
         let msaAvatar = MSFAvatar(style: .group, size: .large)
         msaAvatar.state.primaryText = "kat.larrson@live.com"
-        msaAccountCell.leadingUIView = msaAvatar.view
+        msaAccountCell.leadingView = MSFView(msaAvatar.view)
         msaAccountCell.leadingViewSize = .large
 
         let addAccountCell = MSFListCellState()
@@ -230,7 +230,7 @@ class LeftNavMenuViewController: UIViewController {
         addAccountCell.title = "Add Account"
         let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
         addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        addAccountCell.leadingUIView = addAccountImageView
+        addAccountCell.leadingView = MSFView(addAccountImageView)
         addAccountCell.onTapAction = defaultMenuAction
 
         let accountsSection = MSFListSectionState()
@@ -253,7 +253,7 @@ class LeftNavMenuViewController: UIViewController {
         persona.state.primaryText = "Kat Larrson"
         persona.state.secondaryText = "Designer"
         persona.state.image = UIImage(named: "avatar_kat_larsson")
-        persona.state.titleTrailingAccessoryUIView = chevron
+        persona.state.titleTrailingAccessoryView = MSFView(chevron)
         persona.state.backgroundColor = .systemBackground
         persona.state.onTapAction = {
             self.dismiss(animated: true, completion: {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -39,7 +39,7 @@ class ListDemoController: DemoController {
                                   image: samplePersonas[4].avatarImage,
                                   style: .default)
         listCell.title = avatar.state.primaryText ?? ""
-        listCell.leadingUIView = avatar.view
+        listCell.leadingView = MSFView(avatar.view)
         listCell.onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[4].name)
         }
@@ -54,7 +54,7 @@ class ListDemoController: DemoController {
                                       image: samplePersonas[index].avatarImage,
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
-            listCell.leadingUIView = avatar.view
+            listCell.leadingView = MSFView(avatar.view)
             children.append(listCell)
         }
         children[0].children = subchildren
@@ -74,7 +74,7 @@ class ListDemoController: DemoController {
                                       image: samplePersonas[index].avatarImage,
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
-            listCell.leadingUIView = avatar.view
+            listCell.leadingView = MSFView(avatar.view)
             listSection.cells.append(listCell)
         }
         listSection.cells[0].children = children
@@ -103,15 +103,26 @@ class ListDemoController: DemoController {
                 listCell.footnote = cell.text3
                 if !listCell.subtitle.isEmpty {
                     listCell.leadingViewSize = MSFListCellLeadingViewSize.large
-                    listCell.subtitleLeadingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "success-12x12", imageType: "subtitle") : nil
-                    listCell.subtitleTrailingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-down-20x20", imageType: "subtitle") : nil
+                    if showsLabelAccessoryView, let customView = createCustomView(imageName: "success-12x12", imageType: "subtitle") {
+                        listCell.subtitleLeadingAccessoryView = MSFView(customView)
+                    }
+                    if showsLabelAccessoryView, let customView = createCustomView(imageName: "chevron-down-20x20", imageType: "subtitle") {
+                        listCell.subtitleTrailingAccessoryView = MSFView(customView)
+                    }
                 }
 
-                listCell.titleLeadingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "ic_fluent_presence_available_16_filled", imageType: "title") : nil
-                listCell.titleTrailingAccessoryUIView = showsLabelAccessoryView ? createCustomView(imageName: "chevron-right-20x20", imageType: "title") : nil
-
-                listCell.leadingUIView = createCustomView(imageName: cell.image)
-                listCell.trailingUIView = section.hasAccessory ? createCustomView(imageName: cell.image) : nil
+                if showsLabelAccessoryView, let customView = createCustomView(imageName: "ic_fluent_presence_available_16_filled", imageType: "title") {
+                    listCell.titleLeadingAccessoryView = MSFView(customView)
+                }
+                if showsLabelAccessoryView, let customView = createCustomView(imageName: "chevron-right-20x20", imageType: "title") {
+                    listCell.titleTrailingAccessoryView = MSFView(customView)
+                }
+                if let customView = createCustomView(imageName: cell.image) {
+                    listCell.leadingView = MSFView(customView)
+                }
+                if section.hasAccessory, let customView = createCustomView(imageName: cell.image) {
+                    listCell.trailingView = MSFView(customView)
+                }
                 listCell.accessoryType = accessoryType(for: rowIndex)
                 listCell.onTapAction = {
                     indexPath.row = rowIndex

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -89,7 +89,7 @@
     [listCell3 setTitle:@"SampleTitle3"];
     [listCell3 setSubtitle:@"SampleTitle3"];
     UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]];
-    [listCell3 setLeadingUIView:image];
+    [listCell3 setLeadingView:[[MSFView alloc] init:image]];
     [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
     [listCell3 setLayoutType:MSFListCellLayoutTypeTwoLines];
     [listCell3 setOnTapAction:^{

--- a/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Vnext/Core/UIKit+SwiftUI_interoperability.swift
@@ -58,3 +58,23 @@ struct UIViewAdapter: UIViewRepresentable {
         stackView.addArrangedSubview(makeView())
     }
 }
+
+/// This is View wrapper that contains a UIView, View for SwiftUI/UIKit components.
+@objc public class MSFView: NSObject {
+
+    // Retrieve View for SwiftUI rendering
+    public let swiftView: AnyView
+
+    // Retrieve View for UIKit rendering
+    public let UIView: UIView
+
+    public init(_ swiftView: AnyView) {
+        self.swiftView = swiftView
+        self.UIView = UIHostingController(rootView: swiftView).view
+    }
+
+    @objc public init(_ uiView: UIView) {
+        self.UIView = uiView
+        self.swiftView = AnyView(UIViewAdapter(uiView))
+    }
+}

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -30,14 +30,14 @@ import SwiftUI
 @objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
 
-    @Published public var leadingView: AnyView?
-    @Published public var titleLeadingAccessoryView: AnyView?
-    @Published public var titleTrailingAccessoryView: AnyView?
-    @Published public var subtitleLeadingAccessoryView: AnyView?
-    @Published public var subtitleTrailingAccessoryView: AnyView?
-    @Published public var footnoteLeadingAccessoryView: AnyView?
-    @Published public var footnoteTrailingAccessoryView: AnyView?
-    @Published public var trailingView: AnyView?
+    @objc @Published public var leadingView: MSFView?
+    @Published public var titleLeadingAccessoryView: MSFView?
+    @objc @Published public var titleTrailingAccessoryView: MSFView?
+    @Published public var subtitleLeadingAccessoryView: MSFView?
+    @objc @Published public var subtitleTrailingAccessoryView: MSFView?
+    @Published public var footnoteLeadingAccessoryView: MSFView?
+    @Published public var footnoteTrailingAccessoryView: MSFView?
+    @Published public var trailingView: MSFView?
 
     @objc @Published public var leadingViewSize: MSFListCellLeadingViewSize = .medium {
         didSet {
@@ -62,94 +62,6 @@ import SwiftUI
     @objc @Published public var layoutType: MSFListCellLayoutType = .automatic
     @objc @Published public var hasDivider: Bool = false
     @objc public var onTapAction: (() -> Void)?
-
-    @objc public var leadingUIView: UIView? {
-        didSet {
-            guard let view = leadingUIView else {
-                leadingView = nil
-                return
-            }
-
-            leadingView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var titleLeadingAccessoryUIView: UIView? {
-        didSet {
-            guard let view = titleLeadingAccessoryUIView else {
-                titleLeadingAccessoryView = nil
-                return
-            }
-
-            titleLeadingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var titleTrailingAccessoryUIView: UIView? {
-        didSet {
-            guard let view = titleTrailingAccessoryUIView else {
-                titleTrailingAccessoryView = nil
-                return
-            }
-
-            titleTrailingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var subtitleLeadingAccessoryUIView: UIView? {
-        didSet {
-            guard let view = subtitleLeadingAccessoryUIView else {
-                subtitleLeadingAccessoryView = nil
-                return
-            }
-
-            subtitleLeadingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var subtitleTrailingAccessoryUIView: UIView? {
-        didSet {
-            guard let view = subtitleTrailingAccessoryUIView else {
-                subtitleTrailingAccessoryView = nil
-                return
-            }
-
-            subtitleTrailingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var footnoteLeadingAccessoryUIView: UIView? {
-        didSet {
-            guard let view = footnoteLeadingAccessoryUIView else {
-                footnoteLeadingAccessoryView = nil
-                return
-            }
-
-            footnoteLeadingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var footnoteTrailingAccessoryUIView: UIView? {
-        didSet {
-            guard let view = footnoteTrailingAccessoryUIView else {
-                footnoteTrailingAccessoryView = nil
-                return
-            }
-
-            footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    @objc public var trailingUIView: UIView? {
-        didSet {
-            guard let view = trailingUIView else {
-                trailingView = nil
-                return
-            }
-
-            trailingView = AnyView(UIViewAdapter(view))
-        }
-    }
 
     var tokens: MSFCellBaseTokens = MSFListCellTokens(cellLeadingViewSize: .medium)
 }
@@ -191,7 +103,7 @@ struct MSFListCellView: View {
                     let labelAccessorySize = tokens.labelAccessorySize
                     let sublabelAccessorySize = tokens.sublabelAccessorySize
 
-                    if let leadingView = state.leadingView {
+                    if let leadingView = state.leadingView?.swiftView {
                         leadingView
                             .frame(width: tokens.leadingViewSize, height: tokens.leadingViewSize)
                             .padding(.trailing, tokens.iconInterspace)
@@ -199,7 +111,7 @@ struct MSFListCellView: View {
 
                     VStack(alignment: .leading, spacing: 0) {
                         HStack(spacing: 0) {
-                            if let titleLeadingAccessoryView = state.titleLeadingAccessoryView {
+                            if let titleLeadingAccessoryView = state.titleLeadingAccessoryView?.swiftView {
                                 titleLeadingAccessoryView
                                     .frame(width: labelAccessorySize, height: labelAccessorySize)
                                     .padding(.trailing, labelAccessoryInterspace)
@@ -210,7 +122,7 @@ struct MSFListCellView: View {
                                     .foregroundColor(Color(tokens.labelColor))
                                     .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)
                             }
-                            if let titleTrailingAccessoryView = state.titleTrailingAccessoryView {
+                            if let titleTrailingAccessoryView = state.titleTrailingAccessoryView?.swiftView {
                                 titleTrailingAccessoryView
                                     .frame(width: labelAccessorySize, height: labelAccessorySize)
                                     .padding(.leading, labelAccessoryInterspace)
@@ -218,7 +130,7 @@ struct MSFListCellView: View {
                         }
 
                         HStack(spacing: 0) {
-                            if let subtitleLeadingAccessoryView = state.subtitleLeadingAccessoryView {
+                            if let subtitleLeadingAccessoryView = state.subtitleLeadingAccessoryView?.swiftView {
                                 subtitleLeadingAccessoryView
                                     .frame(width: sublabelAccessorySize, height: sublabelAccessorySize)
                                     .padding(.trailing, labelAccessoryInterspace)
@@ -229,7 +141,7 @@ struct MSFListCellView: View {
                                     .foregroundColor(Color(tokens.sublabelColor))
                                     .lineLimit(state.subtitleLineLimit == 0 ? nil : state.subtitleLineLimit)
                             }
-                            if let subtitleTrailingAccessoryView = state.subtitleTrailingAccessoryView {
+                            if let subtitleTrailingAccessoryView = state.subtitleTrailingAccessoryView?.swiftView {
                                 subtitleTrailingAccessoryView
                                     .frame(width: sublabelAccessorySize, height: sublabelAccessorySize)
                                     .padding(.leading, labelAccessoryInterspace)
@@ -237,7 +149,7 @@ struct MSFListCellView: View {
                         }
 
                         HStack(spacing: 0) {
-                            if let footnoteLeadingAccessoryView = state.footnoteLeadingAccessoryView {
+                            if let footnoteLeadingAccessoryView = state.footnoteLeadingAccessoryView?.swiftView {
                                 footnoteLeadingAccessoryView
                                     .frame(width: labelAccessorySize, height: labelAccessorySize)
                                     .padding(.trailing, labelAccessoryInterspace)
@@ -248,7 +160,7 @@ struct MSFListCellView: View {
                                     .foregroundColor(Color(tokens.sublabelColor))
                                     .lineLimit(state.footnoteLineLimit == 0 ? nil : state.footnoteLineLimit)
                             }
-                            if let footnoteTrailingAccessoryView = state.footnoteTrailingAccessoryView {
+                            if let footnoteTrailingAccessoryView = state.footnoteTrailingAccessoryView?.swiftView {
                                 footnoteTrailingAccessoryView
                                     .frame(width: labelAccessorySize, height: labelAccessorySize)
                                     .padding(.leading, labelAccessoryInterspace)
@@ -258,7 +170,7 @@ struct MSFListCellView: View {
 
                     Spacer()
 
-                    if let trailingView = state.trailingView {
+                    if let trailingView = state.trailingView?.swiftView {
                         trailingView
                             .frame(width: tokens.trailingItemSize, height: tokens.trailingItemSize)
                             .fixedSize()

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -13,15 +13,11 @@ import SwiftUI
 ///
 /// `onTapAction` provides tap gesture for PersonaView.
 ///
-@objc public protocol MSFPersonaViewState: MSFAvatarState {
-    var titleTrailingAccessoryUIView: UIView? { get set }
-    var subtitleTrailingAccessoryUIView: UIView? { get set }
+@objc(MSFPersonaViewState)
+public protocol PersonaViewState: MSFAvatarState {
+    var titleTrailingAccessoryView: MSFView? { get set }
+    var subtitleTrailingAccessoryView: MSFView? { get set }
     var onTapAction: (() -> Void)? { get set }
-}
-
-public protocol PersonaViewState: MSFPersonaViewState {
-    var titleTrailingAccessoryView: AnyView? { get set }
-    var subtitleTrailingAccessoryView: AnyView? { get set }
 }
 
 /// Properties that make up PersonaView content
@@ -160,7 +156,7 @@ public struct PersonaView: View {
         tokens = MSFPersonaViewTokens()
         let avatar = AvatarView(style: .default, size: .xlarge)
         state = MSFPersonaViewStateImpl(avatarState: avatar.state)
-        state.leadingView = AnyView(avatar)
+        state.leadingView = MSFView(AnyView(avatar))
         state.leadingViewSize = .xlarge
         state.layoutType = .threeLines
     }
@@ -195,7 +191,7 @@ public struct PersonaView: View {
         return hostingController.view
     }
 
-    @objc open var state: MSFPersonaViewState {
+    @objc open var state: PersonaViewState {
         return personaView.state
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Currently List support two variants of each datasource/delegate that interacts with UIView/AnyView. 
This view consolidates them into single wrapper view `MSFView`. 

E.g Instead of 
```swift
   @Published public var leadingView: AnyView? 
   
   @objc public var leadingUIView: UIView? {
        didSet {
            guard let view = leadingUIView else {
                leadingView = nil
                return
            }

            leadingView = AnyView(UIViewAdapter(view))
        }
    }
```

We now have 

```swift
  @objc @Published public var leadingView: MSFView? 
```

usage for SwiftUI  : `leadingView.swiftView`
Objective-C : `leadingView.uiView`

This would allow extension of views without duplicating additional methods for selection/disabled state. 

### Verification

LeftNav 
![Screen Shot 2021-05-10 at 3 53 05 PM](https://user-images.githubusercontent.com/63682282/117734798-0a941b80-b1a9-11eb-89df-a6de00983cac.png)

ListDemo
![Screen Shot 2021-05-10 at 3 52 56 PM](https://user-images.githubusercontent.com/63682282/117734810-0f58cf80-b1a9-11eb-84ad-6f15645aa4b5.png)

Objective-C Demo
![Screen Shot 2021-05-10 at 3 52 45 PM](https://user-images.githubusercontent.com/63682282/117734821-15e74700-b1a9-11eb-9f5f-591fab51a292.png)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/561)