### PR TITLE
update ccb dark mode selected colors to match design spec

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -74,15 +74,15 @@ class CommandBarButton: UIButton {
             return Colors.communicationBlue
         }
 
-        return Colors.primary(for: window)
+        return UIColor(light: Colors.primary(for: window), dark: .black)
     }
 
     private var selectedBackgroundColor: UIColor {
         guard let window = window else {
-            return Colors.Palette.communicationBlueTint30.color
+            return UIColor(light: Colors.Palette.communicationBlueTint30.color, dark: Colors.Palette.communicationBlue.color)
         }
 
-        return Colors.primaryTint30(for: window)
+        return  UIColor(light: Colors.primaryTint30(for: window), dark: Colors.primary(for: window))
     }
 
     private func updateStyle() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Dark mode ccb selected button tint color should be black and background should be primary.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-16 at 15 57 19](https://user-images.githubusercontent.com/20715435/126015961-15e03e83-8c28-454f-9510-5f92b9852b14.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-07-16 at 15 56 06](https://user-images.githubusercontent.com/20715435/126015983-02dd94e7-5ee0-4ead-876f-3fbaf0f05aeb.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/634)