### PR TITLE
[vNext] PersonaButtonCarousel

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -5,7 +5,8 @@
 
 import UIKit
 
-class PersonaButtonCarouselDemoController: UITableViewController {
+class PersonaButtonCarouselDemoController: UITableViewController,
+                                           MSFPersonaButtonCarouselDelegate {
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(style: .grouped)
     }
@@ -17,6 +18,9 @@ class PersonaButtonCarouselDemoController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        tableView.register(ActionsCell.self, forCellReuseIdentifier: PersonaButtonCarouselDemoController.controlReuseIdentifier)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: PersonaButtonCarouselDemoController.largeCarouselReuseIdentifier)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: PersonaButtonCarouselDemoController.smallCarouselReuseIdentifier)
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: PersonaButtonCarouselDemoController.largeButtonReuseIdentifier)
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: PersonaButtonCarouselDemoController.smallButtonReuseIdentifier)
 
@@ -25,18 +29,42 @@ class PersonaButtonCarouselDemoController: UITableViewController {
 
     // MARK: - Table view data source
 
+    struct TableSectionInfo {
+        var actionButtons: Bool = false
+        var size: MSFPersonaButtonSize = .large
+        var carousel: Bool = false
+    }
+    let tableInfo: [TableSectionInfo] = [
+        TableSectionInfo(actionButtons: true),
+        TableSectionInfo(size: .large, carousel: true),
+        TableSectionInfo(size: .small, carousel: true),
+        TableSectionInfo(size: .large, carousel: false),
+        TableSectionInfo(size: .small, carousel: false)
+    ]
+
+    struct ActionButtonInfo {
+        var title: String
+        var action: Selector
+    }
+    let actionButtons: [ActionButtonInfo] = [
+        ActionButtonInfo(title: "Append random persona", action: #selector(handleAppendPersona)),
+        ActionButtonInfo(title: "Remove random persona", action: #selector(handleRemovePersona))
+    ]
+
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 2
+        return tableInfo.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return tableInfo[section].actionButtons ? actionButtons.count : 1
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var cell: UITableViewCell
-        if showsFullCarousel(at: indexPath) {
-            fatalError("showsFullCarousel() should always return false right now!")
+        if isActionButtonsSection(indexPath.section) {
+            cell = self.tableView(tableView, controlCellForRowAt: indexPath)
+        } else if showsFullCarousel(at: indexPath.section) {
+            cell = self.tableView(tableView, carouselCellForRowAt: indexPath)
         } else {
             cell = self.tableView(tableView, buttonCellForRowAt: indexPath)
         }
@@ -45,23 +73,107 @@ class PersonaButtonCarouselDemoController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        switch personaButtonSize(for: section) {
-        case .small:
-            return "Small"
-        case .large:
-            return "Large"
+        if isActionButtonsSection(section) {
+            return "Actions"
+        }
+        let sizeString = { () -> String in
+            switch self.personaButtonSize(for: section) {
+            case .small:
+                return "Small"
+            case .large:
+                return "Large"
+            }
+        }()
+        let styleString = { () -> String in
+            if self.showsFullCarousel(at: section) {
+                return "Carousel"
+            } else {
+                return "Button"
+            }
+        }()
+        return "\(String(describing: sizeString)) \(String(describing: styleString))"
+    }
+
+    // MARK: - MSFPersonaButtonCarouselDelegate
+    func didTap(on personaData: PersonaData, at index: Int) {
+        let identifier = personaData.name.count > 0 ? personaData.name : personaData.email
+        let alert = UIAlertController(title: "\(identifier) at index \(index) was selected", message: nil, preferredStyle: .alert)
+        let action = UIAlertAction(title: "OK", style: .default, handler: nil)
+        alert.addAction(action)
+        self.present(alert, animated: true)
+    }
+
+    // MARK: - Actions
+
+    @objc private func handleAppendPersona() {
+        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+            let random = Int.random(in: 0...personas.count - 1)
+            carousel.append(personas[random])
+        }
+    }
+
+    @objc private func handleRemovePersona() {
+        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+            let count = carousel.count()
+            if count > 0 {
+                let random = Int.random(in: 0...count - 1)
+                carousel.remove(at: random)
+            }
         }
     }
 
     // MARK: - Helpers
 
-    private func personaButtonSize(for section: Int) -> MSFPersonaButtonSize {
-        return (section % 2 == 0) ? .small : .large
+    private func isActionButtonsSection(_ section: Int) -> Bool {
+        return tableInfo[section].actionButtons
     }
 
-    private func showsFullCarousel(at indexPath: IndexPath) -> Bool {
-        // TODO: Create PersonaButtonCarousel
-        return false
+    private func personaButtonSize(for section: Int) -> MSFPersonaButtonSize {
+        return tableInfo[section].size
+    }
+
+    private func showsFullCarousel(at section: Int) -> Bool {
+        return tableInfo[section].carousel
+    }
+
+    private func tableView(_ tableView: UITableView, controlCellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: PersonaButtonCarouselDemoController.controlReuseIdentifier, for: indexPath) as! ActionsCell
+        let info = actionButtons[indexPath.item]
+        cell.setup(action1Title: info.title)
+        cell.action1Button.addTarget(self, action: info.action, for: .touchUpInside)
+        return cell
+    }
+
+    private func tableView(_ tableView: UITableView, carouselCellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        var cell: UITableViewCell
+        let size = personaButtonSize(for: indexPath.section)
+        switch size {
+        case .large:
+            cell = tableView.dequeueReusableCell(withIdentifier: PersonaButtonCarouselDemoController.largeCarouselReuseIdentifier, for: indexPath)
+        case .small:
+            cell = tableView.dequeueReusableCell(withIdentifier: PersonaButtonCarouselDemoController.smallCarouselReuseIdentifier, for: indexPath)
+        }
+
+        let carousel = MSFPersonaButtonCarousel(size: size, personas: personas, theme: nil)
+        carousels[size] = carousel
+        carousel.delegate = self
+
+        cell.contentView.addSubview(carousel.view)
+        cell.selectionStyle = .none
+        cell.backgroundColor = .tertiarySystemFill
+        var constraints: [NSLayoutConstraint] = []
+        carousel.view.translatesAutoresizingMaskIntoConstraints = false
+
+        constraints.append(contentsOf: [
+            carousel.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            carousel.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            carousel.view.leftAnchor.constraint(equalTo: cell.contentView.leftAnchor),
+            carousel.view.rightAnchor.constraint(equalTo: cell.contentView.rightAnchor)
+        ])
+
+        cell.contentView.addConstraints(constraints)
+
+        return cell
     }
 
     private func tableView(_ tableView: UITableView, buttonCellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -103,6 +215,9 @@ class PersonaButtonCarouselDemoController: UITableViewController {
         return cell
     }
 
+    private var carousels: [MSFPersonaButtonSize: MSFPersonaButtonCarousel] = [:]
+
+    private static let controlReuseIdentifier: String = "controlReuseIdentifier"
     private static let largeCarouselReuseIdentifier: String = "largeCarouselReuseIdentifier"
     private static let smallCarouselReuseIdentifier: String = "smallCarouselReuseIdentifier"
     private static let largeButtonReuseIdentifier: String = "largeButtonReuseIdentifier"

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -223,6 +223,10 @@
 		8FD01188228A82A600D25925 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC16C20D98EE70016922A /* Colors.swift */; };
 		92088EF82666DB2C003F571A /* PersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92088EF72666DB2C003F571A /* PersonaButton.swift */; };
 		92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92088EF72666DB2C003F571A /* PersonaButton.swift */; };
+		92751052268142CD00F12730 /* MSFAvatarPresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92751051268142CD00F12730 /* MSFAvatarPresence.swift */; };
+		92751053268142CD00F12730 /* MSFAvatarPresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92751051268142CD00F12730 /* MSFAvatarPresence.swift */; };
+		9275105526815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */; };
+		9275105626815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */; };
 		927E34C72668350800998031 /* PersonaButtonTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927E34C62668350800998031 /* PersonaButtonTokens.swift */; };
 		9298798B2669A875002B1EB4 /* PersonaButtonTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927E34C62668350800998031 /* PersonaButtonTokens.swift */; };
 		9298798F266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9298798D266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift */; };
