### PR TITLE
[FHL] Initial version of the SwiftUI Avatar Demo Controller.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		22EABB182509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EABB172509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift */; };
 		2F0A96FC25CA047100EF9736 /* SearchBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */; };
 		497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */; };
+		5303259126B1FAC700611D05 /* FluentUIDemoToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5303259026B1FAC700611D05 /* FluentUIDemoToggle.swift */; };
 		531CC51426AF3B350059DCCE /* AvatarDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531CC51326AF3B340059DCCE /* AvatarDemoController_SwiftUI.swift */; };
 		53224AC225D65D220063FBDB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		532854F825A3C70C0042C3B9 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -98,6 +99,7 @@
 		22EABB172509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
 		2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBarDemoController.swift; sourceTree = "<group>"; };
 		497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarDemoController.swift; sourceTree = "<group>"; };
+		5303259026B1FAC700611D05 /* FluentUIDemoToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentUIDemoToggle.swift; sourceTree = "<group>"; };
 		531CC51326AF3B340059DCCE /* AvatarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		53A16D72267C0EE40030FFAC /* ActivityIndicatorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorDemoController.swift; sourceTree = "<group>"; };
 		53A16D73267C0EE40030FFAC /* ButtonDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonDemoController.swift; sourceTree = "<group>"; };
@@ -208,6 +210,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5303258F26B1F9ED00611D05 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				5303259026B1FAC700611D05 /* FluentUIDemoToggle.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		A52B637E21387566009F7ADF /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
@@ -258,6 +268,7 @@
 			children = (
 				A5CEC23220E452B80016922A /* Demos */,
 				A591A3F520F42A9E001ED23B /* Shell */,
+				5303258F26B1F9ED00611D05 /* SwiftUI */,
 				B4C39550227A4A9300539EC2 /* Utilities */,
 				A577FC96225EC76900B5BBE0 /* Resources */,
 				A52B637E21387566009F7ADF /* Configuration */,
@@ -463,6 +474,7 @@
 			files = (
 				B441478F228E02540040E88E /* OtherCellsDemoController.swift in Sources */,
 				536DDA08264C534900CD41B5 /* (null) in Sources */,
+				5303259126B1FAC700611D05 /* FluentUIDemoToggle.swift in Sources */,
 				53B659C5257AA6AA00070405 /* NavigationControllerDemoController.swift in Sources */,
 				53F7386B257964AB0043071D /* AvatarGroupViewDemoController.swift in Sources */,
 				53B659C4257AA69E00070405 /* DrawerDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		22EABB182509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22EABB172509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift */; };
 		2F0A96FC25CA047100EF9736 /* SearchBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */; };
 		497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */; };
+		531CC51426AF3B350059DCCE /* AvatarDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531CC51326AF3B340059DCCE /* AvatarDemoController_SwiftUI.swift */; };
 		53224AC225D65D220063FBDB /* (null) in Sources */ = {isa = PBXBuildFile; };
 		532854F825A3C70C0042C3B9 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		535401CC25BB4FEA0047DC47 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -41,10 +42,10 @@
 		80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */; };
 		80B1F7012628D8BB004DFEE5 /* BottomSheetDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */; };
 		8AF03E2024B6BE3100E6E2A2 /* ContactCollectionViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF03E1F24B6BE3100E6E2A2 /* ContactCollectionViewDemoController.swift */; };
-		92E4784C2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E4784B2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift */; };
 		8F0B81122670200300463726 /* AppCenterDistribute in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0B81112670200300463726 /* AppCenterDistribute */; };
 		8F0B8114267021A700463726 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0B8113267021A700463726 /* AppCenterAnalytics */; };
 		8F0B8116267021A700463726 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0B8115267021A700463726 /* AppCenterCrashes */; };
