### PR TITLE
turn off ASAN for device build even for debug config.

### DIFF
--- a/.ado/xcconfig/publish_overrides_ios_device.xcconfig
+++ b/.ado/xcconfig/publish_overrides_ios_device.xcconfig
@@ -2,3 +2,4 @@
 
 // Explicitly build arm64e for iOS device builds in case our clients need it
 ARCHS = $(ARCHS_STANDARD) arm64e
+ENABLE_ADDRESS_SANITIZER = NO


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

turn off ASAN for device build even for debug config.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Debug iphoneos  61.7MB | Debug iphoneos 42.4MB |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/869)