### PR TITLE
larger text support in popupmenudemocontroller

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -15,8 +15,6 @@ class PopupMenuDemoController: DemoController {
         case month
     }
 
-    override var allowsContentToScroll: Bool { return false }
-
     private var calendarLayout: CalendarLayout = .agenda
     private var cityIndexPath: IndexPath? = IndexPath(item: 2, section: 1)
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
`allowsContentToScroll` was overrided in popupmenudemocontroller which didn't adjust the buttons to resize appropriate in larger text size setting.

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-08-06 at 15 35 41](https://user-images.githubusercontent.com/20715435/128577657-be87d4be-4e29-4e31-9ec9-d47b022794bf.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-08-06 at 15 35 18](https://user-images.githubusercontent.com/20715435/128577673-df8f32d8-3b6d-43d3-b5d2-b6fcea3fe07d.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/666)