### PR TITLE
Fix content trailing margin bug

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -211,10 +211,10 @@ open class NavigationBar: UINavigationBar {
         }
     }
 
-    /// The navigation bar's leading content margin.
+    /// The navigation bar's trailing content margin.
     @objc open var contentTrailingMargin: CGFloat = defaultContentTrailingMargin {
         didSet {
-            if oldValue != contentLeadingMargin {
+            if oldValue != contentTrailingMargin {
                 updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Fix the documentation and didSet method for the content trailing margin variable in the MSFNavigationBar.

### Verification

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/691)