@@ -449,6 +453,8 @@
 		8FA3CB5A246B19EA0049E431 /* ColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
 		8FD01166228A820600D25925 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		92088EF72666DB2C003F571A /* PersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButton.swift; sourceTree = "<group>"; };
+		92751051268142CD00F12730 /* MSFAvatarPresence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatarPresence.swift; sourceTree = "<group>"; };
+		9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarousel.swift; sourceTree = "<group>"; };
 		927E34C62668350800998031 /* PersonaButtonTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonTokens.swift; sourceTree = "<group>"; };
 		9298798D266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonTokens.generated.swift; sourceTree = "<group>"; };
 		9298798E266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarouselTokens.generated.swift; sourceTree = "<group>"; };
@@ -875,6 +881,7 @@
 			children = (
 				536AEF3D25F1EC0300A36206 /* Avatar.swift */,
 				536AEF3E25F1EC0300A36206 /* AvatarTokens.swift */,
+				92751051268142CD00F12730 /* MSFAvatarPresence.swift */,
 				536AEF3C25F1EC0300A36206 /* MSFAvatarTokens.generated.swift */,
 			);
 			path = Avatar;
@@ -936,6 +943,7 @@
 		92F2C5FD267287CF0087C65B /* PersonaButtonCarousel */ = {
 			isa = PBXGroup;
 			children = (
+				9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */,
 				9298798E266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift */,
 				929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */,
 				929DD255266ED3AC00E8175E /* PersonaButtonCarouselTokens.swift */,
@@ -1642,6 +1650,7 @@
 				5314E1BB25F01B070099271A /* TouchForwardingView.swift in Sources */,
 				5314E2EC25F025710099271A /* DayOfMonth.swift in Sources */,
 				5314E0B325F010400099271A /* EasyTapButton.swift in Sources */,
+				92751053268142CD00F12730 /* MSFAvatarPresence.swift in Sources */,
 				5314E19625F019650099271A /* TabBarView.swift in Sources */,
 				C708B05F260A8778007190FA /* SegmentPillButton.swift in Sources */,
 				5314E11925F015EA0099271A /* ContactCollectionView.swift in Sources */,
@@ -1684,6 +1693,7 @@
 				536DDA02264C4D7200CD41B5 /* ActivityIndicator.swift in Sources */,
 				536DD9F4264C4AE700CD41B5 /* MSFActivityIndicatorTokens.generated.swift in Sources */,
 				5314E1A625F01A7C0099271A /* BooleanCell.swift in Sources */,
+				9275105626815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */,
 				5314E0BC25F0106F0099271A /* HUDView.swift in Sources */,
 				5314E0F225F012C80099271A /* ShyHeaderView.swift in Sources */,
 				5314E02825F00DA80099271A /* BlurringView.swift in Sources */,
@@ -1821,6 +1831,7 @@
 				537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */,
 				FDFB8AF121361C9D0046850A /* CalendarViewDayMonthCell.swift in Sources */,
 				B47B58B822F8E5840078DE38 /* PeoplePicker.swift in Sources */,
+				92751052268142CD00F12730 /* MSFAvatarPresence.swift in Sources */,
 				FD41C89E22DD13230086F899 /* NavigationController.swift in Sources */,
 				FD4F2A20214AE20400C437D6 /* DatePickerController.swift in Sources */,
 				22EABB1A2509AAD100C4BE72 /* IndeterminateProgressBarView.swift in Sources */,
@@ -1863,6 +1874,7 @@
 				B444D6B62183A9740002B4D4 /* BadgeView.swift in Sources */,
 				FD7254E72146E946002F4069 /* CalendarViewDayCell.swift in Sources */,
 				536DDA01264C4D7200CD41B5 /* ActivityIndicator.swift in Sources */,
+				9275105526815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */,
 				536DD9F3264C4AE700CD41B5 /* MSFActivityIndicatorTokens.generated.swift in Sources */,
 				536AEF5D25F1EC0300A36206 /* ListCell.swift in Sources */,
 				A589F854211BA03200471C23 /* Label.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -237,6 +237,8 @@
 		929DD257266ED3AC00E8175E /* PersonaButtonCarouselTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD255266ED3AC00E8175E /* PersonaButtonCarouselTokens.swift */; };
 		929DD259266ED3B600E8175E /* PersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */; };
 		929DD25A266ED3B600E8175E /* PersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */; };
+		92B7E6A22684262900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
+		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A5237ACB21DED7030040BF27 /* ResizingHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */; };
@@ -460,6 +462,7 @@
 		9298798E266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarouselTokens.generated.swift; sourceTree = "<group>"; };
 		929DD255266ED3AC00E8175E /* PersonaButtonCarouselTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselTokens.swift; sourceTree = "<group>"; };
 		929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarousel.swift; sourceTree = "<group>"; };
+		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -935,6 +938,7 @@
 			children = (
 				9298798D266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift */,
 				92088EF72666DB2C003F571A /* PersonaButton.swift */,
+				92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */,
 				927E34C62668350800998031 /* PersonaButtonTokens.swift */,
 			);
 			path = PersonaButton;
@@ -1646,6 +1650,7 @@
 				8035CAB62633A4DB007B3FD1 /* BottomCommandingController.swift in Sources */,
 				5314E13725F016370099271A /* PopupMenuProtocols.swift in Sources */,
 				5314E19725F019650099271A /* TabBarItem.swift in Sources */,
+				92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */,
 				92987992266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift in Sources */,
 				5314E1BB25F01B070099271A /* TouchForwardingView.swift in Sources */,
 				5314E2EC25F025710099271A /* DayOfMonth.swift in Sources */,
@@ -1827,6 +1832,7 @@
 				C708B04C260A8696007190FA /* SegmentItem.swift in Sources */,
 				FD41C88622DD13230086F899 /* ShyHeaderController.swift in Sources */,
 				8035CAAC2633A442007B3FD1 /* BottomCommandingController.swift in Sources */,
+				92B7E6A22684262900EFC15E /* MSFPersonaButton.swift in Sources */,
 				92987991266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift in Sources */,
 				537315B325438B15001FD14C /* iOS13_4_compatibility.swift in Sources */,
 				FDFB8AF121361C9D0046850A /* CalendarViewDayMonthCell.swift in Sources */,

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -70,33 +70,6 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
     }
 }
 
