### PR TITLE
Add accessibility label fix to badge label button

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -472,6 +472,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         } else {
             let dismissItem = UIBarButtonItem(title: BarButtonItemTag.dismiss.title, style: .plain, target: self, action: #selector(dismissSelf))
             dismissItem.tag = BarButtonItemTag.dismiss.rawValue
+            dismissItem.accessibilityLabel = "Dismiss"
             var items = [dismissItem]
             if allowsCellSelection {
                 let selectItem = UIBarButtonItem(title: BarButtonItemTag.select.title, style: .plain, target: self, action: #selector(showSelectionMode))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -513,9 +513,8 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
                 let badgeValue = isOn ? "12" : nil
                 item.setBadgeValue(badgeValue, badgeAccessibilityLabel: nil)
             } else {
-                let badgeValue = isOn ? "12" : nil
-                let badgeAccessibilityLabel = isOn ? "new items" : nil
-                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
+                let badgeValue = isOn ? "New" : nil
+                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: nil)
             }
         }
         showBadgeOnBarButtonItem = isOn

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -507,14 +507,16 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         for item in items {
             if item.tag == BarButtonItemTag.dismiss.rawValue {
                 let badgeValue = isOn ? "12345" : nil
-                let badgeAccessibilityLabel = isOn ? "items" : nil
+                let badgeAccessibilityLabel = isOn ? "\(badgeValue ?? "Zero") items" : nil
                 item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             } else if item.tag == BarButtonItemTag.threeDay.rawValue {
                 let badgeValue = isOn ? "12" : nil
-                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: nil)
+                let badgeAccessibilityLabel = isOn ? "\(badgeValue ?? "Zero") new items" : nil
+                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             } else {
                 let badgeValue = isOn ? "New" : nil
-                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: nil)
+                let badgeAccessibilityLabel = isOn ? "New feature" : nil
+                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             }
         }
         showBadgeOnBarButtonItem = isOn

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -507,11 +507,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         for item in items {
             if item.tag == BarButtonItemTag.dismiss.rawValue {
                 let badgeValue = isOn ? "12345" : nil
-                let badgeAccessibilityLabel = isOn ? "\(badgeValue ?? "Zero") items" : nil
+                let badgeAccessibilityLabel = isOn ? "\(badgeValue!) items" : nil
                 item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             } else if item.tag == BarButtonItemTag.threeDay.rawValue {
                 let badgeValue = isOn ? "12" : nil
-                let badgeAccessibilityLabel = isOn ? "\(badgeValue ?? "Zero") new items" : nil
+                let badgeAccessibilityLabel = isOn ? "\(badgeValue!) new items" : nil
                 item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             } else {
                 let badgeValue = isOn ? "New" : nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -506,11 +506,16 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
         for item in items {
             if item.tag == BarButtonItemTag.dismiss.rawValue {
-                item.badgeValue = isOn ? "12345" : nil
+                let badgeValue = isOn ? "12345" : nil
+                let badgeAccessibilityLabel = isOn ? "items" : nil
+                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             } else if item.tag == BarButtonItemTag.threeDay.rawValue {
-                item.badgeValue = isOn ? "12" : nil
+                let badgeValue = isOn ? "New" : nil
+                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: nil)
             } else {
-                item.badgeValue = isOn ? "New" : nil
+                let badgeValue = isOn ? "12" : nil
+                let badgeAccessibilityLabel = isOn ? "new items" : nil
+                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             }
         }
         showBadgeOnBarButtonItem = isOn

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -505,8 +505,8 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             return
         }
         for item in items {
-            var badgeValue: String? = nil
-            var badgeAccessibilityLabel: String? = nil
+            var badgeValue: String?
+            var badgeAccessibilityLabel: String?
             if isOn {
                 if item.tag == BarButtonItemTag.dismiss.rawValue {
                     badgeValue = "12345"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -510,7 +510,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
                 let badgeAccessibilityLabel = isOn ? "items" : nil
                 item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
             } else if item.tag == BarButtonItemTag.threeDay.rawValue {
-                let badgeValue = isOn ? "New" : nil
+                let badgeValue = isOn ? "12" : nil
                 item.setBadgeValue(badgeValue, badgeAccessibilityLabel: nil)
             } else {
                 let badgeValue = isOn ? "12" : nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -506,17 +506,19 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
         for item in items {
             if item.tag == BarButtonItemTag.dismiss.rawValue {
-                let badgeValue = isOn ? "12345" : nil
-                let badgeAccessibilityLabel = isOn ? "\(badgeValue!) items" : nil
-                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
+                let badgeValue = "12345"
+                let badgeAccessibilityLabel = "\(badgeValue) items"
+                item.setBadgeValue(isOn ? badgeValue : nil,
+                                   badgeAccessibilityLabel: isOn ? badgeAccessibilityLabel : nil)
             } else if item.tag == BarButtonItemTag.threeDay.rawValue {
-                let badgeValue = isOn ? "12" : nil
-                let badgeAccessibilityLabel = isOn ? "\(badgeValue!) new items" : nil
-                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
+                let badgeValue = "12"
+                let badgeAccessibilityLabel = "\(badgeValue) new items"
+                item.setBadgeValue(isOn ? badgeValue : nil,
+                                   badgeAccessibilityLabel: isOn ? badgeAccessibilityLabel : nil)
             } else {
-                let badgeValue = isOn ? "New" : nil
-                let badgeAccessibilityLabel = isOn ? "New feature" : nil
-                item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
+                let badgeValue = "New"
+                let badgeAccessibilityLabel = "New feature"
+                item.setBadgeValue(isOn ? badgeValue : nil, badgeAccessibilityLabel: isOn ? badgeAccessibilityLabel : nil)
             }
         }
         showBadgeOnBarButtonItem = isOn

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -505,21 +505,21 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             return
         }
         for item in items {
-            if item.tag == BarButtonItemTag.dismiss.rawValue {
-                let badgeValue = "12345"
-                let badgeAccessibilityLabel = "\(badgeValue) items"
-                item.setBadgeValue(isOn ? badgeValue : nil,
-                                   badgeAccessibilityLabel: isOn ? badgeAccessibilityLabel : nil)
-            } else if item.tag == BarButtonItemTag.threeDay.rawValue {
-                let badgeValue = "12"
-                let badgeAccessibilityLabel = "\(badgeValue) new items"
-                item.setBadgeValue(isOn ? badgeValue : nil,
-                                   badgeAccessibilityLabel: isOn ? badgeAccessibilityLabel : nil)
-            } else {
-                let badgeValue = "New"
-                let badgeAccessibilityLabel = "New feature"
-                item.setBadgeValue(isOn ? badgeValue : nil, badgeAccessibilityLabel: isOn ? badgeAccessibilityLabel : nil)
+            var badgeValue: String? = nil
+            var badgeAccessibilityLabel: String? = nil
+            if isOn {
+                if item.tag == BarButtonItemTag.dismiss.rawValue {
+                    badgeValue = "12345"
+                    badgeAccessibilityLabel = "12345 items"
+                } else if item.tag == BarButtonItemTag.threeDay.rawValue {
+                    badgeValue = "12"
+                    badgeAccessibilityLabel = "12 new items"
+                } else {
+                    badgeValue = "New"
+                    badgeAccessibilityLabel = "New feature"
+                }
             }
+            item.setBadgeValue(badgeValue, badgeAccessibilityLabel: badgeAccessibilityLabel)
         }
         showBadgeOnBarButtonItem = isOn
     }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -11,7 +11,6 @@ class BadgeLabelButton: UIButton {
         didSet {
             setupButton()
             prepareButtonForBadgeLabel()
-            updateAccessibilityLabel()
         }
     }
 
@@ -27,8 +26,8 @@ class BadgeLabelButton: UIButton {
         super.init(frame: frame)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(badgeValueDidChange),
-                                               name: UIBarButtonItem.badgeValueDidChangeNotification,
+                                               selector: #selector(badgePropertiesDidChange),
+                                               name: UIBarButtonItem.badgePropertiesDidChangeNotification,
                                                object: item)
     }
 
@@ -125,6 +124,7 @@ class BadgeLabelButton: UIButton {
         }
 
         accessibilityIdentifier = item.accessibilityIdentifier
+        accessibilityLabel = item.accessibilityLabel
         accessibilityHint = item.accessibilityHint
         showsLargeContentViewer = true
 
@@ -206,7 +206,7 @@ class BadgeLabelButton: UIButton {
                       height: frame.size.height + 2 * Constants.badgeBorderWidth)
     }
 
