### PR TITLE
remove .header accessibilityTrait from accessoryView in tableviewheaderfooterview

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -432,6 +432,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 origin: CGPoint(x: xOffset, y: yOffset),
                 size: accessoryView.frame.size
             )
+
+            // seems like an iOS issue that any subviews of the headerView automatically gets the header trait which isn't the behavior we want other than the titleView.
+            accessoryView.accessibilityTraits.remove(.header)
+            if let accsesoryButton = accessoryView as? UIButton {
+                // unclear why just removing the .header traits remove the existing .button trait of the accessoryView but adding it back if needed
+                accsesoryButton.accessibilityTraits.insert(.button)
+            }
         }
         contentView.flipSubviewsForRTL()
     }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -435,9 +435,9 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
             // seems like an iOS issue that any subviews of the headerView automatically gets the header trait which isn't the behavior we want other than the titleView.
             accessoryView.accessibilityTraits.remove(.header)
-            if let accsesoryButton = accessoryView as? UIButton {
+            if let accessoryButton = accessoryView as? UIButton {
                 // unclear why just removing the .header traits remove the existing .button trait of the accessoryView but adding it back if needed
-                accsesoryButton.accessibilityTraits.insert(.button)
+                accessoryButton.accessibilityTraits.insert(.button)
             }
         }
         contentView.flipSubviewsForRTL()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Unclear why but iOS seems to put unnecessary .header trait on the accessoryView inside the TableViewHeaderFooterView. The workaround for now is to remove the .header trait for the accessoryView. White the accessibility trait should be bit operation, removing .header seem to remove .button trait if the accessoryView is an UIButton. So, add another workaround to add .button accessibilityTrait.

### Verification
VoiceOver test on iPhoneX device

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/606)