### PR TITLE
Add image support for borderless button style

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -84,9 +84,9 @@ extension ButtonStyle {
         switch self {
         case .primaryFilled, .primaryOutline:
             return UIImage(named: "Placeholder_24")!
-        case .secondaryOutline:
+        case .secondaryOutline, .borderless:
             return UIImage(named: "Placeholder_20")!
-        case .tertiaryOutline, .borderless:
+        case .tertiaryOutline:
             return nil
         }
     }

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -71,9 +71,9 @@ public enum ButtonStyle: Int, CaseIterable {
         switch self {
         case .primaryFilled, .primaryOutline:
             return 10
-        case .secondaryOutline:
+        case .secondaryOutline, .borderless:
             return 8
-        case .tertiaryOutline, .borderless:
+        case .tertiaryOutline:
             return 0
         }
     }
@@ -114,7 +114,7 @@ open class Button: UIButton {
 
     /// The button's image.
     /// For ButtonStyle.primaryFilled and ButtonStyle.primaryOutline, the image must be 24x24.
-    /// For ButtonStyle.secondaryOutline, the image must be 20x20.
+    /// For ButtonStyle.secondaryOutline and ButtonStyle.borderless, the image must be 20x20.
     /// For other styles, the image is not displayed.
     @objc open var image: UIImage? {
         didSet {
@@ -241,7 +241,7 @@ open class Button: UIButton {
     }
 
     private func updateImage() {
-        let isDisplayingImage = (style == .primaryFilled || style == .primaryOutline || style == .secondaryOutline) && image != nil
+        let isDisplayingImage = (style == .primaryFilled || style == .primaryOutline || style == .secondaryOutline || style == .borderless) && image != nil
 
         if let window = window {
             let normalColor = normalTitleAndImageColor(for: window)

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -241,7 +241,7 @@ open class Button: UIButton {
     }
 
     private func updateImage() {
-        let isDisplayingImage = (style == .primaryFilled || style == .primaryOutline || style == .secondaryOutline || style == .borderless) && image != nil
+        let isDisplayingImage = style != .tertiaryOutline && image != nil
 
         if let window = window {
             let normalColor = normalTitleAndImageColor(for: window)


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

Files are only related to ios.

### Description of changes

#### Button.swift
Added support for having an image on a button that is styled as `.borderless`. Also updated a comment about the size supported for an image and added spacing between the image and label of a `.borderless` button.

#### ButtonDemoController.swift
Added examples of the `.borderless` style with an image.

### Verification

Manually tested the change in the demo application to show that current uses of the button (no image specified), still work correctly alongside buttons that do have an image.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/21343215/123683288-e3e57f00-d800-11eb-8751-1cfeeff77d33.png) | ![image](https://user-images.githubusercontent.com/21343215/123683344-f364c800-d800-11eb-8e7a-d9eb6b41f28c.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/618)