-    @objc private func badgeValueDidChange() {
+    @objc private func badgePropertiesDidChange() {
         updateBadgeLabel()
         updateAccessibilityLabel()
     }
@@ -215,14 +215,6 @@ class BadgeLabelButton: UIButton {
         guard let item = item else {
             return
         }
-        if let badgeValue = item.badgeValue, let itemAccessibilityLabel = item.accessibilityLabel {
-            if let accessibilityLabelFormatString = item.accessibilityLabelFormatString {
-                accessibilityLabel = String(format: accessibilityLabelFormatString, itemAccessibilityLabel, badgeValue)
-            } else {
-                accessibilityLabel = String(format: "Accessibility.BadgeLabelButton.LabelFormat".localized, itemAccessibilityLabel, badgeValue)
-            }
-        } else {
-            accessibilityLabel = item.accessibilityLabel
-        }
+        accessibilityLabel = (item.accessibilityLabel ?? "").appending(item.badgeAccessibilityLabel ?? "")
     }
 }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -217,7 +217,9 @@ class BadgeLabelButton: UIButton {
         }
         if let badgeAccessibilityLabel = item.badgeAccessibilityLabel {
             if let itemAccessibilityLabel = item.accessibilityLabel {
-                accessibilityLabel = String.localizedStringWithFormat("Accessibility.BadgeLabelButton.LabelFormat".localized, itemAccessibilityLabel, badgeAccessibilityLabel)
+                accessibilityLabel = String.localizedStringWithFormat("Accessibility.BadgeLabelButton.LabelFormat".localized,
+                                                                      itemAccessibilityLabel,
+                                                                      badgeAccessibilityLabel)
             } else {
                 accessibilityLabel = badgeAccessibilityLabel
             }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -27,7 +27,7 @@ class BadgeLabelButton: UIButton {
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(badgePropertiesDidChange),
-                                               name: UIBarButtonItem.badgePropertiesDidChangeNotification,
+                                               name: UIBarButtonItem.badgeValueDidChangeNotification,
                                                object: item)
     }
 

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -215,6 +215,12 @@ class BadgeLabelButton: UIButton {
         guard let item = item else {
             return
         }
-        accessibilityLabel = (item.accessibilityLabel ?? "").appending(item.badgeAccessibilityLabel ?? "")
+        if let itemAccessibilityLabel = item.accessibilityLabel, let badgeAccessibilityLabel = item.badgeAccessibilityLabel {
+            accessibilityLabel = String(format: "Accessibility.BadgeLabelButton.LabelFormat".localized,
+                                        itemAccessibilityLabel,
+                                        badgeAccessibilityLabel)
+        } else {
+            accessibilityLabel = item.accessibilityLabel
+        }
     }
 }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -215,10 +215,12 @@ class BadgeLabelButton: UIButton {
         guard let item = item else {
             return
         }
-        if let itemAccessibilityLabel = item.accessibilityLabel, let badgeAccessibilityLabel = item.badgeAccessibilityLabel {
-            accessibilityLabel = String(format: "Accessibility.BadgeLabelButton.LabelFormat".localized,
-                                        itemAccessibilityLabel,
-                                        badgeAccessibilityLabel)
+        if let badgeAccessibilityLabel = item.badgeAccessibilityLabel {
+            if let itemAccessibilityLabel = item.accessibilityLabel {
+                accessibilityLabel = String.localizedStringWithFormat("Accessibility.BadgeLabelButton.LabelFormat".localized, itemAccessibilityLabel, badgeAccessibilityLabel)
+            } else {
+                accessibilityLabel = badgeAccessibilityLabel
+            }
         } else {
             accessibilityLabel = item.accessibilityLabel
         }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -11,6 +11,7 @@ class BadgeLabelButton: UIButton {
         didSet {
             setupButton()
             prepareButtonForBadgeLabel()
+            updateAccessibilityLabel()
         }
     }
 
@@ -124,7 +125,6 @@ class BadgeLabelButton: UIButton {
         }
 
         accessibilityIdentifier = item.accessibilityIdentifier
-        accessibilityLabel = item.accessibilityLabel
         accessibilityHint = item.accessibilityHint
         showsLargeContentViewer = true
 
@@ -208,5 +208,21 @@ class BadgeLabelButton: UIButton {
 
     @objc private func badgeValueDidChange() {
         updateBadgeLabel()
+        updateAccessibilityLabel()
+    }
+
+    private func updateAccessibilityLabel() {
+        guard let item = item, let itemAccessibilityLabel = item.accessibilityLabel else {
+            return
+        }
+        if let badgeValue = item.badgeValue {
+            if let accessibilityLabelFormatString = item.accessibilityLabelFormatString {
+                accessibilityLabel = String(format: accessibilityLabelFormatString, itemAccessibilityLabel, badgeValue)
+            } else {
+                accessibilityLabel = String(format: "Accessibility.BadgeLabelButton.LabelFormat".localized, itemAccessibilityLabel, badgeValue)
+            }
+        } else {
+            accessibilityLabel = itemAccessibilityLabel
+        }
     }
 }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -26,7 +26,7 @@ class BadgeLabelButton: UIButton {
         super.init(frame: frame)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(badgePropertiesDidChange),
+                                               selector: #selector(badgeValueDidChange),
                                                name: UIBarButtonItem.badgeValueDidChangeNotification,
                                                object: item)
     }
@@ -206,7 +206,7 @@ class BadgeLabelButton: UIButton {
                       height: frame.size.height + 2 * Constants.badgeBorderWidth)
     }
 
