### PR TITLE
[vNext Tokens] Adding `ShadowInfo` and `FontInfo`

### DIFF
--- a/ios/FluentUI.Tests/FontTests.swift
+++ b/ios/FluentUI.Tests/FontTests.swift
@@ -1,0 +1,78 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+import SwiftUI
+@testable import FluentUI
+
+class FontTests: XCTestCase {
+
+    func testBasicFont() throws {
+        // Basic system font
+        let size = 24.0
+        let weight = Font.Weight.regular
+
+        let fontInfo = FontInfo(size: size)
+        let font = Font.fluent(fontInfo)
+        let otherFont = Font.system(size: size).weight(weight)
+        XCTAssertEqual(font, otherFont)
+    }
+
+    func testAdvancedFont() throws {
+        // More advanced font info
+        let name = "Papyrus"
+        let size = 16.0
+        let weight = Font.Weight.semibold
+
+        let fontInfo = FontInfo(name: name, size: size, weight: weight)
+        let font = Font.fluent(fontInfo, shouldScale: false)
+        let otherFont = Font.custom(name, fixedSize: size).weight(weight)
+        XCTAssertEqual(font, otherFont)
+    }
+
+    func testScalingFont() throws {
+        // Scaling
+        let size = 24.0
+        let weight = Font.Weight.regular
+
+        let fontInfo = FontInfo(size: size)
+        let font = Font.fluent(fontInfo, shouldScale: true)
+        let otherFont = Font.system(size: UIFontMetrics.default.scaledValue(for: fontInfo.size)).weight(weight)
+        XCTAssertEqual(font, otherFont)
+    }
+
+    func testBasicUIFont() throws {
+        // Basic system font
+        let size = 24.0
+
+        let fontInfo = FontInfo(size: size)
+        let font = UIFont.fluent(fontInfo)
+        let otherFont = UIFont.systemFont(ofSize: size, weight: UIFont.Weight.regular)
+        XCTAssertEqual(font, otherFont)
+    }
+
+    func testAdvancedUIFont() throws {
+        // More advanced font info
+        let name = "Baskerville"
+        let size = 16.0
+        let weight = Font.Weight.semibold
+
+        let fontInfo = FontInfo(name: name, size: size, weight: weight)
+        let font = UIFont.fluent(fontInfo)
+        let otherFontDescriptor = UIFontDescriptor(name: name.appending("-Semibold"), size: size)
+        let otherFont = UIFont(descriptor: otherFontDescriptor, size: size)
+        XCTAssertEqual(font, otherFont)
+    }
+
+    func testScalingUIFont() throws {
+        // Scaling
+        let size = 24.0
+
+        let fontInfo = FontInfo(size: size)
+        let font = UIFont.fluent(fontInfo, shouldScale: true)
+        let otherFont = UIFont.systemFont(ofSize: UIFontMetrics.default.scaledValue(for: fontInfo.size))
+        XCTAssertEqual(font, otherFont)
+    }
+}

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -181,6 +181,9 @@
 		923DB9D7274CB66D00D8E58A /* ControlHostingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923DB9D6274CB66D00D8E58A /* ControlHostingContainer.swift */; };
 		923DF2E72712B6AB00637646 /* libFluentUI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FD01166228A820600D25925 /* libFluentUI.a */; };
 		923DF2E82712B6C400637646 /* FluentUIResources-ios.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A5DA88FC226FAA01000A8EA8 /* FluentUIResources-ios.bundle */; };
+		924268A2277AD9F700C5A452 /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924268A1277AD9F700C5A452 /* FontTests.swift */; };
+		925728F7276D6AF800EE1019 /* ShadowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925728F6276D6AF800EE1019 /* ShadowInfo.swift */; };
+		925728F9276D6B5800EE1019 /* FontInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925728F8276D6B5800EE1019 /* FontInfo.swift */; };
 		925D461D26FD133600179583 /* GlobalTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D461B26FD133600179583 /* GlobalTokens.swift */; };
 		925D462026FD18B200179583 /* AliasTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D461E26FD18B200179583 /* AliasTokens.swift */; };
 		9275105626815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */; };
