### PR TITLE
[vNext] Adopting protocols in List vNext

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -125,123 +125,7 @@ class LeftNavMenuViewController: UIViewController {
 
     private var statusCell = MSFListCellState()
 
-    private var leftNavMenuSections: [MSFListSectionState] {
-        let defaultMenuAction = {
-            guard let menuAction = self.menuAction else {
-                return
-            }
-            menuAction()
-        }
-
-        var statusCellChildren: [MSFListCellState] = []
-
-        for presence in LeftNavPresence.allCases {
-            let statusCellChild = MSFListCellState()
-            statusCellChild.leadingViewSize = .small
-            statusCellChild.title = presence.cellTitle()
-            statusCellChild.leadingUIView = presence.imageView()
-            statusCellChild.backgroundColor = .systemBackground
-            statusCellChild.onTapAction = {
-                self.setPresence(presence: presence)
-            }
-
-            statusCellChildren.append(statusCellChild)
-        }
-
-        let resetStatusCell = MSFListCellState()
-        resetStatusCell.title = "Reset status"
-        resetStatusCell.leadingViewSize = .small
-        resetStatusCell.backgroundColor = .systemBackground
-        let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
-        resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        resetStatusCell.leadingUIView = resetStatusImageView
-        resetStatusCell.onTapAction = {
-            self.setPresence(presence: .available)
-        }
-        statusCellChildren.append(resetStatusCell)
-
-        statusCell.title = LeftNavPresence.available.cellTitle()
-        statusCell.backgroundColor = .systemBackground
-        let statusImageView = LeftNavPresence.available.imageView()
-        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-        statusCell.leadingUIView = statusImageView
-        statusCell.children = statusCellChildren
-
-        let statusMessageCell = MSFListCellState()
-        statusMessageCell.backgroundColor = .systemBackground
-        statusMessageCell.title = "Set Status Message"
-        let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
-        statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        statusMessageCell.leadingUIView = statusMessageImageView
-        statusMessageCell.onTapAction = defaultMenuAction
-
-        let notificationsCell = MSFListCellState()
-        notificationsCell.backgroundColor = .systemBackground
-        notificationsCell.title = "Notifications"
-        notificationsCell.subtitle = "On"
-        notificationsCell.layoutType = .twoLines
-        let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
-        notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        notificationsCell.leadingUIView = notificationsImageView
-        notificationsCell.onTapAction = defaultMenuAction
-
-        let settingsCell = MSFListCellState()
-        settingsCell.backgroundColor = .systemBackground
-        settingsCell.title = "Settings"
-        let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
-        settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        settingsCell.leadingUIView = settingsImageView
-        settingsCell.onTapAction = defaultMenuAction
-
-        let whatsNewCell = MSFListCellState()
-        whatsNewCell.backgroundColor = .systemBackground
-        whatsNewCell.title = "What's new"
-        let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
-        whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        whatsNewCell.leadingUIView = whatsNewImageView
-        whatsNewCell.onTapAction = defaultMenuAction
-
-        let menuSection = MSFListSectionState()
-        menuSection.cells = [statusCell, statusMessageCell, notificationsCell, settingsCell, whatsNewCell]
-
-        let microsoftAccountCell = MSFListCellState()
-        microsoftAccountCell.backgroundColor = .systemBackground
-        microsoftAccountCell.layoutType = .twoLines
-        microsoftAccountCell.title = "Contoso"
-        microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
-        microsoftAccountCell.accessoryType = .checkmark
-        let orgAvatar = MSFAvatar(style: .group, size: .large)
-        orgAvatar.state.primaryText = "Kat Larrson"
-        microsoftAccountCell.leadingUIView = orgAvatar.view
-        microsoftAccountCell.leadingViewSize = .large
-
-        let msaAccountCell = MSFListCellState()
-        msaAccountCell.backgroundColor = .systemBackground
-        msaAccountCell.layoutType = .twoLines
-        msaAccountCell.title = "Personal"
-        msaAccountCell.subtitle = "kat.larrson@live.com"
-        let msaAvatar = MSFAvatar(style: .group, size: .large)
-        msaAvatar.state.primaryText = "kat.larrson@live.com"
-        msaAccountCell.leadingUIView = msaAvatar.view
-        msaAccountCell.leadingViewSize = .large
-
-        let addAccountCell = MSFListCellState()
-        addAccountCell.backgroundColor = .systemBackground
-        addAccountCell.title = "Add Account"
-        let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
-        addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        addAccountCell.leadingUIView = addAccountImageView
-        addAccountCell.onTapAction = defaultMenuAction
-
-        let accountsSection = MSFListSectionState()
-        accountsSection.title = "Accounts and Orgs"
-        accountsSection.backgroundColor = .systemBackground
-        accountsSection.cells = [microsoftAccountCell, msaAccountCell, addAccountCell]
-
-        return [menuSection, accountsSection]
-    }
-
-    private var leftNavMenuList = MSFList(sections: [])
+    private var leftNavMenuList = MSFList()
 
     private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
 
@@ -277,10 +161,120 @@ class LeftNavMenuViewController: UIViewController {
                                                  left: Constant.margin,
                                                  bottom: Constant.margin,
                                                  right: Constant.margin)
+        let defaultMenuAction = {
+            guard let menuAction = self.menuAction else {
+                return
+            }
+            menuAction()
+        }
+
+        var statusCellChildren: [MSFListCellState] = []
+
+        for presence in LeftNavPresence.allCases {
+            let statusCellChild = MSFListCellState()
+            statusCellChild.leadingViewSize = .small
+            statusCellChild.title = presence.cellTitle()
+            statusCellChild.leadingUIView = presence.imageView()
+            statusCellChild.backgroundColor = .systemBackground
+            statusCellChild.onTapAction = {
+                self.setPresence(presence: presence)
+            }
+
+            statusCellChildren.append(statusCellChild)
+        }
+
+        let resetStatusCell = MSFListCellState()
+        resetStatusCell.title = "Reset status"
+        resetStatusCell.leadingViewSize = .small
+        resetStatusCell.backgroundColor = .systemBackground
+        let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
+        resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        resetStatusCell.leadingUIView = resetStatusImageView
+        resetStatusCell.onTapAction = {
+            self.setPresence(presence: .available)
+        }
+        statusCellChildren.append(resetStatusCell)
+
+        let menuSection = leftNavMenuList.state.createSection()
+
+        statusCell = menuSection.createCell()
+        statusCell.title = LeftNavPresence.available.cellTitle()
+        statusCell.backgroundColor = .systemBackground
+        let statusImageView = LeftNavPresence.available.imageView()
+        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+        statusCell.leadingUIView = statusImageView
+        statusCell.children = statusCellChildren
+
+        let statusMessageCell = menuSection.createCell()
+        statusMessageCell.backgroundColor = .systemBackground
+        statusMessageCell.title = "Set Status Message"
+        let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
+        statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        statusMessageCell.leadingUIView = statusMessageImageView
+        statusMessageCell.onTapAction = defaultMenuAction
+
+        let notificationsCell = menuSection.createCell()
+        notificationsCell.backgroundColor = .systemBackground
+        notificationsCell.title = "Notifications"
+        notificationsCell.subtitle = "On"
+        notificationsCell.layoutType = .twoLines
+        let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
+        notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        notificationsCell.leadingUIView = notificationsImageView
+        notificationsCell.onTapAction = defaultMenuAction
+
+        let settingsCell = menuSection.createCell()
+        settingsCell.backgroundColor = .systemBackground
+        settingsCell.title = "Settings"
+        let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
+        settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        settingsCell.leadingUIView = settingsImageView
+        settingsCell.onTapAction = defaultMenuAction
+
+        let whatsNewCell = menuSection.createCell()
+        whatsNewCell.backgroundColor = .systemBackground
+        whatsNewCell.title = "What's new"
+        let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
+        whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        whatsNewCell.leadingUIView = whatsNewImageView
+        whatsNewCell.onTapAction = defaultMenuAction
+
+        let accountsSection = leftNavMenuList.state.createSection()
+        accountsSection.title = "Accounts and Orgs"
+        accountsSection.backgroundColor = .systemBackground
+
+        let microsoftAccountCell = accountsSection.createCell()
+        microsoftAccountCell.backgroundColor = .systemBackground
+        microsoftAccountCell.layoutType = .twoLines
+        microsoftAccountCell.title = "Contoso"
+        microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
+        microsoftAccountCell.accessoryType = .checkmark
+        let orgAvatar = MSFAvatar(style: .group, size: .large)
+        orgAvatar.state.primaryText = "Kat Larrson"
+        microsoftAccountCell.leadingUIView = orgAvatar.view
+        microsoftAccountCell.leadingViewSize = .large
+
+        let msaAccountCell = accountsSection.createCell()
+        msaAccountCell.backgroundColor = .systemBackground
+        msaAccountCell.layoutType = .twoLines
+        msaAccountCell.title = "Personal"
+        msaAccountCell.subtitle = "kat.larrson@live.com"
+        let msaAvatar = MSFAvatar(style: .group, size: .large)
+        msaAvatar.state.primaryText = "kat.larrson@live.com"
+        msaAccountCell.leadingUIView = msaAvatar.view
+        msaAccountCell.leadingViewSize = .large
+
+        let addAccountCell = accountsSection.createCell()
+        addAccountCell.backgroundColor = .systemBackground
+        addAccountCell.title = "Add Account"
+        let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
+        addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        addAccountCell.leadingUIView = addAccountImageView
+        addAccountCell.onTapAction = defaultMenuAction
+
         let accountView = leftNavAccountView
         let menuListView = leftNavMenuList.view
         menuListView.translatesAutoresizingMaskIntoConstraints = false
-        leftNavMenuList.state.sections = leftNavMenuSections
 
         contentView.addSubview(accountView)
         contentView.addSubview(menuListView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -51,7 +51,7 @@ class LeftNavDemoController: DemoController {
     }
 
     private lazy var navigationButton: UIView = {
-        return createButton(title: "Show Left Navigation Menu", action: { [weak self ] _ in
+        return createButton(title: "Show Left Navigation Menu", action: { [weak self] _ in
             if let strongSelf = self {
                 strongSelf.showLeftNavButtonTapped()
             }
@@ -132,16 +132,17 @@ class LeftNavMenuViewController: UIViewController {
     private lazy var leftNavAccountView: UIView = {
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
         chevron.tintColor = Colors.textPrimary
+        let personaState = persona.state
 
-        persona.state.presence = .available
-        persona.state.primaryText = "Kat Larrson"
-        persona.state.secondaryText = "Designer"
-        persona.state.image = UIImage(named: "avatar_kat_larsson")
-        persona.state.titleTrailingAccessoryUIView = chevron
-        persona.state.backgroundColor = .systemBackground
-        persona.state.onTapAction = {
-            self.dismiss(animated: true, completion: {
-                guard let menuAction = self.menuAction else {
+        personaState.presence = .available
+        personaState.primaryText = "Kat Larrson"
+        personaState.secondaryText = "Designer"
+        personaState.image = UIImage(named: "avatar_kat_larsson")
+        personaState.titleTrailingAccessoryUIView = chevron
+        personaState.backgroundColor = .systemBackground
+        personaState.onTapAction = {
+            self.dismiss(animated: true, completion: { [weak self] in
+                guard let menuAction = self?.menuAction else {
                     return
                 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -7,386 +7,385 @@ import FluentUI
 import UIKit
 import SwiftUI
 
-class LeftNavDemoController: DemoController { }
-//class LeftNavDemoController: DemoController {
-//
-//    override func viewDidLoad() {
-//        super.viewDidLoad()
-//
-//        addTitle(text: "Left navigation control")
-//        addDescription(text: "The LeftNav control is built from a composition of the Avatar, Drawer and List controls.")
-//
-//        container.addArrangedSubview(navigationButton)
-//
-//        let isLeadingEdgeLeftToRight = view.effectiveUserInterfaceLayoutDirection == .leftToRight
-//
-//        let leadingEdgeGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePan))
-//        leadingEdgeGesture.edges = isLeadingEdgeLeftToRight ? .left : .right
-//        view.addGestureRecognizer(leadingEdgeGesture)
-//        navigationController?.navigationController?.interactivePopGestureRecognizer?.require(toFail: leadingEdgeGesture)
-//
-//        let lefNavController = LeftNavMenuViewController(menuAction: { [weak self] in
-//            guard let strongSelf = self else {
-//                return
-//            }
-//            strongSelf.dismiss(animated: true, completion: { [weak self] in
-//                guard let strongSelf = self else {
-//                    return
-//                }
-//                strongSelf.showMessage("Menu item selected.")
-//            })
-//        })
-//
-//        drawerController.contentView = lefNavController.view
-//        drawerController.presentingGesture = leadingEdgeGesture
-//    }
-//
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
-//    }
-//
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-//    }
-//
-//    private lazy var navigationButton: UIView = {
-//        return createButton(title: "Show Left Navigation Menu", action: { [weak self ] _ in
-//            if let strongSelf = self {
-//                strongSelf.showLeftNavButtonTapped()
-//            }
-//        }).view
-//    }()
-//
-//    private lazy var drawerController: DrawerController = {
-//        let drawerController = DrawerController(sourceView: navigationButton,
-//                                            sourceRect: navigationButton.bounds,
-//                                            presentationDirection: .fromLeading)
-//        drawerController.presentationBackground = .black
-//        drawerController.preferredContentSize.width = 360
-//        drawerController.resizingBehavior = .dismiss
-//        return drawerController
-//    }()
-//
-//    @objc private func showLeftNavButtonTapped() {
-//        present(drawerController, animated: true, completion: nil)
-//    }
-//
-//    @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {
-//        guard gesture.state == .began else {
-//            return
-//        }
-//
-//        present(drawerController,
-//                animated: true,
-//                completion: nil)
-//    }
-//}
+class LeftNavDemoController: DemoController {
 
-//class LeftNavMenuViewController: UIViewController {
-//
-//    init(menuAction: (() -> Void)?) {
-//        self.menuAction = menuAction
-//
-//        super.init(nibName: nil, bundle: nil)
-//    }
-//
-//    @available(*, unavailable)
-//    @objc public required init?(coder: NSCoder) {
-//        preconditionFailure("init(coder:) has not been implemented")
-//    }
-//
-//    override func viewDidLoad() {
-//        super.viewDidLoad()
-//
-//        view = leftNavView
-//    }
-//
-//    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-//        super.traitCollectionDidChange(previousTraitCollection)
-//        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
-//            sizeCategory != self.traitCollection.preferredContentSizeCategory {
-//            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
-//        }
-//    }
-//
-//    var menuAction: (() -> Void)?
-//
-//    private func setPresence(presence: LeftNavPresence) {
-//        self.persona.state.presence = presence.avatarPresence()
-//        self.statusCell.isExpanded = false
-//        self.statusCell.title = presence.cellTitle()
-//        self.statusCell.leadingUIView = presence.imageView()
-//    }
-//
-//    private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
-//
-//    private var persona = MSFPersonaView()
-//
-//    private var statusCell = MSFListCellState()
-//
-//    private var leftNavMenuSections: [MSFListSectionStateImpl] {
-//        let defaultMenuAction = {
-//            guard let menuAction = self.menuAction else {
-//                return
-//            }
-//            menuAction()
-//        }
-//
-//        var statusCellChildren: [MSFListCellState] = []
-//
-//        for presence in LeftNavPresence.allCases {
-//            let statusCellChild = MSFListCellState()
-//            statusCellChild.leadingViewSize = .small
-//            statusCellChild.title = presence.cellTitle()
-//            statusCellChild.leadingUIView = presence.imageView()
-//            statusCellChild.backgroundColor = .systemBackground
-//            statusCellChild.onTapAction = {
-//                self.setPresence(presence: presence)
-//            }
-//
-//            statusCellChildren.append(statusCellChild)
-//        }
-//
-//        let resetStatusCell = MSFListCellState()
-//        resetStatusCell.title = "Reset status"
-//        resetStatusCell.leadingViewSize = .small
-//        resetStatusCell.backgroundColor = .systemBackground
-//        let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
-//        resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-//        resetStatusCell.leadingUIView = resetStatusImageView
-//        resetStatusCell.onTapAction = {
-//            self.setPresence(presence: .available)
-//        }
-//        statusCellChildren.append(resetStatusCell)
-//
-//        statusCell.title = LeftNavPresence.available.cellTitle()
-//        statusCell.backgroundColor = .systemBackground
-//        let statusImageView = LeftNavPresence.available.imageView()
-//        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-//        statusCell.leadingUIView = statusImageView
-//        statusCell.children = statusCellChildren
-//
-//        let statusMessageCell = MSFListCellState()
-//        statusMessageCell.backgroundColor = .systemBackground
-//        statusMessageCell.title = "Set Status Message"
-//        let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
-//        statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-//        statusMessageCell.leadingUIView = statusMessageImageView
-//        statusMessageCell.onTapAction = defaultMenuAction
-//
-//        let notificationsCell = MSFListCellState()
-//        notificationsCell.backgroundColor = .systemBackground
-//        notificationsCell.title = "Notifications"
-//        notificationsCell.subtitle = "On"
-//        notificationsCell.layoutType = .twoLines
-//        let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
-//        notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-//        notificationsCell.leadingUIView = notificationsImageView
-//        notificationsCell.onTapAction = defaultMenuAction
-//
-//        let settingsCell = MSFListCellState()
-//        settingsCell.backgroundColor = .systemBackground
-//        settingsCell.title = "Settings"
-//        let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
-//        settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-//        settingsCell.leadingUIView = settingsImageView
-//        settingsCell.onTapAction = defaultMenuAction
-//
-//        let whatsNewCell = MSFListCellState()
-//        whatsNewCell.backgroundColor = .systemBackground
-//        whatsNewCell.title = "What's new"
-//        let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
-//        whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-//        whatsNewCell.leadingUIView = whatsNewImageView
-//        whatsNewCell.onTapAction = defaultMenuAction
-//
-//        let menuSection = MSFListSectionStateImpl()
-//        menuSection.cells = [statusCell, statusMessageCell, notificationsCell, settingsCell, whatsNewCell]
-//
-//        let microsoftAccountCell = MSFListCellState()
-//        microsoftAccountCell.backgroundColor = .systemBackground
-//        microsoftAccountCell.layoutType = .twoLines
-//        microsoftAccountCell.title = "Contoso"
-//        microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
-//        microsoftAccountCell.accessoryType = .checkmark
-//        let orgAvatar = MSFAvatar(style: .group, size: .large)
-//        orgAvatar.state.primaryText = "Kat Larrson"
-//        microsoftAccountCell.leadingUIView = orgAvatar.view
-//        microsoftAccountCell.leadingViewSize = .large
-//
-//        let msaAccountCell = MSFListCellState()
-//        msaAccountCell.backgroundColor = .systemBackground
-//        msaAccountCell.layoutType = .twoLines
-//        msaAccountCell.title = "Personal"
-//        msaAccountCell.subtitle = "kat.larrson@live.com"
-//        let msaAvatar = MSFAvatar(style: .group, size: .large)
-//        msaAvatar.state.primaryText = "kat.larrson@live.com"
-//        msaAccountCell.leadingUIView = msaAvatar.view
-//        msaAccountCell.leadingViewSize = .large
-//
-//        let addAccountCell = MSFListCellState()
-//        addAccountCell.backgroundColor = .systemBackground
-//        addAccountCell.title = "Add Account"
-//        let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
-//        addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-//        addAccountCell.leadingUIView = addAccountImageView
-//        addAccountCell.onTapAction = defaultMenuAction
-//
-//        let accountsSection = MSFListSectionStateImpl()
-//        accountsSection.title = "Accounts and Orgs"
-//        accountsSection.backgroundColor = .systemBackground
-//        accountsSection.cells = [microsoftAccountCell, msaAccountCell, addAccountCell]
-//
-//        return [menuSection, accountsSection]
-//    }
-//
-//    private var leftNavMenuList = MSFList(sections: [])
-//
-//    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
-//
-//    private lazy var leftNavAccountView: UIView = {
-//        let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
-//        chevron.tintColor = Colors.textPrimary
-//
-//        persona.state.presence = .available
-//        persona.state.primaryText = "Kat Larrson"
-//        persona.state.secondaryText = "Designer"
-//        persona.state.image = UIImage(named: "avatar_kat_larsson")
-//        persona.state.titleTrailingAccessoryUIView = chevron
-//        persona.state.backgroundColor = .systemBackground
-//        persona.state.onTapAction = {
-//            self.dismiss(animated: true, completion: {
-//                guard let menuAction = self.menuAction else {
-//                    return
-//                }
-//
-//                menuAction()
-//            })
-//        }
-//
-//        let personaView = persona.view
-//        personaView.translatesAutoresizingMaskIntoConstraints = false
-//        return personaView
-//    }()
-//
-//    private var leftNavContentView: UIView {
-//        let contentView = UIView()
-//        contentView.translatesAutoresizingMaskIntoConstraints = false
-//        contentView.layoutMargins = UIEdgeInsets(top: Constant.margin,
-//                                                 left: Constant.margin,
-//                                                 bottom: Constant.margin,
-//                                                 right: Constant.margin)
-//        let accountView = leftNavAccountView
-//        let menuListView = leftNavMenuList.view
-//        menuListView.translatesAutoresizingMaskIntoConstraints = false
-//        leftNavMenuList.state.sections = leftNavMenuSections
-//
-//        contentView.addSubview(accountView)
-//        contentView.addSubview(menuListView)
-//
-//        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
-//        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
-//
-//        NSLayoutConstraint.activate([accountViewHeightConstraint,
-//                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
-//                                     accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-//                                     accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-//                                     menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
-//                                     menuListView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-//                                     menuListView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-//                                     menuListView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-//        ])
-//
-//        return contentView
-//    }
-//
-//    private var leftNavView: UIView {
-//        let container = UIView(frame: .zero)
-//
-//        let contentView = leftNavContentView
-//        container.addSubview(contentView)
-//
-//        container.backgroundColor = .systemBackground
-//
-//        NSLayoutConstraint.activate([container.safeAreaLayoutGuide.topAnchor.constraint(equalTo: contentView.topAnchor),
-//                                     container.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-//                                     container.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-//                                     container.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
-//        return container
-//    }
-//
-//    private enum Constant {
-//        static let margin: CGFloat = 16
-//        static let verticalSpacing: CGFloat = 5
-//    }
-//}
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-//enum LeftNavPresence: Int, CaseIterable {
-//    case available
-//    case busy
-//    case doNotDisturb
-//    case beRightBack
-//    case away
-//    case offline
-//
-//    func imageView() -> UIImageView {
-//        let imageView: UIImageView
-//
-//        switch self {
-//        case .available:
-//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_available_16_filled"))
-//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-//        case .away, .beRightBack:
-//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_away_16_filled"))
-//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.away
-//        case .busy:
-//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_busy_16_filled"))
-//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.busy
-//        case .doNotDisturb:
-//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_dnd_16_filled"))
-//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
-//        case .offline:
-//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_offline_16_regular"))
-//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.offline
-//        }
-//
-//        return imageView
-//    }
-//
-//    func cellTitle() -> String {
-//        let cellTitle: String
-//        switch self {
-//        case .available:
-//            cellTitle = "Available"
-//        case .busy:
-//            cellTitle = "Busy"
-//        case .doNotDisturb:
-//            cellTitle = "Do not disturb"
-//        case .beRightBack:
-//            cellTitle = "Be right back"
-//        case .away:
-//            cellTitle = "Appear away"
-//        case .offline:
-//            cellTitle = "Appear offline"
-//        }
-//
-//        return cellTitle
-//    }
-//
-//    func avatarPresence() -> MSFAvatarPresence {
-//        switch self {
-//        case .available:
-//            return .available
-//        case .busy:
-//            return .busy
-//        case .doNotDisturb:
-//            return .doNotDisturb
-//        case .away, .beRightBack:
-//            return .away
-//        case .offline:
-//            return .offline
-//        }
-//    }
-//}
+        addTitle(text: "Left navigation control")
+        addDescription(text: "The LeftNav control is built from a composition of the Avatar, Drawer and List controls.")
+
+        container.addArrangedSubview(navigationButton)
+
+        let isLeadingEdgeLeftToRight = view.effectiveUserInterfaceLayoutDirection == .leftToRight
+
+        let leadingEdgeGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePan))
+        leadingEdgeGesture.edges = isLeadingEdgeLeftToRight ? .left : .right
+        view.addGestureRecognizer(leadingEdgeGesture)
+        navigationController?.navigationController?.interactivePopGestureRecognizer?.require(toFail: leadingEdgeGesture)
+
+        let lefNavController = LeftNavMenuViewController(menuAction: { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.dismiss(animated: true, completion: { [weak self] in
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.showMessage("Menu item selected.")
+            })
+        })
+
+        drawerController.contentView = lefNavController.view
+        drawerController.presentingGesture = leadingEdgeGesture
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+    }
+
+    private lazy var navigationButton: UIView = {
+        return createButton(title: "Show Left Navigation Menu", action: { [weak self ] _ in
+            if let strongSelf = self {
+                strongSelf.showLeftNavButtonTapped()
+            }
+        }).view
+    }()
+
+    private lazy var drawerController: DrawerController = {
+        let drawerController = DrawerController(sourceView: navigationButton,
+                                            sourceRect: navigationButton.bounds,
+                                            presentationDirection: .fromLeading)
+        drawerController.presentationBackground = .black
+        drawerController.preferredContentSize.width = 360
+        drawerController.resizingBehavior = .dismiss
+        return drawerController
+    }()
+
+    @objc private func showLeftNavButtonTapped() {
+        present(drawerController, animated: true, completion: nil)
+    }
+
+    @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {
+        guard gesture.state == .began else {
+            return
+        }
+
+        present(drawerController,
+                animated: true,
+                completion: nil)
+    }
+}
+
+class LeftNavMenuViewController: UIViewController {
+
+    init(menuAction: (() -> Void)?) {
+        self.menuAction = menuAction
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    @objc public required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view = leftNavView
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
+            sizeCategory != self.traitCollection.preferredContentSizeCategory {
+            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
+        }
+    }
+
+    var menuAction: (() -> Void)?
+
+    private func setPresence(presence: LeftNavPresence) {
+        self.persona.state.presence = presence.avatarPresence()
+        self.statusCell.isExpanded = false
+        self.statusCell.title = presence.cellTitle()
+        self.statusCell.leadingUIView = presence.imageView()
+    }
+
+    private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
+
+    private var persona = MSFPersonaView()
+
+    private var statusCell = MSFListCellState()
+
+    private var leftNavMenuSections: [MSFListSectionState] {
+        let defaultMenuAction = {
+            guard let menuAction = self.menuAction else {
+                return
+            }
+            menuAction()
+        }
+
+        var statusCellChildren: [MSFListCellState] = []
+
+        for presence in LeftNavPresence.allCases {
+            let statusCellChild = MSFListCellState()
+            statusCellChild.leadingViewSize = .small
+            statusCellChild.title = presence.cellTitle()
+            statusCellChild.leadingUIView = presence.imageView()
+            statusCellChild.backgroundColor = .systemBackground
+            statusCellChild.onTapAction = {
+                self.setPresence(presence: presence)
+            }
+
+            statusCellChildren.append(statusCellChild)
+        }
+
+        let resetStatusCell = MSFListCellState()
+        resetStatusCell.title = "Reset status"
+        resetStatusCell.leadingViewSize = .small
+        resetStatusCell.backgroundColor = .systemBackground
+        let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
+        resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        resetStatusCell.leadingUIView = resetStatusImageView
+        resetStatusCell.onTapAction = {
+            self.setPresence(presence: .available)
+        }
+        statusCellChildren.append(resetStatusCell)
+
+        statusCell.title = LeftNavPresence.available.cellTitle()
+        statusCell.backgroundColor = .systemBackground
+        let statusImageView = LeftNavPresence.available.imageView()
+        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+        statusCell.leadingUIView = statusImageView
+        statusCell.children = statusCellChildren
+
+        let statusMessageCell = MSFListCellState()
+        statusMessageCell.backgroundColor = .systemBackground
+        statusMessageCell.title = "Set Status Message"
+        let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
+        statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        statusMessageCell.leadingUIView = statusMessageImageView
+        statusMessageCell.onTapAction = defaultMenuAction
+
+        let notificationsCell = MSFListCellState()
+        notificationsCell.backgroundColor = .systemBackground
+        notificationsCell.title = "Notifications"
+        notificationsCell.subtitle = "On"
+        notificationsCell.layoutType = .twoLines
+        let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
+        notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        notificationsCell.leadingUIView = notificationsImageView
+        notificationsCell.onTapAction = defaultMenuAction
+
+        let settingsCell = MSFListCellState()
+        settingsCell.backgroundColor = .systemBackground
+        settingsCell.title = "Settings"
+        let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
+        settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        settingsCell.leadingUIView = settingsImageView
+        settingsCell.onTapAction = defaultMenuAction
+
+        let whatsNewCell = MSFListCellState()
+        whatsNewCell.backgroundColor = .systemBackground
+        whatsNewCell.title = "What's new"
+        let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
+        whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        whatsNewCell.leadingUIView = whatsNewImageView
+        whatsNewCell.onTapAction = defaultMenuAction
+
+        let menuSection = MSFListSectionState()
+        menuSection.cells = [statusCell, statusMessageCell, notificationsCell, settingsCell, whatsNewCell]
+
+        let microsoftAccountCell = MSFListCellState()
+        microsoftAccountCell.backgroundColor = .systemBackground
+        microsoftAccountCell.layoutType = .twoLines
+        microsoftAccountCell.title = "Contoso"
+        microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
+        microsoftAccountCell.accessoryType = .checkmark
+        let orgAvatar = MSFAvatar(style: .group, size: .large)
+        orgAvatar.state.primaryText = "Kat Larrson"
+        microsoftAccountCell.leadingUIView = orgAvatar.view
+        microsoftAccountCell.leadingViewSize = .large
+
+        let msaAccountCell = MSFListCellState()
+        msaAccountCell.backgroundColor = .systemBackground
+        msaAccountCell.layoutType = .twoLines
+        msaAccountCell.title = "Personal"
+        msaAccountCell.subtitle = "kat.larrson@live.com"
+        let msaAvatar = MSFAvatar(style: .group, size: .large)
+        msaAvatar.state.primaryText = "kat.larrson@live.com"
+        msaAccountCell.leadingUIView = msaAvatar.view
+        msaAccountCell.leadingViewSize = .large
+
+        let addAccountCell = MSFListCellState()
+        addAccountCell.backgroundColor = .systemBackground
+        addAccountCell.title = "Add Account"
+        let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
+        addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+        addAccountCell.leadingUIView = addAccountImageView
+        addAccountCell.onTapAction = defaultMenuAction
+
+        let accountsSection = MSFListSectionState()
+        accountsSection.title = "Accounts and Orgs"
+        accountsSection.backgroundColor = .systemBackground
+        accountsSection.cells = [microsoftAccountCell, msaAccountCell, addAccountCell]
+
+        return [menuSection, accountsSection]
+    }
+
+    private var leftNavMenuList = MSFList(sections: [])
+
+    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
+
+    private lazy var leftNavAccountView: UIView = {
+        let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
+        chevron.tintColor = Colors.textPrimary
+
+        persona.state.presence = .available
+        persona.state.primaryText = "Kat Larrson"
+        persona.state.secondaryText = "Designer"
+        persona.state.image = UIImage(named: "avatar_kat_larsson")
+        persona.state.titleTrailingAccessoryUIView = chevron
+        persona.state.backgroundColor = .systemBackground
+        persona.state.onTapAction = {
+            self.dismiss(animated: true, completion: {
+                guard let menuAction = self.menuAction else {
+                    return
+                }
+
+                menuAction()
+            })
+        }
+
+        let personaView = persona.view
+        personaView.translatesAutoresizingMaskIntoConstraints = false
+        return personaView
+    }()
+
+    private var leftNavContentView: UIView {
+        let contentView = UIView()
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.layoutMargins = UIEdgeInsets(top: Constant.margin,
+                                                 left: Constant.margin,
+                                                 bottom: Constant.margin,
+                                                 right: Constant.margin)
+        let accountView = leftNavAccountView
+        let menuListView = leftNavMenuList.view
+        menuListView.translatesAutoresizingMaskIntoConstraints = false
+        leftNavMenuList.state.sections = leftNavMenuSections
+
+        contentView.addSubview(accountView)
+        contentView.addSubview(menuListView)
+
+        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
+        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
+
+        NSLayoutConstraint.activate([accountViewHeightConstraint,
+                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                                     accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                                     accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                                     menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
+                                     menuListView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                                     menuListView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                                     menuListView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+
+        return contentView
+    }
+
+    private var leftNavView: UIView {
+        let container = UIView(frame: .zero)
+
+        let contentView = leftNavContentView
+        container.addSubview(contentView)
+
+        container.backgroundColor = .systemBackground
+
+        NSLayoutConstraint.activate([container.safeAreaLayoutGuide.topAnchor.constraint(equalTo: contentView.topAnchor),
+                                     container.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                                     container.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                                     container.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
+        return container
+    }
+
+    private enum Constant {
+        static let margin: CGFloat = 16
+        static let verticalSpacing: CGFloat = 5
+    }
+}
+
+enum LeftNavPresence: Int, CaseIterable {
+    case available
+    case busy
+    case doNotDisturb
+    case beRightBack
+    case away
+    case offline
+
+    func imageView() -> UIImageView {
+        let imageView: UIImageView
+
+        switch self {
+        case .available:
+            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_available_16_filled"))
+            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+        case .away, .beRightBack:
+            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_away_16_filled"))
+            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.away
+        case .busy:
+            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_busy_16_filled"))
+            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.busy
+        case .doNotDisturb:
+            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_dnd_16_filled"))
+            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
+        case .offline:
+            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_offline_16_regular"))
+            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.offline
+        }
+
+        return imageView
+    }
+
+    func cellTitle() -> String {
+        let cellTitle: String
+        switch self {
+        case .available:
+            cellTitle = "Available"
+        case .busy:
+            cellTitle = "Busy"
+        case .doNotDisturb:
+            cellTitle = "Do not disturb"
+        case .beRightBack:
+            cellTitle = "Be right back"
+        case .away:
+            cellTitle = "Appear away"
+        case .offline:
+            cellTitle = "Appear offline"
+        }
+
+        return cellTitle
+    }
+
+    func avatarPresence() -> MSFAvatarPresence {
+        switch self {
+        case .available:
+            return .available
+        case .busy:
+            return .busy
+        case .doNotDisturb:
+            return .doNotDisturb
+        case .away, .beRightBack:
+            return .away
+        case .offline:
+            return .offline
+        }
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -142,11 +142,10 @@ class LeftNavMenuViewController: UIViewController {
         personaState.backgroundColor = .systemBackground
         personaState.onTapAction = {
             self.dismiss(animated: true, completion: { [weak self] in
-                guard let menuAction = self?.menuAction else {
+                guard let strongSelf = self else {
                     return
                 }
-
-                menuAction()
+                strongSelf.menuAction?()
             })
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -7,385 +7,386 @@ import FluentUI
 import UIKit
 import SwiftUI
 
-class LeftNavDemoController: DemoController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        addTitle(text: "Left navigation control")
-        addDescription(text: "The LeftNav control is built from a composition of the Avatar, Drawer and List controls.")
-
-        container.addArrangedSubview(navigationButton)
-
-        let isLeadingEdgeLeftToRight = view.effectiveUserInterfaceLayoutDirection == .leftToRight
-
-        let leadingEdgeGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePan))
-        leadingEdgeGesture.edges = isLeadingEdgeLeftToRight ? .left : .right
-        view.addGestureRecognizer(leadingEdgeGesture)
-        navigationController?.navigationController?.interactivePopGestureRecognizer?.require(toFail: leadingEdgeGesture)
-
-        let lefNavController = LeftNavMenuViewController(menuAction: { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.dismiss(animated: true, completion: { [weak self] in
-                guard let strongSelf = self else {
-                    return
-                }
-                strongSelf.showMessage("Menu item selected.")
-            })
-        })
-
-        drawerController.contentView = lefNavController.view
-        drawerController.presentingGesture = leadingEdgeGesture
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
-    }
-
-    private lazy var navigationButton: UIView = {
-        return createButton(title: "Show Left Navigation Menu", action: { [weak self ] _ in
-            if let strongSelf = self {
-                strongSelf.showLeftNavButtonTapped()
-            }
-        }).view
-    }()
-
-    private lazy var drawerController: DrawerController = {
-        let drawerController = DrawerController(sourceView: navigationButton,
-                                            sourceRect: navigationButton.bounds,
-                                            presentationDirection: .fromLeading)
-        drawerController.presentationBackground = .black
-        drawerController.preferredContentSize.width = 360
-        drawerController.resizingBehavior = .dismiss
-        return drawerController
-    }()
-
-    @objc private func showLeftNavButtonTapped() {
-        present(drawerController, animated: true, completion: nil)
-    }
-
-    @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {
-        guard gesture.state == .began else {
-            return
-        }
-
-        present(drawerController,
-                animated: true,
-                completion: nil)
-    }
-}
-
-class LeftNavMenuViewController: UIViewController {
-
-    init(menuAction: (() -> Void)?) {
-        self.menuAction = menuAction
-
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    @available(*, unavailable)
-    @objc public required init?(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        view = leftNavView
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
-            sizeCategory != self.traitCollection.preferredContentSizeCategory {
-            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
-        }
-    }
-
-    var menuAction: (() -> Void)?
-
-    private func setPresence(presence: LeftNavPresence) {
-        self.persona.state.presence = presence.avatarPresence()
-        self.statusCell.isExpanded = false
-        self.statusCell.title = presence.cellTitle()
-        self.statusCell.leadingUIView = presence.imageView()
-    }
-
-    private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
-
-    private var persona = MSFPersonaView()
-
-    private var statusCell = MSFListCellState()
-
-    private var leftNavMenuSections: [MSFListSectionState] {
-        let defaultMenuAction = {
-            guard let menuAction = self.menuAction else {
-                return
-            }
-            menuAction()
-        }
-
-        var statusCellChildren: [MSFListCellState] = []
-
-        for presence in LeftNavPresence.allCases {
-            let statusCellChild = MSFListCellState()
-            statusCellChild.leadingViewSize = .small
-            statusCellChild.title = presence.cellTitle()
-            statusCellChild.leadingUIView = presence.imageView()
-            statusCellChild.backgroundColor = .systemBackground
-            statusCellChild.onTapAction = {
-                self.setPresence(presence: presence)
-            }
-
-            statusCellChildren.append(statusCellChild)
-        }
-
-        let resetStatusCell = MSFListCellState()
-        resetStatusCell.title = "Reset status"
-        resetStatusCell.leadingViewSize = .small
-        resetStatusCell.backgroundColor = .systemBackground
-        let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
-        resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        resetStatusCell.leadingUIView = resetStatusImageView
-        resetStatusCell.onTapAction = {
-            self.setPresence(presence: .available)
-        }
-        statusCellChildren.append(resetStatusCell)
-
-        statusCell.title = LeftNavPresence.available.cellTitle()
-        statusCell.backgroundColor = .systemBackground
-        let statusImageView = LeftNavPresence.available.imageView()
-        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-        statusCell.leadingUIView = statusImageView
-        statusCell.children = statusCellChildren
-
-        let statusMessageCell = MSFListCellState()
-        statusMessageCell.backgroundColor = .systemBackground
-        statusMessageCell.title = "Set Status Message"
-        let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
-        statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        statusMessageCell.leadingUIView = statusMessageImageView
-        statusMessageCell.onTapAction = defaultMenuAction
-
-        let notificationsCell = MSFListCellState()
-        notificationsCell.backgroundColor = .systemBackground
-        notificationsCell.title = "Notifications"
-        notificationsCell.subtitle = "On"
-        notificationsCell.layoutType = .twoLines
-        let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
-        notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        notificationsCell.leadingUIView = notificationsImageView
-        notificationsCell.onTapAction = defaultMenuAction
-
-        let settingsCell = MSFListCellState()
-        settingsCell.backgroundColor = .systemBackground
-        settingsCell.title = "Settings"
-        let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
-        settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        settingsCell.leadingUIView = settingsImageView
-        settingsCell.onTapAction = defaultMenuAction
-
-        let whatsNewCell = MSFListCellState()
-        whatsNewCell.backgroundColor = .systemBackground
-        whatsNewCell.title = "What's new"
-        let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
-        whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        whatsNewCell.leadingUIView = whatsNewImageView
-        whatsNewCell.onTapAction = defaultMenuAction
-
-        let menuSection = MSFListSectionState()
-        menuSection.cells = [statusCell, statusMessageCell, notificationsCell, settingsCell, whatsNewCell]
-
-        let microsoftAccountCell = MSFListCellState()
-        microsoftAccountCell.backgroundColor = .systemBackground
-        microsoftAccountCell.layoutType = .twoLines
-        microsoftAccountCell.title = "Contoso"
-        microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
-        microsoftAccountCell.accessoryType = .checkmark
-        let orgAvatar = MSFAvatar(style: .group, size: .large)
-        orgAvatar.state.primaryText = "Kat Larrson"
-        microsoftAccountCell.leadingUIView = orgAvatar.view
-        microsoftAccountCell.leadingViewSize = .large
-
-        let msaAccountCell = MSFListCellState()
-        msaAccountCell.backgroundColor = .systemBackground
-        msaAccountCell.layoutType = .twoLines
-        msaAccountCell.title = "Personal"
-        msaAccountCell.subtitle = "kat.larrson@live.com"
-        let msaAvatar = MSFAvatar(style: .group, size: .large)
-        msaAvatar.state.primaryText = "kat.larrson@live.com"
-        msaAccountCell.leadingUIView = msaAvatar.view
-        msaAccountCell.leadingViewSize = .large
-
-        let addAccountCell = MSFListCellState()
-        addAccountCell.backgroundColor = .systemBackground
-        addAccountCell.title = "Add Account"
-        let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
-        addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
-        addAccountCell.leadingUIView = addAccountImageView
-        addAccountCell.onTapAction = defaultMenuAction
-
-        let accountsSection = MSFListSectionState()
-        accountsSection.title = "Accounts and Orgs"
-        accountsSection.backgroundColor = .systemBackground
-        accountsSection.cells = [microsoftAccountCell, msaAccountCell, addAccountCell]
-
-        return [menuSection, accountsSection]
-    }
-
-    private var leftNavMenuList = MSFList(sections: [])
-
-    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
-
-    private lazy var leftNavAccountView: UIView = {
-        let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
-        chevron.tintColor = Colors.textPrimary
-
-        persona.state.presence = .available
-        persona.state.primaryText = "Kat Larrson"
-        persona.state.secondaryText = "Designer"
-        persona.state.image = UIImage(named: "avatar_kat_larsson")
-        persona.state.titleTrailingAccessoryUIView = chevron
-        persona.state.backgroundColor = .systemBackground
-        persona.state.onTapAction = {
-            self.dismiss(animated: true, completion: {
-                guard let menuAction = self.menuAction else {
-                    return
-                }
-
-                menuAction()
-            })
-        }
-
-        let personaView = persona.view
-        personaView.translatesAutoresizingMaskIntoConstraints = false
-        return personaView
-    }()
-
-    private var leftNavContentView: UIView {
-        let contentView = UIView()
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.layoutMargins = UIEdgeInsets(top: Constant.margin,
-                                                 left: Constant.margin,
-                                                 bottom: Constant.margin,
-                                                 right: Constant.margin)
-        let accountView = leftNavAccountView
-        let menuListView = leftNavMenuList.view
-        menuListView.translatesAutoresizingMaskIntoConstraints = false
-        leftNavMenuList.state.sections = leftNavMenuSections
-
-        contentView.addSubview(accountView)
-        contentView.addSubview(menuListView)
-
-        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
-        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
-
-        NSLayoutConstraint.activate([accountViewHeightConstraint,
-                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
-                                     accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                                     accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-                                     menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
-                                     menuListView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-                                     menuListView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                                     menuListView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-        ])
-
-        return contentView
-    }
-
-    private var leftNavView: UIView {
-        let container = UIView(frame: .zero)
-
-        let contentView = leftNavContentView
-        container.addSubview(contentView)
-
-        container.backgroundColor = .systemBackground
-
-        NSLayoutConstraint.activate([container.safeAreaLayoutGuide.topAnchor.constraint(equalTo: contentView.topAnchor),
-                                     container.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-                                     container.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                                     container.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
-        return container
-    }
-
-    private enum Constant {
-        static let margin: CGFloat = 16
-        static let verticalSpacing: CGFloat = 5
-    }
-}
-
-enum LeftNavPresence: Int, CaseIterable {
-    case available
-    case busy
-    case doNotDisturb
-    case beRightBack
-    case away
-    case offline
-
-    func imageView() -> UIImageView {
-        let imageView: UIImageView
-
-        switch self {
-        case .available:
-            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_available_16_filled"))
-            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-        case .away, .beRightBack:
-            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_away_16_filled"))
-            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.away
-        case .busy:
-            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_busy_16_filled"))
-            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.busy
-        case .doNotDisturb:
-            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_dnd_16_filled"))
-            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
-        case .offline:
-            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_offline_16_regular"))
-            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.offline
-        }
-
-        return imageView
-    }
-
-    func cellTitle() -> String {
-        let cellTitle: String
-        switch self {
-        case .available:
-            cellTitle = "Available"
-        case .busy:
-            cellTitle = "Busy"
-        case .doNotDisturb:
-            cellTitle = "Do not disturb"
-        case .beRightBack:
-            cellTitle = "Be right back"
-        case .away:
-            cellTitle = "Appear away"
-        case .offline:
-            cellTitle = "Appear offline"
-        }
-
-        return cellTitle
-    }
-
-    func avatarPresence() -> MSFAvatarPresence {
-        switch self {
-        case .available:
-            return .available
-        case .busy:
-            return .busy
-        case .doNotDisturb:
-            return .doNotDisturb
-        case .away, .beRightBack:
-            return .away
-        case .offline:
-            return .offline
-        }
-    }
-}
+class LeftNavDemoController: DemoController { }
+//class LeftNavDemoController: DemoController {
+//
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//
+//        addTitle(text: "Left navigation control")
+//        addDescription(text: "The LeftNav control is built from a composition of the Avatar, Drawer and List controls.")
+//
+//        container.addArrangedSubview(navigationButton)
+//
+//        let isLeadingEdgeLeftToRight = view.effectiveUserInterfaceLayoutDirection == .leftToRight
+//
+//        let leadingEdgeGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePan))
+//        leadingEdgeGesture.edges = isLeadingEdgeLeftToRight ? .left : .right
+//        view.addGestureRecognizer(leadingEdgeGesture)
+//        navigationController?.navigationController?.interactivePopGestureRecognizer?.require(toFail: leadingEdgeGesture)
+//
+//        let lefNavController = LeftNavMenuViewController(menuAction: { [weak self] in
+//            guard let strongSelf = self else {
+//                return
+//            }
+//            strongSelf.dismiss(animated: true, completion: { [weak self] in
+//                guard let strongSelf = self else {
+//                    return
+//                }
+//                strongSelf.showMessage("Menu item selected.")
+//            })
+//        })
+//
+//        drawerController.contentView = lefNavController.view
+//        drawerController.presentingGesture = leadingEdgeGesture
+//    }
+//
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+//    }
+//
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+//    }
+//
+//    private lazy var navigationButton: UIView = {
+//        return createButton(title: "Show Left Navigation Menu", action: { [weak self ] _ in
+//            if let strongSelf = self {
+//                strongSelf.showLeftNavButtonTapped()
+//            }
+//        }).view
+//    }()
+//
+//    private lazy var drawerController: DrawerController = {
+//        let drawerController = DrawerController(sourceView: navigationButton,
+//                                            sourceRect: navigationButton.bounds,
+//                                            presentationDirection: .fromLeading)
+//        drawerController.presentationBackground = .black
+//        drawerController.preferredContentSize.width = 360
+//        drawerController.resizingBehavior = .dismiss
+//        return drawerController
+//    }()
+//
+//    @objc private func showLeftNavButtonTapped() {
+//        present(drawerController, animated: true, completion: nil)
+//    }
+//
+//    @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {
+//        guard gesture.state == .began else {
+//            return
+//        }
+//
+//        present(drawerController,
+//                animated: true,
+//                completion: nil)
+//    }
+//}
+
+//class LeftNavMenuViewController: UIViewController {
+//
+//    init(menuAction: (() -> Void)?) {
+//        self.menuAction = menuAction
+//
+//        super.init(nibName: nil, bundle: nil)
+//    }
+//
+//    @available(*, unavailable)
+//    @objc public required init?(coder: NSCoder) {
+//        preconditionFailure("init(coder:) has not been implemented")
+//    }
+//
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//
+//        view = leftNavView
+//    }
+//
+//    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+//        super.traitCollectionDidChange(previousTraitCollection)
+//        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
+//            sizeCategory != self.traitCollection.preferredContentSizeCategory {
+//            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
+//        }
+//    }
+//
+//    var menuAction: (() -> Void)?
+//
+//    private func setPresence(presence: LeftNavPresence) {
+//        self.persona.state.presence = presence.avatarPresence()
+//        self.statusCell.isExpanded = false
+//        self.statusCell.title = presence.cellTitle()
+//        self.statusCell.leadingUIView = presence.imageView()
+//    }
+//
+//    private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
+//
+//    private var persona = MSFPersonaView()
+//
+//    private var statusCell = MSFListCellState()
+//
+//    private var leftNavMenuSections: [MSFListSectionStateImpl] {
+//        let defaultMenuAction = {
+//            guard let menuAction = self.menuAction else {
+//                return
+//            }
+//            menuAction()
+//        }
+//
+//        var statusCellChildren: [MSFListCellState] = []
+//
+//        for presence in LeftNavPresence.allCases {
+//            let statusCellChild = MSFListCellState()
+//            statusCellChild.leadingViewSize = .small
+//            statusCellChild.title = presence.cellTitle()
+//            statusCellChild.leadingUIView = presence.imageView()
+//            statusCellChild.backgroundColor = .systemBackground
+//            statusCellChild.onTapAction = {
+//                self.setPresence(presence: presence)
+//            }
+//
+//            statusCellChildren.append(statusCellChild)
+//        }
+//
+//        let resetStatusCell = MSFListCellState()
+//        resetStatusCell.title = "Reset status"
+//        resetStatusCell.leadingViewSize = .small
+//        resetStatusCell.backgroundColor = .systemBackground
+//        let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
+//        resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+//        resetStatusCell.leadingUIView = resetStatusImageView
+//        resetStatusCell.onTapAction = {
+//            self.setPresence(presence: .available)
+//        }
+//        statusCellChildren.append(resetStatusCell)
+//
+//        statusCell.title = LeftNavPresence.available.cellTitle()
+//        statusCell.backgroundColor = .systemBackground
+//        let statusImageView = LeftNavPresence.available.imageView()
+//        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+//        statusCell.leadingUIView = statusImageView
+//        statusCell.children = statusCellChildren
+//
+//        let statusMessageCell = MSFListCellState()
+//        statusMessageCell.backgroundColor = .systemBackground
+//        statusMessageCell.title = "Set Status Message"
+//        let statusMessageImageView = UIImageView(image: UIImage(named: "ic_fluent_status_24_regular"))
+//        statusMessageImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+//        statusMessageCell.leadingUIView = statusMessageImageView
+//        statusMessageCell.onTapAction = defaultMenuAction
+//
+//        let notificationsCell = MSFListCellState()
+//        notificationsCell.backgroundColor = .systemBackground
+//        notificationsCell.title = "Notifications"
+//        notificationsCell.subtitle = "On"
+//        notificationsCell.layoutType = .twoLines
+//        let notificationsImageView = UIImageView(image: UIImage(named: "ic_fluent_alert_24_regular"))
+//        notificationsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+//        notificationsCell.leadingUIView = notificationsImageView
+//        notificationsCell.onTapAction = defaultMenuAction
+//
+//        let settingsCell = MSFListCellState()
+//        settingsCell.backgroundColor = .systemBackground
+//        settingsCell.title = "Settings"
+//        let settingsImageView = UIImageView(image: UIImage(named: "ic_fluent_settings_24_regular"))
+//        settingsImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+//        settingsCell.leadingUIView = settingsImageView
+//        settingsCell.onTapAction = defaultMenuAction
+//
+//        let whatsNewCell = MSFListCellState()
+//        whatsNewCell.backgroundColor = .systemBackground
+//        whatsNewCell.title = "What's new"
+//        let whatsNewImageView = UIImageView(image: UIImage(named: "ic_fluent_lightbulb_24_regular"))
+//        whatsNewImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+//        whatsNewCell.leadingUIView = whatsNewImageView
+//        whatsNewCell.onTapAction = defaultMenuAction
+//
+//        let menuSection = MSFListSectionStateImpl()
+//        menuSection.cells = [statusCell, statusMessageCell, notificationsCell, settingsCell, whatsNewCell]
+//
+//        let microsoftAccountCell = MSFListCellState()
+//        microsoftAccountCell.backgroundColor = .systemBackground
+//        microsoftAccountCell.layoutType = .twoLines
+//        microsoftAccountCell.title = "Contoso"
+//        microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
+//        microsoftAccountCell.accessoryType = .checkmark
+//        let orgAvatar = MSFAvatar(style: .group, size: .large)
+//        orgAvatar.state.primaryText = "Kat Larrson"
+//        microsoftAccountCell.leadingUIView = orgAvatar.view
+//        microsoftAccountCell.leadingViewSize = .large
+//
+//        let msaAccountCell = MSFListCellState()
+//        msaAccountCell.backgroundColor = .systemBackground
+//        msaAccountCell.layoutType = .twoLines
+//        msaAccountCell.title = "Personal"
+//        msaAccountCell.subtitle = "kat.larrson@live.com"
+//        let msaAvatar = MSFAvatar(style: .group, size: .large)
+//        msaAvatar.state.primaryText = "kat.larrson@live.com"
+//        msaAccountCell.leadingUIView = msaAvatar.view
+//        msaAccountCell.leadingViewSize = .large
+//
+//        let addAccountCell = MSFListCellState()
+//        addAccountCell.backgroundColor = .systemBackground
+//        addAccountCell.title = "Add Account"
+//        let addAccountImageView = UIImageView(image: UIImage(named: "ic_fluent_add_24_regular"))
+//        addAccountImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
+//        addAccountCell.leadingUIView = addAccountImageView
+//        addAccountCell.onTapAction = defaultMenuAction
+//
+//        let accountsSection = MSFListSectionStateImpl()
+//        accountsSection.title = "Accounts and Orgs"
+//        accountsSection.backgroundColor = .systemBackground
+//        accountsSection.cells = [microsoftAccountCell, msaAccountCell, addAccountCell]
+//
+//        return [menuSection, accountsSection]
+//    }
+//
+//    private var leftNavMenuList = MSFList(sections: [])
+//
+//    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
+//
+//    private lazy var leftNavAccountView: UIView = {
+//        let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
+//        chevron.tintColor = Colors.textPrimary
+//
+//        persona.state.presence = .available
+//        persona.state.primaryText = "Kat Larrson"
+//        persona.state.secondaryText = "Designer"
+//        persona.state.image = UIImage(named: "avatar_kat_larsson")
+//        persona.state.titleTrailingAccessoryUIView = chevron
+//        persona.state.backgroundColor = .systemBackground
+//        persona.state.onTapAction = {
+//            self.dismiss(animated: true, completion: {
+//                guard let menuAction = self.menuAction else {
+//                    return
+//                }
+//
+//                menuAction()
+//            })
+//        }
+//
+//        let personaView = persona.view
+//        personaView.translatesAutoresizingMaskIntoConstraints = false
+//        return personaView
+//    }()
+//
+//    private var leftNavContentView: UIView {
+//        let contentView = UIView()
+//        contentView.translatesAutoresizingMaskIntoConstraints = false
+//        contentView.layoutMargins = UIEdgeInsets(top: Constant.margin,
+//                                                 left: Constant.margin,
+//                                                 bottom: Constant.margin,
+//                                                 right: Constant.margin)
+//        let accountView = leftNavAccountView
+//        let menuListView = leftNavMenuList.view
+//        menuListView.translatesAutoresizingMaskIntoConstraints = false
+//        leftNavMenuList.state.sections = leftNavMenuSections
+//
+//        contentView.addSubview(accountView)
+//        contentView.addSubview(menuListView)
+//
+//        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
+//        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
+//
+//        NSLayoutConstraint.activate([accountViewHeightConstraint,
+//                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
+//                                     accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+//                                     accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+//                                     menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
+//                                     menuListView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+//                                     menuListView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+//                                     menuListView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+//        ])
+//
+//        return contentView
+//    }
+//
+//    private var leftNavView: UIView {
+//        let container = UIView(frame: .zero)
+//
+//        let contentView = leftNavContentView
+//        container.addSubview(contentView)
+//
+//        container.backgroundColor = .systemBackground
+//
+//        NSLayoutConstraint.activate([container.safeAreaLayoutGuide.topAnchor.constraint(equalTo: contentView.topAnchor),
+//                                     container.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+//                                     container.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+//                                     container.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
+//        return container
+//    }
+//
+//    private enum Constant {
+//        static let margin: CGFloat = 16
+//        static let verticalSpacing: CGFloat = 5
+//    }
+//}
+
+//enum LeftNavPresence: Int, CaseIterable {
+//    case available
+//    case busy
+//    case doNotDisturb
+//    case beRightBack
+//    case away
+//    case offline
+//
+//    func imageView() -> UIImageView {
+//        let imageView: UIImageView
+//
+//        switch self {
+//        case .available:
+//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_available_16_filled"))
+//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+//        case .away, .beRightBack:
+//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_away_16_filled"))
+//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.away
+//        case .busy:
+//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_busy_16_filled"))
+//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.busy
+//        case .doNotDisturb:
+//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_dnd_16_filled"))
+//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.doNotDisturb
+//        case .offline:
+//            imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_offline_16_regular"))
+//            imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.offline
+//        }
+//
+//        return imageView
+//    }
+//
+//    func cellTitle() -> String {
+//        let cellTitle: String
+//        switch self {
+//        case .available:
+//            cellTitle = "Available"
+//        case .busy:
+//            cellTitle = "Busy"
+//        case .doNotDisturb:
+//            cellTitle = "Do not disturb"
+//        case .beRightBack:
+//            cellTitle = "Be right back"
+//        case .away:
+//            cellTitle = "Appear away"
+//        case .offline:
+//            cellTitle = "Appear offline"
+//        }
+//
+//        return cellTitle
+//    }
+//
+//    func avatarPresence() -> MSFAvatarPresence {
+//        switch self {
+//        case .available:
+//            return .available
+//        case .busy:
+//            return .busy
+//        case .doNotDisturb:
+//            return .doNotDisturb
+//        case .away, .beRightBack:
+//            return .away
+//        case .offline:
+//            return .offline
+//        }
+//    }
+//}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -52,9 +52,10 @@ class LeftNavDemoController: DemoController {
 
     private lazy var navigationButton: UIView = {
         return createButton(title: "Show Left Navigation Menu", action: { [weak self] _ in
-            if let strongSelf = self {
-                strongSelf.showLeftNavButtonTapped()
+            guard let strongSelf = self else {
+                return
             }
+            strongSelf.showLeftNavButtonTapped()
         }).view
     }()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -67,19 +67,18 @@ class ListDemoController: DemoController {
         let collapsibleSection = list.state.createSection()
         collapsibleSection.title = "AvatarSection"
         for index in 0...1 {
-            listCell = MSFListCellState()
+            listCell = collapsibleSection.createCell()
             avatar = createAvatarView(size: .medium,
                                       name: samplePersonas[index].name,
                                       image: samplePersonas[index].image,
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
             listCell.leadingUIView = avatar.view
-            collapsibleSection.cells.append(listCell)
-            collapsibleSection.hasDividers = true
+        collapsibleSection.hasDividers = true
         }
-        collapsibleSection.cells[0].children = children
-        collapsibleSection.cells[0].isExpanded = true
-        collapsibleSection.cells[1].onTapAction = {
+        collapsibleSection.getCellState(at: 0).children = children
+        collapsibleSection.getCellState(at: 0).isExpanded = true
+        collapsibleSection.getCellState(at: 1).onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }
 
@@ -96,7 +95,7 @@ class ListDemoController: DemoController {
                 indexPath.row = rowIndex
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
                 cell = section.item
-                listCell = MSFListCellState()
+                listCell = sectionState.createCell()
                 listCell.title = cell.text1
                 listCell.subtitle = cell.text2
                 listCell.footnote = cell.text3
@@ -117,7 +116,6 @@ class ListDemoController: DemoController {
                     indexPath.section = sectionIndex
                     self.showAlertForCellTapped(indexPath: indexPath)
                 }
-                sectionState.cells.append(listCell)
             }
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -16,10 +16,8 @@ class ListDemoController: DemoController {
         var indexPath = IndexPath(row: 0, section: 0)
         var showsLabelAccessoryView: Bool
 
-        var list: MSFList
+        let list: MSFList = MSFList()
         var listCell: MSFListCellState
-        var listSection: MSFListSectionState
-        var listData: [MSFListSectionState] = []
 
         let samplePersonas: [PersonaData] = [
             PersonaData(name: "Kat Larrson", email: "kat.larrson@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_kat_larsson"), color: Colors.Palette.cyanBlue10.color),
@@ -66,9 +64,8 @@ class ListDemoController: DemoController {
         }
 
         /// Custom Leading View with collapsible children items
-        listSection = MSFListSectionState()
-        listSection.title = "Avatar Section"
-        listSection.cells = []
+        let collapsibleSection = list.state.createSection()
+        collapsibleSection.title = "AvatarSection"
         for index in 0...1 {
             listCell = MSFListCellState()
             avatar = createAvatarView(size: .medium,
@@ -77,25 +74,24 @@ class ListDemoController: DemoController {
                                       style: .default)
             listCell.title = avatar.state.primaryText ?? ""
             listCell.leadingUIView = avatar.view
-            listSection.cells.append(listCell)
-            listSection.hasDividers = true
+            collapsibleSection.cells.append(listCell)
+            collapsibleSection.hasDividers = true
         }
-        listSection.cells[0].children = children
-        listSection.cells[0].isExpanded = true
-        listSection.cells[1].onTapAction = {
+        collapsibleSection.cells[0].children = children
+        collapsibleSection.cells[0].isExpanded = true
+        collapsibleSection.cells[1].onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }
-        listData.append(listSection)
 
         /// TableViewCell Sample Data Sections
         for sectionIndex in 0...sections.count - 1 {
             indexPath.section = sectionIndex
             section = sections[sectionIndex]
 
-            listSection = MSFListSectionState()
-            listSection.title = section.title
-            listSection.cells = []
-            listSection.style = MSFHeaderFooterStyle.headerSecondary
+            let sectionState = list.state.createSection()
+            sectionState.title = section.title
+            sectionState.style = MSFHeaderFooterStyle.headerSecondary
+            sectionState.hasDividers = true
             for rowIndex in 0...TableViewCellSampleData.numberOfItemsInSection - 1 {
                 indexPath.row = rowIndex
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
@@ -121,13 +117,9 @@ class ListDemoController: DemoController {
                     indexPath.section = sectionIndex
                     self.showAlertForCellTapped(indexPath: indexPath)
                 }
-                listSection.cells.append(listCell)
-                listSection.hasDividers = true
+                sectionState.cells.append(listCell)
             }
-            listData.append(listSection)
         }
-
-        list = MSFList(sections: listData)
 
         let listView = list.view
         listView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -83,7 +83,7 @@ class ListDemoController: DemoController {
         }
 
         /// TableViewCell Sample Data Sections
-        for sectionIndex in 0...sections.count - 1 {
+        for sectionIndex in 0..<sections.count {
             indexPath.section = sectionIndex
             section = sections[sectionIndex]
 
@@ -91,7 +91,7 @@ class ListDemoController: DemoController {
             sectionState.title = section.title
             sectionState.style = MSFHeaderFooterStyle.headerSecondary
             sectionState.hasDividers = true
-            for rowIndex in 0...TableViewCellSampleData.numberOfItemsInSection - 1 {
+            for rowIndex in 0..<TableViewCellSampleData.numberOfItemsInSection {
                 indexPath.row = rowIndex
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
                 cell = section.item

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -76,8 +76,9 @@ class ListDemoController: DemoController {
             listCell.leadingUIView = avatar.view
         collapsibleSection.hasDividers = true
         }
-        collapsibleSection.getCellState(at: 0).children = children
-        collapsibleSection.getCellState(at: 0).isExpanded = true
+        let firstCellState = collapsibleSection.getCellState(at: 0)
+        firstCellState.children = children
+        firstCellState.isExpanded = true
         collapsibleSection.getCellState(at: 1).onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -12,7 +12,6 @@
 @property (nonatomic) UIStackView *container;
 @property (nonatomic) UIScrollView *scrollingContainer;
 @property (nonatomic) MSFButton *testButton;
-@property (nonatomic) MSFList *testList;
 
 @end
 
@@ -65,13 +64,13 @@
 
     MSFButtonLegacy *resetButton = [self createButtonWithTitle:@"Reset Button" action:@selector(resetButton)];
     [self.container addArrangedSubview:resetButton];
-    
+
     UILabel *listVnextLabel = [[UILabel alloc] init];
     [listVnextLabel setText:@"List (vNext)"];
     [self.container addArrangedSubview:listVnextLabel];
-    
-    _testList = [[MSFList alloc] initWithTheme:nil];
-    id<MSFListSectionState> sectionState = [[_testList state] createSection];
+
+    MSFList *testList = [[MSFList alloc] initWithTheme:nil];
+    id<MSFListSectionState> sectionState = [[testList state] createSection];
     MSFListCellState *listCell1 = [sectionState createCell];
     MSFListCellState *listCell2 = [sectionState createCell];
     MSFListCellState *listCell3 = [sectionState createCell];
@@ -101,10 +100,10 @@
         [self showAlertForCellTapped:@"Sample Title3"];
     }];
 
-    UIView *listView = [_testList view];
+    UIView *listView = [testList view];
     listView.translatesAutoresizingMaskIntoConstraints = false;
 
-    [self.container addArrangedSubview:[_testList view]];
+    [self.container addArrangedSubview:[testList view]];
 
     [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -65,50 +65,50 @@
     MSFButtonLegacy *resetButton = [self createButtonWithTitle:@"Reset Button" action:@selector(resetButton)];
     [self.container addArrangedSubview:resetButton];
     
-    UILabel *listVnextLabel = [[UILabel alloc] init];
-    [listVnextLabel setText:@"List (vNext)"];
-    [self.container addArrangedSubview:listVnextLabel];
-
-    MSFListCellState *childCell = [[MSFListCellState alloc] init];
-    [childCell setTitle:@"Child Cell"];
-    NSArray *children = [NSArray arrayWithObject:childCell];
-
-    MSFListCellState *listCell1 = [[MSFListCellState alloc] init];
-    [listCell1 setTitle:@"SampleTitle1"];
-    [listCell1 setIsExpanded:TRUE];
-    [listCell1 setChildren:children];
-
-    MSFListCellState *listCell2 = [[MSFListCellState alloc] init];
-    [listCell2 setTitle:@"SampleTitle2"];
-    [listCell2 setSubtitle:@"SampleTitle2"];
-    [listCell2 setLayoutType:MSFListCellLayoutTypeTwoLines];
-    [listCell2 setOnTapAction:^{
-        [self showAlertForCellTapped:@"SampleTitle2"];
-    }];
-
-    MSFListCellState *listCell3 = [[MSFListCellState alloc] init];
-    [listCell3 setTitle:@"SampleTitle3"];
-    [listCell3 setSubtitle:@"SampleTitle3"];
-    UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]];
-    [listCell3 setLeadingUIView:image];
-    [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
-    [listCell3 setLayoutType:MSFListCellLayoutTypeTwoLines];
-    [listCell3 setOnTapAction:^{
-        [self showAlertForCellTapped:@"Sample Title3"];
-    }];
-
-    MSFListSectionState *section = [[MSFListSectionState alloc] init];
-    [section setCells:@[listCell1, listCell2, listCell3]];
-    NSArray *sections = @[section];
-
-    MSFList *list = [[MSFList alloc] initWithSections:sections];
-
-    UIView *listView = [list view];
-    listView.translatesAutoresizingMaskIntoConstraints = false;
-
-    [self.container addArrangedSubview:[list view]];
-
-    [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
+//    UILabel *listVnextLabel = [[UILabel alloc] init];
+//    [listVnextLabel setText:@"List (vNext)"];
+//    [self.container addArrangedSubview:listVnextLabel];
+//
+//    MSFListCellState *childCell = [[MSFListCellState alloc] init];
+//    [childCell setTitle:@"Child Cell"];
+//    NSArray *children = [NSArray arrayWithObject:childCell];
+//
+//    MSFListCellState *listCell1 = [[MSFListCellState alloc] init];
+//    [listCell1 setTitle:@"SampleTitle1"];
+//    [listCell1 setIsExpanded:TRUE];
+//    [listCell1 setChildren:children];
+//
+//    MSFListCellState *listCell2 = [[MSFListCellState alloc] init];
+//    [listCell2 setTitle:@"SampleTitle2"];
+//    [listCell2 setSubtitle:@"SampleTitle2"];
+//    [listCell2 setLayoutType:MSFListCellLayoutTypeTwoLines];
+//    [listCell2 setOnTapAction:^{
+//        [self showAlertForCellTapped:@"SampleTitle2"];
+//    }];
+//
+//    MSFListCellState *listCell3 = [[MSFListCellState alloc] init];
+//    [listCell3 setTitle:@"SampleTitle3"];
+//    [listCell3 setSubtitle:@"SampleTitle3"];
+//    UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]];
+//    [listCell3 setLeadingUIView:image];
+//    [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
+//    [listCell3 setLayoutType:MSFListCellLayoutTypeTwoLines];
+//    [listCell3 setOnTapAction:^{
+//        [self showAlertForCellTapped:@"Sample Title3"];
+//    }];
+//
+//    MSFListSectionStateImpl *section = [[MSFListSectionStateImpl alloc] init];
+//    [section setCells:@[listCell1, listCell2, listCell3]];
+//    NSArray *sections = @[section];
+//
+//    MSFList *list = [[MSFList alloc] initWithSections:sections];
+//
+//    UIView *listView = [list view];
+//    listView.translatesAutoresizingMaskIntoConstraints = false;
+//
+//    [self.container addArrangedSubview:[list view]];
+//
+//    [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
 }
 
 - (void)enableButton {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -12,6 +12,7 @@
 @property (nonatomic) UIStackView *container;
 @property (nonatomic) UIScrollView *scrollingContainer;
 @property (nonatomic) MSFButton *testButton;
+@property (nonatomic) MSFList *testList;
 
 @end
 
@@ -68,17 +69,20 @@
     UILabel *listVnextLabel = [[UILabel alloc] init];
     [listVnextLabel setText:@"List (vNext)"];
     [self.container addArrangedSubview:listVnextLabel];
+    
+    _testList = [[MSFList alloc] initWithTheme:nil];
+    MSFListCellState *listCell1 = [[[_testList state] createSection] createCell];
+    MSFListCellState *listCell2 = [[[_testList state] getSectionStateAt:0] createCell];
+    MSFListCellState *listCell3 = [[[_testList state] getSectionStateAt:0] createCell];
 
     MSFListCellState *childCell = [[MSFListCellState alloc] init];
     [childCell setTitle:@"Child Cell"];
     NSArray *children = [NSArray arrayWithObject:childCell];
 
-    MSFListCellState *listCell1 = [[MSFListCellState alloc] init];
     [listCell1 setTitle:@"SampleTitle1"];
     [listCell1 setIsExpanded:TRUE];
     [listCell1 setChildren:children];
 
-    MSFListCellState *listCell2 = [[MSFListCellState alloc] init];
     [listCell2 setTitle:@"SampleTitle2"];
     [listCell2 setSubtitle:@"SampleTitle2"];
     [listCell2 setLayoutType:MSFListCellLayoutTypeTwoLines];
@@ -86,7 +90,6 @@
         [self showAlertForCellTapped:@"SampleTitle2"];
     }];
 
-    MSFListCellState *listCell3 = [[MSFListCellState alloc] init];
     [listCell3 setTitle:@"SampleTitle3"];
     [listCell3 setSubtitle:@"SampleTitle3"];
     UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]];
@@ -97,16 +100,10 @@
         [self showAlertForCellTapped:@"Sample Title3"];
     }];
 
-    MSFListSectionState *section = [[MSFListSectionState alloc] init];
-    [section setCells:@[listCell1, listCell2, listCell3]];
-    NSArray *sections = @[section];
-
-    MSFList *list = [[MSFList alloc] initWithSections:sections];
-
-    UIView *listView = [list view];
+    UIView *listView = [_testList view];
     listView.translatesAutoresizingMaskIntoConstraints = false;
 
-    [self.container addArrangedSubview:[list view]];
+    [self.container addArrangedSubview:[_testList view]];
 
     [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -71,9 +71,10 @@
     [self.container addArrangedSubview:listVnextLabel];
     
     _testList = [[MSFList alloc] initWithTheme:nil];
-    MSFListCellState *listCell1 = [[[_testList state] createSection] createCell];
-    MSFListCellState *listCell2 = [[[_testList state] getSectionStateAt:0] createCell];
-    MSFListCellState *listCell3 = [[[_testList state] getSectionStateAt:0] createCell];
+    id<MSFListSectionState> sectionState = [[_testList state] createSection];
+    MSFListCellState *listCell1 = [sectionState createCell];
+    MSFListCellState *listCell2 = [sectionState createCell];
+    MSFListCellState *listCell3 = [sectionState createCell];
 
     MSFListCellState *childCell = [[MSFListCellState alloc] init];
     [childCell setTitle:@"Child Cell"];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -65,50 +65,50 @@
     MSFButtonLegacy *resetButton = [self createButtonWithTitle:@"Reset Button" action:@selector(resetButton)];
     [self.container addArrangedSubview:resetButton];
     
-//    UILabel *listVnextLabel = [[UILabel alloc] init];
-//    [listVnextLabel setText:@"List (vNext)"];
-//    [self.container addArrangedSubview:listVnextLabel];
-//
-//    MSFListCellState *childCell = [[MSFListCellState alloc] init];
-//    [childCell setTitle:@"Child Cell"];
-//    NSArray *children = [NSArray arrayWithObject:childCell];
-//
-//    MSFListCellState *listCell1 = [[MSFListCellState alloc] init];
-//    [listCell1 setTitle:@"SampleTitle1"];
-//    [listCell1 setIsExpanded:TRUE];
-//    [listCell1 setChildren:children];
-//
-//    MSFListCellState *listCell2 = [[MSFListCellState alloc] init];
-//    [listCell2 setTitle:@"SampleTitle2"];
-//    [listCell2 setSubtitle:@"SampleTitle2"];
-//    [listCell2 setLayoutType:MSFListCellLayoutTypeTwoLines];
-//    [listCell2 setOnTapAction:^{
-//        [self showAlertForCellTapped:@"SampleTitle2"];
-//    }];
-//
-//    MSFListCellState *listCell3 = [[MSFListCellState alloc] init];
-//    [listCell3 setTitle:@"SampleTitle3"];
-//    [listCell3 setSubtitle:@"SampleTitle3"];
-//    UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]];
-//    [listCell3 setLeadingUIView:image];
-//    [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
-//    [listCell3 setLayoutType:MSFListCellLayoutTypeTwoLines];
-//    [listCell3 setOnTapAction:^{
-//        [self showAlertForCellTapped:@"Sample Title3"];
-//    }];
-//
-//    MSFListSectionStateImpl *section = [[MSFListSectionStateImpl alloc] init];
-//    [section setCells:@[listCell1, listCell2, listCell3]];
-//    NSArray *sections = @[section];
-//
-//    MSFList *list = [[MSFList alloc] initWithSections:sections];
-//
-//    UIView *listView = [list view];
-//    listView.translatesAutoresizingMaskIntoConstraints = false;
-//
-//    [self.container addArrangedSubview:[list view]];
-//
-//    [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
+    UILabel *listVnextLabel = [[UILabel alloc] init];
+    [listVnextLabel setText:@"List (vNext)"];
+    [self.container addArrangedSubview:listVnextLabel];
+
+    MSFListCellState *childCell = [[MSFListCellState alloc] init];
+    [childCell setTitle:@"Child Cell"];
+    NSArray *children = [NSArray arrayWithObject:childCell];
+
+    MSFListCellState *listCell1 = [[MSFListCellState alloc] init];
+    [listCell1 setTitle:@"SampleTitle1"];
+    [listCell1 setIsExpanded:TRUE];
+    [listCell1 setChildren:children];
+
+    MSFListCellState *listCell2 = [[MSFListCellState alloc] init];
+    [listCell2 setTitle:@"SampleTitle2"];
+    [listCell2 setSubtitle:@"SampleTitle2"];
+    [listCell2 setLayoutType:MSFListCellLayoutTypeTwoLines];
+    [listCell2 setOnTapAction:^{
+        [self showAlertForCellTapped:@"SampleTitle2"];
+    }];
+
+    MSFListCellState *listCell3 = [[MSFListCellState alloc] init];
+    [listCell3 setTitle:@"SampleTitle3"];
+    [listCell3 setSubtitle:@"SampleTitle3"];
+    UIImageView *image = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"excelIcon"]];
+    [listCell3 setLeadingUIView:image];
+    [listCell3 setAccessoryType:MSFListAccessoryTypeDisclosure];
+    [listCell3 setLayoutType:MSFListCellLayoutTypeTwoLines];
+    [listCell3 setOnTapAction:^{
+        [self showAlertForCellTapped:@"Sample Title3"];
+    }];
+
+    MSFListSectionState *section = [[MSFListSectionState alloc] init];
+    [section setCells:@[listCell1, listCell2, listCell3]];
+    NSArray *sections = @[section];
+
+    MSFList *list = [[MSFList alloc] initWithSections:sections];
+
+    UIView *listView = [list view];
+    listView.translatesAutoresizingMaskIntoConstraints = false;
+
+    [self.container addArrangedSubview:[list view]];
+
+    [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
 }
 
 - (void)enableButton {

--- a/ios/FluentUI/Vnext/List/HeaderFooterTokens.swift
+++ b/ios/FluentUI/Vnext/List/HeaderFooterTokens.swift
@@ -24,7 +24,13 @@ class MSFHeaderFooterTokens: MSFTokensBase, ObservableObject {
 
     @Published public var textFont: UIFont!
 
-    @Published public var style: MSFHeaderFooterStyle!
+    var style: MSFHeaderFooterStyle {
+            didSet {
+                if oldValue != style {
+                    updateForCurrentTheme()
+                }
+            }
+        }
 
     init(style: MSFHeaderFooterStyle) {
         self.style = style
@@ -46,7 +52,7 @@ class MSFHeaderFooterTokens: MSFTokensBase, ObservableObject {
         switch style {
         case .headerSecondary:
             appearanceProxy = currentTheme.MSFHeaderFooterTokens
-        case .headerPrimary, .none:
+        case .headerPrimary:
             appearanceProxy = currentTheme.MSFPrimaryHeaderTokens
         }
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -6,29 +6,48 @@
 import UIKit
 import SwiftUI
 
-/// Properties that make up section content
-@objc public class MSFListSectionState: NSObject, ObservableObject, Identifiable {
-    public var id = UUID()
-    @objc @Published public var cells: [MSFListCellState] = []
-    @objc @Published public var title: String?
-    @objc @Published public var backgroundColor: UIColor?
-    @objc @Published public var hasDividers: Bool = false
-    @objc @Published public var style: MSFHeaderFooterStyle = .headerPrimary {
-        didSet {
-            if style != oldValue {
-                headerTokens.style = style
-                headerTokens.updateForCurrentTheme()
-            }
-        }
+/// UIKit wrapper that exposes the SwiftUI List implementation
+@objc open class MSFList: NSObject, FluentUIWindowProvider {
+
+    @objc public init(sections: [MSFListSectionState],
+                      theme: FluentUIStyle? = nil) {
+        super.init()
+
+        listView = MSFListView(sections: sections)
+        hostingController = FluentUIHostingController(rootView: AnyView(listView
+                                                                            .windowProvider(self)
+                                                                            .modifyIf(theme != nil, { listView in
+                                                                                listView.customTheme(theme!)
+                                                                            })))
+        hostingController.disableSafeAreaInsets()
+        view.backgroundColor = UIColor.clear
     }
 
-    var headerTokens = MSFHeaderFooterTokens(style: .headerPrimary)
+    @objc public convenience init(sections: [MSFListSectionState]) {
+        self.init(sections: sections,
+                  theme: nil)
+    }
+
+    @objc open var view: UIView {
+        return hostingController.view
+    }
+
+    @objc open var state: MSFListState {
+        return listView.state
+    }
+
+    var window: UIWindow? {
+        return self.view.window
+    }
+
+    private var hostingController: FluentUIHostingController!
+
+    private var listView: MSFListView!
 }
 
-/// Properties that make up list content
-@objc public class MSFListState: NSObject, ObservableObject {
-    @objc @Published public var sections: [MSFListSectionState] = []
-}
+/// Protocol goes here
+
+
 
 public struct MSFListView: View {
     @Environment(\.theme) var theme: FluentUIStyle
@@ -97,41 +116,26 @@ public struct MSFListView: View {
     }
 }
 
-/// UIKit wrapper that exposes the SwiftUI List implementation
-@objc open class MSFList: NSObject, FluentUIWindowProvider {
-
-    @objc public init(sections: [MSFListSectionState],
-                      theme: FluentUIStyle? = nil) {
-        super.init()
-
-        listView = MSFListView(sections: sections)
-        hostingController = FluentUIHostingController(rootView: AnyView(listView
-                                                                            .windowProvider(self)
-                                                                            .modifyIf(theme != nil, { listView in
-                                                                                listView.customTheme(theme!)
-                                                                            })))
-        hostingController.disableSafeAreaInsets()
-        view.backgroundColor = UIColor.clear
+/// Properties that make up section content
+@objc public class MSFListSectionState: NSObject, ObservableObject, Identifiable {
+    public var id = UUID()
+    @objc @Published public var cells: [MSFListCellState] = []
+    @objc @Published public var title: String?
+    @objc @Published public var backgroundColor: UIColor?
+    @objc @Published public var hasDividers: Bool = false
+    @objc @Published public var style: MSFHeaderFooterStyle = .headerPrimary {
+        didSet {
+            if style != oldValue {
+                headerTokens.style = style
+                headerTokens.updateForCurrentTheme()
+            }
+        }
     }
 
-    @objc public convenience init(sections: [MSFListSectionState]) {
-        self.init(sections: sections,
-                  theme: nil)
-    }
+    var headerTokens = MSFHeaderFooterTokens(style: .headerPrimary)
+}
 
-    @objc open var view: UIView {
-        return hostingController.view
-    }
-
-    @objc open var state: MSFListState {
-        return listView.state
-    }
-
-    var window: UIWindow? {
-        return self.view.window
-    }
-
-    private var hostingController: FluentUIHostingController!
-
-    private var listView: MSFListView!
+/// Properties that make up list content
+@objc public class MSFListState: NSObject, ObservableObject {
+    @objc @Published public var sections: [MSFListSectionState] = []
 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -53,6 +53,9 @@ import SwiftUI
     /// Configures the Section's `HeaderFooter` style.
     var style: MSFHeaderFooterStyle { get set }
 
+    /// The number of Cells in the Section.
+    var count: Int { get }
+
     /// Creates a new Cell within the Section.
     func createCell() -> MSFListCellState
 
@@ -63,12 +66,16 @@ import SwiftUI
     /// - Parameter index: The zero-based index of the Cell in the Section.
     func getCellState(at index: Int) -> MSFListCellState
 
-    /// Remove an Cell from the Section.
+    /// Remove a Cell from the Section.
     /// - Parameter index: The zero-based index of the Cell that will be removed from the Section.
     func removeCell(at index: Int)
 }
 
+/// Properties that can be used to customize the appearance of the List.
 @objc public protocol MSFListState {
+    /// The number of Sections in the List.
+    var count: Int { get }
+
     /// Creates a new Section within the List.
     func createSection() -> MSFListSectionState
 
@@ -79,7 +86,7 @@ import SwiftUI
     /// - Parameter index: The zero-based index of the Section in the List.
     func getSectionState(at index: Int) -> MSFListSectionState
 
-    /// Remove an Section from the List.
+    /// Remove a Section from the List.
     /// - Parameter index: The zero-based index of the Section that will be removed from the List.
     func removeSection(at index: Int)
 }
@@ -187,6 +194,10 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, MSFList
     @Published var backgroundColor: UIColor?
     @Published var hasDividers: Bool = false
 
+    var count: Int {
+        return cells.count
+    }
+
     var style: MSFHeaderFooterStyle {
         get {
             return headerTokens.style
@@ -235,6 +246,10 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
     }
 
     @Published var sections: [MSFListSectionStateImpl] = []
+
+    var count: Int {
+        return sections.count
+    }
 
     var tokens: MSFListTokens
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -60,6 +60,7 @@ import SwiftUI
     func createCell() -> MSFListCellState
 
     /// Creates a new Cell within the Section at a specific index.
+    /// - Parameter index: The zero-based index of the Cell that will be inserted into the Section.
     func createCell(at index: Int) -> MSFListCellState
 
     /// Retrieves the state object for a specific Cell so its appearance can be customized.
@@ -80,6 +81,7 @@ import SwiftUI
     func createSection() -> MSFListSectionState
 
     /// Creates a new Section within the List at a specific index.
+    /// - Parameter index: The zero-based index of the Section that will be inserted into the List.
     func createSection(at index: Int) -> MSFListSectionState
 
     /// Retrieves the state object for a specific Section so its appearance can be customized.

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -54,9 +54,9 @@ import SwiftUI
     var style: MSFHeaderFooterStyle { get set }
 
     /// The number of Cells in the Section.
-    var count: Int { get }
+    var cellCount: Int { get }
 
-    /// Creates a new Cell within the Section.
+    /// Creates a new Cell and appends it to the array of cells in a Section.
     func createCell() -> MSFListCellState
 
     /// Creates a new Cell within the Section at a specific index.
@@ -74,9 +74,9 @@ import SwiftUI
 /// Properties that can be used to customize the appearance of the List.
 @objc public protocol MSFListState {
     /// The number of Sections in the List.
-    var count: Int { get }
+    var sectionCount: Int { get }
 
-    /// Creates a new Section within the List.
+    /// Creates a new Section and appends it to the array of sections in a List.
     func createSection() -> MSFListSectionState
 
     /// Creates a new Section within the List at a specific index.
@@ -92,11 +92,6 @@ import SwiftUI
 }
 
 public struct MSFListView: View {
-    @Environment(\.theme) var theme: FluentUIStyle
-    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
-    @ObservedObject var tokens: MSFListTokens
-    @ObservedObject var state: MSFListStateImpl
-
     public init() {
         self.state = MSFListStateImpl()
         self.tokens = MSFListTokens()
@@ -130,6 +125,11 @@ public struct MSFListView: View {
                           from: theme,
                           with: windowProvider)
     }
+
+    @Environment(\.theme) var theme: FluentUIStyle
+    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+    @ObservedObject var tokens: MSFListTokens
+    @ObservedObject var state: MSFListStateImpl
 
     /// Finds the last cell directly adjacent to the end of a list section. This is used to remove the redundant separator that is
     /// inserted between each cell. Used as a fix until we are able to use the new List Separators in iOS 15.
@@ -189,12 +189,12 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, MSFList
     }
 
     var id = UUID()
-    @Published var cells: [MSFListCellState] = []
+    @Published private(set) var cells: [MSFListCellState] = []
     @Published var title: String?
     @Published var backgroundColor: UIColor?
     @Published var hasDividers: Bool = false
 
-    var count: Int {
+    var cellCount: Int {
         return cells.count
     }
 
@@ -204,7 +204,6 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, MSFList
         }
         set {
             headerTokens.style = newValue
-            headerTokens.updateForCurrentTheme()
         }
     }
 
@@ -245,9 +244,9 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         sections.remove(at: index)
     }
 
-    @Published var sections: [MSFListSectionStateImpl] = []
+    @Published private(set) var sections: [MSFListSectionStateImpl] = []
 
-    var count: Int {
+    var sectionCount: Int {
         return sections.count
     }
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -39,10 +39,18 @@ import SwiftUI
     private var listView: MSFListView!
 }
 
+/// Properties that can be used to customize the appearance of the List Section.
 @objc public protocol MSFListSectionState {
+    /// Sets the Section title.
     var title: String? { get set }
+
+    /// Sets a custom background color for the List Section.
     var backgroundColor: UIColor? { get set }
+
+    /// Configures divider presence within the Section.
     var hasDividers: Bool { get set }
+
+    /// Configures the Section's `HeaderFooter` style.
     var style: MSFHeaderFooterStyle { get set }
 
     /// Creates a new Cell within the Section.
@@ -85,7 +93,6 @@ public struct MSFListView: View {
     public init() {
         self.state = MSFListStateImpl()
         self.tokens = MSFListTokens()
-//        self.state.sections = sections
     }
 
     public var body: some View {
@@ -102,6 +109,7 @@ public struct MSFListView: View {
                             MSFListCellView(state: cellState)
                                 .frame(maxWidth: .infinity)
                         }
+
                         if section.hasDividers {
                             FluentDivider()
                         }
@@ -130,6 +138,7 @@ public struct MSFListView: View {
         return lastCell
     }
 
+    /// Updates the status of dividers presence within the entire List.
     private func updateCellDividers() -> [MSFListSectionStateImpl] {
         state.sections.forEach { section in
             section.cells.forEach { cell in

--- a/ios/FluentUI/Vnext/List/ListHeaderFooter.swift
+++ b/ios/FluentUI/Vnext/List/ListHeaderFooter.swift
@@ -10,9 +10,9 @@ struct Header: View {
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFHeaderFooterTokens
-    @ObservedObject var state: MSFListSectionState
+    @ObservedObject var state: MSFListSectionStateImpl
 
-    init(state: MSFListSectionState) {
+    init(state: MSFListSectionStateImpl) {
         self.state = state
         self.tokens = state.headerTokens
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The List vNext control is a bit outdated and needed some polishing. This PR adds public protocols to the control and reorganizes the file contents to match the other controls. 

### Verification

Tested on iOS 14/15, Dark/Light, verified that List works the same in List/LeftNav/ObjC demo controllers.

Demo:

https://user-images.githubusercontent.com/22566866/149566445-6b695909-b1b8-40b1-a938-19ba65de0125.mov

Theming validation:

https://user-images.githubusercontent.com/22566866/149566537-233e8051-d27e-4084-91c2-d3cc0f05854a.mov



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/865)