### PR TITLE
Convert `ColorValue` from a pure `UInt32` to a wrapper struct

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -207,7 +207,7 @@ open class CustomStyle: FluentUIStyle {
 }
 
 private var customCardNudgeTokens: CardNudgeTokens {
-    let purplePrimary: ColorSet = ColorSet(light: 0x6227A7, dark: 0x7A7FEA)
+    let purplePrimary: ColorSet = ColorSet(light: ColorValue(0x6227A7), dark: ColorValue(0x7A7FEA))
     return CardNudgeTokens(style: .standard,
                            accentColor: purplePrimary,
                            cornerRadius: 0.0,

--- a/ios/FluentUI.Tests/ColorTests.swift
+++ b/ios/FluentUI.Tests/ColorTests.swift
@@ -48,4 +48,34 @@ class ColorTests: XCTestCase {
                            "Index \(index): Background color in dark mode does not match Foreground color in light mode.")
         }
     }
+
+    func testColorValue() {
+        let hexColorValue = ColorValue(0xC7E0F4)
+        XCTAssertEqual(hexColorValue.a, 1.0)
+        XCTAssertEqual(hexColorValue.r, CGFloat(0xC7) / 255.0)
+        XCTAssertEqual(hexColorValue.g, CGFloat(0xE0) / 255.0)
+        XCTAssertEqual(hexColorValue.b, CGFloat(0xF4) / 255.0)
+
+        let rgbaColorValue = ColorValue(r: 0.35, g: 1.0, b: 0.82, a: 0.75)
+        XCTAssertEqual(rgbaColorValue.a, 0.75, accuracy: 0.01)
+        XCTAssertEqual(rgbaColorValue.r, 0.35, accuracy: 0.01)
+        XCTAssertEqual(rgbaColorValue.g, 1.0, accuracy: 0.01)
+        XCTAssertEqual(rgbaColorValue.b, 0.82, accuracy: 0.01)
+    }
+
+    func testColorValueConversions() {
+        let colorValue = ColorValue(r: 0.35, g: 1.0, b: 0.82, a: 0.75)
+        let color = UIColor(colorValue: colorValue)
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+
+        // Verify that UIColor's getters return the same values as ColorValue's
+        XCTAssertTrue(color.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
+        XCTAssertEqual(colorValue.a, alpha)
+        XCTAssertEqual(colorValue.r, red)
+        XCTAssertEqual(colorValue.g, green)
+        XCTAssertEqual(colorValue.b, blue)
+    }
 }

--- a/ios/FluentUI/Core/Theme/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/DynamicColor.swift
@@ -62,8 +62,8 @@ private func dynamicColor(colorSet: ColorSet, colorScheme: ColorScheme, contrast
                                isElevated: isElevated)
 
     // `Color` does not natively support alpha channel, so it will be added as an opacity modifier.
-    Color(red: Double(value.r) / 255.0,
-          green: Double(value.g) / 255.0,
-          blue: Double(value.b) / 255.0)
-        .opacity(Double(value.a) / 255.0)
+    Color(red: value.r,
+          green: value.g,
+          blue: value.b)
+        .opacity(value.a)
 }

--- a/ios/FluentUI/Core/Theme/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/DynamicColor.swift
@@ -61,7 +61,9 @@ private func dynamicColor(colorSet: ColorSet, colorScheme: ColorScheme, contrast
                                contrast: contrast,
                                isElevated: isElevated)
 
-    Color(red: Double((value & 0xFF0000) >> 16) / 255.0,
-          green: Double((value & 0x00FF00) >> 8) / 255.0,
-          blue: Double((value & 0x0000FF) >> 0) / 255.0)
+    // `Color` does not natively support alpha channel, so it will be added as an opacity modifier.
+    Color(red: Double(value.r) / 255.0,
+          green: Double(value.g) / 255.0,
+          blue: Double(value.b) / 255.0)
+        .opacity(Double(value.a) / 255.0)
 }

