### PR TITLE
Fix titleTextAttributes by moving to appearance objects

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -510,15 +510,13 @@ open class NavigationBar: UINavigationBar {
             }
 
             standardAppearance.backgroundColor = color
-            scrollEdgeAppearance = standardAppearance
             backgroundView.backgroundColor = color
             tintColor = style.tintColor
-            if var titleTextAttributes = titleTextAttributes {
-                titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor
-                self.titleTextAttributes = titleTextAttributes
-            } else {
-                titleTextAttributes = [NSAttributedString.Key.foregroundColor: style.titleColor]
-            }
+            standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor
+            standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor
+
+            // Update the scroll edge appearance to match the new standard appearance
+            scrollEdgeAppearance = standardAppearance
 
             navigationBarColorObserver = navigationItem?.observe(\.customNavigationBarColor) { [unowned self] navigationItem, _ in
                 // Unlike title or barButtonItems that depends on the topItem, navigation bar color can be set from the parentViewController's navigationItem


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Change 99d8763aff4bee2060b376b991d87f2347c57c97 updated how we set the background color of `MSFNavigationBar` to match new iOS 15 expectations, but did not update text color. This moves the setting of a style's text color to the standard (and subsequently scrollEdge) appearance object.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/137438872-824993b5-f301-48c5-9b4a-9e513c4150ba.png) | ![after](https://user-images.githubusercontent.com/4934719/137438891-efafe394-67b7-442c-8ac1-7f388553a4ed.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/758)