### PR TITLE
Updating ci.yml to run macOS 11

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: fluentui_apple_publish_nuget
   pool:
-    vmImage: 'macos-10.15'
+    vmImage: 'macos-11'
   displayName: FluentUI Apple Publish NuGet
   timeoutInMinutes: 60 # how long to run the job before automatically cancelling
   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,17 @@ on:
 
 jobs:
   validation:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: true
     steps:
     - uses: actions/checkout@v2
-    - name: Switch to current version of Xcode
-      run: scripts/xcode_select_current_version.sh
     - name: pod lib lint
       run: scripts/podliblint.sh
     - name: validation
       run: scripts/validation.sh
   xcodebuild:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       fail-fast: true
     steps:
     - uses: actions/checkout@v2
+    - name: Switch to current version of Xcode
+      run: scripts/xcode_select_current_version.sh
     - name: pod lib lint
       run: scripts/podliblint.sh
     - name: validation

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -11,7 +11,7 @@ on:
       - 0.[0-9]+.[0-9]+_main*
 jobs:
   Pod-Publish:
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     
     steps:
     - uses: actions/checkout@v2

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_12.2.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_12.5.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Updated ci.yml to run on macOS 11, and removed running script for current Xcode version (currently 12.2 in the script).
Bringing back some changes from #560.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/679)