### PR TITLE
[iOS 15] Fixing safe area insets when the drawer is being dragged vertically out of screen bounds.

### DIFF
--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -294,19 +294,21 @@ class DrawerPresentationController: UIPresentationController {
         if let presentedView = presentedView {
             let presentedViewFrame = frameForPresentedViewController(in: presentedView.superview == containerView ? contentView.frame : contentView.bounds)
 
-            let isVerticallyPresentedViewPartiallyOffScreen: Bool = {
-                // Calculates the origin of the presentedView frame in relation to the device screen.
-                guard let origin = presentedView.superview?.convert(presentedViewFrame.origin, to: nil) else {
-                    return false
-                }
+            // On iOS 13 and iOS 14 the safeAreaInsets are not applied when the presentedView is not entirely within the screen bounds.
+            // As a workaround, additional safe area insets need to be set to compensate.
+            if #available(iOS 15.0, *) {} else {
+                let isVerticallyPresentedViewPartiallyOffScreen: Bool = {
+                    // Calculates the origin of the presentedView frame in relation to the device screen.
+                    guard let origin = presentedView.superview?.convert(presentedViewFrame.origin, to: nil) else {
+                        return false
+                    }
 
-                return (presentationDirection == .down && origin.y < 0) ||
-                       (presentationDirection == .up && (origin.y + presentedViewFrame.height - UIScreen.main.bounds.height) > 0)
-            }()
+                    return (presentationDirection == .down && origin.y < 0) ||
+                           (presentationDirection == .up && (origin.y + presentedViewFrame.height - UIScreen.main.bounds.height) > 0)
+                }()
 
-            // The safeAreaInsets are not applied when the presentedView is no entirely within the screen bounds.
-            // Additional safe area insets need to be set to compensate.
-            presentedViewController.additionalSafeAreaInsets = isVerticallyPresentedViewPartiallyOffScreen ? contentView.safeAreaInsets : .zero
+                presentedViewController.additionalSafeAreaInsets = isVerticallyPresentedViewPartiallyOffScreen ? contentView.safeAreaInsets : .zero
+            }
 
             presentedView.frame = presentedViewFrame
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Changes made as part of #668 introduced a workaround to make sure the safe area insets of the drawer remained unchanged while it was being dragged out of the screen.
This was likely a bug on Apple's side which got fixed on iOS 15. 

With the workaround in place on iOS15, the opposite unwanted effect happens as the video below shows:


https://user-images.githubusercontent.com/68076145/145085151-e414c323-f167-4001-90cc-0b1dc148da65.mov


This change ensures the workaround mentioned before is only applied on versions previous to iOS 15.

### Verification

Tested the fixed version on iOS 13, 14 and 14 to validate all versions behave as expected:


https://user-images.githubusercontent.com/68076145/145085303-a3837c73-7d0e-4dbd-a28a-bb455c2ecb72.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/820)