### PR TITLE
Add support for showing tooltip to navbar buttons

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -382,6 +382,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             }
             cell.setup(action1Title: "Show tooltip on 3 day view button in navbar")
             cell.action1Button.addTarget(self, action: #selector(showTooltipButtonPressed), for: .touchUpInside)
+            cell.bottomSeparatorType = .full
             return cell
         }
 
@@ -458,7 +459,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     @objc private func showTooltipButtonPressed() {
         let navigationBar = msfNavigationController?.msfNavigationBar
-        guard let view = navigationBar?.barButtonItemView(tag: 1) else {
+        guard let view = navigationBar?.barButtonItemView(with: 1) else {
             return
         }
         Tooltip.shared.show(with: "Tap anywhere for this tooltip to dismiss.",

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -237,6 +237,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         tableView.delegate = self
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
+        tableView.register(ActionsCell.self, forCellReuseIdentifier: ActionsCell.identifier)
         return tableView
     }()
 
@@ -376,14 +377,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
 
         if indexPath.row == 2 {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier, for: indexPath) as? ActionsCell else {
                 return UITableViewCell()
             }
-            cell.setup(title: "Show tooltip on 3 day view button in navigation bar", isOn: false)
-            cell.titleNumberOfLines = 0
-            cell.onValueChanged = { [weak self] in
-                self?.shouldShowTooltip()
-            }
+            cell.setup(action1Title: "Show tooltip on 3 day view button in navbar")
+            cell.action1Button.addTarget(self, action: #selector(showTooltipButtonPressed), for: .touchUpInside)
             return cell
         }
 
@@ -458,18 +456,15 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         showRainbowRingForAvatar = isOn
     }
 
-    @objc private func shouldShowTooltip() {
+    @objc private func showTooltipButtonPressed() {
         let navigationBar = msfNavigationController?.msfNavigationBar
         guard let view = navigationBar?.barButtonItemView(tag: 1) else {
             return
         }
-        Tooltip.shared.show(with: "Tap on this tooltip to dismiss.",
+        Tooltip.shared.show(with: "Tap anywhere for this tooltip to dismiss.",
                             for: view,
                             preferredArrowDirection: .up,
-                            dismissOn: .tapOnTooltip,
-                            onTap: { [weak self] in
-                                self?.tableView.reloadData()
-                            })
+                            dismissOn: .tapAnywhere)
     }
 
     @objc private func dismissSelf() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -462,9 +462,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         guard let view = navigationBar?.barButtonItemView(with: 1) else {
             return
         }
+        let offset: CGPoint = navigationItem.usesLargeTitle ? .init(x: 0, y: 0) : .init(x: 0, y: -4)
         Tooltip.shared.show(with: "Tap anywhere for this tooltip to dismiss.",
                             for: view,
                             preferredArrowDirection: .up,
+                            offset: offset,
                             dismissOn: .tapAnywhere)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -462,11 +462,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         guard let view = navigationBar?.barButtonItemView(with: 1) else {
             return
         }
-        let offset: CGPoint = navigationItem.usesLargeTitle ? .init(x: 0, y: 0) : .init(x: 0, y: -4)
         Tooltip.shared.show(with: "Tap anywhere for this tooltip to dismiss.",
                             for: view,
                             preferredArrowDirection: .up,
-                            offset: offset,
                             dismissOn: .tapAnywhere)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -375,6 +375,18 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             return cell
         }
 
+        if indexPath.row == 2 {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
+                return UITableViewCell()
+            }
+            cell.setup(title: "Show tooltip on 3 day view button in navigation bar", isOn: false)
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self] in
+                self?.shouldShowTooltip()
+            }
+            return cell
+        }
+
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath) as? TableViewCell else {
             return UITableViewCell()
         }
