### PR TITLE
add `maxFontSize` for badgeview

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -271,6 +271,18 @@ open class BadgeView: UIView {
         }
     }
 
+    /**
+     The maximum allowed size point for the label's font. This property can be used
+     to restrict the largest size of the label when scaling due to Dynamic Type. The
+     default value is 0, indicating there is no maximum size.
+     */
+    open var maxFontSize: CGFloat = 0 {
+        didSet {
+            label.maxFontSize = maxFontSize
+            invalidateIntrinsicContentSize()
+        }
+    }
+
     open override var intrinsicContentSize: CGSize {
         return sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
     }
@@ -327,15 +339,7 @@ open class BadgeView: UIView {
     open override func layoutSubviews() {
         super.layoutSubviews()
         backgroundView.frame = bounds
-
-        let labelHeight = label.font.deviceLineHeight
-        let labelSize = label.sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
-        let fittingLabelWidth = UIScreen.main.roundToDevicePixels(labelSize.width)
-
-        let minLabelWidth = minWidth - size.horizontalPadding * 2
-        let maxLabelWidth = frame.width - size.horizontalPadding * 2
-        let labelWidth = max(minLabelWidth, min(maxLabelWidth, fittingLabelWidth))
-        label.frame = CGRect(x: size.horizontalPadding, y: size.verticalPadding, width: labelWidth, height: labelHeight)
+        label.frame = bounds.insetBy(dx: -size.horizontalPadding, dy: -size.verticalPadding)
     }
 
     open func reload() {
@@ -349,7 +353,10 @@ open class BadgeView: UIView {
         let labelSize = label.sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
         let width = UIScreen.main.roundToDevicePixels(labelSize.width) + self.size.horizontalPadding * 2
         let maxWidth = size.width > 0 ? size.width : .infinity
-        return CGSize(width: max(minWidth, min(width, maxWidth)), height: self.size.height)
+        let height = UIScreen.main.roundToDevicePixels(labelSize.height) + self.size.verticalPadding * 2
+        let maxHeight = size.height > 0 ? size.height : .infinity
+
+        return CGSize(width: max(minWidth, min(width, maxWidth)), height: min(height, maxHeight))
     }
 
     open override func didMoveToWindow() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Add `maxFontSize` for clients who need to control the text size of the badgeview label.
Update the logic how the frame is calculated for badgeview so it will dynamically adjust based on label preferred size.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2021-12-09 at 13 14 08](https://user-images.githubusercontent.com/20715435/145476679-2e5303e6-cd6d-4439-963c-d9ca559b0663.png)  | ![Simulator Screen Shot - iPhone 11 Pro Max - 2021-12-09 at 12 00 49](https://user-images.githubusercontent.com/20715435/145476592-142d36f3-2a9e-4078-a43d-d1654e269026.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/827)