### PR TITLE
Update vNext FluentUI Button to support pointer interaction

### DIFF
--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -150,22 +150,22 @@ struct FluentButtonBody: View {
         @ViewBuilder
         var buttonContent: some View {
             HStack(spacing: tokens.interspace) {
-                        if let image = state.image {
-                            Image(uiImage: image)
-                                .resizable()
-                                .foregroundColor(Color(iconColor))
-                                .frame(width: tokens.iconSize, height: tokens.iconSize, alignment: .center)
-                            }
-                        if let text = state.text {
-                            Text(text)
-                                .fontWeight(.medium)
-                                .multilineTextAlignment(.center)
-                                .scalableFont(font: tokens.textFont,
-                                              shouldScale: !isFloatingStyle)
-                                .modifyIf(isFloatingStyle, { view in
-                                    view.frame(minHeight: tokens.textMinimumHeight)
-                                })
-                            }
+                if let image = state.image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .foregroundColor(Color(iconColor))
+                        .frame(width: tokens.iconSize, height: tokens.iconSize, alignment: .center)
+                }
+                if let text = state.text {
+                    Text(text)
+                        .fontWeight(.medium)
+                        .multilineTextAlignment(.center)
+                        .scalableFont(font: tokens.textFont,
+                                      shouldScale: !isFloatingStyle)
+                        .modifyIf(isFloatingStyle, { view in
+                            view.frame(minHeight: tokens.textMinimumHeight)
+                        })
+                }
             }
             .padding(tokens.padding)
             .modifyIf(isFloatingStyle && !(state.text?.isEmpty ?? true), { view in
@@ -224,13 +224,13 @@ struct FluentButtonBody: View {
                 buttonBackground
                     .clipShape(Capsule())
                     .shadow(color: shadow1Color,
-                           radius: shadow1Blur,
-                                x: shadow1DepthX,
-                                y: shadow1DepthY)
+                            radius: shadow1Blur,
+                            x: shadow1DepthX,
+                            y: shadow1DepthY)
                     .shadow(color: shadow2Color,
                             radius: shadow2Blur,
-                                x: shadow2DepthX,
-                                y: shadow2DepthY)
+                            x: shadow2DepthX,
+                            y: shadow2DepthY)
                     .contentShape(Capsule())
             } else {
                 buttonBackground

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -126,55 +126,117 @@ struct FluentButtonBody: View {
         let isDisabled = !isEnabled
         let isFloatingStyle = tokens.style.isFloatingStyle
         let shouldUsePressedShadow = isDisabled || isPressed
-
-        return HStack(spacing: tokens.interspace) {
-            if let image = state.image {
-                Image(uiImage: image)
-                    .resizable()
-                    .foregroundColor(Color(isDisabled ? tokens.disabledIconColor :
-                                            (isPressed ? tokens.highlightedIconColor : tokens.iconColor)))
-                    .frame(width: tokens.iconSize, height: tokens.iconSize, alignment: .center)
-                }
-
-            if let text = state.text {
-                Text(text)
-                    .fontWeight(.medium)
-                    .multilineTextAlignment(.center)
-                    .scalableFont(font: tokens.textFont,
-                                  shouldScale: !isFloatingStyle)
-                    .modifyIf(isFloatingStyle, { view in
-                        view.frame(minHeight: tokens.textMinimumHeight)
-                    })
-                }
+        let iconColor: UIColor
+        let titleColor: UIColor
+        let borderColor: UIColor
+        let backgroundColor: UIColor
+        if isDisabled {
+            iconColor = tokens.disabledIconColor
+            titleColor = tokens.disabledTitleColor
+            borderColor = tokens.disabledBorderColor
+            backgroundColor = tokens.disabledBackgroundColor
+        } else if isPressed {
+            iconColor = tokens.highlightedIconColor
+            titleColor = tokens.highlightedTitleColor
+            borderColor = tokens.highlightedBorderColor
+            backgroundColor = tokens.highlightedBackgroundColor
+        } else {
+            iconColor = tokens.iconColor
+            titleColor = tokens.titleColor
+            borderColor = tokens.borderColor
+            backgroundColor = tokens.backgroundColor
         }
-        .padding(tokens.padding)
-        .modifyIf(isFloatingStyle && !(state.text?.isEmpty ?? true), { view in
-            view.padding(.horizontal, tokens.textAdditionalHorizontalPadding )
-        })
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .foregroundColor(Color(isDisabled ? tokens.disabledTitleColor :
-                                (isPressed ? tokens.highlightedTitleColor : tokens.titleColor)))
-        .background((tokens.borderSize > 0) ?
-                        AnyView(RoundedRectangle(cornerRadius: tokens.borderRadius)
-                                    .strokeBorder(lineWidth: tokens.borderSize, antialiased: false)
-                                    .foregroundColor(Color(isDisabled ? tokens.disabledBorderColor :
-                                                            (isPressed ? tokens.highlightedBorderColor : tokens.borderColor)))
-                                    .contentShape(Rectangle()))
-                                    :
-                        AnyView(RoundedRectangle(cornerRadius: tokens.borderRadius)
-                                    .fill(Color(isDisabled ? tokens.disabledBackgroundColor :
-                                                    (isPressed ? tokens.highlightedBackgroundColor : tokens.backgroundColor)))))
-        .modifyIf(isFloatingStyle, { view in
-            view.clipShape(Capsule())
-                .shadow(color: shouldUsePressedShadow ? tokens.pressedShadow1Color : tokens.restShadow1Color,
-                        radius: shouldUsePressedShadow ? tokens.pressedShadow1Blur : tokens.restShadow1Blur,
-                        x: shouldUsePressedShadow ? tokens.pressedShadow1DepthX : tokens.restShadow1DepthX,
-                        y: shouldUsePressedShadow ? tokens.pressedShadow1DepthY : tokens.restShadow1DepthY)
-                .shadow(color: shouldUsePressedShadow ? tokens.pressedShadow2Color : tokens.restShadow2Color,
-                        radius: shouldUsePressedShadow ? tokens.pressedShadow2Blur : tokens.restShadow2Blur,
-                        x: shouldUsePressedShadow ? tokens.pressedShadow2DepthX : tokens.restShadow2DepthX,
-                        y: shouldUsePressedShadow ? tokens.pressedShadow2DepthY : tokens.restShadow2DepthY)
-        })
+
+        @ViewBuilder
+        var buttonContent: some View {
+            HStack(spacing: tokens.interspace) {
+                        if let image = state.image {
+                            Image(uiImage: image)
+                                .resizable()
+                                .foregroundColor(Color(iconColor))
+                                .frame(width: tokens.iconSize, height: tokens.iconSize, alignment: .center)
+                            }
+                        if let text = state.text {
+                            Text(text)
+                                .fontWeight(.medium)
+                                .multilineTextAlignment(.center)
+                                .scalableFont(font: tokens.textFont,
+                                              shouldScale: !isFloatingStyle)
+                                .modifyIf(isFloatingStyle, { view in
+                                    view.frame(minHeight: tokens.textMinimumHeight)
+                                })
+                            }
+            }
+            .padding(tokens.padding)
+            .modifyIf(isFloatingStyle && !(state.text?.isEmpty ?? true), { view in
+                view.padding(.horizontal, tokens.textAdditionalHorizontalPadding )
+            })
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .foregroundColor(Color(titleColor))
+        }
+
+        @ViewBuilder
+        var buttonBackground: some View {
+            if tokens.borderSize > 0 {
+                buttonContent.background(
+                    AnyView(RoundedRectangle(cornerRadius: tokens.borderRadius)
+                                .strokeBorder(lineWidth: tokens.borderSize, antialiased: false)
+                                .foregroundColor(Color(borderColor))
+                                .contentShape(Rectangle())))
+            } else {
+                buttonContent.background(
+                    AnyView(RoundedRectangle(cornerRadius: tokens.borderRadius)
+                                .fill(Color(backgroundColor))))
+            }
+        }
+
+        let shadow1Color: Color
+        let shadow1Blur: CGFloat
+        let shadow1DepthX: CGFloat
+        let shadow1DepthY: CGFloat
+        let shadow2Color: Color
+        let shadow2Blur: CGFloat
+        let shadow2DepthX: CGFloat
+        let shadow2DepthY: CGFloat
+        if shouldUsePressedShadow {
+            shadow1Color = tokens.pressedShadow1Color
+            shadow1Blur = tokens.pressedShadow1Blur
+            shadow1DepthX = tokens.pressedShadow1DepthX
+            shadow1DepthY = tokens.pressedShadow1DepthY
+            shadow2Color = tokens.pressedShadow2Color
+            shadow2Blur = tokens.pressedShadow2Blur
+            shadow2DepthX = tokens.pressedShadow2DepthX
+            shadow2DepthY = tokens.pressedShadow2DepthY
+        } else {
+            shadow1Color = tokens.restShadow1Color
+            shadow1Blur = tokens.restShadow1Blur
+            shadow1DepthX = tokens.restShadow1DepthX
+            shadow1DepthY = tokens.restShadow1DepthY
+            shadow2Color = tokens.restShadow2Color
+            shadow2Blur = tokens.restShadow2Blur
+            shadow2DepthX = tokens.restShadow2DepthX
+            shadow2DepthY = tokens.restShadow2DepthY
+        }
+
+        @ViewBuilder
+        var button: some View {
+            if isFloatingStyle {
+                buttonBackground.clipShape(Capsule())
+                    .shadow(color: shadow1Color,
+                           radius: shadow1Blur,
+                                x: shadow1DepthX,
+                                y: shadow1DepthY)
+                    .shadow(color: shadow2Color,
+                            radius: shadow2Blur,
+                                x: shadow2DepthX,
+                                y: shadow2DepthY)
+            } else {
+                buttonBackground
+            }
+        }
+
+        return button
+            .pointerInteraction(isEnabled)
     }
 }
 

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -221,7 +221,8 @@ struct FluentButtonBody: View {
         @ViewBuilder
         var button: some View {
             if isFloatingStyle {
-                buttonBackground.clipShape(Capsule())
+                buttonBackground
+                    .clipShape(Capsule())
                     .shadow(color: shadow1Color,
                            radius: shadow1Blur,
                                 x: shadow1DepthX,
@@ -230,8 +231,10 @@ struct FluentButtonBody: View {
                             radius: shadow2Blur,
                                 x: shadow2DepthX,
                                 y: shadow2DepthY)
+                    .contentShape(Capsule())
             } else {
                 buttonBackground
+                    .contentShape(RoundedRectangle(cornerRadius: tokens.borderRadius))
             }
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Added pointer support to the button when the button is enabled. After talking to design, we decided to go with the system hoverEffect rather than implementing a custom .onHover.

### Verification
Tested on simulator

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| ![PrimaryPointerSupport_Light](https://user-images.githubusercontent.com/67026548/135945840-fae04727-7a07-4f1e-9de9-40f2c0eceab4.gif) | ![PrimaryPointerSupport_Dark](https://user-images.githubusercontent.com/67026548/135945875-0f763051-c7e4-41e5-b5b5-7d6ba1086ef4.gif) |
| ![SecondaryPointerSupport_Light](https://user-images.githubusercontent.com/67026548/135945908-d93f4bcc-fde7-4974-aa37-433349765529.gif) | ![SecondaryPointerSupport_Dark](https://user-images.githubusercontent.com/67026548/135945893-76cc363d-4a48-461e-9b12-b89da90883e4.gif) |
| ![GhostPointerSupport_Light](https://user-images.githubusercontent.com/67026548/135945920-c540a0f8-1ad4-48b2-9fc0-f14bfaa0d764.gif) | ![GhostPointerSupport_Dark](https://user-images.githubusercontent.com/67026548/135945950-07051468-5a41-4624-9a3c-2ead6f691750.gif) |
| ![AccentFABPointerSupport_Light](https://user-images.githubusercontent.com/67026548/135945967-9b41ae11-8a9d-4221-bc0c-1fe4dc575ab1.gif) | ![AccentFABPointerSupport_Dark](https://user-images.githubusercontent.com/67026548/135945957-afcef62c-4cd5-4ee6-a3b1-2fb047143584.gif) |
| ![SubtleFABPointerSupport_Light](https://user-images.githubusercontent.com/67026548/135945979-0ace8723-a645-401b-9bde-6ac6cdb09743.gif) | ![SubtleFABPointerSupport_Dark](https://user-images.githubusercontent.com/67026548/135945987-15097f73-b01b-41fc-8a7e-bf536479679e.gif) |

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/737)