### PR TITLE
Add shouldAlwaysFillWidth API to the bottom sheet

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -85,6 +85,7 @@ class BottomCommandingDemoController: UIViewController {
         return [DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomCommandingController?.isHidden ?? false),
                 DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
                 DemoItem(title: "Sheet more button", type: .boolean, action: #selector(toggleSheetMoreButton), isOn: bottomCommandingController?.prefersSheetMoreButtonVisible ?? true),
+                DemoItem(title: "Sheet should always fill width", type: .boolean, action: #selector(toggleFillWidth), isOn: bottomCommandingController?.sheetShouldAlwaysFillWidth ?? true),
                 DemoItem(title: "Expanded list items", type: .boolean, action: #selector(toggleExpandedItems), isOn: expandedItemsVisible),
                 DemoItem(title: "Additional expanded list items", type: .boolean, action: #selector(toggleAdditionalExpandedItems(_:)), isOn: additionalExpandedItemsVisible),
                 DemoItem(title: "Popover on hero command tap", type: .boolean, action: #selector(toggleHeroPopover)),
@@ -111,6 +112,10 @@ class BottomCommandingDemoController: UIViewController {
 
     @objc private func toggleSheetMoreButton(_ sender: BooleanCell) {
         bottomCommandingController?.prefersSheetMoreButtonVisible = sender.isOn
+    }
+
+    @objc private func toggleFillWidth(_ sender: BooleanCell) {
+        bottomCommandingController?.sheetShouldAlwaysFillWidth = sender.isOn
     }
 
     @objc private func toggleExpandedItems(_ sender: BooleanCell) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -54,6 +54,10 @@ class BottomSheetDemoController: UIViewController {
         bottomSheetViewController?.isHidden = sender.isOn
     }
 
+    @objc private func toggleFillWidth(_ sender: BooleanCell) {
+        bottomSheetViewController?.shouldAlwaysFillWidth = sender.isOn
+    }
+
     @objc private func toggleScrollHiding(_ sender: BooleanCell) {
         scrollHidingEnabled = sender.isOn
     }
@@ -113,6 +117,7 @@ class BottomSheetDemoController: UIViewController {
         [
             DemoItem(title: "Expandable", type: .boolean, action: #selector(toggleExpandable), isOn: bottomSheetViewController?.isExpandable ?? true),
             DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomSheetViewController?.isHidden ?? false),
+            DemoItem(title: "Should always fill width", type: .boolean, action: #selector(toggleFillWidth), isOn: bottomSheetViewController?.shouldAlwaysFillWidth ?? false),
             DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
             DemoItem(title: "Hide collapsed content", type: .boolean, action: #selector(toggleCollapsedContentHiding), isOn: collapsedContentHidingEnabled),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -146,7 +146,7 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    /// Indicates if the sheet should always fill the available width.
+    /// Indicates if the sheet should always fill the available width. The default value is true.
     @objc open var sheetShouldAlwaysFillWidth: Bool = true {
         didSet {
             bottomSheetController?.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -146,6 +146,13 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
+    /// Indicates if the sheet should always fill the available width.
+    @objc open var sheetShouldAlwaysFillWidth: Bool = true {
+        didSet {
+            bottomSheetController?.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth
+        }
+    }
+
     /// A layout guide that covers the on-screen portion of the current commanding view.
     @objc public let commandingLayoutGuide = UILayoutGuide()
 
@@ -359,6 +366,7 @@ open class BottomCommandingController: UIViewController {
         let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
+        sheetController.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth
         sheetController.delegate = self
 
         addChild(sheetController)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -143,7 +143,7 @@ public class BottomSheetController: UIViewController {
         }
     }
 
-    /// Indicates if the sheet should always fill the available width.
+    /// Indicates if the sheet should always fill the available width. The default value is true.
     @objc open var shouldAlwaysFillWidth: Bool = true {
         didSet {
             if shouldAlwaysFillWidth != oldValue {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds an API for a sheet variation that doesn't fill the available width. This is especially useful on iPhone in landscape, where the sheet can waste a lot of horizontal space.
The default value is true, which is the old behavior.

### Verification

Sanity checks with bottom sheet and bottom commanding controllers on iPhone 12, 12 Pro Max, 12 Mini, iPad Pro 11/12.9

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|<img width="1048" alt="Screen Shot 2021-11-22 at 7 49 29 PM" src="https://user-images.githubusercontent.com/3610850/142968846-1a8d98bc-6c74-4129-811d-61dd6b1845ac.png">|<img width="1048" alt="Screen Shot 2021-11-22 at 7 34 49 PM" src="https://user-images.githubusercontent.com/3610850/142968879-f8d1aa10-232e-4f9a-8697-76abfb60dd67.png">|

<img width="1048" alt="Screen Shot 2021-11-22 at 7 34 51 PM" src="https://user-images.githubusercontent.com/3610850/142968900-6a8e7f6d-6bdc-4eac-9869-bc2bf16d7b8b.png">

### Pull request checklist
This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/805)