### PR TITLE
[vNext Tokens] Enable token swapping for new token system

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
@@ -105,19 +105,28 @@ class DemoColorGreenTheme: NSObject, ColorProviding {
 // TODO: this will be replaced with our branding color system once it exists,
 // but in the meantime it's a good demo of swapping out tokens.
 class DemoCardNudgeTokens: CardNudgeTokens {
-    let greenPrimary: ColorSet = ColorSet(light: 0x107C41, dark: 0x10893C)
+    let greenPrimary: ColorSet = ColorSet(light: Constants.greenLight,
+                                          dark: Constants.greenDark)
+
     override var accentColor: ColorSet {
         return greenPrimary
     }
+
     override var subtitleTextColor: ColorSet {
         return greenPrimary
     }
+
     override var textColor: ColorSet {
         return greenPrimary
     }
+
+    private struct Constants {
+        static let greenLight: ColorValue = 0x107C41
+        static let greenDark: ColorValue = 0x10893C
+    }
 }
 
-class DemoTokenFactory: ControlTokenFactory {
+class DemoTokenFactory: TokenFactory {
     override var cardNudgeTokens: CardNudgeTokens {
         return DemoCardNudgeTokens()
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
@@ -101,3 +101,24 @@ class DemoColorGreenTheme: NSObject, ColorProviding {
         return UIColor(named: "Colors/DemoPrimaryShade30Color")
     }
 }
+
+// TODO: this will be replaced with our branding color system once it exists,
+// but in the meantime it's a good demo of swapping out tokens.
+class DemoCardNudgeTokens: CardNudgeTokens {
+    let greenPrimary: ColorSet = ColorSet(light: 0x107C41, dark: 0x10893C)
+    override var accentColor: ColorSet {
+        return greenPrimary
+    }
+    override var subtitleTextColor: ColorSet {
+        return greenPrimary
+    }
+    override var textColor: ColorSet {
+        return greenPrimary
+    }
+}
+
+class DemoTokenFactory: ControlTokenFactory {
+    override var cardNudgeTokens: CardNudgeTokens {
+        return DemoCardNudgeTokens()
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -236,7 +236,7 @@ class CustomCardNudgeTokens: CardNudgeTokens {
     }
 }
 
-class CustomTokenFactory: ControlTokenFactory {
+class CustomTokenFactory: TokenFactory {
     override var cardNudgeTokens: CardNudgeTokens {
         return CustomCardNudgeTokens()
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -8,6 +8,9 @@ import UIKit
 
 class ThemingDemoController: DemoController {
 
+    let cardNudge = MSFCardNudge(style: .outline, title: "Hello!")
+    let customCardNudge = MSFCardNudge(style: .outline, title: "Hello!")
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -49,6 +52,12 @@ class ThemingDemoController: DemoController {
         avatarOutlinedPrimary.state.presence = .away
 
         addRow(items: [avatarAccent.view, avatarDefault.view, avatarOutlinedPrimary.view], itemSpacing: 20)
+
+        cardNudge.state.accentText = "I'm using the token pipeline!"
+        cardNudge.state.dismissButtonAction = { _ in
+        }
+
+        addRow(items: [cardNudge.view])
 
         container.addArrangedSubview(UIView())
 
@@ -98,21 +107,38 @@ class ThemingDemoController: DemoController {
 
         addRow(items: [customThemeAvatarAccent.view, customThemeAvatarDefault.view, customThemeAvatarOutlinedPrimary.view], itemSpacing: 20)
 
+        let customTokenFactory = CustomTokenFactory()
+
+        customCardNudge.tokenFactory = customTokenFactory
+        customCardNudge.state.accentText = "I'm using the token pipeline!"
+        customCardNudge.state.dismissButtonAction = { _ in
+        }
+
+        addRow(items: [customCardNudge.view])
+
         container.addArrangedSubview(UIView())
     }
 
     func didPressOverrideThemeButton() {
         if let window = self.view.window {
+            // Update both the SGen-backed theme...
             let greenThemeColorProviding = DemoColorGreenTheme()
             let stylesheet = ColorProvidingStyle(colorProviding: greenThemeColorProviding,
                                                  window: window)
             FluentUIThemeManager.setStylesheet(stylesheet: stylesheet, for: window)
+
+            // ... and the pipeline-backed theme
+            window.tokenFactory = DemoTokenFactory()
         }
     }
 
     func didPressResetThemeButton() {
         if let window = self.view.window {
+            // Update both the SGen-backed theme...
             FluentUIThemeManager.removeStylesheet(for: window)
+
+            // ... and the pipeline-backed theme
+            window.tokenFactory = nil
         }
     }
 }
@@ -188,5 +214,30 @@ open class CustomStyle: FluentUIStyle {
         open override var xLarge: CGFloat {
             return 0.0
         }
+    }
+}
+
+class CustomCardNudgeTokens: CardNudgeTokens {
+    let purplePrimary: ColorSet = ColorSet(light: 0x6227A7)
+    override var accentColor: ColorSet {
+        return purplePrimary
+    }
+    override var outlineColor: ColorSet {
+        return purplePrimary
+    }
+    override var subtitleTextColor: ColorSet {
+        return purplePrimary
+    }
+    override var textColor: ColorSet {
+        return purplePrimary
+    }
+    override var cornerRadius: CGFloat {
+        return 0.0
+    }
+}
+
+class CustomTokenFactory: ControlTokenFactory {
+    override var cardNudgeTokens: CardNudgeTokens {
+        return CustomCardNudgeTokens()
     }
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -181,8 +181,8 @@
 		923DF2E82712B6C400637646 /* FluentUIResources-ios.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A5DA88FC226FAA01000A8EA8 /* FluentUIResources-ios.bundle */; };
 		925D461D26FD133600179583 /* GlobalTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D461B26FD133600179583 /* GlobalTokens.swift */; };
 		925D462026FD18B200179583 /* AliasTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D461E26FD18B200179583 /* AliasTokens.swift */; };
-		9275105526815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */; };
 		9275105626815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */; };
+		928034A8272A657F00895D04 /* ControlHostingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928034A6272A657F00895D04 /* ControlHostingContainer.swift */; };
 		9298798B2669A875002B1EB4 /* PersonaButtonTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927E34C62668350800998031 /* PersonaButtonTokens.swift */; };
 		92987990266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9298798D266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift */; };
 		92987992266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9298798E266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift */; };
