### PR TITLE
[vNext] Internal init for AvatarView, to be used in collections

### DIFF
--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -168,6 +168,13 @@ public struct AvatarView: View {
         self.tokens = state.tokens
     }
 
+    // This initializer should be used by internal container views. These containers should first initialize
+    // MSFAvatarStateImpl using style and size, and then use that state and this initializer in their ViewBuilder.
+    internal init(_ avatarState: MSFAvatarStateImpl) {
+        state = avatarState
+        tokens = avatarState.tokens
+    }
+
     public var body: some View {
         let style = tokens.style
         let presence = state.presence


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds a new `init` method to `AvatarView` that takes a prebuilt state object (`MSFAvatarStateImpl`). This initializer should be used when `AvatarView` is contained in a container collection view, such as `AvatarGroup`, as it allows us to store and reuse state across multiple passes of the ViewBuilder without having to cache the view.

### Verification

I've verified that this works locally with a prototype container, but it's really an API-level unblock for other work/PRs.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/608)