### PR TITLE
[vNext Tokens] Rename ColorSet -> DynamicColor

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ThemingDemoController.swift
@@ -207,7 +207,7 @@ open class CustomStyle: FluentUIStyle {
 }
 
 private var customCardNudgeTokens: CardNudgeTokens {
-    let purplePrimary: ColorSet = ColorSet(light: ColorValue(0x6227A7), dark: ColorValue(0x7A7FEA))
+    let purplePrimary: DynamicColor = DynamicColor(light: ColorValue(0x6227A7), dark: ColorValue(0x7A7FEA))
     return CardNudgeTokens(style: .standard,
                            accentColor: purplePrimary,
                            cornerRadius: 0.0,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -193,7 +193,7 @@
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598026A0FD2800328FD3 /* CardNudge.swift */; };
 		92DEE2252723D34400E31ED0 /* ControlTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE2232723D34400E31ED0 /* ControlTokens.swift */; };
-		92E7AD5026FE51FF00AE7FF8 /* ColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */; };
+		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
@@ -313,7 +313,7 @@
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D5598026A0FD2800328FD3 /* CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudge.swift; sourceTree = "<group>"; };
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
-		92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorSet.swift; sourceTree = "<group>"; };
+		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
@@ -774,8 +774,8 @@
 			isa = PBXGroup;
 			children = (
 				925D461E26FD18B200179583 /* AliasTokens.swift */,
-				92E7AD4E26FE51FF00AE7FF8 /* ColorSet.swift */,
 				92DEE2232723D34400E31ED0 /* ControlTokens.swift */,
+				92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */,
 				925D461B26FD133600179583 /* GlobalTokens.swift */,
 				923DB9D2274CB65700D8E58A /* TokenizedControl.swift */,
 				92EE82AC27025A94009D52B5 /* TokenSet.swift */,
@@ -1543,7 +1543,7 @@
 				5314E28E25F024590099271A /* Date+Extensions.swift in Sources */,
 				5306076126A201C8002D49CF /* Persona.swift in Sources */,
 				53097D292702895500A6E4DC /* MSFDrawerTokens.swift in Sources */,
-				92E7AD5026FE51FF00AE7FF8 /* ColorSet.swift in Sources */,
+				92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */,
 				5314E14E25F016CD0099271A /* ResizingHandleView.swift in Sources */,
 				5314E1A625F01A7C0099271A /* BooleanCell.swift in Sources */,
 				92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */,

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -59,11 +59,11 @@ public struct CardNudge: View, TokenizedControlInternal {
             ZStack {
                 RoundedRectangle(cornerRadius: tokens.circleRadius)
                     .frame(width: tokens.circleSize, height: tokens.circleSize)
-                    .foregroundColor(Color(colorSet: tokens.buttonBackgroundColor))
+                    .foregroundColor(Color(dynamicColor: tokens.buttonBackgroundColor))
                 Image(uiImage: icon)
                     .renderingMode(.template)
                     .frame(width: tokens.iconSize, height: tokens.iconSize, alignment: .center)
-                    .foregroundColor(Color(colorSet: tokens.accentColor))
+                    .foregroundColor(Color(dynamicColor: tokens.accentColor))
             }
             .padding(.trailing, tokens.horizontalPadding)
         }
