### PR TITLE
set the Xcode version of the pipeline to 13.1

### DIFF
--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_13.2.1.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_13.1.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

partial revert of commit d373e87. Our pipeline is not quite ready for Xcode 13.2.1 and we need to be all in-sync because of swift compiler compatibility problems.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/866)