### PR TITLE
Fixing avatar behavior for .outlined and .outlinedPrimary styles when initials can be computed.

### DIFF
--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -147,11 +147,8 @@ public struct AvatarView: View {
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
             if shouldUseDefaultImage {
-                if style == .outlined || style == .outlinedPrimary {
-                    return (UIImage.staticImageNamed("person_48_regular"), .template)
-                }
-
-                return (UIImage.staticImageNamed("person_48_filled"), .template)
+                let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
+                return (UIImage.staticImageNamed(isOutlinedStyle ? "person_48_regular" : "person_48_filled"), .template)
             }
 
             return (state.image, .original)

--- a/ios/FluentUI/Vnext/Avatar/Avatar.swift
+++ b/ios/FluentUI/Vnext/Avatar/Avatar.swift
@@ -146,13 +146,15 @@ public struct AvatarView: View {
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
-            if style == .outlined || style == .outlinedPrimary {
-                return (UIImage.staticImageNamed("person_48_regular"), .template)
-            } else if shouldUseDefaultImage {
+            if shouldUseDefaultImage {
+                if style == .outlined || style == .outlinedPrimary {
+                    return (UIImage.staticImageNamed("person_48_regular"), .template)
+                }
+
                 return (UIImage.staticImageNamed("person_48_filled"), .template)
-            } else {
-                return (state.image, .original)
             }
+
+            return (state.image, .original)
         }()
         let avatarImageSizeRatio: CGFloat = (shouldUseDefaultImage) ? 0.7 : 1
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There's a bug in the logic that returns the image for the avatar content in the .outlined and .outlinedPrimary style scenarios.
If the initials can be computed, they take precedence over the default image.
If an image is set, it takes precedence over the initials and the default image.

### Verification

Locally changed the demo controller to return "Rafael Assis" in as the primary text for the .outlined and .outlinedPrimary scenarios.
Reproduced the bug and verified the fix.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-07-27 at 4 10 27 PM](https://user-images.githubusercontent.com/68076145/127239321-09b776f5-6fc1-4b14-9968-25d08f76b7b8.png) | ![Screen Shot 2021-07-27 at 4 11 16 PM](https://user-images.githubusercontent.com/68076145/127239329-4670be1d-1157-49be-b001-fdc2de8b50de.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/657)