### PR TITLE
prevent NotificationView toast crash in demoapp

### DIFF
--- a/ios/FluentUI/Notification/NotificationView.swift
+++ b/ios/FluentUI/Notification/NotificationView.swift
@@ -231,6 +231,15 @@ open class NotificationView: UIView {
         initialize()
     }
 
+    open override func removeFromSuperview() {
+        super.removeFromSuperview()
+        
+        isShown = false
+        if NotificationView.currentToast == self {
+            NotificationView.currentToast = nil
+        }
+    }
+
     @objc open func initialize() {
         addSubview(backgroundView)
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
@@ -424,11 +433,6 @@ open class NotificationView: UIView {
         let completionForHide = {
             self.removeFromSuperview()
             UIAccessibility.post(notification: .layoutChanged, argument: nil)
-
-            self.isShown = false
-            if NotificationView.currentToast == self {
-                NotificationView.currentToast = nil
-            }
 
             self.completionsForHide.forEach { $0() }
             self.completionsForHide.removeAll()

--- a/ios/FluentUI/Notification/NotificationView.swift
+++ b/ios/FluentUI/Notification/NotificationView.swift
@@ -233,7 +233,7 @@ open class NotificationView: UIView {
 
     open override func removeFromSuperview() {
         super.removeFromSuperview()
-        
+
         isShown = false
         if NotificationView.currentToast == self {
             NotificationView.currentToast = nil


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Bug steps:
- launch demo app
- go to "NotificationView"
-  show one of the Toast
- go back to main control list
- go to "NotificationView" again
- tap "show" on one of the toast
result: Crash

NotificationView currently has static variable currentToast to prevent from apps showing multiple toast. If toast was removed from the view hierarchy without going throw hide() function, the next time the app tries to show a new toast it might lead to crash because of invalid pointer. instead resetting the static variable in hide() completion block, override the removeFromSuperview.

### Verification
go through the repro steps and not crash anymore


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/651)