@@ -191,6 +191,8 @@
 		92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A1E4F326A791590007ED60 /* MSFCardNudge.swift */; };
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598026A0FD2800328FD3 /* CardNudge.swift */; };
+		92DEE21C272338F400E31ED0 /* ControlTokenFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE21A272338F400E31ED0 /* ControlTokenFactory.swift */; };
+		92DEE21F2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE21D2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift */; };
 		92DEE2252723D34400E31ED0 /* ControlTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE2232723D34400E31ED0 /* ControlTokens.swift */; };
 		92E7AD5026FE51FF00AE7FF8 /* ColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */; };
 		92E7AD5326FE904D00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD5126FE904D00AE7FF8 /* DynamicColor.swift */; };
@@ -299,6 +301,7 @@
 		925D461E26FD18B200179583 /* AliasTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasTokens.swift; sourceTree = "<group>"; };
 		9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarousel.swift; sourceTree = "<group>"; };
 		927E34C62668350800998031 /* PersonaButtonTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonTokens.swift; sourceTree = "<group>"; };
+		928034A6272A657F00895D04 /* ControlHostingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlHostingContainer.swift; sourceTree = "<group>"; };
 		9298798D266A8E1C002B1EB4 /* MSFPersonaButtonTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonTokens.generated.swift; sourceTree = "<group>"; };
 		9298798E266A8E1C002B1EB4 /* MSFPersonaButtonCarouselTokens.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarouselTokens.generated.swift; sourceTree = "<group>"; };
 		929DD255266ED3AC00E8175E /* PersonaButtonCarouselTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselTokens.swift; sourceTree = "<group>"; };
@@ -306,6 +309,8 @@
 		92A1E4F326A791590007ED60 /* MSFCardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFCardNudge.swift; sourceTree = "<group>"; };
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D5598026A0FD2800328FD3 /* CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudge.swift; sourceTree = "<group>"; };
+		92DEE21A272338F400E31ED0 /* ControlTokenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokenFactory.swift; sourceTree = "<group>"; };
+		92DEE21D2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ControlTokenFactory+CardNudge.swift"; sourceTree = "<group>"; };
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSet.swift; sourceTree = "<group>"; };
 		92E7AD5126FE904D00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
@@ -763,6 +768,7 @@
 			isa = PBXGroup;
 			children = (
 				925D461A26FD126800179583 /* Tokens */,
