### PR TITLE
Cherry picking applicable changes from #755 (FluentUIHostingView changes).

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -42,11 +42,12 @@ import SwiftUI
 
         avatarGroup = AvatarGroup(style: style,
                                   size: size)
-        hostingController = UIHostingController(rootView: AnyView(avatarGroup
-                                                                    .windowProvider(self)
-                                                                    .modifyIf(theme != nil, { avatarGroupView in
-                                                                        avatarGroupView.customTheme(theme!)
-                                                                    })))
+        hostingController = FluentUIHostingController(rootView: AnyView(avatarGroup
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { avatarGroupView in
+                                                                                avatarGroupView.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
         view.backgroundColor = UIColor.clear
     }
 
@@ -54,7 +55,7 @@ import SwiftUI
         return self.view.window
     }
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
 
     private var avatarGroup: AvatarGroup!
 }

--- a/ios/FluentUI/Card Nudge/MSFCardNudge.swift
+++ b/ios/FluentUI/Card Nudge/MSFCardNudge.swift
@@ -24,12 +24,13 @@ import UIKit
                       theme: FluentUIStyle? = nil) {
         super.init()
 
-        self.cardNudge = CardNudge(style: style, title: title)
-        self.hostingController = UIHostingController(rootView: AnyView(cardNudge
-                                                                        .windowProvider(self)
-                                                                        .modifyIf(theme != nil, { cardNudge in
-                                                                            cardNudge.customTheme(theme!)
-                                                                        })))
+        cardNudge = CardNudge(style: style, title: title)
+        hostingController = FluentUIHostingController(rootView: AnyView(cardNudge
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { cardNudge in
+                                                                                cardNudge.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
     }
 
     @objc public var state: MSFCardNudgeState {
@@ -44,6 +45,6 @@ import UIKit
 
     // MARK: - Private helpers
 
-    private var hostingController: UIHostingController<AnyView>!
+    private var hostingController: FluentUIHostingController!
     private var cardNudge: CardNudge!
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change brings the applicable file updates related to 0a4828a944c0e2fc2f270137de33ccff008928ec that was recently merged into the vnext-prototype branch as part of #755.

### Verification

Sanity test on all controls changed.
Verified that no regression was caused while running their demo apps on an iPhone with the notch.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/756)