-    @objc private func badgePropertiesDidChange() {
+    @objc private func badgeValueDidChange() {
         updateBadgeLabel()
         updateAccessibilityLabel()
     }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -212,17 +212,17 @@ class BadgeLabelButton: UIButton {
     }
 
     private func updateAccessibilityLabel() {
-        guard let item = item, let itemAccessibilityLabel = item.accessibilityLabel else {
+        guard let item = item else {
             return
         }
-        if let badgeValue = item.badgeValue {
+        if let badgeValue = item.badgeValue, let itemAccessibilityLabel = item.accessibilityLabel {
             if let accessibilityLabelFormatString = item.accessibilityLabelFormatString {
                 accessibilityLabel = String(format: accessibilityLabelFormatString, itemAccessibilityLabel, badgeValue)
             } else {
                 accessibilityLabel = String(format: "Accessibility.BadgeLabelButton.LabelFormat".localized, itemAccessibilityLabel, badgeValue)
             }
         } else {
-            accessibilityLabel = itemAccessibilityLabel
+            accessibilityLabel = item.accessibilityLabel
         }
     }
 }

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -8,42 +8,32 @@ import UIKit
 @objc public extension UIBarButtonItem {
     private struct AssociatedKeys {
         static var badgeValue: String = "badgeValue"
-        static var accessibilityLabelFormatString: String = "accessibilityLabelFormatString"
+        static var badgeAccessibilityLabel: String = "badgeAccessibilityLabel"
     }
 
-    static let badgeValueDidChangeNotification = NSNotification.Name(rawValue: "UIBarButtonItemBadgeValueDidChangeNotification")
+    static let badgePropertiesDidChangeNotification = NSNotification.Name(rawValue: "UIBarButtonItemBadgePropertiesDidChangeNotification")
 
-    /// The badge value will be displayed in a red oval above the UIBarButtonItem.
-    /// Set the badge value to nil to hide the red oval.
-    @objc var badgeValue: String? {
+    @objc internal var badgeValue: String? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.badgeValue) as? String ?? nil
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.badgeValue, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-            NotificationCenter.default.post(name: UIBarButtonItem.badgeValueDidChangeNotification, object: self)
         }
     }
 
-    /// Convenience method to set the badge value to a number.
-    /// If the number is zero, the badge value will be hidden.
-    @objc func setBadgeNumber(_ number: UInt) {
-        if number > 0 {
-            badgeValue = NumberFormatter.localizedString(from: NSNumber(value: number), number: .none)
-        } else {
-            badgeValue = nil
-        }
-    }
-
-    /// Set this format string in a way that takes two parameters: item's accessibility label and badge value.
-    /// Format: %@ %@ <some string>
-    /// Example: "<Activity> <5> new activities" which will be called by voice over as "Activity 5 new activities button"
-    @objc var accessibilityLabelFormatString: String? {
+    @objc internal var badgeAccessibilityLabel: String? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.accessibilityLabelFormatString) as? String ?? nil
+            return objc_getAssociatedObject(self, &AssociatedKeys.badgeAccessibilityLabel) as? String ?? nil
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.accessibilityLabelFormatString, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKeys.badgeAccessibilityLabel, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
+    }
+
+    @objc func setBadgeValue(_ badgeValue: String?, badgeAccessibilityLabel: String?) {
+        self.badgeValue = badgeValue
+        self.badgeAccessibilityLabel = (badgeValue ?? "").appending(badgeAccessibilityLabel ?? "")
+        NotificationCenter.default.post(name: UIBarButtonItem.badgePropertiesDidChangeNotification, object: self)
     }
 }

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -11,14 +11,17 @@ import UIKit
         static var badgeAccessibilityLabel: String = "badgeAccessibilityLabel"
     }
 
