### PR TITLE
Fix bottom sheet bugs related to unhiding

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -728,6 +728,7 @@ open class BottomCommandingController: UIViewController {
                 strongSelf._isHidden = isHidden
             } else if finalPosition == .start {
                 bottomBarView.isHidden = initialHiddenState
+                strongSelf._isHidden = initialHiddenState
                 bottomConstraint.constant = initialBottomConstant
             }
         }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -712,6 +712,7 @@ open class BottomCommandingController: UIViewController {
 
         bottomConstraint.constant = isHidden ? -Constants.BottomBar.hiddenBottomOffset : -Constants.BottomBar.bottomOffset
         bottomBarView.isHidden = false
+        _isHidden = false
 
         animator.addAnimations { [weak self] in
             self?.view.layoutIfNeeded()

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -518,7 +518,7 @@ public class BottomSheetController: UIViewController {
                       shouldNotifyDelegate: Bool = true,
                       allowUnhiding: Bool = false,
                       completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
-        guard !isHiddenOrHiding || allowUnhiding else {
+        guard targetExpansionState == .hidden || !isHiddenOrHiding || allowUnhiding else {
             return
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#### Problem
While integrating the bottom sheet, I noticed a few issues where the sheet would unhide itself in edge cases where a property that changes the expansion state in its setter is changed during a hiding animation. This is basically caused by callers of `move(to:)` checking `currentExpansionState` or `isHidden`, neither of which catch the case where the sheet isn't hidden now, but it's animating to a hidden state.

#### Fix
`BottomSheetController.swift`
1. Change the source of truth for `isHidden` getter to `bottomSheetView.isHidden` - reflecting the actual state of the UI is the most simple and consistent
2. Guard all state changes through `move(to:)` in a way that stops any unhiding, unless the caller explicitly opts in by passing in `allowsUnhiding=true`. This ensures that when we add more callers of `move(to:)` in the future, it'll be impossible to accidentally unhide.

`BottomCommandingController.swift`
Follow the bottom sheet logic of "Only return isHidden==true when the underlying UI is actually hidden".

### Verification

Lots of sanity checking going through the bug edge cases and regular usage.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/723)