### PR TITLE
Fix `sgen` on Xcode 13

### DIFF
--- a/tools/sgen/Pods/PathKit/Sources/PathKit.swift
+++ b/tools/sgen/Pods/PathKit/Sources/PathKit.swift
@@ -580,7 +580,9 @@ extension Path {
     let cPattern = strdup(pattern)
     defer {
       globfree(&gt)
-      free(cPattern)
+      if let cPattern = cPattern {
+        free(cPattern)
+      }
     }
 
     let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK

--- a/tools/sgen/Pods/xcodeproj/Sources/xcodeproj/Extensions/Path+Extras.swift
+++ b/tools/sgen/Pods/xcodeproj/Sources/xcodeproj/Extensions/Path+Extras.swift
@@ -23,7 +23,9 @@ extension Path {
         let cPattern = strdup((self + pattern).string)
         defer {
             globfree(&gt)
-            free(cPattern)
+            if let cPattern = cPattern {
+              free(cPattern)
+            }
         }
 
         let flags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`sgen` depends on `PathKit`, a cocoapod which (as of this writing) has not been updated to build under Xcode 13. This is a simple patch, borrowed from TeamsUI (née Stardust), to get that code building again.

### Verification

Verified that `sgen` now builds and runs as expected in the `vnext-prototype` branch when using Xcode 13.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/735)