### PR TITLE
Add support for bottom safe area inset in BottomSheetController 

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -5,7 +5,6 @@
 
 import FluentUI
 
-class BottomSheetDemoController: UIViewController {
 
     override func loadView() {
         view = UIView()
@@ -19,7 +18,7 @@ class BottomSheetDemoController: UIViewController {
         optionTableView.separatorStyle = .none
         view.addSubview(optionTableView)
 
-        let bottomSheetViewController = BottomSheetController(contentView: personaListView)
+        let bottomSheetViewController = BottomSheetController(sheetHeaderContentView: headerView, sheetExpandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
 
         self.bottomSheetViewController = bottomSheetViewController
@@ -57,6 +56,20 @@ class BottomSheetDemoController: UIViewController {
         personaListView.personaList = samplePersonas
         personaListView.translatesAutoresizingMaskIntoConstraints = false
         return personaListView
+    }()
+
+    private let headerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemTeal
+        view.heightAnchor.constraint(equalToConstant: 70).isActive = true
+        return view
+    }()
+
+    private let expandedContentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemIndigo
+//        view.heightAnchor.constraint(equalToConstant: 400).isActive = true
+        return view
     }()
 
     private var bottomSheetViewController: BottomSheetController?

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -60,15 +60,26 @@ import FluentUI
 
     private let headerView: UIView = {
         let view = UIView()
-        view.backgroundColor = .systemTeal
-        view.heightAnchor.constraint(equalToConstant: 70).isActive = true
+        view.backgroundColor = .systemGray6
+        view.heightAnchor.constraint(equalToConstant: headerHeight).isActive = true
+
+        let label = UILabel()
+        label.text = "Sheet header view"
+        label.font = .systemFont(ofSize: 24)
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
         return view
     }()
 
     private let expandedContentView: UIView = {
         let view = UIView()
         view.backgroundColor = .systemIndigo
-//        view.heightAnchor.constraint(equalToConstant: 400).isActive = true
         return view
     }()
 
@@ -81,6 +92,8 @@ import FluentUI
             DemoItem(title: "Half screen expansion height", type: .action, action: #selector(halfScreenExpandedOffset))
         ]
     }()
+
+    private static let headerHeight: CGFloat = 70
 
     private enum DemoItemType {
         case action

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -68,7 +68,6 @@ class BottomSheetDemoController: UIViewController {
 
         let label = Label()
         label.text = "Header view"
-        label.font = .systemFont(ofSize: 24)
         label.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(label)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -21,6 +21,7 @@ class BottomSheetDemoController: UIViewController {
 
         let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
+        bottomSheetViewController.collapsedContentHeight = BottomSheetDemoController.headerHeight
 
         self.bottomSheetViewController = bottomSheetViewController
 
@@ -76,12 +77,6 @@ class BottomSheetDemoController: UIViewController {
             label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
-        return view
-    }()
-
-    private let expandedContentView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .systemIndigo
         return view
     }()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -18,6 +18,7 @@ class BottomSheetDemoController: UIViewController {
         optionTableView.delegate = self
         optionTableView.separatorStyle = .none
         view.addSubview(optionTableView)
+
         let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -18,7 +18,7 @@ class BottomSheetDemoController: UIViewController {
         optionTableView.delegate = self
         optionTableView.separatorStyle = .none
         view.addSubview(optionTableView)
-        let bottomSheetViewController = BottomSheetController(sheetHeaderContentView: headerView, sheetExpandedContentView: personaListView)
+        let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
 
         self.bottomSheetViewController = bottomSheetViewController

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -5,6 +5,7 @@
 
 import FluentUI
 
+class BottomSheetDemoController: UIViewController {
 
     override func loadView() {
         view = UIView()
@@ -17,7 +18,6 @@ import FluentUI
         optionTableView.delegate = self
         optionTableView.separatorStyle = .none
         view.addSubview(optionTableView)
-
         let bottomSheetViewController = BottomSheetController(sheetHeaderContentView: headerView, sheetExpandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -63,10 +63,10 @@ class BottomSheetDemoController: UIViewController {
 
     private let headerView: UIView = {
         let view = UIView()
-        view.backgroundColor = .systemGray6
+        view.backgroundColor = Colors.gray100
         view.heightAnchor.constraint(equalToConstant: headerHeight).isActive = true
 
-        let label = UILabel()
+        let label = Label()
         label.text = "Header view"
         label.font = .systemFont(ofSize: 24)
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -54,6 +54,7 @@ class BottomSheetDemoController: UIViewController {
     private let personaListView: PersonaListView = {
         let personaListView = PersonaListView()
         personaListView.personaList = samplePersonas
+        personaListView.backgroundColor = Colors.NavigationBar.background
         personaListView.translatesAutoresizingMaskIntoConstraints = false
         return personaListView
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -64,7 +64,7 @@ import FluentUI
         view.heightAnchor.constraint(equalToConstant: headerHeight).isActive = true
 
         let label = UILabel()
-        label.text = "Sheet header view"
+        label.text = "Header view"
         label.font = .systemFont(ofSize: 24)
         label.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -98,10 +98,6 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    public override func viewSafeAreaInsetsDidChange() {
-        updateSheetCollapsedContentHeight()
-    }
-
     private func setupBottomBarLayout() {
         NSLayoutConstraint.activate(heroCommandWidthConstraints)
         heroCommandStack.distribution = .equalSpacing
@@ -216,17 +212,15 @@ open class BottomCommandingController: UIViewController {
     }
 
     private func updateExpandability() {
-        if isInSheetMode {
-            bottomSheetController?.isExpandable = isExpandable
-            bottomSheetHeroStackTopConstraint?.constant = bottomSheetHeroStackTopMargin
-            updateSheetCollapsedContentHeight()
+        if isInSheetMode,
+           let bottomSheetController = bottomSheetController,
+           let heroStackTopConstraint = bottomSheetHeroStackTopConstraint {
+            bottomSheetController.isExpandable = isExpandable
+            bottomSheetController.collapsedContentHeight = bottomSheetHeroStackHeight
+            heroStackTopConstraint.constant = bottomSheetHeroStackTopMargin
         } else {
             moreButtonView.isHidden = !isExpandable
         }
-    }
-
-    private func updateSheetCollapsedContentHeight() {
-        bottomSheetController?.collapsedContentHeight = bottomSheetHeroStackHeight + view.safeAreaInsets.bottom
     }
 
     private lazy var moreButtonView: UIView = {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -127,7 +127,7 @@ open class BottomCommandingController: UIViewController {
         let commandStackContainer = UIView()
         commandStackContainer.addSubview(heroCommandStack)
 
-        let sheetController = BottomSheetController(sheetHeaderContentView: commandStackContainer, sheetExpandedContentView: expandedContentView)
+        let sheetController = BottomSheetController(headerContentView: commandStackContainer, expandedContentView: expandedContentView)
         sheetController.hostedScrollView = tableView
         sheetController.expandedHeightFraction = Constants.BottomSheet.expandedFraction
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -98,6 +98,10 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
+    public override func viewSafeAreaInsetsDidChange() {
+        updateSheetCollapsedContentHeight()
+    }
+
     private func setupBottomBarLayout() {
         NSLayoutConstraint.activate(heroCommandWidthConstraints)
         heroCommandStack.distribution = .equalSpacing
@@ -127,9 +131,8 @@ open class BottomCommandingController: UIViewController {
         let commandStackContainer = UIView()
         commandStackContainer.addSubview(heroCommandStack)
 
-        let sheetController = BottomSheetController(contentView: makeBottomSheetContent(headerView: commandStackContainer, expandedContentView: tableView))
+        let sheetController = BottomSheetController(sheetHeaderContentView: commandStackContainer, sheetExpandedContentView: expandedContentView)
         sheetController.hostedScrollView = tableView
-        sheetController.collapsedContentHeight = bottomSheetHeroStackHeight
         sheetController.expandedHeightFraction = Constants.BottomSheet.expandedFraction
 
         addChild(sheetController)
@@ -147,7 +150,7 @@ open class BottomCommandingController: UIViewController {
             sheetController.view.topAnchor.constraint(equalTo: view.topAnchor),
             heroCommandStack.leadingAnchor.constraint(equalTo: commandStackContainer.leadingAnchor, constant: Constants.BottomSheet.heroStackLeadingTrailingMargin),
             heroCommandStack.trailingAnchor.constraint(equalTo: commandStackContainer.trailingAnchor, constant: -Constants.BottomSheet.heroStackLeadingTrailingMargin),
-            heroCommandStack.bottomAnchor.constraint(equalTo: commandStackContainer.bottomAnchor, constant: -Constants.BottomSheet.heroStackBottomMargin),
+            heroCommandStack.bottomAnchor.constraint(equalTo: commandStackContainer.bottomAnchor),
             heroStackTopConstraint
         ])
 
@@ -214,12 +217,16 @@ open class BottomCommandingController: UIViewController {
 
     private func updateExpandability() {
         if isInSheetMode {
-            bottomSheetController?.collapsedContentHeight = bottomSheetHeroStackHeight
             bottomSheetController?.isExpandable = isExpandable
             bottomSheetHeroStackTopConstraint?.constant = bottomSheetHeroStackTopMargin
+            updateSheetCollapsedContentHeight()
         } else {
             moreButtonView.isHidden = !isExpandable
         }
+    }
+
+    private func updateSheetCollapsedContentHeight() {
+        bottomSheetController?.collapsedContentHeight = bottomSheetHeroStackHeight + view.safeAreaInsets.bottom
     }
 
     private lazy var moreButtonView: UIView = {
@@ -247,6 +254,26 @@ open class BottomCommandingController: UIViewController {
 
         isHeroCommandStackLoaded = true
         return stackView
+    }()
+
+    private lazy var expandedContentView: UIView = {
+        let view = UIView()
+        let separator = Separator()
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(tableView)
+        view.addSubview(separator)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.BottomSheet.expandedContentTopMargin),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            separator.topAnchor.constraint(equalTo: tableView.topAnchor),
+            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        return view
     }()
 
     private lazy var tableView: UITableView = {
@@ -411,7 +438,7 @@ open class BottomCommandingController: UIViewController {
         isExpandable ? Constants.BottomSheet.heroStackExpandableTopMargin : Constants.BottomSheet.heroStackNonExpandableTopMargin
     }
 
-    private var bottomSheetHeroStackHeight: CGFloat { Constants.heroButtonHeight + Constants.BottomSheet.heroStackBottomMargin + bottomSheetHeroStackTopMargin }
+    private var bottomSheetHeroStackHeight: CGFloat { Constants.heroButtonHeight + bottomSheetHeroStackTopMargin }
 
     private var heroCommandWidthConstraints: [NSLayoutConstraint] {
         heroItems.compactMap { (itemToBindingMap[$0] as? HeroItemBindingInfo)?.widthConstraint }
@@ -469,14 +496,14 @@ open class BottomCommandingController: UIViewController {
         }
 
         struct BottomSheet {
-            static let expandedFraction: CGFloat = 0.7 // Probably should be more customizable / based on content
-            static let heroStackBottomMargin: CGFloat = 16
+            static let expandedFraction: CGFloat = 0.9 // Probably should be more customizable / based on content
             static let heroStackExpandableTopMargin: CGFloat = 0
             static let heroStackNonExpandableTopMargin: CGFloat = 16
             static let heroStackLeadingTrailingMargin: CGFloat = 8
+
+            static let expandedContentTopMargin: CGFloat = 16
         }
     }
-
 }
 
 extension BottomCommandingController: UITableViewDataSource {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -490,7 +490,7 @@ open class BottomCommandingController: UIViewController {
         }
 
         struct BottomSheet {
-            static let expandedFraction: CGFloat = 0.9 // Probably should be more customizable / based on content
+            static let expandedFraction: CGFloat = 0.7 // Probably should be more customizable / based on content
             static let heroStackExpandableTopMargin: CGFloat = 0
             static let heroStackNonExpandableTopMargin: CGFloat = 16
             static let heroStackLeadingTrailingMargin: CGFloat = 8

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -97,7 +97,7 @@ open class CommandingItem: NSObject {
     weak var delegate: CommandingItemDelegate?
 }
 
-protocol CommandingItemDelegate: class {
+protocol CommandingItemDelegate: AnyObject {
     /// Called after the `title` property changed.
     func commandingItem(_ item: CommandingItem, didChangeTitleTo value: String)
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -232,6 +232,7 @@ public class BottomSheetController: UIViewController {
         switch sender.state {
         case .began:
             stopAnimationIfNeeded()
+            hostedScrollView?.setContentOffset(.zero, animated: true)
             fallthrough
         case .changed:
             translateSheet(by: sender.translation(in: view))
@@ -347,7 +348,7 @@ public class BottomSheetController: UIViewController {
 
         // The AutoLayout constant doesn't animate, so we need to set it to whatever it should be
         // based on the frame calculated during the interrupted animation
-        let offsetFromBottom = view.frame.height - bottomSheetView.frame.origin.y
+        let offsetFromBottom = view.frame.height - bottomSheetView.frame.origin.y - view.safeAreaInsets.bottom
         bottomSheetOffsetConstraint.constant = -offsetFromBottom
     }
 
@@ -459,9 +460,9 @@ extension BottomSheetController: UIGestureRecognizerDelegate {
         if fullyExpanded {
             let scrolledToTop = scrollView.contentOffset.y <= 0
             let panningDown = panGesture.velocity(in: view).y > 0
-            shouldBegin = scrolledToTop && panningDown
+            let panInHostedScrollView = scrollView.frame.contains(panGesture.location(in: scrollView.superview))
+            shouldBegin = (scrolledToTop && panningDown) || !panInHostedScrollView
         }
-
         return shouldBegin
     }
 }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -21,7 +21,7 @@ public class BottomSheetController: UIViewController {
     /// - Parameters:
     ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.
     ///   - expandedContentView: Sheet content below the header which is only visible when the sheet is expanded.
-    @objc public init(headerContentView: UIView, expandedContentView: UIView) {
+    @objc public init(headerContentView: UIView? = nil, expandedContentView: UIView) {
         self.headerContentView = headerContentView
         self.expandedContentView = expandedContentView
         super.init(nibName: nil, bundle: nil)
@@ -33,7 +33,7 @@ public class BottomSheetController: UIViewController {
     }
 
     /// Top part of the sheet content that is visible in both collapsed and expanded state.
-    @objc public let headerContentView: UIView
+    @objc public let headerContentView: UIView?
 
     /// Sheet content below the header which is only visible when the sheet is expanded.
     @objc public let expandedContentView: UIView
@@ -129,7 +129,11 @@ public class BottomSheetController: UIViewController {
         stackView.spacing = 0.0
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.addArrangedSubview(headerContentView)
+
+        if let headerView = headerContentView {
+            stackView.addArrangedSubview(headerView)
+        }
+
         stackView.addArrangedSubview(expandedContentView)
         bottomSheetContentView.addSubview(stackView)
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -244,7 +244,6 @@ public class BottomSheetController: UIViewController {
         switch sender.state {
         case .began:
             stopAnimationIfNeeded()
-            hostedScrollView?.setContentOffset(.zero, animated: true)
             fallthrough
         case .changed:
             translateSheet(by: sender.translation(in: view))
@@ -292,6 +291,10 @@ public class BottomSheetController: UIViewController {
         } else {
             // Velocity high enough, animate to the offset we're swiping towards
             targetState = velocity > 0 ? .collapsed : .expanded
+        }
+
+        if targetState == .collapsed {
+            hostedScrollView?.setContentOffset(.zero, animated: true)
         }
         move(to: targetState, velocity: velocity)
     }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -17,9 +17,13 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 @objc(MSFBottomSheetController)
 public class BottomSheetController: UIViewController {
 
-    @objc public init(sheetHeaderContentView: UIView, sheetExpandedContentView: UIView) {
-        headerContentView = sheetHeaderContentView
-        expandedContentView = sheetExpandedContentView
+    /// Initializes the bottom sheet controller
+    /// - Parameters:
+    ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.
+    ///   - expandedContentView: Sheet content below the header which is only visible when the sheet is expanded.
+    @objc public init(headerContentView: UIView, expandedContentView: UIView) {
+        self.headerContentView = headerContentView
+        self.expandedContentView = expandedContentView
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -28,7 +32,13 @@ public class BottomSheetController: UIViewController {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    /// A scroll view in `contentViewController`'s view hierarchy.
+    /// Top part of the sheet content that is visible in both collapsed and expanded state.
+    @objc public let headerContentView: UIView
+
+    /// Sheet content below the header which is only visible when the sheet is expanded.
+    @objc public let expandedContentView: UIView
+
+    /// A scroll view in `expandedContentView`'s view hierarchy.
     /// Provide this to ensure the bottom sheet pan gesture recognizer coordinates with the scroll view to enable scrolling based on current bottom sheet position and content offset.
     @objc open var hostedScrollView: UIScrollView?
 
@@ -46,8 +56,6 @@ public class BottomSheetController: UIViewController {
     }
 
     /// Fraction of the available area that the bottom sheet should take up in the expanded position.
-    ///
-    /// Ignored when `respectsPreferredContentSize` is set to `true`
     @objc open var expandedHeightFraction: CGFloat = 1.0 {
         didSet {
             if expandedHeightFraction != oldValue {
@@ -377,10 +385,6 @@ public class BottomSheetController: UIViewController {
 
     private lazy var bottomSheetOffsetConstraint: NSLayoutConstraint =
         bottomSheetView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -collapsedOffsetFromBottom)
-
-    private let headerContentView: UIView
-
-    private let expandedContentView: UIView
 
     private lazy var panGestureRecognizer: UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#### Problem
In our (and basically any) usage of a persistent bottom sheet, there is some notion of a header which is always visible, and main content which is only visible when you expand the sheet. The problem is that with the chunky iPhone bottom safe area inset, offsetting the collapsed sheet high enough to have the header in the safe area would mean revealing a part of the expanded content. This looks bad, so we need to hide the expanded content when the sheet is collapsed.

Example of the problematic case:
<img width="394" alt="Screen Shot 2021-05-21 at 6 18 10 PM" src="https://user-images.githubusercontent.com/3610850/119210422-e82fb700-ba60-11eb-92c7-63efa3db398e.png">


#### Fix
To solve this, the sheet needs know about the distinct header + expanded content views. I added a new init which lets clients provide these two separate views. I also removed the old init methods (contentView and contentViewController), because they just complicate the implementation and I think most clients can get by with the split content pattern. It's the only way to always enforce good safe area handling. What's also good is that this would let us implement other cool effects in the future, like expanded content that gradually overlaps the header as the sheet expands.

Solution:

https://user-images.githubusercontent.com/3610850/119210727-a142c100-ba62-11eb-8b5f-7ab51d914370.mov

### Verification

Modified test app to use the header / expanded content split pattern. Also verified this works well in `BottomCommandingController`.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 12 - 2021-05-21 at 18 25 37](https://user-images.githubusercontent.com/3610850/119210683-650f6080-ba62-11eb-99cc-85a22bead562.png)![Simulator Screen Shot - iPhone 12 - 2021-05-21 at 18 25 48](https://user-images.githubusercontent.com/3610850/119210686-69d41480-ba62-11eb-981c-9aaee4ceec30.png)|![Simulator Screen Shot - iPhone 12 - 2021-05-21 at 18 38 59](https://user-images.githubusercontent.com/3610850/119210919-ea474500-ba63-11eb-8d5e-bb176dce4b6a.png)![Simulator Screen Shot - iPhone 12 - 2021-05-21 at 18 26 43](https://user-images.githubusercontent.com/3610850/119210699-7b1d2100-ba62-11eb-96de-e77fe0783771.png)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/584)