### PR TITLE
BottomSheet: Adding custom accessibility labels for the handle.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -62,9 +62,15 @@ class BottomSheetDemoController: UIViewController {
         scrollHidingEnabled = sender.isOn
     }
 
-	@objc private func toggleCollapsedContentHiding(_ sender: BooleanCell) {
-		bottomSheetViewController?.shouldHideCollapsedContent.toggle()
-	}
+    @objc private func toggleCollapsedContentHiding(_ sender: BooleanCell) {
+        bottomSheetViewController?.shouldHideCollapsedContent.toggle()
+    }
+
+    @objc private func toggleHandleUsingCustomAccessibilityLabel(_ sender: BooleanCell) {
+        let isOn = sender.isOn
+        bottomSheetViewController?.handleCollapseCustomAccessibilityLabel = isOn ? "Collapse Bottom Sheet" : nil
+        bottomSheetViewController?.handleExpandCustomAccessibilityLabel = isOn ? "Expand Bottom Sheet" : nil
+    }
 
     @objc private func fullScreenSheetContent() {
         // This is also the default value which results in a full screen sheet.
@@ -109,6 +115,8 @@ class BottomSheetDemoController: UIViewController {
 
     private var collapsedContentHidingEnabled: Bool = true
 
+    private var isHandleUsingCustomAccessibilityLabel: Bool = false
+
     private var isHiding: Bool = false
 
     private var interactiveHidingAnimator: UIViewAnimating?
@@ -120,6 +128,7 @@ class BottomSheetDemoController: UIViewController {
             DemoItem(title: "Should always fill width", type: .boolean, action: #selector(toggleFillWidth), isOn: bottomSheetViewController?.shouldAlwaysFillWidth ?? false),
             DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
             DemoItem(title: "Hide collapsed content", type: .boolean, action: #selector(toggleCollapsedContentHiding), isOn: collapsedContentHidingEnabled),
+            DemoItem(title: "Use custom handle accessibility label", type: .boolean, action: #selector(toggleHandleUsingCustomAccessibilityLabel), isOn: isHandleUsingCustomAccessibilityLabel),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))
         ]

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -110,6 +110,22 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// A string to optionally customize the accessibility label of the bottom sheet handle.
+    /// The message should convey the "Expand" action and will be used when the bottom sheet is collapsed.
+    @objc public var handleExpandCustomAccessibilityLabel: String? {
+        didSet {
+            updateResizingHandleViewAccessibility()
+        }
+    }
+
+    /// A string to optionally customize the accessibility label of the bottom sheet handle.
+    /// The message should convey the "Collapse" action and will be used when the bottom sheet is expanded.
+    @objc public var handleCollapseCustomAccessibilityLabel: String? {
+        didSet {
+            updateResizingHandleViewAccessibility()
+        }
+    }
+
     /// Indicates if the bottom sheet is expanded.
     ///
     /// Changes to this property are animated. A new value is reflected in the getter only after the animation completes.
@@ -431,10 +447,10 @@ public class BottomSheetController: UIViewController {
 
     private func updateResizingHandleViewAccessibility() {
         if currentExpansionState == .expanded {
-            resizingHandleView.accessibilityLabel = "Accessibility.Drawer.ResizingHandle.Label.Collapse".localized
+            resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Collapse".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
         } else {
-            resizingHandleView.accessibilityLabel = "Accessibility.Drawer.ResizingHandle.Label.Expand".localized
+            resizingHandleView.accessibilityLabel = handleExpandCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Expand".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

One of our client apps requested the ability to set a custom accessibility label for the Bottom Sheet handle.
This change adds 2 new properties to set the custom accessibility label of the Bottom Sheet handle for each of its visible state: expanded and collapsed.

### Verification

Ran changes in a physical device in the Voice Over scenario:

https://user-images.githubusercontent.com/68076145/145899362-ecb4f316-0550-481b-8714-66a9591df6f9.MP4



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/830)