### PR TITLE
Fix nav bar and colors in iOS 15

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -21,6 +21,8 @@ class DemoListViewController: UITableViewController {
         let demoListViewController = DemoListViewController(nibName: nil, bundle: nil)
 
         let navigationController = UINavigationController(rootViewController: demoListViewController)
+        navigationController.navigationBar.isTranslucent = true
+
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -123,16 +123,18 @@ class ColorDemoController: UIViewController {
             segmentedControl.selectedSegmentIndex = 0
         }
 
+        // Only use safe area for top and bottom, not left and right, to ensure that the scroll view extends edge to edge
+        // when in landscape mode
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-        
+
         NotificationCenter.default.addObserver(self, selector: #selector(didChangeTheme), name: Notification.Name.didChangeTheme, object: nil)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         navigationController?.navigationBar.shadowImage = UIImage()
@@ -156,7 +158,7 @@ class ColorDemoController: UIViewController {
             }
         }
     }
-    
+
     @objc private func didChangeTheme() {
         // The controls in this controller are not fully theme-aware yet, so
         // we need to manually poke them and have them refresh their colors.
@@ -216,7 +218,7 @@ class DemoColorView: UIView {
         super.init(frame: .zero)
         backgroundColor = color
     }
-    
+
     init(text: String, colorProvider: @escaping (UIWindow) -> (UIColor)) {
         self.text = text
         super.init(frame: .zero)
@@ -236,7 +238,7 @@ class DemoColorView: UIView {
         super.didMoveToWindow()
         updateBackgroundColor()
     }
-    
+
     func updateBackgroundColor() {
         if let colorProvider = colorProvider,
             let window = window {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When building in Xcode 13 against iOS 15, `UINavigationBar` handles its appearance differently, and no longer defaults to a single color. It's unclear if this is a bug or an intended change, but lots of folks on the web seem to have run into the same issue.

Instead of forcing a return to the previous appearance, let's take the opportunity to switch to a modern, translucent nav bar. This gives us much nicer fade animations when scrolling and navigating through the app.

It did, however regress the layout of the segmented control in the `ColorDemoController`. So I fixed that to properly lay out against safe areas.

While I was in the color picker, I discovered a separate issue: some color swatches weren't properly updating, and were actively disappearing on color swap. This likely has to do with the fact that we reuse the same color swatch view and transplant them between iterations of the table view, which is a bit dicey and undefined in the best of situations. So instead of a full `reloadData()`, I've updated the controller to simply refresh the existing color swatches when a theme change notification is fired.

### Verification

- Verified dark and light modes.
- Checked iPads and iPhones both with and without rounded corners (to verify safe area insets).
- Tested against iOS 13, 14, and 15.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![broken](https://user-images.githubusercontent.com/4934719/135691160-1f98a5b0-3b70-4fe6-bd77-9cef226c4627.png) | ![fixed](https://user-images.githubusercontent.com/4934719/135691179-22b22bfa-947e-430d-a238-26e69de64609.png) |
| ![broken-c](https://user-images.githubusercontent.com/4934719/135691259-a68efa2d-5d9e-4b67-9613-a49da76c523e.png) | ![fixed-c](https://user-images.githubusercontent.com/4934719/135691283-c746ea56-dd73-42a0-a3d6-127fe0d451ff.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/733)