### PR TITLE
Update AvatarGroupDemo to use UITableViewController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -8,27 +8,387 @@ import UIKit
 
 // MARK: - AvatarGroupDemoController
 
-class AvatarGroupDemoController: DemoController {
+class AvatarGroupDemoController: UITableViewController {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(style: .grouped)
+
+        initDemoAvatarGroups()
+    }
+
+    required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        reloadAvatarViews()
+        tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
+        tableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
+        tableView.register(ActionsCell.self, forCellReuseIdentifier: ActionsCell.identifier)
+
+        tableView.separatorStyle = .none
     }
 
-    private lazy var incrementBadgeButton: Button = {
-        return createButton(title: "+", action: #selector(incrementBadgeNumbers))
-    }()
+    // MARK: - Table view data source
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return AvatarGroupDemoSection.allCases.count
+    }
 
-    private lazy var decrementBadgeButton: Button = {
-        return createButton(title: "-", action: #selector(decrementBadgeNumbers))
-    }()
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return AvatarGroupDemoSection.allCases[section].rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return AvatarGroupDemoSection.allCases[section].title
+    }
+
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let section = AvatarGroupDemoSection.allCases[indexPath.section]
+        let row = section.rows[indexPath.row]
+
+        switch row {
+        case .avatarCount:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier) as? ActionsCell else {
+                return UITableViewCell()
+            }
+
+            cell.setup(action1Title: "Increase Avatar Count", action2Title: "Decrease Avatar Count", action1Type: .regular, action2Type: .regular)
+            cell.action1Button.addTarget(self, action: #selector(addAvatarCount(_:)), for: UIControl.Event.touchUpInside)
+            cell.action2Button.addTarget(self, action: #selector(subtractAvatarCount(_:)), for: UIControl.Event.touchUpInside)
+
+            return cell
+
+        case .alternateBackground:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
+                return UITableViewCell()
+            }
+
+            cell.setup(title: row.title, isOn: self.isUsingAlternateBackgroundColor)
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.isUsingAlternateBackgroundColor = cell?.isOn ?? true
+            }
+
+            return cell
+
+        case .maxDisplayedAvatars,
+             .overflow:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
+                return UITableViewCell()
+            }
+
+            let buttonView: [UIView] = {
+                switch row {
+                case .maxDisplayedAvatars:
+                    return [maxAvatarsTextField, maxAvatarButton]
+                case .overflow:
+                    return [overflowCountTextField, overflowCountButton]
+                default:
+                    return []
+                }
+            }()
+
+            let stackView = UIStackView(arrangedSubviews: buttonView)
+            stackView.frame = CGRect(x: 0,
+                                     y: 0,
+                                     width: 100,
+                                     height: 40)
+            stackView.distribution = .fillEqually
+            stackView.alignment = .center
+            stackView.spacing = 4
+
+            cell.setup(title: row.title, customAccessoryView: stackView)
+            cell.titleNumberOfLines = 0
+            return cell
+
+        case .xxlargeTitle,
+             .xlargeTitle,
+             .largeTitle,
+             .mediumTitle,
+             .smallTitle,
+             .xsmallTitle:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
+                return UITableViewCell()
+            }
+
+            cell.setup(title: row.title)
+            cell.titleNumberOfLines = 0
+            return cell
+
+        case .xxlargeGroupView,
+             .xlargeGroupView,
+             .largeGroupView,
+             .mediumGroupView,
+             .smallGroupView,
+             .xsmallGroupView:
+            let cell = UITableViewCell()
+
+            guard let avatarGroup = demoAvatarGroupsBySection[section]?[row] else {
+                return cell
+            }
+
+            let avatarGroupView = avatarGroup.view
+            avatarGroupView.translatesAutoresizingMaskIntoConstraints = false
+
+            cell.contentView.addSubview(avatarGroupView)
+            NSLayoutConstraint.activate([
+                cell.contentView.leadingAnchor.constraint(equalTo: avatarGroupView.leadingAnchor, constant: -20),
+                cell.contentView.topAnchor.constraint(equalTo: avatarGroupView.topAnchor, constant: -15),
+                cell.contentView.bottomAnchor.constraint(equalTo: avatarGroupView.bottomAnchor, constant: 15)
+            ])
+
+            cell.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
+
+            return cell
+        }
+    }
+
+    // MARK: - Helpers
+
+    private let avatarSizes: [MSFAvatarSize] = MSFAvatarSize.allCases.reversed()
+
+    private enum AvatarGroupDemoSection: CaseIterable {
+        case settings
+        case avatarStackNoBorder
+        case avatarStackWithBorder
+        case avatarStackWithMixedBorder
+        case avatarPileNoBorder
+        case avatarPileWithBorder
+        case avatarPileWithMixedBorder
+
+        var avatarStyle: MSFAvatarGroupStyle {
+            switch self {
+            case .avatarStackNoBorder,
+                 .avatarStackWithBorder,
+                 .avatarStackWithMixedBorder:
+                return .stack
+            case .avatarPileNoBorder,
+                 .avatarPileWithBorder,
+                 .avatarPileWithMixedBorder:
+                return .pile
+            case .settings:
+                preconditionFailure("Settings rows should not display an Avatar Group")
+            }
+        }
+
+        var showBorders: Bool {
+            switch self {
+            case .avatarStackNoBorder,
+                 .avatarPileNoBorder:
+                return false
+            case .avatarStackWithBorder,
+                 .avatarStackWithMixedBorder,
+                 .avatarPileWithBorder,
+                 .avatarPileWithMixedBorder:
+                return true
+            case .settings:
+                preconditionFailure("Settings rows should not display an Avatar Group")
+            }
+        }
+
+        var isMixedBorder: Bool {
+            switch self {
+            case .avatarPileWithMixedBorder,
+                 .avatarStackWithMixedBorder:
+                return true
+            case .avatarStackWithBorder,
+                 .avatarStackNoBorder,
+                 .avatarPileWithBorder,
+                 .avatarPileNoBorder:
+                return false
+            case .settings:
+                preconditionFailure("Settings rows should not display an Avatar Group")
+            }
+        }
+
+        var isDemoSection: Bool {
+            return self != .settings
+        }
+
+        var title: String {
+            switch self {
+            case .settings:
+                return "Settings"
+            case .avatarStackNoBorder:
+                return "Avatar Stack No Border"
+            case .avatarStackWithBorder:
+                return "Avatar Stack With Border"
+            case .avatarStackWithMixedBorder:
+                return "Avatar Stack With Mixed Border"
+            case .avatarPileNoBorder:
+                return "Avatar Pile No Border"
+            case .avatarPileWithBorder:
+                return "Avatar Pile With Border"
+            case .avatarPileWithMixedBorder:
+                return "Avatar Pile With Mixed Border"
+            }
+        }
+
+        var rows: [AvatarGroupDemoRow] {
+            switch self {
+            case .settings:
+                return [.avatarCount,
+                        .alternateBackground,
+                        .maxDisplayedAvatars,
+                        .overflow]
+            case .avatarStackNoBorder,
+                 .avatarStackWithBorder,
+                 .avatarStackWithMixedBorder,
+                 .avatarPileNoBorder,
+                 .avatarPileWithBorder,
+                 .avatarPileWithMixedBorder:
+                return [.xxlargeTitle,
+                        .xxlargeGroupView,
+                        .xlargeTitle,
+                        .xlargeGroupView,
+                        .largeTitle,
+                        .largeGroupView,
+                        .mediumTitle,
+                        .mediumGroupView,
+                        .smallTitle,
+                        .smallGroupView,
+                        .xsmallTitle,
+                        .xsmallGroupView]
+            }
+        }
+    }
+
+    private enum AvatarGroupDemoRow: CaseIterable {
+        case avatarCount
+        case alternateBackground
+        case maxDisplayedAvatars
+        case overflow
+        case xxlargeTitle
+        case xxlargeGroupView
+        case xlargeTitle
+        case xlargeGroupView
+        case largeTitle
+        case largeGroupView
+        case mediumTitle
+        case mediumGroupView
+        case smallTitle
+        case smallGroupView
+        case xsmallTitle
+        case xsmallGroupView
+
+        var isDemoRow: Bool {
+            switch self {
+            case .xxlargeGroupView,
+                 .xlargeGroupView,
+                 .largeGroupView,
+                 .mediumGroupView,
+                 .smallGroupView,
+                 .xsmallGroupView:
+                return true
+            case .xxlargeTitle,
+                 .xlargeTitle,
+                 .largeTitle,
+                 .mediumTitle,
+                 .smallTitle,
+                 .xsmallTitle,
+                 .avatarCount,
+                 .alternateBackground,
+                 .maxDisplayedAvatars,
+                 .overflow:
+                return false
+            }
+        }
+
+        var avatarSize: MSFAvatarSize {
+            switch self {
+            case .xxlargeGroupView:
+                return .xxlarge
+            case .xlargeGroupView:
+                return .xlarge
+            case .largeGroupView:
+                return .large
+            case .mediumGroupView:
+                return .medium
+            case .smallGroupView:
+                return .small
+            case .xsmallGroupView:
+                return .xsmall
+            case .xxlargeTitle,
+                 .xlargeTitle,
+                 .largeTitle,
+                 .mediumTitle,
+                 .smallTitle,
+                 .xsmallTitle,
+                 .avatarCount,
+                 .alternateBackground,
+                 .maxDisplayedAvatars,
+                 .overflow:
+                preconditionFailure("Row should not display an Avatar Group")
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .avatarCount:
+                return "Avatar count"
+            case .alternateBackground:
+                return "Use alternate background color"
+            case.maxDisplayedAvatars:
+                return "Max displayed avatars"
+            case .overflow:
+                return "Overflow count"
+            case .xxlargeTitle:
+                return "ExtraExtraLarge"
+            case .xlargeTitle:
+                return "ExtraLarge"
+            case .largeTitle:
+                return "Large"
+            case .mediumTitle:
+                return "Medium"
+            case .smallTitle:
+                return "Small"
+            case .xsmallTitle:
+                return "ExtraSmall"
+            case .xxlargeGroupView,
+                 .xlargeGroupView,
+                 .largeGroupView,
+                 .mediumGroupView,
+                 .smallGroupView,
+                 .xsmallGroupView:
+                preconditionFailure("Row should not have title")
+            }
+        }
+    }
+
+    private var maxDisplayedAvatars: Int = 4 {
+        didSet {
+            if oldValue != maxDisplayedAvatars {
+                maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
+
+                for avatarGroup in allDemoAvatarGroupsCombined {
+                    avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
+                }
+            }
+        }
+    }
 
     private lazy var maxAvatarButton: Button = {
-        let button = createButton(title: "Set", action: #selector(maxAvatarButtonWasPressed))
+        let button = Button()
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.numberOfLines = 0
+        button.setTitle("Set", for: .normal)
+        button.addTarget(self, action: #selector(setMaxAvatarCount), for: .touchUpInside)
         button.isEnabled = false
-
         return button
     }()
+
+    @objc private func setMaxAvatarCount() {
+        if let text = maxAvatarsTextField.text, let count = Int(text) {
+            maxDisplayedAvatars = count
+            maxAvatarButton.isEnabled = false
+        }
+
+        maxAvatarsTextField.resignFirstResponder()
+    }
 
     private lazy var maxAvatarsTextField: UITextField = {
         let textField = UITextField(frame: .zero)
@@ -39,12 +399,36 @@ class AvatarGroupDemoController: DemoController {
         return textField
     }()
 
-    private lazy var overflowCountButton: Button = {
-        let button = createButton(title: "Set", action: #selector(overflowCountButtonWasPressed))
-        button.isEnabled = false
+    private var overflowCount: Int = 0 {
+        didSet {
+            if oldValue != overflowCount {
+                overflowCountTextField.text = "\(overflowCount)"
 
+                for avatarGroup in allDemoAvatarGroupsCombined {
+                    avatarGroup.state.overflowCount = overflowCount
+                }
+            }
+        }
+    }
+
+    private lazy var overflowCountButton: Button = {
+        let button = Button()
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.numberOfLines = 0
+        button.setTitle("Set", for: .normal)
+        button.addTarget(self, action: #selector(setOverflowCount), for: .touchUpInside)
+        button.isEnabled = false
         return button
     }()
+
+    @objc private func setOverflowCount() {
+        if let text = overflowCountTextField.text, let count = Int(text) {
+            overflowCount = count
+            overflowCountButton.isEnabled = false
+        }
+
+        overflowCountTextField.resignFirstResponder()
+    }
 
     private lazy var overflowCountTextField: UITextField = {
         let textField = UITextField(frame: .zero)
@@ -55,68 +439,47 @@ class AvatarGroupDemoController: DemoController {
         return textField
     }()
 
-    private func reloadAvatarViews() {
-        avatarGroups.removeAll()
-
-        for view in container.arrangedSubviews {
-            view.removeFromSuperview()
-        }
-
-        let settingsTitle = Label(style: .headline, colorStyle: .regular)
-        settingsTitle.text = "Settings"
-        container.addArrangedSubview(settingsTitle)
-
-        let avatarCountButtonsStackView = UIStackView(arrangedSubviews: [incrementBadgeButton, decrementBadgeButton])
-        avatarCountButtonsStackView.spacing = 30
-        addRow(text: "Avatar count", items: [avatarCountButtonsStackView], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
-
-        let backgroundColorSwitch = UISwitch(frame: .zero)
-        backgroundColorSwitch.isOn = isUsingAlternateBackgroundColor
-        backgroundColorSwitch.addTarget(self, action: #selector(toggleAlternateBackground(switchView:)), for: .valueChanged)
-
-        addRow(text: "Use alternate background color", items: [backgroundColorSwitch], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
-
-        addRow(text: "Max displayed avatars", items: [maxAvatarsTextField, maxAvatarButton], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
-        addRow(text: "Overflow count", items: [overflowCountTextField, overflowCountButton], textStyle: .footnote, textWidth: Constants.settingsTextWidth)
-
-        addTitle(text: "Avatar Stack No Border")
-        insertAvatarViews(style: .stack, showBorders: false)
-        addTitle(text: "Avatar Stack With Border")
-        insertAvatarViews(style: .stack, showBorders: true)
-        addTitle(text: "Avatar Stack With Mixed Border")
-        insertAvatarViews(style: .stack, showBorders: true, mixed: true)
-        addTitle(text: "Avatar Pile No Border")
-        insertAvatarViews(style: .pile, showBorders: false)
-        addTitle(text: "Avatar Pile With Border")
-        insertAvatarViews(style: .pile, showBorders: true)
-        addTitle(text: "Avatar Pile With Mixed Border")
-        insertAvatarViews(style: .pile, showBorders: true, mixed: true)
-    }
-
-    private struct Constants {
-        static let settingsTextWidth: CGFloat = 200
-        static let avatarsTextWidth: CGFloat = 100
-        static let maxTextInputCharCount: Int = 4
-    }
-
-    private var avatarGroups: [MSFAvatarGroup] = []
-
     private var avatarCount: Int = 5 {
         didSet {
-            reloadAvatarViews()
+            AvatarGroupDemoSection.allCases.filter({ section in
+                return section.isDemoSection
+            }).forEach { section in
+                var avatarGroupsForCurrentSection: [AvatarGroupDemoRow: MSFAvatarGroup] = [:]
+
+                AvatarGroupDemoRow.allCases.filter({ row in
+                    return row.isDemoRow
+                }).forEach { row in
+                    let avatarGroup = demoAvatarGroupsBySection[section]![row]
+                    if oldValue < avatarCount {
+                        let avatarState = avatarGroup?.state.createAvatar()
+                        for index in 0...avatarCount - 1 {
+                            let samplePersona = samplePersonas[index]
+                            avatarState!.image = samplePersona.image
+                            avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                            avatarState!.primaryText = samplePersona.name
+                            avatarState!.secondaryText = samplePersona.email
+                        }
+                    } else {
+                        avatarGroup?.state.removeAvatar(at: avatarCount)
+                    }
+
+                    avatarGroupsForCurrentSection.updateValue(avatarGroup!, forKey: row)
+                }
+                demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
+            }
         }
     }
 
-    @objc private func incrementBadgeNumbers() {
-        if avatarCount < samplePersonas.count {
-            avatarCount += 1
-        }
+    @objc private func addAvatarCount(_ cell: ActionsCell) {
+        avatarCount += 1
     }
 
-    @objc private func decrementBadgeNumbers() {
-        if avatarCount > 1 {
-            avatarCount -= 1
-        }
+    @objc private func subtractAvatarCount(_ cell: ActionsCell) {
+        avatarCount -= 1
+    }
+
+    @objc private func toggleAlternateBackground(_ cell: BooleanCell) {
+        isUsingAlternateBackgroundColor = cell.isOn
     }
 
     private var isUsingAlternateBackgroundColor: Bool = false {
@@ -126,93 +489,40 @@ class AvatarGroupDemoController: DemoController {
     }
 
     private func updateBackgroundColor() {
-        view.backgroundColor = isUsingAlternateBackgroundColor ? UIColor(light: Colors.gray100, dark: Colors.gray600) : Colors.surfacePrimary
+        self.tableView.reloadData()
     }
 
-    @objc private func toggleAlternateBackground(switchView: UISwitch) {
-        isUsingAlternateBackgroundColor = switchView.isOn
-    }
+    private var allDemoAvatarGroupsCombined: [MSFAvatarGroup] = []
 
-    private var maxDisplayedAvatars: Int = 4 {
-        didSet {
-            if oldValue != maxDisplayedAvatars {
-                maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
+    private var demoAvatarGroupsBySection: [AvatarGroupDemoSection: [AvatarGroupDemoRow: MSFAvatarGroup]] = [:]
 
-                for avatarGroup in avatarGroups {
-                    avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
+    private func initDemoAvatarGroups() {
+        AvatarGroupDemoSection.allCases.filter({ section in
+            return section.isDemoSection
+        }).forEach { section in
+            var avatarGroupsForCurrentSection: [AvatarGroupDemoRow: MSFAvatarGroup] = [:]
+
+            AvatarGroupDemoRow.allCases.filter({ row in
+                return row.isDemoRow
+            }).forEach { row in
+                let avatarGroup = MSFAvatarGroup(style: section.avatarStyle,
+                                       size: row.avatarSize)
+                for index in 0...avatarCount - 1 {
+                    let avatarState = avatarGroup.state.createAvatar()
+                    let samplePersona = samplePersonas[index]
+                    avatarState.image = samplePersona.image
+                    avatarState.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                    avatarState.primaryText = samplePersona.name
+                    avatarState.secondaryText = samplePersona.email
                 }
+
+                avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
+                avatarGroup.state.overflowCount = overflowCount
+                avatarGroupsForCurrentSection.updateValue(avatarGroup, forKey: row)
+                allDemoAvatarGroupsCombined.append(avatarGroup)
             }
+            demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
         }
-    }
-
-    @objc private func maxAvatarButtonWasPressed() {
-        if let text = maxAvatarsTextField.text, let count = Int(text) {
-            maxDisplayedAvatars = count
-            maxAvatarButton.isEnabled = false
-        }
-
-        maxAvatarsTextField.resignFirstResponder()
-    }
-
-    private var overflowCount: Int = 0 {
-        didSet {
-            if oldValue != overflowCount {
-                overflowCountTextField.text = "\(overflowCount)"
-
-                for avatarGroup in avatarGroups {
-                    avatarGroup.state.overflowCount = overflowCount
-                }
-            }
-        }
-    }
-
-    @objc private func overflowCountButtonWasPressed() {
-        if let text = overflowCountTextField.text, let count = Int(text) {
-            overflowCount = count
-            overflowCountButton.isEnabled = false
-        }
-
-        overflowCountTextField.resignFirstResponder()
-    }
-
-    private func insertAvatarViews(style: MSFAvatarGroupStyle, showBorders: Bool, mixed: Bool = false) {
-        var constraints: [NSLayoutConstraint] = []
-
-        for size in MSFAvatarSize.allCases.reversed() {
-            let containerView = UIView(frame: .zero)
-
-            let avatarGroup = MSFAvatarGroup(style: style, size: size)
-            for index in 0...avatarCount - 1 {
-                let avatarState = avatarGroup.state.createAvatar()
-                let samplePersona = samplePersonas[index]
-
-                avatarState.image = samplePersona.image
-                avatarState.isRingVisible = mixed ? index % 2 == 0 : showBorders
-                avatarState.primaryText = samplePersona.name
-                avatarState.secondaryText = samplePersona.email
-            }
-
-            avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
-            avatarGroup.state.overflowCount = overflowCount
-            avatarGroups.append(avatarGroup)
-            let avatarGroupView = avatarGroup.view
-            avatarGroupView.translatesAutoresizingMaskIntoConstraints = false
-            containerView.addSubview(avatarGroupView)
-
-            let trailingConstraint = containerView.trailingAnchor.constraint(equalTo: container.trailingAnchor)
-            trailingConstraint.priority = .defaultHigh
-
-            constraints.append(contentsOf: [
-                avatarGroupView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-                avatarGroupView.topAnchor.constraint(equalTo: containerView.topAnchor),
-                avatarGroupView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-                trailingConstraint
-            ])
-
-            addRow(text: size.description, items: [containerView], textStyle: .footnote, textWidth: 100)
-        }
-
-        NSLayoutConstraint.activate(constraints)
     }
 }
 
@@ -231,7 +541,7 @@ extension AvatarGroupDemoController: UITextFieldDelegate {
 
         if shouldChangeCharacters {
             text = text.replacingCharacters(in: stringRange, with: string)
-            shouldChangeCharacters = text.count <= Constants.maxTextInputCharCount
+            shouldChangeCharacters = text.count <= 4
         }
 
         let button = textField == maxAvatarsTextField ? maxAvatarButton : overflowCountButton
@@ -239,31 +549,12 @@ extension AvatarGroupDemoController: UITextFieldDelegate {
             if textField == maxAvatarsTextField {
                 button.isEnabled = count > 0 && count != maxDisplayedAvatars
             } else {
-                button.isEnabled = count != overflowCount
+                button.isEnabled = count > 0 && count != overflowCount
             }
         } else {
             button.isEnabled = false
         }
 
         return shouldChangeCharacters
-    }
-}
-
-extension MSFAvatarSize {
-    var description: String {
-        switch self {
-        case .xsmall:
-            return "ExtraSmall"
-        case .small:
-            return "Small"
-        case .medium:
-            return "Medium"
-        case .large:
-            return "Large"
-        case .xlarge:
-            return "ExtraLarge"
-        case .xxlarge:
-            return "ExtraExtraLarge"
-        }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update AvatarGroupDemo to use UITableViewController instead of DemoController to comply with accessibility standards.

### Verification

Tested to ensure toggle setting is now associated with it's row

| DemoController                                       | UITableViewController                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/31874971/129122227-c99a5659-3ea4-4457-a84d-4c4022622a07.png) | ![image](https://user-images.githubusercontent.com/31874971/129122213-63d107dd-418c-4a8c-bdb0-243b4ac4e0fa.png) |
|![image](https://user-images.githubusercontent.com/31874971/129266600-b0d939f0-5b08-49bf-8ac6-85a23b8e976c.png) | ![image](https://user-images.githubusercontent.com/31874971/129265501-fc6bde5f-2d5c-4e03-a810-5a2949ff6c6a.png) |
| ![image](https://user-images.githubusercontent.com/31874971/129268567-7c38136a-b0bf-4dce-804b-ba15e0747dbd.png) | ![image](https://user-images.githubusercontent.com/31874971/129268406-5db3125c-9f9b-430f-bf50-1726585cc6cb.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/674)