### PR TITLE
Adding setting to suppress Avatar ring inner gap.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -40,6 +40,11 @@ class AvatarDemoController: DemoController {
                                                            isOn: isShowingRings)
         addRow(items: [showRingsSettingView])
 
+        let enableRingInnerGapSettingView = createLabelAndSwitchRow(labelText: "Enable ring inner gap",
+                                                                    switchAction: #selector(toggleShowRingInnerGap(switchView:)),
+                                                                    isOn: isShowingRingInnerGap)
+        addRow(items: [enableRingInnerGapSettingView])
+
         addTitle(text: "Default style")
         for size in MSFAvatarSize.allCases.reversed() {
             let name = "Kat Larrson"
@@ -165,6 +170,16 @@ class AvatarDemoController: DemoController {
         }
     }
 
+    private var isShowingRingInnerGap: Bool = true {
+        didSet {
+            if oldValue != isShowingRingInnerGap {
+                for avatarView in avatarViews {
+                    avatarView.state.hasRingInnerGap = isShowingRingInnerGap
+                }
+            }
+        }
+    }
+
     private var isTransparent: Bool = true {
         didSet {
             if oldValue != isTransparent {
@@ -206,6 +221,10 @@ class AvatarDemoController: DemoController {
 
     @objc private func toggleShowRings(switchView: UISwitch) {
         isShowingRings = switchView.isOn
+    }
+
+    @objc private func toggleShowRingInnerGap(switchView: UISwitch) {
+        isShowingRingInnerGap = switchView.isOn
     }
 
     @objc private func toggleAlternateBackground(switchView: UISwitch) {

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -100,6 +100,7 @@ import SwiftUI
     var foregroundColor: UIColor? { get set }
     var presence: MSFAvatarPresence { get set }
     var hasPointerInteraction: Bool { get set }
+    var hasRingInnerGap: Bool { get set }
     var isRingVisible: Bool { get set }
     var isTransparent: Bool { get set }
     var isOutOfOffice: Bool { get set }
@@ -115,6 +116,7 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
     @Published var foregroundColor: UIColor?
     @Published var presence: MSFAvatarPresence = .none
     @Published var hasPointerInteraction: Bool = false
+    @Published var hasRingInnerGap: Bool = true
     @Published var isRingVisible: Bool = false
     @Published var isTransparent: Bool = true
     @Published var isOutOfOffice: Bool = false
@@ -138,13 +140,14 @@ public struct AvatarView: View {
         let presence = state.presence
         let shouldDisplayPresence = presence != .none
         let isRingVisible = state.isRingVisible
+        let hasRingInnerGap = state.hasRingInnerGap
         let isTransparent = state.isTransparent
         let isOutOfOffice = state.isOutOfOffice
         let initialsString: String = ((style == .overflow) ? state.primaryText ?? "" : InitialsView.initialsText(fromPrimaryText: state.primaryText,
                                                                                                                  secondaryText: state.secondaryText))
         let shouldUseCalculatedColors = !initialsString.isEmpty && style != .overflow
 
-        let ringInnerGap: CGFloat = isRingVisible ? tokens.ringInnerGap : 0
+        let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
         let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
         let ringOuterGap: CGFloat = isRingVisible ? tokens.ringOuterGap : 0
         let avatarImageSize: CGFloat = tokens.avatarSize!

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -116,6 +116,16 @@ class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
         }
     }
 
+    var hasRingInnerGap: Bool {
+        get {
+            return avatarState.hasRingInnerGap
+        }
+
+        set {
+            avatarState.hasRingInnerGap = newValue
+        }
+    }
+
     var isRingVisible: Bool {
         get {
             return avatarState.isRingVisible


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding the state property to control whether the gap between the Avatar ring and the content circle should exist.
This is one of the properties needed to ensure the Avatar Vnext supports all the customization provided by the current AvatarView (UIKit).

Note: I'll update the demo controller (in a further PR) to use a Table View as we're getting more setting toggles which don't work well with Large Text accessibility modes.

### Verification

Added a demo app setting to control the property and exercised the scenarios to ensure the animations and visuals are correct:

| Light Mode                                       | Dark Mode                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-05-25 at 10 06 28 AM](https://user-images.githubusercontent.com/68076145/119539306-e0ae2d80-bd40-11eb-9e3b-be0906eb748e.png) | ![Screen Shot 2021-05-25 at 10 07 01 AM](https://user-images.githubusercontent.com/68076145/119539374-f3c0fd80-bd40-11eb-8457-1fb7f84bfeb6.png) |

https://user-images.githubusercontent.com/68076145/119539652-4ac6d280-bd41-11eb-9bd1-a5e9d3d7283d.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/585)