-    static let badgePropertiesDidChangeNotification = NSNotification.Name(rawValue: "UIBarButtonItemBadgePropertiesDidChangeNotification")
+    static let badgeValueDidChangeNotification = NSNotification.Name(rawValue: "UIBarButtonItemBadgeValueDidChangeNotification")
 
-    @objc internal var badgeValue: String? {
+    /// The badge value will be displayed in a red oval above the UIBarButtonItem.
+    /// Set the badge value to nil to hide the red oval.
+    @objc var badgeValue: String? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.badgeValue) as? String ?? nil
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.badgeValue, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: UIBarButtonItem.badgeValueDidChangeNotification, object: self)
         }
     }
 
@@ -32,11 +35,11 @@ import UIKit
     }
 
     /// Use this method on bar button item's instance to set the badge value and badge accessibility label.
+    /// Set the badge value to nil to hide the red oval.
     /// Complete badge accessibility label would be the concatenation of the badge value and badge accessibility label.
     /// Complete accessibility label for the item in the navigation bar would be item's accessibility label concatenated with the complete badge accessibility label.
     @objc func setBadgeValue(_ badgeValue: String?, badgeAccessibilityLabel: String?) {
-        self.badgeValue = badgeValue
         self.badgeAccessibilityLabel = (badgeValue ?? "").appending(badgeAccessibilityLabel ?? "")
-        NotificationCenter.default.post(name: UIBarButtonItem.badgePropertiesDidChangeNotification, object: self)
+        self.badgeValue = badgeValue
     }
 }

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -31,6 +31,9 @@ import UIKit
         }
     }
 
