### PR TITLE
[vNext] Update PersonaButton accessibility spacing to match new designs

### DIFF
--- a/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/Vnext/PersonaButton/PersonaButton.swift
@@ -251,22 +251,15 @@ public struct PersonaButton: View {
 
     /// Width of the button is conditional on the current size category
     private var adjustedWidth: CGFloat {
-        return state.avatarState.size.size + (2 * tokens.horizontalAvatarPadding) + {
-            switch sizeCategory {
-            case .accessibilityMedium:
-                return 20
-            case .accessibilityLarge:
-                return 32
-            case .accessibilityExtraLarge:
-                return 48
-            case .accessibilityExtraExtraLarge:
-                return 64
-            case .accessibilityExtraExtraExtraLarge:
-                return 80
-            default:
-                return 0
-            }
-        }()
+        let accessibilityAdjustments: [ ContentSizeCategory: [ MSFPersonaButtonSize: CGFloat] ] = [
+            .accessibilityMedium: [ .large: 4, .small: 0 ],
+            .accessibilityLarge: [ .large: 20, .small: 12 ],
+            .accessibilityExtraLarge: [ .large: 36, .small: 32 ],
+            .accessibilityExtraExtraLarge: [ .large: 56, .small: 38 ],
+            .accessibilityExtraExtraExtraLarge: [ .large: 80, .small: 68 ]
+        ]
+
+        return state.avatarState.size.size + (2 * tokens.horizontalAvatarPadding) + (accessibilityAdjustments[sizeCategory]?[state.buttonSize] ?? 0)
     }
 
     public var body: some View {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

After talking with design, we have new values for the sizing scale to be used under a11y text sizing. This updates the mapping, separating out scales for `.large` and `.small` sizes of `PersonaButton`.

### Verification

Verified all sizing and scaling across both sizes of `PersonaButton`.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/124675910-75449900-de72-11eb-8a27-1945827bf00d.png) | ![after](https://user-images.githubusercontent.com/4934719/125020511-d2d11500-e02d-11eb-9870-b8acbbac1aef.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/628)