### PR TITLE
Avatar Vnext: Adding capability to set an image based custom ring color.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -40,6 +40,11 @@ class AvatarDemoController: DemoController {
                                                            isOn: isShowingRings)
         addRow(items: [showRingsSettingView])
 
+        let useImageBasedCustomRingColorSettingView = createLabelAndSwitchRow(labelText: "Use image based custom ring color",
+                                                                              switchAction: #selector(toggleImageBasedCustomRingColor(switchView:)),
+                                                                              isOn: isUsingImageBasedCustomColor)
+        addRow(items: [useImageBasedCustomRingColorSettingView])
+
         let enableRingInnerGapSettingView = createLabelAndSwitchRow(labelText: "Enable ring inner gap",
                                                                     switchAction: #selector(toggleShowRingInnerGap(switchView:)),
                                                                     isOn: isShowingRingInnerGap)
@@ -170,6 +175,16 @@ class AvatarDemoController: DemoController {
         }
     }
 
+    private var isUsingImageBasedCustomColor: Bool = false {
+        didSet {
+            if oldValue != isUsingImageBasedCustomColor {
+                for avatarView in avatarViews {
+                    avatarView.state.imageBasedRingColor = isUsingImageBasedCustomColor ? colorfulCustomImage : nil
+                }
+            }
+        }
+    }
+
     private var isShowingRingInnerGap: Bool = true {
         didSet {
             if oldValue != isShowingRingInnerGap {
@@ -191,6 +206,36 @@ class AvatarDemoController: DemoController {
     }
 
     private lazy var presenceIterator = MSFAvatarPresence.allCases.makeIterator()
+
+    private var colorfulCustomImage: UIImage? {
+        let gradientColors = [
+            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor,
+            UIColor(red: 0.18, green: 0.45, blue: 0.96, alpha: 1).cgColor,
+            UIColor(red: 0.36, green: 0.80, blue: 0.98, alpha: 1).cgColor,
+            UIColor(red: 0.45, green: 0.72, blue: 0.22, alpha: 1).cgColor,
+            UIColor(red: 0.97, green: 0.78, blue: 0.27, alpha: 1).cgColor,
+            UIColor(red: 0.94, green: 0.52, blue: 0.20, alpha: 1).cgColor,
+            UIColor(red: 0.92, green: 0.26, blue: 0.16, alpha: 1).cgColor,
+            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor]
+
+        let colorfulGradient = CAGradientLayer()
+        let size = CGSize(width: 76, height: 76)
+        colorfulGradient.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
+        colorfulGradient.colors = gradientColors
+        colorfulGradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+        colorfulGradient.endPoint = CGPoint(x: 0.5, y: 0)
+        colorfulGradient.type = .conic
+
+        var customBorderImage: UIImage?
+        UIGraphicsBeginImageContext(size)
+        if let context = UIGraphicsGetCurrentContext() {
+            colorfulGradient.render(in: context)
+            customBorderImage = UIGraphicsGetImageFromCurrentImageContext()
+        }
+        UIGraphicsEndImageContext()
+
+        return customBorderImage
+    }
 
     private func nextPresence() -> MSFAvatarPresence {
         var presence = presenceIterator.next()
@@ -221,6 +266,10 @@ class AvatarDemoController: DemoController {
 
     @objc private func toggleShowRings(switchView: UISwitch) {
         isShowingRings = switchView.isOn
+    }
+
+    @objc private func toggleImageBasedCustomRingColor(switchView: UISwitch) {
+        isUsingImageBasedCustomColor = switchView.isOn
     }
 
     @objc private func toggleShowRingInnerGap(switchView: UISwitch) {

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -235,6 +235,10 @@ public struct AvatarView: View {
                 // transitions during the animation as the ImagePaint scale value is not animatable.
                 let ringMaxSize = avatarImageSize + (tokens.ringInnerGap + tokens.ringThickness) * 2
                 let scaleFactor = ringMaxSize / imageBasedRingColor.size.width
+
+                // ImagePaint is being used as creating a Color struct from a UIColor created with
+                // the patternImage initializer (https://developer.apple.com/documentation/uikit/uicolor/1621933-init)
+                // does not render any content.
                 Circle()
                     .strokeBorder(ImagePaint(image: Image(uiImage: imageBasedRingColor),
                                              scale: scaleFactor),

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -96,6 +96,7 @@ import SwiftUI
     var primaryText: String? { get set }
     var secondaryText: String? { get set }
     var ringColor: UIColor? { get set }
+    var imageBasedRingColor: UIImage? { get set }
     var backgroundColor: UIColor? { get set }
     var foregroundColor: UIColor? { get set }
     var presence: MSFAvatarPresence { get set }
@@ -112,6 +113,7 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
     @Published var primaryText: String?
     @Published var secondaryText: String?
     @Published var ringColor: UIColor?
+    @Published var imageBasedRingColor: UIImage?
     @Published var backgroundColor: UIColor?
     @Published var foregroundColor: UIColor?
     @Published var presence: MSFAvatarPresence = .none
@@ -225,6 +227,24 @@ public struct AvatarView: View {
         }
 
         @ViewBuilder
+        var avatarRingView: some View {
+            if let imageBasedRingColor = state.imageBasedRingColor {
+                // The potentially maximum size of the ring view must be used in order to avoid abrupt
+                // transitions during the animation as the ImagePaint scale value is not animatable.
+                let ringMaxSize = avatarImageSize + (tokens.ringInnerGap + tokens.ringThickness) * 2
+                let scaleFactor = ringMaxSize / imageBasedRingColor.size.width
+                Circle()
+                    .strokeBorder(ImagePaint(image: Image(uiImage: imageBasedRingColor),
+                                             scale: scaleFactor),
+                                  lineWidth: ringThickness)
+            } else {
+                Circle()
+                    .strokeBorder(ringColor,
+                                  lineWidth: ringThickness)
+            }
+        }
+
+        @ViewBuilder
         var avatarBody: some View {
             if tokens.style == .group {
                 avatarContent
@@ -238,8 +258,7 @@ public struct AvatarView: View {
                 Circle()
                     .foregroundColor(ringGapColor)
                     .frame(width: ringOuterGapSize, height: ringOuterGapSize, alignment: .center)
-                    .overlay(Circle()
-                                .strokeBorder(ringColor, lineWidth: ringThickness)
+                    .overlay(avatarRingView
                                 .frame(width: ringSize, height: ringSize, alignment: .center)
                                 .overlay(Circle()
                                             .foregroundColor(Color(backgroundColor))

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -226,6 +226,8 @@ public struct AvatarView: View {
             }
         }
 
+        // The avatarRingView is not available in the .group style.
+        // This variable is not going to be computed in that scenario.
         @ViewBuilder
         var avatarRingView: some View {
             if let imageBasedRingColor = state.imageBasedRingColor {

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -126,6 +126,16 @@ class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
         }
     }
 
+    var imageBasedRingColor: UIImage? {
+        get {
+            return avatarState.imageBasedRingColor
+        }
+
+        set {
+            avatarState.imageBasedRingColor = newValue
+        }
+    }
+
     var isRingVisible: Bool {
         get {
             return avatarState.isRingVisible


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding the state property to enable a custom ring color that can be generated from an image.
This is the last remaining property needed to ensure the Avatar Vnext supports all the customization provided by the current AvatarView (UIKit).

Note: I'll update the demo controller (in a further PR) to use a Table View as we're getting more setting toggles which don't work well with Large Text accessibility modes.

### Verification

Added a demo app setting to control the property and exercised the scenarios to ensure the animations and visuals are correct:

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| ![avatar_image_ring_light](https://user-images.githubusercontent.com/68076145/119601325-cd7d7b00-bd9d-11eb-960f-15dea6b2c5a2.png) | ![avatar_image_ring_dark](https://user-images.githubusercontent.com/68076145/119601335-d40bf280-bd9d-11eb-8a29-6ac894dbe72b.png) |


https://user-images.githubusercontent.com/68076145/119601268-aa52cb80-bd9d-11eb-9750-c00c3b4356a6.mov



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/586)