### PR TITLE
[NavigationController] Fix: VoiceOver announces hidden profile button.

### DIFF
--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -378,9 +378,9 @@ class LargeTitleView: UIView {
 
         updateAvatarAccessibility()
 
-        // Sets the accessibility elements in the same order as they are laid you in the content view.
-        accessibilityElements = contentStackView.arrangedSubviews.filter({ arrangedSubView in
-            return !arrangedSubView.isHidden
+        // Sets the accessibility elements in the same order as they are laid out in the content view.
+        accessibilityElements = contentStackView.arrangedSubviews.filter({ arrangedSubview in
+            return !arrangedSubview.isHidden
         })
     }
 }

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -135,6 +135,7 @@ class LargeTitleView: UIView {
     private var showsProfileButton: Bool = true { // whether to display the customizable profile button
         didSet {
             avatar?.view.isHidden = !showsProfileButton
+            setupAccessibility()
         }
     }
 
@@ -375,10 +376,12 @@ class LargeTitleView: UIView {
     private func setupAccessibility() {
         titleButton.accessibilityTraits = .header
 
-        // Sets the accessibility elements in the same order as they are laid you in the content view.
-        accessibilityElements = contentStackView.arrangedSubviews
-
         updateAvatarAccessibility()
+
+        // Sets the accessibility elements in the same order as they are laid you in the content view.
+        accessibilityElements = contentStackView.arrangedSubviews.filter({ arrangedSubView in
+            return !arrangedSubView.isHidden
+        })
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Voice Over announces the profile button (Avatar) in the Navigation Bar even when it is hidden.
This change fixes the issue by filtering out the hidden views when setting the accessibility elements of content view of the header bar.

### Verification

Ran accessibility scenarios with Voice Over on a device to ensure the problem is fixed and no other regressions were introduced:

**Before:**

https://user-images.githubusercontent.com/68076145/145878191-07f483e9-052b-4f63-9492-8412deb5f1c3.MP4


**After:**


https://user-images.githubusercontent.com/68076145/145878279-62bb9eba-cd2e-429f-8e85-ab5952bf4a20.MP4



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/829)