### PR TITLE
[DrawerController]Changing default to vNext token

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -394,9 +394,6 @@ open class DrawerController: UIViewController, FluentUIWindowProvider {
 
     /// Shadow is required if background is transparent
     var shadowOffset: CGFloat {
-        if presentationDirection.isHorizontal {
-            return presentationBackground == .none ? drawerTokens.shadowOffset : 0
-        }
         return presentationBackground == .none ? drawerTokens.shadowOffset : 0
     }
 

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -395,9 +395,9 @@ open class DrawerController: UIViewController, FluentUIWindowProvider {
     /// Shadow is required if background is transparent
     var shadowOffset: CGFloat {
         if presentationDirection.isHorizontal {
-            return presentationBackground == .none ? drawerTokens.horizontalShadowOffset : 0
+            return presentationBackground == .none ? drawerTokens.shadowOffset : 0
         }
-        return presentationBackground == .none ? drawerTokens.verticalShadowOffset : 0
+        return presentationBackground == .none ? drawerTokens.shadowOffset : 0
     }
 
     private let sourceView: UIView?
@@ -780,9 +780,10 @@ open class DrawerController: UIViewController, FluentUIWindowProvider {
             } else if useNavigationBarBackgroundColor {
                 backgroundColor = drawerTokens.navigationBarBackground
             } else {
-                backgroundColor = presentationDirection.isVertical ? drawerTokens.drawerVerticalContentBackground : drawerTokens.drawerHorizontalContentBackground
+                backgroundColor = drawerTokens.drawerContentBackground
             }
         }
+
         guard let presentationController = (presentationController as? DrawerPresentationController) else {
             return
         }
@@ -975,7 +976,7 @@ open class DrawerController: UIViewController, FluentUIWindowProvider {
 
 extension DrawerController {
     static var drawerBackgroundColor: UIColor {
-        return MSFDrawerTokens().drawerHorizontalContentBackground
+        return MSFDrawerTokens().drawerContentBackground
     }
 
     static var drawerPopoverBackgroundColor: UIColor {

--- a/ios/FluentUI/Drawer/DrawerShadowView.swift
+++ b/ios/FluentUI/Drawer/DrawerShadowView.swift
@@ -119,9 +119,9 @@ class DrawerShadowView: UIView {
         if let shadowDirection = shadowDirection {
             switch shadowDirection {
             case .down:
-                offset.height = drawerTokens.verticalShadowOffset
+                offset.height = drawerTokens.shadowOffset
             case .up:
-                offset.height = -drawerTokens.verticalShadowOffset
+                offset.height = -drawerTokens.shadowOffset
             case .fromLeading:
                 offset.width = isFirst ? drawerTokens.shadow1DepthX : drawerTokens.shadow2DepthX
                 offset.height = isFirst ? drawerTokens.shadow1DepthY : drawerTokens.shadow2DepthY

--- a/ios/FluentUI/Drawer/MSFDrawerTokens.generated.swift
+++ b/ios/FluentUI/Drawer/MSFDrawerTokens.generated.swift
@@ -25,19 +25,9 @@ extension FluentUIStyle {
 			return mainProxy().Border.radius.xxLarge
 		}
 
-		// MARK: - drawerHorizontalContentBackground 
-		open var drawerHorizontalContentBackground: UIColor {
-			return mainProxy().Colors.Background.neutral1
-		}
-
-		// MARK: - drawerVerticalContentBackground 
-		open var drawerVerticalContentBackground: UIColor {
+		// MARK: - drawerBackground 
+		open var drawerBackground: UIColor {
 			return UIColor(light: mainProxy().Colors.Background.neutral1, lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Background.neutral3, darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-		}
-
-		// MARK: - horizontalShadowOffset 
-		open var horizontalShadowOffset: CGFloat {
-			return mainProxy().Spacing.small
 		}
 
 		// MARK: - minMargin
@@ -112,8 +102,8 @@ extension FluentUIStyle {
 			return mainProxy().Shadow.shadow28.y2
 		}
 
-		// MARK: - verticalShadowOffset 
-		open var verticalShadowOffset: CGFloat {
+		// MARK: - shadowOffset 
+		open var shadowOffset: CGFloat {
 			return mainProxy().Spacing.xSmall
 		}
 	}

--- a/ios/FluentUI/Drawer/MSFDrawerTokens.swift
+++ b/ios/FluentUI/Drawer/MSFDrawerTokens.swift
@@ -17,15 +17,13 @@ class MSFDrawerTokens: MSFTokensBase {
     var shadow2DepthX: CGFloat!
     var shadow2DepthY: CGFloat!
     var backgroundDimmedColor: UIColor!
-    var drawerVerticalContentBackground: UIColor!
-    var drawerHorizontalContentBackground: UIColor!
+    var drawerContentBackground: UIColor!
     var popoverContentBackground: UIColor!
     var navigationBarBackground: UIColor!
     var cornerRadius: CGFloat!
     var minHorizontalMargin: CGFloat!
     var minVerticalMargin: CGFloat!
-    var verticalShadowOffset: CGFloat!
-    var horizontalShadowOffset: CGFloat!
+    var shadowOffset: CGFloat!
 
     /// Notifies the drawer controller to refresh its UI to reflect its design token values
     var themeDidUpdate: (() -> Void)?
@@ -57,14 +55,12 @@ class MSFDrawerTokens: MSFTokensBase {
         shadow2DepthX = appearanceProxy.shadow2OffsetX
         shadow2DepthY = appearanceProxy.shadow2OffsetY
         backgroundDimmedColor = appearanceProxy.backgroundDimmedColor
-        drawerVerticalContentBackground = appearanceProxy.drawerVerticalContentBackground
-        drawerHorizontalContentBackground = appearanceProxy.drawerHorizontalContentBackground
+        drawerContentBackground = appearanceProxy.drawerBackground
         popoverContentBackground = appearanceProxy.popoverContentBackground
         navigationBarBackground = appearanceProxy.navigationBarBackground
         cornerRadius = appearanceProxy.cornerRadius
         minHorizontalMargin = appearanceProxy.minMargin.horizontal
         minVerticalMargin = appearanceProxy.minMargin.vertical
-        verticalShadowOffset = appearanceProxy.verticalShadowOffset
-        horizontalShadowOffset = appearanceProxy.horizontalShadowOffset
+        shadowOffset = appearanceProxy.shadowOffset
     }
 }

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -282,8 +282,7 @@ MSFSubtleFloatingActionButtonTokens extends MSFButtonTokens:
 
 AP_MSFDrawerTokens:
   backgroundDimmedColor: $Colors.Elevation.highElevation
-  drawerHorizontalContentBackground: "$Colors.Background.neutral1"
-  drawerVerticalContentBackground: "FluentUIColor(light: $Colors.Background.neutral1, dark: $Colors.Background.neutral3)"
+  drawerBackground: "FluentUIColor(light: $Colors.Background.neutral1, dark: $Colors.Background.neutral3)"
   popoverContentBackground: "FluentUIColor(light: $Colors.Background.surfacePrimary, dark: $Colors.Background.surfaceQuaternary)"
   navigationBarBackground: "FluentUIColor(light: $Colors.Background.surfacePrimary, dark: NamedColor(grey14))"
   shadow1Color: $Shadow.shadow28.color1
@@ -296,8 +295,7 @@ AP_MSFDrawerTokens:
   shadow2OffsetY: $Shadow.shadow28.y2
   minMargin: [horizontal: $Spacing.xxxLarge, vertical: $Spacing.large]
   cornerRadius: $Border.radius.xxLarge
-  verticalShadowOffset: $Spacing.xSmall
-  horizontalShadowOffset: $Spacing.small
+  shadowOffset: $Spacing.xSmall
 
 AP_MSFHeaderFooterTokens:
   backgroundColor: $Colors.Background.neutral1

--- a/tools/sgen/output/MSFDrawerTokens.generated.swift
+++ b/tools/sgen/output/MSFDrawerTokens.generated.swift
@@ -25,19 +25,9 @@ extension FluentUIStyle {
 			return mainProxy().Border.radius.xxLarge
 		}
 
-		// MARK: - drawerHorizontalContentBackground 
-		open var drawerHorizontalContentBackground: UIColor {
-			return mainProxy().Colors.Background.neutral1
-		}
-
-		// MARK: - drawerVerticalContentBackground 
-		open var drawerVerticalContentBackground: UIColor {
+		// MARK: - drawerBackground 
+		open var drawerBackground: UIColor {
 			return UIColor(light: mainProxy().Colors.Background.neutral1, lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: mainProxy().Colors.Background.neutral3, darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
-		}
-
-		// MARK: - horizontalShadowOffset 
-		open var horizontalShadowOffset: CGFloat {
-			return mainProxy().Spacing.small
 		}
 
 		// MARK: - minMargin
@@ -112,8 +102,8 @@ extension FluentUIStyle {
 			return mainProxy().Shadow.shadow28.y2
 		}
 
-		// MARK: - verticalShadowOffset 
-		open var verticalShadowOffset: CGFloat {
+		// MARK: - shadowOffset 
+		open var shadowOffset: CGFloat {
 			return mainProxy().Spacing.xSmall
 		}
 	}


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Currently the `DrawerBackground` Color has separate tokens for vertical/horizontal scenarios. Consolidating it into one and defaulting to vertical tokens (vnext). 

This eliminates the need for explicit override from client end to match desired left nav color.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-07-08 at 11 41 27 AM](https://user-images.githubusercontent.com/63682282/124975275-b78ce800-dfe2-11eb-901b-271048b8c22e.png) | ![Screen Shot 2021-07-08 at 11 34 44 AM](https://user-images.githubusercontent.com/63682282/124975284-b9ef4200-dfe2-11eb-8d17-e52c13d1cc64.png) |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/627)