-// MARK: - PersonaData MSFAvatarStateImpl extension
-
-extension MSFAvatarStateImpl {
-    convenience init(style: MSFAvatarStyle, size: MSFAvatarSize, personaData: PersonaData) {
-        self.init(style: style, size: size)
-        self.copyProperties(from: personaData)
-    }
-
-    func copyProperties(from personaData: PersonaData) {
-        if let name = personaData.composedName {
-            self.primaryText = name.0
-            self.secondaryText = name.1
-        } else {
-            let identifier = (personaData.name.count > 0) ? personaData.name : personaData.email
-            self.primaryText = identifier
-        }
-
-        self.foregroundColor = personaData.color
-        self.image = personaData.image
-        self.imageBasedRingColor = personaData.customBorderImage
-        self.isOutOfOffice = personaData.presence == .outOfOffice
-        self.hasRingInnerGap = !personaData.hideInsideGapForBorder
-        self.presence = MSFAvatarPresence(personaData.presence)
-        self.ringColor = personaData.color
-    }
-}
-
 /// View that represents the avatar
 public struct AvatarView: View {
     @Environment(\.theme) var theme: FluentUIStyle

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -6,89 +6,6 @@
 import UIKit
 import SwiftUI
 
-@objc public enum MSFAvatarPresence: Int, CaseIterable {
-    case none
-    case available
-    case away
-    case blocked
-    case busy
-    case doNotDisturb
-    case offline
-    case unknown
-
-    func color(isOutOfOffice: Bool) -> Color {
-        var color = UIColor.clear
-
-        switch self {
-        case .none:
-            break
-        case .available:
-            color = FluentUIThemeManager.S.Colors.Presence.available
-        case .away:
-            color = isOutOfOffice ? FluentUIThemeManager.S.Colors.Presence.outOfOffice : FluentUIThemeManager.S.Colors.Presence.away
-        case .busy:
-            color = FluentUIThemeManager.S.Colors.Presence.busy
-        case .blocked:
-            color = FluentUIThemeManager.S.Colors.Presence.blocked
-        case .doNotDisturb:
-            color = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
-        case .offline:
-            color = isOutOfOffice ? FluentUIThemeManager.S.Colors.Presence.outOfOffice : FluentUIThemeManager.S.Colors.Presence.offline
-        case .unknown:
-            color = FluentUIThemeManager.S.Colors.Presence.unknown
-        }
-
-        return Color(color)
-    }
-
-    func image(isOutOfOffice: Bool) -> Image {
-        var imageName = ""
-
-        switch self {
-        case .none:
-            break
-        case .available:
-            imageName = isOutOfOffice ? "ic_fluent_presence_available_16_regular" : "ic_fluent_presence_available_16_filled"
-        case .away:
-            imageName = isOutOfOffice ? "ic_fluent_presence_oof_16_regular" : "ic_fluent_presence_away_16_filled"
-        case .busy:
-            imageName = isOutOfOffice ? "ic_fluent_presence_unknown_16_regular" : "ic_fluent_presence_busy_16_filled"
-        case .blocked:
-            imageName = "ic_fluent_presence_blocked_16_regular"
-        case .doNotDisturb:
-            imageName = isOutOfOffice ? "ic_fluent_presence_dnd_16_regular" : "ic_fluent_presence_dnd_16_filled"
-        case .offline:
-            imageName = isOutOfOffice ? "ic_fluent_presence_oof_16_regular" : "ic_fluent_presence_offline_16_regular"
-        case .unknown:
-            imageName = "ic_fluent_presence_unknown_16_regular"
-        }
-
-        return Image(imageName,
-                     bundle: FluentUIFramework.resourceBundle)
-    }
-
-    public func string() -> String? {
-        switch self {
-        case .none:
-            return nil
-        case .available:
-            return "Presence.Available".localized
-        case .away:
-            return "Presence.Away".localized
-        case .busy:
-            return "Presence.Busy".localized
-        case .blocked:
-            return "Presence.Blocked".localized
-        case .doNotDisturb:
-            return "Presence.DND".localized
-        case .offline:
-            return "Presence.Offline".localized
-        case .unknown:
-            return "Presence.Unknown".localized
-        }
-    }
-}
-
 /// Properties available to customize the state of the avatar
 @objc public protocol MSFAvatarState {
     var accessibilityLabel: String? { get set }
@@ -150,6 +67,33 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
         self.tokens = MSFAvatarTokens(style: style,
                                       size: size)
         super.init()
+    }
+}
+
+// MARK: - PersonaData MSFAvatarStateImpl extension
+
+extension MSFAvatarStateImpl {
+    convenience init(style: MSFAvatarStyle, size: MSFAvatarSize, personaData: PersonaData) {
+        self.init(style: style, size: size)
+        self.copyProperties(from: personaData)
+    }
+
+    func copyProperties(from personaData: PersonaData) {
+        if let name = personaData.composedName {
+            self.primaryText = name.0
+            self.secondaryText = name.1
+        } else {
+            let identifier = (personaData.name.count > 0) ? personaData.name : personaData.email
+            self.primaryText = identifier
+        }
+
+        self.foregroundColor = personaData.color
+        self.image = personaData.image
+        self.imageBasedRingColor = personaData.customBorderImage
+        self.isOutOfOffice = personaData.presence == .outOfOffice
+        self.hasRingInnerGap = !personaData.hideInsideGapForBorder
+        self.presence = MSFAvatarPresence(personaData.presence)
+        self.ringColor = personaData.color
     }
 }
 

