### PR TITLE
[vNext] Fix `Avatar` image rendering mode

### DIFF
--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -227,8 +227,15 @@ public struct AvatarView: View {
                                                                                     backgroundColor))
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
-        let avatarImage: UIImage? = ((style == .outlined || style == .outlinedPrimary) ? UIImage.staticImageNamed("person_48_regular") :
-                                        (shouldUseDefaultImage ? UIImage.staticImageNamed("person_48_filled") : state.image))
+        let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
+            if style == .outlined || style == .outlinedPrimary {
+                return (UIImage.staticImageNamed("person_48_regular"), .template)
+            } else if shouldUseDefaultImage {
+                return (UIImage.staticImageNamed("person_48_filled"), .template)
+            } else {
+                return (state.image, .original)
+            }
+        }()
         let avatarImageSizeRatio: CGFloat = (shouldUseDefaultImage) ? 0.7 : 1
 
         let accessibilityLabel: String = {
@@ -244,9 +251,9 @@ public struct AvatarView: View {
 
         @ViewBuilder
         var avatarContent: some View {
-            if let image = avatarImage {
+            if let image = avatarImageInfo.image {
                 Image(uiImage: image)
-                    .renderingMode(.original)
+                    .renderingMode(avatarImageInfo.renderingMode)
                     .resizable()
                     .foregroundColor(Color(foregroundColor))
             } else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Problem: a while back, I added a forced `.renderingMode(.original)` to the `Image` inside `Avatar` to fix an issue with iOS 13. Specifically, when you embed an `Image` inside a `Button` in iOS 13, that `Image` is always forced to a `.template` rendering mode. I manually specified `.original`, and the issue went away for `Avatar`s with an actual image.

Problem is, sometimes it really *does* need to be rendered with a `renderingMode` of `.template`, depending on which image we're drawing. So this change adds a bit more sophisticated logic to determine which mode to render.

### Verification

Compared `Avatar` controls with all modes of image, both inside and outside a button, on both iOS 13 and iOS 14.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/123585196-9aad1500-d797-11eb-8ab0-44e494c9d68e.png) | ![after](https://user-images.githubusercontent.com/4934719/123585191-98e35180-d797-11eb-866a-330ccfa309a7.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/617)