### PR TITLE
Cherry-picking TabBar Voiceover changes to main_0.2

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -45,9 +45,11 @@ open class TabBarView: UIView {
                 let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTabBarItemTapped(_:)))
                 tabBarItemView.addGestureRecognizer(tapGesture)
 
-                // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+                // iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
                 if #available(iOS 14.0, *) {
-                    tabBarItemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                    if #available(iOS 14.6, *) { } else {
+                        tabBarItemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, numberOfItems)
+                    }
                 }
                 stackView.addArrangedSubview(tabBarItemView)
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking TabBar accessibility fixes (2f9363af01f02cdbf4129198dbde8d14e555ff09) to main_0.2.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/731)