### PR TITLE
[fix] Shy Header is not shown correctly

### DIFF
--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -442,16 +442,8 @@ class ShyHeaderController: UIViewController {
         let momentum: CGFloat = abs(velocity.y)
         let springVelocity = min(momentum, 3.0) // 3.0 arbitrarily decided through manual testing
 
-        /// if the user's finger is not moving, we expand/collapse based on current progress
-        /// otherwise, we use velocity to determine which direction to move the header
-        let expanding: Bool
-        if velocity.y == 0.0 {
-            let currentProgress = shyHeaderView.exposure.progress
-            expanding = currentProgress >= 0.5
-        } else {
-            expanding = velocity.y >= 0.0
-        }
-
+        /// we expand/collapse based on current progress
+        let expanding = shyHeaderView.exposure.progress >= 0.5
         let progress: CGFloat = expanding ? 1.0 : 0.0
 
         UIView.animate(withDuration: ShyHeaderController.Constants.headerShowHideAnimationDuration,


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

When users scroll very fast, then stop the scroll view. velocity.y may be still greater than 0 which will cause the shy header show/hidden unexpectedly. in my understanding, we should depend on currentProgress to tell if we should expand or not.

before:
https://user-images.githubusercontent.com/1324616/146864893-546a2ca5-113b-4e18-ba0a-5c5fb0db8368.MP4


### Verification

Tested in Demo app


### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [X] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/840)