### PR TITLE
Add support for 2-line hero command titles in `BottomCommandingController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -88,6 +88,7 @@ class BottomCommandingDemoController: UIViewController {
                 DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff)),
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: true),
                 DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
+                DemoItem(title: "Long title hero items", type: .boolean, action: #selector(toggleLongTitleHeroItems), isOn: false),
                 DemoItem(title: "Toggle boolean cells", type: .action, action: #selector(toggleBooleanCells)),
                 DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeHeroCommandTitle)),
                 DemoItem(title: "Change hero command images", type: .action, action: #selector(changeHeroCommandIcon)),
@@ -139,6 +140,12 @@ class BottomCommandingDemoController: UIViewController {
     @objc private func toggleListCommandEnabled() {
         modifiedCommandIndices.forEach {
             currentExpandedListSections[0].items[$0].isEnabled.toggle()
+        }
+    }
+
+    @objc private func toggleLongTitleHeroItems(_ sender: BooleanCell) {
+        heroItems.enumerated().forEach { (ix, item) in
+            item.title = (sender.isOn ? "Long Title Hero Item " : "Item ") + String(ix)
         }
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -179,7 +179,6 @@ open class BottomCommandingController: UIViewController {
         if let contentViewController = contentViewController {
             addChildContentViewController(contentViewController)
         }
-        delegate?.bottomCommandingControllerCollapsedHeightInSafeAreaDidChange?(self)
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -202,7 +201,6 @@ open class BottomCommandingController: UIViewController {
             } else {
                 setupBottomSheetLayout()
             }
-            delegate?.bottomCommandingControllerCollapsedHeightInSafeAreaDidChange?(self)
         }
 
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
@@ -240,6 +238,8 @@ open class BottomCommandingController: UIViewController {
         bottomBarViewBottomConstraint = bottomConstraint
         self.bottomBarView = bottomBarView
         reloadHeroCommandStack()
+
+        delegate?.bottomCommandingControllerCollapsedHeightInSafeAreaDidChange?(self)
     }
 
     private func setupBottomSheetLayout() {
@@ -253,6 +253,7 @@ open class BottomCommandingController: UIViewController {
         let sheetController = BottomSheetController(headerContentView: commandStackContainer, expandedContentView: makeSheetExpandedContent(with: tableView))
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
+        sheetController.delegate = self
 
         addChild(sheetController)
         view.addSubview(sheetController.view)
@@ -557,7 +558,6 @@ open class BottomCommandingController: UIViewController {
 
         if newHeaderHeight != oldHeaderHeight {
             bottomSheetController.collapsedContentHeight = newHeaderHeight
-            delegate?.bottomCommandingControllerCollapsedHeightInSafeAreaDidChange?(self)
         }
     }
 
@@ -830,5 +830,11 @@ extension BottomCommandingController: CommandingItemDelegate {
         default:
             break
         }
+    }
+}
+
+extension BottomCommandingController: BottomSheetControllerDelegate {
+    public func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController) {
+        delegate?.bottomCommandingControllerCollapsedHeightInSafeAreaDidChange?(self)
     }
 }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -547,9 +547,9 @@ open class BottomCommandingController: UIViewController {
         let reducedBottomWhitespace = max(0, requiredBottomWhitespace - view.safeAreaInsets.bottom)
 
         // We need additional top margin to account for missing resizing handle when isExpandable is false
-        let addedHeaderTopMargin = isExpandable
-            ? Constants.BottomSheet.headerExpandableAddedTopMargin
-            : Constants.BottomSheet.headerNonExpandableAddedTopMargin
+        let addedHeaderTopMargin = !isExpandable
+            ? BottomSheetController.resizingHandleHeight
+            : 0
         bottomSheetHeroStackTopConstraint?.constant = Constants.BottomSheet.headerTopMargin + addedHeaderTopMargin
 
         let oldCollapsedContentHeight = bottomSheetController.collapsedContentHeight
@@ -688,10 +688,7 @@ open class BottomCommandingController: UIViewController {
 
         struct BottomSheet {
             static let headerHeight: CGFloat = 64
-
-            static let headerTopMargin: CGFloat = 5
-            static let headerExpandableAddedTopMargin: CGFloat = 0
-            static let headerNonExpandableAddedTopMargin: CGFloat = 16
+            static let headerTopMargin: CGFloat = 4
             static let headerLeadingTrailingMargin: CGFloat = 8
         }
     }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -780,6 +780,11 @@ extension BottomCommandingController: UITableViewDelegate {
 extension BottomCommandingController: CommandingItemDelegate {
     func commandingItem(_ item: CommandingItem, didChangeTitleTo value: String?) {
         reloadView(from: item)
+
+        if let binding = itemToBindingMap[item], binding.location == .heroSet {
+            // A title change in the hero set can cause a sheet size change, so we need to recalculate
+            updateSheetSizingParameters()
+        }
     }
 
     func commandingItem(_ item: CommandingItem, didChangeImageTo value: UIImage?) {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -142,6 +142,11 @@ public class BottomSheetController: UIViewController {
     /// The object that acts as the delegate of the bottom sheet.
     @objc open weak var delegate: BottomSheetControllerDelegate?
 
+    /// Height of the resizing handle
+    @objc public static var resizingHandleHeight: CGFloat {
+        return ResizingHandleView.height
+    }
+
     // MARK: - View loading
 
     // View hierarchy

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -57,6 +57,16 @@ class TabBarItemView: UIView {
         }
     }
 
+    /// The `preferredMaxLayoutWidth` of the underlying title label.
+    var preferredLabelMaxLayoutWidth: CGFloat {
+        get {
+            titleLabel.preferredMaxLayoutWidth
+        }
+        set {
+            titleLabel.preferredMaxLayoutWidth = newValue
+        }
+    }
+
     init(item: TabBarItem, showsTitle: Bool, canResizeImage: Bool = true) {
         self.canResizeImage = canResizeImage
         self.item = item


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

As per the design spec, hero commands in the bottom sheet need to support 2-line labels. To follow the spec, the hero items now have to be top aligned and the spacing between the header content and expanded content needs to vary depending on whether there is at least one 2-line hero item title.

The changes in this PR per file:

`BottomCommandingDemoController.swift`
Add a toggle for long hero item titles

`TabBarItemView.swift`
Add a passthrough property for titleLabel.preferredMaxLayoutWidth. We need to set this on the label to ensure that the fitting width is restricted when calculating intrinsic content size. Without this, the height given will always correspond to a 1-line label, even if the actual view ends up taller with a 2-line label. The correct intrinsic content height is necessary to know when we have at least one tall hero command.

`BottomCommandingController.swift`
- change a few constraints in the hero command stack, because the commands now don't have a fixed height
- recalculate the header size given to the sheet controller whenever a relevant change happens
- make sure that for the sheet specifically, we don't directly call the delegate with CollapsedHeightInSafeAreaDidChange and we just forward the equivalent delegate calls from the sheet controller. This ensures no change will be missed by he client.
- also slightly change bottom bar constraints, because now we need a fixed bar height to allow the hero stack to grow vertically without growing the bar itself
- things were getting messy, so I factored all sheet sizing logic into `updateSheetSizingParameters`

### Verification
Various sanity checks in the demo app
- make sure sheet size changes properly as titles are updated
- bottom bar doesn't grow with long titles
- delegate is informed about the height changes to update scroll view insets

https://user-images.githubusercontent.com/3610850/126695895-f48e77d3-b615-40be-9f1b-b321d04f37fc.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/644)