### PR TITLE
Cherry picking change to make the CommandBarButton's accessibility hint configurable.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -252,7 +252,8 @@ class CommandBarDemoController: DemoController {
             isSelected: isSelected,
             itemTappedHandler: { [weak self] (_, item) in
                 self?.handleCommandItemTapped(command: command, item: item)
-            }
+            },
+            accessibilityHint: "sample accessibility hint"
         )
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -37,6 +37,7 @@ class CommandBarButton: UIButton {
 
         let accessibilityDescription = item.accessibilityLabel
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
+        accessibilityHint = item.accessibilityHint
         contentEdgeInsets = CommandBarButton.contentEdgeInsets
 
         if #available(iOS 14.0, *) {
@@ -65,6 +66,7 @@ class CommandBarButton: UIButton {
         titleLabel?.isEnabled = isEnabled
         titleLabel?.font = item.titleFont
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
+        accessibilityHint = item.accessibilityHint
     }
 
     private let isPersistSelection: Bool

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -18,7 +18,8 @@ open class CommandBarItem: NSObject {
         isEnabled: Bool = true,
         isSelected: Bool = false,
         itemTappedHandler: @escaping ItemTappedHandler = defaultItemTappedHandler,
-        accessbilityLabel: String? = nil
+        accessibilityLabel: String? = nil,
+        accessibilityHint: String? = nil
     ) {
         self.iconImage = iconImage
         self.title = title
@@ -29,7 +30,8 @@ open class CommandBarItem: NSObject {
 
         super.init()
 
-        self.accessibilityLabel = accessbilityLabel
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityHint = accessibilityHint
     }
 
     @available(iOS 14.0, *)
@@ -42,7 +44,8 @@ open class CommandBarItem: NSObject {
         itemTappedHandler: @escaping ItemTappedHandler = defaultItemTappedHandler,
         menu: UIMenu,
         showsMenuAsPrimaryAction: Bool = false,
-        accessbilityLabel: String? = nil
+        accessibilityLabel: String? = nil,
+        accessibilityHint: String? = nil
     ) {
         self.iconImage = iconImage
         self.title = title
@@ -55,7 +58,8 @@ open class CommandBarItem: NSObject {
 
         self.menu = menu
         self.showsMenuAsPrimaryAction = showsMenuAsPrimaryAction
-        self.accessibilityLabel = accessbilityLabel
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityHint = accessibilityHint
     }
 
     @objc public var iconImage: UIImage?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry picking changes in commit 2720dd13406bd3ca64d7c8f8e4383e1955065f26 as part of #643 to the main_0.1 branch.

### Verification

Basic sanity test of launching the Demo App and validating the accessibility hint in the same way it was validated on #643.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/646)