### PR TITLE
Cherry picking Button danger styles to main_0.1 branch.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -67,6 +67,12 @@ class ButtonDemoController: DemoController {
 extension ButtonStyle {
     var description: String {
         switch self {
+        case .borderless:
+            return "Borderless"
+        case .dangerFilled:
+            return "Danger filled"
+        case .dangerOutline:
+            return "Danger outline"
         case .primaryFilled:
             return "Primary filled"
         case .primaryOutline:
@@ -75,14 +81,12 @@ extension ButtonStyle {
             return "Secondary outline"
         case .tertiaryOutline:
             return "Tertiary outline"
-        case .borderless:
-            return "Borderless"
         }
     }
 
     var image: UIImage? {
         switch self {
-        case .primaryFilled, .primaryOutline:
+        case .dangerFilled, .dangerOutline, .primaryFilled, .primaryOutline:
             return UIImage(named: "Placeholder_24")!
         case .secondaryOutline:
             return UIImage(named: "Placeholder_20")!


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry picking a9e33dc38f2002dea875510a499af80a0d67ba93 (#809) into the main_0.1 branch.

### Verification

Sanity run in an iOS 13 simulator.

| Light mode                                       | Dark mode                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screen Shot 2021-11-29 at 4 07 19 PM](https://user-images.githubusercontent.com/68076145/143962067-414834bd-9f22-4ef0-ac48-f8375872b419.png) | ![Screen Shot 2021-11-29 at 4 07 09 PM](https://user-images.githubusercontent.com/68076145/143962055-c7ba6bfd-34f3-4a8f-bf5a-f76d504cbecf.png) |




### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/810)