### PR TITLE
Replace fatalError with preconditionFailure

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -12,7 +12,7 @@ class TableViewCellFileAccessoryViewDemoController: UITableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -46,7 +46,7 @@ open class CommandBar: UIView {
 
     @available(*, unavailable)
     public required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     /// Apply `isEnabled` and `isSelected` state from `CommandBarItem` to the buttons
@@ -139,7 +139,7 @@ open class CommandBar: UIView {
         itemGroups.map { items in
             CommandBarButtonGroupView(buttons: items.compactMap { item in
                 guard let button = itemsToButtonsMap[item] else {
-                    fatalError("Button is not initialized in commandsToButtons")
+                    preconditionFailure("Button is not initialized in commandsToButtons")
                 }
 
                 return button

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -49,7 +49,7 @@ class CommandBarButton: UIButton {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     func updateState() {

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -24,7 +24,7 @@ class CommandBarButtonGroupView: UIView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     private lazy var stackView: UIStackView = {

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -48,7 +48,7 @@ class SegmentPillButton: UIButton {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func layoutSubviews() {

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -698,7 +698,7 @@ class BorderView: NSView {
 	}
 
 	required init?(coder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 
 	override func draw(_ dirtyRect: NSRect) {

--- a/scripts/removeUnusedResourcesFromAssets.swift
+++ b/scripts/removeUnusedResourcesFromAssets.swift
@@ -49,11 +49,11 @@ func findUsedResources(in rootPath: String) -> Set<String> {
 #endif
                         }
                     } catch {
-                        fatalError("Failed to read contents resource file: \(filePath) \nError: \(error)")
+                        preconditionFailure("Failed to read contents resource file: \(filePath) \nError: \(error)")
                    }
                 }
             } catch {
-                fatalError("Failed to retrieve resource file: \(fileURL) \nError: \(error)")
+                preconditionFailure("Failed to retrieve resource file: \(fileURL) \nError: \(error)")
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Quick find and replace to replace `fatalError` with `preconditionFailure`.

### Verification

Basic sanity pass of affected components in iOS and macOS demo apps.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/647)