@@ -301,6 +304,9 @@
 		923DB9D2274CB65700D8E58A /* TokenizedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenizedControl.swift; sourceTree = "<group>"; };
 		923DB9D3274CB65700D8E58A /* FluentTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentTheme.swift; sourceTree = "<group>"; };
 		923DB9D6274CB66D00D8E58A /* ControlHostingContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlHostingContainer.swift; sourceTree = "<group>"; };
+		924268A1277AD9F700C5A452 /* FontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontTests.swift; sourceTree = "<group>"; };
+		925728F6276D6AF800EE1019 /* ShadowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowInfo.swift; sourceTree = "<group>"; };
+		925728F8276D6B5800EE1019 /* FontInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontInfo.swift; sourceTree = "<group>"; };
 		925D461B26FD133600179583 /* GlobalTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTokens.swift; sourceTree = "<group>"; };
 		925D461E26FD18B200179583 /* AliasTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasTokens.swift; sourceTree = "<group>"; };
 		9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarousel.swift; sourceTree = "<group>"; };
@@ -776,7 +782,9 @@
 				925D461E26FD18B200179583 /* AliasTokens.swift */,
 				92DEE2232723D34400E31ED0 /* ControlTokens.swift */,
 				92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */,
+				925728F8276D6B5800EE1019 /* FontInfo.swift */,
 				925D461B26FD133600179583 /* GlobalTokens.swift */,
+				925728F6276D6AF800EE1019 /* ShadowInfo.swift */,
 				923DB9D2274CB65700D8E58A /* TokenizedControl.swift */,
 				92EE82AC27025A94009D52B5 /* TokenSet.swift */,
 			);
@@ -942,6 +950,7 @@
 				8FA3CB5A246B19EA0049E431 /* ColorTests.swift */,
 				FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */,
 				A5CEC15F20D980B30016922A /* FluentUITests.swift */,
+				924268A1277AD9F700C5A452 /* FontTests.swift */,
 				A5CEC16120D980B30016922A /* Info.plist */,
 			);
 			path = FluentUI.Tests;
@@ -1608,6 +1617,7 @@
 				5314E08A25F00F2D0099271A /* CommandBar.swift in Sources */,
 				5314E18D25F0195C0099271A /* ShimmerView.swift in Sources */,
 				80AECC22263339E5005AF2F3 /* BottomSheetPassthroughView.swift in Sources */,
+				925728F9276D6B5800EE1019 /* FontInfo.swift in Sources */,
 				5314E1CD25F01B730099271A /* AnimationSynchronizer.swift in Sources */,
 				53097D252702890900A6E4DC /* ListCell.swift in Sources */,
 				92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */,
@@ -1626,6 +1636,7 @@
 				92DEE2252723D34400E31ED0 /* ControlTokens.swift in Sources */,
 				5314E0E425F012C00099271A /* NavigationController.swift in Sources */,
 				5373D5712694D66F0032A3B4 /* Theming.swift in Sources */,
+				925728F7276D6AF800EE1019 /* ShadowInfo.swift in Sources */,
 				5328D97326FBA3D700F3723B /* IndeterminateProgressBarModifiers.swift in Sources */,
 				923DB9D7274CB66D00D8E58A /* ControlHostingContainer.swift in Sources */,
 				5314E03B25F00E3D0099271A /* BadgeStringExtractor.swift in Sources */,
@@ -1653,6 +1664,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				924268A2277AD9F700C5A452 /* FontTests.swift in Sources */,
 				A5CEC16020D980B30016922A /* FluentUITests.swift in Sources */,
 				8FA3CB5B246B19EA0049E431 /* ColorTests.swift in Sources */,
 				FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */,

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -15,6 +15,11 @@ public final class AliasTokens {
         case neutral3
         case neutralDisabled
         case neutralInverted
+        case brandRest
+        case brandHover
+        case brandPressed
+        case brandSelected
+        case brandDisabled
     }
     public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
@@ -44,6 +49,20 @@ public final class AliasTokens {
                                 lightHighContrast: strongSelf.globalTokens.neutralColors[.white],
                                 dark: strongSelf.globalTokens.neutralColors[.black],
                                 darkHighContrast: strongSelf.globalTokens.neutralColors[.black])
