### PR TITLE
Keyboard accessibility fix by overriding canBecomeFocused to True and…

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -94,6 +94,10 @@ class TabBarItemView: UIView {
             }
         }
 
+        if #available(iOS 14.0, *) {
+            focusGroupIdentifier = item.title
+        }
+
         isAccessibilityElement = true
         updateAccessibilityLabel()
 
@@ -128,6 +132,10 @@ class TabBarItemView: UIView {
         container.layoutSubviews()
         imageViewFrame = imageView.frame
     }
+
+    open override var canBecomeFocused: Bool {
+        return true
+   }
 
     open override var intrinsicContentSize: CGSize {
         return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))


### PR DESCRIPTION
… setting focus group id for tabBarView

### Platforms Impacted
- [x ] iOS
- [ ] macOS

### Description of changes

1. Added focusGroupIdentifier for TabBarItemView. Used title of the item as identifier.
2. Overrided canBecomeFocused of TabBarItemView to return true always
3. 
### Verification

-No automation
- Tested by simulating the OfficeMobile Create Button scenario on the TabBarViewDemoController and validated that the tab bar button views and the Create button view is accessible via keyboard tab key.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [x ] Light and Dark appearances
- [ x] VoiceOver and Keyboard Accessibility
- [ x] Internationalization and Right to Left layouts
- [x ] Different resolutions (1x, 2x, 3x)
- [x ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/716)