### PR TITLE
Fixing repeated VoiceOver on SideTabBar

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -355,6 +355,17 @@ public struct Avatar: View {
         var yOrigin: CGFloat
         var cutoutSize: CGFloat
 
+        public var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
+            get {
+                AnimatablePair(AnimatablePair(xOrigin, yOrigin), cutoutSize)
+            }
+            set {
+                xOrigin = newValue.first.first
+                yOrigin = newValue.first.second
+                cutoutSize = newValue.second
+            }
+        }
+
         public func path(in rect: CGRect) -> Path {
             var cutoutFrame = Rectangle().path(in: rect)
             cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
@@ -467,7 +478,9 @@ public struct Avatar: View {
 }
 
 /// Properties available to customize the state of the avatar
-class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
+class MSFAvatarStateImpl: NSObject, ObservableObject, Identifiable, MSFAvatarState {
+    public var id = UUID()
+
     @Published var backgroundColor: UIColor?
     @Published var foregroundColor: UIColor?
     @Published var hasButtonAccessibilityTrait: Bool = false

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -245,10 +245,24 @@ public struct AvatarGroup: View {
                        height: geo.size.height,
                        alignment: .leading)
             }
-            .frame(height: groupHeight)
+            .frame(width: calcWidth(), height: groupHeight)
         }
 
         return avatarGroupContent
+    }
+
+    private func calcWidth() -> CGFloat {
+        var width: CGFloat = 0
+        let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
+        for index in 0 ..< maxShown {
+            width += state.avatars[index].size.size
+            if index < maxShown - 1 {
+                width += tokens.interspace
+            } else {
+                width += tokens.size.size
+            }
+        }
+        return width
     }
 
     private func createOverflow(count: Int) -> Avatar {

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -245,22 +245,20 @@ public struct AvatarGroup: View {
                        height: geo.size.height,
                        alignment: .leading)
             }
-            .frame(width: calcWidth(), height: groupHeight)
+            .frame(width: calcwidth, height: groupHeight)
         }
 
         return avatarGroupContent
     }
 
