### PR TITLE
Add state tracking callbacks to `BottomCommandingController` and `BottomSheetController`

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -34,6 +34,7 @@ public protocol BottomCommandingControllerDelegate: AnyObject {
     @objc optional func bottomCommandingControllerDidDismissPopover(_ bottomCommandingController: BottomCommandingController, commandingInteraction: BottomCommandingInteraction)
 }
 
+/// User interactions that can trigger a state change.
 @objc public enum BottomCommandingInteraction: Int {
     case none
     case sheetInteraction

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -133,6 +133,8 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
+    /// When in sheet layout, `BottomSheetController` holds it's own `isHidden` state which is the main
+    /// source of truth and the public getter will return that instead of this backing variable.
     private var _isHidden: Bool = false
 
     /// Indicates whether a more button is visible in the sheet style when `expandedListSections` is non-empty.

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -19,28 +19,33 @@ public protocol BottomCommandingControllerDelegate: AnyObject {
     ///   - expansionState: The expansion state the sheet moved to.
     ///   - commandingInteraction: If the state change was caused by user interaction, it will be indicated using this enum.
     ///   - sheetInteraction: If `commandingInteraction` is `.sheetInteraction`, this enum will contain more information about what triggered the state change.
-    @objc optional func bottomCommandingController(_ bottomCommandingController: BottomCommandingController, sheetDidMoveTo expansionState: BottomSheetExpansionState, commandingInteraction: BottomCommandingInteraction, sheetInteraction: BottomSheetInteraction)
+    @objc optional func bottomCommandingController(_ bottomCommandingController: BottomCommandingController,
+                                                   sheetDidMoveTo expansionState: BottomSheetExpansionState,
+                                                   commandingInteraction: BottomCommandingInteraction,
+                                                   sheetInteraction: BottomSheetInteraction)
 
     /// Called after the bottom bar popover is presented.
     /// - Parameters:
     ///   - bottomCommandingController: The caller object.
     ///   - commandingInteraction: The user interaction that caused the popover to show.
-    @objc optional func bottomCommandingControllerDidPresentPopover(_ bottomCommandingController: BottomCommandingController, commandingInteraction: BottomCommandingInteraction)
+    @objc optional func bottomCommandingController(_ bottomCommandingController: BottomCommandingController,
+                                                   didPresentPopoverWith commandingInteraction: BottomCommandingInteraction)
 
     /// Called after the bottom bar popover is dismissed.
     /// - Parameters:
     ///   - bottomCommandingController: The caller object.
     ///   - commandingInteraction: The user interaction that caused the popover to dismiss.
-    @objc optional func bottomCommandingControllerDidDismissPopover(_ bottomCommandingController: BottomCommandingController, commandingInteraction: BottomCommandingInteraction)
+    @objc optional func bottomCommandingController(_ bottomCommandingController: BottomCommandingController,
+                                                   didDismissPopoverWith commandingInteraction: BottomCommandingInteraction)
 }
 
-/// User interactions that can trigger a state change.
+/// Interactions that can trigger a state change.
 @objc public enum BottomCommandingInteraction: Int {
-    case none
-    case sheetInteraction
-    case moreButtonTap
-    case commandTap
-    case otherUserAction
+    case noUserAction // No user action, used for events not triggered by users
+    case otherUserAction // Any other user action not listed below
+    case sheetInteraction // General sheet interaction
+    case moreButtonTap // Tap on the more hero command
+    case commandTap // Tap on any command
 }
 
 /// Persistent commanding surface displayed at the bottom of the available area.
@@ -275,7 +280,7 @@ open class BottomCommandingController: UIViewController {
                 guard let strongSelf = self else {
                     return
                 }
-                strongSelf.delegate?.bottomCommandingControllerDidDismissPopover?(strongSelf, commandingInteraction: .none)
+                strongSelf.delegate?.bottomCommandingController?(strongSelf, didDismissPopoverWith: .noUserAction)
             }
         }
     }
@@ -507,7 +512,7 @@ open class BottomCommandingController: UIViewController {
                 guard let strongSelf = self else {
                     return
                 }
-                strongSelf.delegate?.bottomCommandingControllerDidPresentPopover?(strongSelf, commandingInteraction: .moreButtonTap)
+                strongSelf.delegate?.bottomCommandingController?(strongSelf, didPresentPopoverWith: .moreButtonTap)
             }
         }
     }
@@ -519,7 +524,7 @@ open class BottomCommandingController: UIViewController {
                 return
             }
             if isFinished {
-                strongSelf.delegate?.bottomCommandingController?(strongSelf, sheetDidMoveTo: targetState, commandingInteraction: commandingInteraction, sheetInteraction: .none)
+                strongSelf.delegate?.bottomCommandingController?(strongSelf, sheetDidMoveTo: targetState, commandingInteraction: commandingInteraction, sheetInteraction: .noUserAction)
             }
         }
     }
@@ -833,7 +838,7 @@ extension BottomCommandingController: UITableViewDelegate {
                     guard let strongSelf = self else {
                         return
                     }
-                    strongSelf.delegate?.bottomCommandingControllerDidDismissPopover?(strongSelf, commandingInteraction: .commandTap)
+                    strongSelf.delegate?.bottomCommandingController?(strongSelf, didDismissPopoverWith: .commandTap)
                 }
             }
             setSheetIsExpanded(to: false, commandingInteraction: .commandTap)