+				92DEE21A272338F400E31ED0 /* ControlTokenFactory.swift */,
 				92E7AD5126FE904D00AE7FF8 /* DynamicColor.swift */,
 			);
 			path = Theme;
@@ -786,6 +792,7 @@
 				92D5598026A0FD2800328FD3 /* CardNudge.swift */,
 				92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */,
 				920945472703DDA000B38E1A /* CardNudgeTokens.swift */,
+				92DEE21D2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift */,
 				92A1E4F326A791590007ED60 /* MSFCardNudge.swift */,
 			);
 			path = "Card Nudge";
@@ -948,6 +955,7 @@
 			children = (
 				925D461926FD124B00179583 /* Theme */,
 				A5CEC16C20D98EE70016922A /* Colors.swift */,
+				928034A6272A657F00895D04 /* ControlHostingContainer.swift */,
 				A559BB82212B7D870055E107 /* FluentUIFramework.swift */,
 				535559E22711411E0094A871 /* FluentUIHostingController.swift */,
 				5373D56E2694D66F0032A3B4 /* FluentUIStyle.generated.swift */,
@@ -1455,6 +1463,7 @@
 				5314E2BB25F024C60099271A /* CALayer+Extensions.swift in Sources */,
 				5314E12B25F016230099271A /* PillButtonBar.swift in Sources */,
 				53097D09270288FB00A6E4DC /* Button.swift in Sources */,
+				928034A8272A657F00895D04 /* ControlHostingContainer.swift in Sources */,
 				53097D1F2702890900A6E4DC /* MSFHeaderFooterTokens.generated.swift in Sources */,
 				5314E07E25F00F1A0099271A /* DateTimePickerView.swift in Sources */,
 				5328D97726FBA3D700F3723B /* IndeterminateProgressBar.swift in Sources */,
@@ -1469,6 +1478,7 @@
 				92E7AD5326FE904D00AE7FF8 /* DynamicColor.swift in Sources */,
 				5314E08025F00F1A0099271A /* DateTimePickerViewComponent.swift in Sources */,
 				532FE3D226EA6D74007539C0 /* MSFActivityIndicatorTokens.generated.swift in Sources */,
+				92DEE21C272338F400E31ED0 /* ControlTokenFactory.swift in Sources */,
 				5314E06325F00EFD0099271A /* CalendarViewDayMonthYearCell.swift in Sources */,
 				5314E1A225F01A7C0099271A /* ActivityIndicatorCell.swift in Sources */,
 				5373D5652694D65C0032A3B4 /* AvatarTokens.swift in Sources */,
@@ -1511,6 +1521,7 @@
 				92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */,
 				53097D0B270288FB00A6E4DC /* ButtonModifiers.swift in Sources */,
 				5314E28125F0240D0099271A /* DateComponents+Extensions.swift in Sources */,
+				92DEE2252723D34400E31ED0 /* ControlTokens.swift in Sources */,
 				5314E07025F00F140099271A /* DatePickerController.swift in Sources */,
 				436F6B3F26F4924200D18073 /* MSFNotificationTokens.generated.swift in Sources */,
 				5373D5692694D65C0032A3B4 /* MSFAvatarTokens.generated.swift in Sources */,
@@ -1603,6 +1614,7 @@
 				0ACD82192620453B0035CD9F /* PersonaViewTokens.swift in Sources */,
 				5314E2DA25F025370099271A /* Fonts.swift in Sources */,
 				5373D5772694D66F0032A3B4 /* SwiftUI+ViewModifiers.swift in Sources */,
+				92DEE21F2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift in Sources */,
 				5314E07F25F00F1A0099271A /* DateTimePickerViewComponentCell.swift in Sources */,
 				0AA874162600237A00D47421 /* PersonaView.swift in Sources */,
 				8035CADE2638E435007B3FD1 /* CommandingSection.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -191,7 +191,7 @@
 		92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A1E4F326A791590007ED60 /* MSFCardNudge.swift */; };
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598026A0FD2800328FD3 /* CardNudge.swift */; };
-		92DEE21C272338F400E31ED0 /* ControlTokenFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE21A272338F400E31ED0 /* ControlTokenFactory.swift */; };
+		92DEE21C272338F400E31ED0 /* TokenFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE21A272338F400E31ED0 /* TokenFactory.swift */; };
 		92DEE21F2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE21D2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift */; };
 		92DEE2252723D34400E31ED0 /* ControlTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE2232723D34400E31ED0 /* ControlTokens.swift */; };
 		92E7AD5026FE51FF00AE7FF8 /* ColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */; };
