### PR TITLE
Add Objective-C directive to public functions

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1044,14 +1044,14 @@ open class TableViewCell: UITableViewCell {
 
     /// To set color for title label
     /// - Parameter color: UIColor to set
-    public func setTitleLabelTextColor(color: UIColor) {
+    @objc public func setTitleLabelTextColor(color: UIColor) {
         titleLabel.textColor = color
         isUsingCustomTextColors = true
     }
 
     /// To set color for subTitle label
     /// - Parameter color: UIColor to set
-    public func setSubTitleLabelTextColor(color: UIColor) {
+    @objc public func setSubTitleLabelTextColor(color: UIColor) {
         subtitleLabel.textColor = color
         isUsingCustomTextColors = true
     }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

`TableViewCell.swift`

Adding the `@objc` directive to `setTitleLabelTextColor(color: UIColor)` and `setSubTitleLabelTextColor(color: UIColor)` in order to make them accessible for usage in HistoryUI (devmain).

### Verification

No additional testing was done as this only changes whether the code is visible in Objective-C and should not affect current functionality.

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/635)