@@ -901,13 +906,13 @@ extension BottomCommandingController: CommandingItemDelegate {
 
 extension BottomCommandingController: BottomSheetControllerDelegate {
     public func bottomSheetController(_ bottomSheetController: BottomSheetController, didMoveTo expansionState: BottomSheetExpansionState, interaction: BottomSheetInteraction) {
-        let commandingInteraction: BottomCommandingInteraction = interaction == .none ? .none : .sheetInteraction
+        let commandingInteraction: BottomCommandingInteraction = interaction == .noUserAction ? .noUserAction : .sheetInteraction
         delegate?.bottomCommandingController?(self, sheetDidMoveTo: expansionState, commandingInteraction: commandingInteraction, sheetInteraction: interaction)
     }
 }
 
 extension BottomCommandingController: UIPopoverPresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        delegate?.bottomCommandingControllerDidDismissPopover?(self, commandingInteraction: .otherUserAction)
+        delegate?.bottomCommandingController?(self, didDismissPopoverWith: .otherUserAction)
     }
 }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -15,17 +15,19 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     ///   - bottomSheetController: The caller object.
     ///   - expansionState: The expansion state that the sheet moved to.
     ///   - interaction: The user interaction that caused the state change.
-    @objc optional func bottomSheetController(_ bottomSheetController: BottomSheetController, didMoveTo expansionState: BottomSheetExpansionState, interaction: BottomSheetInteraction)
+    @objc optional func bottomSheetController(_ bottomSheetController: BottomSheetController,
+                                              didMoveTo expansionState: BottomSheetExpansionState,
+                                              interaction: BottomSheetInteraction)
 
     /// Called when `collapsedHeightInSafeArea` changes.
     @objc optional func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController)
 }
 
-/// User interactions that can trigger a state change.
+/// Interactions that can trigger a state change.
 @objc public enum BottomSheetInteraction: Int {
-    case none
-    case swipe
-    case resizingHandleTap
+    case noUserAction // No user action, used for events not triggered by users
+    case swipe // Swipe on the sheet view
+    case resizingHandleTap // Tap on the sheet resizing handle
 }
 
 /// Defines the position the sheet is currently in
@@ -473,7 +475,7 @@ public class BottomSheetController: UIViewController {
     private func move(to targetExpansionState: BottomSheetExpansionState,
                       animated: Bool = true,
                       velocity: CGFloat = 0.0,
-                      interaction: BottomSheetInteraction = .none,
+                      interaction: BottomSheetInteraction = .noUserAction,
                       shouldNotifyDelegate: Bool = true,
                       completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
         let targetOffsetFromBottom = offset(for: targetExpansionState)
@@ -545,7 +547,7 @@ public class BottomSheetController: UIViewController {
     }
 
     private func handleCompletedStateChange(to targetExpansionState: BottomSheetExpansionState,
-                                            interaction: BottomSheetInteraction = .none,
+                                            interaction: BottomSheetInteraction = .noUserAction,
                                             shouldNotifyDelegate: Bool = true) {
         if shouldNotifyDelegate {
             self.delegate?.bottomSheetController?(self, didMoveTo: targetExpansionState, interaction: interaction)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -21,6 +21,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     @objc optional func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController)
 }
 
+/// User interactions that can trigger a state change.
 @objc public enum BottomSheetInteraction: Int {
     case none
     case swipe

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -427,7 +427,7 @@ public class BottomSheetController: UIViewController {
         move(to: targetState, velocity: velocity, interaction: .swipe)
     }
 
-    private func move(to targetExpansionState: BottomSheetExpansionState, animated: Bool = true, velocity: CGFloat = 0.0, completion: ((UIViewAnimatingPosition) -> Void)? = nil, interaction: BottomSheetInteraction = .none) {
+    private func move(to targetExpansionState: BottomSheetExpansionState, animated: Bool = true, velocity: CGFloat = 0.0, interaction: BottomSheetInteraction = .none, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
         let targetOffsetFromBottom = offset(for: targetExpansionState)
         currentExpansionState = targetExpansionState
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Clients need to be notified about various state changes and what interactions triggered them for telemetry purposes. This PR adds delegate callbacks to notify about:
Sheet state changes
Bottom bar popover presentation / dismiss

Each of these send additional information about what user interaction triggered the event, if any, using the `BottomSheetInteraction` and `BottomCommandingInteraction` enums. 
`BottomCommandingController` also passes through the interaction enum coming from the sheet directly.

The PR also adds more powerful `isHidden` and `isExpanded` setters which allow clients to turn off animations and provide completion handlers. The old setters are still there, refactored to just call the bigger ones.
External changes to properties which support completion handlers will not result in state change delegate callbacks to avoid sending two callbacks about the same event.

### Verification

Local testing with a delegate plugged in to verify:
Sheet-specific interactions (swipe, grippie tap) are passed through.
Commanding-specific interactions come in correctly.
Bottom bar popover callbacks are called with correct user interactions enums, always after the animation completes.
Interrupted state change animations don't fire off a delegate callback.
No double callbacks when isHidden / isExpanded are changed.


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/641)