### PR TITLE
Make commandbar accessibility hint configurable

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -252,7 +252,8 @@ class CommandBarDemoController: DemoController {
             isSelected: isSelected,
             itemTappedHandler: { [weak self] (_, item) in
                 self?.handleCommandItemTapped(command: command, item: item)
-            }
+            },
+            accessibilityHint: "sample accessibility hint"
         )
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -37,6 +37,7 @@ class CommandBarButton: UIButton {
 
         let accessibilityDescription = item.accessibilityLabel
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
+        accessibilityHint = item.accessibilityHint
         contentEdgeInsets = CommandBarButton.contentEdgeInsets
 
         if #available(iOS 14.0, *) {
@@ -65,6 +66,7 @@ class CommandBarButton: UIButton {
         titleLabel?.isEnabled = isEnabled
         titleLabel?.font = item.titleFont
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
+        accessibilityHint = item.accessibilityHint
     }
 
     private let isPersistSelection: Bool

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -18,7 +18,7 @@ open class CommandBarItem: NSObject {
         isEnabled: Bool = true,
         isSelected: Bool = false,
         itemTappedHandler: @escaping ItemTappedHandler = defaultItemTappedHandler,
-        accessbilityLabel: String? = nil,
+        accessibilityLabel: String? = nil,
         accessibilityHint: String? = nil
     ) {
         self.iconImage = iconImage
@@ -30,7 +30,7 @@ open class CommandBarItem: NSObject {
 
         super.init()
 
-        self.accessibilityLabel = accessbilityLabel
+        self.accessibilityLabel = accessibilityLabel
         self.accessibilityHint = accessibilityHint
     }
 
@@ -44,7 +44,7 @@ open class CommandBarItem: NSObject {
         itemTappedHandler: @escaping ItemTappedHandler = defaultItemTappedHandler,
         menu: UIMenu,
         showsMenuAsPrimaryAction: Bool = false,
-        accessbilityLabel: String? = nil,
+        accessibilityLabel: String? = nil,
         accessibilityHint: String? = nil
     ) {
         self.iconImage = iconImage
@@ -58,7 +58,7 @@ open class CommandBarItem: NSObject {
 
         self.menu = menu
         self.showsMenuAsPrimaryAction = showsMenuAsPrimaryAction
-        self.accessibilityLabel = accessbilityLabel
+        self.accessibilityLabel = accessibilityLabel
         self.accessibilityHint = accessibilityHint
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -18,7 +18,8 @@ open class CommandBarItem: NSObject {
         isEnabled: Bool = true,
         isSelected: Bool = false,
         itemTappedHandler: @escaping ItemTappedHandler = defaultItemTappedHandler,
-        accessbilityLabel: String? = nil
+        accessbilityLabel: String? = nil,
+        accessibilityHint: String? = nil
     ) {
         self.iconImage = iconImage
         self.title = title
@@ -30,6 +31,7 @@ open class CommandBarItem: NSObject {
         super.init()
 
         self.accessibilityLabel = accessbilityLabel
+        self.accessibilityHint = accessibilityHint
     }
 
     @available(iOS 14.0, *)
@@ -42,7 +44,8 @@ open class CommandBarItem: NSObject {
         itemTappedHandler: @escaping ItemTappedHandler = defaultItemTappedHandler,
         menu: UIMenu,
         showsMenuAsPrimaryAction: Bool = false,
-        accessbilityLabel: String? = nil
+        accessbilityLabel: String? = nil,
+        accessibilityHint: String? = nil
     ) {
         self.iconImage = iconImage
         self.title = title
@@ -56,6 +59,7 @@ open class CommandBarItem: NSObject {
         self.menu = menu
         self.showsMenuAsPrimaryAction = showsMenuAsPrimaryAction
         self.accessibilityLabel = accessbilityLabel
+        self.accessibilityHint = accessibilityHint
     }
 
     @objc public var iconImage: UIImage?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There are scenarios where we need to add helpful text as command bar button's accessibility hint. This PR exposes command bar button's accessibility hint and allows consuming code to configure this value. 

### Verification

Used view hierarchy debugger to inspect the accessibility hint, and verified that the accessibility hint of the command bar button is set correctly. 
![Screen Shot 2021-07-21 at 4 50 45 PM](https://user-images.githubusercontent.com/59622334/126576983-fefd34fb-e0ba-4004-966c-2f80660d5054.png)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/643)