### PR TITLE
Add a public function to return a view for side tab bar item

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -23,6 +23,10 @@ class SideTabBarDemoController: DemoController {
         return SideTabBar(frame: .zero)
     }()
 
+    private let homeItem: TabBarItem = {
+        return TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!)
+    }()
+
     private var contentViewController: UIViewController?
 
     private var badgeNumbers: [UInt] = Constants.initialBadgeNumbers
@@ -68,7 +72,7 @@ class SideTabBarDemoController: DemoController {
         sideTabBar.delegate = self
 
         sideTabBar.topItems = [
-            TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!),
+            homeItem,
             TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!),
             TabBarItem(title: "Open", image: UIImage(named: "Open_28")!, selectedImage: UIImage(named: "Open_Selected_28")!)
         ]
@@ -119,6 +123,16 @@ class SideTabBarDemoController: DemoController {
 
         updateBadgeNumbers()
         updateBadgeButtons()
+    }
+
+    @objc private func showTooltipForSettingsButton() {
+        guard let view = sideTabBar.itemView(with: homeItem) else {
+            return
+        }
+        Tooltip.shared.show(with: "Tap anywhere to dismiss this tooltip",
+                            for: view,
+                            preferredArrowDirection: .left,
+                            dismissOn: .tapAnywhere)
     }
 
     @objc private func dismissSideTabBar() {
@@ -212,6 +226,7 @@ class SideTabBarDemoController: DemoController {
                 CellItem(title: "Show badge numbers", type: .boolean, action: #selector(toggleShowBadgeNumbers(_:))),
                 CellItem(title: "Use higher badge numbers", type: .boolean, action: #selector(toggleUseHigherBadgeNumbers(_:))),
                 CellItem(title: "Modify badge numbers", type: .stepper, action: nil),
+                CellItem(title: "Show tooltip for Home button", type: .action, action: #selector(showTooltipForSettingsButton)),
                 CellItem(title: "Dismiss", type: .action, action: #selector(dismissSideTabBar))
         ]
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -23,10 +23,6 @@ class SideTabBarDemoController: DemoController {
         return SideTabBar(frame: .zero)
     }()
 
-    private let homeItem: TabBarItem = {
-        return TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!)
-    }()
-
     private var contentViewController: UIViewController?
 
     private var badgeNumbers: [UInt] = Constants.initialBadgeNumbers
@@ -59,6 +55,10 @@ class SideTabBarDemoController: DemoController {
         button.accessibilityLabel = "Decrement badge numbers"
         button.addTarget(self, action: #selector(decrementBadgeNumbers), for: .touchUpInside)
         return button
+    }()
+
+    private lazy var homeItem: TabBarItem = {
+        return TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!)
     }()
 
     private func presentSideTabBar() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -132,6 +132,7 @@ class SideTabBarDemoController: DemoController {
         Tooltip.shared.show(with: "Tap anywhere to dismiss this tooltip",
                             for: view,
                             preferredArrowDirection: .left,
+                            offset: .init(x: 9, y: 0),
                             dismissOn: .tapAnywhere)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -129,6 +129,7 @@ class SideTabBarDemoController: DemoController {
         guard let view = sideTabBar.itemView(with: homeItem) else {
             return
         }
+
         Tooltip.shared.show(with: "Tap anywhere to dismiss this tooltip",
                             for: view,
                             preferredArrowDirection: .left,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -154,6 +154,7 @@ class TabBarViewDemoController: DemoController {
         guard let tabBarView = tabBarView, let view = tabBarView.itemView(with: homeItem) else {
             return
         }
+
         Tooltip.shared.show(with: "Tap anywhere to dismiss this tooltip",
                             for: view,
                             preferredArrowDirection: .down,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -32,11 +32,19 @@ class TabBarViewDemoController: DemoController {
         return createButton(title: "-", action: #selector(decrementBadgeNumbers))
     }()
 
+    private lazy var homeItem: TabBarItem = {
+        return TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!)
+    }()
+
     private var badgeNumbers: [UInt] = Constants.initialBadgeNumbers
     private var higherBadgeNumbers: [UInt] = Constants.initialHigherBadgeNumbers
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        container.addArrangedSubview(createButton(title: "Show tooltip for Home button", action: #selector(showTooltipForHomeButton)))
+
+        container.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
 
         addRow(text: "Show item titles", items: [itemTitleVisibilitySwitch], textWidth: Constants.switchSettingTextWidth)
         itemTitleVisibilitySwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
@@ -73,7 +81,7 @@ class TabBarViewDemoController: DemoController {
             ]
         } else {
             updatedTabBarView.items = [
-                TabBarItem(title: "Home", image: UIImage(named: "Home_28")!, selectedImage: UIImage(named: "Home_Selected_28")!, landscapeImage: UIImage(named: "Home_24")!, landscapeSelectedImage: UIImage(named: "Home_Selected_24")!),
+                homeItem,
                 TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),
                 TabBarItem(title: "Open", image: UIImage(named: "Open_28")!, selectedImage: UIImage(named: "Open_Selected_28")!, landscapeImage: UIImage(named: "Open_24")!, landscapeSelectedImage: UIImage(named: "Open_Selected_24")!)
             ]
@@ -140,6 +148,17 @@ class TabBarViewDemoController: DemoController {
 
     @objc private func decrementBadgeNumbers() {
         modifyBadgeNumbers(increment: -1)
+    }
+
+    @objc private func showTooltipForHomeButton() {
+        guard let tabBarView = tabBarView, let view = tabBarView.itemView(with: homeItem) else {
+            return
+        }
+        Tooltip.shared.show(with: "Tap anywhere to dismiss this tooltip",
+                            for: view,
+                            preferredArrowDirection: .down,
+                            offset: .init(x: 0, y: 6),
+                            dismissOn: .tapAnywhere)
     }
 }
 

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -323,7 +323,7 @@ open class SideTabBar: UIView {
     }
 
     /// Returns the first match of an optional view for a given tab bar item.
-    /// Searches for the view in the top and bottom sections in that order of priority. Returns nil if the view is not found in either section
+    /// Searches for the view in the top and bottom sections in that order of priority. Returns nil if the view is not found in either section.
     @objc public func itemView(with item: TabBarItem) -> UIView? {
         if let view = itemView(with: item, in: .top) {
             return view

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -322,8 +322,8 @@ open class SideTabBar: UIView {
         return nil
     }
 
-    /// This method returns an optional view for the given tab bar item.
-    /// It will searche the top section first and then the bottom one if not found in the top section.
+    /// Returns the first match of an optional view for a given tab bar item.
+    /// Searches for the view in the top and bottom sections in that order of priority. Returns nil if the view is not found in either section
     @objc public func itemView(with item: TabBarItem) -> UIView? {
         if let view = itemView(with: item, in: .top) {
             return view

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -325,9 +325,8 @@ open class SideTabBar: UIView {
     @objc public func itemView(with item: TabBarItem) -> UIView? {
         if let view = itemView(with: item, in: .top) {
             return view
-        } else {
-            return itemView(with: item, in: .bottom)
         }
+        return itemView(with: item, in: .bottom)
     }
 
     private class func createStackView(spacing: CGFloat) -> UIStackView {

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -322,6 +322,8 @@ open class SideTabBar: UIView {
         return nil
     }
 
+    /// This method returns an optional view for the given tab bar item.
+    /// It will searche the top section first and then the bottom one if not found in the top section.
     @objc public func itemView(with item: TabBarItem) -> UIView? {
         if let view = itemView(with: item, in: .top) {
             return view

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -322,6 +322,13 @@ open class SideTabBar: UIView {
         return nil
     }
 
+    @objc public func itemView(with item: TabBarItem) -> UIView? {
+        guard let view = itemView(with: item, in: .top) else {
+            return itemView(with: item, in: .bottom)
+        }
+        return view
+    }
+
     private class func createStackView(spacing: CGFloat) -> UIStackView {
         let stackView = UIStackView(frame: .zero)
         stackView.axis = .vertical

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -328,6 +328,7 @@ open class SideTabBar: UIView {
         if let view = itemView(with: item, in: .top) {
             return view
         }
+
         return itemView(with: item, in: .bottom)
     }
 

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -323,10 +323,11 @@ open class SideTabBar: UIView {
     }
 
     @objc public func itemView(with item: TabBarItem) -> UIView? {
-        guard let view = itemView(with: item, in: .top) else {
+        if let view = itemView(with: item, in: .top) {
+            return view
+        } else {
             return itemView(with: item, in: .bottom)
         }
-        return view
     }
 
     private class func createStackView(spacing: CGFloat) -> UIStackView {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
I need to make a public function in the case of the Side tab bar i.e MSFSideTabBar whereas there is already an available public function in the case of Bottom Tab Bar i.e. MSFTabBarView

### Verification
SIDE TAB BAR
<img width="338" alt="Screenshot 2021-08-19 at 5 53 38 PM" src="https://user-images.githubusercontent.com/33866787/130067972-a056f622-b543-41b1-865c-5e893b478174.png">
<img width="718" alt="Screenshot 2021-08-19 at 5 53 55 PM" src="https://user-images.githubusercontent.com/33866787/130067994-22001d38-704e-4ac9-885b-510b7107a6e6.png">
<img width="491" alt="Screenshot 2021-08-19 at 5 58 04 PM" src="https://user-images.githubusercontent.com/33866787/130068406-ef41abda-eac8-4342-b62a-a4c9a5e1afd6.png">

BOTTOM TAB BAR
<img width="332" alt="Screenshot 2021-08-19 at 5 54 32 PM" src="https://user-images.githubusercontent.com/33866787/130068011-eaceb7b1-954e-4de4-b76d-9f858fe647b8.png">
<img width="716" alt="Screenshot 2021-08-19 at 5 54 18 PM" src="https://user-images.githubusercontent.com/33866787/130068001-7fbdbf97-d43a-4893-9ceb-d97cd2c6b7e5.png">
<img width="487" alt="Screenshot 2021-08-19 at 5 58 43 PM" src="https://user-images.githubusercontent.com/33866787/130068394-f831865f-ce3a-4131-810d-6da401aef6c2.png">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/688)