### PR TITLE
Update SearchBar progress spinner light content colors

### DIFF
--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -24,6 +24,7 @@ public extension Colors {
             public static var cancelButton: UIColor = LightContent.text
             public static var clearIcon = UIColor(light: iconOnAccent, dark: textSecondary)
             public static var placeholderText = UIColor(light: textOnAccent, dark: textSecondary)
+            public static var progressSpinner = UIColor(light: textOnAccent, dark: textSecondary)
             public static var searchIcon: UIColor = placeholderText
             public static var text = UIColor(light: textOnAccent, dark: textDominant)
             public static var tint: UIColor = LightContent.text
@@ -115,10 +116,10 @@ open class SearchBar: UIView {
             }
         }
 
-        func progressSpinnerColor(for window: UIWindow) -> UIColor {
+        var progressSpinnerColor: UIColor {
             switch self {
             case .lightContent:
-                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textPrimary)
+                return Colors.SearchBar.LightContent.progressSpinner
             case .darkContent:
                 return Colors.SearchBar.DarkContent.progressSpinner
             }
@@ -438,9 +439,7 @@ open class SearchBar: UIView {
         // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
-        if let window = window {
-            progressSpinner.color = style.progressSpinnerColor(for: window)
-        }
+        progressSpinner.color = style.progressSpinnerColor
         cancelButton.setTitleColor(style.cancelButtonColor, for: .normal)
         attributePlaceholderText()
     }


### PR DESCRIPTION
Search Bar progress spinner should not use the primary tint, but instead use the same as text color in order to ensure that we match accessibility requirements of minimum contrast ratios.

This originally came in as part of commit 4130adbdca2334cf9cc16249ac6e91017008aa8b but does not match the specified designs.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Make the search bar progress color match designs & accessibility requirements (i.e. minimum contrast ratio) for light content style.

### Verification

Manually tested in the simulator in both styles (and three header styles).

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
![gradient_1_before](https://user-images.githubusercontent.com/6126317/132389769-072cbe44-e1ef-46c1-922b-6e4caaa82850.png) | ![gradient_2_after](https://user-images.githubusercontent.com/6126317/132389774-d57ee468-323b-48b5-985f-f7f69fe00d1a.png)
![primary_1_before](https://user-images.githubusercontent.com/6126317/132389777-45c89a4f-42a4-4000-ad7b-08776e530379.png)| ![primary_2_after](https://user-images.githubusercontent.com/6126317/132389781-6f869540-53bc-4ab6-9799-380fbaa1f814.png)
![system_1_before](https://user-images.githubusercontent.com/6126317/132389782-34a02352-fdc8-44d8-affb-23027c61c1a3.png) | ![system_2_after](https://user-images.githubusercontent.com/6126317/132389783-b5d2f42c-ac07-48c9-ad8c-9d88a9b85ba7.png)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/704)