### PR TITLE
Remove deprecated API delegate method to fix auto popover dismiss in Xcode 12.5

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -1021,10 +1021,6 @@ extension DrawerController: UIPopoverPresentationControllerDelegate {
     public func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
         return delegate?.drawerControllerShouldDismissDrawer?(self) ?? true
     }
-
-//    public func popoverPresentationControllerShouldDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) -> Bool {
-//        return delegate?.drawerControllerShouldDismissDrawer?(self) ?? true
-//    }
 }
 
 // MARK: - DrawerController: UIGestureRecognizerDelegate

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -1018,9 +1018,13 @@ extension DrawerController: UIPopoverPresentationControllerDelegate {
         return .none
     }
 
-    public func popoverPresentationControllerShouldDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) -> Bool {
-        return dismissPresentingViewController(animated: true)
+    public func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
+        return delegate?.drawerControllerShouldDismissDrawer?(self) ?? true
     }
+
+//    public func popoverPresentationControllerShouldDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) -> Bool {
+//        return delegate?.drawerControllerShouldDismissDrawer?(self) ?? true
+//    }
 }
 
 // MARK: - DrawerController: UIGestureRecognizerDelegate


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

API `presentationControllerShouldDismiss` is deprecated. A side effect of using it causes the popover to be dismissed when hovered by accessibility inspector. 

Substituting it with `presentationControllerShouldDismiss` and relaying call to `drawerControllerShouldDismissDrawer` resolves the problem and allows client to control the default functionality. 

### Verification

The video below shows the simulation of the behavior when delegates are not implemented by client. 

Before:

https://user-images.githubusercontent.com/63682282/118921504-23a97480-b8ed-11eb-9fc5-1846e25f27da.mov

After:

https://user-images.githubusercontent.com/63682282/118921542-315efa00-b8ed-11eb-9b30-44e7d43b8bc7.mov

Test scenarios for dismissal work with the new API's as expected 

iPhone:

https://user-images.githubusercontent.com/63682282/118921730-84d14800-b8ed-11eb-978f-5948ce50e037.mov

iPad:

https://user-images.githubusercontent.com/63682282/118921759-94e92780-b8ed-11eb-820d-287f4767a397.mov

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/581)