### PR TITLE
Button Vnext SwiftUI support, improvements.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5303259326B3198A00611D05 /* AvatarDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5303259226B3198A00611D05 /* AvatarDemoController_SwiftUI.swift */; };
 		5303259826B31A6300611D05 /* FluentUIDemoToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5303259726B31A6300611D05 /* FluentUIDemoToggle.swift */; };
 		5306075926A1E73F002D49CF /* AvatarGroupDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5306075826A1E73F002D49CF /* AvatarGroupDemoController.swift */; };
+		5340827A26C4B112007716E1 /* ButtonDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827926C4B112007716E1 /* ButtonDemoController_SwiftUI.swift */; };
 		5360997426B8B7BF0069DE71 /* ThemingDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360997026B8B7BF0069DE71 /* ThemingDemoController.swift */; };
 		5360997526B8B7BF0069DE71 /* ActivityIndicatorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360997126B8B7BF0069DE71 /* ActivityIndicatorDemoController.swift */; };
 		5360997626B8B7BF0069DE71 /* LeftNavDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360997226B8B7BF0069DE71 /* LeftNavDemoController.swift */; };
@@ -94,6 +95,7 @@
 		5303259226B3198A00611D05 /* AvatarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		5303259726B31A6300611D05 /* FluentUIDemoToggle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentUIDemoToggle.swift; sourceTree = "<group>"; };
 		5306075826A1E73F002D49CF /* AvatarGroupDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarGroupDemoController.swift; sourceTree = "<group>"; };
+		5340827926C4B112007716E1 /* ButtonDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		5360997026B8B7BF0069DE71 /* ThemingDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemingDemoController.swift; sourceTree = "<group>"; };
 		5360997126B8B7BF0069DE71 /* ActivityIndicatorDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorDemoController.swift; sourceTree = "<group>"; };
 		5360997226B8B7BF0069DE71 /* LeftNavDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeftNavDemoController.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 				80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */,
 				80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */,
 				B4D852DA225C010A004B1B29 /* ButtonDemoController.swift */,
+				5340827926C4B112007716E1 /* ButtonDemoController_SwiftUI.swift */,
 				92ABB38F26BC66FE00BA179A /* ButtonLegacyDemoController.swift */,
 				92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */,
 				CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */,
@@ -483,6 +486,7 @@
 				497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */,
 				5360997A26B8B8140069DE71 /* DrawerDemoController.swift in Sources */,
 				5360997F26B8B8330069DE71 /* PopupMenuDemoController.swift in Sources */,
+				5340827A26C4B112007716E1 /* ButtonDemoController_SwiftUI.swift in Sources */,
 				B4EF53C5215C45C400573E8F /* PersonaListViewDemoController.swift in Sources */,
 				B4414792228F6F740040E88E /* TableViewCellSampleData.swift in Sources */,
 				E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -1,0 +1,110 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import SwiftUI
