### PR TITLE
Replacing .mask modifier with .clipShape due to issue on iOS 13.0 / 13.1.

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -307,9 +307,10 @@ public struct Avatar: View {
                                 .contentShape(Circle()),
                              alignment: .center)
                     .modifyIf(shouldDisplayPresence, { thisView in
-                            thisView.mask(PresenceCutout(presenceCutoutOriginCoordinates: presenceCutoutOriginCoordinates,
-                                                         presenceIconOutlineSize: presenceIconOutlineSize)
-                                            .fill(style: FillStyle(eoFill: true)))
+                            thisView
+                                .clipShape(PresenceCutout(presenceCutoutOriginCoordinates: presenceCutoutOriginCoordinates,
+                                                          presenceIconOutlineSize: presenceIconOutlineSize),
+                                           style: FillStyle(eoFill: true))
                                 .overlay(Circle()
                                             .foregroundColor(Color(tokens.ringGapColor).opacity(isTransparent ? 0 : 1))
                                             .frame(width: presenceIconOutlineSize, height: presenceIconOutlineSize, alignment: .center)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -198,11 +198,10 @@ public struct AvatarGroup: View {
 
                 avatarView
                     .modifyIf(needsCutout, { view in
-                        view.mask(Avatar.AvatarCutout(
-                                    xOrigin: xOrigin,
-                                    yOrigin: yOrigin,
-                                    cutoutSize: cutoutSize)
-                                    .fill(style: FillStyle(eoFill: true)))
+                        view.clipShape(Avatar.AvatarCutout(xOrigin: xOrigin,
+                                                           yOrigin: yOrigin,
+                                                           cutoutSize: cutoutSize),
+                                       style: FillStyle(eoFill: true))
                     })
                     .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a bug/issue with the [.mask(_:) modifier](https://developer.apple.com/documentation/swiftui/list/mask(_:)) which completely hides the view where it's being applied to while running on **iOS 13.0** and **iOS 13.1**.

Because of this issue and also because the mask modifier is **deprecated**, let's replace its usage with the [clipShape(_:style:) modifier](https://developer.apple.com/documentation/swiftui/list/clipshape(_:style:)) that is supported in iOS 13.0 and fixes this issue.


### Verification

Validated that the new application of the [clipShape(_:style:) modifier](https://developer.apple.com/documentation/swiftui/list/clipshape(_:style:)) works correctly on the following iOS versions:
- iOS 13.0
- iOS 13.1
- iOS 13.2
- iOS 13.7
- iOS 14.5

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![avatargroup_before](https://user-images.githubusercontent.com/68076145/132077026-ef3b7756-3500-4e13-90bc-203226f1a706.png) | ![avatargroup_after](https://user-images.githubusercontent.com/68076145/132077105-1c274aa7-6994-4b16-accc-71f1975ea817.png) |
| ![avatar_swiftui_before](https://user-images.githubusercontent.com/68076145/132077037-7d085c46-277d-4e14-aa5b-031dd24bf3ef.png) | ![avatar_swiftui_after](https://user-images.githubusercontent.com/68076145/132077097-86b13a8f-dbed-48bb-b11d-8c854ef7ddc3.png) |

**Video demonstrating the issue being reproduced and fixed after launching the build with the fix:**


https://user-images.githubusercontent.com/68076145/132077045-9426a3a1-c9b0-40da-9ac6-2594eb3009ed.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/703)