### PR TITLE
Clean up UIColor extension, add init from hex.

### DIFF
--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -5,35 +5,44 @@
 
 import UIKit
 
-@objc public extension UIColor {
-    private struct AssociatedKeys {
-        static var light: String = "light"
-        static var lightHighContrast: String = "lightHighContrast"
+public extension UIColor {
+
+    /// Creates a UIColor from a single 32-bit integer value.
+    ///
+    /// - Parameter hexValue: Integer value, generally represented as hexadecimal (e.g. `0x0086F0`), to use to initialize this color.
+    ///     Must be formatted as ARGB. Note: we will not utilize the alpha channel.
+    convenience init(hexValue: UInt32) {
+        self.init(
+            red: CGFloat((hexValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((hexValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat((hexValue & 0x0000FF) >> 0) / 255.0,
+            alpha: 1.0)
     }
 
-    /// Returns self on iOS 13 and later. For older iOS versions returns self for Regular Contrast mode or a specific color for Increased Contrast mode if it's defined either for this color or for one of its ancestors.
-    var current: UIColor {
-        return self
-    }
-
-    private var light: UIColor? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.light) as? UIColor
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.light, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-    private var lightHighContrast: UIColor? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.lightHighContrast) as? UIColor
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.lightHighContrast, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-
-    convenience init(light: UIColor, lightHighContrast: UIColor? = nil, lightElevated: UIColor? = nil, lightElevatedHighContrast: UIColor? = nil, dark: UIColor? = nil, darkHighContrast: UIColor? = nil, darkElevated: UIColor? = nil, darkElevatedHighContrast: UIColor? = nil) {
+    /// Creates a dynamic color object that returns the appropriate color value based on the current
+    /// rendering context.
+    ///
+    /// The decision order for choosing between the colors is based on the following questions, in order:
+    /// - Is the current `userInterfaceStyle` `.dark` or `.light`?
+    /// - Is the current `userInterfaceLevel` `.base` or `.elevated`?
+    /// - Is the current `accessibilityContrast` `.normal` or `.high`?
+    ///
+    /// - Parameter light: The default color for a light context. Required.
+    /// - Parameter lightHighContrast: The override color for a light, high contrast context. Optional.
+    /// - Parameter lightElevated: The override color for a light, elevated context. Optional.
+    /// - Parameter lightElevatedHighContrast: The override color for a light, elevated, high contrast context. Optional.
+    /// - Parameter dark: The override color for a dark context. Optional.
+    /// - Parameter darkHighContrast: The override color for a dark, high contrast context. Optional.
+    /// - Parameter darkElevated: The override color for a dark, elevated context. Optional.
+    /// - Parameter darkElevatedHighContrast: The override color for a dark, elevated, high contrast context. Optional.
+    convenience init(light: UIColor,
+                     lightHighContrast: UIColor? = nil,
+                     lightElevated: UIColor? = nil,
+                     lightElevatedHighContrast: UIColor? = nil,
+                     dark: UIColor? = nil,
+                     darkHighContrast: UIColor? = nil,
+                     darkElevated: UIColor? = nil,
+                     darkElevatedHighContrast: UIColor? = nil) {
         self.init { traits -> UIColor in
             let getColorForContrast = { (_ default: UIColor?, highContrast: UIColor?) -> UIColor? in
                 if traits.accessibilityContrast == .high, let color = highContrast {
@@ -44,17 +53,20 @@ import UIKit
 
             let getColor = { (_ default: UIColor?, highContrast: UIColor?, elevated: UIColor?, elevatedHighContrast: UIColor?) -> UIColor? in
                 if traits.userInterfaceLevel == .elevated,
-                    let color = getColorForContrast(elevated, elevatedHighContrast) {
+                   let color = getColorForContrast(elevated, elevatedHighContrast) {
                     return color
                 }
                 return getColorForContrast(`default`, highContrast)
             }
 
             if traits.userInterfaceStyle == .dark,
-                let color = getColor(dark, darkHighContrast, darkElevated, darkElevatedHighContrast) {
+               let color = getColor(dark, darkHighContrast, darkElevated, darkElevatedHighContrast) {
                 return color
+            } else if let color = getColor(light, lightHighContrast, lightElevated, lightElevatedHighContrast) {
+                return color
+            } else {
+                preconditionFailure("Unable to choose color. Should not be reachable, as `light` color is non-optional.")
             }
-            return getColor(light, lightHighContrast, lightElevated, lightElevatedHighContrast)!
         }
     }
 }

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -112,7 +112,7 @@ open class Label: UILabel {
     private func updateTextColor() {
         if let window = window {
             let currentTextColor = _textColor ?? colorStyle.color(for: window)
-            super.textColor = currentTextColor.current
+            super.textColor = currentTextColor
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Removing unused color extensions and adding a new one for converting from hex.

This required updating one property in `Label`, but there should be no functional difference, as the method unconditionally returned `self` anyway.

### Verification

Ensured that Label looks the same, and that everything builds as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/722)