### PR TITLE
Cherry-picking SideabBar Voiceover changes to main_0.2

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -263,28 +263,30 @@ open class SideTabBar: UIView {
     }
 
     private func updateAccessibilityIndex() {
-        // seems like iOS 14 `.tabBar` accessibilityTrait doesn't seem to read out the index automatically
+        // iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
         if #available(iOS 14.0, *) {
-            var totalCount: Int = 0
-            for section in Section.allCases {
-                let currentStackView = stackView(in: section)
-                totalCount += currentStackView.arrangedSubviews.count
-            }
-
-            var previousSectionCount: Int = 0
-            if let avatar = avatarView, !avatar.isHidden {
-                totalCount += 1
-                previousSectionCount += 1
-            }
-
-            for section in Section.allCases {
-                let currentStackView = stackView(in: section)
-
-                for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
-                    let accessibilityIndex = index + 1 + previousSectionCount
-                    itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+            if #available(iOS 14.6, *) {} else {
+                var totalCount: Int = 0
+                for section in Section.allCases {
+                    let currentStackView = stackView(in: section)
+                    totalCount += currentStackView.arrangedSubviews.count
                 }
-                previousSectionCount += currentStackView.arrangedSubviews.count
+
+                var previousSectionCount: Int = 0
+                if let avatar = avatarView, !avatar.isHidden {
+                    totalCount += 1
+                    previousSectionCount += 1
+                }
+
+                for section in Section.allCases {
+                    let currentStackView = stackView(in: section)
+
+                    for (index, itemView) in currentStackView.arrangedSubviews.enumerated() {
+                        let accessibilityIndex = index + 1 + previousSectionCount
+                        itemView.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, accessibilityIndex, totalCount)
+                    }
+                    previousSectionCount += currentStackView.arrangedSubviews.count
+                }
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking SideTabBar accessibility fixes (b5e80231ad218403f3e629cd6eb0d5a09837e161) to main_0.2.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/787)