### PR TITLE
Chery-pick: Make `TabBarItemView` inherit from UIControl. (#738)

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -5,10 +5,10 @@
 
 import UIKit
 
-class TabBarItemView: UIView {
+class TabBarItemView: UIControl {
     let item: TabBarItem
 
-    var isEnabled: Bool = true {
+    override var isEnabled: Bool {
         didSet {
             titleLabel.isEnabled = isEnabled
             imageView.tintAdjustmentMode = isEnabled ? .automatic : .dimmed
@@ -16,7 +16,7 @@ class TabBarItemView: UIView {
         }
     }
 
-    var isSelected: Bool = false {
+    override var isSelected: Bool {
         didSet {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking TabBarItemView keyboard accessibility fix (4bc55cb) to main_0.2.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
