### PR TITLE
Ensure only iPad gets the bottom bar layout in `BottomCommandingController`

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -170,11 +170,7 @@ open class BottomCommandingController: UIViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addLayoutGuide(commandingLayoutGuide)
 
-        if traitCollection.horizontalSizeClass == .regular {
-            setupBottomBarLayout()
-        } else {
-            setupBottomSheetLayout()
-        }
+        setupCommandingLayout()
 
         if let contentViewController = contentViewController {
             addChildContentViewController(contentViewController)
@@ -197,11 +193,7 @@ open class BottomCommandingController: UIViewController {
             bottomBarView?.removeFromSuperview()
             bottomBarView = nil
 
-            if traitCollection.horizontalSizeClass == .regular {
-                setupBottomBarLayout()
-            } else {
-                setupBottomSheetLayout()
-            }
+            setupCommandingLayout()
             delegate?.bottomCommandingControllerCollapsedHeightInSafeAreaDidChange?(self)
         }
 
@@ -214,6 +206,14 @@ open class BottomCommandingController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
         if presentedViewController != nil {
             dismiss(animated: false)
+        }
+    }
+
+    private func setupCommandingLayout() {
+        if traitCollection.horizontalSizeClass == .regular && traitCollection.userInterfaceIdiom == .pad {
+            setupBottomBarLayout()
+        } else {
+            setupBottomSheetLayout()
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a bug where the bottom bar shows in landscape on the largest iPhones. This is because these iPhones fall under the "regular" horizontal size class when in landscape, and that's currently the only condition we use to switch to the bottom bar layout.
To fix this I added an additional check to see if we're running on an iPad.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-22 at 14 46 28](https://user-images.githubusercontent.com/3610850/126713690-1f139806-e122-41c6-82c4-b088a5105c48.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2021-07-22 at 14 45 47](https://user-images.githubusercontent.com/3610850/126713705-e63eb517-d2f3-439b-9acf-44c3afd6ebdd.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/645)