+    /// Use this method on bar button item's instance to set the badge value and badge accessibility label.
+    /// Complete badge accessibility label would be the concatenation of the badge value and badge accessibility label.
+    /// Complete accessibility label for the item in the navigation bar would be item's accessibility label concatenated with the complete badge accessibility label.
     @objc func setBadgeValue(_ badgeValue: String?, badgeAccessibilityLabel: String?) {
         self.badgeValue = badgeValue
         self.badgeAccessibilityLabel = (badgeValue ?? "").appending(badgeAccessibilityLabel ?? "")

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -35,6 +35,9 @@ import UIKit
         }
     }
 
+    /// Set this format string in a way that takes two parameters: item's accessibility label and badge value.
+    /// Format: %@ %@ <some string>
+    /// Example: "<Activity> <5> new activities" which will be called by voice over as "Activity 5 new activities button"
     @objc var accessibilityLabelFormatString: String? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.accessibilityLabelFormatString) as? String ?? nil

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -35,11 +35,11 @@ import UIKit
     }
 
     /// Use this method on bar button item's instance to set the badge value and badge accessibility label.
-    /// Set the badge value to nil to hide the red oval.
-    /// Complete badge accessibility label would be the concatenation of the badge value and badge accessibility label.
-    /// Complete accessibility label for the item in the navigation bar would be item's accessibility label concatenated with the complete badge accessibility label.
+    /// - Parameters:
+    ///   - badgeValue: Value that will be displayed in a red oval above the bar button item. Set the badgeValue to nil to hide the red oval.
+    ///   - badgeAccessibilityLabel: Accessibility label for the badge. If present, then the overall accessibility label will be item's accessibility label concatenated with the badge's accessibility label, else only the item's accessibility label.
     @objc func setBadgeValue(_ badgeValue: String?, badgeAccessibilityLabel: String?) {
-        self.badgeAccessibilityLabel = (badgeValue ?? "").appending(badgeAccessibilityLabel ?? "")
+        self.badgeAccessibilityLabel = badgeAccessibilityLabel
         self.badgeValue = badgeValue
     }
 }

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -37,7 +37,7 @@ import UIKit
     /// Use this method on bar button item's instance to set the badge value and badge accessibility label.
     /// - Parameters:
     ///   - badgeValue: Value that will be displayed in a red oval above the bar button item. Set the badgeValue to nil to hide the red oval.
