### PR TITLE
Bottom sheet - Add the ability to hide/show the content when sheet is collapsed

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -114,7 +114,7 @@ class BottomSheetDemoController: UIViewController {
             DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: bottomSheetViewController?.isExpandable ?? true),
             DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomSheetViewController?.isHidden ?? false),
             DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
-			DemoItem(title: "Hide collapsed content", type: .boolean, action: #selector(toggleCollapsedContentHiding), isOn: collapsedContentHidingEnabled),
+            DemoItem(title: "Hide collapsed content", type: .boolean, action: #selector(toggleCollapsedContentHiding), isOn: collapsedContentHidingEnabled),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -58,6 +58,10 @@ class BottomSheetDemoController: UIViewController {
         scrollHidingEnabled = sender.isOn
     }
 
+	@objc private func toggleCollapsedContentHiding(_ sender: BooleanCell) {
+		bottomSheetViewController?.shouldHideCollapsedContent.toggle()
+	}
+
     @objc private func fullScreenSheetContent() {
         // This is also the default value which results in a full screen sheet.
         bottomSheetViewController?.preferredExpandedContentHeight = 0
@@ -99,6 +103,8 @@ class BottomSheetDemoController: UIViewController {
 
     private var scrollHidingEnabled: Bool = false
 
+    private var collapsedContentHidingEnabled: Bool = true
+
     private var isHiding: Bool = false
 
     private var interactiveHidingAnimator: UIViewAnimating?
@@ -108,6 +114,7 @@ class BottomSheetDemoController: UIViewController {
             DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: bottomSheetViewController?.isExpandable ?? true),
             DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomSheetViewController?.isHidden ?? false),
             DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
+			DemoItem(title: "Hide collapsed content", type: .boolean, action: #selector(toggleCollapsedContentHiding), isOn: collapsedContentHidingEnabled),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -135,7 +135,13 @@ public class BottomSheetController: UIViewController {
     }
 
     /// Indicates if the content should be hidden when the sheet is collapsed
-	@objc open var shouldHideCollapsedContent: Bool = true
+    @objc open var shouldHideCollapsedContent: Bool = true {
+        didSet {
+            if shouldHideCollapsedContent != oldValue {
+                updateExpandedContentAlpha()
+            }
+        }
+    }
 
     /// Current height of the portion of a collapsed sheet that's in the safe area.
     @objc public var collapsedHeightInSafeArea: CGFloat {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -134,6 +134,9 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// Indicates if the content should be hidden when the sheet is collapsed
+	@objc open var shouldHideCollapsedContent: Bool = true
+
     /// Current height of the portion of a collapsed sheet that's in the safe area.
     @objc public var collapsedHeightInSafeArea: CGFloat {
         return offset(for: .collapsed)
@@ -422,10 +425,12 @@ public class BottomSheetController: UIViewController {
         let collapsedOffset = offset(for: .collapsed)
 
         var targetAlpha: CGFloat = 1.0
-        if currentOffset <= collapsedOffset {
-            targetAlpha = 0.0
-        } else if currentOffset > collapsedOffset && currentOffset < collapsedOffset + transitionLength {
-            targetAlpha = abs(currentOffset - collapsedOffset) / transitionLength
+        if shouldHideCollapsedContent {
+            if currentOffset <= collapsedOffset {
+                targetAlpha = 0.0
+            } else if currentOffset > collapsedOffset && currentOffset < collapsedOffset + transitionLength {
+                targetAlpha = abs(currentOffset - collapsedOffset) / transitionLength
+            }
         }
         expandedContentView.alpha = targetAlpha
     }
@@ -578,7 +583,7 @@ public class BottomSheetController: UIViewController {
         }
 
         let targetRelatedViewAlpha = targetExpansionState.relatedViewAlpha
-        if expandedContentView.alpha != targetRelatedViewAlpha {
+        if shouldHideCollapsedContent && expandedContentView.alpha != targetRelatedViewAlpha {
             translationAnimator.addAnimations {
                 self.expandedContentView.alpha = targetRelatedViewAlpha
             }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes
For a new feature, we update the collapsed height to show the first part of the expanded content so that it's not collapsed all the way down (more than just the header is visible) and hence, we need to prevent the bottom sheet from hiding the content when in collapsed state. 

1) BottomSheetController.swift:
Added a property to control whether the content should be hidden when the sheet is in collapsed state that is true by default to match the existing behaviour. When the property is set to true, there will be no alpha value change applied to the content.

2) BottomSheetDemoController.swift:
Updated the demo controller so that there is a switch to toggle the property to hide/show the content when collapsed.

### Verification
Used the demo controller to test the following scenarios:
- not setting the property at all - the sheet behaves the same way as before, it is hidden when collapsed, and there is an alpha animation.
- setting the property to "false" shows the content when the sheet is collapsed and there is no alpha animation while the sheet being collapsed

Collapsed content hidden (toggle is off):
<img width="438" alt="collapsed content hidden" src="https://user-images.githubusercontent.com/65411058/140584712-5bb60548-5e16-4dcd-9a41-6e850e795280.png">

Collapsed content is NOT hidden (toggle is on):
<img width="433" alt="collapsed content not hidden" src="https://user-images.githubusercontent.com/65411058/140584702-aaa01598-2104-4eae-8f3d-7da239128ac8.png">

### Pull request checklist
none of the checks below are relevant as I didn't add controls or modified any of the controls. It's controlling the alpha changes of the content view only.

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/790)