### PR TITLE
New API for "automatic" avatar borders in groups

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupViewDemoController.swift
@@ -77,16 +77,22 @@ class AvatarGroupViewDemoController: DemoController {
         addRow(text: "Overflow count", items: [overflowCountTextField, overflowCountButton], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
 
         insertLabel(text: "Avatar stack without borders")
-        insertAvatarViews(style: .stack, showBorders: false)
+        insertAvatarViews(style: .stack, borderVisibility: .never)
+
+        insertLabel(text: "Avatar stack with mixed borders")
+        insertAvatarViews(style: .stack, borderVisibility: .automatic)
 
         insertLabel(text: "Avatar stack with borders")
-        insertAvatarViews(style: .stack, showBorders: true)
+        insertAvatarViews(style: .stack, borderVisibility: .always)
 
         insertLabel(text: "Avatar pile without borders")
-        insertAvatarViews(style: .pile, showBorders: false)
+        insertAvatarViews(style: .pile, borderVisibility: .never)
+
+        insertLabel(text: "Avatar pile with mixed borders")
+        insertAvatarViews(style: .pile, borderVisibility: .automatic)
 
         insertLabel(text: "Avatar pile with borders")
-        insertAvatarViews(style: .pile, showBorders: true)
+        insertAvatarViews(style: .pile, borderVisibility: .always)
 
         updateBackgroundColor()
     }
@@ -173,16 +179,20 @@ class AvatarGroupViewDemoController: DemoController {
         overflowCountTextField.resignFirstResponder()
     }
 
-    private func insertAvatarViews(style: AvatarGroupViewStyle, showBorders: Bool) {
+    private func insertAvatarViews(style: AvatarGroupViewStyle, borderVisibility: AvatarGroupViewBorderVisibility) {
         var constraints: [NSLayoutConstraint] = []
 
         for size in AvatarSize.allCases.reversed() {
             let containerView = UIView(frame: .zero)
 
-            let avatarGroupView = AvatarGroupView(avatars: Array(samplePersonas.prefix(avatarCount)),
+            let avatars: [Avatar] = samplePersonas.prefix(avatarCount).map { persona in
+                persona.showsBorder = Int.random(in: 0...1) == 0
+                return persona
+            }
+            let avatarGroupView = AvatarGroupView(avatars: Array(avatars),
                                                   size: size,
                                                   style: style,
-                                                  showBorders: showBorders,
+                                                  borderVisibility: borderVisibility,
                                                   maxDisplayedAvatars: maxDisplayedAvatars,
                                                   overflowCount: overflowCount)
             avatarGroupView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -28,6 +28,9 @@ public protocol Avatar {
     /// The presence state
     var presence: Presence { get }
 
+    /// Whether to show a border
+    var showsBorder: Bool { get }
+
     var hideInsideGapForBorder: Bool { get }
 }
 
@@ -48,13 +51,20 @@ open class AvatarData: NSObject, Avatar {
 
     @objc public var presence: Presence
 
+    @objc public var showsBorder: Bool
+
     @objc public var hideInsideGapForBorder: Bool = false
 
-    @objc public init(primaryText: String = "", secondaryText: String = "", image: UIImage? = nil, presence: Presence = .none, color: UIColor? = nil) {
+    @objc public init(primaryText: String = "", secondaryText: String = "", image: UIImage? = nil, presence: Presence = .none, color: UIColor? = nil, showsBorder: Bool = false) {
         self.primaryText = primaryText
         self.secondaryText = secondaryText
         self.image = image
         self.presence = presence
         self.color = color
+        self.showsBorder = showsBorder
+    }
+
+    @objc public convenience init(primaryText: String = "", secondaryText: String = "", image: UIImage? = nil, presence: Presence = .none, color: UIColor? = nil) {
+        self.init(primaryText: primaryText, secondaryText: secondaryText, image: image, presence: presence, color: color, showsBorder: false)
     }
 }

--- a/ios/FluentUI/Avatar/AvatarGroupView.swift
+++ b/ios/FluentUI/Avatar/AvatarGroupView.swift
@@ -47,13 +47,12 @@ open class AvatarGroupView: UIView {
 
     /// Set to true to show avatar borders in the avatar group view.
     /// Compatibility wrapper for `borderVisibility` which is now the source of truth.
-    @available(*, deprecated, message: "Use `borderVisibility` instead")
     @objc open var showBorders: Bool {
         get {
             return borderVisibility == .always
         }
         set {
-            newValue ? (borderVisibility = .always) : (borderVisibility = .never)
+            borderVisibility = newValue ? .always : .never
         }
     }
 
@@ -93,7 +92,7 @@ open class AvatarGroupView: UIView {
         }
     }
 
-    @available(*, deprecated, message: "Use the designated initializer with `borderVisibility` parameter instead")
+    /// Deprecated. Use the designated initializer with `borderVisibility` parameter instead.
     @objc public convenience init(avatars: [Avatar],
                                   size: AvatarSize,
                                   style: AvatarGroupViewStyle,

--- a/ios/FluentUI/Avatar/Persona.swift
+++ b/ios/FluentUI/Avatar/Persona.swift
@@ -38,6 +38,7 @@ open class PersonaData: NSObject, Persona {
     /// An image that can be used as a frame (outer wide border) for the avatar view
     @objc public var customBorderImage: UIImage?
     @objc public var hideInsideGapForBorder: Bool = false
+    @objc public var showsBorder: Bool = false
 
     /// The color associated to this persona.
     @objc public var color: UIColor?
@@ -83,6 +84,30 @@ open class PersonaData: NSObject, Persona {
         self.avatarImage = avatarImage
         self.presence = presence
         self.color = color
+    }
+
+    /// Initializer for PersonaData
+    /// - Parameter name: The persona's name.
+    /// - Parameter email: The persona's email.
+    /// - Parameter subtitle: The persona's subtitle.
+    /// - Parameter avatarImage: The persona's image.
+    /// - Parameter presence: The persona's presence status.
+    /// - Parameter color: The persona's color.
+    /// - Parameter showsBorder: Whether to show a border.
+    @objc public init(name: String = "",
+                      email: String = "",
+                      subtitle: String = "",
+                      avatarImage: UIImage? = nil,
+                      presence: Presence = .none,
+                      color: UIColor? = nil,
+                      showsBorder: Bool = false) {
+        self.name = name
+        self.email = email
+        self.subtitle = subtitle
+        self.avatarImage = avatarImage
+        self.presence = presence
+        self.color = color
+        self.showsBorder = showsBorder
     }
 
     /// Initializer for PersonaData


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Up until now, borders on the `Avatar` views inside an `AvatarGroup` were an all-or-nothing thing. As of this PR, there's a third option: `automatic`, wherein each border pulls its visibility state from its backing `Avatar` data object.

To do so, I made the following changes:
- Added a new boolean property to the `Avatar` protocol: `showsBorder`.
- Piped that property through various extensions and implementations, culminating in new initializers on `AvatarData` and `PersonaData` where this property can be specified.
- New enum: `AvatarGroupViewBorderVisibility`, with three values:
  - `never`: same as setting `showBorders` to `false`
  - `always`: same as setting `showBorders` to `true`
  - `automatic`: the new mode where the presence of borders is derived from individual `Avatar` data
- Created a new initializer on `AvatarGroupView` that replaces boolean `showBorders` with the `AvatarGroupViewBorderVisibility` enum, and deprecated the now-legacy initializer
- Tested all this in the demo controller.

Note: this has no impact on any existing APIs/behaviors, and is not a breaking change.


### Verification

Updated the demo controller to have a new stack and a new pile with the `automatic` setting and random per-`Avatar` borders

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/124966953-b656bd80-dfd8-11eb-8a72-06d011c2701e.png) | ![after](https://user-images.githubusercontent.com/4934719/124966981-be166200-dfd8-11eb-93cb-bf66ef5c6d41.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/626)