-    ///   - badgeAccessibilityLabel: Accessibility label for the badge. If present, then the overall accessibility label will be item's accessibility label concatenated with the badge's accessibility label, else only the item's accessibility label.
+    ///   - badgeAccessibilityLabel: Accessibility label for the badge. Combined with the item's accessibility label if not nil.
     @objc func setBadgeValue(_ badgeValue: String?, badgeAccessibilityLabel: String?) {
         self.badgeAccessibilityLabel = badgeAccessibilityLabel
         self.badgeValue = badgeValue

--- a/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
+++ b/ios/FluentUI/Navigation/UIBarButtonItem+BadgeValue.swift
@@ -8,6 +8,7 @@ import UIKit
 @objc public extension UIBarButtonItem {
     private struct AssociatedKeys {
         static var badgeValue: String = "badgeValue"
+        static var accessibilityLabelFormatString: String = "accessibilityLabelFormatString"
     }
 
     static let badgeValueDidChangeNotification = NSNotification.Name(rawValue: "UIBarButtonItemBadgeValueDidChangeNotification")
@@ -31,6 +32,15 @@ import UIKit
             badgeValue = NumberFormatter.localizedString(from: NSNumber(value: number), number: .none)
         } else {
             badgeValue = nil
+        }
+    }
+
+    @objc var accessibilityLabelFormatString: String? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.accessibilityLabelFormatString) as? String ?? nil
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.accessibilityLabelFormatString, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 }

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -120,6 +120,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ items";
 
+/* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
+"Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
+
 /* Commanding Bottom Bar - More button */
 "CommandingBottomBar.More" = "More";
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -120,6 +120,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ items";
 
+/* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Dismiss, 5 items" */
+"Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@ items";
+
 /* Commanding Bottom Bar - More button */
 "CommandingBottomBar.More" = "More";
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -120,9 +120,6 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ items";
 
-/* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Dismiss, 5 items" */
-"Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@ items";
-
 /* Commanding Bottom Bar - More button */
 "CommandingBottomBar.More" = "More";
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR is fixing the accessibility label in the badge label button. Currently, accessibility is only for the button itself but not for the badge that is coming on the button. This PR is fixing the issue by asking the clients for an accessibility label together with the badge value.

### Verification
Verified on my device. Device details: iPhone 12, iOS 15.0.2




https://user-images.githubusercontent.com/33866787/142191150-c21ddb7a-9bef-4afc-bb0c-faefdd96e57c.MP4

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/800)