-    private func calcWidth() -> CGFloat {
+    private var calcwidth: CGFloat {
         var width: CGFloat = 0
         let maxShown = state.maxDisplayedAvatars < state.avatars.count ? state.maxDisplayedAvatars : state.avatars.count
+        let interspace: CGFloat = tokens.interspace
+        let avatarSize: CGFloat = tokens.size.size
         for index in 0 ..< maxShown {
-            width += state.avatars[index].size.size
-            if index < maxShown - 1 {
-                width += tokens.interspace
-            } else {
-                width += tokens.size.size
-            }
+            width += state.avatars[index].totalSize()
+            width += index < maxShown - 1 ? interspace : avatarSize
         }
         return width
     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -219,21 +219,26 @@ public struct AvatarGroup: View {
                         let yOrigin = sizeDiff / 2
                         let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
 
-                        avatarView
-                            .modifyIf(needsCutout, { view in
-                                view.mask(Avatar.AvatarCutout(
-                                            xOrigin: xOrigin,
-                                            yOrigin: yOrigin,
-                                            cutoutSize: cutoutSize)
-                                            .fill(style: FillStyle(eoFill: true)))
-                            })
-                            .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
-                            .animation(Animation.linear(duration: 0.1))
-                            .transition(AnyTransition.move(edge: .leading))
+                        VStack {
+                            avatarView
+                                .transition(.identity)
+                                .modifyIf(needsCutout, { view in
+                                    view.mask(Avatar.AvatarCutout(
+                                                xOrigin: xOrigin,
+                                                yOrigin: yOrigin,
+                                                cutoutSize: cutoutSize)
+                                                .fill(style: FillStyle(eoFill: true)))
+                                })
+                        }
+                        .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
+                        .animation(Animation.linear(duration: 0.1))
+                        .transition(AnyTransition.move(edge: .leading))
                     }
                     if overflowCount > 0 {
-                        createOverflow(count: overflowCount)
-                            .transition(AnyTransition.move(edge: .leading))
+                        VStack {
+                            createOverflow(count: overflowCount)
+                        }
+                        .transition(AnyTransition.move(edge: .leading))
                     }
                 }
                 .frame(width: geo.frame(in: .local).minX,

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -176,8 +176,8 @@ public struct AvatarGroup: View {
 
     public var body: some View {
         let avatars: [MSFAvatarStateImpl] = state.avatars
-        let enumeratedAvatars = Array(avatars.enumerated())
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
+        let enumeratedAvatars = Array(avatars.enumerated())
         let maxDisplayedAvatars: Int = avatars.prefix(state.maxDisplayedAvatars).count
         let overflowCount: Int = (avatars.count > maxDisplayedAvatars ? avatars.count - maxDisplayedAvatars : 0) + state.overflowCount
 
@@ -194,7 +194,6 @@ public struct AvatarGroup: View {
                 HStack(spacing: 0) {
                     ForEach(enumeratedAvatars.prefix(maxDisplayedAvatars), id: \.1) { index, avatar in
                         // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout
-                        let avatar = avatars[index]
                         let avatarView = avatarViews[index]
                         let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
                         let avatarSize: CGFloat = avatarView.state.totalSize()
@@ -234,6 +233,7 @@ public struct AvatarGroup: View {
                     }
                     if overflowCount > 0 {
                         createOverflow(count: overflowCount)
+                            .transition(AnyTransition.move(edge: .leading))
                     }
                 }
                 .frame(width: geo.frame(in: .local).minX,

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -264,7 +264,7 @@ open class SideTabBar: UIView {
     }
 
     private func updateAccessibilityIndex() {
-        // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+        // iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
         if #available(iOS 14.0, *) {
             if #available(iOS 14.6, *) {} else {
                 var totalCount: Int = 0

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -266,26 +266,28 @@ open class SideTabBar: UIView {
     private func updateAccessibilityIndex() {
         // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
         if #available(iOS 14.0, *) {
-            var totalCount: Int = 0
-            for section in Section.allCases {
-                let currentStackView = stackView(in: section)
-                totalCount += currentStackView.arrangedSubviews.count
-            }
-
-            var previousSectionCount: Int = 0
-            if let avatar = avatar, avatar.view.isHidden {
-                totalCount += 1
-                previousSectionCount += 1
-            }
-
-            for section in Section.allCases {
-                let currentStackView = stackView(in: section)
-
-                for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
-                    let accessibilityIndex = index + 1 + previousSectionCount
-                    itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+            if #available(iOS 14.6, *) {} else {
+                var totalCount: Int = 0
+                for section in Section.allCases {
+                    let currentStackView = stackView(in: section)
+                    totalCount += currentStackView.arrangedSubviews.count
                 }
-                previousSectionCount += currentStackView.arrangedSubviews.count
+
+                var previousSectionCount: Int = 0
+                if let avatar = avatar, !avatar.view.isHidden {
+                    totalCount += 1
+                    previousSectionCount += 1
+                }
+
+                for section in Section.allCases {
+                    let currentStackView = stackView(in: section)
+
+                    for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
+                        let accessibilityIndex = index + 1 + previousSectionCount
+                        itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+                    }
+                    previousSectionCount += currentStackView.arrangedSubviews.count
+                }
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Bringing #728 changes to SideTabBar. The avatar in 14.0-14.5 would not be read and the total indexing would be n-1. In 14.6 onwards, the items in the SideTabBar would have multiple index positioning readings.

### Verification

Tested on iOS 14.8 and 14.3 device:

| iOS Version | Before                                       | After                                      |
|---------------------------------|-----------------------------|-----------------------------------|
| 14.3 | Menu item positioning is read once, initial avatar had no reading | Menu item positioning is read once |
| 14.8 | Menu item positioning is read twice with different indexes | Menu item positioning is read once |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/728)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/781)