### PR TITLE
[vNext] Fixing List dividers: last cell with children shows an additional divider

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -59,11 +59,11 @@ class ListDemoController: DemoController {
             children.append(listCell)
             listCell.hasDivider = true
         }
-        children[1].children = subchildren
-        children[1].isExpanded = true
-//        children[1].onTapAction = {
-//            self.showAlertForAvatarTapped(name: samplePersonas[3].name)
-//        }
+        children[0].children = subchildren
+        children[0].isExpanded = true
+        children[1].onTapAction = {
+            self.showAlertForAvatarTapped(name: samplePersonas[3].name)
+        }
 
         /// Custom Leading View with collapsible children items
         listSection = MSFListSectionState()
@@ -80,9 +80,9 @@ class ListDemoController: DemoController {
             listSection.cells.append(listCell)
             listSection.hasDividers = true
         }
-        listSection.cells[1].children = children
-        listSection.cells[1].isExpanded = true
-        listSection.cells[0].onTapAction = {
+        listSection.cells[0].children = children
+        listSection.cells[0].isExpanded = true
+        listSection.cells[1].onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }
         listData.append(listSection)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -43,6 +43,7 @@ class ListDemoController: DemoController {
         listCell.onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[4].name)
         }
+        listCell.hasDivider = true
         subchildren.append(listCell)
 
         /// Children list items
@@ -56,12 +57,13 @@ class ListDemoController: DemoController {
             listCell.title = avatar.state.primaryText ?? ""
             listCell.leadingUIView = avatar.view
             children.append(listCell)
+            listCell.hasDivider = true
         }
-        children[0].children = subchildren
-        children[0].isExpanded = true
-        children[1].onTapAction = {
-            self.showAlertForAvatarTapped(name: samplePersonas[3].name)
-        }
+        children[1].children = subchildren
+        children[1].isExpanded = true
+//        children[1].onTapAction = {
+//            self.showAlertForAvatarTapped(name: samplePersonas[3].name)
+//        }
 
         /// Custom Leading View with collapsible children items
         listSection = MSFListSectionState()
@@ -76,10 +78,11 @@ class ListDemoController: DemoController {
             listCell.title = avatar.state.primaryText ?? ""
             listCell.leadingUIView = avatar.view
             listSection.cells.append(listCell)
+            listSection.hasDividers = true
         }
-        listSection.cells[0].children = children
-        listSection.cells[0].isExpanded = true
-        listSection.cells[1].onTapAction = {
+        listSection.cells[1].children = children
+        listSection.cells[1].isExpanded = true
+        listSection.cells[0].onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }
         listData.append(listSection)

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -79,12 +79,9 @@ public struct MSFListView: View {
                     preconditionFailure("Does not contain any children cells")
                 }
                 return findLastCell(lastChild)
-            } else {
-                return lastCell
             }
-        } else {
-            return lastCell
         }
