### PR TITLE
[vNext] AvatarGroup: Creating smoother animations

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -360,7 +360,7 @@ class AvatarGroupDemoController: DemoTableViewController {
         }
     }
 
-    private var maxDisplayedAvatars: Int = 4 {
+    private var maxDisplayedAvatars: Int = 3 {
         didSet {
             if oldValue != maxDisplayedAvatars {
                 maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
@@ -440,9 +440,9 @@ class AvatarGroupDemoController: DemoTableViewController {
         return textField
     }()
 
-    private var avatarCount: Int = 5 {
+    private var avatarCount: Int = 4 {
         didSet {
-            guard avatarCount != 0 || oldValue != 0 else {
+            guard oldValue != avatarCount && avatarCount >= 0 else {
                 return
             }
             AvatarGroupDemoSection.allCases.filter({ section in
@@ -482,6 +482,7 @@ class AvatarGroupDemoController: DemoTableViewController {
         guard avatarCount > 0 else {
             return
         }
+
         avatarCount -= 1
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -138,7 +138,8 @@ class AvatarGroupDemoController: DemoTableViewController {
             NSLayoutConstraint.activate([
                 cell.contentView.leadingAnchor.constraint(equalTo: avatarGroupView.leadingAnchor, constant: -20),
                 cell.contentView.topAnchor.constraint(equalTo: avatarGroupView.topAnchor, constant: -15),
-                cell.contentView.bottomAnchor.constraint(equalTo: avatarGroupView.bottomAnchor, constant: 15)
+                cell.contentView.bottomAnchor.constraint(equalTo: avatarGroupView.bottomAnchor, constant: 15),
+                cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
             cell.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -441,31 +441,35 @@ class AvatarGroupDemoController: DemoTableViewController {
 
     private var avatarCount: Int = 5 {
         didSet {
-            AvatarGroupDemoSection.allCases.filter({ section in
-                return section.isDemoSection
-            }).forEach { section in
-                var avatarGroupsForCurrentSection: [AvatarGroupDemoRow: MSFAvatarGroup] = [:]
+            if avatarCount == 0 && oldValue == 0 {
+                return
+            } else {
+                AvatarGroupDemoSection.allCases.filter({ section in
+                    return section.isDemoSection
+                }).forEach { section in
+                    var avatarGroupsForCurrentSection: [AvatarGroupDemoRow: MSFAvatarGroup] = [:]
 
-                AvatarGroupDemoRow.allCases.filter({ row in
-                    return row.isDemoRow
-                }).forEach { row in
-                    let avatarGroup = demoAvatarGroupsBySection[section]![row]
-                    if oldValue < avatarCount {
-                        let avatarState = avatarGroup?.state.createAvatar()
-                        for index in 0...avatarCount - 1 {
-                            let samplePersona = samplePersonas[index]
-                            avatarState!.image = samplePersona.image
-                            avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
-                            avatarState!.primaryText = samplePersona.name
-                            avatarState!.secondaryText = samplePersona.email
+                    AvatarGroupDemoRow.allCases.filter({ row in
+                        return row.isDemoRow
+                    }).forEach { row in
+                        let avatarGroup = demoAvatarGroupsBySection[section]![row]
+                        if oldValue < avatarCount {
+                            let avatarState = avatarGroup?.state.createAvatar()
+                            for index in 0...avatarCount - 1 {
+                                let samplePersona = samplePersonas[index]
+                                avatarState!.image = samplePersona.image
+                                avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                                avatarState!.primaryText = samplePersona.name
+                                avatarState!.secondaryText = samplePersona.email
+                            }
+                        } else {
+                            avatarGroup?.state.removeAvatar(at: avatarCount)
                         }
-                    } else {
-                        avatarGroup?.state.removeAvatar(at: avatarCount)
-                    }
 
-                    avatarGroupsForCurrentSection.updateValue(avatarGroup!, forKey: row)
+                        avatarGroupsForCurrentSection.updateValue(avatarGroup!, forKey: row)
+                    }
+                    demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
                 }
-                demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
             }
         }
     }
@@ -475,7 +479,7 @@ class AvatarGroupDemoController: DemoTableViewController {
     }
 
     @objc private func subtractAvatarCount(_ cell: ActionsCell) {
-        avatarCount -= 1
+        avatarCount -= avatarCount == 0 ? 0 : 1
     }
 
     @objc private func toggleAlternateBackground(_ cell: BooleanCell) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -442,35 +442,34 @@ class AvatarGroupDemoController: DemoTableViewController {
 
     private var avatarCount: Int = 5 {
         didSet {
-            if avatarCount == 0 && oldValue == 0 {
+            guard avatarCount != 0 || oldValue != 0 else {
                 return
-            } else {
-                AvatarGroupDemoSection.allCases.filter({ section in
-                    return section.isDemoSection
-                }).forEach { section in
-                    var avatarGroupsForCurrentSection: [AvatarGroupDemoRow: MSFAvatarGroup] = [:]
+            }
+            AvatarGroupDemoSection.allCases.filter({ section in
+                return section.isDemoSection
+            }).forEach { section in
+                var avatarGroupsForCurrentSection: [AvatarGroupDemoRow: MSFAvatarGroup] = [:]
 
-                    AvatarGroupDemoRow.allCases.filter({ row in
-                        return row.isDemoRow
-                    }).forEach { row in
-                        let avatarGroup = demoAvatarGroupsBySection[section]![row]
-                        if oldValue < avatarCount {
-                            let avatarState = avatarGroup?.state.createAvatar()
-                            for index in 0...avatarCount - 1 {
-                                let samplePersona = samplePersonas[index]
-                                avatarState!.image = samplePersona.image
-                                avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
-                                avatarState!.primaryText = samplePersona.name
-                                avatarState!.secondaryText = samplePersona.email
-                            }
-                        } else {
-                            avatarGroup?.state.removeAvatar(at: avatarCount)
+                AvatarGroupDemoRow.allCases.filter({ row in
+                    return row.isDemoRow
+                }).forEach { row in
+                    let avatarGroup = demoAvatarGroupsBySection[section]![row]
+                    if oldValue < avatarCount {
+                        let avatarState = avatarGroup?.state.createAvatar()
+                        for index in 0...avatarCount - 1 {
+                            let samplePersona = samplePersonas[index]
+                            avatarState!.image = samplePersona.image
+                            avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                            avatarState!.primaryText = samplePersona.name
+                            avatarState!.secondaryText = samplePersona.email
                         }
-
-                        avatarGroupsForCurrentSection.updateValue(avatarGroup!, forKey: row)
+                    } else {
+                        avatarGroup?.state.removeAvatar(at: avatarCount)
                     }
-                    demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
+
+                    avatarGroupsForCurrentSection.updateValue(avatarGroup!, forKey: row)
                 }
+                demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
             }
         }
     }
@@ -480,7 +479,10 @@ class AvatarGroupDemoController: DemoTableViewController {
     }
 
     @objc private func subtractAvatarCount(_ cell: ActionsCell) {
-        avatarCount -= avatarCount == 0 ? 0 : 1
+        guard avatarCount > 0 else {
+            return
+        }
+        avatarCount -= 1
     }
 
     @objc private func toggleAlternateBackground(_ cell: BooleanCell) {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -176,7 +176,7 @@ public struct Avatar: View {
         let ringOuterGap: CGFloat = isRingVisible ? tokens.ringOuterGap : 0
         let avatarImageSize: CGFloat = tokens.avatarSize!
         let ringInnerGapSize: CGFloat = avatarImageSize + (ringInnerGap * 2)
-        let ringSize: CGFloat = ringInnerGapSize + ( ringThickness * 2)
+        let ringSize: CGFloat = ringInnerGapSize + (ringThickness * 2)
         let ringOuterGapSize: CGFloat = ringSize + (ringOuterGap * 2)
         let presenceIconSize: CGFloat = tokens.presenceIconSize!
         let presenceIconOutlineSize: CGFloat = presenceIconSize + (tokens.presenceIconOutlineThickness * 2)
@@ -531,7 +531,7 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, Identifiable, MSFAvatarSta
             return avatarImageSize + (ringOuterGap * 2)
         } else {
             let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
-            let ringInnerGap: CGFloat = isRingVisible ? tokens.ringInnerGap : 0
+            let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
             return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
         }
     }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -355,6 +355,17 @@ public struct Avatar: View {
         var yOrigin: CGFloat
         var cutoutSize: CGFloat
 
+        public var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
+            get {
+                AnimatablePair(AnimatablePair(xOrigin, yOrigin), cutoutSize)
+            }
+            set {
+                xOrigin = newValue.first.first
+                yOrigin = newValue.first.second
+                cutoutSize = newValue.second
+            }
+        }
+
         public func path(in rect: CGRect) -> Path {
             var cutoutFrame = Rectangle().path(in: rect)
             cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
@@ -467,7 +478,9 @@ public struct Avatar: View {
 }
 
 /// Properties available to customize the state of the avatar
-class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
+class MSFAvatarStateImpl: NSObject, ObservableObject, Identifiable, MSFAvatarState {
+    public var id = UUID()
+
     @Published var backgroundColor: UIColor?
     @Published var foregroundColor: UIColor?
     @Published var hasButtonAccessibilityTrait: Bool = false

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -245,10 +245,24 @@ public struct AvatarGroup: View {
                        height: geo.size.height,
                        alignment: .leading)
             }
-            .frame(height: groupHeight)
+            .frame(width: calcWidth(), height: groupHeight)
         }
 
         return avatarGroupContent
+    }
+
+    private func calcWidth() -> CGFloat {
+        var width: CGFloat = 0
+        let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
+        for index in 0 ..< maxShown {
+            width += state.avatars[index].size.size
+            if index < maxShown - 1 {
+                width += tokens.interspace
+            } else {
+                width += tokens.size.size
+            }
+        }
+        return width
     }
 
     private func createOverflow(count: Int) -> Avatar {

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -192,14 +192,15 @@ public struct AvatarGroup: View {
         var avatarGroupContent: some View {
                     HStack(spacing: 0) {
                         ForEach(enumeratedAvatars.prefix(maxDisplayedAvatars), id: \.1) { index, avatar in
-                            // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
+                            // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
                             let avatarView = avatarViews[index]
                             let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
                             let avatarSize: CGFloat = avatarView.state.totalSize()
                             let nextAvatarSize: CGFloat = needsCutout ? avatarViews[index + 1].state.totalSize() : 0
                             let isLastDisplayed = index == maxDisplayedAvatars - 1
 
-                            // Calculating the different coordinate scenarios for when an avatar has a ring visible in a Stack group style.
+                            // Calculating the size delta of the current and next avatar based off of ring visibility, which helps determine
+                            // starting coordinates for the cutout.
                             let currentAvatarHasRing = avatar.isRingVisible
                             let nextAvatarHasRing = index + 1 < maxDisplayedAvatars ? avatars[index + 1].isRingVisible : false
                             let avatarSizeDifference = avatarSize - nextAvatarSize

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -244,21 +244,27 @@ public struct AvatarGroup: View {
                 .frame(height: geo.size.height,
                        alignment: .leading)
             }
-            .frame(width: calcwidth, height: groupHeight)
+            .frame(width: calcWidth(hasOverflow: overflowCount > 0), height: groupHeight, alignment: .leading)
         }
 
         return avatarGroupContent
     }
 
-    private var calcwidth: CGFloat {
+    private func calcWidth(hasOverflow: Bool) -> CGFloat {
         var width: CGFloat = 0
         let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
-        let interspace: CGFloat = tokens.interspace
+        let interspace: CGFloat = state.style == .stack ? tokens.interspace - tokens.ringInnerGap : tokens.interspace
         let avatarSize: CGFloat = tokens.size.size
         for index in 0 ..< maxShown {
             width += state.avatars[index].totalSize()
-            width += index < maxShown - 1 ? interspace : avatarSize
+            width += index < maxShown - 1 ? interspace : 0
         }
+
+        if hasOverflow {
+            width += interspace
+            width += avatarSize
+        }
+
         return width
     }
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -245,22 +245,20 @@ public struct AvatarGroup: View {
                        height: geo.size.height,
                        alignment: .leading)
             }
-            .frame(width: calcWidth(), height: groupHeight)
+            .frame(width: calcwidth, height: groupHeight)
         }
 
         return avatarGroupContent
     }
 
-    private func calcWidth() -> CGFloat {
+    private var calcwidth: CGFloat {
         var width: CGFloat = 0
         let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
+        let interspace: CGFloat = tokens.interspace
+        let avatarSize: CGFloat = tokens.size.size
         for index in 0 ..< maxShown {
-            width += state.avatars[index].size.size
-            if index < maxShown - 1 {
-                width += tokens.interspace
-            } else {
-                width += tokens.size.size
-            }
+            width += state.avatars[index].totalSize()
+            width += index < maxShown - 1 ? interspace : avatarSize
         }
         return width
     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -241,8 +241,7 @@ public struct AvatarGroup: View {
                         .transition(AnyTransition.move(edge: .leading))
                     }
                 }
-                .frame(width: geo.frame(in: .local).minX,
-                       height: geo.size.height,
+                .frame(height: geo.size.height,
                        alignment: .leading)
             }
             .frame(width: calcwidth, height: groupHeight)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -157,7 +157,7 @@ public struct AvatarGroup: View {
         self.tokens = state.tokens
     }
 
-    /// Renders the avatar with an optional cutout
+    /// Renders the avatar with an optional cutout for the Stack group style.
     @ViewBuilder
     private func avatarCutout(_ avatar: Avatar,
                               _ needsCutout: Bool,
@@ -199,6 +199,7 @@ public struct AvatarGroup: View {
                             let nextAvatarSize: CGFloat = needsCutout ? avatarViews[index + 1].state.totalSize() : 0
                             let isLastDisplayed = index == maxDisplayedAvatars - 1
 
+                            // Calculating the different coordinate scenarios for when an avatar has a ring visible in a Stack group style.
                             let currentAvatarHasRing = avatar.isRingVisible
                             let nextAvatarHasRing = index + 1 < maxDisplayedAvatars ? avatars[index + 1].isRingVisible : false
                             let avatarSizeDifference = avatarSize - nextAvatarSize
@@ -206,12 +207,14 @@ public struct AvatarGroup: View {
                             currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize
                             let x = avatarSize + tokens.interspace - ringGapOffset
 
+                            // Calculating the different interspace scenarios considering rings, RTL, and group style.
                             let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
                             let noRingPaddingInterspace = nextAvatarHasRing ? interspace - ringOuterGap : interspace
                             let rtlRingPaddingInterspace = nextAvatarHasRing ? -x + ringGapOffset : -x + ringOffset + (ringOuterGap * 3)
                             let rtlNoRingPaddingInterspace = nextAvatarHasRing ? -x - ringOffset - ringGapOffset : -x - ringOuterGap
                             let stackPadding = currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace
 
+                            // Finalized calculations for x and y coordinates of the Avatar if it needs a cutout.
                             let xPosition = currentAvatarHasRing ? x - ringGapOffset : x - ringOuterGap
                             let xPositionRTL = currentAvatarHasRing ? rtlRingPaddingInterspace : rtlNoRingPaddingInterspace
                             let xOrigin = Locale.current.isRightToLeftLayoutDirection() ? xPositionRTL : xPosition
@@ -233,6 +236,7 @@ public struct AvatarGroup: View {
                             .animation(Animation.linear(duration: animationDuration))
                             .transition(AnyTransition.move(edge: .leading))
                         }
+
                         if overflowCount > 0 {
                             VStack {
                                 createOverflow(count: overflowCount)
@@ -250,7 +254,7 @@ public struct AvatarGroup: View {
         return avatarGroupContent
     }
 
-    private let animationDuration = 0.1
+    private let animationDuration: CGFloat = 0.1
 
     private func createOverflow(count: Int) -> Avatar {
         var avatar = Avatar(style: .overflow, size: tokens.size)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -190,8 +190,6 @@ public struct AvatarGroup: View {
 
         @ViewBuilder
         var avatarGroupContent: some View {
-            SwiftUI.ScrollView(.horizontal, showsIndicators: false) {
-                GeometryReader { geo in
                     HStack(spacing: 0) {
                         ForEach(enumeratedAvatars.prefix(maxDisplayedAvatars), id: \.1) { index, avatar in
                             // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
@@ -232,57 +230,27 @@ public struct AvatarGroup: View {
                                     })
                             }
                             .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
-                            .animation(Animation.linear(duration: 0.1))
+                            .animation(Animation.linear(duration: animationDuration))
                             .transition(AnyTransition.move(edge: .leading))
                         }
                         if overflowCount > 0 {
                             VStack {
                                 createOverflow(count: overflowCount)
                             }
+                            .animation(Animation.linear(duration: animationDuration))
                             .transition(AnyTransition.move(edge: .leading))
                         }
                     }
-                    .frame(height: geo.size.height,
+                    .frame(maxWidth: .infinity,
+                           minHeight: groupHeight,
+                           maxHeight: .infinity,
                            alignment: .leading)
-                }
-                .frame(width: calcWidth(hasOverflow: overflowCount > 0), height: groupHeight, alignment: .leading)
-            }
         }
 
         return avatarGroupContent
     }
 
-    private func calcWidth(hasOverflow: Bool) -> CGFloat {
-        var width: CGFloat = 0
-        let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
-        let interspace: CGFloat = tokens.interspace
-        let gapOffset: CGFloat = tokens.ringOuterGap * 2
-        let ringGapOffset: CGFloat = (tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap) * 2
-        let imageSize: CGFloat = tokens.size.size
-        var paddingAdjustment: CGFloat = 0
-        var needsStackAdjustment: CGFloat = 0
-        var previousHasRing: Bool = false
-        for index in 0 ..< maxShown {
-            let avatar = state.avatars[index]
-            let avatarSize: CGFloat = avatar.totalSize() - needsStackAdjustment
-            previousHasRing = avatar.isRingVisible
-            paddingAdjustment = previousHasRing ? ringGapOffset / 2 : gapOffset
-            if index + 1 < maxShown {
-                paddingAdjustment += previousHasRing ? (state.avatars[index + 1].isRingVisible ? gapOffset / 2 : gapOffset) : 0
-            }
-            needsStackAdjustment = tokens.style == .stack ? paddingAdjustment : 0
-
-            width += avatarSize
-            width += index < maxShown - 1 ? interspace : 0
-        }
-
-        if hasOverflow {
-            width += interspace - (previousHasRing ? needsStackAdjustment: 0)
-            width += imageSize
-        }
-
-        return width
-    }
+    private let animationDuration = 0.1
 
     private func createOverflow(count: Int) -> Avatar {
         var avatar = Avatar(style: .overflow, size: tokens.size)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -255,19 +255,29 @@ public struct AvatarGroup: View {
     private func calcWidth(hasOverflow: Bool) -> CGFloat {
         var width: CGFloat = 0
         let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
-        let interspace: CGFloat = state.style == .stack ? tokens.interspace : tokens.interspace
+        let interspace: CGFloat = tokens.interspace
         let gapOffset: CGFloat = tokens.ringOuterGap * 2
-        let ringGapOffset: CGFloat = tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap
+        let ringGapOffset: CGFloat = (tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap) * 2
         let imageSize: CGFloat = tokens.size.size
+        var paddingAdjustment: CGFloat = 0
+        var needsStackAdjustment: CGFloat = 0
+        var previousHasRing: Bool = false
         for index in 0 ..< maxShown {
             let avatar = state.avatars[index]
-            let avatarSize: CGFloat = avatar.totalSize() - (avatar.isRingVisible ? ringGapOffset / 2 : gapOffset)
+            let avatarSize: CGFloat = avatar.totalSize() - needsStackAdjustment
+            previousHasRing = avatar.isRingVisible
+            paddingAdjustment = previousHasRing ? ringGapOffset / 2 : gapOffset
+            if index + 1 < maxShown {
+                paddingAdjustment += previousHasRing ? (state.avatars[index + 1].isRingVisible ? gapOffset / 2 : gapOffset) : 0
+            }
+            needsStackAdjustment = tokens.style == .stack ? paddingAdjustment : 0
+
             width += avatarSize
             width += index < maxShown - 1 ? interspace : 0
         }
 
         if hasOverflow {
-            width += interspace
+            width += interspace - (previousHasRing ? needsStackAdjustment: 0)
             width += imageSize
         }
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -219,21 +219,26 @@ public struct AvatarGroup: View {
                         let yOrigin = sizeDiff / 2
                         let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
 
-                        avatarView
-                            .modifyIf(needsCutout, { view in
-                                view.mask(Avatar.AvatarCutout(
-                                            xOrigin: xOrigin,
-                                            yOrigin: yOrigin,
-                                            cutoutSize: cutoutSize)
-                                            .fill(style: FillStyle(eoFill: true)))
-                            })
-                            .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
-                            .animation(Animation.linear(duration: 0.1))
-                            .transition(AnyTransition.move(edge: .leading))
+                        VStack {
+                            avatarView
+                                .transition(.identity)
+                                .modifyIf(needsCutout, { view in
+                                    view.mask(Avatar.AvatarCutout(
+                                                xOrigin: xOrigin,
+                                                yOrigin: yOrigin,
+                                                cutoutSize: cutoutSize)
+                                                .fill(style: FillStyle(eoFill: true)))
+                                })
+                        }
+                        .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
+                        .animation(Animation.linear(duration: 0.1))
+                        .transition(AnyTransition.move(edge: .leading))
                     }
                     if overflowCount > 0 {
-                        createOverflow(count: overflowCount)
-                            .transition(AnyTransition.move(edge: .leading))
+                        VStack {
+                            createOverflow(count: overflowCount)
+                        }
+                        .transition(AnyTransition.move(edge: .leading))
                     }
                 }
                 .frame(width: geo.frame(in: .local).minX,

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -176,8 +176,8 @@ public struct AvatarGroup: View {
 
     public var body: some View {
         let avatars: [MSFAvatarStateImpl] = state.avatars
-        let enumeratedAvatars = Array(avatars.enumerated())
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
+        let enumeratedAvatars = Array(avatars.enumerated())
         let maxDisplayedAvatars: Int = avatars.prefix(state.maxDisplayedAvatars).count
         let overflowCount: Int = (avatars.count > maxDisplayedAvatars ? avatars.count - maxDisplayedAvatars : 0) + state.overflowCount
 
@@ -194,7 +194,6 @@ public struct AvatarGroup: View {
                 HStack(spacing: 0) {
                     ForEach(enumeratedAvatars.prefix(maxDisplayedAvatars), id: \.1) { index, avatar in
                         // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
-                        let avatar = avatars[index]
                         let avatarView = avatarViews[index]
                         let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
                         let avatarSize: CGFloat = avatarView.state.totalSize()
@@ -234,6 +233,7 @@ public struct AvatarGroup: View {
                     }
                     if overflowCount > 0 {
                         createOverflow(count: overflowCount)
+                            .transition(AnyTransition.move(edge: .leading))
                     }
                 }
                 .frame(width: geo.frame(in: .local).minX,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Animations whenever the AvatarGroup would change would stutter. We added animatableData and encased the group in a ViewBuilder to prevent alignment bugs that cause the group to appear centered.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/22566866/126748328-34fb71b5-7122-49c1-b44d-2e3619ee44b2.gif) | ![after](https://user-images.githubusercontent.com/22566866/145288631-3bef1188-0684-4720-9fd3-f4fdb974f368.mov) |
|  | ![after1](https://user-images.githubusercontent.com/22566866/145288723-befbb597-5935-49dc-ba50-747e8ca24116.mov) |

#### Procedure:
- Add avatar
- Remove avatar
- Change max displayed avatars
- Change overflow count

Tested on iOS 13, 14, & 15,

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/648)