### PR TITLE
Fix background color and text color for a badge label in nav bar

### DIFF
--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -8,10 +8,10 @@ import UIKit
 // MARK: BadgeLabel
 
 class BadgeLabel: UILabel {
-    var shouldUseWindowColor: Bool = true
+    var shouldUseWindowColor: Bool = false
 
-    init() {
-        super.init(frame: .zero)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
         initBase()
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -8,10 +8,9 @@ import UIKit
 // MARK: BadgeLabel
 
 class BadgeLabel: UILabel {
-    private var shouldUseWindowColor: Bool = false
+    var shouldUseWindowColors: Bool = false
 
-    init(shouldUseWindowColor: Bool = false) {
-        self.shouldUseWindowColor = shouldUseWindowColor
+    init() {
         super.init(frame: .zero)
         initBase()
     }
@@ -34,7 +33,7 @@ class BadgeLabel: UILabel {
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
-        if shouldUseWindowColor {
+        if shouldUseWindowColors {
             if let window = window {
                 textColor = UIColor(light: Colors.primary(for: window), dark: .white)
                 backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -22,11 +22,21 @@ class BadgeLabel: UILabel {
     /// Base function for initialization
     private func initBase() {
         layer.masksToBounds = true
-        backgroundColor = Colors.Palette.dangerPrimary.color
-        textColor = .white
         textAlignment = .center
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
         isHidden = true
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateWindowSpecificColors()
+    }
+
+    private func updateWindowSpecificColors() {
+        if let window = window {
+            textColor = UIColor(light: Colors.primary(for: window), dark: .white)
+            backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))
+        }
     }
 
     private struct Constants {

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -8,9 +8,11 @@ import UIKit
 // MARK: BadgeLabel
 
 class BadgeLabel: UILabel {
+    private var shouldUseWindowColor: Bool = false
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(shouldUseWindowColor: Bool = false) {
+        self.shouldUseWindowColor = shouldUseWindowColor
+        super.init(frame: .zero)
         initBase()
     }
 
@@ -22,6 +24,8 @@ class BadgeLabel: UILabel {
     /// Base function for initialization
     private func initBase() {
         layer.masksToBounds = true
+        backgroundColor = Colors.Palette.dangerPrimary.color
+        textColor = .white
         textAlignment = .center
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
         isHidden = true
@@ -29,13 +33,12 @@ class BadgeLabel: UILabel {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateWindowSpecificColors()
-    }
 
-    private func updateWindowSpecificColors() {
-        if let window = window {
-            textColor = UIColor(light: Colors.primary(for: window), dark: .white)
-            backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))
+        if shouldUseWindowColor {
+            if let window = window {
+                textColor = UIColor(light: Colors.primary(for: window), dark: .white)
+                backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))
+            }
         }
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -33,12 +33,11 @@ class BadgeLabel: UILabel {
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
-        if shouldUseWindowColor {
-            if let window = window {
-                textColor = UIColor(light: Colors.primary(for: window), dark: .white)
-                backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))
-            }
+        guard let window = window, shouldUseWindowColor else {
+            return
         }
+        textColor = UIColor(light: Colors.primary(for: window), dark: .white)
+        backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))
     }
 
     private struct Constants {

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: BadgeLabel
 
 class BadgeLabel: UILabel {
-    var shouldUseWindowColors: Bool = false
+    var shouldUseWindowColor: Bool = true
 
     init() {
         super.init(frame: .zero)
@@ -33,7 +33,7 @@ class BadgeLabel: UILabel {
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
-        if shouldUseWindowColors {
+        if shouldUseWindowColor {
             if let window = window {
                 textColor = UIColor(light: Colors.primary(for: window), dark: .white)
                 backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -33,7 +33,7 @@ class BadgeLabel: UILabel {
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
-        guard let window = window, shouldUseWindowColor else {
+        guard shouldUseWindowColor, let window = window else {
             return
         }
         textColor = UIColor(light: Colors.primary(for: window), dark: .white)

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -14,13 +14,15 @@ class BadgeLabelButton: UIButton {
         }
     }
 
-    var shouldUseWindowColorInBadge: Bool? {
+    var shouldUseWindowColorInBadge: Bool {
         didSet {
-            badgeLabel.shouldUseWindowColor = shouldUseWindowColorInBadge ?? true
+            badgeLabel.shouldUseWindowColor = shouldUseWindowColorInBadge
         }
     }
 
     override init(frame: CGRect) {
+        shouldUseWindowColorInBadge = true
+
         super.init(frame: frame)
 
         NotificationCenter.default.addObserver(self,

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -14,9 +14,9 @@ class BadgeLabelButton: UIButton {
         }
     }
 
-    var shouldUseWindowColorsInBadge: Bool? {
+    var shouldUseWindowColorInBadge: Bool? {
         didSet {
-            updateBadgeLabel()
+            badgeLabel.shouldUseWindowColor = shouldUseWindowColorInBadge ?? true
         }
     }
 
@@ -157,7 +157,6 @@ class BadgeLabelButton: UIButton {
 
     private func updateBadgeLabel() {
         badgeLabel.text = item?.badgeValue
-        badgeLabel.shouldUseWindowColors = shouldUseWindowColorsInBadge ?? true
         let isNilBadgeValue = item?.badgeValue == nil
         badgeLabel.isHidden = isNilBadgeValue
 

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -14,6 +14,12 @@ class BadgeLabelButton: UIButton {
         }
     }
 
+    var shouldUseWindowColorsInBadge: Bool? {
+        didSet {
+            updateBadgeLabel()
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -43,7 +49,7 @@ class BadgeLabelButton: UIButton {
         static let badgeCornerRadii: CGFloat = 10
     }
 
-    private let badgeLabel = BadgeLabel(shouldUseWindowColor: true)
+    private let badgeLabel = BadgeLabel()
 
     private var badgeWidth: CGFloat {
         return min(max(badgeLabel.intrinsicContentSize.width + Constants.badgeHorizontalPadding,
@@ -151,6 +157,7 @@ class BadgeLabelButton: UIButton {
 
     private func updateBadgeLabel() {
         badgeLabel.text = item?.badgeValue
+        badgeLabel.shouldUseWindowColors = shouldUseWindowColorsInBadge ?? true
         let isNilBadgeValue = item?.badgeValue == nil
         badgeLabel.isHidden = isNilBadgeValue
 

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -43,7 +43,7 @@ class BadgeLabelButton: UIButton {
         static let badgeCornerRadii: CGFloat = 10
     }
 
-    private let badgeLabel = BadgeLabel()
+    private let badgeLabel = BadgeLabel(shouldUseWindowColor: true)
 
     private var badgeWidth: CGFloat {
         return min(max(badgeLabel.intrinsicContentSize.width + Constants.badgeHorizontalPadding,

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -584,7 +584,7 @@ open class NavigationBar: UINavigationBar {
     private func createBarButtonItemButton(with item: UIBarButtonItem, isLeftItem: Bool) -> UIButton {
         let button = BadgeLabelButton(type: .system)
         button.item = item
-        button.shouldUseWindowColorsInBadge = style != .system
+        button.shouldUseWindowColorInBadge = style != .system
         if isLeftItem {
             let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
             button.contentEdgeInsets = UIEdgeInsets(top: 0, left: isRTL ? 0 : Constants.leftBarButtonItemLeadingMargin, bottom: 0, right: isRTL ? Constants.leftBarButtonItemLeadingMargin : 0)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -584,6 +584,7 @@ open class NavigationBar: UINavigationBar {
     private func createBarButtonItemButton(with item: UIBarButtonItem, isLeftItem: Bool) -> UIButton {
         let button = BadgeLabelButton(type: .system)
         button.item = item
+        button.shouldUseWindowColorsInBadge = style != .system
         if isLeftItem {
             let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
             button.contentEdgeInsets = UIEdgeInsets(top: 0, left: isRTL ? 0 : Constants.leftBarButtonItemLeadingMargin, bottom: 0, right: isRTL ? Constants.leftBarButtonItemLeadingMargin : 0)

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -214,7 +214,7 @@ class TabBarItemView: UIControl {
         return titleLabel
     }()
 
-    let badgeView: UILabel = BadgeLabel()
+    let badgeView: UILabel = BadgeLabel(frame: .zero)
 
     private var suggestImageSize: CGFloat {
         didSet {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -214,7 +214,7 @@ class TabBarItemView: UIControl {
         return titleLabel
     }()
 
-    let badgeView: UILabel = BadgeLabel(frame: .zero)
+    let badgeView: UILabel = BadgeLabel()
 
     private var suggestImageSize: CGFloat {
         didSet {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
How the badge is going to look in different scenarios on icons present in the navigation bar?
**Navigation Bar with Primary Style**

Light Mode                                                
Background Color in badge: White                                               
Text Color in badge: App theme color

Dark Mode
Background Color in badge: App theme color
Text color in badge: White



**Navigation Bar with System style**

Both Light and Dark Mode
Background color in badge: Red                 
Text color in badge: White                                      

### Verification (Dark and Light Modes)
**Screenshots where the navigation bar is of primary style**
|<img width="328" alt="Screenshot 2021-11-02 at 5 38 36 PM" src="https://user-images.githubusercontent.com/33866787/139844687-35803664-6f3a-46c0-b085-32b9c1752e3f.png">|<img width="333" alt="Screenshot 2021-11-02 at 5 43 11 PM" src="https://user-images.githubusercontent.com/33866787/139844698-25629f96-129b-40c5-a93e-a400ca59d52b.png">|


**Screenshots where the navigation bar is of system style**
|<img width="328" alt="Screenshot 2021-11-09 at 6 25 13 PM" src="https://user-images.githubusercontent.com/33866787/140928005-9a86038d-8735-4bd8-917c-7f7c44fc04d7.png">|<img width="327" alt="Screenshot 2021-11-09 at 6 24 48 PM" src="https://user-images.githubusercontent.com/33866787/140928037-aaddac3d-31ac-4c58-8a3c-e23dd43444e6.png">|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