--- a/ios/FluentUI/Vnext/Avatar/MSFAvatarPresence.swift
+++ b/ios/FluentUI/Vnext/Avatar/MSFAvatarPresence.swift
@@ -1,0 +1,116 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+@objc public enum MSFAvatarPresence: Int, CaseIterable {
+    case none
+    case available
+    case away
+    case blocked
+    case busy
+    case doNotDisturb
+    case offline
+    case unknown
+
+    func color(isOutOfOffice: Bool) -> Color {
+        var color = UIColor.clear
+
+        switch self {
+        case .none:
+            break
+        case .available:
+            color = FluentUIThemeManager.S.Colors.Presence.available
+        case .away:
+            color = isOutOfOffice ? FluentUIThemeManager.S.Colors.Presence.outOfOffice : FluentUIThemeManager.S.Colors.Presence.away
+        case .busy:
+            color = FluentUIThemeManager.S.Colors.Presence.busy
+        case .blocked:
+            color = FluentUIThemeManager.S.Colors.Presence.blocked
+        case .doNotDisturb:
+            color = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
+        case .offline:
+            color = isOutOfOffice ? FluentUIThemeManager.S.Colors.Presence.outOfOffice : FluentUIThemeManager.S.Colors.Presence.offline
+        case .unknown:
+            color = FluentUIThemeManager.S.Colors.Presence.unknown
+        }
+
+        return Color(color)
+    }
+
+    func image(isOutOfOffice: Bool) -> Image {
+        var imageName = ""
+
+        switch self {
+        case .none:
+            break
+        case .available:
+            imageName = isOutOfOffice ? "ic_fluent_presence_available_16_regular" : "ic_fluent_presence_available_16_filled"
+        case .away:
+            imageName = isOutOfOffice ? "ic_fluent_presence_oof_16_regular" : "ic_fluent_presence_away_16_filled"
+        case .busy:
+            imageName = isOutOfOffice ? "ic_fluent_presence_unknown_16_regular" : "ic_fluent_presence_busy_16_filled"
+        case .blocked:
+            imageName = "ic_fluent_presence_blocked_16_regular"
+        case .doNotDisturb:
+            imageName = isOutOfOffice ? "ic_fluent_presence_dnd_16_regular" : "ic_fluent_presence_dnd_16_filled"
+        case .offline:
+            imageName = isOutOfOffice ? "ic_fluent_presence_oof_16_regular" : "ic_fluent_presence_offline_16_regular"
+        case .unknown:
+            imageName = "ic_fluent_presence_unknown_16_regular"
+        }
+
+        return Image(imageName,
+                     bundle: FluentUIFramework.resourceBundle)
+    }
+
+    public func string() -> String? {
+        switch self {
+        case .none:
+            return nil
+        case .available:
+            return "Presence.Available".localized
+        case .away:
+            return "Presence.Away".localized
+        case .busy:
+            return "Presence.Busy".localized
+        case .blocked:
+            return "Presence.Blocked".localized
+        case .doNotDisturb:
+            return "Presence.DND".localized
+        case .offline:
+            return "Presence.Offline".localized
+        case .unknown:
+            return "Presence.Unknown".localized
+        }
+    }
+}
+
+extension MSFAvatarPresence {
+    init(_ presence: Presence) {
+        switch presence {
+        case .none:
+            self = .none
+        case .available:
+            self = .available
+        case .away:
+            self = .away
+        case .busy:
+            self = .busy
+        case .doNotDisturb:
+            self = .doNotDisturb
+        case .outOfOffice:
+            // Not supported
+            self = .unknown
+        case .offline:
+            self = .offline
+        case .unknown:
+            self = .unknown
+        case .blocked:
+            self = .blocked
+        }
+    }
+}

--- a/ios/FluentUI/Vnext/Avatar/MSFAvatarPresence.swift
+++ b/ios/FluentUI/Vnext/Avatar/MSFAvatarPresence.swift
@@ -88,29 +88,3 @@ import SwiftUI
         }
     }
 }
-
-extension MSFAvatarPresence {
-    init(_ presence: Presence) {
-        switch presence {
-        case .none:
-            self = .none
-        case .available:
-            self = .available
-        case .away:
-            self = .away
-        case .busy:
-            self = .busy
-        case .doNotDisturb:
-            self = .doNotDisturb
-        case .outOfOffice:
-            // Not supported
-            self = .unknown
-        case .offline:
-            self = .offline
-        case .unknown:
-            self = .unknown
-        case .blocked:
-            self = .blocked
-        }
-    }
-}

--- a/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButton.swift
@@ -1,0 +1,167 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+import UIKit
+
+/// UIKit wrapper that exposes the SwiftUI PersonaButton implementation
+@objc open class MSFPersonaButtonView: NSObject, FluentUIWindowProvider, MSFPersonaButtonAppearance, MSFPersonaButtonData {
+
+    @objc open var view: UIView {
+        return hostingController.view
+    }
+
+    @objc public init(size: MSFPersonaButtonSize = .large,
+                      theme: FluentUIStyle? = nil) {
+        super.init()
+
+        personaButton = PersonaButton(size: size)
+        hostingController = UIHostingController(rootView: AnyView(personaButton
+                                                                    .windowProvider(self)
+                                                                    .modifyIf(theme != nil, { personaButton in
+                                                                        personaButton.customTheme(theme!)
+                                                                    })))
+        hostingController.disableSafeAreaInsets()
+        view.backgroundColor = UIColor.clear
+    }
+
+    // MARK: - MSFPersonaButtonAppearance
+
+    @objc public var buttonSize: MSFPersonaButtonSize {
+        get {
+            return self.personaButton.state.buttonSize
+        }
+        set {
+            self.personaButton.state.buttonSize = newValue
+        }
+    }
+
+    @objc public var onTapAction: (() -> Void)? {
+        get {
+            return self.personaButton.state.onTapAction
+        }
+        set {
+            self.personaButton.state.onTapAction = newValue
+        }
+    }
+
+    // MARK: - MSFPersonaButtonData
+
+    @objc public var avatarBackgroundColor: UIColor? {
+        get {
+            return self.personaButton.state.avatarBackgroundColor
+        }
+        set {
+            self.personaButton.state.avatarBackgroundColor = newValue
+        }
+    }
+
+    @objc public var avatarForegroundColor: UIColor? {
+        get {
+            return self.personaButton.state.avatarForegroundColor
+        }
+        set {
+            self.personaButton.state.avatarForegroundColor = newValue
+        }
+    }
+    @objc public var hasPointerInteraction: Bool {
+        get {
+            return self.personaButton.state.hasPointerInteraction
+        }
+        set {
+            self.personaButton.state.hasPointerInteraction = newValue
+        }
+    }
+    @objc public var hasRingInnerGap: Bool {
+        get {
+            return self.personaButton.state.hasRingInnerGap
+        }
+        set {
+            self.personaButton.state.hasRingInnerGap = newValue
+        }
+    }
+    @objc public var image: UIImage? {
+        get {
+            return self.personaButton.state.image
+        }
+        set {
+            self.personaButton.state.image = newValue
+        }
+    }
+    @objc public var imageBasedRingColor: UIImage? {
+        get {
+            return self.personaButton.state.imageBasedRingColor
+        }
+        set {
+            self.personaButton.state.imageBasedRingColor = newValue
+        }
+    }
+    @objc public var isOutOfOffice: Bool {
+        get {
+            return self.personaButton.state.isOutOfOffice
+        }
+        set {
+            self.personaButton.state.isOutOfOffice = newValue
+        }
+    }
+    @objc public var isRingVisible: Bool {
+        get {
+            return self.personaButton.state.isRingVisible
+        }
+        set {
+            self.personaButton.state.isRingVisible = newValue
+        }
+    }
+    @objc public var isTransparent: Bool {
+        get {
+            return self.personaButton.state.isTransparent
+        }
+        set {
+            self.personaButton.state.isTransparent = newValue
+        }
+    }
+    @objc public var presence: MSFAvatarPresence {
+        get {
+            return self.personaButton.state.presence
+        }
+        set {
+            self.personaButton.state.presence = newValue
+        }
+    }
+    @objc public var primaryText: String? {
+        get {
+            return self.personaButton.state.primaryText
+        }
+        set {
+            self.personaButton.state.primaryText = newValue
+        }
+    }
+    @objc public var ringColor: UIColor? {
+        get {
+            return self.personaButton.state.ringColor
+        }
+        set {
+            self.personaButton.state.ringColor = newValue
+        }
+    }
+    @objc public var secondaryText: String? {
+        get {
+            return self.personaButton.state.secondaryText
+        }
+        set {
+            self.personaButton.state.secondaryText = newValue
+        }
+    }
+
+    // MARK: - FluentUIWindowProvider
+
+    var window: UIWindow? {
+        return self.view.window
+    }
+
+    private var hostingController: UIHostingController<AnyView>!
+
+    private var personaButton: PersonaButton!
+}

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -7,8 +7,21 @@ import SwiftUI
 
 /// `MSFPersonaButtonState` contains PersonaButton properties in addition to a subset of the MSFAvatarState protocol.
 ///
