### PR TITLE
Add support for boolean cells in `BottomCommandingController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -67,7 +67,7 @@ class BottomCommandingDemoController: UIViewController {
                 DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff)),
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: true),
                 DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
-                DemoItem(title: "Toggle random boolean cell", type: .action, action: #selector(toggleRandomBooleanCell)),
+                DemoItem(title: "Toggle boolean cells", type: .action, action: #selector(toggleBooleanCells)),
                 DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeHeroCommandTitle)),
                 DemoItem(title: "Change hero command images", type: .action, action: #selector(changeHeroCommandIcon)),
                 DemoItem(title: "Change list command titles", type: .action, action: #selector(changeListCommandTitle)),
@@ -132,8 +132,8 @@ class BottomCommandingDemoController: UIViewController {
         listIconChanged.toggle()
     }
 
-    @objc private func toggleRandomBooleanCell() {
-        booleanCommands[Int.random(in: 0..<booleanCommands.count)].isOn.toggle()
+    @objc private func toggleBooleanCells() {
+        booleanCommands.forEach { $0.isOn.toggle() }
     }
 
     @objc private func incrementHeroCommands() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -48,10 +48,15 @@ class BottomCommandingDemoController: UIViewController {
         }
     }()
 
+    private lazy var booleanCommands: [CommandingItem] = Array(1...4).map {
+        CommandingItem(title: "Boolean Item " + String($0), image: homeImage, action: commandAction, isToggleable: true)
+    }
+
     private lazy var expandedListSections: [CommandingSection] = [
-        CommandingSection(title: "Section 1", items: Array(1...7).map {
-                CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
-        }),
+        CommandingSection(title: "Section 1", items:
+        Array(1...2).map {
+            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+        } + booleanCommands),
         CommandingSection(title: "Section 2", items: Array(1...7).map {
             CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
         })
@@ -62,6 +67,7 @@ class BottomCommandingDemoController: UIViewController {
                 DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff)),
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: true),
                 DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
+                DemoItem(title: "Toggle random boolean cell", type: .action, action: #selector(toggleRandomBooleanCell)),
                 DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeHeroCommandTitle)),
                 DemoItem(title: "Change hero command images", type: .action, action: #selector(changeHeroCommandIcon)),
                 DemoItem(title: "Change list command titles", type: .action, action: #selector(changeListCommandTitle)),
@@ -126,6 +132,10 @@ class BottomCommandingDemoController: UIViewController {
         listIconChanged.toggle()
     }
 
+    @objc private func toggleRandomBooleanCell() {
+        booleanCommands[Int.random(in: 0..<booleanCommands.count)].isOn.toggle()
+    }
+
     @objc private func incrementHeroCommands() {
         let currentCount = bottomCommandingController?.heroItems.count ?? 0
         if currentCount < 5 {
@@ -146,7 +156,9 @@ class BottomCommandingDemoController: UIViewController {
         if heroItems.contains(item) {
             showMessage("Hero command tapped")
         } else if expandedListSections.contains(where: { $0.items.contains(item) }) {
-            showMessage("Expanded list command tapped")
+            if !item.isToggleable {
+                showMessage("Expanded list command tapped")
+            }
         }
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -567,19 +567,6 @@ extension BottomCommandingController: CommandingItemDelegate {
         reloadView(from: item)
     }
 
-    func commandingItem(_ item: CommandingItem, didChangeToggleableTo value: Bool) {
-        guard let binding = itemToBindingMap[item] else {
-            return
-        }
-
-        // We need a UITableView.reloadRows call here because item.isToggleable changes the cell type
-        if binding.location == .list,
-           let cell = binding.view as? UITableViewCell,
-           let indexPath = tableView.indexPath(for: cell) {
-            tableView.reloadRows(at: [indexPath], with: .automatic)
-        }
-    }
-
     func commandingItem(_ item: CommandingItem, didChangeEnabledTo value: Bool) {
         guard let view = itemToBindingMap[item]?.view else {
             return

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -87,7 +87,7 @@ open class CommandingItem: NSObject {
                       action: @escaping (CommandingItem) -> Void,
                       selectedImage: UIImage? = nil,
                       largeImage: UIImage? = nil,
-                      isSelected: Bool = false,
+                      isOn: Bool = false,
                       isEnabled: Bool = true,
                       isToggleable: Bool = false) {
         self.title = title
@@ -95,7 +95,7 @@ open class CommandingItem: NSObject {
         self.image = image
         self.selectedImage = selectedImage
         self.largeImage = largeImage
-        self.isOn = isSelected
+        self.isOn = isOn
         self.isEnabled = isEnabled
         self.isToggleable = isToggleable
     }

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -74,30 +74,24 @@ open class CommandingItem: NSObject {
     }
 
     /// Indicates whether `isOn` should be toggled automatically before `action` is called.
-    @objc open var isToggleable: Bool {
-        didSet {
-            if isToggleable != oldValue {
-                delegate?.commandingItem(self, didChangeToggleableTo: isToggleable)
-            }
-        }
-    }
+    @objc public let isToggleable: Bool
 
     @objc public init(title: String,
                       image: UIImage,
                       action: @escaping (CommandingItem) -> Void,
+                      isToggleable: Bool = false,
                       selectedImage: UIImage? = nil,
                       largeImage: UIImage? = nil,
                       isOn: Bool = false,
-                      isEnabled: Bool = true,
-                      isToggleable: Bool = false) {
+                      isEnabled: Bool = true) {
         self.title = title
         self.action = action
+        self.isToggleable = isToggleable
         self.image = image
         self.selectedImage = selectedImage
         self.largeImage = largeImage
         self.isOn = isOn
         self.isEnabled = isEnabled
-        self.isToggleable = isToggleable
     }
 
     weak var delegate: CommandingItemDelegate?
@@ -121,7 +115,4 @@ protocol CommandingItemDelegate: class {
 
     /// Called after the `isEnabled` property changed.
     func commandingItem(_ item: CommandingItem, didChangeEnabledTo value: Bool)
-
-    /// Called after the `isToggleable` property changed.
-    func commandingItem(_ item: CommandingItem, didChangeToggleableTo value: Bool)
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds support for `BooleanCell` in `BottomCommandingController`. These are used when a `CommandingItem` has `isToggleable` set to `true`.

`CommandingItem.isToggleable` property change is internally handled in a special way, because the cell type changes so a full cell reload through the `UITableView` is necessary. 
### Verification

Updated the test app to include boolean cells. Also added a button to toggle random isOn states to make sure the binding works.



| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 12 - 2021-05-19 at 13 48 15](https://user-images.githubusercontent.com/3610850/118883073-b32d3400-b8a9-11eb-934e-18e97ececf27.png)|![Simulator Screen Shot - iPhone 12 - 2021-05-19 at 13 47 01](https://user-images.githubusercontent.com/3610850/118883094-baecd880-b8a9-11eb-8550-3e668740fb93.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/579)