+        case .brandRest:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.primary].light,
+                                lightHighContrast: strongSelf.globalTokens.brandColors[.shade20].light,
+                                dark: strongSelf.globalTokens.brandColors[.primary].dark,
+                                darkHighContrast: strongSelf.globalTokens.brandColors[.tint20].dark)
+        case .brandHover:
+            return strongSelf.globalTokens.brandColors[.shade10]
+        case .brandPressed:
+            return strongSelf.globalTokens.brandColors[.shade30]
+        case .brandSelected:
+            return strongSelf.globalTokens.brandColors[.shade20]
+        case .brandDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36])
         }
     }
 
@@ -57,6 +76,10 @@ public final class AliasTokens {
         case neutral5
         case neutralDisabled
         case brandRest
+        case brandHover
+        case brandPressed
+        case brandSelected
+        case brandDisabled
     }
     public lazy var backgroundColors: TokenSet<BackgroundColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
@@ -87,6 +110,15 @@ public final class AliasTokens {
                                 darkElevated: strongSelf.globalTokens.neutralColors[.grey84])
         case .brandRest:
             return strongSelf.globalTokens.brandColors[.primary]
+        case .brandHover:
+            return strongSelf.globalTokens.brandColors[.shade10]
+        case .brandPressed:
+            return strongSelf.globalTokens.brandColors[.shade30]
+        case .brandSelected:
+            return strongSelf.globalTokens.brandColors[.shade20]
+        case .brandDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84])
         }
     }
 
@@ -111,6 +143,201 @@ public final class AliasTokens {
                                 dark: strongSelf.globalTokens.neutralColors[.grey32],
                                 darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
                                 darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+        }
