### PR TITLE
Fixing: UIHostingController does not automatically resize to hug subviews in iOS 15.0

### DIFF
--- a/ios/FluentUI/Core/FluentUIHostingController.swift
+++ b/ios/FluentUI/Core/FluentUIHostingController.swift
@@ -42,6 +42,13 @@ extension UIView {
 /// FluentUI specific implementation of the UIHostingController which adds a workaround for disabling safeAreaInsets for its view.
 class FluentUIHostingController: UIHostingController<AnyView> {
 
+    /// iOS 15.0 fix for UIHostingController that does not automatically resize to hug subviews
+    override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+
+            view.setNeedsUpdateConstraints()
+    }
+
     /// Static constant that will be guaranteed to have its initialization executed only once during the lifetime of the application.
     private static let swizzleSafeAreaInsetsOnce: Void = {
         // A FluentUIHostingController instance needs to be created so that the class type for the private UIHostingViewwe can be retrived.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Addressing a bug discovered here: https://github.com/microsoft/fluentui-apple/pull/648#discussion_r729944484
UIHostingController in iOS 15 does not automatically resize to hug subviews if they are dynamically changing.
Note: The small avatar animation jumps + holes in cutout is a bug separate from this PR and is currently being fixed in #648

### Verification
Below are recordings tested in iOS 15, but manual tests in iOS 13 + 14 were performed as well.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/22566866/137551421-f528fc38-df49-47e9-af57-beb9bf7e9852.gif) | ![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/22566866/137552003-69f57569-97d5-42f9-a6bc-9e7052889d0a.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/759)