@@ -80,7 +80,7 @@ public struct CardNudge: View, TokenizedControlInternal {
                 .font(.subheadline)
                 .fontWeight(.medium)
                 .lineLimit(1)
-                .foregroundColor(Color(colorSet: tokens.textColor))
+                .foregroundColor(Color(dynamicColor: tokens.textColor))
 
             if hasSecondTextRow {
                 HStack(spacing: tokens.accentPadding) {
@@ -88,20 +88,20 @@ public struct CardNudge: View, TokenizedControlInternal {
                         Image(uiImage: accentIcon)
                             .renderingMode(.template)
                             .frame(width: tokens.accentIconSize, height: tokens.accentIconSize)
-                            .foregroundColor(Color(colorSet: tokens.accentColor))
+                            .foregroundColor(Color(dynamicColor: tokens.accentColor))
                     }
                     if let accent = state.accentText {
                         Text(accent)
                             .font(.subheadline)
                             .layoutPriority(1)
                             .lineLimit(1)
-                            .foregroundColor(Color(colorSet: tokens.accentColor))
+                            .foregroundColor(Color(dynamicColor: tokens.accentColor))
                     }
                     if let subtitle = state.subtitle {
                         Text(subtitle)
                             .font(.subheadline)
                             .lineLimit(1)
-                            .foregroundColor(Color(colorSet: tokens.subtitleTextColor))
+                            .foregroundColor(Color(dynamicColor: tokens.subtitleTextColor))
                     }
                 }
             }
@@ -119,10 +119,10 @@ public struct CardNudge: View, TokenizedControlInternal {
                 .lineLimit(1)
                 .padding(.horizontal, tokens.buttonInnerPaddingHorizontal)
                 .padding(.vertical, tokens.verticalPadding)
-                .foregroundColor(Color(colorSet: tokens.accentColor))
+                .foregroundColor(Color(dynamicColor: tokens.accentColor))
                 .background(
                     RoundedRectangle(cornerRadius: tokens.circleRadius)
-                        .foregroundColor(Color(colorSet: tokens.buttonBackgroundColor))
+                        .foregroundColor(Color(dynamicColor: tokens.buttonBackgroundColor))
                 )
             }
             if let dismissAction = state.dismissButtonAction {
@@ -134,7 +134,7 @@ public struct CardNudge: View, TokenizedControlInternal {
                 .padding(.horizontal, tokens.buttonInnerPaddingHorizontal)
                 .padding(.vertical, tokens.verticalPadding)
                 .accessibility(identifier: "Accessibility.Dismiss.Label")
-                .foregroundColor(Color(colorSet: tokens.textColor))
+                .foregroundColor(Color(dynamicColor: tokens.textColor))
             }
         }
     }
