### PR TITLE
[List vNext] Add animation to expand/collapse trigger

### DIFF
--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -63,7 +63,7 @@ public struct MSFListView: View {
                     }
                 }
             }
-            .animation(Animation.default)
+            .animation(.default)
             .environment(\.defaultMinListRowHeight, 0)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .designTokens(tokens,

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -63,6 +63,7 @@ public struct MSFListView: View {
                     }
                 }
             }
+            .animation(Animation.default)
             .environment(\.defaultMinListRowHeight, 0)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .designTokens(tokens,

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -280,6 +280,7 @@ struct MSFListCellView: View {
                 }
             })
             .buttonStyle(ListCellButtonStyle(tokens: tokens, state: state))
+            .animation(Animation.easeInOut)
 
             if state.hasDivider {
                 let padding = tokens.horizontalCellPadding +

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -280,7 +280,6 @@ struct MSFListCellView: View {
                 }
             })
             .buttonStyle(ListCellButtonStyle(tokens: tokens, state: state))
-            .animation(Animation.easeInOut)
 
             if state.hasDivider {
                 let padding = tokens.horizontalCellPadding +


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

List expand/collapse did not have an animation when triggered externally. This fix changes that so the list is able to animate expand/collapse smoothly.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ezgif com-video-to-gif-3](https://user-images.githubusercontent.com/22566866/132048150-026bc68a-a662-4056-8c30-d31b7b8c7b1f.gif) | ![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22566866/132059962-8dd0d6e6-723d-4519-9ca0-bbdde787cfd9.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/702)