### PR TITLE
Auto-size `BottomCommandingController` based on item count

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -22,7 +22,7 @@ class BottomCommandingDemoController: UIViewController {
 
         let bottomCommandingVC = BottomCommandingController()
         bottomCommandingVC.heroItems = heroItems
-        bottomCommandingVC.expandedListSections = fewExpandedListSections
+        bottomCommandingVC.expandedListSections = shortCommandSectionList
 
         addChild(bottomCommandingVC)
         view.addSubview(bottomCommandingVC.view)
@@ -54,35 +54,36 @@ class BottomCommandingDemoController: UIViewController {
         CommandingItem(title: "Boolean Item " + String($0), image: homeImage, action: commandAction, isToggleable: true)
     }
 
-    private lazy var fewExpandedListSections: [CommandingSection] = [
+    private lazy var shortCommandSectionList: [CommandingSection] = [
         CommandingSection(title: "Section 1", items:
         Array(1...2).map {
             CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
         } + booleanCommands)
     ]
 
-    private lazy var manyExpandedListSections: [CommandingSection] = fewExpandedListSections + [
-        CommandingSection(title: "Section 2", items:
-        Array(1...7).map {
-            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
-        }),
-        CommandingSection(title: "Section 3", items:
-        Array(1...7).map {
-            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
-        }),
-        CommandingSection(title: "Section 4", items:
-        Array(1...7).map {
-            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
-        })
-    ]
+    private lazy var longCommandSectionList: [CommandingSection] = shortCommandSectionList
+        + [
+            CommandingSection(title: "Section 2", items:
+            Array(1...7).map {
+                CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+            }),
+            CommandingSection(title: "Section 3", items:
+            Array(1...7).map {
+                CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+            }),
+            CommandingSection(title: "Section 4", items:
+            Array(1...7).map {
+                CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+            })
+        ]
 
-    private lazy var currentExpandedListSections: [CommandingSection] = fewExpandedListSections
+    private lazy var currentExpandedListSections: [CommandingSection] = shortCommandSectionList
 
     private lazy var demoOptionItems: [DemoItem] = {
         return [DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: false),
                 DemoItem(title: "Sheet more button", type: .boolean, action: #selector(toggleSheetMoreButton), isOn: true),
                 DemoItem(title: "Expanded list items", type: .boolean, action: #selector(toggleExpandedItems), isOn: true),
-                DemoItem(title: "Many expanded list items", type: .boolean, action: #selector(toggleManyExpandedItems(_:)), isOn: false),
+                DemoItem(title: "Additional expanded list items", type: .boolean, action: #selector(toggleAdditionalExpandedItems(_:)), isOn: false),
                 DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff)),
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: true),
                 DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
@@ -111,11 +112,11 @@ class BottomCommandingDemoController: UIViewController {
         }
     }
 
-    @objc private func toggleManyExpandedItems(_ sender: BooleanCell) {
+    @objc private func toggleAdditionalExpandedItems(_ sender: BooleanCell) {
         if sender.isOn {
-            currentExpandedListSections = manyExpandedListSections
+            currentExpandedListSections = longCommandSectionList
         } else {
-            currentExpandedListSections = fewExpandedListSections
+            currentExpandedListSections = shortCommandSectionList
         }
         bottomCommandingController?.expandedListSections = currentExpandedListSections
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -22,7 +22,7 @@ class BottomCommandingDemoController: UIViewController {
 
         let bottomCommandingVC = BottomCommandingController()
         bottomCommandingVC.heroItems = heroItems
-        bottomCommandingVC.expandedListSections = expandedListSections
+        bottomCommandingVC.expandedListSections = fewExpandedListSections
 
         addChild(bottomCommandingVC)
         view.addSubview(bottomCommandingVC.view)
@@ -54,20 +54,35 @@ class BottomCommandingDemoController: UIViewController {
         CommandingItem(title: "Boolean Item " + String($0), image: homeImage, action: commandAction, isToggleable: true)
     }
 
-    private lazy var expandedListSections: [CommandingSection] = [
+    private lazy var fewExpandedListSections: [CommandingSection] = [
         CommandingSection(title: "Section 1", items:
         Array(1...2).map {
             CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
-        } + booleanCommands),
-        CommandingSection(title: "Section 2", items: Array(1...7).map {
+        } + booleanCommands)
+    ]
+
+    private lazy var manyExpandedListSections: [CommandingSection] = fewExpandedListSections + [
+        CommandingSection(title: "Section 2", items:
+        Array(1...7).map {
+            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+        }),
+        CommandingSection(title: "Section 3", items:
+        Array(1...7).map {
+            CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+        }),
+        CommandingSection(title: "Section 4", items:
+        Array(1...7).map {
             CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
         })
     ]
+
+    private lazy var currentExpandedListSections: [CommandingSection] = fewExpandedListSections
 
     private lazy var demoOptionItems: [DemoItem] = {
         return [DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: false),
                 DemoItem(title: "Sheet more button", type: .boolean, action: #selector(toggleSheetMoreButton), isOn: true),
                 DemoItem(title: "Expanded list items", type: .boolean, action: #selector(toggleExpandedItems), isOn: true),
+                DemoItem(title: "Many expanded list items", type: .boolean, action: #selector(toggleManyExpandedItems(_:)), isOn: false),
                 DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff)),
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: true),
                 DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
@@ -90,10 +105,19 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func toggleExpandedItems() {
         if bottomCommandingController?.expandedListSections.count == 0 {
-            bottomCommandingController?.expandedListSections = expandedListSections
+            bottomCommandingController?.expandedListSections = currentExpandedListSections
         } else {
             bottomCommandingController?.expandedListSections = []
         }
+    }
+
+    @objc private func toggleManyExpandedItems(_ sender: BooleanCell) {
+        if sender.isOn {
+            currentExpandedListSections = manyExpandedListSections
+        } else {
+            currentExpandedListSections = fewExpandedListSections
+        }
+        bottomCommandingController?.expandedListSections = currentExpandedListSections
     }
 
     private let modifiedCommandIndices: [Int] = [0, 3]
@@ -112,7 +136,7 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func toggleListCommandEnabled() {
         modifiedCommandIndices.forEach {
-            expandedListSections[0].items[$0].isEnabled.toggle()
+            currentExpandedListSections[0].items[$0].isEnabled.toggle()
         }
     }
 
@@ -124,7 +148,7 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func changeListCommandTitle() {
         modifiedCommandIndices.forEach {
-            expandedListSections[0].items[$0].title = "Item " + String(Int.random(in: 6..<100))
+            currentExpandedListSections[0].items[$0].title = "Item " + String(Int.random(in: 6..<100))
         }
     }
 
@@ -138,8 +162,8 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func changeListCommandIcon() {
         modifiedCommandIndices.forEach {
-            expandedListSections[0].items[$0].image = listIconChanged ? homeImage : boldImage
-            expandedListSections[0].items[$0].selectedImage = listIconChanged ? homeSelectedImage : boldImage
+            currentExpandedListSections[0].items[$0].image = listIconChanged ? homeImage : boldImage
+            currentExpandedListSections[0].items[$0].selectedImage = listIconChanged ? homeSelectedImage : boldImage
         }
         listIconChanged.toggle()
     }
@@ -150,7 +174,7 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func incrementHeroCommands() {
         let currentCount = bottomCommandingController?.heroItems.count ?? 0
-        if currentCount < 5 {
+        if currentCount < 4 {
             let newCount = currentCount + 1
             bottomCommandingController?.heroItems = Array(heroItems[0..<newCount])
         }
@@ -167,7 +191,7 @@ class BottomCommandingDemoController: UIViewController {
     @objc private func commandAction(item: CommandingItem) {
         if heroItems.contains(item) {
             showMessage("Hero command tapped")
-        } else if expandedListSections.contains(where: { $0.items.contains(item) }) {
+        } else if currentExpandedListSections.contains(where: { $0.items.contains(item) }) {
             if !item.isToggleable {
                 showMessage("Expanded list command tapped")
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -49,12 +49,12 @@ class BottomSheetDemoController: UIViewController {
         bottomSheetViewController?.isHidden.toggle()
     }
 
-    @objc private func fullScreenExpandedOffset() {
-        bottomSheetViewController?.expandedHeightFraction = 1.0
+    @objc private func fullScreenSheetContent() {
+        bottomSheetViewController?.preferredExpandedContentHeight = 0
     }
 
-    @objc private func halfScreenExpandedOffset() {
-        bottomSheetViewController?.expandedHeightFraction = 0.5
+    @objc private func fixedHeightSheetContent() {
+        bottomSheetViewController?.preferredExpandedContentHeight = 400
     }
 
     private let personaListView: PersonaListView = {
@@ -89,8 +89,8 @@ class BottomSheetDemoController: UIViewController {
         return [
             DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: true),
             DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: false),
-            DemoItem(title: "Full screen expansion height", type: .action, action: #selector(fullScreenExpandedOffset)),
-            DemoItem(title: "Half screen expansion height", type: .action, action: #selector(halfScreenExpandedOffset))
+            DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
+            DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]
     }()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -50,6 +50,7 @@ class BottomSheetDemoController: UIViewController {
     }
 
     @objc private func fullScreenSheetContent() {
+        // This is also the default value which results in a full screen sheet.
         bottomSheetViewController?.preferredExpandedContentHeight = 0
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -327,7 +327,7 @@ open class BottomCommandingController: UIViewController {
             popoverContentViewController.view.addSubview(tableView)
             popoverContentViewController.modalPresentationStyle = .popover
             popoverContentViewController.popoverPresentationController?.sourceView = moreButtonView
-            popoverContentViewController.preferredContentSize = CGSize(width: 0, height: fittingTableViewHeight)
+            popoverContentViewController.preferredContentSize.height = fittingTableViewHeight
 
             NSLayoutConstraint.activate([
                 tableView.leadingAnchor.constraint(equalTo: popoverContentViewController.view.leadingAnchor),
@@ -591,6 +591,7 @@ extension BottomCommandingController: UITableViewDataSource {
 
 extension BottomCommandingController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        // This gets rid of a 20pt margin after the last section which UITableView adds automatically.
         return CGFloat.leastNormalMagnitude
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -119,25 +119,27 @@ open class BottomCommandingController: UIViewController {
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        guard previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass else {
-            return
+        if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass {
+            // On a horizontal size class change the top level sheet / bar surfaces get recreated,
+            // but the item views, containers and bindings persist and are rearranged during the individual setup functions.
+            if let bottomSheetController = bottomSheetController {
+                bottomSheetController.willMove(toParent: nil)
+                bottomSheetController.removeFromParent()
+                bottomSheetController.view.removeFromSuperview()
+            }
+            bottomSheetController = nil
+            bottomBarView?.removeFromSuperview()
+            bottomBarView = nil
+
+            if traitCollection.horizontalSizeClass == .regular {
+                setupBottomBarLayout()
+            } else {
+                setupBottomSheetLayout()
+            }
         }
 
-        // On a horizontal size class change the top level sheet / bar surfaces get recreated,
-        // but the item views, containers and bindings persist and are rearranged during the individual setup functions.
-        if let bottomSheetController = bottomSheetController {
-            bottomSheetController.willMove(toParent: nil)
-            bottomSheetController.removeFromParent()
-            bottomSheetController.view.removeFromSuperview()
-        }
-        bottomSheetController = nil
-        bottomBarView?.removeFromSuperview()
-        bottomBarView = nil
-
-        if traitCollection.horizontalSizeClass == .regular {
-            setupBottomBarLayout()
-        } else {
-            setupBottomSheetLayout()
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            updateSheetExpandedContentHeight()
         }
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -439,7 +439,7 @@ open class BottomCommandingController: UIViewController {
         for section in expandedListSections {
             totalHeight += TableViewHeaderFooterView.height(style: .header, title: section.title ?? "")
             for item in section.items {
-                totalHeight += TableViewCell.height(title: item.title)
+                totalHeight += TableViewCell.height(title: item.title ?? "")
             }
         }
         return totalHeight

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -287,7 +287,6 @@ open class BottomCommandingController: UIViewController {
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .grouped)
-        tableView.contentInsetAdjustmentBehavior = .automatic
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
         tableView.alwaysBounceVertical = false
@@ -327,7 +326,7 @@ open class BottomCommandingController: UIViewController {
             popoverContentViewController.view.addSubview(tableView)
             popoverContentViewController.modalPresentationStyle = .popover
             popoverContentViewController.popoverPresentationController?.sourceView = moreButtonView
-            popoverContentViewController.preferredContentSize.height = fittingTableViewHeight
+            popoverContentViewController.preferredContentSize.height = estimatedTableViewHeight
 
             NSLayoutConstraint.activate([
                 tableView.leadingAnchor.constraint(equalTo: popoverContentViewController.view.leadingAnchor),
@@ -432,11 +431,12 @@ open class BottomCommandingController: UIViewController {
 
     private func updateSheetExpandedContentHeight() {
         if let bottomSheetController = bottomSheetController {
-            bottomSheetController.preferredExpandedContentHeight = fittingTableViewHeight + Constants.BottomSheet.expandedContentTopMargin
+            bottomSheetController.preferredExpandedContentHeight = estimatedTableViewHeight + Constants.BottomSheet.expandedContentTopMargin
         }
     }
 
-    private var fittingTableViewHeight: CGFloat {
+    // Estimated fitting height of `tableView`.
+    private var estimatedTableViewHeight: CGFloat {
         var totalHeight: CGFloat = 0
         for section in expandedListSections {
             totalHeight += TableViewHeaderFooterView.height(style: .header, title: section.title ?? "")

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -103,10 +103,6 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    public override func viewSafeAreaInsetsDidChange() {
-        updateSheetExpandedContentHeight()
-    }
-
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -327,7 +323,6 @@ open class BottomCommandingController: UIViewController {
         popoverContentViewController.view.addSubview(tableView)
         popoverContentViewController.modalPresentationStyle = .popover
         popoverContentViewController.popoverPresentationController?.sourceView = sender.view
-        print(fittingTableViewHeight)
         popoverContentViewController.preferredContentSize = CGSize(width: 0, height: fittingTableViewHeight)
 
         NSLayoutConstraint.activate([
@@ -442,7 +437,7 @@ open class BottomCommandingController: UIViewController {
 
     private func updateSheetExpandedContentHeight() {
         if let bottomSheetController = bottomSheetController {
-            bottomSheetController.preferredExpandedContentHeight = fittingTableViewHeight + Constants.BottomSheet.expandedContentTopMargin + view.safeAreaInsets.bottom
+            bottomSheetController.preferredExpandedContentHeight = fittingTableViewHeight + Constants.BottomSheet.expandedContentTopMargin
         }
     }
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -91,6 +91,9 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// Preferred height of `expandedContentView`.
+    ///
+    /// The default value is 0, which results in a full screen sheet expansion.
     @objc open var preferredExpandedContentHeight: CGFloat = 0 {
         didSet {
             if isViewLoaded {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -509,13 +509,13 @@ public class BottomSheetController: UIViewController {
 
     private lazy var preferredExpandedContentHeightConstraint: NSLayoutConstraint = {
         let constraint = expandedContentView.heightAnchor.constraint(equalTo: preferredExpandedContentLayoutGuide.heightAnchor)
-        constraint.priority = .defaultHigh
+        constraint.priority = .defaultHigh // Lower than required so Auto Layout can enforce max sheet height
         return constraint
     }()
 
     private lazy var fullScreenSheetConstraint: NSLayoutConstraint = {
         let constraint = bottomSheetView.heightAnchor.constraint(equalTo: maxSheetHeightLayoutGuide.heightAnchor)
-        constraint.priority = .defaultHigh
+        constraint.priority = .defaultHigh // Lower than required so Auto Layout can enforce max sheet height
         return constraint
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

BottomCommandingController had a temporary solution in place to always expand the sheet to a constant fraction of screen height. This doesn't work well for clients with only a few commands, where the expected behavior is for the sheet to fit the commands table view. This PR implements auto sizing to fit the command table view, both in the sheet and bottom bar (popover) presentations.

`BottomSheetController.swift`
Add an API for preferred expanded content height. This will be used to set the height of `expandedContentView`, up to an upper limit determined by screen size.

`BottomCommandingController.swift`
Using the provided commands, calculate the table view height and pass this to the `BottomSheetController` or the popover presentation controller so they display at the correct size.

`BottomCommandingDemoController`
Add distinct sets of low and high # of commands to test both the fitting and fullscreen sheet variants.

`BottomSheetDemoController`
Add buttons to test the new sizing API.


https://user-images.githubusercontent.com/3610850/124060898-c96afb80-d9e2-11eb-902b-fe86e051c8e6.MP4


### Verification
Testing in the test app on simulator and device, various sanity checks in portrait / landscape, changing safe area insets.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/622)