### PR TITLE
Add simplified inits and `tag` to `CommandingItem`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -44,7 +44,9 @@ class BottomCommandingDemoController: UIViewController {
 
     private lazy var heroItems: [CommandingItem] = {
         return Array(1...5).map {
-            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction, selectedImage: homeSelectedImage)
+            let item = CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+            item.selectedImage = homeSelectedImage
+            return item
         }
     }()
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -366,8 +366,9 @@ open class BottomCommandingController: UIViewController {
 
     private func createAndBindHeroCommandView(with item: CommandingItem) -> UIView {
         let itemImage = item.image ?? UIImage()
-        let tabItem = TabBarItem(title: item.title ?? "", image: itemImage, selectedImage: item.selectedImage, largeContentImage: item.largeImage)
-        let itemView = TabBarItemView(item: tabItem, showsTitle: item.title != nil)
+        let itemTitle = item.title ?? ""
+        let tabItem = TabBarItem(title: itemTitle, image: itemImage, selectedImage: item.selectedImage, largeContentImage: item.largeImage)
+        let itemView = TabBarItemView(item: tabItem, showsTitle: itemTitle != "")
         itemView.alwaysShowTitleBelowImage = true
         itemView.numberOfTitleLines = 1
         itemView.isSelected = item.isOn

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -313,7 +313,7 @@ open class BottomCommandingController: UIViewController {
             tabBarItemView.isSelected.toggle()
             item.isOn = tabBarItemView.isSelected
         }
-        item.action(binding.item)
+        item.action?(binding.item)
     }
 
     @objc private func handleMoreButtonTap(_ sender: UITapGestureRecognizer) {
@@ -365,8 +365,9 @@ open class BottomCommandingController: UIViewController {
     }
 
     private func createAndBindHeroCommandView(with item: CommandingItem) -> UIView {
-        let tabItem = TabBarItem(title: item.title, image: item.image, selectedImage: item.selectedImage, largeContentImage: item.largeImage)
-        let itemView = TabBarItemView(item: tabItem, showsTitle: true)
+        let itemImage = item.image ?? UIImage()
+        let tabItem = TabBarItem(title: item.title ?? "", image: itemImage, selectedImage: item.selectedImage, largeContentImage: item.largeImage)
+        let itemView = TabBarItemView(item: tabItem, showsTitle: item.title != nil)
         itemView.alwaysShowTitleBelowImage = true
         itemView.numberOfTitleLines = 1
         itemView.isSelected = item.isOn
@@ -393,13 +394,13 @@ open class BottomCommandingController: UIViewController {
         iconView.tintColor = Constants.tableViewIconTintColor
 
         if item.isToggleable, let booleanCell = cell as? BooleanCell {
-            booleanCell.setup(title: item.title, customView: iconView, isOn: item.isOn)
+            booleanCell.setup(title: item.title ?? "", customView: iconView, isOn: item.isOn)
             booleanCell.onValueChanged = {
                 item.isOn = booleanCell.isOn
-                item.action(item)
+                item.action?(item)
             }
         } else {
-            cell.setup(title: item.title, customView: iconView)
+            cell.setup(title: item.title ?? "", customView: iconView)
         }
         cell.isEnabled = item.isEnabled
         cell.backgroundColor = Constants.tableViewBackgroundColor
@@ -595,18 +596,18 @@ extension BottomCommandingController: UITableViewDelegate {
             if presentedViewController != nil {
                 dismiss(animated: true)
             }
-            binding.item.action(binding.item)
+            binding.item.action?(binding.item)
         }
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 
 extension BottomCommandingController: CommandingItemDelegate {
-    func commandingItem(_ item: CommandingItem, didChangeTitleTo value: String) {
+    func commandingItem(_ item: CommandingItem, didChangeTitleTo value: String?) {
         reloadView(from: item)
     }
 
-    func commandingItem(_ item: CommandingItem, didChangeImageTo value: UIImage) {
+    func commandingItem(_ item: CommandingItem, didChangeImageTo value: UIImage?) {
         reloadView(from: item)
     }
 

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -56,7 +56,7 @@ open class CommandingItem: NSObject {
     /// Indicates whether the command is currently on.
     ///
     /// When `isToggleable` is `true`, this property is toggled automatically before `action` is called.
-    @objc open var isOn: Bool {
+    @objc open var isOn: Bool = false {
         didSet {
             if isOn != oldValue {
                 delegate?.commandingItem(self, didChangeOnTo: isOn)
@@ -65,7 +65,7 @@ open class CommandingItem: NSObject {
     }
 
     /// Indicates whether the command is enabled.
-    @objc open var isEnabled: Bool {
+    @objc open var isEnabled: Bool = true {
         didSet {
             if isEnabled != oldValue {
                 delegate?.commandingItem(self, didChangeEnabledTo: isEnabled)
@@ -74,41 +74,20 @@ open class CommandingItem: NSObject {
     }
 
     /// Applications can use this to keep track of items.
-	@objc public var tag: Int
+	@objc public var tag: Int = 0
 
     /// Indicates whether `isOn` should be toggled automatically before `action` is called.
     @objc public let isToggleable: Bool
 
-    @objc public init(title: String? = nil,
-                      image: UIImage? = nil,
-                      action: ((CommandingItem) -> Void)? = nil,
-                      isToggleable: Bool = false,
-                      selectedImage: UIImage? = nil,
-                      largeImage: UIImage? = nil,
-                      isOn: Bool = false,
-                      isEnabled: Bool = true,
-                      tag: Int = 0) {
+    @objc public init(title: String, image: UIImage, action: @escaping (CommandingItem) -> Void, isToggleable: Bool = false) {
         self.title = title
+        self.image = image
         self.action = action
         self.isToggleable = isToggleable
-        self.image = image
-        self.selectedImage = selectedImage
-        self.largeImage = largeImage
-        self.isOn = isOn
-        self.isEnabled = isEnabled
-        self.tag = tag
     }
 
-    // ObjC-only convenience inits
-
-    @available(*, unavailable)
-    @objc public convenience init(title: String?, image: UIImage?, action: ((CommandingItem) -> Void)?) {
-        self.init(title: title, image: image, action: action)
-    }
-
-    @available(*, unavailable)
-    @objc public override convenience init() {
-        self.init()
+    @objc public init(isToggleable: Bool = false) {
+        self.isToggleable = isToggleable
     }
 
     weak var delegate: CommandingItemDelegate?

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -79,7 +79,7 @@ open class CommandingItem: NSObject {
     /// Indicates whether `isOn` should be toggled automatically before `action` is called.
     @objc public let isToggleable: Bool
 
-    @objc public init(title: String = "",
+    @objc public init(title: String? = nil,
                       image: UIImage? = nil,
                       action: ((CommandingItem) -> Void)? = nil,
                       isToggleable: Bool = false,
@@ -97,6 +97,18 @@ open class CommandingItem: NSObject {
         self.isOn = isOn
         self.isEnabled = isEnabled
         self.tag = tag
+    }
+
+    // ObjC-only convenience inits
+
+    @available(*, unavailable)
+    @objc public convenience init(title: String?, image: UIImage?, action: ((CommandingItem) -> Void)?) {
+        self.init(title: title, image: image, action: action)
+    }
+
+    @available(*, unavailable)
+    @objc public override convenience init() {
+        self.init()
     }
 
     weak var delegate: CommandingItemDelegate?

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -13,10 +13,10 @@ import UIKit
 open class CommandingItem: NSObject {
 
     /// A closure that's called when the command is triggered
-    @objc open var action: (CommandingItem) -> Void
+    @objc open var action: ((CommandingItem) -> Void)?
 
     /// The title of the command item.
-    @objc open var title: String {
+    @objc open var title: String? {
         didSet {
             if title != oldValue {
                 delegate?.commandingItem(self, didChangeTitleTo: title)
@@ -25,7 +25,7 @@ open class CommandingItem: NSObject {
     }
 
     /// A `UIImage` to be displayed with the command.
-    @objc open var image: UIImage {
+    @objc open var image: UIImage? {
         didSet {
             if image != oldValue {
                 delegate?.commandingItem(self, didChangeImageTo: image)
@@ -73,17 +73,21 @@ open class CommandingItem: NSObject {
         }
     }
 
+    /// Applications can use this to keep track of items.
+	@objc public var tag: Int
+
     /// Indicates whether `isOn` should be toggled automatically before `action` is called.
     @objc public let isToggleable: Bool
 
-    @objc public init(title: String,
-                      image: UIImage,
-                      action: @escaping (CommandingItem) -> Void,
+    @objc public init(title: String = "",
+                      image: UIImage? = nil,
+                      action: ((CommandingItem) -> Void)? = nil,
                       isToggleable: Bool = false,
                       selectedImage: UIImage? = nil,
                       largeImage: UIImage? = nil,
                       isOn: Bool = false,
-                      isEnabled: Bool = true) {
+                      isEnabled: Bool = true,
+                      tag: Int = 0) {
         self.title = title
         self.action = action
         self.isToggleable = isToggleable
@@ -92,6 +96,7 @@ open class CommandingItem: NSObject {
         self.largeImage = largeImage
         self.isOn = isOn
         self.isEnabled = isEnabled
+        self.tag = tag
     }
 
     weak var delegate: CommandingItemDelegate?
@@ -99,10 +104,10 @@ open class CommandingItem: NSObject {
 
 protocol CommandingItemDelegate: AnyObject {
     /// Called after the `title` property changed.
-    func commandingItem(_ item: CommandingItem, didChangeTitleTo value: String)
+    func commandingItem(_ item: CommandingItem, didChangeTitleTo value: String?)
 
     /// Called after the `image` property changed.
-    func commandingItem(_ item: CommandingItem, didChangeImageTo value: UIImage)
+    func commandingItem(_ item: CommandingItem, didChangeImageTo value: UIImage?)
 
     /// Called after the `largeImage` property changed.
     func commandingItem(_ item: CommandingItem, didChangeLargeImageTo value: UIImage?)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Some objc clients need an init that just takes title/image/action. Separately, for integration that I'm working on I need a simple init(), because most of the properties are filled during a separate binding process.

I also added a new tag property to help application-side tracking of the items.

### Verification
Sanity checks + manually checked the bridging header to verify the objc inits are there.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/615)