### PR TITLE
Fixing the order of accessibility items in the LargeTitleView.

### DIFF
--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -379,6 +379,10 @@ class LargeTitleView: UIView {
     /// Updates various properties of the TitleView to properly conform to accessibility requirements
     private func setupAccessibility() {
         titleButton.accessibilityTraits = .header
+
+        // Sets the accessibility elements in the same order as they are laid you in the content view.
+        accessibilityElements = contentStackView.arrangedSubviews
+
         updateAvatarAccessibility()
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The order of the items navigated by Voice Over is incorrect (as the video below shows).
It is currently following the order of:
1. Large Title Button
2. Avatar
3. AccessoryView Buttons.


https://user-images.githubusercontent.com/68076145/133951794-5244663c-496b-4771-969b-de21acad7cf5.MP4


Items 1 and 2 above should be inverted to follow the left to right order as they are laid out in the screen.

### Verification

Verified Voice Over accessibility scenarios in all of the Demo Controller variations and ensured the correct order is followed by Voice Over:


https://user-images.githubusercontent.com/68076145/133951878-018ea68b-4ce6-45d3-b24b-219471733ae6.MP4


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/713)