### PR TITLE
Avatar API improvements.

### DIFF
--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -46,9 +46,9 @@ class LargeTitleView: UIView {
             case .automatic:
                 return
             case .contracted:
-                avatar?.setSize(size: Constants.compactAvatarSize)
+                avatar?.state.size = Constants.compactAvatarSize
             case .expanded:
-                avatar?.setSize(size: Constants.avatarSize)
+                avatar?.state.size = Constants.avatarSize
             }
         }
     }
@@ -70,7 +70,7 @@ class LargeTitleView: UIView {
         didSet {
             if let style = avatarOverrideStyle {
                 updateProfileButtonVisibility()
-                avatar?.setStyle(style: style)
+                avatar?.state.style = style
             }
         }
     }
@@ -78,7 +78,7 @@ class LargeTitleView: UIView {
     var style: Style = .light {
         didSet {
             titleButton.setTitleColor(colorForStyle, for: .normal)
-            avatar?.setStyle(style: style == .light ? .default : .accent)
+            avatar?.state.style = style == .light ? .default : .accent
         }
     }
 
@@ -241,7 +241,7 @@ class LargeTitleView: UIView {
         }
 
         if avatarSize == .automatic {
-            avatar?.setSize(size: Constants.avatarSize)
+            avatar?.state.size = Constants.avatarSize
             avatarWidthConstraint?.constant = Constants.avatarSize.size
             avatarHeightConstraint?.constant = Constants.avatarSize.size
         }
@@ -255,7 +255,7 @@ class LargeTitleView: UIView {
         }
 
         if avatarSize == .automatic {
-            avatar?.setSize(size: Constants.compactAvatarSize)
+            avatar?.state.size = Constants.compactAvatarSize
             avatarWidthConstraint?.constant = Constants.compactAvatarSize.size
             avatarHeightConstraint?.constant = Constants.compactAvatarSize.size
         }

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -43,8 +43,9 @@ open class SideTabBar: UIView {
         }
         didSet {
             if let avatar = avatar {
-                avatar.setSize(size: .medium)
-                avatar.state.accessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
+                let avatarState = avatar.state
+                avatarState.size = .medium
+                avatarState.accessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
 
                 let avatarView = avatar.view
                 avatarView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -92,36 +92,65 @@ import SwiftUI
 /// Properties available to customize the state of the avatar
 @objc public protocol MSFAvatarState {
     var accessibilityLabel: String? { get set }
-    var image: UIImage? { get set }
-    var primaryText: String? { get set }
-    var secondaryText: String? { get set }
-    var ringColor: UIColor? { get set }
-    var imageBasedRingColor: UIImage? { get set }
     var backgroundColor: UIColor? { get set }
     var foregroundColor: UIColor? { get set }
-    var presence: MSFAvatarPresence { get set }
     var hasPointerInteraction: Bool { get set }
     var hasRingInnerGap: Bool { get set }
+    var image: UIImage? { get set }
+    var imageBasedRingColor: UIImage? { get set }
+    var isOutOfOffice: Bool { get set }
     var isRingVisible: Bool { get set }
     var isTransparent: Bool { get set }
-    var isOutOfOffice: Bool { get set }
+    var presence: MSFAvatarPresence { get set }
+    var primaryText: String? { get set }
+    var ringColor: UIColor? { get set }
+    var secondaryText: String? { get set }
+    var size: MSFAvatarSize { get set }
+    var style: MSFAvatarStyle { get set }
 }
 
 /// Properties available to customize the state of the avatar
 class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
-    @Published var image: UIImage?
-    @Published var primaryText: String?
-    @Published var secondaryText: String?
-    @Published var ringColor: UIColor?
-    @Published var imageBasedRingColor: UIImage?
     @Published var backgroundColor: UIColor?
     @Published var foregroundColor: UIColor?
-    @Published var presence: MSFAvatarPresence = .none
     @Published var hasPointerInteraction: Bool = false
     @Published var hasRingInnerGap: Bool = true
+    @Published var image: UIImage?
+    @Published var imageBasedRingColor: UIImage?
+    @Published var isOutOfOffice: Bool = false
     @Published var isRingVisible: Bool = false
     @Published var isTransparent: Bool = true
-    @Published var isOutOfOffice: Bool = false
+    @Published var presence: MSFAvatarPresence = .none
+    @Published var primaryText: String?
+    @Published var ringColor: UIColor?
+    @Published var secondaryText: String?
+
+    var size: MSFAvatarSize {
+        get {
+            return tokens.size
+        }
+        set {
+            tokens.size = newValue
+        }
+    }
+
+    var style: MSFAvatarStyle {
+        get {
+            return tokens.style
+        }
+        set {
+            tokens.style = newValue
+        }
+    }
+
+    var tokens: MSFAvatarTokens
+
+    init(style: MSFAvatarStyle,
+         size: MSFAvatarSize) {
+        self.tokens = MSFAvatarTokens(style: style,
+                                      size: size)
+        super.init()
+    }
 }
 
 /// View that represents the avatar
@@ -133,8 +162,10 @@ public struct AvatarView: View {
 
     public init(style: MSFAvatarStyle,
                 size: MSFAvatarSize) {
-        self.tokens = MSFAvatarTokens(style: style, size: size)
-        self.state = MSFAvatarStateImpl()
+        let state = MSFAvatarStateImpl(style: style,
+                                       size: size)
+        self.state = state
+        self.tokens = state.tokens
     }
 
     public var body: some View {
@@ -323,14 +354,6 @@ public struct AvatarView: View {
                           with: windowProvider)
     }
 
-    public func setStyle(style: MSFAvatarStyle) {
-        tokens.style = style
-    }
-
-    public func setSize(size: MSFAvatarSize) {
-        tokens.size = size
-    }
-
     private let animationDuration: Double = 0.1
 
     private struct PresenceCutout: Shape {
@@ -368,14 +391,6 @@ public struct AvatarView: View {
 
     @objc open var state: MSFAvatarState {
         return self.avatarview.state
-    }
-
-    @objc open func setStyle(style: MSFAvatarStyle) {
-        self.avatarview.setStyle(style: style)
-    }
-
-    @objc open func setSize(size: MSFAvatarSize) {
-        self.avatarview.setSize(size: size)
     }
 
     @objc public convenience init(style: MSFAvatarStyle = .default,

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -26,56 +26,6 @@ public protocol PersonaViewState: MSFPersonaViewState {
 
 /// Properties that make up PersonaView content
 class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
-    init(avatarState: MSFAvatarState) {
-        self.avatarState = avatarState
-
-        super.init()
-
-        self.tokens = MSFPersonaViewTokens()
-    }
-
-    var image: UIImage? {
-        get {
-            return avatarState.image
-        }
-
-        set {
-            avatarState.image = newValue
-        }
-    }
-
-    var primaryText: String? {
-        get {
-            return avatarState.primaryText
-        }
-
-        set {
-            avatarState.primaryText = newValue
-            title = newValue ?? ""
-        }
-    }
-
-    var secondaryText: String? {
-        get {
-            return avatarState.secondaryText
-        }
-
-        set {
-            avatarState.secondaryText = newValue
-            subtitle = newValue ?? ""
-        }
-    }
-
-    var ringColor: UIColor? {
-        get {
-            return avatarState.ringColor
-        }
-
-        set {
-            avatarState.ringColor = newValue
-        }
-    }
-
     override var backgroundColor: UIColor? {
         get {
             return avatarState.backgroundColor
@@ -93,16 +43,6 @@ class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
 
         set {
             avatarState.foregroundColor = newValue
-        }
-    }
-
-    var presence: MSFAvatarPresence {
-        get {
-            return avatarState.presence
-        }
-
-        set {
-            avatarState.presence = newValue
         }
     }
 
@@ -126,6 +66,16 @@ class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
         }
     }
 
+    var image: UIImage? {
+        get {
+            return avatarState.image
+        }
+
+        set {
+            avatarState.image = newValue
+        }
+    }
+
     var imageBasedRingColor: UIImage? {
         get {
             return avatarState.imageBasedRingColor
@@ -133,6 +83,16 @@ class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
 
         set {
             avatarState.imageBasedRingColor = newValue
+        }
+    }
+
+    var isOutOfOffice: Bool {
+        get {
+            return avatarState.isOutOfOffice
+        }
+
+        set {
+            avatarState.isOutOfOffice = newValue
         }
     }
 
@@ -156,14 +116,74 @@ class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
         }
     }
 
-    var isOutOfOffice: Bool {
+    var presence: MSFAvatarPresence {
         get {
-            return avatarState.isOutOfOffice
+            return avatarState.presence
         }
 
         set {
-            avatarState.isOutOfOffice = newValue
+            avatarState.presence = newValue
         }
+    }
+
+    var primaryText: String? {
+        get {
+            return avatarState.primaryText
+        }
+
+        set {
+            avatarState.primaryText = newValue
+            title = newValue ?? ""
+        }
+    }
+
+    var ringColor: UIColor? {
+        get {
+            return avatarState.ringColor
+        }
+
+        set {
+            avatarState.ringColor = newValue
+        }
+    }
+
+    var secondaryText: String? {
+        get {
+            return avatarState.secondaryText
+        }
+
+        set {
+            avatarState.secondaryText = newValue
+            subtitle = newValue ?? ""
+        }
+    }
+
+    var size: MSFAvatarSize {
+        get {
+            return avatarState.size
+        }
+
+        set {
+            avatarState.size = newValue
+        }
+    }
+
+    var style: MSFAvatarStyle {
+        get {
+            return avatarState.style
+        }
+
+        set {
+            avatarState.style = newValue
+        }
+    }
+
+    init(avatarState: MSFAvatarState) {
+        self.avatarState = avatarState
+
+        super.init()
+
+        self.tokens = MSFPersonaViewTokens()
     }
 
     private var avatarState: MSFAvatarState


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently the public API of the Avatar Vnext has 2 different avenues to modify its appearance:
- its state object
- setSize and setStyle methods

This change aims to simplify the Avatar API so that the state object holds all the properties that modify the Avatar's appearance.

As a result, the Avatar state now contains the tokens class and just exposes the style and size properties that are tied to design token values.

### Verification

Ran the demo app ensuring that changes to the style and size of the Avatar are rendered correctly.
The video below depicts the scenario of the NavigationController where the Avatar is resized when the table view is scrolled up and down:

https://user-images.githubusercontent.com/68076145/119734232-8770f780-be2f-11eb-8411-08bb9e9adabf.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/589)