### PR TITLE
Cherry-picking CCB accessibility fixes (#557) to main_0.1.

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -35,7 +35,8 @@ class CommandBarButton: UIButton {
         translatesAutoresizingMaskIntoConstraints = false
         setImage(item.iconImage, for: .normal)
 
-        accessibilityLabel = item.accessibilityLabel
+        let accessibilityDescription = item.accessibilityLabel
+        accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
         contentEdgeInsets = CommandBarButton.contentEdgeInsets
 
         if #available(iOS 14.0, *) {
@@ -57,10 +58,13 @@ class CommandBarButton: UIButton {
 
         // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
         let iconImage = item.iconImage
+        let title = item.title
+        let accessibilityDescription = item.accessibilityLabel
         setImage(iconImage, for: .normal)
-        setTitle(iconImage != nil ? nil : item.title, for: .normal)
+        setTitle(iconImage != nil ? nil : title, for: .normal)
         titleLabel?.isEnabled = isEnabled
         titleLabel?.font = item.titleFont
+        accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
     }
 
     private let isPersistSelection: Bool


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking CCB accessibility fixes (#557) to main_0.1.

### Verification

Sanity build and run of the Demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/562)