### PR TITLE
Fixing TableViewCellFileAccessoryView date label overlap in large text accessibility mode.

### DIFF
--- a/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
@@ -207,7 +207,9 @@ open class TableViewCellFileAccessoryView: UIView {
 
         NSLayoutConstraint.activate([
             view.topAnchor.constraint(equalTo: dateLabel.topAnchor),
-            view.bottomAnchor.constraint(equalTo: dateLabel.bottomAnchor)
+            view.bottomAnchor.constraint(equalTo: dateLabel.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: dateLabel.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: dateLabel.trailingAnchor)
         ])
 
         return view
@@ -358,6 +360,7 @@ open class TableViewCellFileAccessoryView: UIView {
     private func updateDateLabel() {
         let dateString = date?.displayString(short: (dateColumnWidth.constant < Constants.fullDateMinWidth)) ?? ""
         dateLabel.text = dateString
+        dateLabel.numberOfLines = traitCollection.preferredContentSizeCategory.dateLabelNumberOfLines
     }
 
     @objc private func updateLayout() {
@@ -546,6 +549,17 @@ extension UIContentSizeCategory {
             return false
         default:
             return true
+        }
+    }
+
+    var dateLabelNumberOfLines: Int {
+        switch self {
+        case .accessibilityExtraExtraExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraLarge:
+            // Three lines for accessibility XXXL/XXL/XL content size categories (like the title label) so that
+            // the text can fit in its label's available width without overlapping with accessory buttons.
+            return 3
+        default:
+            return 1
         }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In the Large Text accessibility mode the date label text might overlap with the accessory view buttons depending on how long it is.
This change fixes this scenario by introducing a line break to that label when XXXL, XXL or XL accessibility content sizes are enabled, so that the longer text in the bigger font size can be broken into 2 lines.

### Verification

1. Reproduced the scenario on the Demo app and verified the fix on it.
2. Validated consumption in one of our client apps which also reproduced the same issue.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![dateLabel_largetext_before](https://user-images.githubusercontent.com/68076145/122980169-36302700-d34d-11eb-9ecd-01b0cc995cc7.png) | ![dateLabel_largetext_after](https://user-images.githubusercontent.com/68076145/122980138-2dd7ec00-d34d-11eb-809e-3d502833e145.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/613)