### PR TITLE
Fixing accessibility announcement for Atom Button in the demo app.

### DIFF
--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -192,6 +192,7 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 		// Parameters for buttons in "Custom" row
 		let customTitle = "Atom"
 		let customImage = NSImage(named: TestButtonViewController.nonTemplateImage)!
+		customImage.accessibilityDescription = customTitle
 		customImage.isTemplate = true
 		let customFormat = ButtonFormat(size: .large, style: .primary, accentColor: Colors.Palette.blueMagenta30.color)
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Our accessibility test team reported that the "image only" version of the Atom button is not being announced properly.
It's currently being announced by Voice Over as just "Button", and it does need to be announced as "Atom, Button".

This fix addresses the issue by setting the **accessibilityDescription** property of the custom image being set on the button.

### Verification

Ran the FluentUI Demo app on the Mac and validated that the Atom button is now correctly announced:


https://user-images.githubusercontent.com/68076145/139510700-1538409c-68c8-4d01-9348-88f34950e3ec.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/784)