### PR TITLE
pillsegmentedcontrol mask label shouldn't be accessible

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -554,6 +554,7 @@ open class SegmentedControl: UIControl {
         maskedLabel.text = button.currentTitle
         maskedLabel.font = button.titleLabel?.font
         maskedLabel.translatesAutoresizingMaskIntoConstraints = false
+        maskedLabel.isAccessibilityElement = false
         pillMaskedLabelsContainerView.addSubview(maskedLabel)
         pillMaskedLabels.insert(maskedLabel, at: index)
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Mask labels are rendered on top of the pill buttons to show smooth animation transition. However, it shouldn't VO accessible because user should directly interact with the pill button.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-07-23 at 1 30 24 PM](https://user-images.githubusercontent.com/20715435/126839006-a903a9ad-5450-4779-8b04-b8a5d7a7043e.png)| ![Screen Shot 2021-07-23 at 1 29 49 PM](https://user-images.githubusercontent.com/20715435/126839025-0ac4b8a9-388a-4898-bb51-083e2fde5bc6.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/649)