### PR TITLE
Fixing failed validation due to Redundant Optional Initialization

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -664,7 +664,7 @@ open class TableViewCell: UITableViewCell {
     }
     private var _customViewSize: CustomViewSize = .default
 
-    @objc open private(set) var customAccessoryView: UIView? = nil {
+    @objc open private(set) var customAccessoryView: UIView? {
         didSet {
             oldValue?.removeFromSuperview()
             if let customAccessoryView = customAccessoryView {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -231,7 +231,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
     private let titleView = TableViewHeaderFooterTitleView()
 
-    private var accessoryView: UIView? = nil {
+    private var accessoryView: UIView? {
         didSet {
             oldValue?.removeFromSuperview()
             if let accessoryView = accessoryView {
@@ -240,7 +240,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         }
     }
 
-    private var accessoryButton: UIButton? = nil {
+    private var accessoryButton: UIButton? {
         didSet {
             accessoryView = accessoryButton
             if accessoryButton != nil {
@@ -249,7 +249,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         }
     }
 
-    private var leadingView: UIView? = nil {
+    private var leadingView: UIView? {
         didSet {
             oldValue?.removeFromSuperview()
             if let leadingView = leadingView {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Validation started to fail on TableView-related files for [redundant optional initialization](https://realm.github.io/SwiftLint/redundant_optional_initialization.html). (PRs [702](https://github.com/microsoft/fluentui-apple/pull/702/checks?check_run_id=3626321767#step:5:151) & [705](https://github.com/microsoft/fluentui-apple/pull/705/checks?check_run_id=3636778667#step:5:154)) This should fix the failures. 

### Verification

pod lib lint is successful & the checks below

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/710)