@@ -158,9 +158,9 @@ public struct CardNudge: View, TokenizedControlInternal {
             .background(
                 RoundedRectangle(cornerRadius: tokens.cornerRadius)
                     .strokeBorder(lineWidth: tokens.outlineWidth)
-                    .foregroundColor(Color(colorSet: tokens.outlineColor))
+                    .foregroundColor(Color(dynamicColor: tokens.outlineColor))
                     .background(
-                        Color(colorSet: tokens.backgroundColor)
+                        Color(dynamicColor: tokens.backgroundColor)
                             .cornerRadius(tokens.cornerRadius)
                     )
             )

--- a/ios/FluentUI/Card Nudge/CardNudgeTokens.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokens.swift
@@ -43,11 +43,11 @@ public class CardNudgeTokens: ControlTokens {
 
     /// Creates an instance of `CardNudgeTokens` with optional token value overrides.
     public init(style: MSFCardNudgeStyle,
-                accentColor: ColorSet? = nil,
+                accentColor: DynamicColor? = nil,
                 accentIconSize: CGFloat? = nil,
                 accentPadding: CGFloat? = nil,
-                backgroundColor: ColorSet? = nil,
-                buttonBackgroundColor: ColorSet? = nil,
+                backgroundColor: DynamicColor? = nil,
+                buttonBackgroundColor: DynamicColor? = nil,
                 buttonInnerPaddingHorizontal: CGFloat? = nil,
                 circleRadius: CGFloat? = nil,
                 circleSize: CGFloat? = nil,
@@ -57,10 +57,10 @@ public class CardNudgeTokens: ControlTokens {
                 interTextVerticalPadding: CGFloat? = nil,
                 mainContentVerticalPadding: CGFloat? = nil,
                 minimumHeight: CGFloat? = nil,
-                outlineColor: ColorSet? = nil,
+                outlineColor: DynamicColor? = nil,
                 outlineWidth: CGFloat? = nil,
-                subtitleTextColor: ColorSet? = nil,
-                textColor: ColorSet? = nil,
+                subtitleTextColor: DynamicColor? = nil,
+                textColor: DynamicColor? = nil,
                 verticalPadding: CGFloat? = nil) {
 
         self.style = style
@@ -131,13 +131,13 @@ public class CardNudgeTokens: ControlTokens {
 
     // MARK: - Design Tokens
 
-    lazy var accentColor: ColorSet = globalTokens.brandColors[.shade20]
+    lazy var accentColor: DynamicColor = globalTokens.brandColors[.shade20]
 
     lazy var accentIconSize: CGFloat = globalTokens.iconSize[.xxSmall]
 
     lazy var accentPadding: CGFloat = globalTokens.spacing[.xxSmall]
 
-    lazy var backgroundColor: ColorSet = {
+    lazy var backgroundColor: DynamicColor = {
         switch style {
         case .standard:
             return aliasTokens.backgroundColors[.neutral2]
@@ -146,7 +146,7 @@ public class CardNudgeTokens: ControlTokens {
         }
     }()
 
-    lazy var buttonBackgroundColor: ColorSet = globalTokens.brandColors[.tint30]
+    lazy var buttonBackgroundColor: DynamicColor = globalTokens.brandColors[.tint30]
 
     lazy var buttonInnerPaddingHorizontal: CGFloat = globalTokens.spacing[.small]
 
@@ -166,7 +166,7 @@ public class CardNudgeTokens: ControlTokens {
 
     lazy var minimumHeight: CGFloat = 56.0
 
-    lazy var outlineColor: ColorSet = {
+    lazy var outlineColor: DynamicColor = {
         switch style {
         case .standard:
             return aliasTokens.backgroundColors[.neutral2]
@@ -177,9 +177,9 @@ public class CardNudgeTokens: ControlTokens {
 
     lazy var outlineWidth: CGFloat = globalTokens.borderSize[.thin]
 
-    lazy var subtitleTextColor: ColorSet = aliasTokens.foregroundColors[.neutral3]
+    lazy var subtitleTextColor: DynamicColor = aliasTokens.foregroundColors[.neutral3]
 
-    lazy var textColor: ColorSet = {
+    lazy var textColor: DynamicColor = {
         switch style {
         case .standard:
             return aliasTokens.foregroundColors[.neutral1]

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -37,7 +37,7 @@ public class CommandBar: UIView, TokenizedControlInternal, ControlConfiguration 
             self.trailingButton = button(forItem: trailingItem, isPersistSelection: false)
         }
 
-        backgroundColor = UIColor(colorSet: tokens.backgroundColor)
+        backgroundColor = UIColor(dynamicColor: tokens.backgroundColor)
         translatesAutoresizingMaskIntoConstraints = false
 
         NotificationCenter.default.addObserver(self,

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -85,23 +85,23 @@ class CommandBarButton: UIButton {
 
     private func updateStyle() {
         let commandBarTokens = self.commandBarTokens
-        tintColor = UIColor(colorSet: isSelected ? commandBarTokens.itemIconColor.selected : commandBarTokens.itemIconColor.rest)
+        tintColor = UIColor(dynamicColor: isSelected ? commandBarTokens.itemIconColor.selected : commandBarTokens.itemIconColor.rest)
         setTitleColor(tintColor, for: .normal)
 
         if !isPersistSelection {
             backgroundColor = .clear
-            tintColor = UIColor(colorSet: commandBarTokens.itemFixedIconColor)
+            tintColor = UIColor(dynamicColor: commandBarTokens.itemFixedIconColor)
         } else {
             if !isEnabled {
-                backgroundColor = UIColor(colorSet: commandBarTokens.itemBackgroundColor.disabled)
-                tintColor = UIColor(colorSet: commandBarTokens.itemIconColor.disabled)
+                backgroundColor = UIColor(dynamicColor: commandBarTokens.itemBackgroundColor.disabled)
+                tintColor = UIColor(dynamicColor: commandBarTokens.itemIconColor.disabled)
             } else if isSelected {
-                backgroundColor = UIColor(colorSet: commandBarTokens.itemBackgroundColor.selected)
+                backgroundColor = UIColor(dynamicColor: commandBarTokens.itemBackgroundColor.selected)
             } else if isHighlighted {
-                backgroundColor = UIColor(colorSet: commandBarTokens.itemBackgroundColor.pressed)
-                tintColor = UIColor(colorSet: commandBarTokens.itemIconColor.pressed)
+                backgroundColor = UIColor(dynamicColor: commandBarTokens.itemBackgroundColor.pressed)
+                tintColor = UIColor(dynamicColor: commandBarTokens.itemIconColor.pressed)
             } else {
-                backgroundColor = UIColor(colorSet: commandBarTokens.itemBackgroundColor.rest)
+                backgroundColor = UIColor(dynamicColor: commandBarTokens.itemBackgroundColor.rest)
             }
         }
     }
@@ -114,8 +114,8 @@ class CommandBarButton: UIButton {
 extension CommandBarButton: UIPointerInteractionDelegate {
     @available(iOS 13.4, *)
     public func pointerInteraction(_ interaction: UIPointerInteraction, willEnter region: UIPointerRegion, animator: UIPointerInteractionAnimating) {
-        backgroundColor = UIColor(colorSet: isSelected ? commandBarTokens.itemBackgroundColor.selected : commandBarTokens.itemBackgroundColor.hover)
-        tintColor = UIColor(colorSet: isSelected ? commandBarTokens.itemIconColor.selected : commandBarTokens.itemIconColor.hover)
+        backgroundColor = UIColor(dynamicColor: isSelected ? commandBarTokens.itemBackgroundColor.selected : commandBarTokens.itemBackgroundColor.hover)
+        tintColor = UIColor(dynamicColor: isSelected ? commandBarTokens.itemIconColor.selected : commandBarTokens.itemIconColor.hover)
     }
 
     @available(iOS 13.4, *)

--- a/ios/FluentUI/Command Bar/CommandBarTokens.swift
+++ b/ios/FluentUI/Command Bar/CommandBarTokens.swift
@@ -5,13 +5,13 @@
 
 import UIKit
 
-/// Represents the set of `ColorSet` values for the various states of a button.
-public struct ButtonColorSets {
-    let rest: ColorSet
-    let hover: ColorSet
-    let pressed: ColorSet
-    let selected: ColorSet
-    let disabled: ColorSet
+/// Represents the set of `DynamicColor` values for the various states of a button.
+public struct ButtonDynamicColors {
+    let rest: DynamicColor
+    let hover: DynamicColor
+    let pressed: DynamicColor
+    let selected: DynamicColor
+    let disabled: DynamicColor
 }
 
 /// Design token set for the `CommandBar` control.
@@ -28,12 +28,12 @@ public class CommandBarTokens: ControlTokens {
     }
 
     /// Creates an instance of `CommandBarTokens` with optional token value overrides.
-    public init(backgroundColor: ColorSet? = nil,
+    public init(backgroundColor: DynamicColor? = nil,
                 groupBorderRadius: CGFloat? = nil,
                 groupInterspace: CGFloat? = nil,
-                itemBackgroundColor: ButtonColorSets? = nil,
-                itemFixedIconColor: ColorSet? = nil,
-                itemIconColor: ButtonColorSets? = nil,
+                itemBackgroundColor: ButtonDynamicColors? = nil,
+                itemFixedIconColor: DynamicColor? = nil,
+                itemIconColor: ButtonDynamicColors? = nil,
                 itemInterspace: CGFloat? = nil) {
 
         super.init()
@@ -61,28 +61,28 @@ public class CommandBarTokens: ControlTokens {
         }
     }
 
-    lazy var backgroundColor: ColorSet = aliasTokens.backgroundColors[.neutral1]
+    lazy var backgroundColor: DynamicColor = aliasTokens.backgroundColors[.neutral1]
 
     lazy var groupBorderRadius: CGFloat = globalTokens.borderRadius[.xLarge]
 
     lazy var groupInterspace: CGFloat = globalTokens.spacing[.medium]
 
-    lazy var itemBackgroundColor: ButtonColorSets = .init(rest: aliasTokens.backgroundColors[.neutral4],
-                                                          hover: ColorSet(light: aliasTokens.backgroundColors[.neutral5].light,
-                                                                          dark: aliasTokens.strokeColors[.neutral2].dark),
-                                                          pressed: ColorSet(light: aliasTokens.backgroundColors[.neutralDisabled].light,
-                                                                            dark: aliasTokens.backgroundColors[.neutral5].dark),
-                                                          selected: aliasTokens.backgroundColors[.brandRest],
-                                                          disabled: aliasTokens.strokeColors[.neutral1])
+    lazy var itemBackgroundColor: ButtonDynamicColors = .init(rest: aliasTokens.backgroundColors[.neutral4],
+                                                              hover: DynamicColor(light: aliasTokens.backgroundColors[.neutral5].light,
+                                                                                  dark: aliasTokens.strokeColors[.neutral2].dark),
+                                                              pressed: DynamicColor(light: aliasTokens.backgroundColors[.neutralDisabled].light,
+                                                                                    dark: aliasTokens.backgroundColors[.neutral5].dark),
+                                                              selected: aliasTokens.backgroundColors[.brandRest],
+                                                              disabled: aliasTokens.strokeColors[.neutral1])
 
-    lazy var itemFixedIconColor: ColorSet = ColorSet(light: aliasTokens.foregroundColors[.neutral1].light,
-                                                     dark: aliasTokens.foregroundColors[.neutral3].dark)
+    lazy var itemFixedIconColor: DynamicColor = .init(light: aliasTokens.foregroundColors[.neutral1].light,
+                                                      dark: aliasTokens.foregroundColors[.neutral3].dark)
 
-    lazy var itemIconColor: ButtonColorSets = .init(rest: aliasTokens.foregroundColors[.neutral1],
-                                                    hover: aliasTokens.foregroundColors[.neutral1],
-                                                    pressed: aliasTokens.foregroundColors[.neutral1],
-                                                    selected: aliasTokens.foregroundColors[.neutralInverted],
-                                                    disabled: aliasTokens.foregroundColors[.neutralDisabled])
+    lazy var itemIconColor: ButtonDynamicColors = .init(rest: aliasTokens.foregroundColors[.neutral1],
+                                                        hover: aliasTokens.foregroundColors[.neutral1],
+                                                        pressed: aliasTokens.foregroundColors[.neutral1],
+                                                        selected: aliasTokens.foregroundColors[.neutralInverted],
+                                                        disabled: aliasTokens.foregroundColors[.neutralDisabled])
 
     lazy var itemInterspace: CGFloat = globalTokens.spacing[.xxxSmall]
 }

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -109,28 +109,28 @@ open class ColorProvidingStyle: FluentUIStyle {
 private func brandedGlobalTokens(provider: ColorProviding, for window: UIWindow) -> GlobalTokens {
     let globalTokens = GlobalTokens()
     let brandColors = globalTokens.brandColors
-    if let primary = provider.primaryColor(for: window)?.colorSet {
+    if let primary = provider.primaryColor(for: window)?.dynamicColor {
         brandColors[.primary] = primary
     }
-    if let tint10 = provider.primaryTint10Color(for: window)?.colorSet {
+    if let tint10 = provider.primaryTint10Color(for: window)?.dynamicColor {
         brandColors[.tint10] = tint10
     }
-    if let tint20 = provider.primaryTint20Color(for: window)?.colorSet {
+    if let tint20 = provider.primaryTint20Color(for: window)?.dynamicColor {
         brandColors[.tint20] = tint20
     }
-    if let tint30 = provider.primaryTint30Color(for: window)?.colorSet {
+    if let tint30 = provider.primaryTint30Color(for: window)?.dynamicColor {
         brandColors[.tint30] = tint30
     }
-    if let tint40 = provider.primaryTint40Color(for: window)?.colorSet {
+    if let tint40 = provider.primaryTint40Color(for: window)?.dynamicColor {
         brandColors[.tint40] = tint40
     }
-    if let shade10 = provider.primaryShade10Color(for: window)?.colorSet {
+    if let shade10 = provider.primaryShade10Color(for: window)?.dynamicColor {
         brandColors[.shade10] = shade10
     }
-    if let shade20 = provider.primaryShade20Color(for: window)?.colorSet {
+    if let shade20 = provider.primaryShade20Color(for: window)?.dynamicColor {
         brandColors[.shade20] = shade20
     }
-    if let shade30 = provider.primaryShade30Color(for: window)?.colorSet {
+    if let shade30 = provider.primaryShade30Color(for: window)?.dynamicColor {
         brandColors[.shade30] = shade30
     }
     return globalTokens

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -16,34 +16,34 @@ public final class AliasTokens {
         case neutralDisabled
         case neutralInverted
     }
-    public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, ColorSet> = .init { [weak self] token in
+    public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .neutral1:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey14],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
-                            dark: strongSelf.globalTokens.neutralColors[.white],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
+                                dark: strongSelf.globalTokens.neutralColors[.white],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
         case .neutral2:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey26],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
-                            dark: strongSelf.globalTokens.neutralColors[.grey84],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey26],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
         case .neutral3:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey38],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.grey14],
-                            dark: strongSelf.globalTokens.neutralColors[.grey68],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey14],
+                                dark: strongSelf.globalTokens.neutralColors[.grey68],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
         case .neutralDisabled:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey74],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                            dark: strongSelf.globalTokens.neutralColors[.grey36],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.grey62])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey62])
         case .neutralInverted:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.white],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.white],
-                            dark: strongSelf.globalTokens.neutralColors[.black],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.black])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.black],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.black])
         }
     }
 
@@ -58,33 +58,33 @@ public final class AliasTokens {
         case neutralDisabled
         case brandRest
     }
-    public lazy var backgroundColors: TokenSet<BackgroundColorsTokens, ColorSet> = .init { [weak self] token in
+    public lazy var backgroundColors: TokenSet<BackgroundColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .neutral1:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.white],
-                            dark: strongSelf.globalTokens.neutralColors[.black],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey4])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.black],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey4])
         case .neutral2:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey98],
-                            dark: strongSelf.globalTokens.neutralColors[.grey4],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey8])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
+                                dark: strongSelf.globalTokens.neutralColors[.grey4],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey8])
         case .neutral3:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey96],