+    }
+
+    // MARK: - ShadowColors
+
+    public enum ShadowColorsTokens: CaseIterable {
+        case neutralAmbient
+        case neutralKey
+        case neutralAmbientLighter
+        case neutralKeyLighter
+        case neutralAmbientDarker
+        case neutralKeyDarker
+        case brandAmbient
+        case brandKey
+    }
+    lazy public var shadowColors: TokenSet<ShadowColorsTokens, DynamicColor> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .neutralAmbient:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24))
+        case .neutralKey:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28))
+        case .neutralAmbientLighter:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.06),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12))
+        case .neutralKeyLighter:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.07),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14))
+        case .neutralAmbientDarker:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40))
+        case .neutralKeyDarker:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48))
+        case .brandAmbient:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.30),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.30))
+        case .brandKey:
+            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.25),
+                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.25))
+        }
+    }
+
+    // MARK: - Typography
+
+    public enum TypographyTokens: CaseIterable {
+        case display
+        case largeTitle
+        case title1
+        case title2
+        case title3
+        case body1Strong
+        case body1
+        case body2Strong
+        case body2
+        case caption1Strong
+        case caption1
+        case caption2
+    }
+    lazy public var typography: TokenSet<TypographyTokens, FontInfo> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .display:
+            return .init(size: strongSelf.globalTokens.fontSize[.size900],
+                         weight: strongSelf.globalTokens.fontWeight[.bold])
+        case .largeTitle:
+            return .init(size: strongSelf.globalTokens.fontSize[.size800],
+                         weight: strongSelf.globalTokens.fontWeight[.bold])
+        case .title1:
+            return .init(size: strongSelf.globalTokens.fontSize[.size700],
+                         weight: strongSelf.globalTokens.fontWeight[.bold])
+        case .title2:
+            return .init(size: strongSelf.globalTokens.fontSize[.size600],
+                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+        case .title3:
+            return .init(size: strongSelf.globalTokens.fontSize[.size500],
+                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+        case .body1Strong:
+            return .init(size: strongSelf.globalTokens.fontSize[.size400],
+                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+        case .body1:
+            return .init(size: strongSelf.globalTokens.fontSize[.size400],
+                         weight: strongSelf.globalTokens.fontWeight[.regular])
+        case .body2Strong:
+            return .init(size: strongSelf.globalTokens.fontSize[.size300],
+                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+        case .body2:
+            return .init(size: strongSelf.globalTokens.fontSize[.size300],
+                         weight: strongSelf.globalTokens.fontWeight[.regular])
+        case .caption1Strong:
+            return .init(size: strongSelf.globalTokens.fontSize[.size200],
+                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+        case .caption1:
+            return .init(size: strongSelf.globalTokens.fontSize[.size200],
+                         weight: strongSelf.globalTokens.fontWeight[.regular])
+        case .caption2:
+            return .init(size: strongSelf.globalTokens.fontSize[.size100],
+                         weight: strongSelf.globalTokens.fontWeight[.regular])
+        }
+    }
+
+    // MARK: - Shadow
+
+    public enum ShadowTokens: CaseIterable {
+        case shadow02
+        case shadow04
+        case shadow08
+        case shadow16
+        case shadow28
+        case shadow64
+    }
+    lazy public var shadow: TokenSet<ShadowTokens, ShadowInfo> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .shadow02:
+            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+                              blurOne: 1,
+                              xOne: 0,
+                              yOne: 1,
+                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              blurTwo: 1,
+                              xTwo: 0,
+                              yTwo: 0)
+        case .shadow04:
+            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+                              blurOne: 2,
+                              xOne: 0,
+                              yOne: 2,
+                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              blurTwo: 1,
+                              xTwo: 0,
+                              yTwo: 0)
+        case .shadow08:
+            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+                              blurOne: 4,
+                              xOne: 0,
+                              yOne: 4,
+                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              blurTwo: 1,
+                              xTwo: 0,
+                              yTwo: 0)
+        case .shadow16:
+            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+                              blurOne: 8,
+                              xOne: 0,
+                              yOne: 8,
+                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              blurTwo: 1,
+                              xTwo: 0,
+                              yTwo: 0)
+        case .shadow28:
+            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKeyDarker],
+                              blurOne: 14,
+                              xOne: 0,
+                              yOne: 14,
+                              colorTwo: strongSelf.shadowColors[.neutralAmbientDarker],
+                              blurTwo: 4,
+                              xTwo: 0,
+                              yTwo: 0)
+        case .shadow64:
+            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKeyDarker],
+                              blurOne: 32,
+                              xOne: 0,
+                              yOne: 32,
+                              colorTwo: strongSelf.shadowColors[.neutralAmbientDarker],
+                              blurTwo: 4,
+                              xTwo: 0,
+                              yTwo: 0)
+        }
+    }
+
+    // MARK: Elevation
+
+    public enum ElevationTokens: CaseIterable {
+        case interactiveElevation1Rest
+        case interactiveElevation1Hover
+        case interactiveElevation1Pressed
+        case interactiveElevation1Selected
+        case interactiveElevation1Disabled
+    }
+    lazy public var elevation: TokenSet<ElevationTokens, ShadowInfo> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .interactiveElevation1Rest:
+            return strongSelf.shadow[.shadow08]
+        case .interactiveElevation1Hover:
+            return strongSelf.shadow[.shadow02]
+        case .interactiveElevation1Pressed:
+            return strongSelf.shadow[.shadow02]
+        case .interactiveElevation1Selected:
+            return strongSelf.shadow[.shadow02]
+        case .interactiveElevation1Disabled:
+            return strongSelf.shadow[.shadow02]
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -1,0 +1,94 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public struct FontInfo {
+    public init(name: String? = nil, size: CGFloat, weight: Font.Weight = .regular) {
+        self.name = name
+        self.size = size
+        self.weight = weight
+    }
+
+    let name: String?
+    let size: CGFloat
+    let weight: Font.Weight
+}
+
+// MARK: - ViewModifier
+
+extension Font {
+    static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> Font {
+        let size = shouldScale ?
+            UIFontMetrics.default.scaledValue(for: fontInfo.size) :
+            fontInfo.size
+
+        let font: Font
+        if let name = fontInfo.name {
+            // We use fixedSize because scaling is already managed above.
+            font = .custom(name, fixedSize: size)
+        } else {
+            font = .system(size: size)
+        }
+        return font.weight(fontInfo.weight)
+    }
+}
+
+extension UIFont {
+    static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
+        let size = shouldScale ?
+            UIFontMetrics.default.scaledValue(for: fontInfo.size) :
+            fontInfo.size
+
+        if let name = fontInfo.name,
+           let font = UIFont(name: name, size: size) {
+            return font.withWeight(uiWeight(fontInfo.weight))
+        } else {
+            return .systemFont(ofSize: size, weight: uiWeight(fontInfo.weight))
+        }
+    }
+
+    private func withWeight(_ weight: UIFont.Weight) -> UIFont {
+        var attributes = fontDescriptor.fontAttributes
+        var traits = (attributes[.traits] as? [UIFontDescriptor.TraitKey: Any]) ?? [:]
+
+        traits[.weight] = weight
+
+        // We need to remove `.name` since it may clash with the requested font weight, but
+        // `.family` will ensure that e.g. Helvetica stays Helvetica.
+        attributes[.name] = nil
+        attributes[.traits] = traits
+        attributes[.family] = familyName
+
+        let descriptor = UIFontDescriptor(fontAttributes: attributes)
+
+        return UIFont(descriptor: descriptor, size: pointSize)
+    }
+
+    private static func uiWeight(_ weight: Font.Weight) -> UIFont.Weight {
+        switch weight {
+        case .ultraLight:
+            return .ultraLight
+        case .thin:
+            return .thin
+        case .light:
+            return .light
+        case .regular:
+            return .regular
+        case .medium:
+            return .medium
+        case .semibold:
+            return .semibold
+        case .bold:
+            return .bold
+        case .heavy:
+            return .heavy
+        case .black:
+            return .black
+        default:
+            return .regular
+        }
+    }
+}

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -5,7 +5,18 @@
 
 import SwiftUI
 
