### PR TITLE
Bump Xcode and macOS versions (again)

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: fluentui_apple_publish_nuget
   pool:
-    vmImage: 'macos-10.15'
+    vmImage: 'macos-11'
   displayName: FluentUI Apple Publish NuGet
   timeoutInMinutes: 60 # how long to run the job before automatically cancelling
   cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   validation:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: true
     steps:
@@ -26,7 +26,7 @@ jobs:
     - name: validation
       run: scripts/validation.sh
   xcodebuild:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -7,7 +7,7 @@ on:
       - 0.2.[0-9]+_main_0.2
 jobs:
   Pod-Publish:
-    runs-on: macOS-10.15
+    runs-on: macos-11
     
     steps:
     - uses: actions/checkout@v2

--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { "Microsoft" => "fluentuinativeowners@microsoft.com"}
   s.source       = { :git => "https://github.com/microsoft/fluentui-apple.git", :tag => "#{s.version}" }
-  s.swift_version = "5.0"
+  s.swift_version = "5.4"
   s.module_name = 'FluentUI'
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Fluent UI Apple contains native UIKit and AppKit controls aligned with [Microsof
 #### Requirements
 
 - iOS 13+ or macOS 10.14+
-- Xcode 11+
-- Swift 5.0+
+- Xcode 12.5+
+- Swift 5.4+
 
 #### Using Carthage
 

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_12.4.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_12.5.1.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_12.5.1.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_12.5.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

We previously tried to move our minimum required Xcode to 12.5, but ran into two problems:
1. Azure Pipelines did not yet support `macos-11`, which is the minimum supported OS for Xcode 12.5.
2. One of our clients was not yet ready to move to Xcode 12.5, which would have resulted in potential build breaks due to using different versions of Swift compiler.

But now both of these blocking issues are resolved, so we're ready to re-apply @sophialee0416's change and begin using Xcode 12.5.1 as our primary build environment.

Documentation verifying that we can upgrade:

**Microsoft-hosted agents**
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software

**Virtual environments:**
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode

### Verification

- Built Static Library and Framework targets
- Basic smoke test of test app
- Verified that ADO integration functions as expected

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/700)