### PR TITLE
making the leadingView of the TableViewHeaderFooterView to be centered

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -410,7 +410,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
         if let leadingView = leadingView {
             let xOffset = Constants.accessoryViewMarginLeft
-            let yOffset = contentView.frame.height - leadingView.frame.height - Constants.titleDefaultBottomMargin
+            let yOffset = floor(titleYOffset + (titleHeight - leadingView.frame.height) / 2)
             leadingView.frame = CGRect(
                 origin: CGPoint(x: xOffset, y: yOffset),
                 size: leadingView.frame.size


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

making the leadingView of the TableViewHeaderFooterView to be center of the of the titleView rather than anchor from the bottom of the contentView

### Verification

tested larger text setting as well.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 14 39 37](https://user-images.githubusercontent.com/20715435/122127254-c4edf280-cde7-11eb-89ca-6a8008ef7c17.png)|  ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 14 33 21](https://user-images.githubusercontent.com/20715435/122127316-dafbb300-cde7-11eb-87d7-6da0a1513850.png)|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 14 39 54](https://user-images.githubusercontent.com/20715435/122127263-ca4b3d00-cde7-11eb-96e1-0b2aee0cd928.png)| ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-06-15 at 14 33 35](https://user-images.githubusercontent.com/20715435/122127343-e2bb5780-cde7-11eb-88dd-0461fb72ad40.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/607)