### PR TITLE
Updating all SwiftUI controls to use FluentUIHostingController in their UIKit wrapper.

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -42,11 +42,12 @@ import SwiftUI
 
         avatarGroup = AvatarGroup(style: style,
                                   size: size)
-        hostingController = UIHostingController(rootView: AnyView(avatarGroup
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { avatarGroupView in
-                                                                        avatarGroupView.customTheme(theme!)
-                                                                    })))
+        hostingController = FluentUIHostingController(rootView: AnyView(avatarGroup
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { avatarGroupView in
+                                                                                avatarGroupView.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
         view.backgroundColor = UIColor.clear
     }
 
@@ -54,7 +55,7 @@ import SwiftUI
         return self.view.window
     }
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
 
     private var avatarGroup: AvatarGroup!
 }

--- a/ios/FluentUI/Card Nudge/MSFCardNudge.swift
+++ b/ios/FluentUI/Card Nudge/MSFCardNudge.swift
@@ -24,12 +24,13 @@ import UIKit
                       theme: FluentUIStyle? = nil) {
         super.init()
 
-        self.cardNudge = CardNudge(style: style, title: title)
-        self.hostingController = UIHostingController(rootView: AnyView(cardNudge
-                                                                        .windowProvider(self)
-                                                                        .modifyIf(theme != nil, { cardNudge in
-                                                                            cardNudge.customTheme(theme!)
-                                                                        })))
+        cardNudge = CardNudge(style: style, title: title)
+        hostingController = FluentUIHostingController(rootView: AnyView(cardNudge
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { cardNudge in
+                                                                                cardNudge.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
     }
 
     @objc public var state: MSFCardNudgeState {
@@ -44,6 +45,6 @@ import UIKit
 
     // MARK: - Private helpers
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
     private var cardNudge: CardNudge!
 }

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -86,11 +86,12 @@ import UIKit
             strongSelf.action?(strongSelf)
         }
 
-        hostingController = UIHostingController(rootView: AnyView(buttonView
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { buttonView in
-                                                                        buttonView.customTheme(theme!)
-                                                                    })))
+        hostingController = FluentUIHostingController(rootView: AnyView(buttonView
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { buttonView in
+                                                                                buttonView.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
         view.backgroundColor = UIColor.clear
         setupLargeContentViewer()
     }
@@ -115,7 +116,7 @@ import UIKit
 
     private var imagePropertySubscriber: AnyCancellable?
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
 
     private var buttonView: FluentButton!
 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -106,11 +106,12 @@ public struct MSFListView: View {
         super.init()
 
         listView = MSFListView(sections: sections)
-        hostingController = UIHostingController(rootView: AnyView(listView
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { listView in
-                                                                        listView.customTheme(theme!)
-                                                                    })))
+        hostingController = FluentUIHostingController(rootView: AnyView(listView
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { listView in
+                                                                                listView.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
         view.backgroundColor = UIColor.clear
     }
 
@@ -131,7 +132,7 @@ public struct MSFListView: View {
         return self.view.window
     }
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
 
     private var listView: MSFListView!
 }

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -219,11 +219,12 @@ public struct PersonaView: View {
         super.init()
 
         personaView = PersonaView()
-        hostingController = UIHostingController(rootView: AnyView(personaView
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { personaView in
-                                                                        personaView.customTheme(theme!)
-                                                                    })))
+        hostingController = FluentUIHostingController(rootView: AnyView(personaView
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { personaView in
+                                                                                personaView.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
         view.backgroundColor = UIColor.clear
     }
 
@@ -243,7 +244,7 @@ public struct PersonaView: View {
         return self.view.window
     }
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
 
     private var personaView: PersonaView!
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Following up on the fix added by ee02dfa24483e3f506aa91b0cc9062673018b4d7 (#745) and applying the use of the FluentUIHostingController to all Vnext controls (including the ones that are not yet integrated into main.

This change will be cherry picked to main once it's merged (for the CardNudge and AvatarGroup that missed the update).

### Verification

Sanity test on all controls changed.
Verified that no regression was caused while running their demo apps on an iPhone with the notch.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/755)