### PR TITLE
Update DemoController class to be more accessible

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -50,6 +50,7 @@ class DemoController: UIViewController {
         description.numberOfLines = 0
         description.text = text
         description.textAlignment = textAlignment
+        description.numberOfLines = 0
         container.addArrangedSubview(description)
         return description
     }
@@ -59,6 +60,7 @@ class DemoController: UIViewController {
         titleLabel.text = text
         titleLabel.textAlignment = .center
         titleLabel.accessibilityTraits.insert(.header)
+        titleLabel.numberOfLines = 0
         container.addArrangedSubview(titleLabel)
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update DemoController class to be more accessible by setting the number of lines of the description/title label to 0 to allow multi-line for large text.

### Verification

Tested by increasing the text size and ensuring the text doesn't get truncated. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/31874971/135027830-af242bb3-1c44-47e4-ac77-7812586a19d0.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2021-09-27 at 22 20 23](https://user-images.githubusercontent.com/31874971/135027770-a2845a69-ddb4-4000-9d24-7c78ffd9d20b.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/726)