### PR TITLE
Disable largeTitleDisplayMode for `DemoController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -154,5 +154,9 @@ class DemoController: UIViewController {
             container.frame = view.bounds
             container.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         }
+
+        // Child scroll views interfere with largeTitleDisplayMode, so let's
+        // disable it for all DemoController subclasses.
+        self.navigationItem.largeTitleDisplayMode = .never
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

UIKit seems to struggle with `.largeTitleDisplayMode` when (A) its view controller hosts a custom UIScrollView, and (B) the scroll view has been scrolled, backgrounded, and then brought back to the foreground. Since this just affects our test app, not the FluentUI framework itself, the simplest solution is to suppress `.largeTitleDisplayMode` on `DemoController`, which suffers from this exact issue. Demos using `DemoTableViewController` will continue to display large titles as expected.

### Verification

Verified dismissal of app, as well as display of Navigation overlays. Checked both iOS 14 and 15.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![b](https://user-images.githubusercontent.com/4934719/146972604-2005e63f-8dca-49b1-a233-66c133363305.png) | ![a](https://user-images.githubusercontent.com/4934719/146972595-9e992777-ef07-4439-9065-507c9dd82ffa.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/841)