+import UIKit
+
+class ButtonDemoControllerSwiftUI: UIHostingController<ButtonDemoView> {
+    override init?(coder aDecoder: NSCoder, rootView: ButtonDemoView) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    init() {
+        super.init(rootView: ButtonDemoView())
+        self.title = "Button Vnext (SwiftUI)"
+    }
+}
+
+struct ButtonDemoView: View {
+    @State var isDisabled: Bool = false
+    @State var text: String = "Button"
+    @State var showImage: Bool = true
+    @State var showLabel: Bool = true
+    @State var showAlert: Bool = false
+    @State var size: MSFButtonSize = .large
+    @State var style: MSFButtonStyle = .accentFloating
+
+    public var body: some View {
+        VStack {
+            MSFButtonView(action: {
+                showAlert = true
+            },
+            style: style,
+            size: size,
+            image: showImage ? UIImage(named: "Placeholder_24") : nil,
+            text: showLabel ? text : nil)
+            .isDisabled(isDisabled)
+            .fixedSize()
+            .padding()
+            .alert(isPresented: $showAlert, content: {
+                Alert(title: Text("Button tapped"))
+            })
+
+            ScrollView {
+                Group {
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Content")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        TextField("Text", text: $text)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                        FluentUIDemoToggle(titleKey: "Show image", isOn: $showImage)
+                        FluentUIDemoToggle(titleKey: "Show label", isOn: $showLabel)
+                        FluentUIDemoToggle(titleKey: "Disable", isOn: $isDisabled)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Style")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $style, label: EmptyView()) {
+                            Text(".primary").tag(MSFButtonStyle.primary)
+                            Text(".secondary").tag(MSFButtonStyle.secondary)
+                            Text(".ghost").tag(MSFButtonStyle.ghost)
+                            Text(".accentFloating").tag(MSFButtonStyle.accentFloating)
+                            Text(".subtleFloating").tag(MSFButtonStyle.subtleFloating)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Size")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $size, label: EmptyView()) {
+                            Text(".large").tag(MSFButtonSize.large)
+                            Text(".medium").tag(MSFButtonSize.medium)
+                            Text(".small").tag(MSFButtonSize.small)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -33,13 +33,12 @@ struct ButtonDemoView: View {
 
     public var body: some View {
         VStack {
-            MSFButtonView(action: {
+            MSFButtonView(style: style,
+                          size: size,
+                          image: showImage ? UIImage(named: "Placeholder_24") : nil,
+                          text: showLabel ? text : nil) {
                 showAlert = true
-            },
-            style: style,
-            size: size,
-            image: showImage ? UIImage(named: "Placeholder_24") : nil,
-            text: showLabel ? text : nil)
+            }
             .isDisabled(isDisabled)
             .fixedSize()
             .padding()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -39,7 +39,7 @@ struct ButtonDemoView: View {
                           text: showLabel ? text : nil) {
                 showAlert = true
             }
-            .isDisabled(isDisabled)
+            .disabled(isDisabled)
             .fixedSize()
             .padding()
             .alert(isPresented: $showAlert, content: {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -112,21 +112,21 @@
 }
 
 - (void)enableButton {
-    MSFButtonState *state = [self->_testButton state];
+    id<MSFButtonState> state = [self->_testButton state];
     [state setText:@"Enabled"];
     [state setIsDisabled:NO];
     [state setImage:[UIImage imageNamed:@"Placeholder_20"]];
 }
 
 - (void)disableButton {
-    MSFButtonState *state = [self->_testButton state];
+    id<MSFButtonState> state = [self->_testButton state];
     [state setText:@"Disabled"];
     [state setIsDisabled:YES];
     [state setImage:nil];
 }
 
 - (void)resetButton {
-    MSFButtonState *state = [self->_testButton state];
+    id<MSFButtonState> state = [self->_testButton state];
     [state setText:@"Button (Vnext)"];
     [state setImage:nil];
     [state setIsDisabled:NO];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -58,22 +58,22 @@ class ThemingDemoController: DemoController {
         let overridingTheme = CustomStyle()
         let customThemeButtonPrimary = MSFButton(style: .primary,
                                                       size: .medium,
-                                                      action: nil,
-                                                      theme: overridingTheme)
+                                                      theme: overridingTheme,
+                                                      action: nil)
         customThemeButtonPrimary.state.text = "Button"
         customThemeButtonPrimary.state.image = UIImage(named: "Placeholder_24")!
 
         let customThemeButtonSecondary = MSFButton(style: .secondary,
                                                         size: .medium,
-                                                        action: nil,
-                                                        theme: overridingTheme)
+                                                        theme: overridingTheme,
+                                                        action: nil)
         customThemeButtonSecondary.state.text = "Button"
         customThemeButtonSecondary.state.image = UIImage(named: "Placeholder_24")!
 
         let customThemeButtonGhost = MSFButton(style: .ghost,
                                                     size: .medium,
-                                                    action: nil,
-                                                    theme: overridingTheme)
+                                                    theme: overridingTheme,
+                                                    action: nil)
         customThemeButtonGhost.state.text = "Button"
 
         addRow(items: [customThemeButtonPrimary.view, customThemeButtonSecondary.view, customThemeButtonGhost.view], itemSpacing: 20)

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		5314E30325F0260E0099271A /* AccessibleViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD599D052134A682008845EE /* AccessibleViewDelegate.swift */; };
 		5340827426C48241007716E1 /* MSFButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827326C48241007716E1 /* MSFButton.swift */; };
 		5340827526C4824B007716E1 /* MSFButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827326C48241007716E1 /* MSFButton.swift */; };
+		5340827726C48B2B007716E1 /* ButtonModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827626C48B2B007716E1 /* ButtonModifiers.swift */; };
+		5340827826C48B2B007716E1 /* ButtonModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827626C48B2B007716E1 /* ButtonModifiers.swift */; };
 		5360994126B8B2710069DE71 /* PersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */; };
 		5360994A26B8B4990069DE71 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360994226B8B4980069DE71 /* List.swift */; };
 		5360994B26B8B4990069DE71 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360994226B8B4980069DE71 /* List.swift */; };
@@ -441,6 +443,7 @@
 		5306075026A1E6A4002D49CF /* MSFAvatarGroupTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFAvatarGroupTokens.generated.swift; sourceTree = "<group>"; };
 		5306075126A1E6A4002D49CF /* AvatarGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarGroup.swift; sourceTree = "<group>"; };
 		5340827326C48241007716E1 /* MSFButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFButton.swift; sourceTree = "<group>"; };
+		5340827626C48B2B007716E1 /* ButtonModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonModifiers.swift; sourceTree = "<group>"; };
 		5360994226B8B4980069DE71 /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		5360994326B8B4980069DE71 /* MSFHeaderFooterTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFHeaderFooterTokens.generated.swift; sourceTree = "<group>"; };
 		5360994426B8B4990069DE71 /* ListHeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListHeaderFooter.swift; sourceTree = "<group>"; };
@@ -889,6 +892,7 @@
 			isa = PBXGroup;
 			children = (
 				5360995B26B8B4DE0069DE71 /* Button.swift */,
