### PR TITLE
Update bottom sheet offset when the safe area changes

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -392,6 +392,7 @@ public class BottomSheetController: UIViewController {
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
+
         if size.height != view.frame.height {
             needsOffsetUpdate = true
         }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -400,6 +400,7 @@ public class BottomSheetController: UIViewController {
 
     public override func viewSafeAreaInsetsDidChange() {
         needsOffsetUpdate = true
+        super.viewSafeAreaInsetsDidChange()
     }
 
     public override func viewWillAppear(_ animated: Bool) {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -392,10 +392,13 @@ public class BottomSheetController: UIViewController {
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-
         if size.height != view.frame.height {
             needsOffsetUpdate = true
         }
+    }
+
+    public override func viewSafeAreaInsetsDidChange() {
+        needsOffsetUpdate = true
     }
 
     public override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A change in safe area insets can affect the sheet height and hence the desired sheet offset, so let's make sure we update that after the next layout pass. This also has the nice side effect of ensuring the sheet has the right initial offset, because this callback is guaranteed to be called just before the view appears on screen - https://developer.apple.com/documentation/uikit/uiviewcontroller/2891116-viewsafeareainsetsdidchange

### Verification

Sanity checks in the test app with non-default initial values for isHidden and isExpanded.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/804)