### PR TITLE
Fixing Toggle issue in PillButtonBar Demo

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -22,9 +22,10 @@ class PillButtonBarDemoController: DemoController {
         let disableOnBrandSwitchView = UISwitch()
         disableOnBrandSwitchView.isOn = true
         disableOnBrandSwitchView.addTarget(self, action: #selector(toggleOnBrandPills(switchView:)), for: .valueChanged)
+        NSLayoutConstraint.activate([disableOnBrandSwitchView.widthAnchor.constraint(equalToConstant: disableOnBrandSwitchView.frame.width)])
 
         container.addArrangedSubview(createLabelWithText("onBrand"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in onBrand Pill Bar"), disableOnBrandSwitchView], itemSpacing: 20, centerItems: true)
+        addRow(items: [createLabelWithText("Enable/Disable pills in onBrand Pill Bar TES TES TES TES"), disableOnBrandSwitchView], itemSpacing: 20, centerItems: true)
         let onBrandBar = createBar(items: items, style: .onBrand)
         container.addArrangedSubview(onBrandBar)
         self.onBrandBar = onBrandBar
@@ -33,6 +34,7 @@ class PillButtonBarDemoController: DemoController {
         let disableCustomOnBrandSwitchView = UISwitch()
         disableCustomOnBrandSwitchView.isOn = true
         disableCustomOnBrandSwitchView.addTarget(self, action: #selector(toggleCustomOnBrandPills(switchView:)), for: .valueChanged)
+        NSLayoutConstraint.activate([disableCustomOnBrandSwitchView.widthAnchor.constraint(equalToConstant: disableCustomOnBrandSwitchView.frame.width)])
 
         container.addArrangedSubview(createLabelWithText("onBrand With Custom Pills Background"))
         addRow(items: [createLabelWithText("Enable/Disable pills in custom onBrand Pill Bar"), disableCustomOnBrandSwitchView], itemSpacing: 20, centerItems: true)
@@ -44,6 +46,7 @@ class PillButtonBarDemoController: DemoController {
         let disablePrimarySwitchView = UISwitch()
         disablePrimarySwitchView.isOn = true
         disablePrimarySwitchView.addTarget(self, action: #selector(togglePrimaryPills(switchView:)), for: .valueChanged)
+        NSLayoutConstraint.activate([disablePrimarySwitchView.widthAnchor.constraint(equalToConstant: disablePrimarySwitchView.frame.width)])
 
         container.addArrangedSubview(createLabelWithText("Primary"))
         addRow(items: [createLabelWithText("Enable/Disable pills in Primary Pill bar"), disablePrimarySwitchView], itemSpacing: 20, centerItems: true)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -25,7 +25,7 @@ class PillButtonBarDemoController: DemoController {
         NSLayoutConstraint.activate([disableOnBrandSwitchView.widthAnchor.constraint(equalToConstant: disableOnBrandSwitchView.frame.width)])
 
         container.addArrangedSubview(createLabelWithText("onBrand"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in onBrand Pill Bar TES TES TES TES"), disableOnBrandSwitchView], itemSpacing: 20, centerItems: true)
+        addRow(items: [createLabelWithText("Enable/Disable pills in onBrand Pill Bar"), disableOnBrandSwitchView], itemSpacing: 20, centerItems: true)
         let onBrandBar = createBar(items: items, style: .onBrand)
         container.addArrangedSubview(onBrandBar)
         self.onBrandBar = onBrandBar


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding an NSLayoutConstraint to each toggle button to prevent them from being pushed offscreen or overlapping when next to long blocks of text (especially when font size is increased on a small screen).

### Verification

Manually tested using the demo app in various font sizes, RTL/LTR languages, different size screens, etc.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/23249106/146459046-f5efc4ac-4e0d-43d3-a0aa-d6d3967021ce.png) | ![image](https://user-images.githubusercontent.com/23249106/146460698-a7055268-66df-4aac-ba79-0b5f60257808.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/835)