### PR TITLE
ToolBar in PopupMenuDemoController is persistent

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -46,6 +46,11 @@ class PopupMenuDemoController: DemoController {
         navigationController?.isToolbarHidden = false
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isToolbarHidden = true
+    }
+
     private func createAccessoryView(text: String) -> UIView {
         let accessoryView = BadgeView(dataSource: BadgeViewDataSource(text: text, style: .default, size: .small))
         accessoryView.isUserInteractionEnabled = false


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When you enter PopupMenuDemoController, a toolBar emerges from the bottom. Upon exiting, the toolBar space remains, although it is empty. It persists across the demo app, but only goes away if you enter the TableViewCellDemoController 

### Verification

Enter/exited PopupMenuDemoController, observed bottom screen.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ezgif com-gif-maker](https://user-images.githubusercontent.com/22566866/149050878-6b0d55f0-33ec-42b7-a5cf-52eb41c1d168.gif) | ![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/22566866/149050955-10d8ccce-077a-4ca0-b4e7-6bbedc406485.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/859)