### PR TITLE
Setting accessibility label to NSPopUpButton in the demo app.

### DIFF
--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -101,44 +101,56 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 	var fluentButtons: [Button] = []
 
 	override func loadView() {
+		let materialPopupLabel = "Pane Material"
 		materialsPopup.addItems(withTitles: effectViewMaterials.keys.sorted())
 		materialsPopup.menu?.delegate = self
 		materialsPopup.target = self
 		materialsPopup.action = #selector(TestButtonViewController.materialChanged)
+		materialsPopup.setAccessibilityLabel(materialPopupLabel)
 
+		let backgroundColorsPopupLabel = "Pane Color"
 		backgroundColorsPopup.addItems(withTitles: backgroundColors.keys.sorted())
 		backgroundColorsPopup.menu?.delegate = self
 		backgroundColorsPopup.target = self
 		backgroundColorsPopup.action = #selector(TestButtonViewController.backgroundColorChanged)
+		backgroundColorsPopup.setAccessibilityLabel(backgroundColorsPopupLabel)
 
+		let imagePositionsPopupLabel = "Image Position"
 		imagePositionsPopup.addItems(withTitles: imagePositions.keys.sorted())
 		imagePositionsPopup.selectItem(withTitle: defaultImagePosition)
 		imagePositionsPopup.menu?.delegate = self
 		imagePositionsPopup.target = self
 		imagePositionsPopup.action = #selector(TestButtonViewController.imagePositionChanged)
+		imagePositionsPopup.setAccessibilityLabel(imagePositionsPopupLabel)
 
+		let buttonStatesPopupLabel = "Button State"
 		buttonStatesPopup.addItems(withTitles: buttonStates)
 		buttonStatesPopup.menu?.delegate = self
 		buttonStatesPopup.target = self
 		buttonStatesPopup.action = #selector(TestButtonViewController.stateChanged)
+		buttonStatesPopup.setAccessibilityLabel(buttonStatesPopupLabel)
 
+		let widthPopupLabel = "Button Width"
 		widthPopup.addItems(withTitles: widths.keys.sorted())
 		widthPopup.menu?.delegate = self
 		widthPopup.target = self
 		widthPopup.action = #selector(TestButtonViewController.widthConstraintsChanged)
+		widthPopup.setAccessibilityLabel(widthPopupLabel)
 
+		let heightPopupLabel = "Button Height"
 		heightPopup.addItems(withTitles: heights.keys.sorted())
 		heightPopup.menu?.delegate = self
 		heightPopup.target = self
 		heightPopup.action = #selector(TestButtonViewController.heightConstraintsChanged)
+		heightPopup.setAccessibilityLabel(heightPopupLabel)
 
 		let tools = [
-			[NSTextField(labelWithString: "Pane Material:"), materialsPopup],
-			[NSTextField(labelWithString: "Pane Color:"), backgroundColorsPopup],
-			[NSTextField(labelWithString: "Image Position:"), imagePositionsPopup],
-			[NSTextField(labelWithString: "Button State:"), buttonStatesPopup],
-			[NSTextField(labelWithString: "Button Width:"), widthPopup],
-			[NSTextField(labelWithString: "Button Height:"), heightPopup]
+			[NSTextField(labelWithString: "\(materialPopupLabel):"), materialsPopup],
+			[NSTextField(labelWithString: "\(backgroundColorsPopupLabel):"), backgroundColorsPopup],
+			[NSTextField(labelWithString: "\(imagePositionsPopupLabel):"), imagePositionsPopup],
+			[NSTextField(labelWithString: "\(buttonStatesPopupLabel):"), buttonStatesPopup],
+			[NSTextField(labelWithString: "\(widthPopupLabel):"), widthPopup],
+			[NSTextField(labelWithString: "\(heightPopupLabel):"), heightPopup]
 		]
 
 		let toolsGrid = NSGridView(views: tools)

--- a/macos/FluentUITestViewControllers/TestFilledTemplateImageViewController.swift
+++ b/macos/FluentUITestViewControllers/TestFilledTemplateImageViewController.swift
@@ -35,20 +35,24 @@ class TestFilledTemplateImageViewController: NSViewController, NSMenuDelegate {
 	override func loadView() {
 
 		// Load the popup menus
+		let borderColorsPopupLabel = "Border Color"
 		borderColorsPopup.addItems(withTitles: borderColors.keys.sorted())
 		borderColorsPopup.menu?.delegate = self
 		borderColorsPopup.target = self
 		borderColorsPopup.action = #selector(borderColorChanged)
-		let borderColorTextField = NSTextField(labelWithString: "Border Color:")
+		borderColorsPopup.setAccessibilityLabel(borderColorsPopupLabel)
+		let borderColorTextField = NSTextField(labelWithString: "\(borderColorsPopupLabel):")
 		borderColorTextField.textColor = .white
 		let borderPopupContainer = NSStackView(views: [borderColorTextField, borderColorsPopup])
 
+		let fillColorsPopupLabel = "Fill Color"
 		fillColorsPopup.addItems(withTitles: fillColors.keys.sorted())
 		fillColorsPopup.menu?.delegate = self
 		fillColorsPopup.target = self
 		fillColorsPopup.action = #selector(fillColorChanged)
+		fillColorsPopup.setAccessibilityLabel(fillColorsPopupLabel)
 
-		let fillColorTextField = NSTextField(labelWithString: "Fill Color:")
+		let fillColorTextField = NSTextField(labelWithString: "\(fillColorsPopupLabel):")
 		fillColorTextField.textColor = .white
 		let fillPopupContainer = NSStackView(views: [fillColorTextField, fillColorsPopup])
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Our accessibility test team reported an issue where the NSPopupButton in the Buttons demo controller does not announce the label.
This change makes both the Button and FilledTemplateImage demo controllers compliant by setting the accessibility label of their respective NSPopupButtons.

### Verification

https://user-images.githubusercontent.com/68076145/142279593-0064b8d2-86c3-42b4-94b1-ef57b41854a7.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/802)