### PR TITLE
sometimes don't add index info on accessibilityHints in pillbuttonbaritems

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -312,7 +312,12 @@ open class PillButtonBar: UIScrollView {
             let button = createButtonWithItem(item)
             buttons.append(button)
             stackView.addArrangedSubview(button)
-            button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+            
+            // in case pillbuttonbar is used as .tabbar, adding our own index would be repetitive
+            if self.accessibilityTraits != .tabBar {
+                button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+            }
+
             if let customButtonBackgroundColor = self.customPillButtonBackgroundColor {
                 button.customBackgroundColor = customButtonBackgroundColor
             }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -317,7 +317,7 @@ open class PillButtonBar: UIScrollView {
             if #available(iOS 14.6, *) {
                 // in case pillbuttonbar is used as .tabbar, adding our own index would be repetitive
                 // However, iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
-                shouldAddAccessibilityHint = self.accessibilityTraits != .tabBar
+                shouldAddAccessibilityHint = !self.accessibilityTraits.contains(.tabBar)
             }
 
             if shouldAddAccessibilityHint {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -313,8 +313,14 @@ open class PillButtonBar: UIScrollView {
             buttons.append(button)
             stackView.addArrangedSubview(button)
 
-            // in case pillbuttonbar is used as .tabbar, adding our own index would be repetitive
-            if self.accessibilityTraits != .tabBar {
+            var shouldAddAccessibilityHint: Bool = true
+            if #available(iOS 14.6, *) {
+                // in case pillbuttonbar is used as .tabbar, adding our own index would be repetitive
+                // However, iOS 14.0 - 14.5 `.tabBar` accessibilityTrait does not read out the index automatically
+                shouldAddAccessibilityHint = self.accessibilityTraits != .tabBar
+            }
+
+            if shouldAddAccessibilityHint {
                 button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
             }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -312,7 +312,7 @@ open class PillButtonBar: UIScrollView {
             let button = createButtonWithItem(item)
             buttons.append(button)
             stackView.addArrangedSubview(button)
-            
+
             // in case pillbuttonbar is used as .tabbar, adding our own index would be repetitive
             if self.accessibilityTraits != .tabBar {
                 button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -321,7 +321,7 @@ open class PillButtonBar: UIScrollView {
             }
 
             if shouldAddAccessibilityHint {
-                button.accessibilityHint = String(format: "Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+                button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
             }
 
             if let customButtonBackgroundColor = self.customPillButtonBackgroundColor {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

If the client decide to add .tabbar accessibilityTrait on pillbuttonbar, VoiceOver might read the button index twice. Check if the self has the tabbar trait and skip adding custom accessibilityHints on pillbuttonbaritem buttons.

### Verification

VoiceOver iPhone X device testing with Fluent app with and without adding .tabbar trait

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/849)