### PR TITLE
Removing SWIFT_REFLECTION_METADATA_LEVEL override to none.

### DIFF
--- a/.ado/xcconfig/publish_overrides.xcconfig
+++ b/.ado/xcconfig/publish_overrides.xcconfig
@@ -4,7 +4,6 @@ OTHER_SWIFT_FLAGS=-gline-tables-only
 
 // Optimize for size in publish builds
 SWIFT_OPTIMIZATION_LEVEL=-Osize
-SWIFT_REFLECTION_METADATA_LEVEL=none
 
 // Build for all architectures, not just the active one
 ONLY_ACTIVE_ARCH=NO


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We're about to start using SwiftUI in FluentUI which will consumed in its static lib form.
The Combine framework relies heavily on reflection to power the mechanism that SwiftUI uses to update/refresh its controls upon changes of properties (ObservableObject/ObservedObject/Published properties).

This change removes the override of SWIFT_REFLECTION_METADATA_LEVEL that was previously set to "none" which gets in the way of the SwiftUI mechanism just mentioned before.

### Verification

Previously validated changes while consuming SwiftUI controls from the vnext-prototype branch as a static library.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/636)