### PR TITLE
[vNext] Fixing broken pod lib lint

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -247,9 +247,9 @@ fi', :execution_position => :before_compile }
 
   s.subspec 'PopupMenu_ios' do |popupmenu_ios|
     popupmenu_ios.platform = :ios
-    popupmenu_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     popupmenu_ios.dependency 'MicrosoftFluentUI/Drawer_ios'
     popupmenu_ios.dependency 'MicrosoftFluentUI/Label_ios'
+    popupmenu_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     popupmenu_ios.dependency 'MicrosoftFluentUI/TableView_ios'
     popupmenu_ios.source_files = ["ios/FluentUI/Popup Menu/**/*.{swift,h}"]
   end

--- a/MicrosoftFluentUIVnext.podspec
+++ b/MicrosoftFluentUIVnext.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
 # iOS
 
-  s.ios.deployment_target = "13.0"
+  s.ios.deployment_target = "14.0"
   
   s.subspec 'ActivityIndicator_ios' do |activityindicator_ios|
     activityindicator_ios.platform = :ios
@@ -82,6 +82,7 @@ xcodebuild ${XCODEBUILDPARAMS} -project ${PROJECT_FILE_PATH} -target "MicrosoftF
   s.subspec 'List_ios' do |list_ios|
     list_ios.platform = :ios
     list_ios.dependency 'MicrosoftFluentUIVnext/Core_ios'
+    list_ios.dependency 'MicrosoftFluentUIVnext/Divider_ios'
     list_ios.source_files = ["ios/FluentUI/Vnext/List/**/*.{swift,h}"]
   end
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

pod lib lint was failing on the vNext branch. Bumping iOS deployment target to 14.0 and adding Divider dependency to List subspec appears to resolve this.

### Verification

ran pod lib lint + confirmed vNext podspec was successful

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/857)