### PR TITLE
Add auto-collapsing of the bottom sheet when a command is executed

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -415,6 +415,8 @@ open class BottomCommandingController: UIViewController {
         if item.isToggleable {
             tabBarItemView.isSelected.toggle()
             item.isOn = tabBarItemView.isSelected
+        } else {
+            bottomSheetController?.isExpanded = false
         }
         item.action?(binding.item)
     }
@@ -748,6 +750,7 @@ extension BottomCommandingController: UITableViewDelegate {
             if presentedViewController != nil {
                 dismiss(animated: true)
             }
+            bottomSheetController?.isExpanded = false
             binding.item.action?(binding.item)
         }
         tableView.deselectRow(at: indexPath, animated: true)

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -415,7 +415,7 @@ open class BottomCommandingController: UIViewController {
         if item.isToggleable {
             tabBarItemView.isSelected.toggle()
             item.isOn = tabBarItemView.isSelected
-        } else {
+        } else if item != moreHeroItem { // The more button handles sheet expanding in its own action closure.
             bottomSheetController?.isExpanded = false
         }
         item.action?(binding.item)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Clients want to collapse the bottom sheet when a command is executed which makes total sense and is consistent with the existing popover behavior. Rather than adding an API and having them do it (and possibly forget in some cases), let's automatically collapse the sheet when a non-toggleable command is executed. 
For the toggle case, I confirmed with design and PM that we do not want to collapse the sheet.

### Verification
No visual change, sanity checking in the demo app.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/638)