### PR TITLE
pod-publishing support for multiple branches

### DIFF
--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -4,9 +4,10 @@ on:
     branches:
       - main
       - main_0.1
+      - main_0.2
     tags:
-      - [0-9]+.[0-9]+.* # Run automatically on new tags matching a 0.N.M pattern
-
+      - 0.[0-9]+.[0-9]+ # Run automatically on new tags matching a 0.N.M pattern
+      - 0.[0-9]+.[0-9]+_main*
 jobs:
   Pod-Publish:
     runs-on: macOS-10.15

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -1,12 +1,14 @@
 name: Pod-Publish
 on:
   push:
+    branches:
+      - main
+      - main_0.1
     tags:
       - 0.[0-9]+.[0-9]+ # Run automatically on new tags matching a 0.N.M pattern
 
 jobs:
   Pod-Publish:
-    if: github.event.base_ref == 'refs/heads/main'
     runs-on: macOS-10.15
     
     steps:

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -5,7 +5,7 @@ on:
       - main
       - main_0.1
     tags:
-      - 0.[0-9]+.[0-9]+ # Run automatically on new tags matching a 0.N.M pattern
+      - [0-9]+.[0-9]+.* # Run automatically on new tags matching a 0.N.M pattern
 
 jobs:
   Pod-Publish:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes
to reduce the hassle of manually publishing main_0.1 for CocoaPods, update the yml file to handle both main and main_0.1 branches.

### Verification

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/650)