@@ -309,7 +309,7 @@
 		92A1E4F326A791590007ED60 /* MSFCardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFCardNudge.swift; sourceTree = "<group>"; };
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D5598026A0FD2800328FD3 /* CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudge.swift; sourceTree = "<group>"; };
-		92DEE21A272338F400E31ED0 /* ControlTokenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokenFactory.swift; sourceTree = "<group>"; };
+		92DEE21A272338F400E31ED0 /* TokenFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenFactory.swift; sourceTree = "<group>"; };
 		92DEE21D2723395B00E31ED0 /* ControlTokenFactory+CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ControlTokenFactory+CardNudge.swift"; sourceTree = "<group>"; };
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSet.swift; sourceTree = "<group>"; };
@@ -768,7 +768,6 @@
 			isa = PBXGroup;
 			children = (
 				925D461A26FD126800179583 /* Tokens */,
-				92DEE21A272338F400E31ED0 /* ControlTokenFactory.swift */,
 				92E7AD5126FE904D00AE7FF8 /* DynamicColor.swift */,
 			);
 			path = Theme;
@@ -781,6 +780,7 @@
 				92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */,
 				92DEE2232723D34400E31ED0 /* ControlTokens.swift */,
 				925D461B26FD133600179583 /* GlobalTokens.swift */,
+				92DEE21A272338F400E31ED0 /* TokenFactory.swift */,
 				92EE82AC27025A94009D52B5 /* TokenSet.swift */,
 			);
 			path = Tokens;
@@ -1478,7 +1478,7 @@
 				92E7AD5326FE904D00AE7FF8 /* DynamicColor.swift in Sources */,
 				5314E08025F00F1A0099271A /* DateTimePickerViewComponent.swift in Sources */,
 				532FE3D226EA6D74007539C0 /* MSFActivityIndicatorTokens.generated.swift in Sources */,