-/// `onTapAction` provides tap gesture for PersonaButton.
-///
+/// - `buttonSize`: specifies whether to use small or large avatars
+/// - `onTapAction`: provides tap gesture for PersonaButton
+/// - `avatarBackgroundColor`: background color for the persona image
+/// - `avatarForegroundColor`: foreground color for the persona image
+/// - `hasPointerInteraction`: indicates whether the image should interact with pointer hover (iPadOS 13.4+ only)
+/// - `hasRingInnerGap`: indicates whether there is a gap between the ring and the image
+/// - `image`: image to display for persona
+/// - `imageBasedRingColor`: image to use as a backdrop for the ring
+/// - `isOutOfOffice`: indicates whether to show out of office status
+/// - `isRingVisible`: indicates if the status ring should be visible
+/// - `isTransparent`: indicates if the avatar should be drawn with transparency
+/// - `presence`: enum that describes persence status for the persona
+/// - `primaryText`: primary text to be displayed under the persona image (e.g. first name)
+/// - `ringColor`: color to draw the status ring, if one is visible
+/// - `secondaryText`: secondary text to be displayed under the persona image (e.g. last name or email address)
 @objc public protocol MSFPersonaButtonState {
     var buttonSize: MSFPersonaButtonSize { get set }
     var onTapAction: (() -> Void)? { get set }
@@ -29,11 +42,13 @@ import SwiftUI
 }
 
 /// Properties that make up PersonaButton content
-class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, MSFPersonaButtonState {
+class MSFPersonaButtonStateImpl: NSObject, ObservableObject, Identifiable, MSFPersonaButtonState {
     @Published var buttonSize: MSFPersonaButtonSize
     @Published var onTapAction: (() -> Void)?
 
+    let avatarState: MSFAvatarStateImpl
     let tokens: MSFPersonaButtonTokens
+    var personaData: PersonaData?
 
     var avatarBackgroundColor: UIColor? {
         get {
@@ -41,7 +56,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.backgroundColor = newValue
-            objectWillChange.send()
         }
     }
 
@@ -51,7 +65,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.foregroundColor = newValue
-            objectWillChange.send()
         }
     }
 
@@ -61,7 +74,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.hasPointerInteraction = newValue
-            objectWillChange.send()
         }
     }
 
@@ -71,7 +83,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.hasRingInnerGap = newValue
-            objectWillChange.send()
         }
     }
 
@@ -81,7 +92,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.image = newValue
-            objectWillChange.send()
         }
     }
 
@@ -91,7 +101,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.imageBasedRingColor = newValue
-            objectWillChange.send()
         }
     }
 
@@ -101,7 +110,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.isOutOfOffice = newValue
-            objectWillChange.send()
         }
     }
 
@@ -111,7 +119,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.isRingVisible = newValue
-            objectWillChange.send()
         }
     }
 
@@ -121,7 +128,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.isTransparent = newValue
-            objectWillChange.send()
         }
     }
 
@@ -131,7 +137,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.presence = newValue
-            objectWillChange.send()
         }
     }
 
@@ -141,7 +146,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.primaryText = newValue
-            objectWillChange.send()
         }
     }
 
@@ -151,7 +155,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.ringColor = newValue
-            objectWillChange.send()
         }
     }
 
@@ -161,7 +164,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.secondaryText = newValue
-            objectWillChange.send()
         }
     }
 
@@ -171,7 +173,6 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.size = newValue
-            objectWillChange.send()
         }
     }
 
@@ -181,11 +182,10 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         }
         set {
             avatarState.style = newValue
-            objectWillChange.send()
         }
     }
 
-    init(size: MSFPersonaButtonSize, avatarState: MSFAvatarState) {
+    init(size: MSFPersonaButtonSize, avatarState: MSFAvatarStateImpl) {
         self.buttonSize = size
         self.avatarState = avatarState
         self.tokens = MSFPersonaButtonTokens(size: size)
@@ -193,20 +193,35 @@ class MSFPersonaButtonViewStateImpl: NSObject, ObservableObject, Identifiable, M
         super.init()
     }
 
-    private var avatarState: MSFAvatarState
+    convenience init(size: MSFPersonaButtonSize) {
+        let avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize)
+        self.init(size: size, avatarState: avatarState)
+    }
+
+    convenience init(size: MSFPersonaButtonSize, personaData: PersonaData) {
+        let avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize, personaData: personaData)
+        self.init(size: size, avatarState: avatarState)
+
+        self.personaData = personaData
+    }
 }
 
 public struct PersonaButton: View {
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFPersonaButtonTokens
-    @ObservedObject var state: MSFPersonaButtonViewStateImpl
+    @ObservedObject var state: MSFPersonaButtonStateImpl
     @ObservedObject var avatarState: MSFAvatarStateImpl
 
     public init(size: MSFPersonaButtonSize) {
-        let avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize)
-        let state = MSFPersonaButtonViewStateImpl(size: size, avatarState: avatarState)
-        self.avatarState = avatarState
+        let state = MSFPersonaButtonStateImpl(size: size)
+        self.avatarState = state.avatarState
+        self.state = state
+        self.tokens = state.tokens
+    }
+
+    internal init(state: MSFPersonaButtonStateImpl) {
+        self.avatarState = state.avatarState
         self.state = state
         self.tokens = state.tokens
     }

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -5,36 +5,41 @@
 
 import SwiftUI
 
-/// `MSFPersonaButtonState` contains PersonaButton properties in addition to a subset of the MSFAvatarState protocol.
+/// `MSFPersonaButtonAppearance` contains properties to customize the appearance and interaction of a `PersonaButton`.
 ///
 /// - `buttonSize`: specifies whether to use small or large avatars
 /// - `onTapAction`: provides tap gesture for PersonaButton
-/// - `avatarBackgroundColor`: background color for the persona image
-/// - `avatarForegroundColor`: foreground color for the persona image
 /// - `hasPointerInteraction`: indicates whether the image should interact with pointer hover (iPadOS 13.4+ only)
 /// - `hasRingInnerGap`: indicates whether there is a gap between the ring and the image
+/// - `isTransparent`: indicates if the avatar should be drawn with transparency
+@objc public protocol MSFPersonaButtonAppearance {
+    var buttonSize: MSFPersonaButtonSize { get set }
+    var onTapAction: (() -> Void)? { get set }
+
+    var hasPointerInteraction: Bool { get set }
+    var hasRingInnerGap: Bool { get set }
+    var isTransparent: Bool { get set }
+}
+
+/// `MSFPersonaButtonData` contains properties to customize the data of a `PersonaButton`.
+///
+/// - `avatarBackgroundColor`: background color for the persona image
+/// - `avatarForegroundColor`: foreground color for the persona image
 /// - `image`: image to display for persona
 /// - `imageBasedRingColor`: image to use as a backdrop for the ring
 /// - `isOutOfOffice`: indicates whether to show out of office status
 /// - `isRingVisible`: indicates if the status ring should be visible
