### PR TITLE
Disable switch in case of regular title

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -387,7 +387,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
-            cell.setup(title: "Show rainbow ring on avatar", isOn: showRainbowRingForAvatar)
+            cell.setup(title: "Show rainbow ring on avatar",
+                       isOn: showRainbowRingForAvatar,
+                       isSwitchEnabled: navigationItem.usesLargeTitle)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowRainbowRing(isOn: cell?.isOn ?? false)
@@ -399,7 +401,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
-            cell.setup(title: "Show badge on right bar button items", isOn: showBadgeOnBarButtonItem)
+            cell.setup(title: "Show badge on right bar button items",
+                       isOn: showBadgeOnBarButtonItem,
+                       isSwitchEnabled: navigationItem.usesLargeTitle)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowBadge(isOn: cell?.isOn ?? false)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -387,9 +387,10 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
+            let isSwitchEnabled = navigationItem.usesLargeTitle && msfNavigationController?.msfNavigationBar.personaData != nil
             cell.setup(title: "Show rainbow ring on avatar",
                        isOn: showRainbowRingForAvatar,
-                       isSwitchEnabled: navigationItem.usesLargeTitle)
+                       isSwitchEnabled: isSwitchEnabled)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowRainbowRing(isOn: cell?.isOn ?? false)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
When we are using a regular title then we are not showing the avatar and we are also not using the BadgeLabelButton so switch off these options in the demo controller.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|<img width="326" alt="Screenshot 2021-11-10 at 12 56 06 PM" src="https://user-images.githubusercontent.com/33866787/141068465-bbb1eaac-0742-44bb-81be-ba85e7cdcec8.png">|<img width="330" alt="Screenshot 2021-11-10 at 12 51 46 PM" src="https://user-images.githubusercontent.com/33866787/141068457-cfcbff5e-b649-4c98-850e-04f6a30e79ee.png">|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/793)