### PR TITLE
Bumping Vnext podspec number for MSBLOX release (0.0.5).

### DIFF
--- a/MicrosoftFluentUIVnext.podspec
+++ b/MicrosoftFluentUIVnext.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUIVnext'
-  s.version          = '0.0.4'
+  s.version          = '0.0.5'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

What's new:

- PersonaButton: New Vnext control added (available in the PersonaButton_ios subspec)
- PersonaButtonCarousel: New Vnext control added (available in the PersonaButtonCarousel_ios subspec), replaces ContactCollectionView

### Verification

Successfully ran the demo app and "pod lib lint".

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/630)