### PR TITLE
let title lines of popupmenucells to grow in larger text mode

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -106,6 +106,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
         setup(title: item.title, subtitle: item.subtitle ?? "", customView: _imageView.image != nil ? _imageView : nil, customAccessoryView: item.accessoryView)
         isEnabled = item.isEnabled
+        titleNumberOfLines = 0
 
         updateViews()
         updateAccessibilityTraits()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

let popupmenucell title's line number to be increased when larger text mode is on.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-11-12 at 12 52 18](https://user-images.githubusercontent.com/20715435/141533103-307874e5-ce44-44d4-adf4-d8db2f9f1ebe.png) |![Simulator Screen Shot - iPhone 11 Pro Max - 2021-11-12 at 12 56 02](https://user-images.githubusercontent.com/20715435/141533515-89f59ede-34cf-415a-b1ca-8e4db0c6aae7.png)| 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/797)