+		92E4784C2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E4784B2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift */; };
 		A589F856211BA71000471C23 /* LabelDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A589F855211BA71000471C23 /* LabelDemoController.swift */; };
 		A591A3F420F429EB001ED23B /* Demos.swift in Sources */ = {isa = PBXBuildFile; fileRef = A591A3F320F429EB001ED23B /* Demos.swift */; };
 		A5CEC21020E436F10016922A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC20F20E436F10016922A /* AppDelegate.swift */; };
@@ -97,6 +98,7 @@
 		22EABB172509A80B00C4BE72 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
 		2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBarDemoController.swift; sourceTree = "<group>"; };
 		497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarDemoController.swift; sourceTree = "<group>"; };
+		531CC51326AF3B340059DCCE /* AvatarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		53A16D72267C0EE40030FFAC /* ActivityIndicatorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorDemoController.swift; sourceTree = "<group>"; };
 		53A16D73267C0EE40030FFAC /* ButtonDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonDemoController.swift; sourceTree = "<group>"; };
 		53A16D74267C0EE40030FFAC /* AvatarLegacyDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarLegacyDemoController.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				53A16D72267C0EE40030FFAC /* ActivityIndicatorDemoController.swift */,
 				B4D852D822580661004B1B29 /* ActivityIndicatorViewDemoController.swift */,
 				53A16D77267C0EE40030FFAC /* AvatarDemoController.swift */,
+				531CC51326AF3B340059DCCE /* AvatarDemoController_SwiftUI.swift */,
 				0A2FBB4026547C50004D056C /* AvatarGroupDemoController.swift */,
 				7D23482924D89C1C00FBE057 /* AvatarGroupViewDemoController.swift */,
 				53A16D74267C0EE40030FFAC /* AvatarLegacyDemoController.swift */,
@@ -475,6 +478,7 @@
 				497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */,
 				B4EF53C5215C45C400573E8F /* PersonaListViewDemoController.swift in Sources */,
 				B4414792228F6F740040E88E /* TableViewCellSampleData.swift in Sources */,
