### PR TITLE
Add  UISwitch `isEnabled` property in BooleanCell for customization

### DIFF
--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -29,8 +29,19 @@ open class BooleanCell: TableViewCell {
 
     /// Updates the cell accessory view's `isEnabled` property
     @objc public var isSwitchEnabled: Bool {
-      get { return `switch`.isEnabled }
-      set { `switch`.isEnabled = newValue }
+      get {
+        return `switch`.isEnabled && isEnabled
+      }
+      set {
+        `switch`.isEnabled = newValue
+        updateAccessibility()
+      }
+    }
+
+    @objc open override var isEnabled: Bool {
+        didSet {
+            updateAccessibility()
+        }
     }
 
     /// `onValueChanged` is called when the cell accessory view's value has changed
@@ -41,6 +52,26 @@ open class BooleanCell: TableViewCell {
         `switch`.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
         return `switch`
     }()
+
+    @objc public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        updateAccessibility()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        updateAccessibility()
+    }
+
+    /// Sets up the content of the cell
+    ///
+    /// - Parameters:
+    ///   - title: Text that appears as a single line
+    ///   - customView: An optional custom view that appears on the leading edge, adjacent to the start of the `title` text
+    ///   - isOn: A boolean value describing the `isOn` state of the accessory view
+    @objc open func setup(title: String, customView: UIView? = nil, isOn: Bool = false) {
+        setup(title: title, customView: customView, isOn: isOn, isSwitchEnabled: true)
+    }
 
     /// Sets up the content of the cell
     ///
@@ -63,6 +94,14 @@ open class BooleanCell: TableViewCell {
         super.didMoveToWindow()
         if let window = window {
             `switch`.onTintColor = Colors.primary(for: window)
+        }
+    }
+
+    private func updateAccessibility() {
+        if isEnabled && isSwitchEnabled {
+            accessibilityTraits.remove(.notEnabled)
+        } else {
+            accessibilityTraits.insert(.notEnabled)
         }
     }
 }

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -15,6 +15,8 @@ public typealias MSBooleanCell = BooleanCell
 
  Use the `isOn` property to update the cell accessory view's `isOn` property.
 
+ Use the `isSwitchEnabled` property to update the cell accessory view's `isEnabled` property.
+
  Use `onValueChanged` as a callback for an event that changes the value of the accessory view.
  */
 @objc(MSFBooleanCell)
@@ -23,6 +25,12 @@ open class BooleanCell: TableViewCell {
     @objc public var isOn: Bool {
         get { return `switch`.isOn }
         set { `switch`.isOn = newValue }
+    }
+
+    /// Updates the cell accessory view's `isEnabled` property
+    @objc public var isSwitchEnabled: Bool {
+      get { return `switch`.isEnabled }
+      set { `switch`.isEnabled = newValue }
     }
 
     /// `onValueChanged` is called when the cell accessory view's value has changed
@@ -40,9 +48,11 @@ open class BooleanCell: TableViewCell {
     ///   - title: Text that appears as a single line
     ///   - customView: An optional custom view that appears on the leading edge, adjacent to the start of the `title` text
     ///   - isOn: A boolean value describing the `isOn` state of the accessory view
-    @objc open func setup(title: String, customView: UIView? = nil, isOn: Bool = false) {
+    ///   - isSwitchEnabled: A boolean value describing the `isEnabled` state of the accessory view
+    @objc open func setup(title: String, customView: UIView? = nil, isOn: Bool = false, isSwitchEnabled: Bool = true) {
         setup(title: title, customView: customView, customAccessoryView: `switch`)
         self.isOn = isOn
+        self.isSwitchEnabled = isSwitchEnabled
     }
 
     @objc private func handleOnSwitchValueChanged() {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -789,8 +789,7 @@ open class TableViewCell: UITableViewCell {
             if let customSwitch = customAccessoryView as? UISwitch {
                 if isEnabled && customSwitch.isEnabled {
                   return "Accessibility.TableViewCell.Switch.Hint".localized
-                }
-                else {
+                } else {
                     return nil
                 }
             }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -786,8 +786,13 @@ open class TableViewCell: UITableViewCell {
             if isInSelectionMode && isEnabled {
                 return "Accessibility.MultiSelect.Hint".localized
             }
-            if customAccessoryView is UISwitch {
-                return "Accessibility.TableViewCell.Switch.Hint".localized
+            if let customSwitch = customAccessoryView as? UISwitch {
+                if isEnabled && customSwitch.isEnabled {
+                  return "Accessibility.TableViewCell.Switch.Hint".localized
+                }
+                else {
+                    return nil
+                }
             }
             return super.accessibilityHint
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

According to the requirement of an in-progress feature in Outlook iOS in Microsoft, we need to have the disabled style of UISwitch inside BooleanCell. So we make this change then callers can customize.

### Verification

I included the update locally and did sanity checks in the test app to verify the cell works as expected with and without the property been setup.

| `isSwitchEnabled` == true                                | `isSwitchEnabled` == false                            |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 12 Pro - 2021-05-19 at 22 01 19](https://user-images.githubusercontent.com/4921232/118826201-da0d5980-b8ed-11eb-851f-574585266573.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-05-19 at 22 00 35](https://user-images.githubusercontent.com/4921232/118825961-b3e7b980-b8ed-11eb-91f2-225af877f1bb.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/577)