@@ -429,6 +441,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             } else {
                 let modalViewItem = UIBarButtonItem(image: UIImage(named: "3-day-view-28x28"), landscapeImagePhone: UIImage(named: "3-day-view-24x24"), style: .plain, target: self, action: #selector(showModalView))
                 modalViewItem.accessibilityLabel = "Modal View"
+                modalViewItem.tag = 1
                 items.append(modalViewItem)
             }
             navigationItem.rightBarButtonItems = items
@@ -443,6 +456,21 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         personaData.customBorderImage = isOn ? RootViewController.colorfulImageForFrame() : nil
         msfNavigationController?.msfNavigationBar.avatar = personaData
         showRainbowRingForAvatar = isOn
+    }
+
+    @objc private func shouldShowTooltip() {
+        let buttons = msfNavigationController?.msfNavigationBar.rightBarButtonItemsStackView.arrangedSubviews ?? []
+        for button in buttons {
+            if button.tag == 1 {
+                Tooltip.shared.show(with: "Tap on this tooltip to dismiss.",
+                                    for: button,
+                                    preferredArrowDirection: .up,
+                                    dismissOn: .tapOnTooltip,
+                                    onTap: {
+                                        self.tableView.reloadData()
+                                    })
+            }
+        }
     }
 
     @objc private func dismissSelf() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -459,18 +459,17 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     @objc private func shouldShowTooltip() {
-        let buttons = msfNavigationController?.msfNavigationBar.rightBarButtonItemsStackView.arrangedSubviews ?? []
-        for button in buttons {
-            if button.tag == 1 {
-                Tooltip.shared.show(with: "Tap on this tooltip to dismiss.",
-                                    for: button,
-                                    preferredArrowDirection: .up,
-                                    dismissOn: .tapOnTooltip,
-                                    onTap: {
-                                        self.tableView.reloadData()
-                                    })
-            }
+        let navigationBar = msfNavigationController?.msfNavigationBar
+        guard let view = navigationBar?.barButtonItemView(tag: 1) else {
+            return
         }
+        Tooltip.shared.show(with: "Tap on this tooltip to dismiss.",
+                            for: view,
+                            preferredArrowDirection: .up,
+                            dismissOn: .tapOnTooltip,
+                            onTap: { [weak self] in
+                                self?.tableView.reloadData()
+                            })
     }
 
     @objc private func dismissSelf() {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -156,10 +156,9 @@ open class NavigationBar: UINavigationBar {
         return nil
     }
 
-    @objc public func barButtonItemView(tag: Int) -> UIView? {
-        let leftBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews
-        let rightBarButtonItemViews = rightBarButtonItemsStackView.arrangedSubviews
-        let totalBarButtonItemViews = leftBarButtonItemViews + rightBarButtonItemViews
+    /// This method will return an optional view for a bar button item with a given tag in the navigation bar.
+    @objc public func barButtonItemView(with tag: Int) -> UIView? {
+        let totalBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews + rightBarButtonItemsStackView.arrangedSubviews
         for view in totalBarButtonItemViews {
             if view.tag == tag {
                 return view

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -156,7 +156,7 @@ open class NavigationBar: UINavigationBar {
         return nil
     }
 
-    /// This method will return an optional view for a bar button item with a given tag in the navigation bar.
+    /// Returns the first match of an optional view for a bar button item with the given tag.
     @objc public func barButtonItemView(with tag: Int) -> UIView? {
         if showsLargeTitle {
             let totalBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews + rightBarButtonItemsStackView.arrangedSubviews

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -158,13 +158,21 @@ open class NavigationBar: UINavigationBar {
 
     /// This method will return an optional view for a bar button item with a given tag in the navigation bar.
     @objc public func barButtonItemView(with tag: Int) -> UIView? {
-        let totalBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews + rightBarButtonItemsStackView.arrangedSubviews
-        for view in totalBarButtonItemViews {
-            if view.tag == tag {
-                return view
+        if showsLargeTitle {
+            let totalBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews + rightBarButtonItemsStackView.arrangedSubviews
+            for view in totalBarButtonItemViews {
+                if view.tag == tag {
+                    return view
+                }
+            }
+        } else {
+            let totalBarButtonItems = (topItem?.leftBarButtonItems ?? []) + (topItem?.rightBarButtonItems ?? [])
+            for item in totalBarButtonItems {
+                if item.tag == tag {
+                    return item.value(forKey: "view") as? UIView
+                }
             }
         }
-
         return nil
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -156,6 +156,19 @@ open class NavigationBar: UINavigationBar {
         return nil
     }
 
+    @objc public func barButtonItemView(tag: Int) -> UIView? {
+        let leftBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews
+        let rightBarButtonItemViews = rightBarButtonItemsStackView.arrangedSubviews
+        let totalBarButtonItemViews = leftBarButtonItemViews + rightBarButtonItemViews
+        for view in totalBarButtonItemViews {
+            if view.tag == tag {
+                return view
+            }
+        }
+
+        return nil
+    }
+
     /// An element size to describe the behavior of the navigation bar's expanded height. Set automatically when the values of `avatarSize` and `titleSize` are changed. The bar will lock to expanded size if either element is set to `.expanded`, lock to contracted if both elements are `.contracted`, and stay automatic in any other case.
     @objc open private(set) dynamic var barHeight: ElementSize = .automatic {
         didSet {
@@ -241,17 +254,14 @@ open class NavigationBar: UINavigationBar {
         }
     }
 
-    /// Making these stack views as public so as to access the arranged subviews of these stack view.
-    /// One use case is to access the arranged subview to show the tooltip.
-    @objc public let rightBarButtonItemsStackView = UIStackView()
-    @objc public let leftBarButtonItemsStackView = UIStackView()
-
     // @objc dynamic - so we can do KVO on this
     @objc dynamic private(set) var style: Style = defaultStyle
 
     let backgroundView = UIView() //used for coloration
     //used to cover the navigationbar during animated transitions between VCs
     private let contentStackView = ContentStackView() //used to contain the various custom UI Elements
+    private let rightBarButtonItemsStackView = UIStackView()
+    private let leftBarButtonItemsStackView = UIStackView()
     private let leadingSpacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
     private let trailingSpacerView = UIView() //defines the trailing space between the left and right barbuttonitems stack
     private var topAccessoryView: UIView?

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -241,14 +241,17 @@ open class NavigationBar: UINavigationBar {
         }
     }
 
+    /// Making these stack views as public so as to access the arranged subviews of these stack view.
+    /// One use case is to access the arranged subview to show the tooltip.
+    @objc public let rightBarButtonItemsStackView = UIStackView()
+    @objc public let leftBarButtonItemsStackView = UIStackView()
+
     // @objc dynamic - so we can do KVO on this
     @objc dynamic private(set) var style: Style = defaultStyle
 
     let backgroundView = UIView() //used for coloration
     //used to cover the navigationbar during animated transitions between VCs
     private let contentStackView = ContentStackView() //used to contain the various custom UI Elements
-    private let rightBarButtonItemsStackView = UIStackView()
-    private let leftBarButtonItemsStackView = UIStackView()
     private let leadingSpacerView = UIView() //defines the leading space between the left and right barbuttonitems stack
     private let trailingSpacerView = UIView() //defines the trailing space between the left and right barbuttonitems stack
     private var topAccessoryView: UIView?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Expose left and right item button stack view in the navigation bar.

### Verification
The change was tested manually and also added functionality to the demo controller. Attached screenshots.

<img width="333" alt="Screenshot 2021-08-18 at 1 59 48 PM" src="https://user-images.githubusercontent.com/33866787/129865542-daf1557f-f16c-4f91-8338-61b41ff595cd.png"> 
<img width="716" alt="Screenshot 2021-08-18 at 2 00 40 PM" src="https://user-images.githubusercontent.com/33866787/129865640-ee94ea86-0686-4d09-8805-65b4ef59fb7a.png">
<img width="487" alt="Screenshot 2021-08-18 at 1 58 32 PM" src="https://user-images.githubusercontent.com/33866787/129865696-285d2efe-a763-4755-be2b-6656c38458b1.png">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/686)