+				531CC51426AF3B350059DCCE /* AvatarDemoController_SwiftUI.swift in Sources */,
 				53A16D7F267C0EE50030FFAC /* ThemingDemoController.swift in Sources */,
 				0A2FBB4126547C50004D056C /* AvatarGroupDemoController.swift in Sources */,
 				53F7386125776C560043071D /* NotificationViewDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -49,14 +49,11 @@ struct AvatarDemoView: View {
 
     public var body: some View {
         VStack {
-            AvatarView(style: .default,
-                       size: .xxlarge,
-                       image: nil,
+            AvatarView(style: style,
+                       size: size,
+                       image: showImage ? UIImage(named: "avatar_kat_larsson") : nil,
                        primaryText: primaryText,
                        secondaryText: secondaryText)
-                .size(size)
-                .style(style)
-                .image(showImage ? UIImage(named: "avatar_kat_larsson") : nil)
                 .isRingVisible(isRingVisible)
                 .hasRingInnerGap(hasRingInnerGap)
                 .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -37,6 +37,16 @@ struct AvatarDemoView: View {
     @State var size: MSFAvatarSize = .xxlarge
     @State var style: MSFAvatarStyle = .default
 
+    let switchToggleStyle: SwitchToggleStyle = {
+        if #available(iOS 14.0, *) {
+            // Workaround for SwiftUI Toggles that switch to green tint color
+            // when they're toggled for the first time
+            return SwitchToggleStyle(tint: Color(Colors.communicationBlue))
+        } else {
+            return SwitchToggleStyle()
+        }
+    }()
+
     public var body: some View {
         VStack {
             AvatarView(style: .default,
@@ -78,9 +88,13 @@ struct AvatarDemoView: View {
                             .textFieldStyle(RoundedBorderTextFieldStyle())
 
                         Toggle("Set image", isOn: $showImage)
+                            .toggleStyle(switchToggleStyle)
                         Toggle("Set alternate background", isOn: $useAlternateBackground)
+                            .toggleStyle(switchToggleStyle)
                         Toggle("Transparency", isOn: $isTransparent)
+                            .toggleStyle(switchToggleStyle)
                         Toggle("iPad Pointer interaction", isOn: $hasPointerInteraction)
+                            .toggleStyle(switchToggleStyle)
                     }
 
                     Group {
@@ -91,8 +105,11 @@ struct AvatarDemoView: View {
                             Divider()
                         }
                         Toggle("Ring visible", isOn: $isRingVisible)
+                            .toggleStyle(switchToggleStyle)
                         Toggle("Ring inner gap", isOn: $hasRingInnerGap)
+                            .toggleStyle(switchToggleStyle)
                         Toggle("Set image based ring color", isOn: $showImageBasedRingColor)
+                            .toggleStyle(switchToggleStyle)
                     }
 
                     Group {
@@ -117,6 +134,7 @@ struct AvatarDemoView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                         Toggle("Out of office", isOn: $isOutOfOffice)
+                            .toggleStyle(switchToggleStyle)
                     }
 
                     Group {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -1,0 +1,166 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+import SwiftUI
+
+class AvatarDemoControllerSwiftUI: UIHostingController<AvatarDemoView> {
+    override init?(coder aDecoder: NSCoder, rootView: AvatarDemoView) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    init() {
+        super.init(rootView: AvatarDemoView())
+        self.title = "Avatar Vnext (SwiftUI)"
+    }
+}
+
+struct AvatarDemoView: View {
+    @State var useAlternateBackground: Bool = false
+    @State var isOutOfOffice: Bool = false
+    @State var isRingVisible: Bool = true
+    @State var isTransparent: Bool = true
+    @State var hasPointerInteraction: Bool = false
+    @State var hasRingInnerGap: Bool = true
+    @State var primaryText: String = "Kat Larrson"
+    @State var secondaryText: String = ""
+    @State var presence: MSFAvatarPresence = .none
+    @State var showImage: Bool = false
+    @State var showImageBasedRingColor: Bool = false
+    @State var size: MSFAvatarSize = .xxlarge
+    @State var style: MSFAvatarStyle = .default
+
+    public var body: some View {
+        VStack {
+            AvatarView(style: .default,
+                       size: .xxlarge,
+                       image: nil,
+                       primaryText: primaryText,
+                       secondaryText: secondaryText)
+                .size(size)
+                .style(style)
+                .image(showImage ? UIImage(named: "avatar_kat_larsson") : nil)
+                .isRingVisible(isRingVisible)
+                .hasRingInnerGap(hasRingInnerGap)
+                .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
+                .isTransparent(isTransparent)
+                .presence(presence)
+                .isOutOfOffice(isOutOfOffice)
+                .hasPointerInteraction(hasPointerInteraction)
+                .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
+                .background(useAlternateBackground ? Color.gray : Color.clear)
+
+            ScrollView {
+                Group {
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Content")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        TextField("Primary Text", text: $primaryText)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                        TextField("Secondary Text", text: $secondaryText)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                        Toggle("Set image", isOn: $showImage)
+                        Toggle("Set alternate background", isOn: $useAlternateBackground)
+                        Toggle("Transparency", isOn: $isTransparent)
+                        Toggle("iPad Pointer interaction", isOn: $hasPointerInteraction)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Ring")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+                        Toggle("Ring visible", isOn: $isRingVisible)
+                        Toggle("Ring inner gap", isOn: $hasRingInnerGap)
+                        Toggle("Set image based ring color", isOn: $showImageBasedRingColor)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Presence")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $presence, label: EmptyView()) {
+                            Text(".none").tag(MSFAvatarPresence.none)
+                            Text(".available").tag(MSFAvatarPresence.available)
+                            Text(".away").tag(MSFAvatarPresence.away)
+                            Text(".blocked").tag(MSFAvatarPresence.blocked)
+                            Text(".busy").tag(MSFAvatarPresence.busy)
+                            Text(".doNotDisturb").tag(MSFAvatarPresence.doNotDisturb)
+                            Text(".offline").tag(MSFAvatarPresence.offline)
+                            Text(".unknown").tag(MSFAvatarPresence.unknown)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Toggle("Out of office", isOn: $isOutOfOffice)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Style")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $style, label: EmptyView()) {
+                            Text(".default").tag(MSFAvatarStyle.default)
+                            Text(".accent").tag(MSFAvatarStyle.accent)
+                            Text(".group").tag(MSFAvatarStyle.group)
+                            Text(".outlined").tag(MSFAvatarStyle.outlined)
+                            Text(".outlinedPrimary").tag(MSFAvatarStyle.outlinedPrimary)
+                            Text(".overflow").tag(MSFAvatarStyle.overflow)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Size")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $size, label: EmptyView()) {
+                            Text(".xxlarge").tag(MSFAvatarSize.xxlarge)
+                            Text(".xlarge").tag(MSFAvatarSize.xlarge)
+                            Text(".large").tag(MSFAvatarSize.large)
+                            Text(".medium").tag(MSFAvatarSize.medium)
+                            Text(".small").tag(MSFAvatarSize.small)
+                            Text(".xsmall").tag(MSFAvatarSize.xsmall)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -37,16 +37,6 @@ struct AvatarDemoView: View {
     @State var size: MSFAvatarSize = .xxlarge
     @State var style: MSFAvatarStyle = .default
 
-    let switchToggleStyle: SwitchToggleStyle = {
-        if #available(iOS 14.0, *) {
-            // Workaround for SwiftUI Toggles that switch to green tint color
-            // when they're toggled for the first time
-            return SwitchToggleStyle(tint: Color(Colors.communicationBlue))
-        } else {
-            return SwitchToggleStyle()
-        }
-    }()
-
     public var body: some View {
         VStack {
             AvatarView(style: style,
@@ -84,14 +74,10 @@ struct AvatarDemoView: View {
                             .disableAutocorrection(true)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
 
-                        Toggle("Set image", isOn: $showImage)
-                            .toggleStyle(switchToggleStyle)
-                        Toggle("Set alternate background", isOn: $useAlternateBackground)
-                            .toggleStyle(switchToggleStyle)
-                        Toggle("Transparency", isOn: $isTransparent)
-                            .toggleStyle(switchToggleStyle)
-                        Toggle("iPad Pointer interaction", isOn: $hasPointerInteraction)
-                            .toggleStyle(switchToggleStyle)
+                        FluentUIDemoToggle(titleKey: "Set image", isOn: $showImage)
+                        FluentUIDemoToggle(titleKey: "Set alternate background", isOn: $useAlternateBackground)
+                        FluentUIDemoToggle(titleKey: "Transparency", isOn: $isTransparent)
+                        FluentUIDemoToggle(titleKey: "iPad Pointer interaction", isOn: $hasPointerInteraction)
                     }
 
                     Group {
@@ -101,12 +87,9 @@ struct AvatarDemoView: View {
                                 .font(.title)
                             Divider()
                         }
-                        Toggle("Ring visible", isOn: $isRingVisible)
-                            .toggleStyle(switchToggleStyle)
-                        Toggle("Ring inner gap", isOn: $hasRingInnerGap)
-                            .toggleStyle(switchToggleStyle)
-                        Toggle("Set image based ring color", isOn: $showImageBasedRingColor)
-                            .toggleStyle(switchToggleStyle)
+                        FluentUIDemoToggle(titleKey: "Ring visible", isOn: $isRingVisible)
+                        FluentUIDemoToggle(titleKey: "Ring inner gap", isOn: $hasRingInnerGap)
+                        FluentUIDemoToggle(titleKey: "Set image based ring color", isOn: $showImageBasedRingColor)
                     }
 
                     Group {
@@ -130,8 +113,7 @@ struct AvatarDemoView: View {
                         .labelsHidden()
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Toggle("Out of office", isOn: $isOutOfOffice)
-                            .toggleStyle(switchToggleStyle)
+                        FluentUIDemoToggle(titleKey: "Out of office", isOn: $isOutOfOffice)
                     }
 
                     Group {

--- a/ios/FluentUI.Demo/FluentUI.Demo/SwiftUI/FluentUIDemoToggle.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/SwiftUI/FluentUIDemoToggle.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import SwiftUI
+
+struct FluentUIDemoToggle: View {
+    var titleKey: LocalizedStringKey
+    var isOn: Binding<Bool>
+
+    let switchToggleStyle: SwitchToggleStyle = {
+        if #available(iOS 14.0, *) {
+            // Workaround for SwiftUI Toggles that switch to green tint color
+            // when they're toggled for the first time
+            return SwitchToggleStyle(tint: Color(Colors.communicationBlue))
+        } else {
+            return SwitchToggleStyle()
+        }
+    }()
+
+    var body: some View {
+        Toggle(titleKey, isOn: isOn)
+            .toggleStyle(switchToggleStyle)
+    }
+}

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF41ED82141A02200EC527C /* CalendarConfiguration.swift */; };
 		5314E30225F0260E0099271A /* AccessibilityContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD77752A219E455A00033D58 /* AccessibilityContainerView.swift */; };
 		5314E30325F0260E0099271A /* AccessibleViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD599D052134A682008845EE /* AccessibleViewDelegate.swift */; };
