### PR TITLE
Add sheet sizing helpers to `BottomCommandingController` and `BottomSheetController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -305,9 +305,9 @@ extension BottomCommandingDemoController: UITableViewDataSource {
 }
 
 extension BottomCommandingDemoController: BottomCommandingControllerDelegate {
-    func bottomCommandingControllerCollapsedChromeHeightDidChange(_ bottomCommandingController: BottomCommandingController) {
+    func bottomCommandingControllerCollapsedHeightInSafeAreaDidChange(_ bottomCommandingController: BottomCommandingController) {
         if let tableView = mainTableViewController?.tableView {
-            tableView.contentInset.bottom = bottomCommandingController.collapsedChromeHeight
+            tableView.contentInset.bottom = bottomCommandingController.collapsedHeightInSafeArea
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -11,6 +11,8 @@ class BottomCommandingDemoController: UIViewController {
         view = UIView()
 
         let optionTableViewController = UITableViewController(style: .plain)
+        mainTableViewController = optionTableViewController
+
         let optionTableView: UITableView = optionTableViewController.tableView
         optionTableView.translatesAutoresizingMaskIntoConstraints = false
         optionTableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
@@ -23,6 +25,7 @@ class BottomCommandingDemoController: UIViewController {
         let bottomCommandingVC = BottomCommandingController(with: optionTableViewController)
         bottomCommandingVC.heroItems = heroItems
         bottomCommandingVC.expandedListSections = shortCommandSectionList
+        bottomCommandingVC.delegate = self
 
         addChild(bottomCommandingVC)
         view.addSubview(bottomCommandingVC.view)
@@ -37,6 +40,8 @@ class BottomCommandingDemoController: UIViewController {
             bottomCommandingVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
+
+    private var mainTableViewController: UITableViewController?
 
     private lazy var heroItems: [CommandingItem] = {
         return Array(1...4).map {
@@ -296,5 +301,13 @@ extension BottomCommandingDemoController: UITableViewDataSource {
         }
 
         return UITableViewCell()
+    }
+}
+
+extension BottomCommandingDemoController: BottomCommandingControllerDelegate {
+    func bottomCommandingControllerCollapsedChromeHeightDidChange(_ bottomCommandingController: BottomCommandingController) {
+        if let tableView = mainTableViewController?.tableView {
+            tableView.contentInset.bottom = bottomCommandingController.collapsedChromeHeight
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -18,10 +18,12 @@ class BottomSheetDemoController: UIViewController {
         optionTableView.delegate = self
         optionTableView.separatorStyle = .none
         view.addSubview(optionTableView)
+        mainTableView = optionTableView
 
         let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
         bottomSheetViewController.collapsedContentHeight = BottomSheetDemoController.headerHeight
+        bottomSheetViewController.delegate = self
 
         self.bottomSheetViewController = bottomSheetViewController
 
@@ -40,6 +42,8 @@ class BottomSheetDemoController: UIViewController {
             bottomSheetViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
+
+    private var mainTableView: UITableView?
 
     @objc private func toggleExpandable() {
         bottomSheetViewController?.isExpandable.toggle()
@@ -173,5 +177,13 @@ extension BottomSheetDemoController: UITableViewDataSource {
         }
 
         return UITableViewCell()
+    }
+}
+
+extension BottomSheetDemoController: BottomSheetControllerDelegate {
+    func bottomSheetControllerCollapsedSheetHeightDidChange(_ bottomSheetController: BottomSheetController) {
+        if let tableView = mainTableView {
+            tableView.contentInset.bottom = bottomSheetController.collapsedSheetHeight
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -183,7 +183,7 @@ extension BottomSheetDemoController: UITableViewDataSource {
 extension BottomSheetDemoController: BottomSheetControllerDelegate {
     func bottomSheetControllerCollapsedSheetHeightDidChange(_ bottomSheetController: BottomSheetController) {
         if let tableView = mainTableView {
-            tableView.contentInset.bottom = bottomSheetController.collapsedSheetHeight
+            tableView.contentInset.bottom = bottomSheetController.collapsedHeightInSafeArea
         }
     }
 }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -133,6 +133,7 @@ open class BottomCommandingController: UIViewController {
     @objc public let commandingLayoutGuide = UILayoutGuide()
 
     /// Height of the portion of the collapsed commanding UI that's in the safe area.
+    /// When using the bottom bar style, this will include the entire height of the bottom bar.
     ///
     /// Valid after the root view is loaded.
     ///

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -9,7 +9,10 @@ import UIKit
 public protocol BottomSheetControllerDelegate: AnyObject {
 
     /// Called after the sheet moved to a new expansion state
-    @objc optional func bottomSheetControllerDidMove(to expansionState: BottomSheetExpansionState)
+    @objc optional func bottomSheetController(_ bottomSheetController: BottomSheetController, didMoveTo expansionState: BottomSheetExpansionState)
+
+    /// Called when `collapsedSheetHeight` changes.
+    @objc optional func bottomSheetControllerCollapsedSheetHeightDidChange(_ bottomSheetController: BottomSheetController)
 }
 
 /// Defines the position the sheet is currently in
@@ -57,6 +60,7 @@ public class BottomSheetController: UIViewController {
                 panGestureRecognizer.isEnabled = isExpandable
                 if isViewLoaded && !isHidden {
                     move(to: .collapsed, animated: false)
+                    delegate?.bottomSheetControllerCollapsedSheetHeightDidChange?(self)
                 }
             }
         }
@@ -120,6 +124,7 @@ public class BottomSheetController: UIViewController {
         didSet {
             if isViewLoaded && currentExpansionState == .collapsed {
                 move(to: .collapsed, animated: false)
+                delegate?.bottomSheetControllerCollapsedSheetHeightDidChange?(self)
             }
         }
     }
@@ -479,7 +484,7 @@ public class BottomSheetController: UIViewController {
     }
 
     private func handleCompletedStateChange(to targetExpansionState: BottomSheetExpansionState) {
-        self.delegate?.bottomSheetControllerDidMove?(to: targetExpansionState)
+        self.delegate?.bottomSheetController?(self, didMoveTo: targetExpansionState)
 
         if targetExpansionState == .collapsed {
             hostedScrollView?.setContentOffset(.zero, animated: true)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -124,6 +124,9 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// A layout guide that covers the on-screen portion of the sheet view.
+    @objc public let layoutGuide: UILayoutGuide = UILayoutGuide()
+
     /// The object that acts as the delegate of the bottom sheet.
     @objc open weak var delegate: BottomSheetControllerDelegate?
 
@@ -141,6 +144,7 @@ public class BottomSheetController: UIViewController {
     public override func loadView() {
         view = BottomSheetPassthroughView()
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.addLayoutGuide(layoutGuide)
 
         if shouldShowDimmingView {
             view.addSubview(dimmingView)
@@ -184,6 +188,8 @@ public class BottomSheetController: UIViewController {
             overflowView.topAnchor.constraint(equalTo: bottomSheetView.bottomAnchor),
             bottomSheetOffsetConstraint
         ])
+
+        NSLayoutConstraint.activate(makeLayoutGuideConstraints())
 
         self.preferredExpandedContentGuideTopConstraint = preferredExpandedContentTopConstraint
 
@@ -505,6 +511,21 @@ public class BottomSheetController: UIViewController {
             preferredExpandedContentHeightConstraint.isActive = false
             fullScreenSheetConstraint.isActive = true
         }
+    }
+
+    private func makeLayoutGuideConstraints() -> [NSLayoutConstraint] {
+        let requiredConstraints = [
+            layoutGuide.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
+            layoutGuide.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
+            layoutGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            layoutGuide.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
+        ]
+
+        // BottomSheetView will go off-screen when it's hidden, so this constraint is not always required.
+        let breakableConstraint = layoutGuide.topAnchor.constraint(equalTo: bottomSheetView.topAnchor)
+        breakableConstraint.priority = .defaultHigh
+
+        return requiredConstraints + [breakableConstraint]
     }
 
     private lazy var preferredExpandedContentHeightConstraint: NSLayoutConstraint = {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -124,6 +124,11 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// Current height of the portion of a collapsed sheet that's in the safe area.
+    @objc public var collapsedSheetHeight: CGFloat {
+        return offset(for: .collapsed)
+    }
+
     /// A layout guide that covers the on-screen portion of the sheet view.
     @objc public let layoutGuide: UILayoutGuide = UILayoutGuide()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There are two bottom commanding use cases we need to support:
1. Attaching client-owned views to the bottom chrome.
2. Setting scroll view insets to clear the collapsed bottom chrome.

To support (1) I added a `layoutGuide` which always covers the visible portion of the commanding chrome. This allows clients to respond to dynamic sheet / bar position changes in Auto Layout.

For (2) I added `collapsedSheetHeight` and `collapsedChromeHeight` properties to `BottomSheetController` and `BottomCommandingController` which return current height of the collapsed bottom chrome inside the safe area. This allows clients to easily adjust content insets of their scroll views to clear the sheet / bar. Both of these also get delegate functions which notify about any changes.

### Verification

Updated the demo apps to use the collapsed heights to update content insets. Verified these are updated based on the delegate calls.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/632)