### PR TITLE
Fix `BottomCommandingController` table view getting removed from superview

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -127,7 +127,7 @@ open class BottomCommandingController: UIViewController {
         let commandStackContainer = UIView()
         commandStackContainer.addSubview(heroCommandStack)
 
-        let sheetController = BottomSheetController(headerContentView: commandStackContainer, expandedContentView: expandedContentView)
+        let sheetController = BottomSheetController(headerContentView: commandStackContainer, expandedContentView: makeSheetExpandedContent(with: tableView))
         sheetController.hostedScrollView = tableView
         sheetController.expandedHeightFraction = Constants.BottomSheet.expandedFraction
 
@@ -185,6 +185,26 @@ open class BottomCommandingController: UIViewController {
         return bottomBarView
     }
 
+    private func makeSheetExpandedContent(with tableView: UITableView) -> UIView {
+        let view = UIView()
+        let separator = Separator()
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(tableView)
+        view.addSubview(separator)
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.BottomSheet.expandedContentTopMargin),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            separator.topAnchor.constraint(equalTo: tableView.topAnchor),
+            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        return view
+    }
+
     private func updateExpandability() {
         if isInSheetMode,
            let bottomSheetController = bottomSheetController,
@@ -222,26 +242,6 @@ open class BottomCommandingController: UIViewController {
 
         isHeroCommandStackLoaded = true
         return stackView
-    }()
-
-    private lazy var expandedContentView: UIView = {
-        let view = UIView()
-        let separator = Separator()
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-
-        view.addSubview(tableView)
-        view.addSubview(separator)
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.BottomSheet.expandedContentTopMargin),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            separator.topAnchor.constraint(equalTo: tableView.topAnchor),
-            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-        return view
     }()
 
     private lazy var tableView: UITableView = {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -185,32 +185,6 @@ open class BottomCommandingController: UIViewController {
         return bottomBarView
     }
 
-    private func makeBottomSheetContent(headerView: UIView, expandedContentView: UIView) -> UIView {
-        let view = UIView()
-        let separator = Separator()
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        headerView.translatesAutoresizingMaskIntoConstraints = false
-        expandedContentView.translatesAutoresizingMaskIntoConstraints = false
-
-        view.addSubview(headerView)
-        view.addSubview(expandedContentView)
-        view.addSubview(separator)
-        NSLayoutConstraint.activate([
-            headerView.topAnchor.constraint(equalTo: view.topAnchor),
-            headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            expandedContentView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
-            expandedContentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            expandedContentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            expandedContentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            separator.topAnchor.constraint(equalTo: expandedContentView.topAnchor),
-            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-
-        return view
-    }
-
     private func updateExpandability() {
         if isInSheetMode,
            let bottomSheetController = bottomSheetController,

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -303,9 +303,16 @@ open class BottomCommandingController: UIViewController {
 
     @objc private func handleMoreButtonTap(_ sender: UITapGestureRecognizer) {
         let popoverContentViewController = UIViewController()
-        popoverContentViewController.view = tableView
+        popoverContentViewController.view.addSubview(tableView)
         popoverContentViewController.modalPresentationStyle = .popover
         popoverContentViewController.popoverPresentationController?.sourceView = sender.view
+
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: popoverContentViewController.view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: popoverContentViewController.view.trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: popoverContentViewController.view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: popoverContentViewController.view.bottomAnchor)
+        ])
 
         present(popoverContentViewController, animated: true)
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#### Problem
The commands table view gets reused between the bar and sheet variants. There are 2 bugs I found:
1. When we transition to the sheet variant while a popover is open from the bar variant, the table view doesn't properly transition to the sheet, because it gets removed when the popover is dismissed.
2. After a recent change, we weren't even re-adding the table view to the sheet hierarchy because it is only added in a lazy property initializer.

#### Fix
1. Add the table view as a subview in the popover VC, not the root view. The root view seems to be handled differently and gets removed from the hierarchy sometime after a dismiss. 
2. Make sure to remake the expanded sheet content every time we recreate the sheet to relocate the table view back to where it should be.


https://user-images.githubusercontent.com/3610850/120560805-44c39800-c3b8-11eb-86d2-52483cb03bb7.mov


### Verification
Sanity checks, making sure all the known bugs are fixed.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/593)