+		535A852126AF67C100E73C51 /* AvatarModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535A852026AF67C100E73C51 /* AvatarModifiers.swift */; };
+		535A852226AF67C100E73C51 /* AvatarModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535A852026AF67C100E73C51 /* AvatarModifiers.swift */; };
 		536AEF4B25F1EC0300A36206 /* FluentUIStyle.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536AEF2A25F1EC0300A36206 /* FluentUIStyle.generated.swift */; };
 		536AEF4C25F1EC0300A36206 /* FluentUIStyle.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536AEF2A25F1EC0300A36206 /* FluentUIStyle.generated.swift */; };
 		536AEF4F25F1EC0300A36206 /* Theming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536AEF2C25F1EC0300A36206 /* Theming.swift */; };
@@ -416,6 +418,7 @@
 		3FC2EDB125F9EA2D007AA0F8 /* MSFDrawerTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFDrawerTokens.swift; sourceTree = "<group>"; };
 		497DC2D724185885008D86F8 /* PillButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBar.swift; sourceTree = "<group>"; };
 		497DC2D824185885008D86F8 /* PillButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButton.swift; sourceTree = "<group>"; };
+		535A852026AF67C100E73C51 /* AvatarModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarModifiers.swift; sourceTree = "<group>"; };
 		536AEF2A25F1EC0300A36206 /* FluentUIStyle.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentUIStyle.generated.swift; sourceTree = "<group>"; };
 		536AEF2C25F1EC0300A36206 /* Theming.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Theming.swift; sourceTree = "<group>"; };
 		536AEF2F25F1EC0300A36206 /* MSFButtonTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFButtonTokens.generated.swift; sourceTree = "<group>"; };
@@ -903,6 +906,7 @@
 			isa = PBXGroup;
 			children = (
 				536AEF3D25F1EC0300A36206 /* Avatar.swift */,
