### PR TITLE
Moving cutout logic to Avatar from AvatarGroup

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -95,7 +95,7 @@ class AvatarGroupDemoController: UITableViewController {
             let stackView = UIStackView(arrangedSubviews: buttonView)
             stackView.frame = CGRect(x: 0,
                                      y: 0,
-                                     width: 100,
+                                     width: 120,
                                      height: 40)
             stackView.distribution = .fillEqually
             stackView.alignment = .center

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -339,6 +339,18 @@ public struct Avatar: View {
                           with: windowProvider)
     }
 
+    public func size() -> CGFloat {
+        let avatarImageSize: CGFloat = state.size.size
+        if !state.isRingVisible {
+            return avatarImageSize
+        } else {
+            let innerRingGap: CGFloat = state.hasRingInnerGap ? tokens.ringInnerGap : 0
+            let ringThickness: CGFloat = state.isRingVisible ? tokens.ringThickness : 0
+            let outerRingGap: CGFloat = state.isRingVisible ? tokens.ringOuterGap : 0
+            return ((innerRingGap + ringThickness + outerRingGap) * 2 + avatarImageSize)
+        }
+    }
+
     private let animationDuration: Double = 0.1
 
     private struct PresenceCutout: Shape {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -339,19 +339,6 @@ public struct Avatar: View {
                           with: windowProvider)
     }
 
-    /// Calculates the size of the avatar
-    public func size() -> CGFloat {
-        let avatarImageSize: CGFloat = state.size.size
-        let ringOuterGap: CGFloat = tokens.ringOuterGap
-        if !state.isRingVisible {
-            return avatarImageSize + (ringOuterGap * 2)
-        } else {
-            let ringThickness: CGFloat = state.isRingVisible ? tokens.ringThickness : 0
-            let ringInnerGap: CGFloat = state.isRingVisible ? tokens.ringInnerGap : 0
-            return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
-        }
-    }
-
     /// `AvatarCutout`: Cutout shape for an Avatar
     ///
     /// `xOrigin`: beginning location of cutout on the x axis
@@ -516,5 +503,18 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
         self.tokens = MSFAvatarTokens(style: style,
                                       size: size)
         super.init()
+    }
+
+    /// Calculates the size of the avatar, including ring spacing
+    func totalSize() -> CGFloat {
+        let avatarImageSize: CGFloat = size.size
+        let ringOuterGap: CGFloat = tokens.ringOuterGap
+        if !isRingVisible {
+            return avatarImageSize + (ringOuterGap * 2)
+        } else {
+            let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
+            let ringInnerGap: CGFloat = isRingVisible ? tokens.ringInnerGap : 0
+            return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
+        }
     }
 }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -342,13 +342,13 @@ public struct Avatar: View {
     /// Calculates the size of the avatar
     public func size() -> CGFloat {
         let avatarImageSize: CGFloat = state.size.size
+        let ringOuterGap: CGFloat = tokens.ringOuterGap
         if !state.isRingVisible {
-            return avatarImageSize
+            return avatarImageSize + (ringOuterGap * 2)
         } else {
-            let innerRingGap: CGFloat = state.hasRingInnerGap ? tokens.ringInnerGap : 0
             let ringThickness: CGFloat = state.isRingVisible ? tokens.ringThickness : 0
-            let outerRingGap: CGFloat = state.isRingVisible ? tokens.ringOuterGap : 0
-            return ((innerRingGap + ringThickness + outerRingGap) * 2 + avatarImageSize)
+            let ringInnerGap: CGFloat = state.isRingVisible ? tokens.ringInnerGap : 0
+            return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
         }
     }
 

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -339,6 +339,7 @@ public struct Avatar: View {
                           with: windowProvider)
     }
 
