### PR TITLE
Adjust width of persona button from size category

### DIFF
--- a/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButtonTokens.generated.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButtonTokens.generated.swift
@@ -69,28 +69,6 @@ extension FluentUIStyle {
 		}
 
 
-		// MARK: - labelWidth
-		open var labelWidth: labelWidthAppearanceProxy {
-			return labelWidthAppearanceProxy(proxy: mainProxy)
-		}
-		open class labelWidthAppearanceProxy {
-			public let mainProxy: () -> FluentUIStyle
-			public init(proxy: @escaping () -> FluentUIStyle) {
-				self.mainProxy = proxy
-			}
-
-			// MARK: - large 
-			open var large: CGFloat {
-				return CGFloat(72.0)
-			}
-
-			// MARK: - small 
-			open var small: CGFloat {
-				return CGFloat(52.0)
-			}
-		}
-
-
 		// MARK: - padding 
 		open var padding: CGFloat {
 			return mainProxy().Spacing.xSmall

--- a/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButtonTokens.generated.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/MSFPersonaButtonTokens.generated.swift
@@ -42,6 +42,33 @@ extension FluentUIStyle {
 			return mainProxy().Colors.Background.neutral1
 		}
 
+		// MARK: - horizontalAvatarPadding
+		open var horizontalAvatarPadding: horizontalAvatarPaddingAppearanceProxy {
+			return horizontalAvatarPaddingAppearanceProxy(proxy: mainProxy)
+		}
+		open class horizontalAvatarPaddingAppearanceProxy {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			// MARK: - large 
+			open var large: CGFloat {
+				return mainProxy().Spacing.xSmall
+			}
+
+			// MARK: - small 
+			open var small: CGFloat {
+				return mainProxy().Spacing.medium
+			}
+		}
+
+
+		// MARK: - horizontalTextPadding 
+		open var horizontalTextPadding: CGFloat {
+			return mainProxy().Spacing.xxxSmall
+		}
+
 		// MARK: - labelColor 
 		open var labelColor: UIColor {
 			return mainProxy().Colors.Foreground.neutral1
@@ -69,11 +96,6 @@ extension FluentUIStyle {
 		}
 
 
-		// MARK: - padding 
-		open var padding: CGFloat {
-			return mainProxy().Spacing.xSmall
-		}
-
 		// MARK: - sublabelColor 
 		open var sublabelColor: UIColor {
 			return mainProxy().Colors.Foreground.neutral3
@@ -82,6 +104,11 @@ extension FluentUIStyle {
 		// MARK: - sublabelFont 
 		open var sublabelFont: UIFont {
 			return mainProxy().Typography.footnote
+		}
+
+		// MARK: - verticalPadding 
+		open var verticalPadding: CGFloat {
+			return mainProxy().Spacing.xSmall
 		}
 	}
 

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -239,30 +239,30 @@ public struct PersonaButton: View {
                     .foregroundColor(Color(tokens.sublabelColor))
             }
         }
-        .padding(.horizontal, tokens.padding)
+        .padding(.horizontal, tokens.horizontalTextPadding)
     }
 
     @ViewBuilder
     private var avatarView: some View {
         AvatarView(state.avatarState)
-            .padding(.top, tokens.padding)
+            .padding(.top, tokens.verticalPadding)
             .padding(.bottom, tokens.avatarInterspace)
     }
 
     /// Width of the button is conditional on the current size category
     private func adjustedWidth() -> CGFloat {
-        return state.avatarState.size.size + (2 * tokens.padding) + {
+        return state.avatarState.size.size + (2 * tokens.horizontalAvatarPadding) + {
             switch UITraitCollection.current.preferredContentSizeCategory {
             case .accessibilityMedium:
                 return 20
             case .accessibilityLarge:
-                return 50
+                return 32
             case .accessibilityExtraLarge:
-                return 60
+                return 48
             case .accessibilityExtraExtraLarge:
-                return 70
+                return 64
             case .accessibilityExtraExtraExtraLarge:
-                return 100
+                return 80
             default:
                 return 0
             }
@@ -276,7 +276,7 @@ public struct PersonaButton: View {
             VStack(spacing: 0) {
                 avatarView
                 personaText
-                Spacer(minLength: tokens.padding)
+                Spacer(minLength: tokens.verticalPadding)
             }
         }
         .background(Color(tokens.backgroundColor))

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -271,7 +271,7 @@ public struct PersonaButton: View {
 
     public var body: some View {
         let action = state.onTapAction ?? {}
-        let adjustedWidth = adjustedWidth()
+        let adjustedWidth = self.adjustedWidth()
         Button(action: action) {
             VStack(spacing: 0) {
                 avatarView

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -250,9 +250,9 @@ public struct PersonaButton: View {
     }
 
     /// Width of the button is conditional on the current size category
-    private func adjustedWidth() -> CGFloat {
+    private var adjustedWidth: CGFloat {
         return state.avatarState.size.size + (2 * tokens.horizontalAvatarPadding) + {
-            switch UITraitCollection.current.preferredContentSizeCategory {
+            switch sizeCategory {
             case .accessibilityMedium:
                 return 20
             case .accessibilityLarge:
@@ -271,7 +271,6 @@ public struct PersonaButton: View {
 
     public var body: some View {
         let action = state.onTapAction ?? {}
-        let adjustedWidth = self.adjustedWidth()
         Button(action: action) {
             VStack(spacing: 0) {
                 avatarView
@@ -279,8 +278,8 @@ public struct PersonaButton: View {
                 Spacer(minLength: tokens.verticalPadding)
             }
         }
-        .background(Color(tokens.backgroundColor))
         .frame(minWidth: adjustedWidth, maxWidth: adjustedWidth, minHeight: 0, maxHeight: .infinity)
+        .background(Color(tokens.backgroundColor))
         .designTokens(tokens,
                       from: theme,
                       with: windowProvider)

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButtonTokens.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButtonTokens.swift
@@ -34,11 +34,13 @@ import UIKit
 class MSFPersonaButtonTokens: MSFTokensBase, ObservableObject {
     @Published public var avatarInterspace: CGFloat!
     @Published public var backgroundColor: UIColor!
+    @Published public var horizontalAvatarPadding: CGFloat!
+    @Published public var horizontalTextPadding: CGFloat!
     @Published public var labelColor: UIColor!
     @Published public var labelFont: UIFont!
-    @Published public var padding: CGFloat!
     @Published public var sublabelColor: UIColor!
     @Published public var sublabelFont: UIFont!
+    @Published public var verticalPadding: CGFloat!
 
     var size: MSFPersonaButtonSize {
         didSet {
@@ -67,18 +69,21 @@ class MSFPersonaButtonTokens: MSFTokensBase, ObservableObject {
         let appearanceProxy = currentTheme.MSFPersonaButtonTokens
 
         backgroundColor = appearanceProxy.backgroundColor
+        horizontalTextPadding = appearanceProxy.horizontalTextPadding
         labelColor = appearanceProxy.labelColor
-        padding = appearanceProxy.padding
         sublabelColor = appearanceProxy.sublabelColor
         sublabelFont = appearanceProxy.sublabelFont
+        verticalPadding = appearanceProxy.verticalPadding
 
         switch size {
         case .small:
             avatarInterspace = appearanceProxy.avatarInterspace.small
             labelFont = appearanceProxy.labelFont.small
+            horizontalAvatarPadding = appearanceProxy.horizontalAvatarPadding.small
         case .large:
             avatarInterspace = appearanceProxy.avatarInterspace.large
             labelFont = appearanceProxy.labelFont.large
+            horizontalAvatarPadding = appearanceProxy.horizontalAvatarPadding.large
         }
     }
 }

--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButtonTokens.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButtonTokens.swift
@@ -36,7 +36,6 @@ class MSFPersonaButtonTokens: MSFTokensBase, ObservableObject {
     @Published public var backgroundColor: UIColor!
     @Published public var labelColor: UIColor!
     @Published public var labelFont: UIFont!
-    @Published public var labelWidth: CGFloat!
     @Published public var padding: CGFloat!
     @Published public var sublabelColor: UIColor!
     @Published public var sublabelFont: UIFont!
@@ -77,11 +76,9 @@ class MSFPersonaButtonTokens: MSFTokensBase, ObservableObject {
         case .small:
             avatarInterspace = appearanceProxy.avatarInterspace.small
             labelFont = appearanceProxy.labelFont.small
-            labelWidth = appearanceProxy.labelWidth.small
         case .large:
             avatarInterspace = appearanceProxy.avatarInterspace.large
             labelFont = appearanceProxy.labelFont.large
-            labelWidth = appearanceProxy.labelWidth.large
         }
     }
 }

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -342,7 +342,6 @@ AP_MSFPersonaButtonTokens:
   backgroundColor: $Colors.Background.neutral1
   labelColor: $Colors.Foreground.neutral1
   labelFont: [ small: $Typography.caption1, large: $Typography.subheadline ]
-  labelWidth: [ small: 52pt, large: 72pt ]
   padding: $Spacing.xSmall
   sublabelColor: $Colors.Foreground.neutral3
   sublabelFont: $Typography.footnote

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -340,11 +340,13 @@ AP_MSFPersonaButtonCarouselTokens:
 AP_MSFPersonaButtonTokens:
   avatarInterspace: [ small: $Spacing.xSmall, large: $Spacing.small ]
   backgroundColor: $Colors.Background.neutral1
+  horizontalAvatarPadding: [ small: $Spacing.medium, large: $Spacing.xSmall ]
+  horizontalTextPadding: $Spacing.xxxSmall
   labelColor: $Colors.Foreground.neutral1
   labelFont: [ small: $Typography.caption1, large: $Typography.subheadline ]
-  padding: $Spacing.xSmall
   sublabelColor: $Colors.Foreground.neutral3
   sublabelFont: $Typography.footnote
+  verticalPadding: $Spacing.xSmall
 
 AP_MSFPersonaViewTokens:
   footnoteFont: $Typography.footnote

--- a/tools/sgen/output/MSFPersonaButtonTokens.generated.swift
+++ b/tools/sgen/output/MSFPersonaButtonTokens.generated.swift
@@ -69,28 +69,6 @@ extension FluentUIStyle {
 		}
 
 
-		// MARK: - labelWidth
-		open var labelWidth: labelWidthAppearanceProxy {
-			return labelWidthAppearanceProxy(proxy: mainProxy)
-		}
-		open class labelWidthAppearanceProxy {
-			public let mainProxy: () -> FluentUIStyle
-			public init(proxy: @escaping () -> FluentUIStyle) {
-				self.mainProxy = proxy
-			}
-
-			// MARK: - large 
-			open var large: CGFloat {
-				return CGFloat(72.0)
-			}
-
-			// MARK: - small 
-			open var small: CGFloat {
-				return CGFloat(52.0)
-			}
-		}
-
-
 		// MARK: - padding 
 		open var padding: CGFloat {
 			return mainProxy().Spacing.xSmall

--- a/tools/sgen/output/MSFPersonaButtonTokens.generated.swift
+++ b/tools/sgen/output/MSFPersonaButtonTokens.generated.swift
@@ -42,6 +42,33 @@ extension FluentUIStyle {
 			return mainProxy().Colors.Background.neutral1
 		}
 
+		// MARK: - horizontalAvatarPadding
+		open var horizontalAvatarPadding: horizontalAvatarPaddingAppearanceProxy {
+			return horizontalAvatarPaddingAppearanceProxy(proxy: mainProxy)
+		}
+		open class horizontalAvatarPaddingAppearanceProxy {
+			public let mainProxy: () -> FluentUIStyle
+			public init(proxy: @escaping () -> FluentUIStyle) {
+				self.mainProxy = proxy
+			}
+
+			// MARK: - large 
+			open var large: CGFloat {
+				return mainProxy().Spacing.xSmall
+			}
+
+			// MARK: - small 
+			open var small: CGFloat {
+				return mainProxy().Spacing.medium
+			}
+		}
+
+
+		// MARK: - horizontalTextPadding 
+		open var horizontalTextPadding: CGFloat {
+			return mainProxy().Spacing.xxxSmall
+		}
+
 		// MARK: - labelColor 
 		open var labelColor: UIColor {
 			return mainProxy().Colors.Foreground.neutral1
@@ -69,11 +96,6 @@ extension FluentUIStyle {
 		}
 
 
-		// MARK: - padding 
-		open var padding: CGFloat {
-			return mainProxy().Spacing.xSmall
-		}
-
 		// MARK: - sublabelColor 
 		open var sublabelColor: UIColor {
 			return mainProxy().Colors.Foreground.neutral3
@@ -82,6 +104,11 @@ extension FluentUIStyle {
 		// MARK: - sublabelFont 
 		open var sublabelFont: UIFont {
 			return mainProxy().Typography.footnote
+		}
+
+		// MARK: - verticalPadding 
+		open var verticalPadding: CGFloat {
+			return mainProxy().Spacing.xSmall
 		}
 	}
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add logic to `PersonaButton` to adjust its width based on the current size category. This also resulted in some subtle changes to how the width of the button is calculated (and the deprecation of a redundant design token), which will result in safer, more predictable layout going forward.

### Verification

Verified accessibility sizes from smallest to largest. All spacing is reasonable and legible, and performance is solid.

Also verified exceptionally short and exceptionally long names at various accessibility sizes.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/124048282-d0860f80-d9ca-11eb-9478-46c3d01d9afd.png) | ![after](https://user-images.githubusercontent.com/4934719/124675910-75449900-de72-11eb-8a27-1945827bf00d.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/621)