### PR TITLE
Making the UIScreen extension internal to the library.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
@@ -179,7 +179,7 @@ class TableViewCellSampleData: TableViewSampleData {
                                      stackView.widthAnchor.constraint(equalTo: container.widthAnchor)])
 
         if withBorder {
-            container.layer.borderWidth = UIScreen.main.devicePixel
+            container.layer.borderWidth = 1 / UIScreen.main.scale // calculated device pixel
             container.layer.borderColor = Colors.textSecondary.cgColor
             container.layer.cornerRadius = 3
         }

--- a/ios/FluentUI/Extensions/UIScreen+Extension.swift
+++ b/ios/FluentUI/Extensions/UIScreen+Extension.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public extension UIScreen {
+extension UIScreen {
     var devicePixel: CGFloat { return 1 / scale }
 
     func roundToDevicePixels(_ value: CGFloat) -> CGFloat {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This public extension of UIScreen is not being used in the vast majority of the cases by client apps.

The devicePixel property will be updated in the case where's being used in our most notable client apps (just like @mischreiber pointed out in [this comment ](https://github.com/microsoft/fluentui-apple/pull/779#pullrequestreview-792509194) in #779)

While it's not the core goal of FluentUI to provide helper methods for client apps, this will still save a bit in the overall binary size of the static library.

### Verification

1. pod lib lint
2. Sanity validation in the demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/780)