### PR TITLE
main_0.1 branch : git cherry-pick 4bd410e for tooltip a11y

### DIFF
--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -27,8 +27,6 @@ class TooltipView: UIView {
 
         static let paddingHorizontal: CGFloat = 13
         static let totalPaddingVertical: CGFloat = 12
-
-        static let maxLines: Int = 3
     }
 
     static let backgroundCornerRadius: CGFloat = 8
@@ -56,7 +54,7 @@ class TooltipView: UIView {
 
     private static func messageLabelSizeThatFits(_ size: CGSize, message: String) -> CGSize {
         let boundingWidth = min(Constants.maximumWidth, size.width) - 2 * Constants.paddingHorizontal
-        return message.preferredSize(for: Constants.messageLabelTextStyle.font, width: boundingWidth, numberOfLines: Constants.maxLines)
+        return message.preferredSize(for: Constants.messageLabelTextStyle.font, width: boundingWidth)
     }
 
     let positionController: TooltipPositionController
@@ -78,7 +76,7 @@ class TooltipView: UIView {
     private let messageLabel: UILabel = {
         let label = Label(style: Constants.messageLabelTextStyle)
         label.textColor = Colors.Tooltip.text
-        label.numberOfLines = Constants.maxLines
+        label.numberOfLines = 0
         return label
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

git cherry-pick 4bd410e 
to main_0.1 branch to make sure tooltip lines can grow in larger text mode

### Verification

![Simulator Screen Shot - iPhone 11 Pro Max - 2021-11-12 at 12 26 31](https://user-images.githubusercontent.com/20715435/141530410-6227a6b0-c511-474a-b2f4-5b5387e6a715.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/796)