+    /// Calculates the size of the avatar
     public func size() -> CGFloat {
         let avatarImageSize: CGFloat = state.size.size
         if !state.isRingVisible {
@@ -348,6 +349,28 @@ public struct Avatar: View {
             let ringThickness: CGFloat = state.isRingVisible ? tokens.ringThickness : 0
             let outerRingGap: CGFloat = state.isRingVisible ? tokens.ringOuterGap : 0
             return ((innerRingGap + ringThickness + outerRingGap) * 2 + avatarImageSize)
+        }
+    }
+
+    /// `AvatarCutout`: Cutout shape for an Avatar
+    ///
+    /// `xOrigin`: beginning location of cutout on the x axis
+    ///
+    /// `yOrigin`: beginning location of cutout on the y axis
+    ///
+    /// `cutoutSize`: dimensions of cutout shape of the Avatar
+    public struct AvatarCutout: Shape {
+        var xOrigin: CGFloat
+        var yOrigin: CGFloat
+        var cutoutSize: CGFloat
+
+        public func path(in rect: CGRect) -> Path {
+            var cutoutFrame = Rectangle().path(in: rect)
+            cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
+                                                         y: yOrigin,
+                                                         width: cutoutSize,
+                                                         height: cutoutSize)))
+            return cutoutFrame
         }
     }
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -171,16 +171,16 @@ public struct AvatarGroup: View {
                 // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
                 let avatar = avatars[index]
                 let avatarView = Avatar(avatar)
+                let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
                 let avatarSize = avatarView.size()
-                let nextAvatarSize = Avatar(avatars[index + 1]).size()
+                let nextAvatarSize: CGFloat = needsCutout ? Avatar(avatars[index + 1]).size() : 0
                 let isLastDisplayed = index == maxDisplayedAvatars - 1
 
                 let currentAvatarHasRing = avatar.isRingVisible
                 let nextAvatarHasRing = index + 1 < maxDisplayedAvatars ? avatars[index + 1].isRingVisible : false
-                let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
                 let avatarSizeDifference = avatarSize - nextAvatarSize
                 let sizeDiff = !isLastDisplayed ? (currentAvatarHasRing ? avatarSizeDifference : avatarSizeDifference - ringGapOffset) :
-                currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize
+                    currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize
                 let x = avatarSize + tokens.interspace - ringGapOffset
 
                 let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
@@ -192,7 +192,7 @@ public struct AvatarGroup: View {
                 let xPosition = currentAvatarHasRing ? x - ringOuterGap - ringOuterGap : x - ringOuterGap
                 let xPositionRTL = currentAvatarHasRing ? rtlRingPaddingInterspace : rtlNoRingPaddingInterspace
                 let xOrigin = Locale.current.isRightToLeftLayoutDirection() ? xPositionRTL : xPosition
-                let yOrigin: CGFloat = sizeDiff / 2
+                let yOrigin = sizeDiff / 2
                 let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
 
                 avatarView

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -162,8 +162,9 @@ public struct AvatarGroup: View {
         let overflowCount: Int = (avatars.count > maxDisplayedAvatars ? avatars.count - maxDisplayedAvatars : 0) + state.overflowCount
 
         let interspace: CGFloat = tokens.interspace
-        let size: CGFloat = tokens.size.size
+        let imageSize: CGFloat = tokens.size.size
         let ringOuterGap: CGFloat = tokens.ringOuterGap
+        let ringGapOffset: CGFloat = ringOuterGap * 2
         let ringOffset: CGFloat = tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap
         HStack(spacing: 0) {
             ForEach(0 ..< maxDisplayedAvatars, id: \.self) { index in
@@ -174,11 +175,13 @@ public struct AvatarGroup: View {
                 let nextAvatarSize = Avatar(avatars[index + 1]).size()
                 let isLastDisplayed = index == maxDisplayedAvatars - 1
 
-                let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
-                let sizeDiff = !isLastDisplayed ? avatarSize - nextAvatarSize : avatarSize - size
-                let x = avatarSize + tokens.interspace
                 let currentAvatarHasRing = avatar.isRingVisible
                 let nextAvatarHasRing = index + 1 < maxDisplayedAvatars ? avatars[index + 1].isRingVisible : false
+                let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
+                let avatarSizeDifference = avatarSize - nextAvatarSize
+                let sizeDiff = !isLastDisplayed ? (currentAvatarHasRing ? avatarSizeDifference : avatarSizeDifference - ringGapOffset) :
+                currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize
+                let x = avatarSize + tokens.interspace - ringGapOffset
 
                 let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
                 let noRingPaddingInterspace = nextAvatarHasRing ? interspace - ringOuterGap : interspace
@@ -186,11 +189,11 @@ public struct AvatarGroup: View {
                 let rtlNoRingPaddingInterspace = (nextAvatarHasRing ? -x - ringOffset - ringOuterGap : -x)
                 let stackPadding = (currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace)
 
-                let xPosition = currentAvatarHasRing ? x - ringOuterGap - ringOffset : x - ringOuterGap
+                let xPosition = currentAvatarHasRing ? x - ringOuterGap - ringOuterGap : x - ringOuterGap
                 let xPositionRTL = currentAvatarHasRing ? rtlRingPaddingInterspace : rtlNoRingPaddingInterspace
                 let xOrigin = Locale.current.isRightToLeftLayoutDirection() ? xPositionRTL : xPosition
                 let yOrigin: CGFloat = sizeDiff / 2
-                let cutoutSize = isLastDisplayed ? size : nextAvatarSize
+                let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
 
                 avatarView
                     .modifyIf(needsCutout, { view in

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -228,7 +228,7 @@ class MSFAvatarGroupStateImpl: NSObject, ObservableObject, MSFAvatarGroupState {
     }
 
     func createAvatar(at index: Int) -> MSFAvatarGroupAvatarState {
-        guard index <= avatars.count else {
+        guard index <= avatars.count && index >= 0 else {
             preconditionFailure("Index is out of bounds")
         }
         let avatar = MSFAvatarGroupAvatarStateImpl(size: tokens.size)
@@ -237,14 +237,14 @@ class MSFAvatarGroupStateImpl: NSObject, ObservableObject, MSFAvatarGroupState {
     }
 
     func getAvatarState(at index: Int) -> MSFAvatarGroupAvatarState {
-        guard index < avatars.count else {
+        guard avatars.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }
         return avatars[index]
     }
 
     func removeAvatar(at index: Int) {
-        guard index < avatars.count else {
+        guard avatars.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }
         avatars.remove(at: index)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -165,12 +165,18 @@ public struct AvatarGroup: View {
         let size: CGFloat = tokens.size.size
         let ringOuterGap: CGFloat = tokens.ringOuterGap
         let ringOffset: CGFloat = tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap
-        let x: CGFloat = size + tokens.interspace - tokens.ringThickness
         HStack(spacing: 0) {
             ForEach(0 ..< maxDisplayedAvatars, id: \.self) { index in
                 // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
-                let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
                 let avatar = avatars[index]
+                let avatarView = Avatar(avatar)
+                let avatarSize = avatarView.size()
+                let nextAvatarSize = Avatar(avatars[index + 1]).size()
+                let isLastDisplayed = index == maxDisplayedAvatars - 1
+
+                let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
+                let sizeDiff = !isLastDisplayed ? avatarSize - nextAvatarSize : avatarSize - size
+                let x = avatarSize + tokens.interspace
                 let currentAvatarHasRing = avatar.isRingVisible
                 let nextAvatarHasRing = index + 1 < maxDisplayedAvatars ? avatars[index + 1].isRingVisible : false
 
@@ -180,14 +186,13 @@ public struct AvatarGroup: View {
                 let rtlNoRingPaddingInterspace = (nextAvatarHasRing ? -x - ringOffset - ringOuterGap : -x)
                 let stackPadding = (currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace)
 
-                let xPosition = currentAvatarHasRing ? x + ringOffset : x
+                let xPosition = currentAvatarHasRing ? x - ringOuterGap - ringOffset : x - ringOuterGap
                 let xPositionRTL = currentAvatarHasRing ? rtlRingPaddingInterspace : rtlNoRingPaddingInterspace
                 let xOrigin = Locale.current.isRightToLeftLayoutDirection() ? xPositionRTL : xPosition
-                let yOrigin = currentAvatarHasRing ? (nextAvatarHasRing ? ringOuterGap : ringOffset) :
-                    (nextAvatarHasRing ? 0 - ringOffset + tokens.ringOuterGap : 0)
-                let cutoutSize = nextAvatarHasRing ? size + ringOffset + ringOuterGap : size
+                let yOrigin: CGFloat = sizeDiff / 2
+                let cutoutSize = isLastDisplayed ? size : nextAvatarSize
 
-                Avatar(avatar)
+                avatarView
                     .modifyIf(needsCutout, { view in
                         view.mask(AvatarCutout(xOrigin: xOrigin,
                                                yOrigin: yOrigin,

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -194,9 +194,10 @@ public struct AvatarGroup: View {
 
                 avatarView
                     .modifyIf(needsCutout, { view in
-                        view.mask(AvatarCutout(xOrigin: xOrigin,
-                                               yOrigin: yOrigin,
-                                               cutoutSize: cutoutSize)
+                        view.mask(Avatar.AvatarCutout(
+                                    xOrigin: xOrigin,
+                                    yOrigin: yOrigin,
+                                    cutoutSize: cutoutSize)
                                     .fill(style: FillStyle(eoFill: true)))
                     })
                     .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
@@ -214,28 +215,6 @@ public struct AvatarGroup: View {
         data.image = nil
         avatar.state = data
         return avatar
-    }
-
-    /// `AvatarCutout`: Cutout shape for  succeeding Avatar in an Avatar Group in Stack style.
-    ///
-    /// `xOrigin`: beginning location of cutout on the x axis
-    ///
-    /// `yOrigin`: beginning location of cutout on the y axis
-    ///
-    /// `cutoutSize`: dimensions of cutout shape of the Avatar
-    private struct AvatarCutout: Shape {
-        var xOrigin: CGFloat
-        var yOrigin: CGFloat
-        var cutoutSize: CGFloat
-
-        func path(in rect: CGRect) -> Path {
-            var cutoutFrame = Rectangle().path(in: rect)
-            cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
-                                                         y: yOrigin,
-                                                         width: cutoutSize,
-                                                         height: cutoutSize)))
-            return cutoutFrame
-        }
     }
 }
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -158,6 +158,7 @@ public struct AvatarGroup: View {
 
     public var body: some View {
         let avatars: [MSFAvatarStateImpl] = state.avatars
+        let avatarViews: [Avatar] = avatars.map { Avatar($0) }
         let maxDisplayedAvatars: Int = avatars.prefix(state.maxDisplayedAvatars).count
         let overflowCount: Int = (avatars.count > maxDisplayedAvatars ? avatars.count - maxDisplayedAvatars : 0) + state.overflowCount
 
@@ -170,10 +171,10 @@ public struct AvatarGroup: View {
             ForEach(0 ..< maxDisplayedAvatars, id: \.self) { index in
                 // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
                 let avatar = avatars[index]
-                let avatarView = Avatar(avatar)
+                let avatarView = avatarViews[index]
                 let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
-                let avatarSize = avatarView.size()
-                let nextAvatarSize: CGFloat = needsCutout ? Avatar(avatars[index + 1]).size() : 0
+                let avatarSize: CGFloat = avatarView.state.totalSize()
+                let nextAvatarSize: CGFloat = needsCutout ? avatarViews[index + 1].state.totalSize() : 0
                 let isLastDisplayed = index == maxDisplayedAvatars - 1
 
                 let currentAvatarHasRing = avatar.isRingVisible


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The cutout shape for overlapping avatars in AvatarGroup is currently calculated within AvatarGroup. Let's move this logic to Avatar to make future reusability easier and more reliable.

Also expanding width of stack view so that settings button does not overflow in iPhone mode.

### Verification

Tested different sized avatars with rings

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-08-24 at 13 07 34](https://user-images.githubusercontent.com/22566866/130682748-334097ea-4a2d-46ac-bcc4-17fd822589d5.png) | ![Simulator Screen Shot - iPhone 11 - 2021-08-27 at 17 01 41](https://user-images.githubusercontent.com/22566866/131199375-80a4d1fe-e18d-408b-a037-4cddba86f3b3.png)|
| ![Simulator Screen Shot - iPhone 11 - 2021-08-27 at 17 02 34](https://user-images.githubusercontent.com/22566866/131199420-31d12b64-d99f-4853-8321-b19ad8bb3563.png) | ![Simulator Screen Shot - iPhone 11 - 2021-08-27 at 17 02 01](https://user-images.githubusercontent.com/22566866/131199396-af68ace5-c405-4866-b7aa-8f795d93ebd0.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/695)