### PR TITLE
Fixing safe area insets when the drawer is being dragged vertically out of screen bounds.

### DIFF
--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -292,7 +292,23 @@ class DrawerPresentationController: UIPresentationController {
         contentView.frame = frame
 
         if let presentedView = presentedView {
-            presentedView.frame = frameForPresentedViewController(in: presentedView.superview == containerView ? contentView.frame : contentView.bounds)
+            let presentedViewFrame = frameForPresentedViewController(in: presentedView.superview == containerView ? contentView.frame : contentView.bounds)
+
+            let isVerticallyPresentedViewPartiallyOffScreen: Bool = {
+                // Calculates the origin of the presentedView frame in relation to the device screen.
+                guard let origin = presentedView.superview?.convert(presentedViewFrame.origin, to: nil) else {
+                    return false
+                }
+
+                return (presentationDirection == .down && origin.y < 0) ||
+                       (presentationDirection == .up && (origin.y + presentedViewFrame.height - UIScreen.main.bounds.height) > 0)
+            }()
+
+            // The safeAreaInsets are not applied when the presentedView is no entirely within the screen bounds.
+            // Additional safe area insets need to be set to compensate.
+            presentedViewController.additionalSafeAreaInsets = isVerticallyPresentedViewPartiallyOffScreen ? contentView.safeAreaInsets : .zero
+
+            presentedView.frame = presentedViewFrame
         }
 
         if separator.superview != nil {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixes #620.
The root cause of this issue is that the safe area insets are only provided when the view is entirely within the screen bounds.
When the user drags the drawer vertically to out of the screen, the safe area insets need to be compensated by setting the additionalSafeAreaInsets property. 

### Verification

Tested the repro scenarios and validated they were fixed and didn't cause regressions on the combination of the following matrix:

- iOS 13 and 14.
- iPhone (notch device) vs regular device
- iPad

**Before (issue reproduced):**

https://user-images.githubusercontent.com/68076145/128812729-1399a184-a0f4-46b0-b425-197a7e0fb139.mov



**After (issue fixed and validated):**

https://user-images.githubusercontent.com/68076145/128812751-a2ac98d1-993a-484d-b583-c09f5ff772ea.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/668)