+				5340827626C48B2B007716E1 /* ButtonModifiers.swift */,
 				5360995A26B8B4DE0069DE71 /* ButtonTokens.swift */,
 				5340827326C48241007716E1 /* MSFButton.swift */,
 				5360995C26B8B4DE0069DE71 /* MSFButtonTokens.generated.swift */,
@@ -1772,6 +1776,7 @@
 				80AECC21263339E3005AF2F3 /* BottomSheetController.swift in Sources */,
 				92079C9026B66E5100D688DA /* CardNudgeModifiers.swift in Sources */,
 				5314E24B25F0232F0099271A /* UIScreen+Extension.swift in Sources */,
+				5340827826C48B2B007716E1 /* ButtonModifiers.swift in Sources */,
 				5314E2E325F025500099271A /* FluentUIFramework.swift in Sources */,
 				5314E0EC25F012C40099271A /* NavigationAnimator.swift in Sources */,
 				5314E17225F0191C0099271A /* Separator.swift in Sources */,
@@ -2020,6 +2025,7 @@
 				536AEF6925F1EC0300A36206 /* (null) in Sources */,
 				A5961FA5218A260500E2A506 /* PopupMenuSectionHeaderView.swift in Sources */,
 				FD56FD9A2194E50D0023C7EA /* DateTimePickerController.swift in Sources */,
+				5340827726C48B2B007716E1 /* ButtonModifiers.swift in Sources */,
 				A5F3B146232B1E3700007A4F /* ScrollView.swift in Sources */,
 				B46D3F9D215985AC0029772C /* PersonaListView.swift in Sources */,
 				7DC2FB2824C0ED1600367A55 /* TableViewCellFileAccessoryView.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF41ED82141A02200EC527C /* CalendarConfiguration.swift */; };
 		5314E30225F0260E0099271A /* AccessibilityContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD77752A219E455A00033D58 /* AccessibilityContainerView.swift */; };
 		5314E30325F0260E0099271A /* AccessibleViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD599D052134A682008845EE /* AccessibleViewDelegate.swift */; };
+		5340827426C48241007716E1 /* MSFButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827326C48241007716E1 /* MSFButton.swift */; };
+		5340827526C4824B007716E1 /* MSFButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5340827326C48241007716E1 /* MSFButton.swift */; };
 		5360994126B8B2710069DE71 /* PersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */; };
 		5360994A26B8B4990069DE71 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360994226B8B4980069DE71 /* List.swift */; };
 		5360994B26B8B4990069DE71 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5360994226B8B4980069DE71 /* List.swift */; };
@@ -438,6 +440,7 @@
 		5306074F26A1E6A4002D49CF /* AvatarGroupTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarGroupTokens.swift; sourceTree = "<group>"; };
 		5306075026A1E6A4002D49CF /* MSFAvatarGroupTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFAvatarGroupTokens.generated.swift; sourceTree = "<group>"; };
 		5306075126A1E6A4002D49CF /* AvatarGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarGroup.swift; sourceTree = "<group>"; };
+		5340827326C48241007716E1 /* MSFButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFButton.swift; sourceTree = "<group>"; };
 		5360994226B8B4980069DE71 /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = List.swift; sourceTree = "<group>"; };
 		5360994326B8B4980069DE71 /* MSFHeaderFooterTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFHeaderFooterTokens.generated.swift; sourceTree = "<group>"; };
 		5360994426B8B4990069DE71 /* ListHeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListHeaderFooter.swift; sourceTree = "<group>"; };
@@ -887,6 +890,7 @@
 			children = (
 				5360995B26B8B4DE0069DE71 /* Button.swift */,
 				5360995A26B8B4DE0069DE71 /* ButtonTokens.swift */,
+				5340827326C48241007716E1 /* MSFButton.swift */,
 				5360995C26B8B4DE0069DE71 /* MSFButtonTokens.generated.swift */,
 			);
 			path = Button;
@@ -1652,6 +1656,7 @@
 				5314E15725F016DB0099271A /* ScrollView.swift in Sources */,
 				5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */,
 				5314E06B25F00F100099271A /* DateTimePicker.swift in Sources */,
+				5340827526C4824B007716E1 /* MSFButton.swift in Sources */,
 				5360994B26B8B4990069DE71 /* List.swift in Sources */,
 				5314E2BB25F024C60099271A /* CALayer+Extensions.swift in Sources */,
 				5314E12B25F016230099271A /* PillButtonBar.swift in Sources */,
@@ -1951,6 +1956,7 @@
 				A5237ACD21ED6CA70040BF27 /* DrawerShadowView.swift in Sources */,
 				FD9DA7B5232C33A80013E41B /* UIViewController+Navigation.swift in Sources */,
 				FD7DF05E21FA7FC100857267 /* TooltipView.swift in Sources */,
