### PR TITLE
[vNext] Fixing RTL order for AvatarGroup

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -173,9 +173,13 @@ public struct AvatarGroup: View {
 
                 let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
                 let noRingPaddingInterspace = nextAvatarHasRing ? interspace - ringOuterGap : interspace
+                let rtlRingPaddingInterspace = (nextAvatarHasRing ? -x - ringOuterGap : -x + ringOffset)
+                let rtlNoRingPaddingInterspace = (nextAvatarHasRing ? -x - ringOffset - ringOuterGap : -x)
                 let stackPadding = (currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace)
 
-                let xOrigin = currentAvatarHasRing ? x + ringOffset : x
+                let xPosition = currentAvatarHasRing ? x + ringOffset : x
+                let xPositionRTL = currentAvatarHasRing ? rtlRingPaddingInterspace : rtlNoRingPaddingInterspace
+                let xOrigin = isLeftToRight() ? xPosition : xPositionRTL
                 let yOrigin = currentAvatarHasRing ? (nextAvatarHasRing ? ringOuterGap : ringOffset) :
                     (nextAvatarHasRing ? 0 - ringOffset + tokens.ringOuterGap : 0)
                 let cutoutSize = nextAvatarHasRing ? size + ringOffset + ringOuterGap : size
@@ -217,13 +221,23 @@ public struct AvatarGroup: View {
         var cutoutSize: CGFloat
 
         func path(in rect: CGRect) -> Path {
-                var cutoutFrame = Rectangle().path(in: rect)
-                cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
-                                                             y: yOrigin,
-                                                             width: cutoutSize,
-                                                             height: cutoutSize)))
-                return cutoutFrame
+            var cutoutFrame = Rectangle().path(in: rect)
+            cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
+                                                         y: yOrigin,
+                                                         width: cutoutSize,
+                                                         height: cutoutSize)))
+            return cutoutFrame
         }
+    }
+
+    // Detects if language code direction is left to right
+    private func isLeftToRight() -> Bool {
+        guard let language = Locale.current.languageCode else {
+            // Default to LTR if no language code is found
+            return true
+        }
+        let direction = Locale.characterDirection(forLanguage: language)
+        return direction == .leftToRight
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixing cutout issue with RTL languages. Changes reflect #658, except this one is merging to main instead of the vnext-prototype branch.

### Verification

Tested with RTL languages to make sure cutout was in the correct side

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 - 2021-07-27 at 17 30 05](https://user-images.githubusercontent.com/22566866/127244811-228dd925-9249-47fc-8d0d-83755a05c6f8.png) | ![Simulator Screen Shot - iPhone 11 - 2021-07-28 at 14 59 27](https://user-images.githubusercontent.com/22566866/127401836-aa83d6ba-2c26-45d8-9f6f-ac5acfe49040.png) |
|  | ![Simulator Screen Shot - iPhone 11 - 2021-07-28 at 15 01 20](https://user-images.githubusercontent.com/22566866/127401900-1fc75d2f-0e69-4c0e-bb2f-06c9dfe68386.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/662)