### PR TITLE
[CCB vNext] Updating theming call

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -48,7 +48,7 @@ open class CommandBar: UIView, FluentUIWindowProvider {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        commandBarTokens.didChangeAppearanceProxy()
+        commandBarTokens.updateForCurrentTheme()
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Addressing [this comment](https://github.com/microsoft/fluentui-apple/pull/705#discussion_r718097588) to updating the theming call in CCB vNext

### Verification

pod lib lint + theming check:

https://user-images.githubusercontent.com/22566866/136869071-5138afe2-f579-4700-9357-0c0e81e8c200.mov



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/751)