### PR TITLE
Add a dimming view to `BottomSheetController`

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -59,6 +59,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'BottomSheet_ios' do |bottomsheet_ios|
     bottomsheet_ios.platform = :ios
+    bottomsheet_ios.dependency 'MicrosoftFluentUI/Obscurable_ios'
     bottomsheet_ios.dependency 'MicrosoftFluentUI/ResizingHandleView_ios'
     bottomsheet_ios.source_files = ["ios/FluentUI/Bottom Sheet/**/*.{swift,h}"]
   end

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -63,7 +63,7 @@ class BottomSheetDemoController: UIViewController {
 
     private let headerView: UIView = {
         let view = UIView()
-        view.backgroundColor = Colors.gray100
+        view.backgroundColor = Colors.surfaceQuaternary
         view.heightAnchor.constraint(equalToConstant: headerHeight).isActive = true
 
         let label = Label()

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -82,7 +82,8 @@ public class BottomSheetController: UIViewController {
 
     // View hierarchy
     // self.view - BottomSheetPassthroughView (full overlay area)
-    // |--bottomSheetView (shadow)
+    // |--dimmingView (spans self.view)
+    // |--bottomSheetView (sheet shadow)
     // |  |--UIStackView (round corner mask)
     // |  |  |--resizingHandleView
     // |  |  |--headerContentView
@@ -91,12 +92,6 @@ public class BottomSheetController: UIViewController {
     public override func loadView() {
         view = BottomSheetPassthroughView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(bottomSheetView)
-
-        let overflowView = UIView()
-        overflowView.translatesAutoresizingMaskIntoConstraints = false
-        overflowView.backgroundColor = Colors.NavigationBar.background
-        view.addSubview(overflowView)
 
         if shouldShowDimmingView {
             view.addSubview(dimmingView)
@@ -108,8 +103,12 @@ public class BottomSheetController: UIViewController {
             ])
         }
 
-        view.bringSubviewToFront(bottomSheetView)
-        view.bringSubviewToFront(overflowView)
+        view.addSubview(bottomSheetView)
+
+        let overflowView = UIView()
+        overflowView.translatesAutoresizingMaskIntoConstraints = false
+        overflowView.backgroundColor = Colors.NavigationBar.background
+        view.addSubview(overflowView)
 
         NSLayoutConstraint.activate([
             bottomSheetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -40,9 +40,6 @@ public class BottomSheetController: UIViewController {
     /// Sheet content below the header which is only visible when the sheet is expanded.
     @objc public let expandedContentView: UIView
 
-    /// Indicates if the main content is dimmed when the sheet is expanded.
-    @objc public let shouldShowDimmingView: Bool
-
     /// A scroll view in `expandedContentView`'s view hierarchy.
     /// Provide this to ensure the bottom sheet pan gesture recognizer coordinates with the scroll view to enable scrolling based on current bottom sheet position and content offset.
     @objc open var hostedScrollView: UIScrollView?
@@ -463,6 +460,8 @@ public class BottomSheetController: UIViewController {
     private var expandedOffsetFromBottom: CGFloat {
         return bottomSheetView.frame.height - view.safeAreaInsets.bottom
     }
+
+    private let shouldShowDimmingView: Bool
 
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -127,12 +127,10 @@ public class BottomSheetController: UIViewController {
         updateResizingHandleViewAccessibility()
     }
 
-    private lazy var dimmingView: UIView = {
-        let dimmingView = UIView()
-        dimmingView.backgroundColor = .black
-        dimmingView.alpha = 0.0
+    private lazy var dimmingView: DimmingView = {
+        var dimmingView = DimmingView(type: .black)
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
-
+        dimmingView.alpha = 0.0
         return dimmingView
     }()
 
@@ -278,11 +276,11 @@ public class BottomSheetController: UIViewController {
 
         var targetAlpha: CGFloat = 0.0
         if currentOffset > expandedOffset {
-            targetAlpha = Constants.maxDimmingAlpha
+            targetAlpha = 1.0
         } else if currentOffset < collapsedOffset {
             targetAlpha = 0.0
         } else {
-            targetAlpha = Constants.maxDimmingAlpha * abs(currentOffset - collapsedOffset) / (expandedOffset - collapsedOffset)
+            targetAlpha = abs(currentOffset - collapsedOffset) / (expandedOffset - collapsedOffset)
         }
         dimmingView.alpha = targetAlpha
     }
@@ -385,7 +383,7 @@ public class BottomSheetController: UIViewController {
         }
 
         if dimsMainContent {
-            let targetDimmingViewAlpha: CGFloat = targetExpansionState == .collapsed ? 0.0 : Constants.maxDimmingAlpha
+            let targetDimmingViewAlpha: CGFloat = targetExpansionState == .collapsed ? 0.0 : 1.0
             translationAnimator.addAnimations {
                 self.dimmingView.alpha = targetDimmingViewAlpha
             }
@@ -482,9 +480,6 @@ public class BottomSheetController: UIViewController {
         static let cornerRadius: CGFloat = 14
 
         static let expandedContentAlphaTransitionLength: CGFloat = 30
-
-        // Maximum alpha value of the dimming view
-        static let maxDimmingAlpha: CGFloat = 0.5
 
         struct Spring {
             // Spring used in slow swipes - no oscillation

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -21,7 +21,7 @@ public class BottomSheetController: UIViewController {
     /// - Parameters:
     ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.
     ///   - expandedContentView: Sheet content below the header which is only visible when the sheet is expanded.
-    ///   - dimsMainContent - Indicates if the main content should be dimmed when the sheet is expanded.
+    ///   - dimsMainContent - Indicates if the main content is dimmed when the sheet is expanded.
     @objc public init(headerContentView: UIView? = nil, expandedContentView: UIView, dimsMainContent: Bool = true) {
         self.headerContentView = headerContentView
         self.expandedContentView = expandedContentView
@@ -40,6 +40,7 @@ public class BottomSheetController: UIViewController {
     /// Sheet content below the header which is only visible when the sheet is expanded.
     @objc public let expandedContentView: UIView
 
+    /// Indicates if the main content is dimmed when the sheet is expanded.
     @objc public let dimsMainContent: Bool
 
     /// A scroll view in `expandedContentView`'s view hierarchy.

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -21,11 +21,11 @@ public class BottomSheetController: UIViewController {
     /// - Parameters:
     ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.
     ///   - expandedContentView: Sheet content below the header which is only visible when the sheet is expanded.
-    ///   - dimsMainContent - Indicates if the main content is dimmed when the sheet is expanded.
-    @objc public init(headerContentView: UIView? = nil, expandedContentView: UIView, dimsMainContent: Bool = true) {
+    ///   - shouldShowDimmingView: Indicates if the main content is dimmed when the sheet is expanded.
+    @objc public init(headerContentView: UIView? = nil, expandedContentView: UIView, shouldShowDimmingView: Bool = true) {
         self.headerContentView = headerContentView
         self.expandedContentView = expandedContentView
-        self.dimsMainContent = dimsMainContent
+        self.shouldShowDimmingView = shouldShowDimmingView
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -41,7 +41,7 @@ public class BottomSheetController: UIViewController {
     @objc public let expandedContentView: UIView
 
     /// Indicates if the main content is dimmed when the sheet is expanded.
-    @objc public let dimsMainContent: Bool
+    @objc public let shouldShowDimmingView: Bool
 
     /// A scroll view in `expandedContentView`'s view hierarchy.
     /// Provide this to ensure the bottom sheet pan gesture recognizer coordinates with the scroll view to enable scrolling based on current bottom sheet position and content offset.
@@ -101,7 +101,7 @@ public class BottomSheetController: UIViewController {
         overflowView.backgroundColor = Colors.NavigationBar.background
         view.addSubview(overflowView)
 
-        if dimsMainContent {
+        if shouldShowDimmingView {
             view.addSubview(dimmingView)
             NSLayoutConstraint.activate([
                 dimmingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -266,7 +266,7 @@ public class BottomSheetController: UIViewController {
     }
 
     private func updateDimmingViewAlpha() {
-        guard dimsMainContent else {
+        guard shouldShowDimmingView else {
             return
         }
 
@@ -382,7 +382,7 @@ public class BottomSheetController: UIViewController {
             }
         }
 
-        if dimsMainContent {
+        if shouldShowDimmingView {
             let targetDimmingViewAlpha: CGFloat = targetExpansionState == .collapsed ? 0.0 : 1.0
             translationAnimator.addAnimations {
                 self.dimmingView.alpha = targetDimmingViewAlpha


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Many clients need the main content to dim when the sheet is expanded, so this PR adds that as an init property (I don't expect people would need to mutate this).

### Verification
I tested that the main content is both accessible and touchable when the dimming view alpha is at zero. When it's non-zero, it's neither accessible nor touchable.


https://user-images.githubusercontent.com/3610850/120409523-efc74980-c305-11eb-8cad-c7ef068f2c36.mov



| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 12 - 2021-06-01 at 18 18 47](https://user-images.githubusercontent.com/3610850/120409474-d7572f00-c305-11eb-984e-cc1eec7f20cf.png)|![Simulator Screen Shot - iPhone 12 - 2021-06-01 at 18 18 26](https://user-images.githubusercontent.com/3610850/120409491-e0480080-c305-11eb-9b40-216aaa24ee53.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/592)