### PR TITLE
Fixing large text mode height calculation for TableViewCellFileAccessoryView.

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -447,6 +447,8 @@ open class TableViewCell: UITableViewCell {
     private static func textAreaTrailingOffset(customAccessoryView: UIView?, customAccessoryViewExtendsToEdge: Bool, accessoryType: TableViewCellAccessoryType, paddingTrailing: CGFloat) -> CGFloat {
         let customAccessoryViewAreaWidth: CGFloat
         if let customAccessoryView = customAccessoryView {
+            // Trigger layout so we can have the frame calculated correctly at this point in time
+            customAccessoryView.layoutIfNeeded()
             customAccessoryViewAreaWidth = customAccessoryView.frame.width + Constants.customAccessoryViewMarginLeading
         } else {
             customAccessoryViewAreaWidth = 0
@@ -1262,7 +1264,9 @@ open class TableViewCell: UITableViewCell {
                 footerNumberOfLines: footerNumberOfLines,
                 customAccessoryViewExtendsToEdge: customAccessoryViewExtendsToEdge,
                 containerWidth: maxWidth,
-                isInSelectionMode: isInSelectionMode
+                isInSelectionMode: isInSelectionMode,
+                paddingLeading: paddingLeading,
+                paddingTrailing: paddingTrailing
             )
         )
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This fixes the issue that #573 attempted to fix. Because it caused a regression in client apps, it was reverted by #594.

The root cause of this issue is the calculation of the area available for the text. The height of the labels will be defined based on the available width, the available width value was incorrect in 2 aspects:

1. It was not considering the accessory view size after it was laid out 
2. The cell paddings were not being passed to the height calculation (which assumed the default value of 16 instead of 24).

With a larger width available, the calculated height was shorter and caused the text overlap in large text mode.

### Verification

Validation in the broken client app scenario:

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![large_text_tableviewcellfileaccessoryview_before](https://user-images.githubusercontent.com/68076145/122845566-d7b96900-d2b8-11eb-8826-cc67c100e747.png) | ![large_text_tableviewcellfileaccessoryview_after](https://user-images.githubusercontent.com/68076145/122845582-e142d100-d2b8-11eb-87e7-10cd232cd269.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/612)