### PR TITLE
Fixing Badge Field alignment inside PeoplePicker when no person is selected

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -271,7 +271,7 @@ open class BadgeField: UIView {
 
         var left = labelViewRightOffset
         var lineIndex = 0
-        var badgeHeight: CGFloat = 0.0
+        var badgeHeight: CGFloat = textField.frame.height
 
         for (index, badge) in currentBadges.enumerated() {
             // Don't layout the dragged badge


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
In Badge Field, when no Person are selected, cursor appear outside of Badge Field text area. In the below image, highlighted area is PeoplePicker but BadgeTextField appearing inside the people picker is not aligned with PeoplePicker. 
<img width="300" alt="Screenshot 2021-12-06 at 2 09 51 PM" src="https://user-images.githubusercontent.com/6141891/144818135-30b35a5c-c49e-4e37-8f9f-567371bae20e.png">

This PR fixes the badge Field alignment issue for People Picker.

### Where reviewer should start
**BadgeField.swift** - In BadgeField.swift -> layoutSubviews(), we set the textField alignment based on badgeHeight. We used to set badgeHeight only when there are any badges to show. For empty badges, by default, setting badgeHeight same as textField height.


### Verification
- Tested on simulator that alignment issue is resolved for Badge Field. 
- Validated the flow for dark and light mode.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="300" alt="Screenshot 2021-12-06 at 2 09 51 PM" src="https://user-images.githubusercontent.com/6141891/144819959-ce8a9581-d39d-425b-bf33-eccf8073faf2.png"> | <img width="300" alt="Screenshot 2021-12-06 at 2 50 14 PM" src="https://user-images.githubusercontent.com/6141891/144820208-422bf62a-2bfa-4325-a090-cf3b3c275859.png"> |
| ![Simulator Screen Shot - iPhone 11 - 2021-12-06 at 14 52 08](https://user-images.githubusercontent.com/6141891/144820577-f8b14821-7e41-4a1c-9411-d7b4668645a5.png) | ![Simulator Screen Shot - iPhone 11 - 2021-12-06 at 14 51 14](https://user-images.githubusercontent.com/6141891/144820582-cc9e6d74-7995-4fde-bbb4-3cb07aab05d9.png) |
| ![Simulator Screen Shot - iPhone 11 - 2021-12-06 at 14 52 20](https://user-images.githubusercontent.com/6141891/144820719-fd76b647-fcf7-487b-bebf-f5c95c1aa861.png) | ![Simulator Screen Shot - iPhone 11 - 2021-12-06 at 14 54 46](https://user-images.githubusercontent.com/6141891/144820872-42fc14cf-d26f-4c49-8e10-87c5a3663377.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/818)