### PR TITLE
Add a sheet expansion button to `BottomCommandingController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -64,6 +64,7 @@ class BottomCommandingDemoController: UIViewController {
 
     private lazy var demoOptionItems: [DemoItem] = {
         return [DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: false),
+                DemoItem(title: "Sheet more button", type: .boolean, action: #selector(toggleSheetMoreButton), isOn: true),
                 DemoItem(title: "Expanded list items", type: .boolean, action: #selector(toggleExpandedItems), isOn: true),
                 DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff)),
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: true),
@@ -79,6 +80,10 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func toggleHidden() {
         bottomCommandingController?.isHidden.toggle()
+    }
+
+    @objc private func toggleSheetMoreButton() {
+        bottomCommandingController?.prefersSheetMoreButtonVisible.toggle()
     }
 
     @objc private func toggleExpandedItems() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -43,7 +43,7 @@ class BottomCommandingDemoController: UIViewController {
     }
 
     private lazy var heroItems: [CommandingItem] = {
-        return Array(1...5).map {
+        return Array(1...4).map {
             CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction, selectedImage: homeSelectedImage)
         }
     }()
@@ -89,7 +89,7 @@ class BottomCommandingDemoController: UIViewController {
         }
     }
 
-    private let modifiedCommandIndices: [Int] = [0, 2, 4]
+    private let modifiedCommandIndices: [Int] = [0, 3]
 
     @objc private func toggleHeroCommandOnOff() {
         modifiedCommandIndices.forEach {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -272,10 +272,7 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    private lazy var moreHeroItem: CommandingItem = {
-        let item = CommandingItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage(), action: handleMoreCommandTap)
-        return item
-    }()
+    private lazy var moreHeroItem: CommandingItem = CommandingItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage(), action: handleMoreCommandTap)
 
     private lazy var heroCommandStack: UIStackView = {
         let stackView = UIStackView()

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -95,8 +95,12 @@ open class BottomCommandingController: UIViewController {
     }
 
     /// Indicates whether a more button is visible in the sheet style when `expandedListSections` is non-empty.
-    /// Tapping the button will expand/collapse the sheet or show a popover in the bottom bar..
-    @objc open var prefersSheetMoreButtonVisible: Bool = true
+    /// Tapping the button will expand or collapse the sheet.
+    @objc open var prefersSheetMoreButtonVisible: Bool = true {
+        didSet {
+            reloadHeroCommandStack()
+        }
+    }
 
     // MARK: - View building and layout
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -25,13 +25,13 @@ open class BottomCommandingController: UIViewController {
     /// At most 5 hero items are supported.
     @objc open var heroItems: [CommandingItem] = [] {
         willSet {
-            clearAllItemViews(in: .heroSet)
+            heroItems.forEach { removeBinding(for: $0) }
         }
         didSet {
             precondition(heroItems.count <= 5, "At most 5 hero commands are supported.")
 
-            if isHeroCommandStackLoaded {
-                heroItems.forEach { heroCommandStack.addArrangedSubview(createAndBindHeroCommandView(with: $0)) }
+            if isViewLoaded {
+                reloadHeroCommandStack()
             }
         }
     }
@@ -39,7 +39,9 @@ open class BottomCommandingController: UIViewController {
     /// Sections with items to be displayed in the list area.
     @objc open var expandedListSections: [CommandingSection] = [] {
         willSet {
-            clearAllItemViews(in: .list)
+            expandedListSections.forEach { section in
+                section.items.forEach { item in removeBinding(for: item) }
+            }
         }
         didSet {
             expandedListSections.forEach { section in
@@ -49,7 +51,10 @@ open class BottomCommandingController: UIViewController {
                 // Item views and bindings will be lazily created during UITableView cellForRowAt
                 tableView.reloadData()
             }
-            updateExpandability()
+            if isViewLoaded {
+                reloadHeroCommandStack()
+                updateExpandabilityConstraints()
+            }
         }
     }
 
@@ -88,6 +93,10 @@ open class BottomCommandingController: UIViewController {
             }
         }
     }
+
+    /// Indicates whether a more button is visible in the sheet style when `expandedListSections` is non-empty.
+    /// Tapping the button will expand/collapse the sheet or show a popover in the bottom bar..
+    @objc open var prefersSheetMoreButtonVisible: Bool = true
 
     // MARK: - View building and layout
 
@@ -138,12 +147,7 @@ open class BottomCommandingController: UIViewController {
         NSLayoutConstraint.activate(heroCommandWidthConstraints)
         heroCommandStack.distribution = .equalSpacing
 
-        let commandContainer = UIStackView()
-        commandContainer.translatesAutoresizingMaskIntoConstraints = false
-        commandContainer.addArrangedSubview(heroCommandStack)
-        commandContainer.addArrangedSubview(moreButtonView)
-
-        let bottomBarView = makeBottomBarByEmbedding(contentView: commandContainer)
+        let bottomBarView = makeBottomBarByEmbedding(contentView: heroCommandStack)
         bottomBarView.translatesAutoresizingMaskIntoConstraints = false
         bottomBarView.isHidden = isHidden
         view.addSubview(bottomBarView)
@@ -157,7 +161,8 @@ open class BottomCommandingController: UIViewController {
 
         bottomBarViewBottomConstraint = bottomConstraint
         self.bottomBarView = bottomBarView
-        updateExpandability()
+        updateExpandabilityConstraints()
+        reloadHeroCommandStack()
     }
 
     private func setupBottomSheetLayout() {
@@ -192,7 +197,8 @@ open class BottomCommandingController: UIViewController {
         ])
 
         bottomSheetController = sheetController
-        updateExpandability()
+        updateExpandabilityConstraints()
+        reloadHeroCommandStack()
     }
 
     private func makeBottomBarByEmbedding(contentView: UIView) -> UIView {
@@ -246,42 +252,31 @@ open class BottomCommandingController: UIViewController {
         return view
     }
 
-    private func updateExpandability() {
+    private func reloadHeroCommandStack() {
+        let heroViews = extendedHeroItems.map { createAndBindHeroCommandView(with: $0) }
+        heroCommandStack.removeAllSubviews()
+        heroViews.forEach {heroCommandStack.addArrangedSubview($0) }
+    }
+
+    private func updateExpandabilityConstraints() {
         if isInSheetMode,
            let bottomSheetController = bottomSheetController,
            let heroStackTopConstraint = bottomSheetHeroStackTopConstraint {
             bottomSheetController.isExpandable = isExpandable
             bottomSheetController.collapsedContentHeight = bottomSheetHeroStackHeight
             heroStackTopConstraint.constant = bottomSheetHeroStackTopMargin
-        } else {
-            moreButtonView.isHidden = !isExpandable
         }
     }
 
-    private lazy var moreButtonView: UIView = {
-        let moreButtonItem = TabBarItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage())
-        let moreButtonView = TabBarItemView(item: moreButtonItem, showsTitle: true)
-        moreButtonView.alwaysShowTitleBelowImage = true
-        moreButtonView.accessibilityTraits.insert(.button)
-
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleMoreButtonTap(_:)))
-        moreButtonView.addGestureRecognizer(tapGesture)
-
-        NSLayoutConstraint.activate([
-            moreButtonView.widthAnchor.constraint(equalToConstant: Constants.heroButtonWidth),
-            moreButtonView.heightAnchor.constraint(equalToConstant: Constants.heroButtonHeight)
-        ])
-
-        return moreButtonView
+    private lazy var moreHeroItem: CommandingItem = {
+        let item = CommandingItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage(), action: handleMoreCommandTap)
+        return item
     }()
 
     private lazy var heroCommandStack: UIStackView = {
-        let itemViews = heroItems.map { createAndBindHeroCommandView(with: $0) }
-        let stackView = UIStackView(arrangedSubviews: itemViews)
+        let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addInteraction(UILargeContentViewerInteraction())
-
-        isHeroCommandStackLoaded = true
         return stackView
     }()
 
@@ -316,26 +311,35 @@ open class BottomCommandingController: UIViewController {
         item.action(binding.item)
     }
 
-    @objc private func handleMoreButtonTap(_ sender: UITapGestureRecognizer) {
-        let popoverContentViewController = UIViewController()
-        popoverContentViewController.view.addSubview(tableView)
-        popoverContentViewController.modalPresentationStyle = .popover
-        popoverContentViewController.popoverPresentationController?.sourceView = sender.view
+    @objc private func handleMoreCommandTap(_ sender: CommandingItem) {
+        if isInSheetMode,
+           let sheetController = bottomSheetController {
+            sheetController.isExpanded.toggle()
+        } else if let binding = itemToBindingMap[sender] {
+            let moreButtonView = binding.view
+            let popoverContentViewController = UIViewController()
+            popoverContentViewController.view.addSubview(tableView)
+            popoverContentViewController.modalPresentationStyle = .popover
+            popoverContentViewController.popoverPresentationController?.sourceView = moreButtonView
 
-        NSLayoutConstraint.activate([
-            tableView.leadingAnchor.constraint(equalTo: popoverContentViewController.view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: popoverContentViewController.view.trailingAnchor),
-            tableView.topAnchor.constraint(equalTo: popoverContentViewController.view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: popoverContentViewController.view.bottomAnchor)
-        ])
-
-        present(popoverContentViewController, animated: true)
+            NSLayoutConstraint.activate([
+                tableView.leadingAnchor.constraint(equalTo: popoverContentViewController.view.leadingAnchor),
+                tableView.trailingAnchor.constraint(equalTo: popoverContentViewController.view.trailingAnchor),
+                tableView.topAnchor.constraint(equalTo: popoverContentViewController.view.topAnchor),
+                tableView.bottomAnchor.constraint(equalTo: popoverContentViewController.view.bottomAnchor)
+            ])
+            present(popoverContentViewController, animated: true)
+        }
     }
 
     // MARK: - Item <-> View Binding
 
     private func addBinding(_ binding: ItemBindingInfo) {
-        itemToBindingMap[binding.item] = binding
+        let item = binding.item
+        if itemToBindingMap[item] != nil {
+            removeBinding(for: item)
+        }
+        itemToBindingMap[item] = binding
         viewToBindingMap[binding.view] = binding
     }
 
@@ -344,23 +348,9 @@ open class BottomCommandingController: UIViewController {
         viewToBindingMap.removeValue(forKey: binding.view)
     }
 
-    private func clearAllItemViews(in location: ItemLocation) {
-        switch location {
-        case .heroSet:
-            heroItems.forEach {
-                if let binding = itemToBindingMap[$0] {
-                    removeBinding(binding)
-                }
-            }
-            heroCommandStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        case .list:
-            expandedListSections.forEach {
-                $0.items.forEach {
-                    if let binding = itemToBindingMap[$0] {
-                        removeBinding(binding)
-                    }
-                }
-            }
+    private func removeBinding(for item: CommandingItem) {
+        if let binding = itemToBindingMap[item] {
+            removeBinding(binding)
         }
     }
 
@@ -370,14 +360,13 @@ open class BottomCommandingController: UIViewController {
         itemView.alwaysShowTitleBelowImage = true
         itemView.numberOfTitleLines = 1
         itemView.isSelected = item.isOn
+        itemView.isEnabled = item.isEnabled
         itemView.accessibilityTraits.insert(.button)
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleHeroCommandTap(_:)))
         itemView.addGestureRecognizer(tapGesture)
 
-        NSLayoutConstraint.activate([
-            itemView.heightAnchor.constraint(equalToConstant: Constants.heroButtonHeight)
-        ])
+        itemView.heightAnchor.constraint(equalToConstant: Constants.heroButtonHeight).isActive = true
         let widthConstraint = itemView.widthAnchor.constraint(equalToConstant: Constants.heroButtonWidth)
         widthConstraint.isActive = !isInSheetMode
 
@@ -442,8 +431,6 @@ open class BottomCommandingController: UIViewController {
 
     private var bottomSheetController: BottomSheetController?
 
-    private var isHeroCommandStackLoaded: Bool = false
-
     private var isTableViewLoaded: Bool = false
 
     private var isInSheetMode: Bool { bottomSheetController != nil }
@@ -458,8 +445,14 @@ open class BottomCommandingController: UIViewController {
 
     private var bottomSheetHeroStackHeight: CGFloat { Constants.heroButtonHeight + bottomSheetHeroStackTopMargin }
 
+    // Hero items that include the more button if it should be shown
+    private var extendedHeroItems: [CommandingItem] {
+        let shouldShowMoreButton = isExpandable && (prefersSheetMoreButtonVisible || !isInSheetMode)
+        return heroItems + (shouldShowMoreButton ? [moreHeroItem] : [])
+    }
+
     private var heroCommandWidthConstraints: [NSLayoutConstraint] {
-        heroItems.compactMap { (itemToBindingMap[$0] as? HeroItemBindingInfo)?.widthConstraint }
+        extendedHeroItems.compactMap { (itemToBindingMap[$0] as? HeroItemBindingInfo)?.widthConstraint }
     }
 
     private var bottomBarHidingAnimator: UIViewPropertyAnimator?

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -91,6 +91,19 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// Indicates if the bottom sheet is expanded.
+    @objc open var isExpanded: Bool {
+        get {
+            return currentExpansionState == .expanded
+        }
+        set {
+            guard !isHidden && isExpandable else {
+                return
+            }
+            move(to: newValue ? .expanded : .collapsed)
+        }
+    }
+
     /// Fraction of the available area that the bottom sheet should take up in the expanded position.
     @objc open var expandedHeightFraction: CGFloat = 1.0 {
         didSet {
@@ -258,15 +271,11 @@ public class BottomSheetController: UIViewController {
     // MARK: - Gesture handling
 
     @objc private func handleResizingHandleViewTap(_ sender: UITapGestureRecognizer) {
-        if currentOffsetFromBottom != offset(for: .collapsed) {
-            move(to: .collapsed, velocity: 0)
-        } else {
-            move(to: .expanded, velocity: 0)
-        }
+        isExpanded.toggle()
     }
 
     private func updateResizingHandleViewAccessibility() {
-        if currentOffsetFromBottom != offset(for: .collapsed) {
+        if currentExpansionState == .expanded {
             resizingHandleView.accessibilityLabel = "Accessibility.Drawer.ResizingHandle.Label.Collapse".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
         } else {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -97,10 +97,9 @@ public class BottomSheetController: UIViewController {
             return currentExpansionState == .expanded
         }
         set {
-            guard !isHidden && isExpandable else {
-                return
+            if !isHidden && isExpandable {
+                move(to: newValue ? .expanded : .collapsed)
             }
-            move(to: newValue ? .expanded : .collapsed)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

After some experimentation we decided to add a "More" button as the last hero command to help discoverability. This button either expands or collapses the sheet.

`BottomSheetController.swift`
Add an `isExpanded` property to let the `BottomCommandingController` programmatically expand the sheet.

`BottomCommandingController.swift`
Add the internal `CommandingItem` that represents the more button. Change the hero stack building code to account for variants with and without the more button. The code is now reused for the internal and external hero items.
I also added a `prefersSheetMoreButtonVisible` property to turn the sheet more button on and off. This doesn't affect the bar button because that's always necessary to show the expanded item popover.

`BottomCommandingDemoController.swift `
Add a toggle for the more button setting.
Also reduce the number of actual hero items to 4. This ensures that with the more button we're at the former limit of 5. While we currently technically support 5 hero commands + the more button, it's not recommended and the hero item limit might go down to 4 in the future (still being discussed).
### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 12 - 2021-06-24 at 21 41 09](https://user-images.githubusercontent.com/3610850/123370622-f62b9880-d534-11eb-9f3c-66aa370236cd.png)|![Simulator Screen Shot - iPhone 12 - 2021-06-24 at 21 49 24](https://user-images.githubusercontent.com/3610850/123371192-17d94f80-d536-11eb-9518-32855be1775a.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/616)