### PR TITLE
[Cherry-pick] Update comm blue dark tint colors

### DIFF
--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint10.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint10.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x2B",
           "alpha" : "1.000",
           "blue" : "0xD8",
-          "green" : "0x88"
+          "green" : "0x88",
+          "red" : "0x2B"
         }
-      }
+      },
+      "idiom" : "universal"
     },
     {
-      "idiom" : "universal",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,12 +22,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x00",
           "alpha" : "1.000",
-          "blue" : "0xD4",
-          "green" : "0x78"
+          "blue" : "0xD3",
+          "green" : "0x74",
+          "red" : "0x00"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint20.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint20.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xC7",
           "alpha" : "1.000",
           "blue" : "0xF4",
-          "green" : "0xE0"
+          "green" : "0xE0",
+          "red" : "0xC7"
         }
-      }
+      },
+      "idiom" : "universal"
     },
     {
-      "idiom" : "universal",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,12 +22,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x00",
           "alpha" : "1.000",
-          "blue" : "0x87",
-          "green" : "0x4C"
+          "blue" : "0x90",
+          "green" : "0x4F",
+          "red" : "0x00"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint30.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint30.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xDE",
           "alpha" : "1.000",
           "blue" : "0xF9",
-          "green" : "0xEC"
+          "green" : "0xEC",
+          "red" : "0xDE"
         }
-      }
+      },
+      "idiom" : "universal"
     },
     {
-      "idiom" : "universal",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,12 +22,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x04",
           "alpha" : "1.000",
-          "blue" : "0x62",
-          "green" : "0x38"
+          "blue" : "0x48",
+          "green" : "0x28",
+          "red" : "0x00"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint40.colorset/Contents.json
+++ b/apple/Resources/FluentUI-apple.xcassets/FluentColors/communicationBlueTint40.colorset/Contents.json
@@ -1,23 +1,18 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0xEF",
           "alpha" : "1.000",
           "blue" : "0xFC",
-          "green" : "0xF6"
+          "green" : "0xF6",
+          "red" : "0xEF"
         }
-      }
+      },
+      "idiom" : "universal"
     },
     {
-      "idiom" : "universal",
       "appearances" : [
         {
           "appearance" : "luminosity",
@@ -27,12 +22,17 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "0x09",
           "alpha" : "1.000",
-          "blue" : "0x47",
-          "green" : "0x2C"
+          "blue" : "0x26",
+          "green" : "0x15",
+          "red" : "0x00"
         }
-      }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/ios/FluentUI/Core/FluentUIStyle.generated.swift
+++ b/ios/FluentUI/Core/FluentUIStyle.generated.swift
@@ -519,22 +519,22 @@ open class FluentUIStyle: NSObject {
 
 			// MARK: - tint10 
 			open var tint10: UIColor {
-				return UIColor(light: UIColor(red: 0.16862746, green: 0.53333336, blue: 0.84705883, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.47058824, blue: 0.83137256, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				return UIColor(light: UIColor(red: 0.16862746, green: 0.53333336, blue: 0.84705883, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.45490196, blue: 0.827451, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 
 			// MARK: - tint20 
 			open var tint20: UIColor {
-				return UIColor(light: UIColor(red: 0.78039217, green: 0.8784314, blue: 0.95686275, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.29803923, blue: 0.5294118, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				return UIColor(light: UIColor(red: 0.78039217, green: 0.8784314, blue: 0.95686275, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.30980393, blue: 0.5647059, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 
 			// MARK: - tint30 
 			open var tint30: UIColor {
-				return UIColor(light: UIColor(red: 0.87058824, green: 0.9254902, blue: 0.9764706, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.015686275, green: 0.21960784, blue: 0.38431373, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				return UIColor(light: UIColor(red: 0.87058824, green: 0.9254902, blue: 0.9764706, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.15686275, blue: 0.28235295, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 
 			// MARK: - tint40 
 			open var tint40: UIColor {
-				return UIColor(light: UIColor(red: 0.9372549, green: 0.9647059, blue: 0.9882353, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.03529412, green: 0.17254902, blue: 0.2784314, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
+				return UIColor(light: UIColor(red: 0.9372549, green: 0.9647059, blue: 0.9882353, alpha: 1.0), lightHighContrast: nil, lightElevated: nil, lightElevatedHighContrast: nil, dark: UIColor(red: 0.0, green: 0.08235294, blue: 0.14901961, alpha: 1.0), darkHighContrast: nil, darkElevated: nil, darkElevatedHighContrast: nil)
 			}
 		}
 


### PR DESCRIPTION
Cherry pick from `vnext-prototype`:
- #736 

Original PR notes:

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Design has provided us with new values for four out of our sixteen "communication blue" colors. Specifically, here's what changed:

|               | Light     | Dark    |
|---------|--------|--------|
| **Shade** *(foregrounds)*  | Unchanged    | Unchanged   |
| **Tint** *(backgrounds)*     | Unchanged    | **Updated** 🥳 |

Here's the mapping from old to new:

| Name | Old | New |
|-----|-----|-----|
| `tint10` | `#0078D4` | `#0074D3` |
| `tint20` | `#004C87` | `#004F90` |
| `tint30` | `#043862` | `#002848` |
| `tint40` | `#092C47` | `#001526` |

Subtle changes, but this will darken the backgrounds of some of our elements in Dark mode, increasing contrast and legibility.

### Verification

- Lots of screenshots and time in Pixelmator to verify color values. See some of the clearest examples below.
- Scrubbed the codebase to ensure that only backgrounds were affected.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![note-before](https://user-images.githubusercontent.com/4934719/135940696-ccf921c5-b13e-4e55-b4ae-4eb4d44aeee0.png) | ![note-after](https://user-images.githubusercontent.com/4934719/135940713-1305afdf-c797-4210-bb3c-765ead6baa15.png) |
| ![card-before](https://user-images.githubusercontent.com/4934719/135940739-adc86500-9f6f-4555-9dd2-dd71b4993d59.png) | ![card-after](https://user-images.githubusercontent.com/4934719/135940750-888580ee-b6bc-4b04-ba04-a74dcc24d1a8.png) |


### Pull request checklist

This PR has considered:

- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/736)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/762)