### PR TITLE
Complete bottom sheet animations when its root view resizes

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -375,6 +375,7 @@ public class BottomSheetController: UIViewController {
     public override func viewDidLayoutSubviews() {
         if needsOffsetUpdate {
             needsOffsetUpdate = false
+            completeAnimationsIfNeeded(skipToEnd: true)
             move(to: currentExpansionState, animated: false, velocity: 0.0)
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#### Problem
When the sheet root view resizes, we call `move(to: currentExpansionState)` to ensure the sheet offset is correct in relation to the new view size. But if a state-changing animation is in progress when the view size changes, the `move` call will cancel it and revert to the original expansion state.

#### Fix
Skip to the end of any animations in progress when the view resizes to ensure the expansion state is up to date.

### Verification

Test app with slow animations on to see that a state change completes when the view resizes during animation.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/721)