### PR TITLE
Support custom view in the badge view

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -16,10 +16,31 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Disabled badge", style: .default, isEnabled: false)
         addBadgeSection(title: "Custom badge", style: .default, overrideColor: true)
         addBadgeSection(title: "Custom disabled badge", style: .default, isEnabled: false, overrideColor: true)
+
+        addCustomBadgeSections()
     }
 
-    func createBadge(text: String, style: BadgeView.Style, size: BadgeView.Size, isEnabled: Bool) -> BadgeView {
-        let badge = BadgeView(dataSource: BadgeViewDataSource(text: text, style: style, size: size))
+    func createBadge(
+        text: String,
+        style: BadgeView.Style,
+        size: BadgeView.Size,
+        isEnabled: Bool,
+        customView: UIView? = nil,
+        customViewVerticalPadding: NSNumber? = nil,
+        customViewLeftPadding: NSNumber? = nil,
+        customViewRightPadding: NSNumber? = nil
+    ) -> BadgeView {
+        let dataSource = BadgeViewDataSource(
+            text: text,
+            style: style,
+            size: size,
+            customView: customView,
+            customViewVerticalPadding: customViewVerticalPadding,
+            customViewPaddingLeft: customViewLeftPadding,
+            customViewPaddingRight: customViewRightPadding
+        )
+
+        let badge = BadgeView(dataSource: dataSource)
         badge.delegate = self
         badge.isActive = isEnabled
         return badge
@@ -42,6 +63,39 @@ class BadgeViewDemoController: DemoController {
             }
             addRow(text: size.description, items: [badge])
         }
+        container.addArrangedSubview(UIView())
+    }
+
+    func addCustomBadgeSections() {
+        addTitle(text: "Badge with custom view")
+
+        let imageView = UIImageView(image: UIImage(named: "ic_fluent_add_20_regular")?.withRenderingMode(.alwaysTemplate))
+        imageView.tintColor = .white
+        imageView.frame.size = CGSize(width: 20, height: 20)
+
+        let avatar = MSFAvatar(style: .default, size: .xsmall)
+        avatar.state.image = UIImage(named: "avatar_kat_larsson")
+
+        let dataSource: [(BadgeView.Size, UIView)] = [
+            (.medium, imageView),
+            (.small, avatar.view)
+        ]
+
+        for (size, customView) in dataSource {
+            let badge = createBadge(
+                text: "Kat Larrson",
+                style: .default,
+                size: size,
+                isEnabled: false,
+                customView: customView,
+                customViewVerticalPadding: 3
+            )
+            badge.disabledBackgroundColor = Colors.Palette.blueMagenta20.color
+            badge.disabledLabelTextColor = .white
+
+            addRow(text: size.description, items: [badge])
+        }
+
         container.addArrangedSubview(UIView())
     }
 }

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -11,12 +11,33 @@ open class BadgeViewDataSource: NSObject {
     @objc open var text: String
     @objc open var style: BadgeView.Style
     @objc open var size: BadgeView.Size
+    @objc open var customView: UIView?
+    @objc open var customViewVerticalPadding: NSNumber?
+    @objc open var customViewPaddingLeft: NSNumber?
+    @objc open var customViewPaddingRight: NSNumber?
 
     @objc public init(text: String, style: BadgeView.Style = .default, size: BadgeView.Size = .medium) {
         self.text = text
         self.style = style
         self.size = size
         super.init()
+    }
+
+    @objc public convenience init(
+        text: String,
+        style: BadgeView.Style = .default,
+        size: BadgeView.Size = .medium,
+        customView: UIView? = nil,
+        customViewVerticalPadding: NSNumber? = nil,
+        customViewPaddingLeft: NSNumber? = nil,
+        customViewPaddingRight: NSNumber? = nil
+    ) {
+        self.init(text: text, style: style, size: size)
+
+        self.customView = customView
+        self.customViewVerticalPadding = customViewVerticalPadding
+        self.customViewPaddingLeft = customViewPaddingLeft
+        self.customViewPaddingRight = customViewPaddingRight
     }
 }
 
@@ -92,10 +113,6 @@ open class BadgeView: UIView {
             case .medium:
                 return 4
             }
-        }
-
-        var height: CGFloat {
-            return verticalPadding + labelTextStyle.font.deviceLineHeight + verticalPadding
         }
     }
 
@@ -300,6 +317,30 @@ open class BadgeView: UIView {
         }
     }
 
+    private var labelSize: CGSize {
+        let size = label.sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
+        let width = UIScreen.main.roundToDevicePixels(size.width)
+        let height = UIScreen.main.roundToDevicePixels(size.height)
+        return CGSize(width: width, height: height)
+    }
+
+    private var customViewPadding: UIEdgeInsets {
+        let getFloat: (_ number: NSNumber?, _ defaultValue: CGFloat) -> CGFloat = { (number, defaultValue) in
+            if let number = number {
+                return CGFloat(truncating: number)
+            }
+            return defaultValue
+        }
+        let defaultVerticalPadding = size.verticalPadding
+        let defaultHorizontalPadding = size.horizontalPadding
+        return UIEdgeInsets(
+            top: getFloat(dataSource?.customViewVerticalPadding, defaultVerticalPadding),
+            left: getFloat(dataSource?.customViewPaddingLeft, defaultHorizontalPadding),
+            bottom: getFloat(dataSource?.customViewVerticalPadding, defaultVerticalPadding),
+            right: getFloat(dataSource?.customViewPaddingRight, defaultHorizontalPadding)
+        )
+    }
+
     private let backgroundView = UIView()
 
     private let label = Label()
