### PR TITLE
Update padding, alignment, and font size of CardView

### DIFF
--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -226,7 +226,7 @@ open class CardView: UIView {
         case .vertical:
             primaryLabel.textAlignment = .center
             primaryLabel.style = .caption1
-		}
+        }
         addSubview(primaryLabel)
 
         // Subtitle

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -369,7 +369,7 @@ open class CardView: UIView {
                 primaryLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Constants.horizontalContentSpacing),
                 iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.paddingLeading),
                 primaryLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.paddingTrailing)
-			])
+            ])
 
             // Center the title vertically if there is no subtitle
             if secondaryText == nil && !twoLineTitle {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Updated card view. Card view currently supports two variations, horizontal and vertical.
- Horizontal layout changes:
   - Changed the padding so the overall card height is larger.
   - Changed the width to be larger.
- Vertical layout changes:
   - Center aligned title, subtitle, and icon.
   - Decreased the title and subtitle font sizes
   - Increased padding to increase overall card size.
### Verification

Manually tested and checked the changes.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 13 Pro - 2022-01-14 at 10 11 48](https://user-images.githubusercontent.com/21343215/149565056-ee6ca941-ed95-4b1b-8db8-91eb22d3fbcd.png)|![Simulator Screen Shot - iPhone 13 - 2022-01-14 at 10 09 06](https://user-images.githubusercontent.com/21343215/149565087-fc097b99-6fa5-45aa-8962-612ea3f83a90.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/868)