+				5340827426C48241007716E1 /* MSFButton.swift in Sources */,
 				A5CEC16F20D98F340016922A /* Fonts.swift in Sources */,
 				FD599D0C2134AB1E008845EE /* CalendarViewDataSource.swift in Sources */,
 				5360995D26B8B4DE0069DE71 /* ButtonTokens.swift in Sources */,

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -20,6 +20,8 @@ public struct MSFButtonView: View {
                 image: UIImage? = nil,
                 text: String? = nil) {
         let state = MSFButtonStateImpl(style: style, size: size)
+        state.text = text
+        state.image = image
         self.state = state
         self.tokens = state.tokens
         self.action = action

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -28,7 +28,7 @@ import UIKit
     var style: MSFButtonStyle { get set }
 }
 
-/// View that represents the button
+/// View that represents the button.
 public struct MSFButtonView: View {
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
@@ -36,6 +36,13 @@ public struct MSFButtonView: View {
     @ObservedObject var state: MSFButtonStateImpl
     var action: () -> Void
 
+    /// Creates a MSFButtonView.
+    /// - Parameters:
+    ///   - style: The MSFButtonStyle used by the button.
+    ///   - size: The MSFButtonSize value used by the button.
+    ///   - image: The image used as the leading icon of the button.
+    ///   - text: The text used in the button label.
+    ///   - action: Closure that handles the button tap event.
     public init(style: MSFButtonStyle,
                 size: MSFButtonSize,
                 image: UIImage? = nil,

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -36,11 +36,11 @@ public struct MSFButtonView: View {
     @ObservedObject var state: MSFButtonStateImpl
     var action: () -> Void
 
-    public init(action: @escaping () -> Void,
-                style: MSFButtonStyle,
+    public init(style: MSFButtonStyle,
                 size: MSFButtonSize,
                 image: UIImage? = nil,
-                text: String? = nil) {
+                text: String? = nil,
+                action: @escaping () -> Void) {
         let state = MSFButtonStateImpl(style: style, size: size)
         state.text = text
         state.image = image

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -34,7 +34,6 @@ public struct MSFButtonView: View {
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFButtonTokens
     @ObservedObject var state: MSFButtonStateImpl
-    var action: () -> Void
 
     /// Creates a MSFButtonView.
     /// - Parameters:
@@ -48,16 +47,17 @@ public struct MSFButtonView: View {
                 image: UIImage? = nil,
                 text: String? = nil,
                 action: @escaping () -> Void) {
-        let state = MSFButtonStateImpl(style: style, size: size)
+        let state = MSFButtonStateImpl(style: style,
+                                       size: size,
+                                       action: action)
         state.text = text
         state.image = image
         self.state = state
         self.tokens = state.tokens
-        self.action = action
     }
 
     public var body: some View {
-        Button(action: action, label: {})
+        Button(action: state.action, label: {})
             .buttonStyle(MSFButtonViewButtonStyle(tokens: tokens,
                                                   state: state))
             .disabled(state.isDisabled)
@@ -69,9 +69,10 @@ public struct MSFButtonView: View {
 }
 
 class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
-    @objc @Published var image: UIImage?
-    @objc @Published var isDisabled: Bool = false
-    @objc @Published var text: String?
+    var action: () -> Void
+    @Published var image: UIImage?
+    @Published var isDisabled: Bool = false
+    @Published var text: String?
 
     var size: MSFButtonSize {
         get {
@@ -94,9 +95,11 @@ class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
     var tokens: MSFButtonTokens
 
     init(style: MSFButtonStyle,
-         size: MSFButtonSize) {
+         size: MSFButtonSize,
+         action: @escaping () -> Void) {
         self.tokens = MSFButtonTokens(style: style,
                                       size: size)
+        self.action = action
         super.init()
     }
 }

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -17,7 +17,9 @@ public struct MSFButtonView: View {
 
     public init(action: @escaping () -> Void,
                 style: MSFButtonStyle,
-                size: MSFButtonSize) {
+                size: MSFButtonSize,
+                image: UIImage? = nil,
+                text: String? = nil) {
         let state = MSFButtonStateImpl(style: style, size: size)
         self.state = state
         self.tokens = state.tokens

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -6,6 +6,28 @@
 import SwiftUI
 import UIKit
 
+/// Properties that can be used to customize the appearance of the Button.
+@objc public protocol MSFButtonState {
+
+    /// The string representing the accessibility label of the button.
+    var accessibilityLabel: String? { get set }
+
+    /// Defines the icon image of the button.
+    var image: UIImage? { get set }
+
+    /// Controls whether the button is available for user interaction, renders the control accordingly.
+    var isDisabled: Bool { get set }
+
+    /// Text used as the label of the button.
+    var text: String? { get set }
+
+    /// Defines the size of the button.
+    var size: MSFButtonSize { get set }
+
+    /// Defines the style of the button.
+    var style: MSFButtonStyle { get set }
+}
+
 /// View that represents the button
 public struct MSFButtonView: View {
     @Environment(\.theme) var theme: FluentUIStyle
@@ -37,28 +59,6 @@ public struct MSFButtonView: View {
                           from: theme,
                           with: windowProvider)
     }
-}
-
-/// Properties that can be used to customize the appearance of the Button.
-@objc public protocol MSFButtonState {
-
-    /// The string representing the accessibility label of the button.
-    var accessibilityLabel: String? { get set }
-
-    /// Defines the icon image of the button.
-    var image: UIImage? { get set }
-
-    /// Controls whether the button is available for user interaction, renders the control accordingly.
-    var isDisabled: Bool { get set }
-
-    /// Text used as the label of the button.
-    var text: String? { get set }
-
-    /// Defines the size of the button.
-    var size: MSFButtonSize { get set }
-
-    /// Defines the style of the button.
-    var style: MSFButtonStyle { get set }
 }
 
 class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -60,7 +60,9 @@ public struct MSFButtonView: View {
         Button(action: state.action, label: {})
             .buttonStyle(MSFButtonViewButtonStyle(tokens: tokens,
                                                   state: state))
-            .disabled(state.isDisabled)
+            .modifyIf(state.disabled != nil, { button in
+                button.disabled(state.disabled!)
+            })
             .frame(maxWidth: .infinity)
             .designTokens(tokens,
                           from: theme,
@@ -71,8 +73,17 @@ public struct MSFButtonView: View {
 class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
     var action: () -> Void
     @Published var image: UIImage?
-    @Published var isDisabled: Bool = false
+    @Published var disabled: Bool?
     @Published var text: String?
+
+    var isDisabled: Bool {
+        get {
+            return disabled ?? false
+        }
+        set {
+            disabled = newValue
+        }
+    }
 
     var size: MSFButtonSize {
         get {
@@ -106,12 +117,13 @@ class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
 
 /// Body of the button adjusted for pressed or rest state
 struct MSFButtonViewBody: View {
+    @Environment(\.isEnabled) var isEnabled: Bool
     @ObservedObject var tokens: MSFButtonTokens
     @ObservedObject var state: MSFButtonStateImpl
     let isPressed: Bool
 
     var body: some View {
-        let isDisabled = state.isDisabled
+        let isDisabled = !isEnabled
         let isFloatingStyle = tokens.style.isFloatingStyle
         let shouldUsePressedShadow = isDisabled || isPressed
 

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -7,17 +7,60 @@ import Combine
 import UIKit
 import SwiftUI
 
-/// Properties available to customize the state of the button
-@objc public class MSFButtonState: NSObject, ObservableObject {
-    @objc @Published public var image: UIImage?
-    @objc @Published public var isDisabled: Bool = false
-    @objc @Published public var text: String?
+/// View that represents the button
+public struct MSFButtonView: View {
+    @Environment(\.theme) var theme: FluentUIStyle
+    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+    @ObservedObject var tokens: MSFButtonTokens
+    @ObservedObject var state: MSFButtonStateImpl
+    var action: () -> Void
+
+    public init(action: @escaping () -> Void,
+                style: MSFButtonStyle,
+                size: MSFButtonSize) {
+        self.action = action
+        self.state = MSFButtonStateImpl()
+        self.tokens = MSFButtonTokens(style: style, size: size)
+    }
+
+    public var body: some View {
+        Button(action: action, label: {})
+            .buttonStyle(MSFButtonViewButtonStyle(tokens: tokens,
+                                                  state: state))
+            .disabled(state.isDisabled)
+            .frame(maxWidth: .infinity)
+            .designTokens(tokens,
+                          from: theme,
+                          with: windowProvider)
+    }
+}
+
+/// Properties that can be used to customize the appearance of the Button.
+@objc public protocol MSFButtonState {
+
+    /// The string representing the accessibility label of the button.
+    var accessibilityLabel: String? { get set }
+
+    /// Defines the icon image of the button.
+    var image: UIImage? { get set }
+
+    /// Controls whether the button is available for user interaction, renders the control accordingly.
+    var isDisabled: Bool { get set }
+
+    /// Text used as the label of the button.
+    var text: String? { get set }
+}
+
+class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
+    @objc @Published var image: UIImage?
+    @objc @Published var isDisabled: Bool = false
+    @objc @Published var text: String?
 }
 
 /// Body of the button adjusted for pressed or rest state
 struct MSFButtonViewBody: View {
     @ObservedObject var tokens: MSFButtonTokens
-    @ObservedObject var state: MSFButtonState
+    @ObservedObject var state: MSFButtonStateImpl
     let isPressed: Bool
 
     var body: some View {
@@ -79,135 +122,11 @@ struct MSFButtonViewBody: View {
 /// ButtonStyle which configures the Button View according to its state and design tokens.
 struct MSFButtonViewButtonStyle: ButtonStyle {
     @ObservedObject var tokens: MSFButtonTokens
-    @ObservedObject var state: MSFButtonState
+    @ObservedObject var state: MSFButtonStateImpl
 
     func makeBody(configuration: Self.Configuration) -> some View {
         MSFButtonViewBody(tokens: tokens,
                           state: state,
                           isPressed: configuration.isPressed)
     }
-}
-
-/// View that represents the button
-public struct MSFButtonView: View {
-    @Environment(\.theme) var theme: FluentUIStyle
-    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
-    @ObservedObject var tokens: MSFButtonTokens
-    @ObservedObject var state: MSFButtonState
-    var action: () -> Void
-
-    public init(action: @escaping () -> Void,
-                style: MSFButtonStyle,
-                size: MSFButtonSize) {
-        self.action = action
-        self.state = MSFButtonState()
-        self.tokens = MSFButtonTokens(style: style, size: size)
-    }
-
-    public var body: some View {
-        Button(action: action, label: {})
-            .buttonStyle(MSFButtonViewButtonStyle(tokens: tokens,
-                                                  state: state))
-            .disabled(state.isDisabled)
-            .frame(maxWidth: .infinity)
-            .designTokens(tokens,
-                          from: theme,
-                          with: windowProvider)
-    }
-}
-
-/// UIKit wrapper that exposes the SwiftUI Button implementation
-@objc open class MSFButton: NSObject,
-                            FluentUIWindowProvider,
-                            UIGestureRecognizerDelegate {
-
-    @objc open var action: ((_ sender: MSFButton) -> Void)?
-
-    @objc open var state: MSFButtonState {
-        return self.buttonView.state
-    }
-
-    @objc open var view: UIView {
-        return hostingController.view
-    }
-
-    @objc public convenience init(style: MSFButtonStyle = .secondary,
-                                  size: MSFButtonSize = .large,
-                                  action: ((_ sender: MSFButton) -> Void)?) {
-        self.init(style: style,
-                  size: size,
-                  action: action,
-                  theme: nil)
-    }
-
-    @objc public init(style: MSFButtonStyle = .secondary,
-                      size: MSFButtonSize = .large,
-                      action: ((_ sender: MSFButton) -> Void)?,
-                      theme: FluentUIStyle? = nil) {
-        super.init()
-        initialize(style: style,
-                   size: size,
-                   action: action,
-                   theme: theme)
-    }
-
-    // MARK: - UIGestureRecognizerDelegate
-
-    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
-                                  shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        // Prevents the Large Content Viewer gesture recognizer from cancelling the SwiftUI button gesture recognizers.
-        return true
-    }
-
-    // MARK: - FluentUIWindowProvider
-
-    var window: UIWindow? {
-        return self.view.window
-    }
-
-    // MARK: - Private members
-
-    private func initialize(style: MSFButtonStyle = .secondary,
-                            size: MSFButtonSize = .large,
-                            action: ((_ sender: MSFButton) -> Void)?,
-                            theme: FluentUIStyle? = nil) {
-        self.action = action
-        buttonView = MSFButtonView(action: {
-            self.action?(self)
-        },
-        style: style,
-        size: size)
-
-        hostingController = UIHostingController(rootView: AnyView(buttonView
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { buttonView in
-                                                                        buttonView.customTheme(theme!)
-                                                                    })))
-        view.backgroundColor = UIColor.clear
-        setupLargeContentViewer()
-    }
-
-    private func setupLargeContentViewer() {
-        let largeContentViewerInteraction = UILargeContentViewerInteraction()
-        view.addInteraction(largeContentViewerInteraction)
-        largeContentViewerInteraction.gestureRecognizerForExclusionRelationship.delegate = self
-        view.scalesLargeContentImage = true
-        view.showsLargeContentViewer = buttonView.tokens.style.isFloatingStyle
-
-        imagePropertySubscriber = buttonView.state.$image.sink { buttonImage in
-            self.view.largeContentImage = buttonImage
-        }
-
-        textPropertySubscriber = buttonView.state.$text.sink { buttonText in
-            self.view.largeContentTitle = buttonText
-        }
-    }
-
-    private var textPropertySubscriber: AnyCancellable?
-
-    private var imagePropertySubscriber: AnyCancellable?
-
-    private var hostingController: UIHostingController<AnyView>!
-
-    private var buttonView: MSFButtonView!
 }

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -3,9 +3,8 @@
 //  Licensed under the MIT License.
 //
 
-import Combine
-import UIKit
 import SwiftUI
+import UIKit
 
 /// View that represents the button
 public struct MSFButtonView: View {

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -18,9 +18,10 @@ public struct MSFButtonView: View {
     public init(action: @escaping () -> Void,
                 style: MSFButtonStyle,
                 size: MSFButtonSize) {
+        let state = MSFButtonStateImpl(style: style, size: size)
+        self.state = state
+        self.tokens = state.tokens
         self.action = action
-        self.state = MSFButtonStateImpl()
-        self.tokens = MSFButtonTokens(style: style, size: size)
     }
 
     public var body: some View {
@@ -49,12 +50,45 @@ public struct MSFButtonView: View {
 
     /// Text used as the label of the button.
     var text: String? { get set }
+
+    /// Defines the size of the button.
+    var size: MSFButtonSize { get set }
+
+    /// Defines the style of the button.
+    var style: MSFButtonStyle { get set }
 }
 
 class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
     @objc @Published var image: UIImage?
     @objc @Published var isDisabled: Bool = false
     @objc @Published var text: String?
+
+    var size: MSFButtonSize {
+        get {
+            return tokens.size
+        }
+        set {
+            tokens.size = newValue
+        }
+    }
+
+    var style: MSFButtonStyle {
+        get {
+            return tokens.style
+        }
+        set {
+            tokens.style = newValue
+        }
+    }
+
+    var tokens: MSFButtonTokens
+
+    init(style: MSFButtonStyle,
+         size: MSFButtonSize) {
+        self.tokens = MSFButtonTokens(style: style,
+                                      size: size)
+        super.init()
+    }
 }
 
 /// Body of the button adjusted for pressed or rest state

--- a/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+public extension MSFButtonView {
+
+    /// Sets the accessibility label for the Button.
+    /// - Parameter accessibilityLabel: Accessibility label string.
+    /// - Returns: The modified Button with the property set.
+    func accessibilityLabel(_ accessibilityLabel: String?) -> MSFButtonView {
+        state.accessibilityLabel = accessibilityLabel
+        return self
+    }
+
+    /// Controls whether the button is available for user interaction, renders the control accordingly.
+    /// - Parameter isDisabled: Boolean value to set the property.
+    /// - Returns: The modified Button with the property set.
+    func isDisabled(_ isDisabled: Bool) -> MSFButtonView {
+        state.isDisabled = isDisabled
+        return self
+    }
+}

--- a/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
@@ -3,8 +3,8 @@
 //  Licensed under the MIT License.
 //
 
-import UIKit
 import SwiftUI
+import UIKit
 
 public extension MSFButtonView {
 

--- a/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
@@ -15,12 +15,4 @@ public extension MSFButtonView {
         state.accessibilityLabel = accessibilityLabel
         return self
     }
-
-    /// Controls whether the button is available for user interaction, renders the control accordingly.
-    /// - Parameter isDisabled: Boolean value to set the property.
-    /// - Returns: The modified Button with the property set.
-    func isDisabled(_ isDisabled: Bool) -> MSFButtonView {
-        state.isDisabled = isDisabled
-        return self
-    }
 }

--- a/ios/FluentUI/Vnext/Button/ButtonTokens.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokens.swift
@@ -3,8 +3,8 @@
 //  Licensed under the MIT License.
 //
 
-import UIKit
 import SwiftUI
+import UIKit
 
 /// Pre-defined styles of the button
 @objc public enum MSFButtonStyle: Int, CaseIterable {

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -78,8 +78,12 @@ import UIKit
                             theme: FluentUIStyle? = nil) {
         self.action = action
         buttonView = MSFButtonView(style: style,
-                                   size: size) {
-            self.action?(self)
+                                   size: size) { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.action?(strongSelf)
         }
 
         hostingController = UIHostingController(rootView: AnyView(buttonView

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -27,14 +27,14 @@ import UIKit
                                   action: ((_ sender: MSFButton) -> Void)?) {
         self.init(style: style,
                   size: size,
-                  action: action,
-                  theme: nil)
+                  theme: nil,
+                  action: action)
     }
 
     @objc public init(style: MSFButtonStyle = .secondary,
                       size: MSFButtonSize = .large,
-                      action: ((_ sender: MSFButton) -> Void)?,
-                      theme: FluentUIStyle? = nil) {
+                      theme: FluentUIStyle? = nil,
+                      action: ((_ sender: MSFButton) -> Void)?) {
         super.init()
         initialize(style: style,
                    size: size,
@@ -63,11 +63,10 @@ import UIKit
                             action: ((_ sender: MSFButton) -> Void)?,
                             theme: FluentUIStyle? = nil) {
         self.action = action
-        buttonView = MSFButtonView(action: {
+        buttonView = MSFButtonView(style: style,
+                                   size: size) {
             self.action?(self)
-        },
-        style: style,
-        size: size)
+        }
 
         hostingController = UIHostingController(rootView: AnyView(buttonView
                                                                     .windowProvider(self)

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -12,16 +12,24 @@ import UIKit
                             FluentUIWindowProvider,
                             UIGestureRecognizerDelegate {
 
+    /// Closure that handles the button tap event.
     @objc open var action: ((_ sender: MSFButton) -> Void)?
 
+    /// The object that groups properties that allow control over the button appearance.
     @objc open var state: MSFButtonState {
         return self.buttonView.state
     }
 
+    /// The UIView representing the button.
     @objc open var view: UIView {
         return hostingController.view
     }
 
+    /// Creates a new MSFButton instance.
+    /// - Parameters:
+    ///   - style: The MSFButtonStyle used by the button. Defaults to secondary.
+    ///   - size: The MSFButtonSize value used by the button. Defaults to large.
+    ///   - action: Closure that handles the button tap event.
     @objc public convenience init(style: MSFButtonStyle = .secondary,
                                   size: MSFButtonSize = .large,
                                   action: ((_ sender: MSFButton) -> Void)?) {
@@ -31,6 +39,12 @@ import UIKit
                   action: action)
     }
 
+    /// Creates a new MSFButton instance.
+    /// - Parameters:
+    ///   - style: The MSFButtonStyle used by the button. Defaults to secondary.
+    ///   - size: The MSFButtonSize value used by the button. Defaults to large.
+    ///   - theme: The FluentUIStyle instance representing the theme to be overriden for this button.
+    ///   - action: Closure that handles the button tap event.
     @objc public init(style: MSFButtonStyle = .secondary,
                       size: MSFButtonSize = .large,
                       theme: FluentUIStyle? = nil,

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -4,8 +4,8 @@
 //
 
 import Combine
-import UIKit
 import SwiftUI
+import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI Button implementation
 @objc open class MSFButton: NSObject,

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -1,0 +1,104 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Combine
+import UIKit
+import SwiftUI
+
+/// UIKit wrapper that exposes the SwiftUI Button implementation
+@objc open class MSFButton: NSObject,
+                            FluentUIWindowProvider,
+                            UIGestureRecognizerDelegate {
+
+    @objc open var action: ((_ sender: MSFButton) -> Void)?
+
+    @objc open var state: MSFButtonState {
+        return self.buttonView.state
+    }
+
+    @objc open var view: UIView {
+        return hostingController.view
+    }
+
+    @objc public convenience init(style: MSFButtonStyle = .secondary,
+                                  size: MSFButtonSize = .large,
+                                  action: ((_ sender: MSFButton) -> Void)?) {
+        self.init(style: style,
+                  size: size,
+                  action: action,
+                  theme: nil)
+    }
+
+    @objc public init(style: MSFButtonStyle = .secondary,
+                      size: MSFButtonSize = .large,
+                      action: ((_ sender: MSFButton) -> Void)?,
+                      theme: FluentUIStyle? = nil) {
+        super.init()
+        initialize(style: style,
+                   size: size,
+                   action: action,
+                   theme: theme)
+    }
+
+    // MARK: - UIGestureRecognizerDelegate
+
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                                  shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // Prevents the Large Content Viewer gesture recognizer from cancelling the SwiftUI button gesture recognizers.
+        return true
+    }
+
+    // MARK: - FluentUIWindowProvider
+
+    var window: UIWindow? {
+        return self.view.window
+    }
+
+    // MARK: - Private members
+
+    private func initialize(style: MSFButtonStyle = .secondary,
+                            size: MSFButtonSize = .large,
+                            action: ((_ sender: MSFButton) -> Void)?,
+                            theme: FluentUIStyle? = nil) {
+        self.action = action
+        buttonView = MSFButtonView(action: {
+            self.action?(self)
+        },
+        style: style,
+        size: size)
+
+        hostingController = UIHostingController(rootView: AnyView(buttonView
+                                                                    .windowProvider(self)
+                                                                    .modifyIf(theme != nil, { buttonView in
+                                                                        buttonView.customTheme(theme!)
+                                                                    })))
+        view.backgroundColor = UIColor.clear
+        setupLargeContentViewer()
+    }
+
+    private func setupLargeContentViewer() {
+        let largeContentViewerInteraction = UILargeContentViewerInteraction()
+        view.addInteraction(largeContentViewerInteraction)
+        largeContentViewerInteraction.gestureRecognizerForExclusionRelationship.delegate = self
+        view.scalesLargeContentImage = true
+        view.showsLargeContentViewer = buttonView.tokens.style.isFloatingStyle
+
+        imagePropertySubscriber = buttonView.state.$image.sink { buttonImage in
+            self.view.largeContentImage = buttonImage
+        }
+
+        textPropertySubscriber = buttonView.state.$text.sink { buttonText in
+            self.view.largeContentTitle = buttonText
+        }
+    }
+
+    private var textPropertySubscriber: AnyCancellable?
+
+    private var imagePropertySubscriber: AnyCancellable?
+
+    private var hostingController: UIHostingController<AnyView>!
+
+    private var buttonView: MSFButtonView!
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change adds SwiftUI support to the Button Vnext:
- Creates the MSFButtonState protocol
- Renames the class MSFButtonState to MSFButtonStateImpl and makes it internal.
- Moves the MSFButtonTokens into the state object.
- Creates SwiftUI modifiers and init parameters so that the Button can be used in a SwiftUI environment.
- Updates the UIKit Demo controller to use UITableView.
- Creates the SwiftUI Demo controller.

### Verification

| Light Mode                                       | Dark mode                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-08-11 at 7 09 57 PM](https://user-images.githubusercontent.com/68076145/129127716-3a85eb4c-0a26-4c81-9e47-a1e04ebc7113.png) | ![Screen Shot 2021-08-11 at 7 10 18 PM](https://user-images.githubusercontent.com/68076145/129127744-352f4a51-49a7-4259-9714-958162322d96.png) |
| ![Screen Shot 2021-08-11 at 7 11 58 PM](https://user-images.githubusercontent.com/68076145/129127870-8cdcf32e-bf57-4dae-936f-ecf5dfce6bc5.png) | ![Screen Shot 2021-08-11 at 7 12 20 PM](https://user-images.githubusercontent.com/68076145/129127892-3f33c7ce-a0f2-4350-b5d5-6a8b30e8df9e.png) |


https://user-images.githubusercontent.com/68076145/129128180-44d10df6-bf56-4590-8a12-2581926c798e.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/675)