### PR TITLE
Fix showing tooltip in demo for bottom tab bar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -125,7 +125,7 @@ class SideTabBarDemoController: DemoController {
         updateBadgeButtons()
     }
 
-    @objc private func showTooltipForSettingsButton() {
+    @objc private func showTooltipForHomeButton() {
         guard let view = sideTabBar.itemView(with: homeItem) else {
             return
         }
@@ -232,7 +232,7 @@ class SideTabBarDemoController: DemoController {
                 CellItem(title: "Show badge numbers", type: .boolean, action: #selector(toggleShowBadgeNumbers(_:))),
                 CellItem(title: "Use higher badge numbers", type: .boolean, action: #selector(toggleUseHigherBadgeNumbers(_:))),
                 CellItem(title: "Modify badge numbers", type: .stepper, action: nil),
-                CellItem(title: "Show tooltip for Home button", type: .action, action: #selector(showTooltipForSettingsButton)),
+                CellItem(title: "Show tooltip for Home button", type: .action, action: #selector(showTooltipForHomeButton)),
                 CellItem(title: "Dismiss", type: .action, action: #selector(dismissSideTabBar))
         ]
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -75,7 +75,7 @@ class TabBarViewDemoController: DemoController {
 
         if showsItemTitles {
             updatedTabBarView.items = [
-                TabBarItem(title: "Home", image: UIImage(named: "Home_24")!, selectedImage: UIImage(named: "Home_Selected_24")!),
+                homeItem,
                 TabBarItem(title: "New", image: UIImage(named: "New_24")!, selectedImage: UIImage(named: "New_Selected_24")!),
               TabBarItem(title: "Open", image: UIImage(named: "Open_24")!, selectedImage: UIImage(named: "Open_Selected_24")!)
             ]


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Problem: Whenever there is a title present for the tab bar item then the tooltip is unable to show for that item whereas it is successfully been shown with the item without a title.

Reason: There are two different arrays with the tab bar items, one array is being used in case of title is present and the other array is being used when the title is not present. While adding support for showing tooltip for the tab bar items, I created and stored reference of one item and then used to it show the tooltip. I used this item's reference in the array which is being used in the case when the title is not present but forgot to use it in the other array which is being used when the title is present. Instead in the other array, we are creating a new item and so tooltip is not being shown for this new item which we don't even have the reference in the method where the tooltip is being shown.

Fix: Used the item's reference in the other array too which is being used when the title is present.


### Verification
<img width="327" alt="Screenshot 2021-11-06 at 11 19 06 AM" src="https://user-images.githubusercontent.com/33866787/140599491-c5188235-9cba-4c7c-b98f-181e92ab29d6.png">

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/791)