-                            dark: strongSelf.globalTokens.neutralColors[.grey8],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey12])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey96],
+                                dark: strongSelf.globalTokens.neutralColors[.grey8],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey12])
         case .neutral4:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey94],
-                            dark: strongSelf.globalTokens.neutralColors[.grey12],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey16])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
+                                dark: strongSelf.globalTokens.neutralColors[.grey12],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey16])
         case .neutral5:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey92],
-                            dark: strongSelf.globalTokens.neutralColors[.grey36],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
         case .neutralDisabled:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey88],
-                            dark: strongSelf.globalTokens.neutralColors[.grey84],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey84])
         case .brandRest:
             return strongSelf.globalTokens.brandColors[.primary]
         }
@@ -96,21 +96,21 @@ public final class AliasTokens {
         case neutral1
         case neutral2
     }
-    public lazy var strokeColors: TokenSet<StrokeColorsTokens, ColorSet> = .init { [weak self] token in
+    public lazy var strokeColors: TokenSet<StrokeColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .neutral1:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey94],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                            dark: strongSelf.globalTokens.neutralColors[.grey24],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey32])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey24],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey32])
         case .neutral2:
-            return ColorSet(light: strongSelf.globalTokens.neutralColors[.grey88],
-                            lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                            dark: strongSelf.globalTokens.neutralColors[.grey32],
-                            darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
-                            darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey32],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -50,7 +50,7 @@ public struct ColorValue {
 }
 
 /// Represents a set of color values to be used in different contexts.