+        return lastCell
     }
 
     private func updateCellDividers() -> [MSFListSectionState] {
@@ -92,9 +89,8 @@ public struct MSFListView: View {
             section.cells.forEach { cell in
                 cell.hasDivider = section.hasDividers
             }
-            if let lastCell = section.cells.last {
-                let adjacent = findLastCell(lastCell)
-                adjacent.hasDivider = false
+            if let lastCell = section.cells.last, section.hasDividers {
+                findLastCell(lastCell).hasDivider = false
             }
         }
         return state.sections

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -57,9 +57,6 @@ public struct MSFListView: View {
                                 .frame(maxWidth: .infinity)
                         }
                         if section.hasDividers {
-                            if let lastCell = section.cells.last {
-                                let last = findLastCell(lastCell)
-                            }
                             Divider()
                                 .overlay(Color(tokens.borderColor))
                         }
@@ -92,7 +89,13 @@ public struct MSFListView: View {
             section.cells.forEach { cell in
                 cell.hasDivider = section.hasDividers
             }
-            section.cells.last?.hasDivider = false
+            if let last = section.cells.last {
+                if last.children != nil && last.isExpanded {
+                    _ = findLastCell(last)
+                } else {
+                    last.hasDivider = false
+                }
+            }
         }
         return state.sections
     }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -53,19 +53,15 @@ public struct MSFListView: View {
 
                         ForEach(section.cells.indices, id: \.self) { index in
                             let cellState = section.cells[index]
-//                            let cellState = findLastCell(section.cells[index])
                             MSFListCellView(state: cellState)
                                 .frame(maxWidth: .infinity)
                         }
                         if section.hasDividers {
                             if let lastCell = section.cells.last {
                                 let last = findLastCell(lastCell)
-//                                last.hasDivider = !(last.isExpanded)
                             }
-//                            if findLastCell(section.cells.)
                             Divider()
-                                .background(Color.red)
-//                                .overlay(Color(tokens.borderColor))
+                                .overlay(Color(tokens.borderColor))
                         }
                     }
                 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -58,8 +58,7 @@ public struct MSFListView: View {
                         }
                         if section.hasDividers {
                             Divider()
-                                .background(Color.red)
-//                                .overlay(Color(tokens.borderColor))
+                                .overlay(Color(tokens.borderColor))
                         }
                     }
                 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -58,7 +58,8 @@ public struct MSFListView: View {
                         }
                         if section.hasDividers {
                             Divider()
-                                .overlay(Color(tokens.borderColor))
+                                .background(Color.red)
+//                                .overlay(Color(tokens.borderColor))
                         }
                     }
                 }
@@ -70,18 +71,21 @@ public struct MSFListView: View {
                           with: windowProvider)
     }
 
