### PR TITLE
Renaming MSFButtonView (SwiftUI Button View) to FluentButton.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -33,10 +33,10 @@ struct ButtonDemoView: View {
 
     public var body: some View {
         VStack {
-            MSFButtonView(style: style,
-                          size: size,
-                          image: showImage ? UIImage(named: "Placeholder_24") : nil,
-                          text: showLabel ? text : nil) {
+            FluentButton(style: style,
+                         size: size,
+                         image: showImage ? UIImage(named: "Placeholder_24") : nil,
+                         text: showLabel ? text : nil) {
                 showAlert = true
             }
             .disabled(isDisabled)

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -29,13 +29,13 @@ import UIKit
 }
 
 /// View that represents the button.
-public struct MSFButtonView: View {
+public struct FluentButton: View {
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFButtonTokens
     @ObservedObject var state: MSFButtonStateImpl
 
-    /// Creates a MSFButtonView.
+    /// Creates a FluentButton.
     /// - Parameters:
     ///   - style: The MSFButtonStyle used by the button.
     ///   - size: The MSFButtonSize value used by the button.
@@ -58,8 +58,8 @@ public struct MSFButtonView: View {
 
     public var body: some View {
         Button(action: state.action, label: {})
-            .buttonStyle(MSFButtonViewButtonStyle(tokens: tokens,
-                                                  state: state))
+            .buttonStyle(FluentButtonStyle(tokens: tokens,
+                                           state: state))
             .modifyIf(state.disabled != nil, { button in
                 button.disabled(state.disabled!)
             })
@@ -116,7 +116,7 @@ class MSFButtonStateImpl: NSObject, ObservableObject, MSFButtonState {
 }
 
 /// Body of the button adjusted for pressed or rest state
-struct MSFButtonViewBody: View {
+struct FluentButtonBody: View {
     @Environment(\.isEnabled) var isEnabled: Bool
     @ObservedObject var tokens: MSFButtonTokens
     @ObservedObject var state: MSFButtonStateImpl
@@ -179,13 +179,13 @@ struct MSFButtonViewBody: View {
 }
 
 /// ButtonStyle which configures the Button View according to its state and design tokens.
-struct MSFButtonViewButtonStyle: ButtonStyle {
+struct FluentButtonStyle: ButtonStyle {
     @ObservedObject var tokens: MSFButtonTokens
     @ObservedObject var state: MSFButtonStateImpl
 
     func makeBody(configuration: Self.Configuration) -> some View {
-        MSFButtonViewBody(tokens: tokens,
-                          state: state,
-                          isPressed: configuration.isPressed)
+        FluentButtonBody(tokens: tokens,
+                         state: state,
+                         isPressed: configuration.isPressed)
     }
 }

--- a/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
@@ -6,12 +6,12 @@
 import SwiftUI
 import UIKit
 
-public extension MSFButtonView {
+public extension FluentButton {
 
     /// Sets the accessibility label for the Button.
     /// - Parameter accessibilityLabel: Accessibility label string.
     /// - Returns: The modified Button with the property set.
-    func accessibilityLabel(_ accessibilityLabel: String?) -> MSFButtonView {
+    func accessibilityLabel(_ accessibilityLabel: String?) -> FluentButton {
         state.accessibilityLabel = accessibilityLabel
         return self
     }

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -77,8 +77,8 @@ import UIKit
                             action: ((_ sender: MSFButton) -> Void)?,
                             theme: FluentUIStyle? = nil) {
         self.action = action
-        buttonView = MSFButtonView(style: style,
-                                   size: size) { [weak self] in
+        buttonView = FluentButton(style: style,
+                                  size: size) { [weak self] in
             guard let strongSelf = self else {
                 return
             }
@@ -117,5 +117,5 @@ import UIKit
 
     private var hostingController: UIHostingController<AnyView>!
 
-    private var buttonView: MSFButtonView!
+    private var buttonView: FluentButton!
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The current SwiftUI View that represents the Fluent Vnext Button is not named in conformance to the standard in FluentUI Vnext.
The main reason for that is that SwiftUI already defines a Button struct for the SwiftUI Button View.
In order to solve the clash and still have the name closer to what the other FluentUI Vnext SwiftUI Views are named after, we're renaming it from **MSFButtonView** to just **FluentButton**.

### Verification

Smoke test on building an running the button Demo controllers.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/690)