### PR TITLE
Make `TabBarItemView` inherit from UIControl.

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -5,10 +5,10 @@
 
 import UIKit
 
-class TabBarItemView: UIView {
+class TabBarItemView: UIControl {
     let item: TabBarItem
 
-    var isEnabled: Bool = true {
+    override var isEnabled: Bool {
         didSet {
             titleLabel.isEnabled = isEnabled
             imageView.tintAdjustmentMode = isEnabled ? .automatic : .dimmed
@@ -16,7 +16,7 @@ class TabBarItemView: UIView {
         }
     }
 
-    var isSelected: Bool = false {
+    override var isSelected: Bool {
         didSet {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

It seems that Full Keyboard Access behaves differently on iPhone and iPad when it comes to automatically recognizing custom views as being interactive controls, resulting in different tabbing behaviors. In particular, iPad would allow you to tab between all items in our custom tab bar view, while iPhone locked us only to those that were marked as `selected`.

In order to avoid this ambiguity, let's have `TabBarItemView` explicitly inherit from `UIControl`. Then everything works and everyone is happy!

As part of this change, I had to remove the default initializers for `isEnabled` and `isSelected`. However, this is no problem because we already mirrored UIControl's default values:

```Objective-C
//  From UIControl.h
@property(nonatomic,getter=isEnabled) BOOL enabled;       // default is YES. if NO, ignores touch events and subclasses may draw differently
@property(nonatomic,getter=isSelected) BOOL selected;     // default is NO may be used by some subclasses or by application
```

### Verification

- Confirmed correct keyboard tabbing and arrowing behavior on both iPhone and iPad
- Ensured that VoiceOver reads the same with and without my change, with all permutations of switches in the `TabBarViewDemoController`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/738)