+    /// Finds the last cell directly adjacent to the end of a list section. This is used to remove the redundant separator that is
+    /// inserted between each cell. Used as a fix until we are able to use the new List Separators in iOS 15.
     private func findLastCell(_ lastCell: MSFListCellState) -> MSFListCellState {
         if let children = lastCell.children {
-            return lastDivider(findLastCell(children[children.count - 1]))
+            if lastCell.isExpanded {
+                guard let lastChild = children.last else {
+                    preconditionFailure("Does not contain any children cells")
+                }
+                return findLastCell(lastChild)
+            } else {
+                return lastCell
+            }
         } else {
-            return lastDivider(lastCell)
+            return lastCell
         }
-    }
-
-    private func lastDivider(_ cell: MSFListCellState) -> MSFListCellState {
-        let state = cell
-        state.hasDivider = false
-        return state
     }
 
     private func updateCellDividers() -> [MSFListSectionState] {
@@ -89,12 +93,9 @@ public struct MSFListView: View {
             section.cells.forEach { cell in
                 cell.hasDivider = section.hasDividers
             }
-            if let last = section.cells.last {
-                if last.children != nil && last.isExpanded {
-                    _ = findLastCell(last)
-                } else {
-                    last.hasDivider = false
-                }
+            if let lastCell = section.cells.last {
+                let adjacent = findLastCell(lastCell)
+                adjacent.hasDivider = false
             }
         }
         return state.sections

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -89,7 +89,7 @@ public struct MSFListView: View {
             section.cells.forEach { cell in
                 cell.hasDivider = section.hasDividers
             }
-            if let lastCell = section.cells.last, section.hasDividers {
+            if section.hasDividers, let lastCell = section.cells.last {
                 findLastCell(lastCell).hasDivider = false
             }
         }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -53,12 +53,19 @@ public struct MSFListView: View {
 
                         ForEach(section.cells.indices, id: \.self) { index in
                             let cellState = section.cells[index]
+//                            let cellState = findLastCell(section.cells[index])
                             MSFListCellView(state: cellState)
                                 .frame(maxWidth: .infinity)
                         }
                         if section.hasDividers {
+                            if let lastCell = section.cells.last {
+                                let last = findLastCell(lastCell)
+//                                last.hasDivider = !(last.isExpanded)
+                            }
+//                            if findLastCell(section.cells.)
                             Divider()
-                                .overlay(Color(tokens.borderColor))
+                                .background(Color.red)
+//                                .overlay(Color(tokens.borderColor))
                         }
                     }
                 }
@@ -68,6 +75,20 @@ public struct MSFListView: View {
             .designTokens(tokens,
                           from: theme,
                           with: windowProvider)
+    }
+
+    private func findLastCell(_ lastCell: MSFListCellState) -> MSFListCellState {
+        if let children = lastCell.children {
+            return lastDivider(findLastCell(children[children.count - 1]))
+        } else {
+            return lastDivider(lastCell)
+        }
+    }
+
+    private func lastDivider(_ cell: MSFListCellState) -> MSFListCellState {
+        let state = cell
+        state.hasDivider = !state.isExpanded
+        return state
     }
 
     private func updateCellDividers() -> [MSFListSectionState] {

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -87,7 +87,7 @@ public struct MSFListView: View {
 
     private func lastDivider(_ cell: MSFListCellState) -> MSFListCellState {
         let state = cell
-        state.hasDivider = !state.isExpanded
+        state.hasDivider = false
         return state
     }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///
 /// `onTapAction`: perform an action on a cell tap.
 ///
-/// `hasDivider`:  displays a separator beneath the cell; default is set to `false`.
+/// `hasDivider`:  displays a separator beneath the cell. Default is set to `false`.
 ///
 @objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
     public var id = UUID()

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -27,6 +27,8 @@ import SwiftUI
 ///
 /// `onTapAction`: perform an action on a cell tap.
 ///
+/// `hasDivider`:  displays a separator beneath the cell; default is set to `false`.
+///
 @objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
     public var id = UUID()
 
@@ -283,7 +285,8 @@ struct MSFListCellView: View {
                 let padding = tokens.horizontalCellPadding +
                     (state.leadingView != nil ? (tokens.leadingViewSize + tokens.iconInterspace) : 0)
                 Divider()
-                    .overlay(Color(tokens.borderColor))
+                    .background(Color.red)
+//                    .overlay(Color(tokens.borderColor))
                     .padding(.leading, padding)
             }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -285,8 +285,7 @@ struct MSFListCellView: View {
                 let padding = tokens.horizontalCellPadding +
                     (state.leadingView != nil ? (tokens.leadingViewSize + tokens.iconInterspace) : 0)
                 Divider()
-                    .background(Color.red)
-//                    .overlay(Color(tokens.borderColor))
+                    .overlay(Color(tokens.borderColor))
                     .padding(.leading, padding)
             }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -283,7 +283,8 @@ struct MSFListCellView: View {
                 let padding = tokens.horizontalCellPadding +
                     (state.leadingView != nil ? (tokens.leadingViewSize + tokens.iconInterspace) : 0)
                 Divider()
-                    .overlay(Color(tokens.borderColor))
+                    .background(Color.red)
+//                    .overlay(Color(tokens.borderColor))
                     .padding(.leading, padding)
             }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -283,8 +283,7 @@ struct MSFListCellView: View {
                 let padding = tokens.horizontalCellPadding +
                     (state.leadingView != nil ? (tokens.leadingViewSize + tokens.iconInterspace) : 0)
                 Divider()
-                    .background(Color.red)
-//                    .overlay(Color(tokens.borderColor))
+                    .overlay(Color(tokens.borderColor))
                     .padding(.leading, padding)
             }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The last cell in a nested list showed double dividers which did not align with the intended appearance. This fix gets rid of the extra divider in the List.

This change is temporary as we will probably adapt to the new [List Separators](https://developer.apple.com/documentation/swiftui/menu/listrowseparator(_:edges:)) in the future (iOS 15+).

### Verification

Note: The separators are in red solely for verification purposes

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 - 2021-07-21 at 16 27 11](https://user-images.githubusercontent.com/22566866/126562413-98c4dedb-b2e4-4e33-9e04-5b056803877d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-07-21 at 16 26 28](https://user-images.githubusercontent.com/22566866/126562351-003b98e3-6a32-4934-8b52-fed913cad4f4.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/629)