+				535A852026AF67C100E73C51 /* AvatarModifiers.swift */,
 				536AEF3E25F1EC0300A36206 /* AvatarTokens.swift */,
 				92751051268142CD00F12730 /* MSFAvatarPresence.swift */,
 				536AEF3C25F1EC0300A36206 /* MSFAvatarTokens.generated.swift */,
@@ -1659,6 +1663,7 @@
 				5314E1A225F01A7C0099271A /* ActivityIndicatorCell.swift in Sources */,
 				5314E11F25F015EA0099271A /* InitialsView.swift in Sources */,
 				536AEF5A25F1EC0300A36206 /* HeaderFooterTokens.swift in Sources */,
+				535A852226AF67C100E73C51 /* AvatarModifiers.swift in Sources */,
 				5314E06125F00EFD0099271A /* CalendarViewDayCell.swift in Sources */,
 				929DD25A266ED3B600E8175E /* PersonaButtonCarousel.swift in Sources */,
 				5314E12A25F016230099271A /* PillButton.swift in Sources */,
@@ -1844,6 +1849,7 @@
 				FD41C8BE22DD47120086F899 /* UINavigationItem+Navigation.swift in Sources */,
 				7DC2FB2D24D209E800367A55 /* Presence.swift in Sources */,
 				B4E782C12176AD5E00A7DFCE /* ActionsCell.swift in Sources */,
