### PR TITLE
Updating toolBar translucency in UINavigationController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -23,6 +23,7 @@ class DemoListViewController: DemoTableViewController {
         let navigationController = UINavigationController(rootViewController: demoListViewController)
         navigationController.navigationBar.isTranslucent = true
         navigationController.navigationBar.prefersLargeTitles = true
+        navigationController.toolbar.isTranslucent = true
 
         window.rootViewController = navigationController
         window.makeKeyAndVisible()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

One of the updates brought in iOS 15 included an updated UINavigationController, which causes all navigation bars to become opaque and adopt the standard appearance instead. Setting the translucency property to true fixes this. The visual change is only noticeable in light mode.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2022-01-05 at 12 28 24](https://user-images.githubusercontent.com/22566866/148285034-7d6eaa9a-c1e1-49ac-aca2-45da4c4a19e6.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2022-01-05 at 12 20 44](https://user-images.githubusercontent.com/22566866/148285053-26fb4759-91cf-4f52-a605-35854c6e0b06.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/850)