-public struct ColorSet {
+public struct DynamicColor {
     /// Creates a dynamic color object that wraps a set of color values for various rendering contexts.
     ///
     /// - Parameter light: The default color for a light context. Required.
@@ -170,9 +170,9 @@ extension Color {
     /// Creates a dynamic color object that returns the appropriate color value based on the current
     /// rendering context.
     ///
-    /// - Parameter colorSet: The set of color values that may be applied based on the current context.
-    init(colorSet: ColorSet) {
-        self.init(UIColor(colorSet: colorSet))
+    /// - Parameter dynamicColor: The set of color values that may be applied based on the current context.
+    init(dynamicColor: DynamicColor) {
+        self.init(UIColor(dynamicColor: dynamicColor))
     }
 
     /// Creates a Color from a `ColorValue` instance.

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -20,24 +20,24 @@ public final class GlobalTokens {
         case tint30
         case tint40
     }
-    lazy public var brandColors: TokenSet<BrandColorsTokens, ColorSet> = .init { token in
+    lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
         switch token {
         case .primary:
-            return ColorSet(light: ColorValue(0x0078D4), dark: ColorValue(0x0086F0))
+            return DynamicColor(light: ColorValue(0x0078D4), dark: ColorValue(0x0086F0))
         case .shade10:
-            return ColorSet(light: ColorValue(0x106EBE), dark: ColorValue(0x1890F1))
+            return DynamicColor(light: ColorValue(0x106EBE), dark: ColorValue(0x1890F1))
         case .shade20:
-            return ColorSet(light: ColorValue(0x005A9E), dark: ColorValue(0x3AA0F3))
+            return DynamicColor(light: ColorValue(0x005A9E), dark: ColorValue(0x3AA0F3))
         case .shade30:
-            return ColorSet(light: ColorValue(0x004578), dark: ColorValue(0x6CB8F6))
+            return DynamicColor(light: ColorValue(0x004578), dark: ColorValue(0x6CB8F6))
         case .tint10:
-            return ColorSet(light: ColorValue(0x2B88D8), dark: ColorValue(0x0074D3))
+            return DynamicColor(light: ColorValue(0x2B88D8), dark: ColorValue(0x0074D3))
         case .tint20:
-            return ColorSet(light: ColorValue(0xC7E0F4), dark: ColorValue(0x004F90))
+            return DynamicColor(light: ColorValue(0xC7E0F4), dark: ColorValue(0x004F90))
         case .tint30:
-            return ColorSet(light: ColorValue(0xDEECF9), dark: ColorValue(0x002848))
+            return DynamicColor(light: ColorValue(0xDEECF9), dark: ColorValue(0x002848))
         case .tint40:
-            return ColorSet(light: ColorValue(0xEFF6FC), dark: ColorValue(0x001526))
+            return DynamicColor(light: ColorValue(0xEFF6FC), dark: ColorValue(0x001526))
         }
     }
 

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -73,20 +73,20 @@ extension UIColor {
     /// Creates a dynamic color object that returns the appropriate color value based on the current
     /// rendering context.
     ///
-    /// - Parameter colorSet: The set of color values that may be applied based on the current context.
-    convenience init(colorSet: ColorSet) {
+    /// - Parameter dynamicColor: The set of color values that may be applied based on the current context.
+    convenience init(dynamicColor: DynamicColor) {
         self.init { traits -> UIColor in
-            let colorValue = colorSet.value(colorScheme: (traits.userInterfaceStyle == .dark ? .dark : .light),
+            let colorValue = dynamicColor.value(colorScheme: (traits.userInterfaceStyle == .dark ? .dark : .light),
                                             contrast: traits.accessibilityContrast == .high ? .increased : .standard,
                                             isElevated: traits.userInterfaceLevel == .elevated)
             return UIColor(colorValue: colorValue)
         }
     }
 
-    var colorSet: ColorSet? {
-        // Only the light color value is mandatory when making a ColorSet.
+    var dynamicColor: DynamicColor? {
+        // Only the light color value is mandatory when making a DynamicColor.
         if let lightColorValue = resolvedColorValue(userInterfaceStyle: .light) {
-            let colors = ColorSet(
+            let colors = DynamicColor(
                 light: lightColorValue,
                 lightHighContrast: resolvedColorValue(userInterfaceStyle: .light,
                                                       accessibilityContrast: .high),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Renaming `ColorSet` to `DynamicColor`, which better describes the intent of the class.

This change also brings FUA-iOS into conceptual alignment with FUA:macOS and RN:macOS.

### Verification

Basic verification of `vnext-tokens` components.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/842)