### PR TITLE
Fix DateTime nav bar on iOS 15

### DIFF
--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -95,21 +95,26 @@ public class FluentUIFramework: NSObject {
 
     static func initializeUINavigationBarAppearance(_ navigationBar: UINavigationBar, traits: UITraitCollection? = nil) {
         navigationBar.isTranslucent = false
-        navigationBar.barTintColor = Colors.NavigationBar.background
-        navigationBar.tintColor = Colors.NavigationBar.tint
-        if #available(iOS 12, *) {
-            let traits = traits ?? navigationBar.traitCollection
-            // Removing built-in shadow for Dark Mode
-            navigationBar.shadowImage = traits.userInterfaceStyle == .dark ? UIImage() : nil
-        }
 
-        var titleAttributes = navigationBar.titleTextAttributes ?? [:]
+        let standardAppearance = navigationBar.standardAppearance
+        navigationBar.tintColor = Colors.NavigationBar.tint
+
+        navigationBar.standardAppearance.backgroundColor = Colors.NavigationBar.background
+
+        let traits = traits ?? navigationBar.traitCollection
+        // Removing built-in shadow for Dark Mode
+        navigationBar.shadowImage = traits.userInterfaceStyle == .dark ? UIImage() : nil
+
+        var titleAttributes = standardAppearance.titleTextAttributes
         titleAttributes[.font] = Fonts.headline
         titleAttributes[.foregroundColor] = Colors.NavigationBar.title
-        navigationBar.titleTextAttributes = titleAttributes
+        standardAppearance.titleTextAttributes = titleAttributes
 
         navigationBar.backIndicatorImage = UIImage.staticImageNamed("back-24x24")
         navigationBar.backIndicatorTransitionMaskImage = navigationBar.backIndicatorImage
+
+        // Update the scroll edge appearance to match the new standard appearance
+        navigationBar.scrollEdgeAppearance = standardAppearance
     }
 
     private static var bundle: Bundle { return Bundle(for: self) }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixed iOS navigation bar on iOS 15.

Reference PRs:
- #733
- #747
- #758

### Verification

- Verified in iOS 13, 14, and 15
- Verified on iPhone and iPad
- Verified Light and Dark modes

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![lb](https://user-images.githubusercontent.com/4934719/143993783-5c116d67-7071-4556-9e85-c5b2095027e7.png) | ![la](https://user-images.githubusercontent.com/4934719/143993779-3383bc0c-a015-4b05-acf2-c74840d21331.png) |
| ![db](https://user-images.githubusercontent.com/4934719/143993787-3f6f6d4b-e345-4515-85dd-2c566b810d28.png) | ![da](https://user-images.githubusercontent.com/4934719/143993791-28ea1332-39e0-4e94-bb80-4076532b283c.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/808)