### PR TITLE
make sure pill segmentedcontrol supports RTL

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -442,6 +442,8 @@ open class SegmentedControl: UIControl {
 
         if style == .tabs {
             bottomSeparator.frame = CGRect(x: 0, y: frame.height - bottomSeparator.frame.height, width: frame.width, height: bottomSeparator.frame.height)
+        } else {
+            pillContainerView.flipSubviewsForRTL()
         }
 
         flipSubviewsForRTL()

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -443,6 +443,7 @@ open class SegmentedControl: UIControl {
         if style == .tabs {
             bottomSeparator.frame = CGRect(x: 0, y: frame.height - bottomSeparator.frame.height, width: frame.width, height: bottomSeparator.frame.height)
         } else {
+            // flipSubviewsForRTL only works on direct children subviews
             pillContainerView.flipSubviewsForRTL()
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When pillsegmentcontrol is shown RTL make sure the pill buttons shown from RTL.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![segement_before](https://user-images.githubusercontent.com/20715435/124674661-05cdaa00-de70-11eb-8107-dd27c75c5141.png) | ![segment_after](https://user-images.githubusercontent.com/20715435/124674672-09613100-de70-11eb-870e-cccc34ea7d69.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/624)