### PR TITLE
Fix `BottomCommandingController` unhiding on horizontal size class change

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -292,6 +292,7 @@ open class BottomCommandingController: UIViewController {
     public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
 
+        // Make sure we only reset our commanding style on iPad. On iPhone we only use the sheet style, so there's no need for unnecessary work.
         if newCollection.horizontalSizeClass != traitCollection.horizontalSizeClass && newCollection.userInterfaceIdiom == .pad {
             // On a horizontal size class change the top level sheet / bar surfaces get recreated,
             // but the item views, containers and bindings persist and are reused during the individual setup functions.

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -312,7 +312,7 @@ public class BottomSheetController: UIViewController {
         }
 
         view.addSubview(bottomSheetView)
-        bottomSheetView.isHidden = isHidden
+        bottomSheetView.isHidden = currentExpansionState == .hidden
 
         // The non-zero frame here ensures the layout engine won't complain if it tries to calculate
         // sheet content layout before view.bounds is set to a non-zero rect.
@@ -442,6 +442,11 @@ public class BottomSheetController: UIViewController {
                 panGestureRecognizer.state = .cancelled
             }
         }
+    }
+
+    public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransition(to: newCollection, with: coordinator)
+        completeAnimationsIfNeeded(skipToEnd: true)
     }
 
     // MARK: - Gesture handling


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This fixes a bug where the bottom commanding could sometimes unhide when the horizontal size class changed between regular and compact. When this class changes, we switch between bottom bar and sheet style.
The problem is that when destroying the `BottomSheetController`, we didn't store the current `isHidden` state to be used in the recreated layout.

#### Fix
- Make sure we remember the sheet `isHidden` state when recreating the bottom commanding.

While we're here:
- Fix `BottomSheetController` not setting `isHidden` of the sheet view correctly in `loadView`
- There was a jarring animation on screen rotation when we recreate the commanding surface (frames animate from `.zero`). To fix this, we now do our view setup before the trait collection changes and we force a layout pass to have meaningful initial frames for the animation. Impact shown in the videos below.
- Make sure we only reset our commanding style on iPads. On iPhone we only use the sheet style, so there's no need for  unnecessary work. 

### Verification

Sanity checking in the test app.

The only visual change is the rotation animation fix. Before:

https://user-images.githubusercontent.com/3610850/150205276-bd411ca5-2ac5-40c1-8a45-84b8a8b21d8a.mov

After:

https://user-images.githubusercontent.com/3610850/150205355-6c56023f-262d-4a0e-8f10-ccbb1ed9b064.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/873)