### PR TITLE
Cherry-picking changes for UIHostingController bug in iOS 15

### DIFF
--- a/ios/FluentUI/Core/FluentUIHostingController.swift
+++ b/ios/FluentUI/Core/FluentUIHostingController.swift
@@ -42,6 +42,13 @@ extension UIView {
 /// FluentUI specific implementation of the UIHostingController which adds a workaround for disabling safeAreaInsets for its view.
 class FluentUIHostingController: UIHostingController<AnyView> {
 
+    /// iOS 15.0 fix for UIHostingController that does not automatically resize to hug subviews
+    override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+
+            view.setNeedsUpdateConstraints()
+    }
+
     /// Static constant that will be guaranteed to have its initialization executed only once during the lifetime of the application.
     private static let swizzleSafeAreaInsetsOnce: Void = {
         // A FluentUIHostingController instance needs to be created so that the class type for the private UIHostingViewwe can be retrived.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

(cherry picked from commit 8192db4df3698a534523f1c83a213f22c6024607)
Bringing in changes that allows UIHostingController to automatically resize for iOS 15.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/760)