### PR TITLE
TableViewHeaderFooterView larger text support when there is accessoryView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewHeaderFooterSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewHeaderFooterSampleData.swift
@@ -12,13 +12,13 @@ class TableViewHeaderFooterSampleData: TableViewSampleData {
 
     static let groupedSections: [Section] = [
         Section(title: "Primary Title", headerStyle: .headerPrimary),
-        Section(title: "Primary Expandable", headerStyle: .headerPrimary, hasCustomLeadingView: true, hasHandler: true),
+        Section(title: "Primary Expandable", numberOfLines: 0, headerStyle: .headerPrimary, hasCustomLeadingView: true, hasHandler: true),
         Section(title: "Default"),
-        Section(title: "Default with accessory button", hasAccessory: true),
-        Section(title: "Default with primary accessory button", hasAccessory: true, accessoryButtonStyle: .primary),
+        Section(title: "Default with accessory button", numberOfLines: 0, hasAccessory: true),
+		Section(title: "Default with primary accessory button", numberOfLines: 0, hasAccessory: true, accessoryButtonStyle: .primary),
         Section(title: "Default with multi-line text - A description that starts at the bottom and provides three to two lines of info.", numberOfLines: 0, hasFooter: true, footerText: "Footer - A description that starts at the top and provides three to two lines of info. Learn More", footerLinkText: "Learn More"),
         Section(title: "Default with multi-line truncated text - A description that starts at the bottom and provides three to two lines of info. Also maybe used for providing detailed documentation for a specific feature.", numberOfLines: 3, hasFooter: true, footerText: "Footer - A description that starts at the top and provides three to two lines of info. Custom Learn More", footerLinkText: "Custom Learn More", hasCustomLinkHandler: true),
-        Section(title: "Default with custom accessory view", hasCustomAccessoryView: true)
+        Section(title: "Default with custom accessory view", numberOfLines: 0, hasCustomAccessoryView: true)
     ]
 
     static let plainSections: [Section] = [

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -109,8 +109,9 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     ///   - title: The title string.
     ///   - titleNumberOfLines: The number of lines that the title should display.
     ///   - containerWidth: The width of the view's super view (e.g. the table view's width).
+    ///   - accessoryView: An optional accessory view that appears near the trailing edge of the view.
     /// - Returns: a value representing the calculated height of the view.
-    @objc public class func height(style: Style, title: String, titleNumberOfLines: Int = 1, containerWidth: CGFloat = .greatestFiniteMagnitude) -> CGFloat {
+    @objc public class func height(style: Style, title: String, titleNumberOfLines: Int = 1, containerWidth: CGFloat = .greatestFiniteMagnitude, accessoryView: UIView? = nil) -> CGFloat {
         let verticalMargin: CGFloat
         let font = style.textFont()
         switch style {
@@ -122,7 +123,11 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             verticalMargin = Constants.titleDividerVerticalMargin * 2
         }
 
-        let titleWidth = containerWidth - (Constants.horizontalMargin + TableViewHeaderFooterView.titleTrailingOffset() + TableViewHeaderFooterView.titleLeadingOffset())
+        if let accessoryView = accessoryView {
+            accessoryView.frame.size = accessoryView.systemLayoutSizeFitting(CGSize(width: containerWidth, height: .infinity))
+        }
+
+        let titleWidth = containerWidth - (Constants.horizontalMargin + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView) + TableViewHeaderFooterView.titleLeadingOffset())
         let titleHeight = title.preferredSize(for: font, width: titleWidth, numberOfLines: titleNumberOfLines).height
 
         return verticalMargin + titleHeight
@@ -455,7 +460,8 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 style: style,
                 title: titleView.text ?? "",
                 titleNumberOfLines: titleNumberOfLines,
-                containerWidth: size.width
+                containerWidth: size.width,
+                accessoryView: accessoryView
             )
         )
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

when calculating  TableViewheaderfooterview height, take in accessoryView into consideration if available.
update the tableviewheaderfootersampledata to show case multiline scenarios.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-14 at 21 43 42](https://user-images.githubusercontent.com/20715435/122097415-809d2b00-cdc4-11eb-81b3-517eee80b34e.png)| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 10 31 41](https://user-images.githubusercontent.com/20715435/122097819-f3a6a180-cdc4-11eb-86d6-0c2cd28dd6cf.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/605)