### PR TITLE
Add an API to get the current rect of a hero item view

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -226,6 +226,21 @@ open class BottomCommandingController: UIViewController {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+    /// Current rectangle of the view that represents the given hero item.
+    ///
+    /// - Parameter heroItem: A `CommandingItem` contained in `heroItems`.
+    /// - Returns: The current rectangle in the coordinate system of the receiver.
+    @objc public func rectFor(heroItem: CommandingItem) -> CGRect {
+        guard isViewLoaded,
+              let bindingInfo = itemToBindingMap[heroItem],
+              bindingInfo.location == .heroSet else {
+            return .null
+        }
+
+        let itemView = bindingInfo.view
+        return itemView.convert(itemView.bounds, to: view)
+    }
+
     // MARK: - View building and layout
 
     public override func loadView() {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -236,7 +236,6 @@ open class BottomCommandingController: UIViewController {
               bindingInfo.location == .heroSet else {
             return .null
         }
-
         let itemView = bindingInfo.view
         return itemView.convert(itemView.bounds, to: view)
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A client needs to present a popover when a hero button is tapped in the bottom bar. This popover needs to attach to the hero item view, but these are internal and we don't want to expose them to clients. 
To cover this scenario, this PR adds an API to get the current rect of a given hero item view in the coordinate space of `BottomCommandingController`'s root view. This allows clients to position the popover correctly, without us exposing the actual view.

### Verification

Various sanity checks to verify the rects are correct, both in sheet and bar styles.
Added a custom popover example code to the demo controller:

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2021-08-23 at 16 53 32](https://user-images.githubusercontent.com/3610850/130534191-6fe21020-8d9c-4743-9758-2a79b1ecd0f2.png)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/689)