+				535A852126AF67C100E73C51 /* AvatarModifiers.swift in Sources */,
 				536AEF5925F1EC0300A36206 /* HeaderFooterTokens.swift in Sources */,
 				929DD259266ED3B600E8175E /* PersonaButtonCarousel.swift in Sources */,
 				FD56FD962192754B0023C7EA /* DateTimePickerViewComponent.swift in Sources */,

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -86,6 +86,25 @@ public struct AvatarView: View {
         self.tokens = state.tokens
     }
 
+    /// Creates and initializes a SwiftUI Avatar
+    /// - Parameters:
+    ///   - style: The style of the avatar.
+    ///   - size: The size of the avatar.
+    ///   - image: The optional image that the avatar should display.
+    ///   - primaryText: The primary text used to calculate the Avatar initials.
+    ///   - secondaryText: The secondary text used to calculate the Avatar initials.
+    public init(style: MSFAvatarStyle,
+                size: MSFAvatarSize,
+                image: UIImage?,
+                primaryText: String?,
+                secondaryText: String?) {
+        self.init(style: style,
+                  size: size)
+        state.image = image
+        state.primaryText = primaryText
+        state.secondaryText = secondaryText
+    }
+
     // This initializer should be used by internal container views. These containers should first initialize
     // MSFAvatarStateImpl using style and size, and then use that state and this initializer in their ViewBuilder.
     internal init(_ avatarState: MSFAvatarStateImpl) {

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -78,14 +78,6 @@ public struct AvatarView: View {
     @ObservedObject var tokens: MSFAvatarTokens
     @ObservedObject var state: MSFAvatarStateImpl
 
-    public init(style: MSFAvatarStyle,
-                size: MSFAvatarSize) {
-        let state = MSFAvatarStateImpl(style: style,
-                                       size: size)
-        self.state = state
-        self.tokens = state.tokens
-    }
-
     /// Creates and initializes a SwiftUI Avatar
     /// - Parameters:
     ///   - style: The style of the avatar.
@@ -95,14 +87,17 @@ public struct AvatarView: View {
     ///   - secondaryText: The secondary text used to calculate the Avatar initials.
     public init(style: MSFAvatarStyle,
                 size: MSFAvatarSize,
-                image: UIImage?,
-                primaryText: String?,
-                secondaryText: String?) {
-        self.init(style: style,
-                  size: size)
+                image: UIImage? = nil,
+                primaryText: String? = nil,
+                secondaryText: String? = nil) {
+        let state = MSFAvatarStateImpl(style: style,
+                                       size: size)
         state.image = image
         state.primaryText = primaryText
         state.secondaryText = secondaryText
+
+        self.state = state
+        self.tokens = state.tokens
     }
 
     // This initializer should be used by internal container views. These containers should first initialize

--- a/ios/FluentUI/Vnext/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Vnext/Avatar/AvatarModifiers.swift
@@ -1,0 +1,90 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+public extension AvatarView {
+
+    func accessibilityLabel(_ accessibilityLabel: String?) -> AvatarView {
+        state.accessibilityLabel = accessibilityLabel
+        return self
+    }
+
+    func backgroundColor(_ backgroundColor: UIColor?) -> AvatarView {
+        state.backgroundColor = backgroundColor
+        return self
+    }
+
+    func foregroundColor(_ foregroundColor: UIColor?) -> AvatarView {
+        state.foregroundColor = foregroundColor
+        return self
+    }
+
+    func hasPointerInteraction(_ hasPointerInteraction: Bool) -> AvatarView {
+        state.hasPointerInteraction = hasPointerInteraction
+        return self
+    }
+
+    func hasRingInnerGap(_ hasRingInnerGap: Bool) -> AvatarView {
+        state.hasRingInnerGap = hasRingInnerGap
+        return self
+    }
+
+    func image(_ image: UIImage?) -> AvatarView {
+        state.image = image
+        return self
+    }
+
+    func imageBasedRingColor(_ imageBasedRingColor: UIImage?) -> AvatarView {
+        state.imageBasedRingColor = imageBasedRingColor
+        return self
+    }
+
+    func isOutOfOffice(_ isOutOfOffice: Bool) -> AvatarView {
+        state.isOutOfOffice = isOutOfOffice
+        return self
+    }
+
+    func isRingVisible(_ isRingVisible: Bool) -> AvatarView {
+        state.isRingVisible = isRingVisible
+        return self
+    }
+
+    func isTransparent(_ isTransparent: Bool) -> AvatarView {
+        state.isTransparent = isTransparent
+        return self
+    }
+
+    func presence(_ presence: MSFAvatarPresence) -> AvatarView {
+        state.presence = presence
+        return self
+    }
+
+    func primaryText(_ primaryText: String?) -> AvatarView {
+        state.primaryText = primaryText
+        return self
+    }
+
+    func ringColor(_ ringColor: UIColor?) -> AvatarView {
+        state.ringColor = ringColor
+        return self
+    }
+
+    func secondaryText(_ secondaryText: String?) -> AvatarView {
+        state.secondaryText = secondaryText
+        return self
+    }
+
+    func size(_ size: MSFAvatarSize) -> AvatarView {
+        state.size = size
+        return self
+    }
+
+    func style(_ style: MSFAvatarStyle) -> AvatarView {
+        state.style = style
+        return self
+    }
+}

--- a/ios/FluentUI/Vnext/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Vnext/Avatar/AvatarModifiers.swift
@@ -33,11 +33,6 @@ public extension AvatarView {
         return self
     }
 
-    func image(_ image: UIImage?) -> AvatarView {
-        state.image = image
-        return self
-    }
-
     func imageBasedRingColor(_ imageBasedRingColor: UIImage?) -> AvatarView {
         state.imageBasedRingColor = imageBasedRingColor
         return self
@@ -63,28 +58,8 @@ public extension AvatarView {
         return self
     }
 
-    func primaryText(_ primaryText: String?) -> AvatarView {
-        state.primaryText = primaryText
-        return self
-    }
-
     func ringColor(_ ringColor: UIColor?) -> AvatarView {
         state.ringColor = ringColor
-        return self
-    }
-
-    func secondaryText(_ secondaryText: String?) -> AvatarView {
-        state.secondaryText = secondaryText
-        return self
-    }
-
-    func size(_ size: MSFAvatarSize) -> AvatarView {
-        state.size = size
-        return self
-    }
-
-    func style(_ style: MSFAvatarStyle) -> AvatarView {
-        state.style = style
         return self
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change introduces the SwiftUI Demo controller for the Avatar Vnext.
Avatar modifiers to set state properties were introduced.

### Verification

https://user-images.githubusercontent.com/68076145/127215305-d81b37bc-9fdd-4dd2-a057-5eaba18003f3.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/656)