### PR TITLE
fix VO order for segmented control in ColorDemoController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -60,13 +60,13 @@ class DemoListViewController: UITableViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if isFirstLaunch {
+        if DemoListViewController.isFirstLaunch {
             if let lastDemoController = UserDefaults.standard.string(forKey: DemoListViewController.lastDemoControllerKey),
                 let index = demos.firstIndex(where: { $0.title == lastDemoController }) {
                 tableView(tableView, didSelectRowAt: IndexPath(row: index, section: 0))
             }
 
-            isFirstLaunch = false
+            DemoListViewController.isFirstLaunch = false
         } else {
             UserDefaults.standard.set(nil, forKey: DemoListViewController.lastDemoControllerKey)
         }
@@ -97,6 +97,6 @@ class DemoListViewController: UITableViewController {
     }
 
     let cellReuseIdentifier: String = "TableViewCell"
-    private var isFirstLaunch: Bool = true
+    private static var isFirstLaunch: Bool = true
     private static let lastDemoControllerKey: String = "LastDemoController"
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -129,7 +129,7 @@ class ColorDemoController: UIViewController {
         super.viewDidAppear(animated)
         navigationController?.navigationBar.shadowImage = UIImage()
         if let window = view.window {
-            segmentedControl.selectedSegmentIndex = colorProviderThemedWindowTypes.firstIndex(where: { return window.isKind(of: $0.windowType) }) ?? 0
+        segmentedControl.selectedSegmentIndex = colorProviderThemes.firstIndex(where: { return window.isKind(of: $0.demoColorTheme.windowType) }) ?? 0
         }
     }
 
@@ -139,14 +139,14 @@ class ColorDemoController: UIViewController {
     }
 
     private lazy var segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: colorProviderThemedWindowTypes.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
+        let segmentedControl = SegmentedControl(items: colorProviderThemes.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
         segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
         return segmentedControl
     }()
 
     @objc private func segmentedControlValueChanged(sender: Any) {
         if let segmentedControl = sender as? SegmentedControl {
-            let window = colorProviderThemedWindows[segmentedControl.selectedSegmentIndex].window
+            let window = colorProviderThemes[segmentedControl.selectedSegmentIndex].demoColorTheme.window
             if let colorProvider = window as? ColorProviding {
                 Colors.setProvider(provider: colorProvider, for: window)
             }
@@ -156,13 +156,14 @@ class ColorDemoController: UIViewController {
     }
 
     private let tableView = UITableView(frame: .zero, style: .grouped)
-    private let colorProviderThemedWindowTypes: [(name: String, windowType: UIWindow.Type)] = [("Default", DemoColorThemeDefaultWindow.self),
-                                                                                               ("Green", DemoColorThemeGreenWindow.self),
-                                                                                               ("None", UIWindow.self)]
+        private let colorProviderThemes: [(name: String, demoColorTheme: DemoColorTheme)] = [("Default", DemoColorTheme.init(window: DemoColorThemeDefaultWindow(), windowType: DemoColorThemeDefaultWindow.self)),
+                                                                                             ("Green", DemoColorTheme.init(window: DemoColorThemeGreenWindow(), windowType: DemoColorThemeGreenWindow.self)),
+                                                                                             ("None", DemoColorTheme.init(window: UIWindow(), windowType: UIWindow.self))]
 
-    private let colorProviderThemedWindows: [(name: String, window: UIWindow)] = [("Default", DemoColorThemeDefaultWindow()),
-                                                                                               ("Green", DemoColorThemeGreenWindow()),
-                                                                                               ("None", UIWindow())]
+    struct DemoColorTheme {
+        var window: UIWindow
+        var windowType: UIWindow.Type
+    }
 }
 
 // MARK: - ColorDemoController: UITableViewDelegate
@@ -192,7 +193,7 @@ extension ColorDemoController: UITableViewDataSource {
             return UITableViewCell()
         }
 
-        let window = colorProviderThemedWindows[segmentedControl.selectedSegmentIndex].window
+        let window = colorProviderThemes[segmentedControl.selectedSegmentIndex].demoColorTheme.window
         let section = sections[indexPath.section]
         let colorView = section.colorViews[indexPath.row]
         colorView.updateColorView(window: window)
@@ -227,13 +228,11 @@ class DemoColorView: UIView {
         return CGSize(width: 30, height: 30)
     }
 
-	func updateColorView(window: UIWindow)
-	{
-		if let colorProvider = colorProvider
-		{
-			backgroundColor = colorProvider(window)
-		}
-	}
+    func updateColorView(window: UIWindow) {
+        if let colorProvider = colorProvider {
+            backgroundColor = colorProvider(window)
+        }
+    }
 }
 
 struct DemoColorSection {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -129,7 +129,7 @@ class ColorDemoController: UIViewController {
         super.viewDidAppear(animated)
         navigationController?.navigationBar.shadowImage = UIImage()
         if let window = view.window {
-        segmentedControl.selectedSegmentIndex = colorProviderThemes.firstIndex(where: { return window.isKind(of: $0.demoColorTheme.windowType) }) ?? 0
+            segmentedControl.selectedSegmentIndex = colorProviderThemes.firstIndex(where: { return window.isKind(of: $0.demoColorTheme.windowType) }) ?? 0
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -117,6 +117,9 @@ class ColorDemoController: UIViewController {
         view.addSubview(stackView)
         view.backgroundColor = Colors.NavigationBar.background
 
+        let window = ColorDemoController.themeWindowType
+        segmentedControl.selectedSegmentIndex = colorProviderThemes.firstIndex(where: { $0.demoColorTheme.windowType == window }) ?? 0
+
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -128,9 +131,6 @@ class ColorDemoController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         navigationController?.navigationBar.shadowImage = UIImage()
-        if let window = view.window {
-            segmentedControl.selectedSegmentIndex = colorProviderThemes.firstIndex(where: { return window.isKind(of: $0.demoColorTheme.windowType) }) ?? 0
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -148,6 +148,7 @@ class ColorDemoController: UIViewController {
         if let segmentedControl = sender as? SegmentedControl {
             let windowType = colorProviderThemes[segmentedControl.selectedSegmentIndex].demoColorTheme.windowType
             let colorThemeHost = view.window?.windowScene?.delegate as? ColorThemeHosting
+            ColorDemoController.themeWindowType = windowType
 
             if let navigationController = navigationController {
                 navigationController.popViewController(animated: false)
@@ -163,6 +164,7 @@ class ColorDemoController: UIViewController {
         tableView.reloadData()
     }
 
+    private static var themeWindowType: UIWindow.Type = DemoColorThemeDefaultWindow.self
     private let tableView = UITableView(frame: .zero, style: .grouped)
     private let colorProviderThemes: [(name: String, demoColorTheme: DemoColorTheme)] = [("Default", DemoColorTheme.init(window: DemoColorThemeDefaultWindow(), windowType: DemoColorThemeDefaultWindow.self)),
                                                                                          ("Green", DemoColorTheme.init(window: DemoColorThemeGreenWindow(), windowType: DemoColorThemeGreenWindow.self)),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -153,6 +153,11 @@ class ColorDemoController: UIViewController {
             if let navigationController = navigationController {
                 navigationController.popViewController(animated: false)
                 colorThemeHost?.updateToWindowWith(type: windowType, pushing: self)
+                UIAccessibility.post(notification: .screenChanged, argument: self.segmentedControl.segmentView(at:segmentedControl.selectedSegmentIndex))
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100))
+                {
+                    UIAccessibility.post(notification: .announcement, argument: self.segmentedControl.segmentView(at:segmentedControl.selectedSegmentIndex)?.accessibilityIdentifier)
+                }
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

fix VO order for segmented control in ColorDemoController by setting a new color provider and reloading the table view when switching themes rather than popping a new view controller which makes the VO start over at the back button when it should stay on the selected control

### Verification

tested on iPad and ensured VO maintained its focus on the newly selected segmented control (mimicking native UI behavior) and announced the proper label after

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/619)