### PR TITLE
Removing forced unwrapping calls from DrawerTransitionAnimator.

### DIFF
--- a/ios/FluentUI/Drawer/DrawerTransitionAnimator.swift
+++ b/ios/FluentUI/Drawer/DrawerTransitionAnimator.swift
@@ -76,7 +76,7 @@ class DrawerTransitionAnimator: NSObject {
         let animationDuration = DrawerTransitionAnimator.animationDuration(forSizeChange: sizeChange)
 
         UIView.animate(withDuration: animationDuration,
-                       delay: 0.0,
+                       delay: 0,
                        options: [.beginFromCurrentState, Constants.animationCurve],
                        animations: {
             presentedView.frame = self.presentedViewRectDismissed(forContentSize: contentView.frame.size)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Client apps reported crashes in the force unwrapping calls in the DrawerTransitionAnimator while running on iOS15.
Let's remove those as the recommended pattern is using if/guard let.

### Verification

Smoke test on drawer presentation/dismissal from the demo app running on various iOS versions (13, 14 and 15).

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/764)