### PR TITLE
Fix nav bar and colors in main_0.1 branch

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -22,6 +22,12 @@ class DemoListViewController: UITableViewController {
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
 
+        if #available(iOS 13, *) {
+            let standardAppearance = navigationController.navigationBar.standardAppearance
+            standardAppearance.backgroundColor = Colors.NavigationBar.background
+            navigationController.navigationBar.scrollEdgeAppearance = standardAppearance
+        }
+
         if let viewController = viewController {
             navigationController.pushViewController(viewController, animated: false)
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -424,6 +424,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     @objc private func showModalView() {
         let modalNavigationController = UINavigationController(rootViewController: ModalViewController(style: .grouped))
+        modalNavigationController.navigationBar.isTranslucent = true
         present(modalNavigationController, animated: true)
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -328,7 +328,9 @@ open class NavigationBar: UINavigationBar {
         isTranslucent = false
 
         // Cache the system shadow color
-        systemShadowColor = standardAppearance.shadowColor
+        if #available(iOS 13, *) {
+            systemShadowColor = standardAppearance.shadowColor
+        }
 
         updateColors(for: topItem)
         updateViewsForLargeTitlePresentation(for: topItem)
@@ -493,8 +495,12 @@ open class NavigationBar: UINavigationBar {
                 titleView.style = .dark
             }
 
-            standardAppearance.backgroundColor = color
-            scrollEdgeAppearance = standardAppearance
+            if #available(iOS 13, *) {
+                standardAppearance.backgroundColor = color
+                scrollEdgeAppearance = standardAppearance
+            } else {
+                barTintColor = color
+            }
             backgroundView.backgroundColor = color
             tintColor = style.tintColor
             if var titleTextAttributes = titleTextAttributes {
@@ -703,13 +709,26 @@ open class NavigationBar: UINavigationBar {
 
     private func updateShadow(for navigationItem: UINavigationItem?) {
         if needsShadow(for: navigationItem) {
-            standardAppearance.shadowColor = systemShadowColor
+            if #available(iOS 13, *) {
+                standardAppearance.shadowColor = systemShadowColor
+            } else {
+                shadowImage = nil
+                // Forcing layout to update size of shadow image view otherwise it stays with 0 height
+                setNeedsLayout()
+                subviews.forEach { $0.setNeedsLayout() }
+            }
         } else {
-            standardAppearance.shadowColor = nil
+            if #available(iOS 13, *) {
+                standardAppearance.shadowColor = nil
+            } else {
+                shadowImage = UIImage()
+            }
         }
 
-        // Update the scroll edge shadow to match standard
-        scrollEdgeAppearance = standardAppearance
+        if #available(iOS 13, *) {
+            // Update the scroll edge shadow to match standard
+            scrollEdgeAppearance = standardAppearance
+        }
     }
 
     private func needsShadow(for navigationItem: UINavigationItem?) -> Bool {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -325,11 +325,13 @@ open class NavigationBar: UINavigationBar {
         rightBarButtonItemsStackView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         rightBarButtonItemsStackView.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
 
-        updateViewsForLargeTitlePresentation(for: topItem)
-        updateColors(for: topItem)
-
         isTranslucent = false
 
+        // Cache the system shadow color
+        systemShadowColor = standardAppearance.shadowColor
+
+        updateColors(for: topItem)
+        updateViewsForLargeTitlePresentation(for: topItem)
         updateAccessibilityElements()
     }
 
@@ -491,7 +493,8 @@ open class NavigationBar: UINavigationBar {
                 titleView.style = .dark
             }
 
-            barTintColor = color
+            standardAppearance.backgroundColor = color
+            scrollEdgeAppearance = standardAppearance
             backgroundView.backgroundColor = color
             tintColor = style.tintColor
             if var titleTextAttributes = titleTextAttributes {
@@ -670,6 +673,9 @@ open class NavigationBar: UINavigationBar {
 
     // MARK: Large/Normal Title handling
 
+    /// Cache for the system shadow color, since the default value is private.
+    private var systemShadowColor: UIColor?
+
     private func updateViewsForLargeTitlePresentation(for navigationItem: UINavigationItem?) {
         // UIView.isHidden has a bug where a series of repeated calls with the same parameter can "glitch" the view into a permanent shown/hidden state
         // i.e. repeatedly trying to hide a UIView that is already in the hidden state
@@ -697,13 +703,13 @@ open class NavigationBar: UINavigationBar {
 
     private func updateShadow(for navigationItem: UINavigationItem?) {
         if needsShadow(for: navigationItem) {
-            shadowImage = nil
-            // Forcing layout to update size of shadow image view otherwise it stays with 0 height
-            setNeedsLayout()
-            subviews.forEach { $0.setNeedsLayout() }
+            standardAppearance.shadowColor = systemShadowColor
         } else {
-            shadowImage = UIImage()
+            standardAppearance.shadowColor = nil
         }
+
+        // Update the scroll edge shadow to match standard
+        scrollEdgeAppearance = standardAppearance
     }
 
     private func needsShadow(for navigationItem: UINavigationItem?) -> Bool {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

These are based on the following PRs into `main`:
- #733
- #747

However, there have been some changes.
- Instead of making the demo controller's nav bar transparent as per `#733`, which would require heavy changes to `ColorDemoController`, we simply apply a similar change as in `MSFNavigationController` wherein we copy properties from `navigationBar.standardAppearance` into `navigationBar.scrollAppearance`.
- Lots of `#available` checks in `MSFNavigationController`, since the code we used in #747 requires iOS 13, and `main_0.1` still supports back to iOS 11 (!)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before-root](https://user-images.githubusercontent.com/4934719/141528092-ee96557e-f1fb-4e47-a0a2-1dbfee952812.png) | ![after-root](https://user-images.githubusercontent.com/4934719/141528087-4febd593-f346-4f6b-974c-c55b5d905bda.png) |
| ![before-nav](https://user-images.githubusercontent.com/4934719/141528094-0304c761-548b-458a-90ab-0a3d6e86e626.png) | ![after-nav](https://user-images.githubusercontent.com/4934719/141528089-c4019635-3e66-4a38-8dcd-e4ec58e1dab0.png) |
| ![before-color](https://user-images.githubusercontent.com/4934719/141528081-0e3c72fb-ccab-4566-bc8f-171dcfb52bbd.png) | ![after-color](https://user-images.githubusercontent.com/4934719/141528086-6c01bd4b-123f-42b8-abbd-6cf2b9ccbdf7.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/795)