### PR TITLE
Fixes to keep our framework building in Xcode 13

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -847,7 +847,7 @@
 			repositoryURL = "https://github.com/microsoft/appcenter-sdk-apple.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.1.1;
+				minimumVersion = 4.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
         "state": {
           "branch": null,
-          "revision": "013bffe628b49433d7bc334146a4ed8c507c0e32",
-          "version": "4.1.1"
+          "revision": "6d60d2361445e959b4fbb3a9d0dbae0e07eead1a",
+          "version": "4.2.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/microsoft/PLCrashReporter.git",
         "state": {
           "branch": null,
-          "revision": "de6b8f9db4b2a0aa859a5507550a70548e4da936",
-          "version": "1.8.1"
+          "revision": "d747ab5de269cd44022bbe96ff9609d8626694ab",
+          "version": "1.9.0"
         }
       }
     ]

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -156,6 +156,23 @@ public struct AvatarGroup: View {
         self.tokens = state.tokens
     }
 
+    /// Renders the avatar with an optional cutout
+    @ViewBuilder
+    private func avatarCutout(_ avatar: Avatar,
+                              _ needsCutout: Bool,
+                              _ xOrigin: CGFloat,
+                              _ yOrigin: CGFloat,
+                              _ cutoutSize: CGFloat,
+                              _ padding: CGFloat) -> some View {
+        avatar.modifyIf(needsCutout, { view in
+            view.clipShape(Avatar.AvatarCutout(xOrigin: xOrigin,
+                                               yOrigin: yOrigin,
+                                               cutoutSize: cutoutSize),
+                           style: FillStyle(eoFill: true))
+            })
+            .padding(.trailing, padding)
+    }
+
     public var body: some View {
         let avatars: [MSFAvatarStateImpl] = state.avatars
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
@@ -196,14 +213,14 @@ public struct AvatarGroup: View {
                 let yOrigin = sizeDiff / 2
                 let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
 
-                avatarView
-                    .modifyIf(needsCutout, { view in
-                        view.clipShape(Avatar.AvatarCutout(xOrigin: xOrigin,
-                                                           yOrigin: yOrigin,
-                                                           cutoutSize: cutoutSize),
-                                       style: FillStyle(eoFill: true))
-                    })
-                    .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
+                // Hand the rendering of the avatar to a helper function to appease Swift's
+                // strict type-checking timeout.
+                self.avatarCutout(avatarView,
+                                  needsCutout,
+                                  xOrigin,
+                                  yOrigin,
+                                  cutoutSize,
+                                  tokens.style == .stack ? stackPadding : interspace)
             }
             if overflowCount > 0 {
                 createOverflow(count: overflowCount)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Two fixes to keep our framework and test app building in Xcode 13.
1. Moving from AppCenter 4.1.1 to 4.2 for our Demo app.
2. Moving some of our `Avatar` cutout rendering logic to a helper `@ViewBuilder` function to eliminate that pesky `The compiler is unable to type-check this expression in reasonable time` problem.

### Verification

- Ensured that we actually build now (Framework, Static Lib, and Demo App) in the latest Xcode 13 beta.
- Basic smoketest around `AvatarGroup`.

Note: this PR does NOT verify any additional functionality under the new compiler or against iOS 15. This is _just_ getting us building.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/706)