--- a/ios/FluentUI/Core/Theme/Tokens/ColorSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ColorSet.swift
@@ -7,25 +7,45 @@ import SwiftUI
 
 /// A platform-agnostic representation of a 32-bit RGBA color value.
 public struct ColorValue {
-    var r: UInt8 { UInt8(hexValue & 0xFF000000) }
-    var g: UInt8 { UInt8(hexValue & 0x00FF0000) }
-    var b: UInt8 { UInt8(hexValue & 0x0000FF00) }
-    var a: UInt8 { UInt8(hexValue & 0x000000FF) }
+    var r: CGFloat { CGFloat(hexValue & 0xFF000000) / 255.0 }
+    var g: CGFloat { CGFloat(hexValue & 0x00FF0000) / 255.0 }
+    var b: CGFloat { CGFloat(hexValue & 0x0000FF00) / 255.0 }
+    var a: CGFloat { CGFloat(hexValue & 0x000000FF) / 255.0 }
 
-    /// Creates a color value instance
-    public init(r: UInt8,
-                g: UInt8,
-                b: UInt8,
-                a: UInt8) {
-        hexValue = UInt32((r << 24) | (g << 16) | (b << 8) | a)
-    }
-
-    /// C
+    /// Creates a color value instance with the specified three-channel, 8-bit-per-channel color value, usually in hex.
+    ///
+    /// For example: `0xFF0000` represents red, `0x00FF00` green, and `0x0000FF` blue.
+    /// There is no way to specify an alpha channel via this initializer. For that, use `init(r:g:b:a)` instead.
+    ///
+    /// - Parameter hexValue: The color value to store, in 24-bit (three-channel, 8-bit) RGB.
+    ///
+    /// - Returns: A color object that stores the provided color information.
     public init(_ hexValue: UInt32) {
         self.hexValue = hexValue << 8 | 0xFF
     }
 
-    // Value is stored as RGBA.
+    /// Creates a color value instance with the specified channel values.
+    ///
+    /// Parameters work just like `UIColor`, `NSColor`, or `SwiftUI.Color`, and should all be in the range of `0.0 ≤ value ≤ 1.0`.
+    /// Any channel that is above 1.0 will be clipped down to 1.0; results are undefined for negative inputs.
+    ///
+    /// - Parameter r: The red channel.
+    /// - Parameter g: The green channel.
+    /// - Parameter b: The blue channel.
+    /// - Parameter a: The alpha channel.
+    ///
+    /// - Returns: A color object that stores the provided color information.
+    public init(r: CGFloat,
+                g: CGFloat,
+                b: CGFloat,
+                a: CGFloat) {
+        hexValue = (max(UInt32(r * 255.0), 0xFF) << 24) |
+                   (max(UInt32(g * 255.0), 0xFF) << 16) |
+                   (max(UInt32(b * 255.0), 0xFF) << 8) |
+                   (max(UInt32(a * 255.0), 0xFF))
+    }
+
+    // Value is stored in RGBA format.
     private let hexValue: UInt32
 }
 

