### PR TITLE
Improving Link accessibility on the Mac.

### DIFF
--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -93,6 +93,7 @@ open class Link: NSButton {
 		setButtonType(.momentaryChange)
 		target = self
 		action = #selector(linkClicked)
+		setAccessibilityRole(.link)
 		updateTitle()
 	}
 
@@ -137,7 +138,8 @@ open class Link: NSButton {
 
 	private func updateTitle() {
 		let titleAttributes = (isEnabled && showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes
-		self.attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
+		attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
+		setAccessibilityTitle(title)
 	}
 
 	@objc private func linkClicked() {

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -12,9 +12,9 @@ class TestLinkViewController: NSViewController {
 	override func loadView() {
 		let url = NSURL(string: "https://github.com/microsoft/fluentui-apple")
 
-		let linkWithNoUnderline = Link(title: "Link", url: url)
+		let linkWithNoUnderline = Link(title: "FluentUI on GitHub", url: url)
 
-		let linkWithHover = Link(title: "Link with hover effects", url: url)
+		let linkWithHover = Link(title: "FluentUI on GitHub (link with hover effects)", url: url)
 		linkWithHover.showsUnderlineWhileMouseInside = true
 
 		let linkWithHoverAndNoURL = Link(title: "Link with hover effects and no URL")
@@ -25,10 +25,12 @@ class TestLinkViewController: NSViewController {
 		linkWithOverridenTargetAction.target = self
 		linkWithOverridenTargetAction.action = #selector(displayAlert)
 
-		let customLink = Link(title: "Link with custom font, color and image", url: url)
+		let customLinkTitle = "FluentUI on GitHub (Link with custom font, color and image)"
+		let customLink = Link(title: customLinkTitle, url: url)
 		customLink.font = NSFont.systemFont(ofSize: 12.0, weight: NSFont.Weight.semibold)
 		customLink.contentTintColor = .textColor
 		customLink.image = NSImage(named: NSImage.goRightTemplateName)!
+		customLink.image?.accessibilityDescription = customLinkTitle
 		customLink.imagePosition = .imageTrailing
 
 		disabledLink.showsUnderlineWhileMouseInside = true


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Our accessibility test team reported 2 accessibility issues with our Link control:
1. Voice Over reports the incorrect role announcing "Button" instead of "Link"
2. The demo app should be more descriptive on the links that it displays.

This change resolve both of these issues.

### Verification

Ran the FluentUI Demo app on the Mac and validated that the links are now correctly announced:


https://user-images.githubusercontent.com/68076145/139510073-3862ec9d-d76c-4f53-8de8-82a91b889183.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/782)