### PR TITLE
Fixing repeated VoiceOver on SideTabBar

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -264,7 +264,7 @@ open class SideTabBar: UIView {
     }
 
     private func updateAccessibilityIndex() {
-        // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+        // iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
         if #available(iOS 14.0, *) {
             if #available(iOS 14.6, *) {} else {
                 var totalCount: Int = 0

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -266,26 +266,28 @@ open class SideTabBar: UIView {
     private func updateAccessibilityIndex() {
         // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
         if #available(iOS 14.0, *) {
-            var totalCount: Int = 0
-            for section in Section.allCases {
-                let currentStackView = stackView(in: section)
-                totalCount += currentStackView.arrangedSubviews.count
-            }
-
-            var previousSectionCount: Int = 0
-            if let avatar = avatar, avatar.view.isHidden {
-                totalCount += 1
-                previousSectionCount += 1
-            }
-
-            for section in Section.allCases {
-                let currentStackView = stackView(in: section)
-
-                for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
-                    let accessibilityIndex = index + 1 + previousSectionCount
-                    itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+            if #available(iOS 14.6, *) {} else {
+                var totalCount: Int = 0
+                for section in Section.allCases {
+                    let currentStackView = stackView(in: section)
+                    totalCount += currentStackView.arrangedSubviews.count
                 }
-                previousSectionCount += currentStackView.arrangedSubviews.count
+
+                var previousSectionCount: Int = 0
+                if let avatar = avatar, !avatar.view.isHidden {
+                    totalCount += 1
+                    previousSectionCount += 1
+                }
+
+                for section in Section.allCases {
+                    let currentStackView = stackView(in: section)
+
+                    for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
+                        let accessibilityIndex = index + 1 + previousSectionCount
+                        itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+                    }
+                    previousSectionCount += currentStackView.arrangedSubviews.count
+                }
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Bringing #728 changes to SideTabBar. The avatar in 14.0-14.5 would not be read and the total indexing would be n-1. In 14.6 onwards, the items in the SideTabBar would have multiple index positioning readings.

### Verification

Tested on iOS 14.8 and 14.3 device:

| iOS Version | Before                                       | After                                      |
|---------------------------------|-----------------------------|-----------------------------------|
| 14.3 | Menu item positioning is read once, initial avatar had no reading | Menu item positioning is read once |
| 14.8 | Menu item positioning is read twice with different indexes | Menu item positioning is read once |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/728)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/781)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/783)