### PR TITLE
[Cherry-pick -> main_0.3] Fixing Badge Field alignment inside PeoplePicker when no person is selected.

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -271,7 +271,7 @@ open class BadgeField: UIView {
 
         var left = labelViewRightOffset
         var lineIndex = 0
-        var badgeHeight: CGFloat = 0.0
+        var badgeHeight: CGFloat = textField.frame.height
 
         for (index, badge) in currentBadges.enumerated() {
             // Don't layout the dragged badge


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking commit e0b5629a08d83494a0cfcd24fa7955e653a21d86 into the main_0.3 branch.
This was merged to main by @ashishprasadgit as part of #818.

### Verification

Sanity build and run demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/822)