### PR TITLE
Fixing ComponentGovernanceComponentDetection task.

### DIFF
--- a/.ado/fluentui-apple-cgcomponentdetection.yml
+++ b/.ado/fluentui-apple-cgcomponentdetection.yml
@@ -1,3 +1,6 @@
+pool:
+  vmImage: 'ubuntu-latest'
+
 steps:
 - task: ComponentGovernanceComponentDetection@0
   inputs:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The component detection task has been failing for the vnext-prototype as it's pointing to the Ubuntu16 as its default image.
The change updates the workflow file to use 'ubuntu-latest' so we don't risk breaking it when older versions of Ubuntu are removed from the ADO pool.

### Verification

Creating this PR triggers the component detection task which ran successfully.
https://dev.azure.com/microsoftdesign/fluentui-native/_build/results?buildId=17702&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/848)