### PR TITLE
Support badge view in the search bar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -7,6 +7,23 @@ import FluentUI
 import UIKit
 
 class SearchBarDemoController: DemoController, SearchBarDelegate {
+    private lazy var searchBarWithBadgeView: SearchBar = {
+        let searchBar = buildSearchBar(
+            autocorrectionType: .yes,
+            placeholderText: "Type badge to add a badge"
+        )
+        return searchBar
+    }()
+
+    private var badgeView: BadgeView = {
+        let dataSource = BadgeViewDataSource(text: "Kat Larrson")
+        let badge = BadgeView(dataSource: dataSource)
+        badge.disabledBackgroundColor = Colors.Palette.blueMagenta20.color
+        badge.disabledLabelTextColor = .white
+        badge.isActive = false
+        return badge
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -15,6 +32,7 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
 
         container.addArrangedSubview(searchBarNoAutocorrect)
         container.addArrangedSubview(searchBarAutocorrect)
+        container.addArrangedSubview(searchBarWithBadgeView)
     }
 
     func buildSearchBar(autocorrectionType: UITextAutocorrectionType, placeholderText: String) -> SearchBar {
@@ -33,7 +51,10 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
     }
 
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
-        searchBar.placeholderText = newSearchText ?? "search"
+        if searchBar == searchBarWithBadgeView && searchBar.searchText?.lowercased() == "badge" && searchBarWithBadgeView.badgeView == nil {
+            searchBarWithBadgeView.badgeView = badgeView
+            searchBar.searchText = ""
+        }
     }
 
     func searchBarDidFinishEditing(_ searchBar: SearchBar) {
@@ -45,5 +66,15 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
 
     func searchBarDidRequestSearch(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = true
+    }
+
+    func searchBar(_ searchBar: SearchBar, didUpdateBadgeView badgeView: BadgeView?) {
+        let badgeInfo = badgeView?.dataSource?.text ?? "nil"
+
+        let alert = UIAlertController(title: "Badge view updated: \(badgeInfo)", message: nil, preferredStyle: .alert)
+        present(alert, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            alert.dismiss(animated: false)
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -8,11 +8,10 @@ import UIKit
 
 class SearchBarDemoController: DemoController, SearchBarDelegate {
     private lazy var searchBarWithBadgeView: SearchBar = {
-        let searchBar = buildSearchBar(
+        buildSearchBar(
             autocorrectionType: .yes,
             placeholderText: "Type badge to add a badge"
         )
-        return searchBar
     }()
 
     private var badgeView: UIView = {
@@ -68,8 +67,8 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         searchBar.progressSpinner.state.isAnimating = true
     }
 
-    func searchBar(_ searchBar: SearchBar, didUpdateBadgeView badgeView: BadgeView?) {
-        let badgeInfo = badgeView?.dataSource?.text ?? "nil"
+    func searchBar(_ searchBar: SearchBar, didUpdateLeadingView leadingView: UIView?) {
+        let badgeInfo = (leadingView as? BadgeView)?.dataSource?.text ?? "nil"
 
         let alert = UIAlertController(title: "Badge view updated: \(badgeInfo)", message: nil, preferredStyle: .alert)
         present(alert, animated: true)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -15,7 +15,7 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         return searchBar
     }()
 
-    private var badgeView: BadgeView = {
+    private var badgeView: UIView = {
         let dataSource = BadgeViewDataSource(text: "Kat Larrson")
         let badge = BadgeView(dataSource: dataSource)
         badge.disabledBackgroundColor = Colors.Palette.blueMagenta20.color
@@ -51,8 +51,8 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
     }
 
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
-        if searchBar == searchBarWithBadgeView && searchBar.searchText?.lowercased() == "badge" && searchBarWithBadgeView.badgeView == nil {
-            searchBarWithBadgeView.badgeView = badgeView
+        if searchBar == searchBarWithBadgeView && searchBar.searchText?.lowercased() == "badge" && searchBarWithBadgeView.leadingView == nil {
+            searchBarWithBadgeView.leadingView = badgeView
             searchBar.searchText = ""
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -8,13 +8,11 @@ import UIKit
 
 class SearchBarDemoController: DemoController, SearchBarDelegate {
     private lazy var searchBarWithBadgeView: SearchBar = {
-        buildSearchBar(
-            autocorrectionType: .yes,
-            placeholderText: "Type badge to add a badge"
-        )
+        buildSearchBar(autocorrectionType: .yes,
+                       placeholderText: "Type \"badge\" to add a leading badge")
     }()
 
-    private var badgeView: UIView = {
+    private lazy var badgeView: UIView = {
         let dataSource = BadgeViewDataSource(text: "Kat Larrson")
         let badge = BadgeView(dataSource: dataSource)
         badge.disabledBackgroundColor = Colors.Palette.blueMagenta20.color

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -42,7 +42,7 @@ public protocol SearchBarDelegate: AnyObject {
     @objc optional func searchBarDidFinishEditing(_ searchBar: SearchBar)
     func searchBarDidCancel(_ searchBar: SearchBar)
     @objc optional func searchBarDidRequestSearch(_ searchBar: SearchBar)
-    @objc optional func searchBar(_ searchBar: SearchBar, didUpdateBadgeView badgeView: BadgeView?)
+    @objc optional func searchBar(_ searchBar: SearchBar, didUpdateLeadingView leadingView: UIView?)
 }
 
 // MARK: - SearchBar
@@ -254,16 +254,16 @@ open class SearchBar: UIView {
         return button
     }()
 
-    @objc public var badgeView: BadgeView? {
+    @objc public var leadingView: UIView? {
         didSet {
-            guard oldValue != badgeView else {
+            guard oldValue != leadingView else {
                 return
             }
 
             oldValue?.removeFromSuperview()
-            setupLayoutForBadgeView()
+            setupLayoutForLeadingView()
             onContentChanged()
-            delegate?.searchBar?(self, didUpdateBadgeView: badgeView)
+            delegate?.searchBar?(self, didUpdateLeadingView: leadingView)
         }
     }
 
@@ -337,7 +337,7 @@ open class SearchBar: UIView {
         isActive = false
         searchTextField.resignFirstResponder()
         searchTextField.text = nil
-        badgeView = nil
+        leadingView = nil
         searchTextDidChange(shouldUpdateDelegate: false)
         delegate?.searchBarDidCancel(self)
         hideCancelButton()
@@ -445,24 +445,24 @@ open class SearchBar: UIView {
         NSLayoutConstraint.activate(constraints)
     }
 
-    private func setupLayoutForBadgeView() {
-        guard let badgeView = badgeView else {
+    private func setupLayoutForLeadingView() {
+        guard let leadingView = leadingView else {
             textFieldLeadingConstraint?.constant = Constants.searchTextFieldLeadingInset
             return
         }
 
-        let badgeViewSize = badgeView.sizeThatFits(searchTextFieldBackgroundView.frame.size)
+        let leadingViewSize = leadingView.sizeThatFits(searchTextFieldBackgroundView.frame.size)
 
-        textFieldLeadingConstraint?.constant = Constants.searchIconInset + badgeViewSize.width + Constants.searchTextFieldLeadingInset
+        textFieldLeadingConstraint?.constant = Constants.searchIconInset + leadingViewSize.width + Constants.searchTextFieldLeadingInset
 
-        searchTextFieldBackgroundView.addSubview(badgeView)
-        badgeView.translatesAutoresizingMaskIntoConstraints = false
+        searchTextFieldBackgroundView.addSubview(leadingView)
+        leadingView.translatesAutoresizingMaskIntoConstraints = false
 
         var constraints = [NSLayoutConstraint]()
-        constraints.append(badgeView.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchIconInset))
-        constraints.append(badgeView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
-        constraints.append(badgeView.widthAnchor.constraint(equalToConstant: badgeViewSize.width))
-        constraints.append(badgeView.heightAnchor.constraint(equalToConstant: badgeViewSize.height))
+        constraints.append(leadingView.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchIconInset))
+        constraints.append(leadingView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
+        constraints.append(leadingView.widthAnchor.constraint(equalToConstant: leadingViewSize.width))
+        constraints.append(leadingView.heightAnchor.constraint(equalToConstant: leadingViewSize.height))
         NSLayoutConstraint.activate(constraints)
     }
 
@@ -489,7 +489,7 @@ open class SearchBar: UIView {
     // Clears all text by setting searchText to nil
     @objc private func clearButtonTapped(sender: UIButton) {
         searchTextField.text = nil
-        badgeView = nil
+        leadingView = nil
         searchTextDidChange(shouldUpdateDelegate: true)
         _ = searchTextField.becomeFirstResponder()
     }
@@ -523,7 +523,7 @@ open class SearchBar: UIView {
     }
 
     private func onContentChanged() {
-        let hasContent = searchTextField.text?.isEmpty == false || badgeView != nil
+        let hasContent = searchTextField.text?.isEmpty == false || leadingView != nil
 
         UIView.animate(withDuration: 0.1) {
             self.attributePlaceholderText()
@@ -592,7 +592,7 @@ extension SearchBar: UITextFieldDelegate {
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         if textField == searchTextField && string == "" && range == NSRange(location: 0, length: 0) {
-            badgeView = nil
+            leadingView = nil
         }
         return true
     }
@@ -604,7 +604,7 @@ extension UINavigationItem {
     var accessorySearchBar: SearchBar? { return accessoryView as? SearchBar }
 }
 
-// MARK: - SearchBarField
+// MARK: - SearchBarTextField
 
 private class SearchBarTextField: UITextField {
     override func deleteBackward() {

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -42,6 +42,7 @@ public protocol SearchBarDelegate: AnyObject {
     @objc optional func searchBarDidFinishEditing(_ searchBar: SearchBar)
     func searchBarDidCancel(_ searchBar: SearchBar)
     @objc optional func searchBarDidRequestSearch(_ searchBar: SearchBar)
+    @objc optional func searchBar(_ searchBar: SearchBar, didUpdateBadgeView badgeView: BadgeView?)
 }
 
 // MARK: - SearchBar
@@ -184,6 +185,7 @@ open class SearchBar: UIView {
     // used to hide the cancelButton in non-active states
     private var searchTextFieldBackgroundViewTrailingConstraint: NSLayoutConstraint?
     private var cancelButtonTrailingConstraint: NSLayoutConstraint?
+    private var textFieldLeadingConstraint: NSLayoutConstraint?
 
     private lazy var searchIconImageViewContainerView = UIView()
 
@@ -196,8 +198,8 @@ open class SearchBar: UIView {
     }()
 
     // user interaction point
-    private lazy var searchTextField: UITextField = {
-        let textField = UITextField()
+    private lazy var searchTextField: SearchBarTextField = {
+        let textField = SearchBarTextField()
         textField.font = Fonts.body.withSize(Constants.fontSize)
         textField.delegate = self
         textField.returnKeyType = .search
@@ -251,6 +253,28 @@ open class SearchBar: UIView {
 
         return button
     }()
+
+    @objc public var badgeView: BadgeView? {
+        didSet {
+            guard oldValue != badgeView else {
+                return
+            }
+
+            oldValue?.removeFromSuperview()
+            setupLayoutForBadgeView()
+            onContentChanged()
+            delegate?.searchBar?(self, didUpdateBadgeView: badgeView)
+        }
+    }
+
+    @objc open var isEditable: Bool = true {
+        didSet {
+            if !isEditable {
+                _ = resignFirstResponder()
+            }
+            searchTextField.isUserInteractionEnabled = isEditable
+        }
+    }
 
     private var originalIsNavigationBarHidden: Bool = false
 
@@ -313,6 +337,7 @@ open class SearchBar: UIView {
         isActive = false
         searchTextField.resignFirstResponder()
         searchTextField.text = nil
+        badgeView = nil
         searchTextDidChange(shouldUpdateDelegate: false)
         delegate?.searchBarDidCancel(self)
         hideCancelButton()
@@ -382,7 +407,8 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundView.addSubview(searchTextField)
         searchTextField.translatesAutoresizingMaskIntoConstraints = false
 
-        constraints.append(searchTextField.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchTextFieldLeadingInset))
+        textFieldLeadingConstraint = searchTextField.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchTextFieldLeadingInset)
+        textFieldLeadingConstraint?.isActive = true
         constraints.append(searchTextField.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
         constraints.append(searchTextField.heightAnchor.constraint(equalTo: searchTextFieldBackgroundView.heightAnchor, constant: -2 * Constants.searchTextFieldVerticalInset))
 
@@ -419,6 +445,27 @@ open class SearchBar: UIView {
         NSLayoutConstraint.activate(constraints)
     }
 
+    private func setupLayoutForBadgeView() {
+        guard let badgeView = badgeView else {
+            textFieldLeadingConstraint?.constant = Constants.searchTextFieldLeadingInset
+            return
+        }
+
+        let badgeViewSize = badgeView.sizeThatFits(searchTextFieldBackgroundView.frame.size)
+
+        textFieldLeadingConstraint?.constant = Constants.searchIconInset + badgeViewSize.width + Constants.searchTextFieldLeadingInset
+
+        searchTextFieldBackgroundView.addSubview(badgeView)
+        badgeView.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints = [NSLayoutConstraint]()
+        constraints.append(badgeView.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchIconInset))
+        constraints.append(badgeView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
+        constraints.append(badgeView.widthAnchor.constraint(equalToConstant: badgeViewSize.width))
+        constraints.append(badgeView.heightAnchor.constraint(equalToConstant: badgeViewSize.height))
+        NSLayoutConstraint.activate(constraints)
+    }
+
     private func updateColorsForStyle() {
         searchTextFieldBackgroundView.backgroundColor = style.backgroundColor
         searchIconImageView.tintColor = style.searchIconColor
@@ -442,6 +489,7 @@ open class SearchBar: UIView {
     // Clears all text by setting searchText to nil
     @objc private func clearButtonTapped(sender: UIButton) {
         searchTextField.text = nil
+        badgeView = nil
         searchTextDidChange(shouldUpdateDelegate: true)
         _ = searchTextField.becomeFirstResponder()
     }
@@ -471,7 +519,11 @@ open class SearchBar: UIView {
             delegate?.searchBar(self, didUpdateSearchText: newSearchText)
         }
 
-        let hasContent = newSearchText?.isEmpty == false
+        onContentChanged()
+    }
+
+    private func onContentChanged() {
+        let hasContent = searchTextField.text?.isEmpty == false || badgeView != nil
 
         UIView.animate(withDuration: 0.1) {
             self.attributePlaceholderText()
@@ -537,10 +589,36 @@ extension SearchBar: UITextFieldDelegate {
         dismissKeyboard()
         return false
     }
+
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if textField == searchTextField && string == "" && range == NSRange(location: 0, length: 0) {
+            badgeView = nil
+        }
+        return true
+    }
 }
 
 // MARK: - UINavigationItem extension
 
 extension UINavigationItem {
     var accessorySearchBar: SearchBar? { return accessoryView as? SearchBar }
+}
+
+// MARK: - SearchBarField
+
+private class SearchBarTextField: UITextField {
+    override func deleteBackward() {
+        // Triggers the delegate method even when the cursor (caret) is in the first postion (regardless of text being empty).
+        // Using the zero width space ("\u{200B}") as the emptyTextFieldString instead of this approach will cause Voice Over
+        // to read it out loud as "zero width space", which is not desirable.
+        if let selectionRange = selectedTextRange,
+           selectionRange.isEmpty,
+           offset(from: beginningOfDocument, to: selectionRange.start) == 0 {
+            _ = self.delegate?.textField?(self,
+                                          shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+                                          replacementString: "")
+        }
+
+        super.deleteBackward()
+    }
 }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -407,10 +407,10 @@ open class SearchBar: UIView {
         searchTextFieldBackgroundView.addSubview(searchTextField)
         searchTextField.translatesAutoresizingMaskIntoConstraints = false
 
-        textFieldLeadingConstraint = searchTextField.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchTextFieldLeadingInset)
-        textFieldLeadingConstraint?.isActive = true
         constraints.append(searchTextField.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
         constraints.append(searchTextField.heightAnchor.constraint(equalTo: searchTextFieldBackgroundView.heightAnchor, constant: -2 * Constants.searchTextFieldVerticalInset))
+        constraints.append(searchTextField.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchTextFieldLeadingInset))
+        textFieldLeadingConstraint = constraints.last
 
         // progressSpinner
         let progressSpinnerView = progressSpinner.view
@@ -446,24 +446,23 @@ open class SearchBar: UIView {
     }
 
     private func setupLayoutForLeadingView() {
+        textFieldLeadingConstraint?.isActive = leadingView == nil
+
         guard let leadingView = leadingView else {
-            textFieldLeadingConstraint?.constant = Constants.searchTextFieldLeadingInset
             return
         }
 
-        let leadingViewSize = leadingView.sizeThatFits(searchTextFieldBackgroundView.frame.size)
-
-        textFieldLeadingConstraint?.constant = Constants.searchIconInset + leadingViewSize.width + Constants.searchTextFieldLeadingInset
-
         searchTextFieldBackgroundView.addSubview(leadingView)
+        let leadingViewSize = leadingView.sizeThatFits(searchTextFieldBackgroundView.frame.size)
         leadingView.translatesAutoresizingMaskIntoConstraints = false
 
-        var constraints = [NSLayoutConstraint]()
-        constraints.append(leadingView.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchIconInset))
-        constraints.append(leadingView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor))
-        constraints.append(leadingView.widthAnchor.constraint(equalToConstant: leadingViewSize.width))
-        constraints.append(leadingView.heightAnchor.constraint(equalToConstant: leadingViewSize.height))
-        NSLayoutConstraint.activate(constraints)
+        NSLayoutConstraint.activate([
+            leadingView.leadingAnchor.constraint(equalTo: searchIconImageViewContainerView.trailingAnchor, constant: Constants.searchIconInset),
+            leadingView.trailingAnchor.constraint(equalTo: searchTextField.leadingAnchor, constant: -Constants.searchTextFieldLeadingInset),
+            leadingView.centerYAnchor.constraint(equalTo: searchTextFieldBackgroundView.centerYAnchor),
+            leadingView.widthAnchor.constraint(equalToConstant: leadingViewSize.width),
+            leadingView.heightAnchor.constraint(equalToConstant: leadingViewSize.height)
+        ])
     }
 
     private func updateColorsForStyle() {
@@ -591,7 +590,7 @@ extension SearchBar: UITextFieldDelegate {
     }
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if textField == searchTextField && string == "" && range == NSRange(location: 0, length: 0) {
+        if textField == searchTextField && string.isEmpty && range == NSRange(location: 0, length: 0) {
             leadingView = nil
         }
         return true


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Support badge view in the search bar:
1.  ios/FluentUI/Navigation/SearchBar.swift
- Add a property `badgeView: BadgeView?`. Enable consumer add a badge into search bar when give a value, or clear it when set it to nil.
- Update layout related functions.
- Replace `searchTextField` from `UITextField` to `SearchBarTextField`, so that we can monitor `deleteBackward` and remove badge view when user press delete on empty text field.
- Add function to notify delegate when badge view is updated.
- Add property `isEditable`. In Office, we need to disable edit when it people centric search mode for now.
2. ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
- Add a demo for search bar with badge view. When user type "badge", a badge will be inserted.

### Verification
Manual test the UI of test demo

| LTR                                       | RTL                                      |
|----------------------------------------------|--------------------------------------------|
| ![IMG_DEE2B6B2D85E-1](https://user-images.githubusercontent.com/3814629/149734690-2cdb3190-d844-4275-85ab-2f3446a56f2c.jpeg) | ![IMG_B5058BF23A4A-1](https://user-images.githubusercontent.com/3814629/149897500-cfb8087c-397f-46a5-9614-1d24f930a42a.jpeg) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/871)