### PR TITLE
Adopt frame based layout in BottomSheetController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -23,7 +23,7 @@ class BottomSheetDemoController: UIViewController {
 
         let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: personaListView)
         bottomSheetViewController.hostedScrollView = personaListView
-        bottomSheetViewController.collapsedContentHeight = BottomSheetDemoController.headerHeight
+        bottomSheetViewController.headerContentHeight = BottomSheetDemoController.headerHeight
         bottomSheetViewController.delegate = self
 
         self.bottomSheetViewController = bottomSheetViewController
@@ -86,7 +86,6 @@ class BottomSheetDemoController: UIViewController {
     private let headerView: UIView = {
         let view = UIView()
         view.backgroundColor = Colors.surfaceQuaternary
-        view.heightAnchor.constraint(equalToConstant: headerHeight).isActive = true
 
         let label = Label()
         label.text = "Header view"

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -364,6 +364,7 @@ open class BottomCommandingController: UIViewController {
         headerView.addSubview(heroCommandStack)
 
         let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
+        sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
         sheetController.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth
@@ -384,7 +385,6 @@ open class BottomCommandingController: UIViewController {
             sheetController.view.topAnchor.constraint(equalTo: view.topAnchor),
             heroCommandStack.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: Constants.BottomSheet.headerLeadingTrailingMargin),
             heroCommandStack.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -Constants.BottomSheet.headerLeadingTrailingMargin),
-            headerView.heightAnchor.constraint(equalToConstant: Constants.BottomSheet.headerHeight),
             heroStackTopConstraint
         ])
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -411,10 +411,14 @@ public class BottomSheetController: UIViewController {
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        if size.height != view.frame.height {
+        if size.height != view.frame.height && currentExpansionState == .intermediate {
             // The view is resizing and we can't guarantee the animation target frame is valid anymore.
             // Completing the animation ensures the sheet will be correctly positioned on the next layout pass
             completeAnimationsIfNeeded(skipToEnd: true)
+
+            if panGestureRecognizer.state != .possible {
+                panGestureRecognizer.state = .cancelled
+            }
         }
     }
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -291,7 +291,7 @@ public class BottomSheetController: UIViewController {
 
         view.addSubview(bottomSheetView)
         bottomSheetView.isHidden = isHidden
-        bottomSheetView.frame = sheetFrame(with: offset(for: currentExpansionState))
+        bottomSheetView.frame = sheetFrame(offset: offset(for: currentExpansionState))
 
         let overflowView = UIView()
         overflowView.translatesAutoresizingMaskIntoConstraints = false
@@ -395,7 +395,7 @@ public class BottomSheetController: UIViewController {
 
     public override func viewWillLayoutSubviews() {
         if currentExpansionState != .intermediate {
-            bottomSheetView.frame = sheetFrame(with: offset(for: currentExpansionState))
+            bottomSheetView.frame = sheetFrame(offset: offset(for: currentExpansionState))
             updateExpandedContentAlpha()
             updateDimmingViewAlpha()
         }
@@ -496,17 +496,17 @@ public class BottomSheetController: UIViewController {
         }
 
         let targetOffset = min(max(bottomSheetView.frame.origin.y + offsetDelta, minOffset), maxOffset)
-        bottomSheetView.frame = sheetFrame(with: targetOffset)
+        bottomSheetView.frame = sheetFrame(offset: targetOffset)
 
         updateExpandedContentAlpha()
         updateDimmingViewAlpha()
     }
 
-    private func sheetFrame(with desiredOffset: CGFloat) -> CGRect {
+    private func sheetFrame(offset: CGFloat) -> CGRect {
         let availableWidth: CGFloat = view.frame.width
         let sheetWidth = max(shouldAlwaysFillWidth ? availableWidth : min(Constants.maxSheetWidth, availableWidth), Constants.minSheetWidth)
 
-        return CGRect(origin: CGPoint(x: (view.frame.width - sheetWidth) / 2, y: desiredOffset),
+        return CGRect(origin: CGPoint(x: (view.frame.width - sheetWidth) / 2, y: offset),
                       size: CGSize(width: sheetWidth, height: expandedSheetHeight))
     }
 
@@ -603,7 +603,7 @@ public class BottomSheetController: UIViewController {
             guard let strongSelf = self else {
                 return
             }
-            strongSelf.bottomSheetView.frame = strongSelf.sheetFrame(with: targetVerticalOffset)
+            strongSelf.bottomSheetView.frame = strongSelf.sheetFrame(offset: targetVerticalOffset)
             strongSelf.view.layoutIfNeeded()
         }
 
@@ -732,6 +732,8 @@ public class BottomSheetController: UIViewController {
             height = min(maxHeight, idealHeight)
         }
 
+        // Min height is required for cases when view.frame is .zero (before the initial layout pass)
+        // This gives the sheet some space to layout in so the Auto Layout engine doesn't complain.
         return max(minHeight, height)
     }
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -36,6 +36,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     case expanded // Sheet is fully expanded
     case collapsed // Sheet is collapsed
     case hidden // Sheet is hidden (fully off-screen)
+    case intermediate // Sheet is in between states, only used during user interaction / animation
 
     // Target alpha of related views like the sheet content or dimming view.
     var relatedViewAlpha: CGFloat { self == .expanded ? 1.0 : 0.0 }
@@ -79,7 +80,6 @@ public class BottomSheetController: UIViewController {
                 panGestureRecognizer.isEnabled = isExpandable
                 if isViewLoaded {
                     move(to: .collapsed, animated: false)
-                    delegate?.bottomSheetControllerCollapsedHeightInSafeAreaDidChange?(self)
                 }
             }
         }
@@ -97,15 +97,26 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// Height of `headerContentView`.
+    ///
+    /// Setting this is required when the `headerContentView` is non-nil.
+    @objc open var headerContentHeight: CGFloat = 0 {
+        didSet {
+            if headerContentHeight != oldValue, isViewLoaded {
+                completeAnimationsIfNeeded(skipToEnd: true)
+                headerContentViewHeightConstraint?.constant = headerContentHeight
+            }
+        }
+    }
+
     /// Preferred height of `expandedContentView`.
     ///
     /// The default value is 0, which results in a full screen sheet expansion.
     @objc open var preferredExpandedContentHeight: CGFloat = 0 {
         didSet {
-            if isViewLoaded {
-                updateSheetSizingConstraints()
+            if preferredExpandedContentHeight != oldValue && isViewLoaded {
                 completeAnimationsIfNeeded(skipToEnd: true)
-                move(to: currentExpansionState, animated: false)
+                view.setNeedsLayout()
             }
         }
     }
@@ -123,13 +134,13 @@ public class BottomSheetController: UIViewController {
     }
 
     /// Height of the top portion of the content view that should be visible when the bottom sheet is collapsed.
-    @objc open var collapsedContentHeight: CGFloat = Constants.defaultCollapsedContentHeight {
+    ///
+    /// When set to 0, `headerContentHeight` will be used.
+    @objc open var collapsedContentHeight: CGFloat = 0 {
         didSet {
-            if isViewLoaded {
-                if currentExpansionState == .collapsed || targetExpansionState == .collapsed {
-                    move(to: .collapsed, animated: false)
-                }
-                delegate?.bottomSheetControllerCollapsedHeightInSafeAreaDidChange?(self)
+            if collapsedContentHeight != oldValue && isViewLoaded {
+                completeAnimationsIfNeeded(skipToEnd: true)
+                view.setNeedsLayout()
             }
         }
     }
@@ -137,8 +148,8 @@ public class BottomSheetController: UIViewController {
     /// Indicates if the content should be hidden when the sheet is collapsed
     @objc open var shouldHideCollapsedContent: Bool = true {
         didSet {
-            if shouldHideCollapsedContent != oldValue {
-                updateExpandedContentAlpha()
+            if shouldHideCollapsedContent != oldValue && isViewLoaded {
+                view.setNeedsLayout()
             }
         }
     }
@@ -146,15 +157,19 @@ public class BottomSheetController: UIViewController {
     /// Indicates if the sheet should always fill the available width. The default value is true.
     @objc open var shouldAlwaysFillWidth: Bool = true {
         didSet {
-            if shouldAlwaysFillWidth != oldValue {
-                updateSheetSizingConstraints()
+            if shouldAlwaysFillWidth != oldValue && isViewLoaded {
+                view.setNeedsLayout()
             }
         }
     }
 
     /// Current height of the portion of a collapsed sheet that's in the safe area.
-    @objc public var collapsedHeightInSafeArea: CGFloat {
-        return offset(for: .collapsed)
+    @objc public private(set) var collapsedHeightInSafeArea: CGFloat = 0 {
+        didSet {
+            if collapsedHeightInSafeArea != oldValue {
+                delegate?.bottomSheetControllerCollapsedHeightInSafeAreaDidChange?(self)
+            }
+        }
     }
 
     /// A layout guide that covers the on-screen portion of the sheet view.
@@ -262,9 +277,11 @@ public class BottomSheetController: UIViewController {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addLayoutGuide(sheetLayoutGuide)
 
+        var constraints = [NSLayoutConstraint]()
+
         if shouldShowDimmingView {
             view.addSubview(dimmingView)
-            NSLayoutConstraint.activate([
+            constraints.append(contentsOf: [
                 dimmingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 dimmingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 dimmingView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -274,43 +291,29 @@ public class BottomSheetController: UIViewController {
 
         view.addSubview(bottomSheetView)
         bottomSheetView.isHidden = isHidden
+        bottomSheetView.frame = sheetFrame(with: offset(for: currentExpansionState))
 
         let overflowView = UIView()
         overflowView.translatesAutoresizingMaskIntoConstraints = false
         overflowView.backgroundColor = Colors.NavigationBar.background
         view.addSubview(overflowView)
 
-        view.addLayoutGuide(maxSheetHeightLayoutGuide)
-        view.addLayoutGuide(preferredExpandedContentLayoutGuide)
+        if let headerContentView = headerContentView {
+            let heightConstraint = headerContentView.heightAnchor.constraint(equalToConstant: headerContentHeight)
+            constraints.append(heightConstraint)
+            headerContentViewHeightConstraint = heightConstraint
+        }
 
-        let preferredExpandedContentTopConstraint = preferredExpandedContentLayoutGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -preferredExpandedContentHeight)
-
-        NSLayoutConstraint.activate([
-            maxSheetHeightLayoutGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            maxSheetHeightLayoutGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            maxSheetHeightLayoutGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            maxSheetHeightLayoutGuide.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constants.minimumTopExpandedPadding),
-            preferredExpandedContentLayoutGuide.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            preferredExpandedContentLayoutGuide.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            preferredExpandedContentLayoutGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            preferredExpandedContentTopConstraint,
-            preferredExpandedContentHeightConstraint,
-            sheetWidthConstraint,
-            bottomSheetView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            bottomSheetView.heightAnchor.constraint(lessThanOrEqualTo: maxSheetHeightLayoutGuide.heightAnchor),
+        constraints.append(contentsOf: [
             overflowView.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
             overflowView.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
             overflowView.heightAnchor.constraint(equalToConstant: Constants.Spring.overflowHeight),
-            overflowView.topAnchor.constraint(equalTo: bottomSheetView.bottomAnchor),
-            bottomSheetOffsetConstraint
+            overflowView.topAnchor.constraint(equalTo: bottomSheetView.bottomAnchor)
         ])
 
-        NSLayoutConstraint.activate(makeLayoutGuideConstraints())
+        constraints.append(contentsOf: makeLayoutGuideConstraints())
 
-        self.preferredExpandedContentGuideTopConstraint = preferredExpandedContentTopConstraint
-
-        updateSheetSizingConstraints()
-        updateResizingHandleViewAccessibility()
+        NSLayoutConstraint.activate(constraints)
     }
 
     private lazy var dimmingView: DimmingView = {
@@ -363,7 +366,6 @@ public class BottomSheetController: UIViewController {
 
     private func makeBottomSheetByEmbedding(contentView: UIView) -> UIView {
         let bottomSheetView = UIView()
-        bottomSheetView.translatesAutoresizingMaskIntoConstraints = false
 
         // We need to have the shadow on a parent of the view that does the corner masking.
         // Otherwise the view will mask its own shadow.
@@ -391,32 +393,23 @@ public class BottomSheetController: UIViewController {
         return bottomSheetView
     }
 
-    public override func viewDidLayoutSubviews() {
-        if needsOffsetUpdate {
-            needsOffsetUpdate = false
-            completeAnimationsIfNeeded(skipToEnd: true)
-            move(to: currentExpansionState, animated: false, velocity: 0.0)
+    public override func viewWillLayoutSubviews() {
+        if currentExpansionState != .intermediate {
+            bottomSheetView.frame = sheetFrame(with: offset(for: currentExpansionState))
+            updateExpandedContentAlpha()
+            updateDimmingViewAlpha()
         }
+        collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
     }
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         if size.height != view.frame.height {
-            needsOffsetUpdate = true
+            // The view is resizing and we can't guarantee the animation target frame is valid anymore.
+            // Completing the animation ensures the sheet will be correctly positioned on the next layout pass
+            completeAnimationsIfNeeded(skipToEnd: true)
         }
-    }
-
-    public override func viewSafeAreaInsetsDidChange() {
-        needsOffsetUpdate = true
-        super.viewSafeAreaInsetsDidChange()
-    }
-
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        updateResizingHandleViewAccessibility()
-        updateExpandedContentAlpha()
     }
 
     // MARK: - Gesture handling
@@ -441,14 +434,14 @@ public class BottomSheetController: UIViewController {
 
     private func updateExpandedContentAlpha() {
         let transitionLength = Constants.expandedContentAlphaTransitionLength
-        let currentOffset = currentOffsetFromBottom
+        let currentOffset = currentSheetVerticalOffset
         let collapsedOffset = offset(for: .collapsed)
 
         var targetAlpha: CGFloat = 1.0
         if shouldHideCollapsedContent {
-            if currentOffset <= collapsedOffset {
+            if currentOffset >= collapsedOffset {
                 targetAlpha = 0.0
-            } else if currentOffset > collapsedOffset && currentOffset < collapsedOffset + transitionLength {
+            } else if currentOffset < collapsedOffset && currentOffset > collapsedOffset - transitionLength {
                 targetAlpha = abs(currentOffset - collapsedOffset) / transitionLength
             }
         }
@@ -460,17 +453,17 @@ public class BottomSheetController: UIViewController {
             return
         }
 
-        let currentOffset = currentOffsetFromBottom
+        let currentOffset = currentSheetVerticalOffset
         let collapsedOffset = offset(for: .collapsed)
         let expandedOffset = offset(for: .expanded)
 
         var targetAlpha: CGFloat = 0.0
-        if currentOffset > expandedOffset {
+        if currentOffset <= expandedOffset {
             targetAlpha = 1.0
-        } else if currentOffset < collapsedOffset {
+        } else if currentOffset >= collapsedOffset {
             targetAlpha = 0.0
         } else {
-            targetAlpha = abs(currentOffset - collapsedOffset) / (expandedOffset - collapsedOffset)
+            targetAlpha = abs(currentOffset - collapsedOffset) / (collapsedOffset - expandedOffset)
         }
         dimmingView.alpha = targetAlpha
     }
@@ -478,13 +471,12 @@ public class BottomSheetController: UIViewController {
     @objc private func handlePan(_ sender: UIPanGestureRecognizer) {
         switch sender.state {
         case .began:
+            currentExpansionState = .intermediate
             completeAnimationsIfNeeded()
             fallthrough
         case .changed:
             translateSheet(by: sender.translation(in: view))
             sender.setTranslation(.zero, in: view)
-            updateExpandedContentAlpha()
-            updateDimmingViewAlpha()
         case .ended, .cancelled, .failed:
             completePan(with: sender.velocity(in: view).y)
         default:
@@ -495,14 +487,27 @@ public class BottomSheetController: UIViewController {
     private func translateSheet(by translationDelta: CGPoint) {
         let expandedOffset = offset(for: .expanded)
         let collapsedOffset = offset(for: .collapsed)
-        let maxOffset = expandedOffset + Constants.maxRubberBandOffset
-        let minOffset = collapsedOffset - Constants.maxRubberBandOffset
+        let minOffset = expandedOffset - Constants.maxRubberBandOffset
+        let maxOffset = collapsedOffset + Constants.maxRubberBandOffset
 
         var offsetDelta = translationDelta.y
-        if currentOffsetFromBottom <= collapsedOffset || currentOffsetFromBottom >= expandedOffset {
-            offsetDelta *= translationRubberBandFactor(for: currentOffsetFromBottom)
+        if currentSheetVerticalOffset >= collapsedOffset || currentSheetVerticalOffset <= expandedOffset {
+            offsetDelta *= translationRubberBandFactor(for: currentSheetVerticalOffset)
         }
-        bottomSheetOffsetConstraint.constant = -min(max(currentOffsetFromBottom - offsetDelta, minOffset), maxOffset)
+
+        let targetOffset = min(max(bottomSheetView.frame.origin.y + offsetDelta, minOffset), maxOffset)
+        bottomSheetView.frame = sheetFrame(with: targetOffset)
+
+        updateExpandedContentAlpha()
+        updateDimmingViewAlpha()
+    }
+
+    private func sheetFrame(with desiredOffset: CGFloat) -> CGRect {
+        let availableWidth: CGFloat = view.frame.width
+        let sheetWidth = max(shouldAlwaysFillWidth ? availableWidth : min(Constants.maxSheetWidth, availableWidth), Constants.minSheetWidth)
+
+        return CGRect(origin: CGPoint(x: (view.frame.width - sheetWidth) / 2, y: desiredOffset),
+                      size: CGSize(width: sheetWidth, height: expandedSheetHeight))
     }
 
     private func translationRubberBandFactor(for currentOffset: CGFloat) -> CGFloat {
@@ -510,10 +515,10 @@ public class BottomSheetController: UIViewController {
         let expandedOffset = offset(for: .expanded)
         let collapsedOffset = offset(for: .collapsed)
 
-        if currentOffset > expandedOffset {
-            offLimitsOffset = min(currentOffset - expandedOffset, Constants.maxRubberBandOffset)
-        } else if currentOffset < collapsedOffset {
-            offLimitsOffset = min(collapsedOffset - currentOffset, Constants.maxRubberBandOffset)
+        if currentOffset < expandedOffset {
+            offLimitsOffset = min(expandedOffset - currentOffset, Constants.maxRubberBandOffset)
+        } else if currentOffset > collapsedOffset {
+            offLimitsOffset = min(currentOffset - collapsedOffset, Constants.maxRubberBandOffset)
         }
 
         return max(1.0 - offLimitsOffset / Constants.maxRubberBandOffset, Constants.minRubberBandScaleFactor)
@@ -526,7 +531,7 @@ public class BottomSheetController: UIViewController {
         if abs(velocity) < Constants.directionOverrideVelocityThreshold {
             // Velocity too low, snap to the closest offset
             targetState =
-                abs(offset(for: .collapsed) - currentOffsetFromBottom) < abs(offset(for: .expanded) - currentOffsetFromBottom)
+                abs(offset(for: .collapsed) - currentSheetVerticalOffset) < abs(offset(for: .expanded) - currentSheetVerticalOffset)
                 ? .collapsed
                 : .expanded
         } else {
@@ -548,9 +553,8 @@ public class BottomSheetController: UIViewController {
         }
 
         completeAnimationsIfNeeded()
-        let targetOffsetFromBottom = offset(for: targetExpansionState)
 
-        if currentOffsetFromBottom != targetOffsetFromBottom {
+        if currentSheetVerticalOffset != offset(for: targetExpansionState) {
             let animator = stateChangeAnimator(to: targetExpansionState, velocity: velocity)
             animator.addCompletion({ finalPosition in
                 completion?(finalPosition)
@@ -573,8 +577,8 @@ public class BottomSheetController: UIViewController {
                                      velocity: CGFloat = 0.0,
                                      interaction: BottomSheetInteraction = .noUserAction,
                                      shouldNotifyDelegate: Bool = true) -> UIViewPropertyAnimator {
-        let targetOffsetFromBottom = offset(for: targetExpansionState)
-        let distanceToGo = abs(currentOffsetFromBottom - targetOffsetFromBottom)
+        let targetVerticalOffset = offset(for: targetExpansionState)
+        let distanceToGo = abs(currentSheetVerticalOffset - targetVerticalOffset)
         let springVelocity = min(abs(velocity / distanceToGo), Constants.Spring.maxInitialVelocity)
         let damping: CGFloat = abs(velocity) > Constants.Spring.flickVelocityThreshold
             ? Constants.Spring.oscillatingDampingRatio
@@ -590,16 +594,17 @@ public class BottomSheetController: UIViewController {
             panGestureRecognizer.isEnabled = false
         }
 
-        view.layoutIfNeeded()
-
         // Animation might be reversed, so we need to remember the original state
         let originalBottomSheetHiddenState = bottomSheetView.isHidden
-        let originalBottomOffsetConstant = bottomSheetOffsetConstraint.constant
+        let originalExpansionState = currentExpansionState
 
         bottomSheetView.isHidden = false
-        bottomSheetOffsetConstraint.constant = -targetOffsetFromBottom
         translationAnimator.addAnimations { [weak self] in
-            self?.view.layoutIfNeeded()
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.bottomSheetView.frame = strongSelf.sheetFrame(with: targetVerticalOffset)
+            strongSelf.view.layoutIfNeeded()
         }
 
         let targetRelatedViewAlpha = targetExpansionState.relatedViewAlpha
@@ -626,28 +631,29 @@ public class BottomSheetController: UIViewController {
                 strongSelf.handleCompletedStateChange(to: targetExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
             } else if finalPosition == .start {
                 strongSelf.bottomSheetView.isHidden = originalBottomSheetHiddenState
-                strongSelf.bottomSheetOffsetConstraint.constant = originalBottomOffsetConstant
-            } else {
-                // The constraint constant doesn't animate, so we need to set it to whatever it should be
-                // based on the frame calculated during the interrupted animation
-                let offsetFromBottom = strongSelf.view.frame.height - strongSelf.bottomSheetView.frame.origin.y - strongSelf.view.safeAreaInsets.bottom
-                strongSelf.bottomSheetOffsetConstraint.constant = -offsetFromBottom
+                strongSelf.currentExpansionState = originalExpansionState
             }
         })
+
+        currentExpansionState = .intermediate
         translationAnimator.pauseAnimation()
         return translationAnimator
     }
 
+    // Vertical offset of bottomSheetView.origin for the given expansion state
     private func offset(for expansionState: BottomSheetExpansionState) -> CGFloat {
         var offset: CGFloat
 
         switch expansionState {
         case .collapsed:
-            offset = collapsedContentHeight + (isExpandable ? ResizingHandleView.height : 0.0)
+            let desiredVisiblePortion = (collapsedContentHeight > 0) ? collapsedContentHeight : headerContentHeight
+            offset = view.frame.maxY - (desiredVisiblePortion + (isExpandable ? ResizingHandleView.height : 0.0) + view.safeAreaInsets.bottom)
         case .expanded:
-            offset = bottomSheetView.frame.height - view.safeAreaInsets.bottom
+            offset = view.frame.maxY - expandedSheetHeight
         case .hidden:
-            offset = -view.safeAreaInsets.bottom
+            offset = view.frame.maxY
+        case .intermediate:
+            offset = bottomSheetView.frame.minY
         }
 
         return offset
@@ -668,9 +674,6 @@ public class BottomSheetController: UIViewController {
         if targetExpansionState == .hidden {
             bottomSheetView.isHidden = true
         }
-
-        updateResizingHandleViewAccessibility()
-        updateExpandedContentAlpha()
     }
 
     private func completeAnimationsIfNeeded(skipToEnd: Bool = false) {
@@ -679,31 +682,6 @@ public class BottomSheetController: UIViewController {
             currentAnimator.stopAnimation(false)
             currentAnimator.finishAnimation(at: skipToEnd ? endPosition : .current)
             currentStateChangeAnimator = nil
-        }
-    }
-
-    private func updateSheetSizingConstraints() {
-        if shouldAlwaysFillWidth {
-            sheetMaxWidthConstraint.isActive = false
-            sheetWidthConstraint.priority = .required
-        } else {
-            sheetWidthConstraint.priority = .defaultHigh
-            sheetMaxWidthConstraint.isActive = true
-        }
-
-        if preferredExpandedContentHeight > 0 {
-            fullScreenSheetConstraint.isActive = false
-
-            // Apply the new preferred height to the static layout guide
-            preferredExpandedContentGuideTopConstraint?.constant = -preferredExpandedContentHeight
-
-            // Activate constraint which ties expandedContentView height to the layout guide height
-            preferredExpandedContentHeightConstraint.isActive = true
-
-        } else {
-            // Tie the sheet size to maxSheetHeightLayoutGuide.heightAnchor to make it full screen
-            preferredExpandedContentHeightConstraint.isActive = false
-            fullScreenSheetConstraint.isActive = true
         }
     }
 
@@ -722,45 +700,39 @@ public class BottomSheetController: UIViewController {
         return requiredConstraints + [breakableConstraint]
     }
 
-    private lazy var preferredExpandedContentHeightConstraint: NSLayoutConstraint = {
-        let constraint = expandedContentView.heightAnchor.constraint(equalTo: preferredExpandedContentLayoutGuide.heightAnchor)
-        constraint.priority = .defaultHigh // Lower than required so Auto Layout can enforce max sheet height
-        return constraint
-    }()
-
-    private lazy var fullScreenSheetConstraint: NSLayoutConstraint = {
-        let constraint = bottomSheetView.heightAnchor.constraint(equalTo: maxSheetHeightLayoutGuide.heightAnchor)
-        constraint.priority = .defaultHigh // Lower than required so Auto Layout can enforce max sheet height
-        return constraint
-    }()
-
-    private lazy var sheetWidthConstraint: NSLayoutConstraint = bottomSheetView.widthAnchor.constraint(equalTo: view.widthAnchor)
-
-    private lazy var sheetMaxWidthConstraint: NSLayoutConstraint = bottomSheetView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxSheetWidth)
-
-    private lazy var maxSheetHeightLayoutGuide: UILayoutGuide = UILayoutGuide()
-
-    private lazy var preferredExpandedContentLayoutGuide: UILayoutGuide = UILayoutGuide()
-
-    private var preferredExpandedContentGuideTopConstraint: NSLayoutConstraint?
-
-    private lazy var bottomSheetOffsetConstraint: NSLayoutConstraint =
-        bottomSheetView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -offset(for: currentExpansionState))
-
     private lazy var panGestureRecognizer: UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
+
+    private var headerContentViewHeightConstraint: NSLayoutConstraint?
 
     private var currentStateChangeAnimator: UIViewPropertyAnimator?
 
-    private var needsOffsetUpdate: Bool = false
-
-    private var currentExpansionState: BottomSheetExpansionState = .collapsed
+    private var currentExpansionState: BottomSheetExpansionState = .collapsed {
+        didSet {
+            updateResizingHandleViewAccessibility()
+        }
+    }
 
     private var targetExpansionState: BottomSheetExpansionState?
 
     private var isHiddenOrHiding: Bool { isHidden || targetExpansionState == .hidden }
 
-    private var currentOffsetFromBottom: CGFloat {
-        -bottomSheetOffsetConstraint.constant
+    private var currentSheetVerticalOffset: CGFloat {
+        bottomSheetView.frame.minY
+    }
+
+    private var expandedSheetHeight: CGFloat {
+        var height: CGFloat = 0
+        let minHeight = headerContentHeight + (isExpandable ? ResizingHandleView.height : 0.0)
+        let maxHeight: CGFloat = view.frame.height - view.safeAreaInsets.top - Constants.minimumTopExpandedPadding
+
+        if preferredExpandedContentHeight == 0 {
+            height = maxHeight
+        } else {
+            let idealHeight = minHeight + preferredExpandedContentHeight + view.safeAreaInsets.bottom
+            height = min(maxHeight, idealHeight)
+        }
+
+        return max(minHeight, height)
     }
 
     private let shouldShowDimmingView: Bool
@@ -776,13 +748,13 @@ public class BottomSheetController: UIViewController {
 
         // Minimum padding from top when the sheet is fully expanded
         static let minimumTopExpandedPadding: CGFloat = 25.0
-        static let defaultCollapsedContentHeight: CGFloat = 75
 
         static let cornerRadius: CGFloat = 14
 
         static let expandedContentAlphaTransitionLength: CGFloat = 30
 
         static let maxSheetWidth: CGFloat = 610
+        static let minSheetWidth: CGFloat = 300
 
         struct Spring {
             // Spring used in slow swipes - no oscillation
@@ -822,7 +794,7 @@ extension BottomSheetController: UIGestureRecognizerDelegate {
             return true
         }
         var shouldBegin = true
-        let fullyExpanded = currentOffsetFromBottom >= offset(for: .expanded)
+        let fullyExpanded = currentSheetVerticalOffset <= offset(for: .expanded)
 
         if fullyExpanded {
             let scrolledToTop = scrollView.contentOffset.y <= 0


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#### Problem
**TL;DR: Sizing and positioning the sheet using Auto Layout was causing more problems than it was solving. Directly calculating the frame simplifies the code and sets us up for future planned additions to the bottom sheet.**

The bottom sheet will soon be used in a new experience in our apps which requires a non-rigid mode i.e. the sheet height will change as the user expands the sheet. In preparation for this change, we need more control over how the sheet is sized.

The sheet is currently sized and positioned using constraints, however it turns out this has several problems:
- the height is determined using a complicated set of UILayoutGuides, this is hard to read by new contributors and doesn't extend well to a flexible height mode
- the width sometimes has to fill parent, sometimes not, which adds more constraints
- vertical position is set using a constant,  so we don't benefit from any Auto Layout magic here
- vertical position also depends on the height, so we need to do a dance of waiting for the layout pass to complete and only updating the offset constraint after that, which can trigger another layout pass
- all animations are frame-based (this is a UIKit limitation), so when an animation is interrupted, we need to convert between constraint offsets and the intermediate frame origin
- the sheet sometimes behaves strangely while rotating the screen, it doesn't stay attached to the bottom edge when the animation is in progress
- many more bits that I can't think of ....

So we already do a lot of calculation and barely benefit from Auto Layout's declarative magic.
Manually calculating the frame for any given state is actually fairly simple and we already do most of it anyways. It has many benefits, like a single source of truth for panning / animating / static positioning, simpler code, and easy implementation of the future flexible mode.

#### Solution
- Add a single source of truth for sheet size and position at any given offset - `func sheetFrame(offset:)`.
- Add `headerContentHeight` property which was the last piece missing to let us directly calculate sheet height.
- Add an `.intermediate` sheet expansion state so we are explicit about being in between states.
- In our viewDidLayoutSubviews override, recalculate sheet size and position if we're not in `.intermediate` state. This is a very cheap constant time calculation so we can afford to do it on every layout pass.
- Remove tons of constraints and layout guides that were used for Auto Layout.
- Sheet offset is now just `bottomSheetView.frame.minY` which is an offset from top, so we need to flip a bunch of conditions from the previous constraint-based offset.
- Simplify multiple property change handlers to just call view.setNeedsLayout().

### Verification

- Sanity checks of all sheet features both in `BotomSheetController` and `BottomCommandingController`.
- Tests of animation interruptions, rotating while animating, panning while animating. 
- Interactive sheet hiding.

No visual or functional change, other than fixing a glitch on screen rotation.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/855)