### PR TITLE
Interactive hiding of the bottom sheet / bottom commanding

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -372,7 +372,7 @@ extension BottomCommandingDemoController: UIScrollViewDelegate {
             var delta = contentOffset - previousScrollOffset
             if interactiveHidingAnimator == nil {
                 isHiding = delta > 0 ? true : false
-                interactiveHidingAnimator = bottomCommandingController?.setIsHiddenInteractively(isHiding) { [weak self] _ in
+                interactiveHidingAnimator = bottomCommandingController?.prepareInteractiveIsHiddenChange(isHiding) { [weak self] _ in
                     self?.mainTableViewController?.tableView?.reloadData()
                     self?.mainTableViewController?.tableView?.layoutIfNeeded()
                     self?.interactiveHidingAnimator = nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -99,16 +99,16 @@ class BottomCommandingDemoController: UIViewController {
         ]
     }()
 
-    @objc private func toggleHidden() {
-        bottomCommandingController?.isHidden.toggle()
+    @objc private func toggleHidden(_ sender: BooleanCell) {
+        bottomCommandingController?.isHidden = sender.isOn
     }
 
-    @objc private func toggleSheetMoreButton() {
-        bottomCommandingController?.prefersSheetMoreButtonVisible.toggle()
+    @objc private func toggleSheetMoreButton(_ sender: BooleanCell) {
+        bottomCommandingController?.prefersSheetMoreButtonVisible = sender.isOn
     }
 
-    @objc private func toggleExpandedItems() {
-        if bottomCommandingController?.expandedListSections.count == 0 {
+    @objc private func toggleExpandedItems(_ sender: BooleanCell) {
+        if sender.isOn {
             bottomCommandingController?.expandedListSections = currentExpandedListSections
         } else {
             bottomCommandingController?.expandedListSections = []
@@ -126,21 +126,21 @@ class BottomCommandingDemoController: UIViewController {
 
     private let modifiedCommandIndices: [Int] = [0, 3]
 
-    @objc private func toggleHeroCommandOnOff() {
+    @objc private func toggleHeroCommandOnOff(_ sender: BooleanCell) {
         modifiedCommandIndices.forEach {
-            heroItems[$0].isOn.toggle()
+            heroItems[$0].isOn = sender.isOn
         }
     }
 
-    @objc private func toggleHeroCommandEnabled() {
+    @objc private func toggleHeroCommandEnabled(_ sender: BooleanCell) {
         modifiedCommandIndices.forEach {
-            heroItems[$0].isEnabled.toggle()
+            heroItems[$0].isEnabled = sender.isOn
         }
     }
 
-    @objc private func toggleListCommandEnabled() {
+    @objc private func toggleListCommandEnabled(_ sender: BooleanCell) {
         modifiedCommandIndices.forEach {
-            currentExpandedListSections[0].items[$0].isEnabled.toggle()
+            currentExpandedListSections[0].items[$0].isEnabled = sender.isOn
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -201,7 +201,7 @@ extension BottomSheetDemoController: UIScrollViewDelegate {
             var delta = contentOffset - previousScrollOffset
             if interactiveHidingAnimator == nil {
                 isHiding = delta > 0 ? true : false
-                interactiveHidingAnimator = bottomSheetViewController?.setIsHiddenInteractively(isHiding) { [weak self] _ in
+                interactiveHidingAnimator = bottomSheetViewController?.prepareInteractiveIsHiddenChange(isHiding) { [weak self] _ in
                     self?.mainTableView?.reloadData()
                     self?.mainTableView?.layoutIfNeeded()
                     self?.interactiveHidingAnimator = nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -102,7 +102,7 @@ class BottomSheetDemoController: UIViewController {
 
     private var isHiding: Bool = false
 
-    private var interactiveHidingAnimator: UIViewPropertyAnimator?
+    private var interactiveHidingAnimator: UIViewAnimating?
 
     private var demoOptionItems: [DemoItem] {
         [
@@ -207,8 +207,7 @@ extension BottomSheetDemoController: UIScrollViewDelegate {
             var delta = contentOffset - previousScrollOffset
             if interactiveHidingAnimator == nil {
                 isHiding = delta > 0 ? true : false
-                interactiveHidingAnimator = bottomSheetViewController?.startInteractiveHiddenStateChange(to: isHiding)
-                interactiveHidingAnimator?.addCompletion { [weak self] _ in
+                interactiveHidingAnimator = bottomSheetViewController?.setIsHiddenInteractively(isHiding) { [weak self] _ in
                     self?.mainTableView?.reloadData()
                     self?.mainTableView?.layoutIfNeeded()
                     self?.interactiveHidingAnimator = nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -45,12 +45,12 @@ class BottomSheetDemoController: UIViewController {
 
     private var mainTableView: UITableView?
 
-    @objc private func toggleExpandable() {
-        bottomSheetViewController?.isExpandable.toggle()
+    @objc private func toggleExpandable(_ sender: BooleanCell) {
+        bottomSheetViewController?.isExpandable = sender.isOn
     }
 
-    @objc private func toggleHidden() {
-        bottomSheetViewController?.isHidden.toggle()
+    @objc private func toggleHidden(_ sender: BooleanCell) {
+        bottomSheetViewController?.isHidden = sender.isOn
     }
 
     @objc private func fullScreenSheetContent() {
@@ -90,14 +90,22 @@ class BottomSheetDemoController: UIViewController {
 
     private var bottomSheetViewController: BottomSheetController?
 
-    private lazy var demoOptionItems: [DemoItem] = {
-        return [
-            DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: true),
-            DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: false),
+    private var previousScrollOffset: CGFloat = 0
+
+    private var isScrolling: Bool = false
+
+    private var isHiding: Bool = false
+
+    private var interactiveHidingAnimator: UIViewPropertyAnimator?
+
+    private var demoOptionItems: [DemoItem] {
+        [
+            DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: bottomSheetViewController?.isExpandable ?? true),
+            DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomSheetViewController?.isHidden ?? false),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]
-    }()
+    }
 
     private static let headerHeight: CGFloat = 70
 
@@ -177,6 +185,53 @@ extension BottomSheetDemoController: UITableViewDataSource {
         }
 
         return UITableViewCell()
+    }
+}
+
+extension BottomSheetDemoController: UIScrollViewDelegate {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        isScrolling = true
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let contentOffset = scrollView.contentOffset.y
+
+        if isScrolling {
+            var delta = contentOffset - previousScrollOffset
+            if interactiveHidingAnimator == nil {
+                isHiding = delta > 0 ? true : false
+                interactiveHidingAnimator = bottomSheetViewController?.startInteractiveHiddenStateChange(isHidden: isHiding)
+                interactiveHidingAnimator?.addCompletion { [weak self] _ in
+                    self?.mainTableView?.reloadData()
+                    self?.mainTableView?.layoutIfNeeded()
+                    self?.interactiveHidingAnimator = nil
+                    print("removing animator")
+                }
+            }
+            if let animator = interactiveHidingAnimator {
+                if animator.isRunning {
+                    animator.pauseAnimation()
+                }
+
+                delta *= isHiding ? 1 : -1
+                animator.fractionComplete += delta / 100
+            }
+        }
+
+        previousScrollOffset = contentOffset
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        isScrolling = false
+        if let animator = interactiveHidingAnimator {
+            if animator.fractionComplete > 0.5 {
+                animator.startAnimation()
+            } else {
+                animator.isReversed.toggle()
+                isHiding.toggle()
+                animator.startAnimation()
+            }
+        }
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -98,8 +98,6 @@ class BottomSheetDemoController: UIViewController {
 
     private var scrollHidingEnabled: Bool = false
 
-    private var isScrolling: Bool = false
-
     private var isHiding: Bool = false
 
     private var interactiveHidingAnimator: UIViewAnimating?
@@ -108,7 +106,7 @@ class BottomSheetDemoController: UIViewController {
         [
             DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: bottomSheetViewController?.isExpandable ?? true),
             DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomSheetViewController?.isHidden ?? false),
-            DemoItem(title: "Hide on scroll", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
+            DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]
@@ -196,14 +194,10 @@ extension BottomSheetDemoController: UITableViewDataSource {
 }
 
 extension BottomSheetDemoController: UIScrollViewDelegate {
-    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        isScrolling = scrollHidingEnabled
-    }
-
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let contentOffset = scrollView.contentOffset.y
 
-        if isScrolling {
+        if scrollView.isTracking && scrollHidingEnabled {
             var delta = contentOffset - previousScrollOffset
             if interactiveHidingAnimator == nil {
                 isHiding = delta > 0 ? true : false
@@ -218,6 +212,8 @@ extension BottomSheetDemoController: UIScrollViewDelegate {
                     animator.pauseAnimation()
                 }
 
+                // fractionComplete either represents progress to hidden or unhidden,
+                // so we need to adjust the delta to account for this
                 delta *= isHiding ? 1 : -1
                 animator.fractionComplete += delta / 100
             }
@@ -227,7 +223,6 @@ extension BottomSheetDemoController: UIScrollViewDelegate {
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        isScrolling = false
         if let animator = interactiveHidingAnimator {
             if animator.fractionComplete > 0.5 {
                 animator.startAnimation()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -53,6 +53,10 @@ class BottomSheetDemoController: UIViewController {
         bottomSheetViewController?.isHidden = sender.isOn
     }
 
+    @objc private func toggleScrollHiding(_ sender: BooleanCell) {
+        scrollHidingEnabled = sender.isOn
+    }
+
     @objc private func fullScreenSheetContent() {
         // This is also the default value which results in a full screen sheet.
         bottomSheetViewController?.preferredExpandedContentHeight = 0
@@ -92,6 +96,8 @@ class BottomSheetDemoController: UIViewController {
 
     private var previousScrollOffset: CGFloat = 0
 
+    private var scrollHidingEnabled: Bool = false
+
     private var isScrolling: Bool = false
 
     private var isHiding: Bool = false
@@ -102,6 +108,7 @@ class BottomSheetDemoController: UIViewController {
         [
             DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: bottomSheetViewController?.isExpandable ?? true),
             DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomSheetViewController?.isHidden ?? false),
+            DemoItem(title: "Hide on scroll", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]
@@ -190,7 +197,7 @@ extension BottomSheetDemoController: UITableViewDataSource {
 
 extension BottomSheetDemoController: UIScrollViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        isScrolling = true
+        isScrolling = scrollHidingEnabled
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -200,12 +207,11 @@ extension BottomSheetDemoController: UIScrollViewDelegate {
             var delta = contentOffset - previousScrollOffset
             if interactiveHidingAnimator == nil {
                 isHiding = delta > 0 ? true : false
-                interactiveHidingAnimator = bottomSheetViewController?.startInteractiveHiddenStateChange(isHidden: isHiding)
+                interactiveHidingAnimator = bottomSheetViewController?.startInteractiveHiddenStateChange(to: isHiding)
                 interactiveHidingAnimator?.addCompletion { [weak self] _ in
                     self?.mainTableView?.reloadData()
                     self?.mainTableView?.layoutIfNeeded()
                     self?.interactiveHidingAnimator = nil
-                    print("removing animator")
                 }
             }
             if let animator = interactiveHidingAnimator {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -211,7 +211,7 @@ open class BottomCommandingController: UIViewController {
         var animator: UIViewPropertyAnimator?
 
         if isInSheetMode {
-            return bottomSheetController?.startInteractiveHiddenStateChange(isHidden: isHidden)
+            return bottomSheetController?.startInteractiveHiddenStateChange(to: isHidden)
         } else {
             if let animator = bottomBarHidingAnimator {
                 animator.stopAnimation(false)

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -718,9 +718,13 @@ open class BottomCommandingController: UIViewController {
         }
 
         animator.addCompletion { [weak self] finalPosition in
+            guard let strongSelf = self else {
+                return
+            }
+
             if finalPosition == .end {
                 bottomBarView.isHidden = isHidden
-                self?._isHidden = isHidden
+                strongSelf._isHidden = isHidden
             } else if finalPosition == .start {
                 bottomBarView.isHidden = initialHiddenState
                 bottomConstraint.constant = initialBottomConstant

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -205,12 +205,12 @@ open class BottomCommandingController: UIViewController {
 
     /// Initiates an interactive `isHidden` state change driven by the returned `UIViewAnimating` object.
     ///
-    /// For usage details, see `BottomSheetController.setIsHiddenInteractively`.
+    /// For usage details, see `BottomSheetController.prepareInteractiveIsHiddenChange`.
     /// - Parameters:
     ///   - isHidden: The target state.
     ///   - completion: Closure to be called when the state change completes.
     /// - Returns: An animator that conforms to `UIViewAnimating`. The associated animations start in a paused state.
-    @objc public func setIsHiddenInteractively(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
+    @objc public func prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
         guard isViewLoaded else {
             return nil
         }
@@ -218,7 +218,7 @@ open class BottomCommandingController: UIViewController {
         var animator: UIViewAnimating?
 
         if isInSheetMode {
-            animator = bottomSheetController?.setIsHiddenInteractively(isHidden, completion: completion)
+            animator = bottomSheetController?.prepareInteractiveIsHiddenChange(isHidden, completion: completion)
         } else {
             completeBottomBarAnimationsIfNeeded(skipToEnd: true)
             if isHidden != self.isHidden, let hidingAnimator = bottomBarHidingAnimator(to: isHidden) {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -196,7 +196,8 @@ public class BottomSheetController: UIViewController {
     /// You can modify the `fractionComplete` property of the animator to interactively drive the animation in the paused state.
     /// You can also change the `isReversed` property to swap the start and target `isHidden` states.
     ///
-    /// When you are done driving the animation interactively, you must call `startAnimation` on the animator to let it complete non-interactively.
+    /// When you are done driving the animation interactively, you must call `startAnimation` on the animator to let the animation resume
+    /// from the current value of `fractionComplete`.
     /// - Parameters:
     ///   - isHidden: The target state.
     ///   - completion: Closure to be called when the state change completes.

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -37,8 +37,8 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     case collapsed // Sheet is collapsed
     case hidden // Sheet is hidden (fully off-screen)
 
-    var expandedContentAlpha: CGFloat { self == .expanded ? 1.0 : 0.0 }
-    var dimmingViewAlpha: CGFloat { self == .expanded ? 1.0 : 0.0 }
+    // Target alpha of related views like the sheet content or dimming view.
+    var relatedViewAlpha: CGFloat { self == .expanded ? 1.0 : 0.0 }
 }
 
 @objc(MSFBottomSheetController)
@@ -568,17 +568,16 @@ public class BottomSheetController: UIViewController {
             self?.view.layoutIfNeeded()
         }
 
-        let targetExpandedContentAlpha = targetExpansionState.expandedContentAlpha
-        if expandedContentView.alpha != targetExpandedContentAlpha {
+        let targetRelatedViewAlpha = targetExpansionState.relatedViewAlpha
+        if expandedContentView.alpha != targetRelatedViewAlpha {
             translationAnimator.addAnimations {
-                self.expandedContentView.alpha = targetExpandedContentAlpha
+                self.expandedContentView.alpha = targetRelatedViewAlpha
             }
         }
 
-        if shouldShowDimmingView {
-            let targetDimmingViewAlpha = targetExpansionState.dimmingViewAlpha
+        if shouldShowDimmingView && dimmingView.alpha != targetRelatedViewAlpha {
             translationAnimator.addAnimations {
-                self.dimmingView.alpha = targetDimmingViewAlpha
+                self.dimmingView.alpha = targetRelatedViewAlpha
             }
         }
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -196,12 +196,12 @@ public class BottomSheetController: UIViewController {
     /// You can modify the `fractionComplete` property of the animator to interactively drive the animation in the paused state.
     /// You can also change the `isReversed` property to swap the start and target `isHidden` states.
     ///
-    /// At the end of the interactive portion of the animation, you must call `startAnimation` on the animator to complete it non-interactively.
+    /// When you are done driving the animation interactively, you must call `startAnimation` on the animator to let it complete non-interactively.
     /// - Parameters:
     ///   - isHidden: The target state.
     ///   - completion: Closure to be called when the state change completes.
     /// - Returns: An animator that conforms to `UIViewAnimating`. The associated animations start in a paused state.
-    @objc public func setIsHiddenInteractively(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
+    @objc public func prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
         guard isViewLoaded else {
             return nil
         }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -189,11 +189,14 @@ public class BottomSheetController: UIViewController {
     /// Initiates an interactive `isHidden` state change driven by the returned `UIViewAnimating` object.
     ///
     /// The returned animator comes preloaded with all the animations required to reach the target `isHidden` state.
+    ///
     /// You can modify the `fractionComplete` property of the animator to interactively drive the animation in the paused state.
-    /// You can change the `isReversed` property of the animator to swap the start and target `isHidden` states.
+    /// You can also change the `isReversed` property to swap the start and target `isHidden` states.
+    ///
     /// At the end of the interactive portion of the animation, you must call `startAnimation` on the animator to complete it non-interactively.
-    /// - Parameter isHidden: The target state.
-    /// - Parameter completion: Closure to be called when the state change completes.
+    /// - Parameters:
+    ///   - isHidden: The target state.
+    ///   - completion: Closure to be called when the state change completes.
     /// - Returns: An animator that conforms to `UIViewAnimating`. The associated animations start in a paused state.
     @objc public func setIsHiddenInteractively(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
         guard isViewLoaded else {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -211,10 +211,6 @@ public class BottomSheetController: UIViewController {
             let targetState: BottomSheetExpansionState = isHidden ? .hidden : .collapsed
 
             move(to: initialState, animated: false)
-
-            panGestureRecognizer.isEnabled = false
-            bottomSheetView.isHidden = false
-
             animator = stateChangeAnimator(to: targetState)
 
             currentStateChangeAnimator = animator

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -36,6 +36,9 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     case expanded // Sheet is fully expanded
     case collapsed // Sheet is collapsed
     case hidden // Sheet is hidden (fully off-screen)
+
+    var expandedContentAlpha: CGFloat { self == .expanded ? 1.0 : 0.0 }
+    var dimmingViewAlpha: CGFloat { self == .expanded ? 1.0 : 0.0 }
 }
 
 @objc(MSFBottomSheetController)
@@ -564,7 +567,7 @@ public class BottomSheetController: UIViewController {
             self?.view.layoutIfNeeded()
         }
 
-        let targetExpandedContentAlpha: CGFloat = targetExpansionState == .collapsed ? 0.0 : 1.0
+        let targetExpandedContentAlpha = targetExpansionState.expandedContentAlpha
         if expandedContentView.alpha != targetExpandedContentAlpha {
             translationAnimator.addAnimations {
                 self.expandedContentView.alpha = targetExpandedContentAlpha
@@ -572,7 +575,7 @@ public class BottomSheetController: UIViewController {
         }
 
         if shouldShowDimmingView {
-            let targetDimmingViewAlpha: CGFloat = targetExpansionState == .expanded ? 1.0 : 0.0
+            let targetDimmingViewAlpha = targetExpansionState.dimmingViewAlpha
             translationAnimator.addAnimations {
                 self.dimmingView.alpha = targetDimmingViewAlpha
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds support for interactive changes to the `isHidden` property on `BottomSheetController` and `BottomCommandingController`. This allows clients to drive the `isHidden` state change animation, for example through a gesture recognizer or a scroll view drag. 

We don't want to expose the underlying views to let the client interactively manipulate them, because it would break internal state. We instead let them set the `isHidden` property "interactively", which gives them a `UIViewAnimating` object through which they can drive the `fractionComplete` of the hiding / unhiding animation. 
When they want to stop the interactive portion (like when the user stops scrolling), they must call `startAnimation` to let it resume and drive itself to completion. If the animation hasn't completed yet, they are free to pause it again and go back into interactive state (like if the user starts dragging again before the animation completes). They can also reverse and resume the animation to go back to the initial state (like when the user didn't scroll enough to hide the UI). This lets us fully own the animation and change it in the future without affecting the clients at all.

This should have no impact on existing clients, new APIs only.

#### Implementation
The only new API added to both controllers is:
`prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating?`

`BottomSheetController`
- Mostly refactoring so there is a single entry point for all state change animations - `stateChangeAnimator(to ...`.
- Changes to the animator to make it more self-contained - it cleans up the surrounding state in its completion handler, depending on which position the animation finished in. This enables us to return it to the client and let them drive it. The only requirement on the client is to eventually finish the animation.
- We now internally also use the animator for non-animated state changes - we just create and finish it synchronously. This again ensures all the bug-prone state changing stuff happens in one place.
- Some fixes for the internal animation interrupting code where we weren't correctly completing the animator.

`BottomCommandingController`
- Analogous refactors to `BottomSheetController`, but simpler because this controller only owns the bottom bar.

`BottomSheetDemoApp`
`BottomCommandingDemoApp`
- Added an example implementation of "shy chrome" which is interactive and interruptible.
- Small changes to the table view model so the toggles always reflect the actual state.

### Verification
- Sanity checking in both demo controllers
- With slow animations enabled, testing scrolling up down, interrupting ongoing state changes
- Making sure existing APIs for `isHidden`, `isExpanded` haven't regressed.

https://user-images.githubusercontent.com/3610850/133532218-3e658e49-5f4f-42b4-a521-f2028f3ef5f0.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/709)