### PR TITLE
IndeterminateProgressBar: Fixing SwiftUI animation issue on iOS 15.

### DIFF
--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -97,9 +97,6 @@ public struct IndeterminateProgressBar: View {
                     .onAppear {
                         startAnimation()
                     }
-                    .onDisappear {
-                        stopAnimation()
-                    }
             })
             .modifyIf(!state.isAnimating) { view in
                 view
@@ -116,6 +113,8 @@ public struct IndeterminateProgressBar: View {
     }
 
     private func startAnimation() {
+        stopAnimation()
+
         withAnimation(Animation.linear(duration: Constants.animationDuration)
                                 .repeatForever(autoreverses: false)) {
             startPoint = Constants.finalStartPoint


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

On previous versions of iOS (13 and 14) we used the .onDisappear modifier (event) to stop the animation and clear the current animation in the main transaction of SwiftUI.

On iOS 15 the timing of the onAppear vs. onDisappear events don't necessarily sync and the main transaction might accumulate more than one animation which generates a faster, flickering effect on the animation (videos below).

The fix is to stop the animation any time a new animation is going to be started on the main transaction to ensure that only one animation is running at a time.

### Verification

1. Ran the tests on the videos below in all iOS 13, 14 and 15 versions.
2. Ensured that all operations (start/stop) keeping the bar visible or not work properly.

Before (issue on iOS 15):

https://user-images.githubusercontent.com/68076145/136826140-6cc846be-747a-4e15-98c0-41b4bb4f602c.mov


After (fixed):

https://user-images.githubusercontent.com/68076145/136826189-f540fbf9-ff22-4b22-87c3-8e7ca24e5d66.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/749)