+/// Represents the description of a font used by FluentUI components.
 public struct FontInfo {
+
+    /// Creates a `FontInfo` instance using the specified information.
+    ///
+    /// This struct simply stores information about a future font. Fluent will use this information to create the appropriate font object internally as needed.
+    ///
+    /// - Parameter name: An optional name for the font. If none is provided, defaults to the standard system font.
+    /// - Parameter size: The point size to use for the font.
+    /// - Parameter weight: The weight to use for the font. Defaults to `.regular`.
+    ///
+    /// - Returns: A struct containing the information needed to create a font object.
     public init(name: String? = nil, size: CGFloat, weight: Font.Weight = .regular) {
         self.name = name
         self.size = size

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-import CoreGraphics
+import SwiftUI
 
 /// Global Tokens represent a unified set of constants to be used by Fluent UI.
 public final class GlobalTokens {
@@ -200,6 +200,62 @@ public final class GlobalTokens {
             return ColorValue(0xFAFAFA)
         case .white:
             return ColorValue(0xFFFFFF)
+        }
+    }
+
+    // MARK: - FontSize
+    public enum FontSizeToken: CaseIterable {
+        case size100
+        case size200
+        case size300
+        case size400
+        case size500
+        case size600
+        case size700
+        case size800
+        case size900
+    }
+    lazy public var fontSize: TokenSet<FontSizeToken, CGFloat> = .init { token in
+        switch token {
+        case .size100:
+            return 12.0
+        case .size200:
+            return 13.0
+        case .size300:
+            return 15.0
+        case .size400:
+            return 17.0
+        case .size500:
+            return 20.0
+        case .size600:
+            return 22.0
+        case .size700:
+            return 28.0
+        case .size800:
+            return 34.0
+        case .size900:
+            return 60.0
+        }
+    }
+
+    // MARK: - FontWeight
+
+    public enum FontWeightToken: CaseIterable {
+        case regular
+        case medium
+        case semibold
+        case bold
+    }
+    lazy public var fontWeight: TokenSet<FontWeightToken, Font.Weight> = .init { token in
+        switch token {
+        case .regular:
+            return .regular
+        case .medium:
+            return .medium
+        case .semibold:
+            return .semibold
+        case .bold:
+            return .bold
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import CoreGraphics
+
+/// Represents a two-part shadow as used by FluentUI.
+public struct ShadowInfo {
+    let colorOne: DynamicColor
+    let blurOne: CGFloat
+    let xOne: CGFloat
+    let yOne: CGFloat
+    let colorTwo: DynamicColor
+    let blurTwo: CGFloat
+    let xTwo: CGFloat
+    let yTwo: CGFloat
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding what should be the last two token types: `ShadowInfo` and `FontInfo`.

They're pretty self-descriptive, and `ShadowInfo` doesn't even have any logic! There is some in `FontInfo`, namely about creating `UIFont` and `Font` objects from the info in `FontInfo`, so I added some UTs to validate that logic.

### Verification

n/a - these are new tokens, not yet being used in any controls.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/844)