### PR TITLE
Fixing repeated VoiceOver on TabBarView

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -39,9 +39,11 @@ open class TabBarView: UIView {
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTabBarItemTapped(_:)))
                 tabBarItemView.addGestureRecognizer(tapGesture)
 
-                // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+                // iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
                 if #available(iOS 14.0, *) {
-                    tabBarItemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                    if #available(iOS 14.6, *) { } else {
+                        tabBarItemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                    }
                 }
                 stackView.addArrangedSubview(tabBarItemView)
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

PR #488 fixed a VoiceOver bug where TabBar menu items were not reading the index positioning. This bug seems to have been fixed in iOS 14.6, causing any versions at and beyond 14.6 to read the index positioning twice. This change adds an additional check to only affect versions within 14.0-14.5 so that any versions outside of the range are not affected.

### Verification

Tested on iOS 14.7 and 14.3 device:

| iOS Version | Before                                       | After                                      |
|---------------------------------|-----------------------------|-----------------------------------|
| 14.3 | Menu item positioning is read once | Menu item positioning is read once |
| 14.7 | Menu item positioning is read twice | Menu item positioning is read once |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/728)