### PR TITLE
[AvatarGroup] Adding createAvatar at index API

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -236,13 +236,11 @@ public struct AvatarGroup: View {
 
 class MSFAvatarGroupStateImpl: NSObject, ObservableObject, MSFAvatarGroupState {
     func createAvatar() -> MSFAvatarGroupAvatarState {
-        let avatar = MSFAvatarGroupAvatarStateImpl(size: tokens.size)
-        avatars.append(avatar)
-        return avatar
+        return createAvatar(at: avatars.endIndex)
     }
 
     func createAvatar(at index: Int) -> MSFAvatarGroupAvatarState {
-        guard index < avatars.count else {
+        guard index <= avatars.count else {
             preconditionFailure("Index is out of bounds")
         }
         let avatar = MSFAvatarGroupAvatarStateImpl(size: tokens.size)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adds an additional createAvatar API that allows adding an avatar at a specified index.

### Verification

Adding new avatar at index 0:

https://user-images.githubusercontent.com/22566866/130862456-96b2f6bc-23df-40ac-835c-dcc0883dc20c.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/696)