-/// - `isTransparent`: indicates if the avatar should be drawn with transparency
 /// - `presence`: enum that describes persence status for the persona
 /// - `primaryText`: primary text to be displayed under the persona image (e.g. first name)
 /// - `ringColor`: color to draw the status ring, if one is visible
 /// - `secondaryText`: secondary text to be displayed under the persona image (e.g. last name or email address)
-@objc public protocol MSFPersonaButtonState {
-    var buttonSize: MSFPersonaButtonSize { get set }
-    var onTapAction: (() -> Void)? { get set }
-
+@objc public protocol MSFPersonaButtonData {
     var avatarBackgroundColor: UIColor? { get set }
     var avatarForegroundColor: UIColor? { get set }
-    var hasPointerInteraction: Bool { get set }
-    var hasRingInnerGap: Bool { get set }
     var image: UIImage? { get set }
     var imageBasedRingColor: UIImage? { get set }
     var isOutOfOffice: Bool { get set }
     var isRingVisible: Bool { get set }
-    var isTransparent: Bool { get set }
     var presence: MSFAvatarPresence { get set }
     var primaryText: String? { get set }
     var ringColor: UIColor? { get set }
@@ -42,13 +47,13 @@ import SwiftUI
 }
 
 /// Properties that make up PersonaButton content
-class MSFPersonaButtonStateImpl: NSObject, ObservableObject, Identifiable, MSFPersonaButtonState {
+class MSFPersonaButtonStateImpl: NSObject, ObservableObject, Identifiable, MSFPersonaButtonAppearance, MSFPersonaButtonData {
     @Published var buttonSize: MSFPersonaButtonSize
     @Published var onTapAction: (() -> Void)?
 
     let avatarState: MSFAvatarStateImpl
     let tokens: MSFPersonaButtonTokens
-    var personaData: PersonaData?
+    let id = UUID()
 
     var avatarBackgroundColor: UIColor? {
         get {
@@ -197,13 +202,6 @@ class MSFPersonaButtonStateImpl: NSObject, ObservableObject, Identifiable, MSFPe
         let avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize)
         self.init(size: size, avatarState: avatarState)
     }
-
-    convenience init(size: MSFPersonaButtonSize, personaData: PersonaData) {
-        let avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize, personaData: personaData)
-        self.init(size: size, avatarState: avatarState)
-
-        self.personaData = personaData
-    }
 }
 
 public struct PersonaButton: View {
@@ -211,17 +209,15 @@ public struct PersonaButton: View {
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFPersonaButtonTokens
     @ObservedObject var state: MSFPersonaButtonStateImpl
-    @ObservedObject var avatarState: MSFAvatarStateImpl
 
     public init(size: MSFPersonaButtonSize) {
         let state = MSFPersonaButtonStateImpl(size: size)
-        self.avatarState = state.avatarState
         self.state = state
         self.tokens = state.tokens
     }
 
-    internal init(state: MSFPersonaButtonStateImpl) {
-        self.avatarState = state.avatarState
+    internal init(state: MSFPersonaButtonStateImpl, action: (() -> Void)?) {
+        state.onTapAction = action
         self.state = state
         self.tokens = state.tokens
     }
@@ -246,7 +242,7 @@ public struct PersonaButton: View {
 
     @ViewBuilder
     private var avatarView: some View {
-        AvatarView(avatarState)
+        AvatarView(state.avatarState)
             .padding(.top, tokens.padding)
             .padding(.bottom, tokens.avatarInterspace)
             .padding(.horizontal, tokens.padding)
@@ -267,38 +263,4 @@ public struct PersonaButton: View {
                       from: theme,
                       with: windowProvider)
     }
-}
-
-/// UIKit wrapper that exposes the SwiftUI PersonaButton implementation
-@objc open class MSFPersonaButtonView: NSObject, FluentUIWindowProvider {
-
-    @objc open var view: UIView {
-        return hostingController.view
-    }
-
-    @objc open var state: MSFPersonaButtonState {
-        return self.personaButton.state
-    }
-
-    @objc public init(size: MSFPersonaButtonSize = .large,
-                      theme: FluentUIStyle? = nil) {
-        super.init()
-
-        personaButton = PersonaButton(size: size)
-        hostingController = UIHostingController(rootView: AnyView(personaButton
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { personaButton in
-                                                                        personaButton.customTheme(theme!)
-                                                                    })))
-        hostingController.disableSafeAreaInsets()
-        view.backgroundColor = UIColor.clear
-    }
-
-    var window: UIWindow? {
-        return self.view.window
-    }
-
-    private var hostingController: UIHostingController<AnyView>!
-
-    private var personaButton: PersonaButton!
 }

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -31,7 +31,7 @@ import SwiftUI
     }
 
     @objc public var count: Int {
-        return self.personaButtonCarousel.state.buttons.count
+        return self.state.count
     }
 
     /// Adds a `PersonaButton` to the carousel, and returns an optional reference for additional property setting
@@ -43,17 +43,17 @@ import SwiftUI
     ///
     /// - Returns: An optional reference to the added `PersonaButton`, which can be used to set additional properties or to update later
     @discardableResult @objc public func add(primaryText: String?, secondaryText: String?, image: UIImage?) -> MSFPersonaButtonData {
+        return self.state.add(primaryText: primaryText, secondaryText: secondaryText, image: image)
+    }
 
-        let persona = MSFPersonaButtonStateImpl(size: self.state.buttonSize)
-
-        // Set passed-in properties
-        persona.primaryText = primaryText
-        persona.secondaryText = secondaryText
-        persona.image = image
-
-        self.personaButtonCarousel.state.buttons.append(persona)
-
-        return persona
+    /// Retrieves the `PersonaButton` at a given index, or nil if the index is out of bounds
+    ///
+    /// - Parameters:
+    ///   - index: The index of the `PersonaButton` to retrieve
+    ///
+    /// - Returns: A reference to the  `PersonaButton` at the given index if one exists
+    @objc public func personaButtonData(at index: Int) -> MSFPersonaButtonData? {
+        return self.state.personaButtonData(at: index)
     }
 
     /// Removes a `PersonaButton` from the carousel.
@@ -61,9 +61,7 @@ import SwiftUI
     /// - Parameters:
     ///   - personaData: The reference to a `PersonaButton` to be removed.
     @objc public func remove(_ personaData: MSFPersonaButtonData) {
-        self.personaButtonCarousel.state.buttons.removeAll { personaState in
-            personaState.isEqual(personaData)
-        }
+        self.state.remove(personaData)
     }
 
     /// Removes a `PersonaButton` from the carousel at the given index.
@@ -71,10 +69,7 @@ import SwiftUI
     /// - Parameters:
     ///   - index: The index at which the `PersonaButton` to be removed can be currently found.
     @objc public func remove(at index: Int) {
-        if index >= count {
-            fatalError("Attempting to remove item outside bounds of carousel")
-        }
-        self.personaButtonCarousel.state.buttons.remove(at: index)
+        self.state.remove(at: index)
     }
 
     // MARK: - MSFPersonaCarouselState

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -6,42 +6,20 @@
 import UIKit
 import SwiftUI
 
-/// Delegate interface for MSFPersonaButtonCarousel
-@objc public protocol MSFPersonaButtonCarouselDelegate: AnyObject {
-    /// Notifies that the user has tapped on a persona button
-    ///
-    /// - Parameters:
-    ///   - personaData: the `PersonaData` instance of the tapped persona
-    ///   - index: the tapped persona's index in the current array of `PersonaData`
-    @objc optional func didTap(on personaData: PersonaData, at index: Int)
-}
-
 /// UIKit wrapper that exposes the SwiftUI PersonaGrid implementation
-@objc open class MSFPersonaButtonCarousel: NSObject, FluentUIWindowProvider {
+@objc open class MSFPersonaButtonCarousel: NSObject, FluentUIWindowProvider, MSFPersonaCarouselState {
+
+    // MARK: - Public API
 
     @objc open var view: UIView {
         return hostingController.view
     }
 
-    @objc open weak var delegate: MSFPersonaButtonCarouselDelegate?
-
     @objc public init(size: MSFPersonaButtonSize = .large,
-                      personas: [PersonaData] = [],
                       theme: FluentUIStyle? = nil) {
         super.init()
 
-        personaButtonCarousel = PersonaButtonCarousel(size: size, personaButtons: personas.map { personaData in
-            MSFPersonaButtonStateImpl(size: size, personaData: personaData)
-        })
-
-        personaButtonCarousel.state.onTapAction = { [weak self] (personaButtonState: MSFPersonaButtonState, index: Int) in
-            // Unfortunate that we have to have this cast, but the alternative is to expose
-            // the internal `PersonaData` property on the public interface
-            guard let personaData = (personaButtonState as? MSFPersonaButtonStateImpl)?.personaData else {
-                fatalError("Unknown type passed in as MSFPersonaButtonState")
-            }
-            self?.delegate?.didTap?(on: personaData, at: index)
-        }
+        personaButtonCarousel = PersonaButtonCarousel(size: size)
 
         hostingController = UIHostingController(rootView: AnyView(personaButtonCarousel
                                                                     .windowProvider(self)
@@ -52,27 +30,77 @@ import SwiftUI
         view.backgroundColor = UIColor.clear
     }
 
-    @objc public func count() -> Int {
+    @objc public var count: Int {
         return self.personaButtonCarousel.state.buttons.count
     }
 
-    @objc public func append(_ personaData: PersonaData) {
-        let persona = MSFPersonaButtonStateImpl(size: self.state.buttonSize, personaData: personaData)
+    /// Adds a `PersonaButton` to the carousel, and returns an optional reference for additional property setting
+    ///
+    /// - Parameters:
+    ///   - primaryText: The primary text to appear in the `PersonaButton`
+    ///   - secondaryText: The secondary text to appear in the `PersonaButton`, below `primaryText`
+    ///   - image: The image to use as the persona's avatar
+    ///
+    /// - Returns: An optional reference to the added `PersonaButton`, which can be used to set additional properties or to update later
+    @discardableResult @objc public func add(primaryText: String?, secondaryText: String?, image: UIImage?) -> MSFPersonaButtonData {
+
+        let persona = MSFPersonaButtonStateImpl(size: self.state.buttonSize)
+
+        // Set passed-in properties
+        persona.primaryText = primaryText
+        persona.secondaryText = secondaryText
+        persona.image = image
+
         self.personaButtonCarousel.state.buttons.append(persona)
+
+        return persona
     }
 
+    /// Removes a `PersonaButton` from the carousel.
+    ///
+    /// - Parameters:
+    ///   - personaData: The reference to a `PersonaButton` to be removed.
+    @objc public func remove(_ personaData: MSFPersonaButtonData) {
+        self.personaButtonCarousel.state.buttons.removeAll { personaState in
+            personaState.isEqual(personaData)
+        }
+    }
+
+    /// Removes a `PersonaButton` from the carousel at the given index.
+    ///
+    /// - Parameters:
+    ///   - index: The index at which the `PersonaButton` to be removed can be currently found.
     @objc public func remove(at index: Int) {
-        if index >= count() {
+        if index >= count {
             fatalError("Attempting to remove item outside bounds of carousel")
         }
         self.personaButtonCarousel.state.buttons.remove(at: index)
     }
 
+    // MARK: - MSFPersonaCarouselState
+
+    @objc public var buttonSize: MSFPersonaButtonSize {
+        return self.state.buttonSize
+    }
+
+    @objc public var onTapAction: ((MSFPersonaButtonData, Int) -> Void)? {
+        get {
+            return self.state.onTapAction
+        }
+        set {
+            self.state.onTapAction = newValue
+        }
+    }
+
+    // MARK: - FluentUIWindowProvider
+
     var window: UIWindow? {
         return self.view.window
     }
 
-    private var state: MSFPersonaCarouselState {
+    // MARK: - private properties
+
+    private var state: MSFPersonaCarouselStateImpl {
         return self.personaButtonCarousel.state
     }
 

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -1,0 +1,82 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+/// Delegate interface for MSFPersonaButtonCarousel
+@objc public protocol MSFPersonaButtonCarouselDelegate: AnyObject {
+    /// Notifies that the user has tapped on a persona button
+    ///
+    /// - Parameters:
+    ///   - personaData: the `PersonaData` instance of the tapped persona
+    ///   - index: the tapped persona's index in the current array of `PersonaData`
+    @objc optional func didTap(on personaData: PersonaData, at index: Int)
+}
+
+/// UIKit wrapper that exposes the SwiftUI PersonaGrid implementation
+@objc open class MSFPersonaButtonCarousel: NSObject, FluentUIWindowProvider {
+
+    @objc open var view: UIView {
+        return hostingController.view
+    }
+
+    @objc open weak var delegate: MSFPersonaButtonCarouselDelegate?
+
+    @objc public init(size: MSFPersonaButtonSize = .large,
+                      personas: [PersonaData] = [],
+                      theme: FluentUIStyle? = nil) {
+        super.init()
+
+        personaButtonCarousel = PersonaButtonCarousel(size: size, personaButtons: personas.map { personaData in
+            MSFPersonaButtonStateImpl(size: size, personaData: personaData)
+        })
+
+        personaButtonCarousel.state.onTapAction = { [weak self] (personaButtonState: MSFPersonaButtonState, index: Int) in
+            // Unfortunate that we have to have this cast, but the alternative is to expose
+            // the internal `PersonaData` property on the public interface
+            guard let personaData = (personaButtonState as? MSFPersonaButtonStateImpl)?.personaData else {
+                fatalError("Unknown type passed in as MSFPersonaButtonState")
+            }
+            self?.delegate?.didTap?(on: personaData, at: index)
+        }
+
+        hostingController = UIHostingController(rootView: AnyView(personaButtonCarousel
+                                                                    .windowProvider(self)
+                                                                    .modifyIf(theme != nil, { personaButtonCarousel in
+                                                                        personaButtonCarousel.customTheme(theme!)
+                                                                    })))
+        hostingController.disableSafeAreaInsets()
+        view.backgroundColor = UIColor.clear
+    }
+
+    @objc public func count() -> Int {
+        return self.personaButtonCarousel.state.buttons.count
+    }
+
+    @objc public func append(_ personaData: PersonaData) {
+        let persona = MSFPersonaButtonStateImpl(size: self.state.buttonSize, personaData: personaData)
+        self.personaButtonCarousel.state.buttons.append(persona)
+    }
+
+    @objc public func remove(at index: Int) {
+        if index >= count() {
+            fatalError("Attempting to remove item outside bounds of carousel")
+        }
+        self.personaButtonCarousel.state.buttons.remove(at: index)
+    }
+
+    var window: UIWindow? {
+        return self.view.window
+    }
+
+    private var state: MSFPersonaCarouselState {
+        return self.personaButtonCarousel.state
+    }
+
+    private var hostingController: UIHostingController<AnyView>!
+
+    private var personaButtonCarousel: PersonaButtonCarousel!
+}

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarouselTokens.generated.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/MSFPersonaButtonCarouselTokens.generated.swift
@@ -19,11 +19,6 @@ extension FluentUIStyle {
 		open var backgroundColor: UIColor {
 			return mainProxy().Colors.Background.neutral1
 		}
-
-		// MARK: - itemHorizontalInterspace 
-		open var itemHorizontalInterspace: CGFloat {
-			return mainProxy().Spacing.medium
-		}
 	}
 
 }

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -7,7 +7,6 @@ import SwiftUI
 
 /// `MSFPersonaCarouselState` contains PersonaCarousel properties
 ///
-/// - `buttons`: the array of buttons displayed in the carousel
 /// - `buttonSize`: returns whether the carousel will display small or large avatars
 /// - `onTapAction`: provides tap gesture
 @objc public protocol MSFPersonaCarouselState {

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -5,9 +5,79 @@
 
 import SwiftUI
 
+/// `MSFPersonaCarouselState` contains PersonaCarousel properties
+///
+/// - `buttonSize`: specifies whether to use small or large avatars
+/// - `onTapAction`: provides tap gesture
+@objc public protocol MSFPersonaCarouselState {
+    var buttonSize: MSFPersonaButtonSize { get }
+    var onTapAction: ((_ personaButtonState: MSFPersonaButtonState, _ index: Int) -> Void)? { get set }
+}
+
+/// Properties that make up PersonaGrid content
+class MSFPersonaCarouselStateImpl: NSObject, ObservableObject, Identifiable, MSFPersonaCarouselState {
+    let tokens: MSFPersonaButtonCarouselTokens
+    let buttonSize: MSFPersonaButtonSize
+
+    @Published var onTapAction: ((_ personaButtonState: MSFPersonaButtonState, _ index: Int) -> Void)?
+
+    @Published var buttons: [MSFPersonaButtonStateImpl] = [] {
+        didSet {
+            // When the buttons array changes, any new entries need to have their action set
+            // to pass through to the main callback for the carousel
+            let old = Set(oldValue)
+            let new = Set(buttons)
+            let newElements = new.subtracting(old)
+
+            newElements.forEach { button in
+                button.onTapAction = { [weak self] in
+                    guard let index = self?.buttons.firstIndex(of: button) else {
+                        return
+                    }
+                    self?.onTapAction?(button, index)
+                }
+            }
+        }
+    }
+
+    init(size: MSFPersonaButtonSize, buttons: [MSFPersonaButtonStateImpl] = []) {
+        self.buttonSize = size
+        self.tokens = MSFPersonaButtonCarouselTokens(size: size)
+
+        super.init()
+
+        // Update the `buttons` array after init in order to trigger the `didSet`
+        self.buttons = buttons
+    }
+}
+
 struct PersonaButtonCarousel: View {
+    @Environment(\.theme) var theme: FluentUIStyle
+    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+    @ObservedObject var tokens: MSFPersonaButtonCarouselTokens
+    @ObservedObject var state: MSFPersonaCarouselStateImpl
+
+    let buttonSize: MSFPersonaButtonSize
+
+    public init(size: MSFPersonaButtonSize,
+                personaButtons: [MSFPersonaButtonStateImpl] = []) {
+        tokens = MSFPersonaButtonCarouselTokens(size: size)
+        state = MSFPersonaCarouselStateImpl(size: size, buttons: personaButtons)
+
+        buttonSize = size
+    }
+
     var body: some View {
-        // TODO: Create PersonaButtonCarousel
-        Text("Hello, World!")
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+                ForEach(state.buttons) { buttonState in
+                    PersonaButton(state: buttonState)
+                }
+            }
+        }
+        .background(Color(tokens.backgroundColor))
+        .designTokens(tokens,
+                      from: theme,
+                      with: windowProvider)
     }
 }

--- a/ios/FluentUI/Vnext/PersonaButtonCarousel/PersonaButtonCarouselTokens.swift
+++ b/ios/FluentUI/Vnext/PersonaButtonCarousel/PersonaButtonCarouselTokens.swift
@@ -3,16 +3,39 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
+import UIKit
 
 /// Representation of design tokens to controls at runtime which interfaces with the Design Token System auto-generated code.
 /// Updating these properties causes the SwiftUI controls to update its view automatically.
 class MSFPersonaButtonCarouselTokens: MSFTokensBase, ObservableObject {
+    @Published var backgroundColor: UIColor!
+
+    var size: MSFPersonaButtonSize {
+        didSet {
+            if oldValue != size {
+                updateForCurrentTheme()
+            }
+        }
+    }
+
+    init(size: MSFPersonaButtonSize) {
+        self.size = size
+
+        super.init()
+
+        self.themeAware = true
+
+        updateForCurrentTheme()
+    }
+
     @objc open func didChangeAppearanceProxy() {
         updateForCurrentTheme()
     }
 
     override func updateForCurrentTheme() {
-        // TODO: Create PersonaButtonCarousel
+        let currentTheme = theme
+        let appearanceProxy = currentTheme.MSFPersonaButtonCarouselTokens
+
+        backgroundColor = appearanceProxy.backgroundColor
     }
 }

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -336,7 +336,6 @@ AP_MSFListTokens:
 
 AP_MSFPersonaButtonCarouselTokens:
   backgroundColor: $Colors.Background.neutral1
-  itemHorizontalInterspace: $Spacing.medium
 
 AP_MSFPersonaButtonTokens:
   avatarInterspace: [ small: $Spacing.xSmall, large: $Spacing.small ]

--- a/tools/sgen/output/MSFPersonaButtonCarouselTokens.generated.swift
+++ b/tools/sgen/output/MSFPersonaButtonCarouselTokens.generated.swift
@@ -19,11 +19,6 @@ extension FluentUIStyle {
 		open var backgroundColor: UIColor {
 			return mainProxy().Colors.Background.neutral1
 		}
-
-		// MARK: - itemHorizontalInterspace 
-		open var itemHorizontalInterspace: CGFloat {
-			return mainProxy().Spacing.medium
-		}
 	}
 
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Implemented `PersonaButtonCarousel` and its UIKit projection, `MSFPersonaButtonCarousel`, along with expanding demo controller testability versus the legacy `ContactCollectionView`.

In implementing these controls, I also began migrating some classes/extensions into separate files to aid with readability.

### Verification

Tested on:
- iOS 13 and 14
- Small, medium, and large devices
- Small, medium, and large numbers of personas
- Adding and removing personas live while the control is visible

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![CCV](https://user-images.githubusercontent.com/4934719/123000024-dabd6380-d363-11eb-960e-9dd82b1952c8.png) | ![PBC](https://user-images.githubusercontent.com/4934719/123000045-e3159e80-d363-11eb-981b-9194189b9422.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/614)