--- a/ios/FluentUI/Core/Theme/Tokens/ColorSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ColorSet.swift
@@ -7,9 +7,9 @@ import SwiftUI
 
 /// A platform-agnostic representation of a 32-bit RGBA color value.
 public struct ColorValue {
-    var r: CGFloat { CGFloat(hexValue & 0xFF000000) / 255.0 }
-    var g: CGFloat { CGFloat(hexValue & 0x00FF0000) / 255.0 }
-    var b: CGFloat { CGFloat(hexValue & 0x0000FF00) / 255.0 }
+    var r: CGFloat { CGFloat((hexValue & 0xFF000000) >> 24) / 255.0 }
+    var g: CGFloat { CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0 }
+    var b: CGFloat { CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0 }
     var a: CGFloat { CGFloat(hexValue & 0x000000FF) / 255.0 }
 
     /// Creates a color value instance with the specified three-channel, 8-bit-per-channel color value, usually in hex.
@@ -39,10 +39,10 @@ public struct ColorValue {
                 g: CGFloat,
                 b: CGFloat,
                 a: CGFloat) {
-        hexValue = (max(UInt32(r * 255.0), 0xFF) << 24) |
-                   (max(UInt32(g * 255.0), 0xFF) << 16) |
-                   (max(UInt32(b * 255.0), 0xFF) << 8) |
-                   (max(UInt32(a * 255.0), 0xFF))
+        hexValue = (min(UInt32(r * 255.0), 0xFF) << 24) |
+                   (min(UInt32(g * 255.0), 0xFF) << 16) |
+                   (min(UInt32(b * 255.0), 0xFF) << 8) |
+                   (min(UInt32(a * 255.0), 0xFF))
     }
 
     // Value is stored in RGBA format.

--- a/ios/FluentUI/Core/Theme/Tokens/ColorSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ColorSet.swift
@@ -5,10 +5,29 @@
 
 import SwiftUI
 
-/// An alias that represents a three-channel, 8-bit-per-channel color value, usually in hex.
-///
-/// For example: `0xFF0000` represents red, `0x00FF00` green, and `0x0000FF` blue.
-public typealias ColorValue = UInt32
+/// A platform-agnostic representation of a 32-bit RGBA color value.
+public struct ColorValue {
+    var r: UInt8 { UInt8(hexValue & 0xFF000000) }
+    var g: UInt8 { UInt8(hexValue & 0x00FF0000) }
+    var b: UInt8 { UInt8(hexValue & 0x0000FF00) }
+    var a: UInt8 { UInt8(hexValue & 0x000000FF) }
+
+    /// Creates a color value instance
+    public init(r: UInt8,
+                g: UInt8,
+                b: UInt8,
+                a: UInt8) {
+        hexValue = UInt32((r << 24) | (g << 16) | (b << 8) | a)
+    }
+
+    /// C
+    public init(_ hexValue: UInt32) {
+        self.hexValue = hexValue << 8 | 0xFF
+    }
+
+    // Value is stored as RGBA.
+    private let hexValue: UInt32
+}
 
 /// Represents a set of color values to be used in different contexts.
 public struct ColorSet {

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -23,21 +23,21 @@ public final class GlobalTokens {
     lazy public var brandColors: TokenSet<BrandColorsTokens, ColorSet> = .init { token in
         switch token {
         case .primary:
-            return ColorSet(light: 0x0078D4, dark: 0x0086F0)
+            return ColorSet(light: ColorValue(0x0078D4), dark: ColorValue(0x0086F0))
         case .shade10:
-            return ColorSet(light: 0x106EBE, dark: 0x1890F1)
+            return ColorSet(light: ColorValue(0x106EBE), dark: ColorValue(0x1890F1))
         case .shade20:
-            return ColorSet(light: 0x005A9E, dark: 0x3AA0F3)
+            return ColorSet(light: ColorValue(0x005A9E), dark: ColorValue(0x3AA0F3))
         case .shade30:
-            return ColorSet(light: 0x004578, dark: 0x6CB8F6)
+            return ColorSet(light: ColorValue(0x004578), dark: ColorValue(0x6CB8F6))
         case .tint10:
-            return ColorSet(light: 0x2B88D8, dark: 0x0074D3)
+            return ColorSet(light: ColorValue(0x2B88D8), dark: ColorValue(0x0074D3))
         case .tint20:
-            return ColorSet(light: 0xC7E0F4, dark: 0x004F90)
+            return ColorSet(light: ColorValue(0xC7E0F4), dark: ColorValue(0x004F90))
         case .tint30:
-            return ColorSet(light: 0xDEECF9, dark: 0x002848)
+            return ColorSet(light: ColorValue(0xDEECF9), dark: ColorValue(0x002848))
         case .tint40:
-            return ColorSet(light: 0xEFF6FC, dark: 0x001526)
+            return ColorSet(light: ColorValue(0xEFF6FC), dark: ColorValue(0x001526))
         }
     }
 
@@ -99,107 +99,107 @@ public final class GlobalTokens {
     lazy public var neutralColors: TokenSet<NeutralColorsToken, ColorValue> = .init { token in
         switch token {
         case .black:
-            return 0x000000
+            return ColorValue(0x000000)
         case .grey2:
-            return 0x050505
+            return ColorValue(0x050505)
         case .grey4:
-            return 0x0A0A0A
+            return ColorValue(0x0A0A0A)
         case .grey6:
-            return 0x0F0F0F
+            return ColorValue(0x0F0F0F)
         case .grey8:
-            return 0x141414
+            return ColorValue(0x141414)
         case .grey10:
-            return 0x1A1A1A
+            return ColorValue(0x1A1A1A)
         case .grey12:
-            return 0x1F1F1F
+            return ColorValue(0x1F1F1F)
         case .grey14:
-            return 0x242424
+            return ColorValue(0x242424)
         case .grey16:
-            return 0x292929
+            return ColorValue(0x292929)
         case .grey18:
-            return 0x2E2E2E
+            return ColorValue(0x2E2E2E)
         case .grey20:
-            return 0x333333
+            return ColorValue(0x333333)
         case .grey22:
-            return 0x383838
+            return ColorValue(0x383838)
         case .grey24:
-            return 0x3D3D3D
+            return ColorValue(0x3D3D3D)
         case .grey26:
-            return 0x424242
+            return ColorValue(0x424242)
         case .grey28:
-            return 0x474747
+            return ColorValue(0x474747)
         case .grey30:
-            return 0x4D4D4D
+            return ColorValue(0x4D4D4D)
         case .grey32:
-            return 0x525252
+            return ColorValue(0x525252)
         case .grey34:
-            return 0x575757
+            return ColorValue(0x575757)
         case .grey36:
-            return 0x5C5C5C
+            return ColorValue(0x5C5C5C)
         case .grey38:
-            return 0x616161
+            return ColorValue(0x616161)
         case .grey40:
-            return 0x666666
+            return ColorValue(0x666666)
         case .grey42:
-            return 0x6B6B6B
+            return ColorValue(0x6B6B6B)
         case .grey44:
-            return 0x707070
+            return ColorValue(0x707070)
         case .grey46:
-            return 0x757575
+            return ColorValue(0x757575)
         case .grey48:
-            return 0x7A7A7A
+            return ColorValue(0x7A7A7A)
         case .grey50:
-            return 0x808080
+            return ColorValue(0x808080)
         case .grey52:
-            return 0x858585
+            return ColorValue(0x858585)
         case .grey54:
-            return 0x8A8A8A
+            return ColorValue(0x8A8A8A)
         case .grey56:
-            return 0x8F8F8F
+            return ColorValue(0x8F8F8F)
         case .grey58:
-            return 0x949494
+            return ColorValue(0x949494)
         case .grey60:
-            return 0x999999
+            return ColorValue(0x999999)
         case .grey62:
-            return 0x9E9E9E
+            return ColorValue(0x9E9E9E)
         case .grey64:
-            return 0xA3A3A3
+            return ColorValue(0xA3A3A3)
         case .grey66:
-            return 0xA8A8A8
+            return ColorValue(0xA8A8A8)
         case .grey68:
-            return 0xADADAD
+            return ColorValue(0xADADAD)
         case .grey70:
-            return 0xB3B3B3
+            return ColorValue(0xB3B3B3)
         case .grey72:
-            return 0xB8B8B8
+            return ColorValue(0xB8B8B8)
         case .grey74:
-            return 0xBDBDBD
+            return ColorValue(0xBDBDBD)
         case .grey76:
-            return 0xC2C2C2
+            return ColorValue(0xC2C2C2)
         case .grey78:
-            return 0xC7C7C7
+            return ColorValue(0xC7C7C7)
         case .grey80:
-            return 0xCCCCCC
+            return ColorValue(0xCCCCCC)
         case .grey82:
-            return 0xD1D1D1
+            return ColorValue(0xD1D1D1)
         case .grey84:
-            return 0xD6D6D6
+            return ColorValue(0xD6D6D6)
         case .grey86:
-            return 0xDBDBDB
+            return ColorValue(0xDBDBDB)
         case .grey88:
-            return 0xE0E0E0
+            return ColorValue(0xE0E0E0)
         case .grey90:
-            return 0xE6E6E6
+            return ColorValue(0xE6E6E6)
         case .grey92:
-            return 0xEBEBEB
+            return ColorValue(0xEBEBEB)
         case .grey94:
-            return 0xF0F0F0
+            return ColorValue(0xF0F0F0)
         case .grey96:
-            return 0xF5F5F5
+            return ColorValue(0xF5F5F5)
         case .grey98:
-            return 0xFAFAFA
+            return ColorValue(0xFAFAFA)
         case .white:
-            return 0xFFFFFF
+            return ColorValue(0xFFFFFF)
         }
     }
 

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -110,10 +110,10 @@ extension UIColor {
     }
 
     private var colorValue: ColorValue? {
-        var redValue: CGFloat = 0.0
-        var greenValue: CGFloat = 0.0
-        var blueValue: CGFloat = 0.0
-        var alphaValue: CGFloat = 0.0
+        var redValue: CGFloat = 1.0
+        var greenValue: CGFloat = 1.0
+        var blueValue: CGFloat = 1.0
+        var alphaValue: CGFloat = 1.0
         if self.getRed(&redValue, green: &greenValue, blue: &blueValue, alpha: &alphaValue) {
             let colorValue = ColorValue(r: redValue, g: greenValue, b: blueValue, a: alphaValue)
             return colorValue

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -113,12 +113,9 @@ extension UIColor {
         var redValue: CGFloat = 0.0
         var greenValue: CGFloat = 0.0
         var blueValue: CGFloat = 0.0
-        if self.getRed(&redValue, green: &greenValue, blue: &blueValue, alpha: nil) {
-            // Ensure that all channels fall within 0x0 and 0xFF
-            let red = min(UInt32(redValue * 255.0), 0xFF)
-            let green = min(UInt32(greenValue * 255.0), 0xFF)
-            let blue = min(UInt32(blueValue * 255.0), 0xFF)
-            let colorValue = ColorValue((red << 16) + (green << 8) + blue)
+        var alphaValue: CGFloat = 0.0
+        if self.getRed(&redValue, green: &greenValue, blue: &blueValue, alpha: &alphaValue) {
+            let colorValue = ColorValue(r: redValue, g: greenValue, b: blueValue, a: alphaValue)
             return colorValue
         } else {
             return nil

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -59,16 +59,15 @@ extension UIColor {
         }
     }
 
-    /// Creates a UIColor from a single 32-bit integer value.
+    /// Creates a UIColor from a `ColorValue` instance.
     ///
-    /// - Parameter hexValue: Integer value, generally represented as hexadecimal (e.g. `0x0086F0`), to use to initialize this color.
-    ///     Must be formatted as ARGB. Note: we will not utilize the alpha channel.
+    /// - Parameter colorValue: Color value to use to initialize this color.
     convenience init(colorValue: ColorValue) {
         self.init(
-            red: CGFloat((colorValue & 0xFF0000) >> 16) / 255.0,
-            green: CGFloat((colorValue & 0x00FF00) >> 8) / 255.0,
-            blue: CGFloat((colorValue & 0x0000FF) >> 0) / 255.0,
-            alpha: 1.0)
+            red: Double(colorValue.r) / 255.0,
+            green: Double(colorValue.g) / 255.0,
+            blue: Double(colorValue.b) / 255.0,
+            alpha: Double(colorValue.a) / 255.0)
     }
 
     /// Creates a dynamic color object that returns the appropriate color value based on the current
@@ -119,7 +118,7 @@ extension UIColor {
             let red = min(UInt32(redValue * 255.0), 0xFF)
             let green = min(UInt32(greenValue * 255.0), 0xFF)
             let blue = min(UInt32(blueValue * 255.0), 0xFF)
-            let colorValue: ColorValue = (red << 16) + (green << 8) + blue
+            let colorValue = ColorValue((red << 16) + (green << 8) + blue)
             return colorValue
         } else {
             return nil

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -64,10 +64,10 @@ extension UIColor {
     /// - Parameter colorValue: Color value to use to initialize this color.
     convenience init(colorValue: ColorValue) {
         self.init(
-            red: Double(colorValue.r) / 255.0,
-            green: Double(colorValue.g) / 255.0,
-            blue: Double(colorValue.b) / 255.0,
-            alpha: Double(colorValue.a) / 255.0)
+            red: colorValue.r,
+            green: colorValue.g,
+            blue: colorValue.b,
+            alpha: colorValue.a)
     }
 
     /// Creates a dynamic color object that returns the appropriate color value based on the current


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

At the start of the `vnext-tokens` effort, we decided to keep our internal `ColorValue` as a pure `UInt32`. This was fine when we were only storing 24 bits of information (8 bits each of r, g, and b), but then alpha came in and made everything trickier. ARGB? RGBA? Fractional definitions?

Well, it was nice while it lasted.

Now `ColorValue` is a simple wrapper around a `UInt32`, with two easy initializers: one that takes an old 24-bit hex value (e.g. 0x0078D4 for primary communication blue), and one that takes basic floating-point r, g, b, and a values a la `UIColor`.

### Verification

Ran through the New Token System™ controls to check for regressions. Verified light and dark mode, default and override themes. All is well!

Binary impact is minor: roughly 5 kB total. Not ideal, but necessary to ensure API clarity going forward.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/834)