### PR TITLE
Return UIViewPropertyAnimator in prepareInteractiveIsHiddenChange

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -203,19 +203,19 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    /// Initiates an interactive `isHidden` state change driven by the returned `UIViewAnimating` object.
+    /// Initiates an interactive `isHidden` state change driven by the returned `UIViewPropertyAnimator`.
     ///
     /// For usage details, see `BottomSheetController.prepareInteractiveIsHiddenChange`.
     /// - Parameters:
     ///   - isHidden: The target state.
     ///   - completion: Closure to be called when the state change completes.
-    /// - Returns: An animator that conforms to `UIViewAnimating`. The associated animations start in a paused state.
-    @objc public func prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
+    /// - Returns: A `UIViewPropertyAnimator`. The associated animations start in a paused state.
+    @objc public func prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewPropertyAnimator? {
         guard isViewLoaded else {
             return nil
         }
 
-        var animator: UIViewAnimating?
+        var animator: UIViewPropertyAnimator?
 
         if isInSheetMode {
             animator = bottomSheetController?.prepareInteractiveIsHiddenChange(isHidden, completion: completion)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -189,7 +189,7 @@ public class BottomSheetController: UIViewController {
         }
     }
 
-    /// Initiates an interactive `isHidden` state change driven by the returned `UIViewAnimating` object.
+    /// Initiates an interactive `isHidden` state change driven by the returned `UIViewPropertyAnimator`.
     ///
     /// The returned animator comes preloaded with all the animations required to reach the target `isHidden` state.
     ///
@@ -201,8 +201,8 @@ public class BottomSheetController: UIViewController {
     /// - Parameters:
     ///   - isHidden: The target state.
     ///   - completion: Closure to be called when the state change completes.
-    /// - Returns: An animator that conforms to `UIViewAnimating`. The associated animations start in a paused state.
-    @objc public func prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewAnimating? {
+    /// - Returns: A `UIViewPropertyAnimator`. The associated animations start in a paused state.
+    @objc public func prepareInteractiveIsHiddenChange(_ isHidden: Bool, completion: ((_ finalPosition: UIViewAnimatingPosition) -> Void)? = nil) -> UIViewPropertyAnimator? {
         guard isViewLoaded else {
             return nil
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Follow up to #709.

When designing the bottom sheet interactive hiding APIs I only wanted to commit to the bare minimum protocol as the return animator type, which I thought would be [UIViewAnimating](https://developer.apple.com/documentation/uikit/uiviewanimating?language=objc). When integrating this internally, I realized we'll need the full [UIViewPropertyAnimator](https://developer.apple.com/documentation/uikit/uiviewpropertyanimator?language=objc) to cover cases where clients want to override duration of the animations (which is handy when you need to sync up multiple pieces of UI showing / hiding).

### Verification

Sanity tests in the test app. This is not a breaking change, and we keep returning the same object as before.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/720)