### PR TITLE
Adopt the container pattern in `BottomCommandingController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -20,8 +20,7 @@ class BottomCommandingDemoController: UIViewController {
         optionTableView.delegate = self
         optionTableView.separatorStyle = .none
 
-        let bottomCommandingVC = BottomCommandingController()
-        bottomCommandingVC.contentViewController = optionTableViewController
+        let bottomCommandingVC = BottomCommandingController(with: optionTableViewController)
         bottomCommandingVC.heroItems = heroItems
         bottomCommandingVC.expandedListSections = expandedListSections
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -10,7 +10,8 @@ class BottomCommandingDemoController: UIViewController {
     override func loadView() {
         view = UIView()
 
-        let optionTableView = UITableView(frame: .zero, style: .plain)
+        let optionTableViewController = UITableViewController(style: .plain)
+        let optionTableView: UITableView = optionTableViewController.tableView
         optionTableView.translatesAutoresizingMaskIntoConstraints = false
         optionTableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         optionTableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
@@ -18,9 +19,9 @@ class BottomCommandingDemoController: UIViewController {
         optionTableView.dataSource = self
         optionTableView.delegate = self
         optionTableView.separatorStyle = .none
-        view.addSubview(optionTableView)
 
         let bottomCommandingVC = BottomCommandingController()
+        bottomCommandingVC.contentViewController = optionTableViewController
         bottomCommandingVC.heroItems = heroItems
         bottomCommandingVC.expandedListSections = expandedListSections
 
@@ -31,10 +32,6 @@ class BottomCommandingDemoController: UIViewController {
         bottomCommandingController = bottomCommandingVC
 
         NSLayoutConstraint.activate([
-            optionTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            optionTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            optionTableView.topAnchor.constraint(equalTo: view.topAnchor),
-            optionTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             bottomCommandingVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomCommandingVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomCommandingVC.view.topAnchor.constraint(equalTo: view.topAnchor),

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -22,22 +22,23 @@ open class BottomCommandingController: UIViewController {
     /// View controller that will be displayed below the bottom commanding UI.
     @objc public var contentViewController: UIViewController? {
         didSet {
-            if let oldViewController = oldValue {
-                oldViewController.willMove(toParent: nil)
-                if oldViewController.isViewLoaded {
+            if isViewLoaded,
+               oldValue != contentViewController {
+                if let oldViewController = oldValue {
+                    oldViewController.willMove(toParent: nil)
                     oldViewController.view.removeFromSuperview()
+                    oldViewController.removeFromParent()
                 }
-                oldViewController.removeFromParent()
-            }
-            if let newContentViewController = contentViewController {
-                addChild(newContentViewController)
-                if isViewLoaded,
-                   let rootCommandingView = rootCommandingView {
-                    let newContentView: UIView = newContentViewController.view
-                    view.insertSubview(newContentView, belowSubview: rootCommandingView)
-                    activateContentViewConstraints(for: newContentView)
+
+                if let newContentViewController = contentViewController {
+                    addChild(newContentViewController)
+                    if let rootCommandingView = rootCommandingView {
+                        let newContentView: UIView = newContentViewController.view
+                        view.insertSubview(newContentView, belowSubview: rootCommandingView)
+                        activateContentViewConstraints(for: newContentView)
+                    }
+                    newContentViewController.didMove(toParent: self)
                 }
-                newContentViewController.didMove(toParent: self)
             }
         }
     }
@@ -139,9 +140,11 @@ open class BottomCommandingController: UIViewController {
 
         if let contentViewController = contentViewController,
            let rootCommandingView = rootCommandingView {
+            addChild(contentViewController)
             let newContentView: UIView = contentViewController.view
             view.insertSubview(newContentView, belowSubview: rootCommandingView)
             activateContentViewConstraints(for: newContentView)
+            contentViewController.didMove(toParent: self)
         }
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -126,6 +126,18 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
+    /// Initializes the bottom commanding controller with a given content view controller.
+    /// - Parameter contentViewController: View controller that will be displayed below the bottom commanding UI.
+    @objc public init(with contentViewController: UIViewController?) {
+        self.contentViewController = contentViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
     // MARK: - View building and layout
 
     public override func loadView() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

After initial integration prototyping and discussions with the team, we found that a container pattern would be a more suitable choice for `BottomCommandingController` than the current sibling pattern. The main disadvantage of the current pattern in Office is that you have to keep fixing the z-order whenever other siblings are added. The code that adds the siblings shouldn't necessarily be aware that the sheet overlay even exists. Container pattern enforces this implicitly and encourages small view controllers. We also have many other overlays in Office, and all of them use the container pattern.

Other advantages of the container pattern I found (we don't make use of these now)
- ownership of the main content view means we can apply more effects, similar to the 3D movement in full screen system sheets
- we can add additional safeAreaInsets on the child VC to account for the collapsed sheet. This would be great for child scroll views

Disadvantages
- the integration can be slightly more difficult, depending on the app's VC hierarchy
- deep nesting of view controllers when there's many overlays

### Verification
Sanity checks in the test app, verifying main content is still touchable and accessible.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/623)