### PR TITLE
Fixing regression introduced in UIViewAdapter.

### DIFF
--- a/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
@@ -15,15 +15,19 @@ struct UIViewAdapter: UIViewRepresentable {
         self.makeView = makeView
     }
 
-    func makeUIView(context: Context) -> UIView {
-        let view = makeView()
-
-        // Ensures that the UIView respects the frame defined in the SwiftUI layer.
-        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
-        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        return view
+    func makeUIView(context: Context) -> UIStackView {
+        // Using a UIStackView as the container ensures that the content
+        // UIView respects the frame defined in the SwiftUI layer.
+        return UIStackView(arrangedSubviews: [makeView()])
     }
 
-    func updateUIView(_ view: UIView, context: Context) { }
+    func updateUIView(_ stackview: UIStackView, context: Context) {
+        // The UIStackView container needs to update its arranged subviews to cover
+        // the case where the makeview property now provides a different view.
+        stackview.arrangedSubviews.forEach({ subview in
+            subview.removeFromSuperview()
+        })
+
+        stackview.addArrangedSubview(makeView())
+    }
 }

--- a/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
@@ -6,7 +6,7 @@
 import UIKit
 import SwiftUI
 
-/// This is a generic UIView wrapper to allow SwiftUI to use views from non-SwiftUI environments.
+/// This is a generic UIView wrapper that allows SwiftUI to use UIKit views in its hierarchy.
 struct UIViewAdapter: UIViewRepresentable {
 
     var makeView: () -> UIView
@@ -16,18 +16,14 @@ struct UIViewAdapter: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> UIView {
-        return makeView()
+        let view = makeView()
+
+        // Ensures that the UIView respects the frame defined in the SwiftUI layer.
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        return view
     }
 
-    func updateUIView(_ view: UIView, context: Context) {
-        // This logic should be removed wnce the "wrapping in a UIStackView" workaround is removed.
-        guard let stackView = view as? UIStackView else {
-            return
-        }
-
-        for view in stackView.arrangedSubviews {
-            view.removeFromSuperview()
-        }
-        stackView.addArrangedSubview(makeView())
-    }
+    func updateUIView(_ view: UIView, context: Context) { }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Commit aa90caa3224f2b5ea0450c9b46c3216576393ca9 (#815) partially removed the UIStackView workaround from the UIViewAdapter class which was needed to prevent a hang on iOS 13.

Another workaround was introduced as part of #442 to address the status cell in the LeftNav which was not updating its leading view when set by the status selection below it.

After experimentations with the UIViewRepresentable in SwiftUI, I noticed that the the view returned from **func makeUIView** is never replaced or updated even the swiftUI body property is refreshed. The **func updateUIView** is called instead.

For that reason, we need a container UIView that will take care of updating its contents when **func updateUIView** is called.

Using a UIStackView as the container seems the most efficient way of doing that since it already handles all the constraints, compression resistance, scale and resizing issues.

### Verification

1. Tested the change in the vnext-prototype code to ensure the regression does not reproduce any longer.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![repro_iOS15](https://user-images.githubusercontent.com/68076145/148620031-764bdc16-df94-4c22-9950-e4238db6740f.png)  | ![fix_ios15](https://user-images.githubusercontent.com/68076145/148620038-d39eeb5a-a5bb-415d-80c2-a0603e3e0839.png) |
| ![repro_ios14](https://user-images.githubusercontent.com/68076145/148620072-ddc69d98-30ab-4634-9dc6-de2c2b7a4af0.png) | ![fix_ios14](https://user-images.githubusercontent.com/68076145/148620098-982b8d60-ecf7-424f-b0fd-290bae52746b.png) |

2. Ensured the LeftNav scenario of switching status updates the leading view correctly:


https://user-images.githubusercontent.com/68076145/148812264-d61d32fa-cdd1-4c51-94ba-e88d5dd32727.mov





### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/856)