@@ -339,21 +380,43 @@ open class BadgeView: UIView {
     open override func layoutSubviews() {
         super.layoutSubviews()
         backgroundView.frame = bounds
-        label.frame = bounds.insetBy(dx: -size.horizontalPadding, dy: -size.verticalPadding)
+
+        if let customViewSize = customViewSize(for: frame.size), customViewSize != .zero {
+            dataSource?.customView?.frame = CGRect(origin: CGPoint(x: customViewPadding.left, y: (frame.height - customViewSize.height) / 2), size: customViewSize)
+            label.frame = CGRect(origin: CGPoint(x: customViewPadding.left + customViewPadding.right + customViewSize.width, y: (frame.height - labelSize.height) / 2), size: labelSize)
+        } else {
+            label.frame = bounds.insetBy(dx: -size.horizontalPadding, dy: -size.verticalPadding)
+        }
+
+        flipSubviewsForRTL()
     }
 
     open func reload() {
         label.text = dataSource?.text
         style = dataSource?.style ?? .default
         size = dataSource?.size ?? .medium
+
+        dataSource?.customView?.removeFromSuperview()
+        if let customView = dataSource?.customView {
+            addSubview(customView)
+        }
+
         setNeedsLayout()
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        let labelSize = label.sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
-        let width = UIScreen.main.roundToDevicePixels(labelSize.width) + self.size.horizontalPadding * 2
+        let width: CGFloat
+        let height: CGFloat
+
+        if let customViewSize = customViewSize(for: size), customViewSize != .zero {
+            height = max(customViewSize.height + customViewPadding.top + customViewPadding.bottom, labelSize.height + self.size.verticalPadding * 2)
+            width = labelSize.width + customViewSize.width + customViewPadding.left + customViewPadding.right + self.size.horizontalPadding
+        } else {
+            height = labelSize.height + self.size.verticalPadding * 2
+            width = labelSize.width + self.size.horizontalPadding * 2
+        }
+
         let maxWidth = size.width > 0 ? size.width : .infinity
-        let height = UIScreen.main.roundToDevicePixels(labelSize.height) + self.size.verticalPadding * 2
         let maxHeight = size.height > 0 ? size.height : .infinity
 
         return CGSize(width: max(minWidth, min(width, maxWidth)), height: min(height, maxHeight))
@@ -362,6 +425,13 @@ open class BadgeView: UIView {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         updateColors()
+    }
+
+    private func customViewSize(for size: CGSize) -> CGSize? {
+        guard let customView = dataSource?.customView else {
+            return nil
+        }
+        return customView.bounds == .zero ? customView.sizeThatFits(size) : customView.bounds.size
     }
 
     private func updateAccessibility() {

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -382,8 +382,10 @@ open class BadgeView: UIView {
         backgroundView.frame = bounds
 
         if let customViewSize = customViewSize(for: frame.size), customViewSize != .zero {
-            dataSource?.customView?.frame = CGRect(origin: CGPoint(x: customViewPadding.left, y: (frame.height - customViewSize.height) / 2), size: customViewSize)
-            label.frame = CGRect(origin: CGPoint(x: customViewPadding.left + customViewPadding.right + customViewSize.width, y: (frame.height - labelSize.height) / 2), size: labelSize)
+			let customViewOrigin = CGPoint(x: customViewPadding.left, y: (frame.height - customViewSize.height) / 2)
+            dataSource?.customView?.frame = CGRect(origin: customViewOrigin, size: customViewSize)
+			let labelOrigin = CGPoint(x: customViewPadding.left + customViewPadding.right + customViewSize.width, y: (frame.height - labelSize.height) / 2)
+            label.frame = CGRect(origin: labelOrigin, size: labelSize)
         } else {
             label.frame = bounds.insetBy(dx: -size.horizontalPadding, dy: -size.verticalPadding)
         }
@@ -409,7 +411,9 @@ open class BadgeView: UIView {
         let height: CGFloat
 
         if let customViewSize = customViewSize(for: size), customViewSize != .zero {
-            height = max(customViewSize.height + customViewPadding.top + customViewPadding.bottom, labelSize.height + self.size.verticalPadding * 2)
+			let heightForCustomView = customViewSize.height + customViewPadding.top + customViewPadding.bottom
+			let heightForLabel = labelSize.height + self.size.verticalPadding * 2
+            height = max(heightForCustomView, heightForLabel)
             width = labelSize.width + customViewSize.width + customViewPadding.left + customViewPadding.right + self.size.horizontalPadding
         } else {
             height = labelSize.height + self.size.verticalPadding * 2


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
1. ios/FluentUI/Badge Field/BadgeView.swift
- Add parameters for init to let user set a custom view for badge view, user can also specify padding for the view
- Update `sizeToFit` and `layoutSubviews`
2. ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
- Add a demo

### Verification
Manual test the UI of test demo

| LTR                                       | RTL                                      |
|----------------------------------------------|--------------------------------------------|
| ![IMG_4733A5CBC732-1](https://user-images.githubusercontent.com/3814629/149725499-8d6076ec-21c2-4aa9-b60f-6995631c3c7e.jpeg) | ![IMG_F5F3F2993475-1](https://user-images.githubusercontent.com/3814629/149725530-098373a5-878f-4104-9548-a194bce7868f.jpeg) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/861)