### PR TITLE
in case commandbarbutton was set before it was added to the window, l…

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -26,6 +26,11 @@ class CommandBarButton: UIButton {
         }
     }
 
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateStyle()
+    }
+
     init(item: CommandBarItem, isPersistSelection: Bool = true) {
         self.item = item
         self.isPersistSelection = isPersistSelection
@@ -67,7 +72,7 @@ class CommandBarButton: UIButton {
 
     private var selectedTintColor: UIColor {
         guard let window = window else {
-            return Colors.communicationBlue
+            return UIColor(light: Colors.communicationBlue, dark: .black)
         }
 
         return Colors.primary(for: window)


### PR DESCRIPTION
…ets make sure the dark color of selected text is black. (#682)

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

git cherry-pick 4419a00 from main branch

### Verification
no update in fluent demo app

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/683)