### PR TITLE
Allow dimming view tap to dismiss the bottom sheet

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -28,6 +28,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     case noUserAction // No user action, used for events not triggered by users
     case swipe // Swipe on the sheet view
     case resizingHandleTap // Tap on the sheet resizing handle
+    case dimmingViewTap // Tap on the dimming view
 }
 
 /// Defines the position the sheet is currently in
@@ -273,6 +274,9 @@ public class BottomSheetController: UIViewController {
         var dimmingView = DimmingView(type: .black)
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
         dimmingView.alpha = 0.0
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleDimmingViewTap))
+        dimmingView.addGestureRecognizer(tapGesture)
         return dimmingView
     }()
 
@@ -367,6 +371,10 @@ public class BottomSheetController: UIViewController {
     }
 
     // MARK: - Gesture handling
+
+    @objc private func handleDimmingViewTap(_ sender: UITapGestureRecognizer) {
+        move(to: .collapsed, interaction: .dimmingViewTap)
+    }
 
     @objc private func handleResizingHandleViewTap(_ sender: UITapGestureRecognizer) {
         move(to: isExpanded ? .collapsed : .expanded, interaction: .resizingHandleTap)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A single tap on the dimming view when the sheet is expanded should cause it to collapse. This PR adds a tap gesture recognizer on the dimming view to do that. I also added a corresponding `BottomSheetInteraction` enum value for correct delegate reporting of the source interaction.

Note - the gesture recognizer is implicitly only active when the dimming view is visible. It receives no touch events when the view alpha is set to 0.

### Verification

Sanity checks in the test app.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/699)