### PR TITLE
Fixing public API break in the PillButtonBarItem class.

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -20,18 +20,25 @@ public protocol PillButtonBarDelegate {
 open class PillButtonBarItem: NSObject {
     @objc public let title: String
 
-    @objc public init(title: String, isUnread: Bool = false) {
+    /// Creates a new instance of the PillButtonBarItem that holds data used to create a pill button in a PillButtonBar.
+    /// - Parameter title: Title that will be displayed by a pill button in the PillButtonBar.
+    @objc public init(title: String) {
         self.title = title
-        self.isUnread = isUnread
         super.init()
     }
 
-    @objc public convenience init(title: String) {
-        self.init(title: title, isUnread: false)
+    /// Creates a new instance of the PillButtonBarItem that holds data used to create a pill button in a PillButtonBar.
+    /// - Parameters:
+    ///   - title: Title that will be displayed by a pill button in the PillButtonBar.
+    ///   - isUnread: Whether the pill button shows the mark that represents the "unread" state.
+    @objc public convenience init(title: String, isUnread: Bool = false) {
+        self.init(title: title)
+        self.isUnread = isUnread
     }
 
-    /// This value will determine whether or not to show dot next to the pill button label
-    public var isUnread: Bool {
+    /// This value will determine whether or not to show the mark that represents the "unread" state (dot next to the pill button label).
+    /// The default value of this property is false.
+    public var isUnread: Bool = false {
        didSet {
            if oldValue != isUnread {
                NotificationCenter.default.post(name: PillButtonBarItem.isUnreadValueDidChangeNotification, object: self)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The change e5b0952e19ff0343edb3240760ab798851fe050e (#743) introduced a public API break in the inheritance scenario.

Subclasses of PillButtonBarItem can't call into convenience initializers, so this change reverts the signature of the designated initializers and adds the parameter to the convenience initializer introduced in the aforementioned change.

### Verification

- Sanity/smoke tests on the demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/776)