### PR TITLE
Fix title overlap when scrolling `TableViewCellDemoController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -8,8 +8,16 @@ import UIKit
 
 // MARK: TableViewCellDemoController
 
-class TableViewCellDemoController: DemoTableViewController {
+class TableViewCellDemoController: UITableViewController {
     let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(style: .grouped)
+    }
+
+    required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
 
     private var isGrouped: Bool = false {
         didSet {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -8,7 +8,7 @@ import UIKit
 
 // MARK: TableViewCellDemoController
 
-class TableViewCellDemoController: DemoController {
+class TableViewCellDemoController: DemoTableViewController {
     let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
 
     private var isGrouped: Bool = false {
@@ -40,8 +40,6 @@ class TableViewCellDemoController: DemoController {
         }
     }
 
-    private var tableView: UITableView!
-
     private var styleButtonTitle: String {
         return isGrouped ? "Switch to Plain style" : "Switch to Grouped style"
     }
@@ -49,16 +47,11 @@ class TableViewCellDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView = UITableView(frame: view.bounds, style: .grouped)
-        tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
-        tableView.dataSource = self
-        tableView.delegate = self
         tableView.separatorStyle = .none
         tableView.sectionFooterHeight = 0
         updateTableView()
-        view.addSubview(tableView)
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Select", style: .plain, target: self, action: #selector(selectionBarButtonTapped))
 
@@ -105,16 +98,16 @@ class TableViewCellDemoController: DemoController {
 
 // MARK: - TableViewCellDemoController: UITableViewDataSource
 
-extension TableViewCellDemoController: UITableViewDataSource {
-    func numberOfSections(in tableView: UITableView) -> Int {
+extension TableViewCellDemoController {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
 
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return TableViewCellSampleData.numberOfItemsInSection
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
             return UITableViewCell()
         }
@@ -160,20 +153,20 @@ extension TableViewCellDemoController: UITableViewDataSource {
 
 // MARK: - TableViewCellDemoController: UITableViewDelegate
 
-extension TableViewCellDemoController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+extension TableViewCellDemoController {
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let section = sections[section]
         header?.setup(style: section.headerStyle, title: section.title)
         return header
     }
 
-    func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, accessoryButtonTappedForRowWith indexPath: IndexPath) {
         let title = sections[indexPath.section].item.text1
         showAlertForDetailButtonTapped(title: title)
     }
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if isInSelectionMode {
             updateNavigationTitle()
         } else {
@@ -181,7 +174,7 @@ extension TableViewCellDemoController: UITableViewDelegate {
         }
     }
 
-    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         if isInSelectionMode {
             updateNavigationTitle()
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR updates `TableViewCellDemoController` to inherit from UITableViewController to fix its broken navigation bar.

Back in [[FHL] Modern Fluent Demo app appearance #761](https://github.com/microsoft/fluentui-apple/pull/761), the demo app's navigation bar was updated to use iOS's large navigation titles, which automatically collapse when their view is scrolled. However, this did not work properly with the `TableViewCellDemoController`, because its view was hosted in a separate subview of the main demo page.

Notes: 
- This PR only affects the demo app, not the actual Fluent library.
- I am not using `DemoTableViewController` because it imposes specific appearance properties that we do not want in this particular demo.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![b](https://user-images.githubusercontent.com/4934719/146824739-73b95683-8c9f-4daf-8f9d-ba023e6f72df.png) | ![a](https://user-images.githubusercontent.com/4934719/146824735-464a9898-a924-4f41-8f11-1cf87c6d34cf.png) |



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/839)