### PR TITLE
try to see if this changes the podpublish to be always be running

### DIFF
--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -2,9 +2,10 @@ name: Pod-Publish
 on:
   push:
     branches:
-      - main
-      - main_0.1
-      - main_0.2
+      # Push events to branches matching refs/heads/
+      - 'main'
+      - 'main_0.1'
+      - 'main_0.2'
     tags:
       - 0.[0-9]+.[0-9]+ # Run automatically on new tags matching a 0.N.M pattern
       - 0.[0-9]+.[0-9]+_main*


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

follow up from https://github.com/microsoft/fluentui-apple/pull/650 to see if every merge to main branch won't trigger podpublish.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/671)