### PR TITLE
Removing passthrough func image(withPrimaryColor primaryColor: UIColor).

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -43,7 +43,7 @@ class ShimmerViewDemoController: DemoController {
         }
 
         let shimmeringImageView = { (shimmerStyle: ShimmerStyle) -> UIView in
-            let imageView = UIImageView(image: UIImage(named: "PlaceholderImage")?.image(withPrimaryColor: Colors.Shimmer.tint))
+            let imageView = UIImageView(image: UIImage(named: "PlaceholderImage")?.withTintColor(Colors.Shimmer.tint, renderingMode: .alwaysOriginal))
             let containerView = UIStackView(arrangedSubviews: [imageView])
             let shimmerView = ShimmerView(containerView: containerView, excludedViews: [], animationSynchronizer: nil, shimmerStyle: shimmerStyle)
             shimmerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -80,7 +80,7 @@ class SideTabBarDemoController: DemoController {
         var premiumImage = UIImage(named: "ic_fluent_premium_24_regular")!
         if let window = view.window {
             let primaryColor = Colors.primary(for: window)
-            premiumImage = premiumImage.image(withPrimaryColor: primaryColor)
+            premiumImage = premiumImage.withTintColor(primaryColor, renderingMode: .alwaysOriginal)
         }
 
         sideTabBar.bottomItems = [

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -245,17 +245,17 @@ open class Button: UIButton {
 
             if needsSetImage || !normalColor.isEqual(normalImageTintColor) {
                 normalImageTintColor = normalColor
-                setImage(image?.image(withPrimaryColor: normalColor), for: .normal)
+                setImage(image?.withTintColor(normalColor, renderingMode: .alwaysOriginal), for: .normal)
             }
 
             if needsSetImage || !highlightedColor.isEqual(highlightedImageTintColor) {
                 highlightedImageTintColor = highlightedColor
-                setImage(image?.image(withPrimaryColor: highlightedColor), for: .highlighted)
+                setImage(image?.withTintColor(highlightedColor, renderingMode: .alwaysOriginal), for: .highlighted)
             }
 
             if needsSetImage || !disabledColor.isEqual(disabledImageTintColor) {
                 disabledImageTintColor = disabledColor
-                setImage(image?.image(withPrimaryColor: disabledColor), for: .disabled)
+                setImage(image?.withTintColor(disabledColor, renderingMode: .alwaysOriginal), for: .disabled)
             }
 
             if needsSetImage {

--- a/ios/FluentUI/Extensions/UIImage+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIImage+Extensions.swift
@@ -5,15 +5,13 @@
 
 import UIKit
 
-@objc public extension UIImage {
-    internal class func staticImageNamed(_ name: String) -> UIImage? {
-        guard let image = UIImage(named: name, in: FluentUIFramework.resourceBundle, compatibleWith: nil) else {
+extension UIImage {
+    class func staticImageNamed(_ name: String) -> UIImage? {
+        guard let image = UIImage(named: name,
+                                  in: FluentUIFramework.resourceBundle,
+                                  compatibleWith: nil) else {
             preconditionFailure("Missing image asset with name: \(name)")
         }
         return image
-    }
-
-    @objc func image(withPrimaryColor primaryColor: UIColor) -> UIImage {
-        return self.withTintColor(primaryColor, renderingMode: .alwaysOriginal)
     }
 }

--- a/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
@@ -225,7 +225,7 @@ open class TableViewCellFileAccessoryView: UIView {
 
     private func updateSharedStatus() {
         let imageName = isShared ? "ic_fluent_people_24_regular" : "ic_fluent_person_24_regular"
-        sharedStatusImageView.image = UIImage.staticImageNamed(imageName)?.image(withPrimaryColor: Colors.gray500)
+        sharedStatusImageView.image = UIImage.staticImageNamed(imageName)?.withTintColor(Colors.gray500, renderingMode: .alwaysOriginal)
         sharedStatusLabel.text = isShared ? "Common.Shared".localized : "Common.OnlyMe".localized
     }
 

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -161,7 +161,7 @@ class TooltipView: UIView {
         if let window = window {
             let backgroundColor = UIColor(light: Colors.gray900.withAlphaComponent(0.95), dark: Colors.primary(for: window))
             backgroundView.backgroundColor = backgroundColor
-            arrowImageView.image = arrowImageViewBaseImage?.image(withPrimaryColor: backgroundColor)
+            arrowImageView.image = arrowImageViewBaseImage?.withTintColor(backgroundColor, renderingMode: .alwaysOriginal)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is currently a UIImage extension in the FluentUI library that includes a single public func that is just a passthrough call to [withTintColor(_:renderingMode:)](https://developer.apple.com/documentation/uikit/uiimage/3327301-withtintcolor).

```
    @objc func image(withPrimaryColor primaryColor: UIColor) -> UIImage {
        return self.withTintColor(primaryColor, renderingMode: .alwaysOriginal)
    }

```

This call does not particularly add value to client apps but it does add a bit on the binary size by creating a public extension that is also exposed to Objc clients.

### Verification

1. pod lib lint, local builds
2. Sanity validation on the updated calls (screenshots below):

- TableViewFileAccessoryView:
![Screen Shot 2021-10-28 at 3 35 28 PM](https://user-images.githubusercontent.com/68076145/139345512-bcf19c93-f876-4b70-b7e6-d2fbd9947f12.png)

- Button:
![Screen Shot 2021-10-28 at 3 39 21 PM](https://user-images.githubusercontent.com/68076145/139345807-d5d9de79-be3d-4be6-80e0-23cb7b29723c.png)

- Tooltip:
![Screen Shot 2021-10-28 at 3 46 44 PM](https://user-images.githubusercontent.com/68076145/139346513-b1e14133-0c89-4a30-b9f9-2967905b5e98.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/779)