### PR TITLE
bug fix when large title view resizing the avatarView when collapsing or expanding

### DIFF
--- a/ios/FluentUI/Avatar/AvatarView.swift
+++ b/ios/FluentUI/Avatar/AvatarView.swift
@@ -216,6 +216,7 @@ open class AvatarView: UIView {
             updatePresenceImage()
 
             frame.size = avatarSize.size
+            containerView.frame = CGRect(origin: .zero, size: avatarSize.size)
             initialsView.avatarSize = avatarSize
 
             invalidateIntrinsicContentSize()
@@ -363,6 +364,7 @@ open class AvatarView: UIView {
 
         initialsView = InitialsView(avatarSize: avatarSize)
         initialsView.isHidden = true
+        initialsView.clipsToBounds = true
 
         imageView = UIImageView(frame: .zero)
         imageView.isHidden = true
@@ -373,9 +375,9 @@ open class AvatarView: UIView {
         borderView.isHidden = !hasBorder
 
         containerView = UIView(frame: CGRect(origin: .zero, size: avatarSize.size))
-        containerView.addSubview(borderView)
         containerView.addSubview(initialsView)
         containerView.addSubview(imageView)
+        containerView.addSubview(borderView)
 
         super.init(frame: containerView.frame)
 

--- a/ios/FluentUI/Avatar/InitialsView.swift
+++ b/ios/FluentUI/Avatar/InitialsView.swift
@@ -156,7 +156,6 @@ class InitialsView: UIView {
 
     public var avatarSize: AvatarSize {
         didSet {
-            frame.size = avatarSize.size
             initialsLabel.font = avatarSize.font
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Now that AvatarView explicitly sets the initialsView size based on border presence remove the initailsView's own frame size adjustment code.

- miscellaneous:
make sure borderView is always the top of the stack

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/20715435/118307607-c7cf8d80-b49f-11eb-8be7-821e95a6f741.mov | https://user-images.githubusercontent.com/20715435/118307703-e897e300-b49f-11eb-9d2e-94583df47d28.mov|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/569)