-				92DEE21C272338F400E31ED0 /* ControlTokenFactory.swift in Sources */,
+				92DEE21C272338F400E31ED0 /* TokenFactory.swift in Sources */,
 				5314E06325F00EFD0099271A /* CalendarViewDayMonthYearCell.swift in Sources */,
 				5314E1A225F01A7C0099271A /* ActivityIndicatorCell.swift in Sources */,
 				5373D5652694D65C0032A3B4 /* AvatarTokens.swift in Sources */,

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -44,7 +44,7 @@ public typealias CardNudgeButtonAction = ((_ state: MSFCardNudgeState) -> Void)
 
 /// View that represents the CardNudge.
 public struct CardNudge: View {
-    @Environment(\.tokenFactory) var tokenFactory: ControlTokenFactory
+    @Environment(\.tokenFactory) var tokenFactory: TokenFactory
     @ObservedObject var state: MSFCardNudgeStateImpl
     var tokens: CardNudgeTokens {
         tokenFactory.cachedCardNudgeTokens.style(state.style)

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -44,10 +44,11 @@ public typealias CardNudgeButtonAction = ((_ state: MSFCardNudgeState) -> Void)
 
 /// View that represents the CardNudge.
 public struct CardNudge: View {
-    @Environment(\.theme) var theme: FluentUIStyle
-    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+    @Environment(\.tokenFactory) var tokenFactory: ControlTokenFactory
     @ObservedObject var state: MSFCardNudgeStateImpl
-    let tokens: CardNudgeTokens
+    var tokens: CardNudgeTokens {
+        tokenFactory.cachedCardNudgeTokens.style(state.style)
+    }
 
     @ViewBuilder
     var icon: some View {
@@ -167,7 +168,6 @@ public struct CardNudge: View {
     init(style: MSFCardNudgeStyle, title: String) {
         let state = MSFCardNudgeStateImpl(style: style, title: title)
         self.state = state
-        self.tokens = state.tokens
     }
 }
 
@@ -193,12 +193,9 @@ class MSFCardNudgeStateImpl: NSObject, ObservableObject, Identifiable, MSFCardNu
     /// Action to be dispatched by the dismiss ("close") button on the trailing edge of the control.
     @Published @objc public var dismissButtonAction: CardNudgeButtonAction?
 
-    let tokens: CardNudgeTokens
-
     @objc init(style: MSFCardNudgeStyle, title: String) {
         self.style = style
         self.title = title
-        self.tokens = CardNudgeTokens(style: style)
 
         super.init()
     }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokens.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokens.swift
@@ -117,9 +117,11 @@ open class CardNudgeTokens: ControlTokens {
         return GlobalTokens.Spacing.xSmall.value
     }
 
-    public init(style: MSFCardNudgeStyle) {
-        self.style = style
-    }
+    // MARK: - Style
 
-    private let style: MSFCardNudgeStyle
+    private(set) var style: MSFCardNudgeStyle = .standard
+    func style(_ style: MSFCardNudgeStyle) -> CardNudgeTokens {
+        self.style = style
+        return self
+    }
 }

--- a/ios/FluentUI/Card Nudge/ControlTokenFactory+CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/ControlTokenFactory+CardNudge.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension ControlTokenFactory {
+extension TokenFactory {
     /// Creates an instance of `CardNudgeTokens` for use in the `CardNudge` control.
     @objc open var cardNudgeTokens: CardNudgeTokens {
         return CardNudgeTokens()

--- a/ios/FluentUI/Card Nudge/ControlTokenFactory+CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/ControlTokenFactory+CardNudge.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+extension ControlTokenFactory {
+    /// Creates an instance of `CardNudgeTokens` for use in the `CardNudge` control.
+    @objc open var cardNudgeTokens: CardNudgeTokens {
+        return CardNudgeTokens()
+    }
+
+    // Attempts to fetch `CardNudgeTokens` from the token cache, and creates
+    // a new instance if the lookup fails.
+    var cachedCardNudgeTokens: CardNudgeTokens {
+        return tokenCache {
+            cardNudgeTokens
+        }
+    }
+}

--- a/ios/FluentUI/Card Nudge/MSFCardNudge.swift
+++ b/ios/FluentUI/Card Nudge/MSFCardNudge.swift
@@ -7,44 +7,20 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI `CardNudge` implementation
-@objc open class MSFCardNudge: NSObject, FluentUIWindowProvider {
-
-    /// The UIView representing the CardNudge.
-    @objc open var view: UIView {
-        return hostingController.view
-    }
+@objc public class MSFCardNudge: ControlHostingContainer {
 
     /// Creates a new MSFCardNudge instance.
     /// - Parameters:
     ///   - style: The MSFCardNudgeStyle value used by the CardNudge.
     ///   - title: The primary text to display in the CardNudge.
-    ///   - theme: The FluentUIStyle instance representing the theme to be overriden for this CardNudge.
+    /// - Returns: An initialized MSFCardNudge instance.
     @objc public init(style: MSFCardNudgeStyle,
-                      title: String,
-                      theme: FluentUIStyle? = nil) {
-        super.init()
-
-        cardNudge = CardNudge(style: style, title: title)
-        hostingController = FluentUIHostingController(rootView: AnyView(cardNudge
-                                                                            .windowProvider(self)
-                                                                            .modifyIf(theme != nil, { cardNudge in
-                                                                                cardNudge.customTheme(theme!)
-                                                                            })))
-        hostingController.disableSafeAreaInsets()
+                      title: String) {
+        let cardNudge = CardNudge(style: style, title: title)
+        state = cardNudge.state
+        super.init(AnyView(cardNudge))
     }
 
-    @objc public var state: MSFCardNudgeState {
-        return cardNudge.state
-    }
-
-    // MARK: - FluentUIWindowProvider
-
-    var window: UIWindow? {
-        return self.view.window
-    }
-
-    // MARK: - Private helpers
-
-    private var hostingController: FluentUIHostingController!
-    private var cardNudge: CardNudge!
+    /// The object that groups properties that allow control over the Card Nudge appearance.
+    @objc public let state: MSFCardNudgeState
 }

--- a/ios/FluentUI/Core/ControlHostingContainer.swift
+++ b/ios/FluentUI/Core/ControlHostingContainer.swift
@@ -15,7 +15,7 @@ public class ControlHostingContainer: NSObject {
     }
 
     /// A custom `TokenFactory` that should be used for styling this control, or `nil` if none exists.
-    public var tokenFactory: ControlTokenFactory? {
+    public var tokenFactory: TokenFactory? {
         didSet {
             updateRootView()
         }
@@ -44,13 +44,13 @@ public class ControlHostingContainer: NSObject {
         self.hostingController.rootView = tokenizedView
     }
 
-    private var currentTokenFactory: ControlTokenFactory {
+    private var currentTokenFactory: TokenFactory {
         if let overriddenTokenFactory = tokenFactory {
             return overriddenTokenFactory
         } else if let windowTokenFactory = self.view.window?.tokenFactory {
             return windowTokenFactory
         } else {
-            return ControlTokenFactory.shared
+            return TokenFactory.shared
         }
     }
 

--- a/ios/FluentUI/Core/ControlHostingContainer.swift
+++ b/ios/FluentUI/Core/ControlHostingContainer.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+import UIKit
+
+/// Common wrapper for hosting and exposing SwiftUI components to UIKit-based clients.
+public class ControlHostingContainer: NSObject {
+
+    /// The UIView representing the SwiftUI view.
+    @objc public var view: UIView {
+        return hostingController.view
+    }
+
+    /// A custom `TokenFactory` that should be used for styling this control, or `nil` if none exists.
+    public var tokenFactory: ControlTokenFactory? {
+        didSet {
+            updateRootView()
+        }
+    }
+
+    init(_ controlView: AnyView) {
+        self.controlView = controlView
+        super.init()
+
+        hostingController.disableSafeAreaInsets()
+
+        // We need to observe theme changes, and use them to update our wrapped control.
+        NotificationCenter.default.addObserver(forName: Notification.Name.didChangeTheme,
+                                               object: nil,
+                                               queue: .main) { [weak self] _ in
+            if let strongSelf = self {
+                strongSelf.updateRootView()
+            }
+        }
+
+        // Set the initial appearance of our control.
+        self.updateRootView()
+    }
+
+    private func updateRootView() {
+        self.hostingController.rootView = tokenizedView
+    }
+
+    private var currentTokenFactory: ControlTokenFactory {
+        if let overriddenTokenFactory = tokenFactory {
+            return overriddenTokenFactory
+        } else if let windowTokenFactory = self.view.window?.tokenFactory {
+            return windowTokenFactory
+        } else {
+            return ControlTokenFactory.shared
+        }
+    }
+
+    private var tokenizedView: AnyView {
+        return AnyView(controlView
+                        .tokenFactory(currentTokenFactory))
+    }
+
+    private let hostingController: FluentUIHostingController = .init(rootView: AnyView(EmptyView()))
+    private let controlView: AnyView
+}

--- a/ios/FluentUI/Core/ControlHostingContainer.swift
+++ b/ios/FluentUI/Core/ControlHostingContainer.swift
@@ -56,7 +56,13 @@ public class ControlHostingContainer: NSObject {
 
     private var tokenizedView: AnyView {
         return AnyView(controlView
-                        .tokenFactory(currentTokenFactory))
+                        .tokenFactory(currentTokenFactory)
+                        .onAppear { [weak self] in
+                            // We don't usually have a window at construction time, so fetch our
+                            // token override during `onAppear`
+                            self?.updateRootView()
+                        }
+        )
     }
 
     private let hostingController: FluentUIHostingController = .init(rootView: AnyView(EmptyView()))

--- a/ios/FluentUI/Core/Theme/ControlTokenFactory.swift
+++ b/ios/FluentUI/Core/Theme/ControlTokenFactory.swift
@@ -1,0 +1,80 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// Creates and manages `ControlTokens` for Fluent controls.
+///
+/// This class should be overridden by clients that want to provide custom control tokens on a larger scale.
+open class ControlTokenFactory {
+    public init() {}
+    static let shared = ControlTokenFactory()
+
+    /// Attempts to return a cached token set of type `T` if one exists. If not, this function will create
+    /// and cache a new set of tokens using the supplied generator function.
+    /// - Parameters:
+    ///   - tokenGenerator: A closure that generates a set of `ControlTokens` of type `T`.
+    /// - Returns:A set of `ControlTokens` of type `T`.
+    func tokenCache<T: ControlTokens>(_ tokenGenerator: () -> T) -> T {
+        if let tokens = currentCachedTokens as? T {
+            return tokens
+        }
+        let tokens = tokenGenerator()
+        currentCachedTokens = tokens
+        return tokens
+    }
+
+    private var currentCachedTokens: ControlTokens?
+}
+
+// MARK: - UIWindow
+
+protocol ControlTokenFactoryHosting {
+    var tokenFactory: ControlTokenFactory? { get }
+}
+
+extension UIWindow: ControlTokenFactoryHosting {
+    private struct Keys {
+        static var tokenFactory: String = "tokenFactory_key"
+    }
+
+    public var tokenFactory: ControlTokenFactory? {
+        get {
+            return objc_getAssociatedObject(self, &Keys.tokenFactory) as? ControlTokenFactory
+        }
+        set {
+            objc_setAssociatedObject(self, &Keys.tokenFactory, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: .didChangeTheme, object: nil)
+        }
+    }
+}
+
+// MARK: - Environment
+
+public extension View {
+    /// Sets a custom token factory for a specific SwiftUI View and its view hierarchy.
+    /// - Parameter tokenFactory: Instance of the custom overriding token factory.
+    /// - Returns: The view with its theme environment value overriden.
+    func tokenFactory(_ tokenFactory: ControlTokenFactory) -> some View {
+        environment(\.tokenFactory, tokenFactory)
+    }
+}
+
+extension EnvironmentValues {
+    var tokenFactory: ControlTokenFactory {
+        get {
+            self[TokenFactoryKey.self]
+        }
+        set {
+            self[TokenFactoryKey.self] = newValue
+        }
+    }
+}
+
+private struct TokenFactoryKey: EnvironmentKey {
+    static var defaultValue: ControlTokenFactory {
+        return ControlTokenFactory.shared
+    }
+}

--- a/ios/FluentUI/Core/Theme/Tokens/TokenFactory.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenFactory.swift
@@ -5,12 +5,12 @@
 
 import SwiftUI
 
-/// Creates and manages `ControlTokens` for Fluent controls.
+/// Creates and manages tokens for Fluent controls.
 ///
 /// This class should be overridden by clients that want to provide custom control tokens on a larger scale.
-open class ControlTokenFactory {
+open class TokenFactory {
     public init() {}
-    static let shared = ControlTokenFactory()
+    static let shared = TokenFactory()
 
     /// Attempts to return a cached token set of type `T` if one exists. If not, this function will create
     /// and cache a new set of tokens using the supplied generator function.
@@ -31,18 +31,18 @@ open class ControlTokenFactory {
 
 // MARK: - UIWindow
 
-protocol ControlTokenFactoryHosting {
-    var tokenFactory: ControlTokenFactory? { get }
+protocol TokenFactoryHosting {
+    var tokenFactory: TokenFactory? { get }
 }
 
-extension UIWindow: ControlTokenFactoryHosting {
+extension UIWindow: TokenFactoryHosting {
     private struct Keys {
         static var tokenFactory: String = "tokenFactory_key"
     }
 
-    public var tokenFactory: ControlTokenFactory? {
+    public var tokenFactory: TokenFactory? {
         get {
-            return objc_getAssociatedObject(self, &Keys.tokenFactory) as? ControlTokenFactory
+            return objc_getAssociatedObject(self, &Keys.tokenFactory) as? TokenFactory
         }
         set {
             objc_setAssociatedObject(self, &Keys.tokenFactory, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
@@ -57,13 +57,13 @@ public extension View {
     /// Sets a custom token factory for a specific SwiftUI View and its view hierarchy.
     /// - Parameter tokenFactory: Instance of the custom overriding token factory.
     /// - Returns: The view with its theme environment value overriden.
-    func tokenFactory(_ tokenFactory: ControlTokenFactory) -> some View {
+    func tokenFactory(_ tokenFactory: TokenFactory) -> some View {
         environment(\.tokenFactory, tokenFactory)
     }
 }
 
 extension EnvironmentValues {
-    var tokenFactory: ControlTokenFactory {
+    var tokenFactory: TokenFactory {
         get {
             self[TokenFactoryKey.self]
         }
@@ -74,7 +74,7 @@ extension EnvironmentValues {
 }
 
 private struct TokenFactoryKey: EnvironmentKey {
-    static var defaultValue: ControlTokenFactory {
-        return ControlTokenFactory.shared
+    static var defaultValue: TokenFactory {
+        return TokenFactory.shared
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Now that we have discrete control tokens (#769), it's time to build out functionality for swapping them out at runtime.

#### ControlTokenFactory

The newest class here is `ControlTokenFactory`, which serves as a central token creator and cache. Alone, its only real responsibility is to cache the most recently created `ControlTokens` subclass, but it has no real knowledge of these. Instead, each component will provide an extension to the factory that can create tokens of that class. This extension will be `open`, allowing clients to subclass and provide their own custom tokens.

An example of this is now available in `ThemingDemoController`, which temporarily features a `CardNudge` in addition to its existing `Button` and `Avatar` instances.

#### ControlTokenFactoryHosting

Generally speaking, our clients will want to apply a custom set of tokens to the entire app, not just to a single instance of a control. In a pure SwiftUI app, there is a simple view modifier called `tokenFactory(_:)` that can be applied to the root of the view hierarchy to be styled.

However, most of our clients are still UIKit-based. To facilitate this, this PR adds a new protocol, `ControlTokenFactoryHosting`, which this PR also applies to UIWindow. This allows us to "hang" a custom `ControlTokenFactory` off a window. Now anyone with access to their window can also access the custom `ControlTokenFactory` to be used for styling.

#### ControlHostingContainer

There's a moderate amount of glue code needed to connect the `ControlTokenFactoryHosting`-provided `ControlTokenFactory` and the SwiftUI controls being wrapped. This is a great opportunity to pull the creeping shared logic across our various UIKit wrappers into a single base class, `ControlHostingContainer`. This class will also contain the necessary logic to observe theme change events and use them to apply styling changes to the wrapped control view.

### Verification

This video demonstrates two important features:
- Dynamic runtime theme swapping for all default-styled controls in a window.
- Specific per-control token customization which is not affected by window-level customization.

https://user-images.githubusercontent.com/4934719/139186179-c4f2944c-fb38-4c23-abff-505ac184dfd1.mp4


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/778)