### PR TITLE
Update small button's border radius

### DIFF
--- a/ios/FluentUI/Vnext/Button/MSFButtonTokens.generated.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButtonTokens.generated.swift
@@ -285,7 +285,7 @@ extension FluentUIStyle {
 
             // MARK: - small
             open var small: CGFloat {
-                return mainProxy().Border.radius.medium
+                return mainProxy().Border.radius.large
             }
         }
 

--- a/tools/sgen/input/FluentUIStyle.yml
+++ b/tools/sgen/input/FluentUIStyle.yml
@@ -239,7 +239,7 @@ MSFAvatarGroupStackTokens extends MSFAvatarGroupTokens:
 AP_MSFButtonTokens:
   backgroundColor: [ rest: NamedColor(clear), hover: NamedColor(clear), pressed: NamedColor(clear), selected: NamedColor(clear), disabled: NamedColor(clear) ]
   borderColor: [ rest: $Colors.Background.brandRest, hover: $Colors.Background.brandHover, pressed: $Colors.Background.brandPressed, selected: $Colors.Background.brandSelected, disabled: $Colors.Background.brandDisabled ]
-  borderRadius: [ small: $Border.radius.medium, medium: $Border.radius.large, large: $Border.radius.xLarge ]
+  borderRadius: [ small: $Border.radius.large, medium: $Border.radius.large, large: $Border.radius.xLarge ]
   borderSize: [ small: $Border.size.none, medium: $Border.size.none, large: $Border.size.none ]
   iconColor: [ rest: $Colors.Foreground.brandRest, hover: $Colors.Foreground.brandHover, pressed: $Colors.Foreground.brandPressed, selected: $Colors.Foreground.brandSelected, disabled: $Colors.Foreground.brandDisabled ]
   iconSize: [ small: $Icon.size.xSmall, medium: $Icon.size.small, large: $Icon.size.small ]

--- a/tools/sgen/output/MSFButtonTokens.generated.swift
+++ b/tools/sgen/output/MSFButtonTokens.generated.swift
@@ -285,7 +285,7 @@ extension FluentUIStyle {
 
 			// MARK: - small 
 			open var small: CGFloat {
-				return mainProxy().Border.radius.medium
+				return mainProxy().Border.radius.large
 			}
 		}
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Updated the small button size to use the correct corner radius. Sounds like the design was updated a month or two ago, but we never updated the implementation.

### Verification

Tested in the simulator test app

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SmallButtonMediumRadius](https://user-images.githubusercontent.com/67026548/136454681-32038f3b-c5f3-4673-a202-c73479fb39de.png) | ![SmallButtonLargeRadius](https://user-images.githubusercontent.com/67026548/136454721-7a4fe6a7-b737-4dfd-bbee-1aa9293bb273.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/744)