### PR TITLE
Adding tooltip to links in the Mac demo app.

### DIFF
--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -7,26 +7,41 @@ import AppKit
 import FluentUI
 
 class TestLinkViewController: NSViewController {
-	let disabledLink = Link(title: "Disabled link with hover effects")
+	let disabledLink: Link = {
+		let disabledLinkTitle = "Disabled link with hover effects"
+		let disabledLink = Link(title: disabledLinkTitle)
+		disabledLink.toolTip = disabledLinkTitle
+
+		return disabledLink
+	}()
 
 	override func loadView() {
 		let url = NSURL(string: "https://github.com/microsoft/fluentui-apple")
 
-		let linkWithNoUnderline = Link(title: "FluentUI on GitHub", url: url)
+		let linkWithNoUnderlineTitle = "FluentUI on GitHub"
+		let linkWithNoUnderline = Link(title: linkWithNoUnderlineTitle, url: url)
+		linkWithNoUnderline.toolTip = linkWithNoUnderlineTitle
 
-		let linkWithHover = Link(title: "FluentUI on GitHub (link with hover effects)", url: url)
+		let linkWithHoverTitle = "FluentUI on GitHub (link with hover effects)"
+		let linkWithHover = Link(title: linkWithHoverTitle, url: url)
+		linkWithHover.toolTip = linkWithHoverTitle
 		linkWithHover.showsUnderlineWhileMouseInside = true
 
-		let linkWithHoverAndNoURL = Link(title: "Link with hover effects and no URL")
+		let linkWithHoverAndNoURLTitle = "Link with hover effects and no URL"
+		let linkWithHoverAndNoURL = Link(title: linkWithHoverAndNoURLTitle)
+		linkWithHoverAndNoURL.toolTip = linkWithHoverAndNoURLTitle
 		linkWithHoverAndNoURL.showsUnderlineWhileMouseInside = true
 
-		let linkWithOverridenTargetAction = Link(title: "Link with overridden Target/Action")
+		let linkWithOverridenTargetActionTitle = "Link with overridden Target/Action"
+		let linkWithOverridenTargetAction = Link(title: linkWithOverridenTargetActionTitle)
+		linkWithOverridenTargetAction.toolTip = linkWithOverridenTargetActionTitle
 		linkWithOverridenTargetAction.showsUnderlineWhileMouseInside = true
 		linkWithOverridenTargetAction.target = self
 		linkWithOverridenTargetAction.action = #selector(displayAlert)
 
 		let customLinkTitle = "FluentUI on GitHub (Link with custom font, color and image)"
 		let customLink = Link(title: customLinkTitle, url: url)
+		customLink.toolTip = customLinkTitle
 		customLink.font = NSFont.systemFont(ofSize: 12.0, weight: NSFont.Weight.semibold)
 		customLink.contentTintColor = .textColor
 		customLink.image = NSImage(named: NSImage.goRightTemplateName)!
@@ -38,7 +53,9 @@ class TestLinkViewController: NSViewController {
 		disabledLink.target = self
 		disabledLink.action = #selector(toggleLink)
 
-		let toggleDisabledLink = Link(title: "Toggle disabled link")
+		let toggleDisabledLinkTitle = "Toggle disabled link"
+		let toggleDisabledLink = Link(title: toggleDisabledLinkTitle)
+		toggleDisabledLink.toolTip = toggleDisabledLinkTitle
 		toggleDisabledLink.showsUnderlineWhileMouseInside = true
 		toggleDisabledLink.target = self
 		toggleDisabledLink.action = #selector(toggleLink)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Our accessibility test team reported an issue where the Links in the demo app do not have the tooltip set.
This change makes it compliant with that requirement and add tooltip to all links in that screen.

### Verification

https://user-images.githubusercontent.com/68076145/142267639-9ee4ed59-9854-4a59-84bb-53cf6fab9a88.mov

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/801)