### PR TITLE
make sure default colors of selected state text color is black on dark mode

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -26,6 +26,11 @@ class CommandBarButton: UIButton {
         }
     }
 
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateStyle()
+    }
+
     init(item: CommandBarItem, isPersistSelection: Bool = true) {
         self.item = item
         self.isPersistSelection = isPersistSelection
@@ -73,7 +78,7 @@ class CommandBarButton: UIButton {
 
     private var selectedTintColor: UIColor {
         guard let window = window else {
-            return Colors.communicationBlue
+            return UIColor(light: Colors.communicationBlue, dark: .black)
         }
 
         return UIColor(light: Colors.primary(for: window), dark: .black)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Make sure when commandingbarbutton gets add to the window it gets the appropriate color

### Verification
no changes on fluent ui demo app.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/682)