### PR TITLE
[vNext] Fix PersonaButton labels for longer names

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -109,6 +109,7 @@ class PersonaButtonCarouselDemoController: UITableViewController {
     private static let smallButtonReuseIdentifier: String = "smallButtonReuseIdentifier"
 
     private let personas: [PersonaData] = [
+        PersonaData(name: "Colin Ballinger", email: "colin.ballinger@contoso.com", avatarImage: UIImage(named: "avatar_colin_ballinger")),
         PersonaData(firstName: "Kat", lastName: "Larrson", avatarImage: UIImage(named: "avatar_kat_larsson")),
         PersonaData(firstName: "Ashley", lastName: "McCarthy", avatarImage: UIImage(named: "avatar_ashley_mccarthy")),
         PersonaData(firstName: "Allan", lastName: "Munger", avatarImage: UIImage(named: "avatar_allan_munger")),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -109,7 +109,6 @@ class PersonaButtonCarouselDemoController: UITableViewController {
     private static let smallButtonReuseIdentifier: String = "smallButtonReuseIdentifier"
 
     private let personas: [PersonaData] = [
-        PersonaData(name: "Colin Ballinger", email: "colin.ballinger@contoso.com", avatarImage: UIImage(named: "avatar_colin_ballinger")),
         PersonaData(firstName: "Kat", lastName: "Larrson", avatarImage: UIImage(named: "avatar_kat_larsson")),
         PersonaData(firstName: "Ashley", lastName: "McCarthy", avatarImage: UIImage(named: "avatar_ashley_mccarthy")),
         PersonaData(firstName: "Allan", lastName: "Munger", avatarImage: UIImage(named: "avatar_allan_munger")),

--- a/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButtonTokens.generated.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButtonTokens.generated.swift
@@ -69,6 +69,28 @@ extension FluentUIStyle {
 		}
 
 
+		// MARK: - labelWidth
+		open var labelWidth: labelWidthAppearanceProxy {
+			return labelWidthAppearanceProxy(proxy: mainProxy)
+		}
+		open class labelWidthAppearanceProxy {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			// MARK: - large 
+			open var large: CGFloat {
+				return CGFloat(72.0)
+			}
+
+			// MARK: - small 
+			open var small: CGFloat {
+				return CGFloat(52.0)
+			}
+		}
+
+
 		// MARK: - padding 
 		open var padding: CGFloat {
 			return mainProxy().Spacing.xSmall

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -203,8 +203,6 @@ public struct PersonaButton: View {
     @ObservedObject var state: MSFPersonaButtonViewStateImpl
     @ObservedObject var avatarState: MSFAvatarStateImpl
 
-    @State private var buttonMaxWidth: CGFloat?
-
     public init(size: MSFPersonaButtonSize) {
         let avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize)
         let state = MSFPersonaButtonViewStateImpl(size: size, avatarState: avatarState)
@@ -213,36 +211,30 @@ public struct PersonaButton: View {
         self.tokens = state.tokens
     }
 
+    @ViewBuilder
     private var personaText: some View {
         Group {
             Text(state.primaryText ?? "")
-                .frame(maxWidth: .infinity, alignment: .center)
+                .lineLimit(1)
+                .frame(maxWidth: tokens.labelWidth, alignment: .center)
                 .scalableFont(font: tokens.labelFont)
                 .foregroundColor(Color(tokens.labelColor))
             if state.buttonSize.shouldShowSubtitle {
                 Text(state.secondaryText ?? "")
-                    .frame(maxWidth: .infinity, alignment: .center)
+                    .lineLimit(1)
+                    .frame(maxWidth: tokens.labelWidth, alignment: .center)
                     .scalableFont(font: tokens.sublabelFont)
                     .foregroundColor(Color(tokens.sublabelColor))
             }
         }
-        .frame(width: buttonMaxWidth)
     }
 
+    @ViewBuilder
     private var avatarView: some View {
         AvatarView(avatarState)
             .padding(.top, tokens.padding)
             .padding(.bottom, tokens.avatarInterspace)
             .padding(.horizontal, tokens.padding)
-            .background(GeometryReader { geometry in
-                Color.clear.preference(
-                    key: ButtonWidthPreferenceKey.self,
-                    value: geometry.size.width
-                )
-            })
-            .onPreferenceChange(ButtonWidthPreferenceKey.self) {
-                buttonMaxWidth = $0 - tokens.padding
-            }
     }
 
     public var body: some View {
@@ -259,17 +251,6 @@ public struct PersonaButton: View {
         .designTokens(tokens,
                       from: theme,
                       with: windowProvider)
-    }
-}
-
-private extension PersonaButton {
-    struct ButtonWidthPreferenceKey: PreferenceKey {
-        static let defaultValue: CGFloat = 0
-
-        static func reduce(value: inout CGFloat,
-                           nextValue: () -> CGFloat) {
-            value = max(value, nextValue())
-        }
     }
 }
 

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButtonTokens.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButtonTokens.swift
@@ -36,6 +36,7 @@ class MSFPersonaButtonTokens: MSFTokensBase, ObservableObject {
     @Published public var backgroundColor: UIColor!
     @Published public var labelColor: UIColor!
     @Published public var labelFont: UIFont!
+    @Published public var labelWidth: CGFloat!
     @Published public var padding: CGFloat!
     @Published public var sublabelColor: UIColor!
     @Published public var sublabelFont: UIFont!
@@ -76,9 +77,11 @@ class MSFPersonaButtonTokens: MSFTokensBase, ObservableObject {
         case .small:
             avatarInterspace = appearanceProxy.avatarInterspace.small
             labelFont = appearanceProxy.labelFont.small
+            labelWidth = appearanceProxy.labelWidth.small
         case .large:
             avatarInterspace = appearanceProxy.avatarInterspace.large
             labelFont = appearanceProxy.labelFont.large
+            labelWidth = appearanceProxy.labelWidth.large
         }
     }
 }

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -343,6 +343,7 @@ AP_MSFPersonaButtonTokens:
   backgroundColor: $Colors.Background.neutral1
   labelColor: $Colors.Foreground.neutral1
   labelFont: [ small: $Typography.caption1, large: $Typography.subheadline ]
+  labelWidth: [ small: 52pt, large: 72pt ]
   padding: $Spacing.xSmall
   sublabelColor: $Colors.Foreground.neutral3
   sublabelFont: $Typography.footnote

--- a/tools/sgen/output/MSFPersonaButtonTokens.generated.swift
+++ b/tools/sgen/output/MSFPersonaButtonTokens.generated.swift
@@ -69,6 +69,28 @@ extension FluentUIStyle {
 		}
 
 
+		// MARK: - labelWidth
+		open var labelWidth: labelWidthAppearanceProxy {
+			return labelWidthAppearanceProxy(proxy: mainProxy)
+		}
+		open class labelWidthAppearanceProxy {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			// MARK: - large 
+			open var large: CGFloat {
+				return CGFloat(72.0)
+			}
+
+			// MARK: - small 
+			open var small: CGFloat {
+				return CGFloat(52.0)
+			}
+		}
+
+
 		// MARK: - padding 
 		open var padding: CGFloat {
 			return mainProxy().Spacing.xSmall


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`PersonaButton` is meant to have a fixed width, based on the size of the `Avatar`. This was not accounted for in the first iteration.

This PR adds a GeometryReader and a preference key to ensure that text labels never exceed the width of the Avatar.

### Verification

Verified short and long labels. Short labels are unaffected, and long labels correctly concatenate from the trailing end.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 mini - 2021-06-18 at 16 25 58](https://user-images.githubusercontent.com/4934719/122623779-4c3e9e80-d052-11eb-94f2-ca645e7724eb.png) | ![Simulator Screen Shot - iPhone 12 mini - 2021-06-18 at 16 25 21](https://user-images.githubusercontent.com/4934719/122623789-56609d00-d052-11eb-886a-1d0f0c0ad600.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/610)