### PR TITLE
Add flexible height mode to `BottomSheetController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -21,9 +21,10 @@ class BottomSheetDemoController: UIViewController {
         view.addSubview(optionTableView)
         mainTableView = optionTableView
 
-        let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: personaListView)
+        let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: expandedContentView)
         bottomSheetViewController.hostedScrollView = personaListView
         bottomSheetViewController.headerContentHeight = BottomSheetDemoController.headerHeight
+        bottomSheetViewController.collapsedContentHeight = 150
         bottomSheetViewController.delegate = self
 
         self.bottomSheetViewController = bottomSheetViewController
@@ -66,6 +67,10 @@ class BottomSheetDemoController: UIViewController {
         bottomSheetViewController?.shouldHideCollapsedContent.toggle()
     }
 
+    @objc private func toggleFlexibleSheetHeight(_ sender: BooleanCell) {
+        bottomSheetViewController?.isFlexibleHeight = sender.isOn
+    }
+
     @objc private func toggleHandleUsingCustomAccessibilityLabel(_ sender: BooleanCell) {
         let isOn = sender.isOn
         bottomSheetViewController?.handleCollapseCustomAccessibilityLabel = isOn ? "Collapse Bottom Sheet" : nil
@@ -81,12 +86,35 @@ class BottomSheetDemoController: UIViewController {
         bottomSheetViewController?.preferredExpandedContentHeight = 400
     }
 
-    private let personaListView: PersonaListView = {
+    private lazy var personaListView: UIScrollView = {
         let personaListView = PersonaListView()
         personaListView.personaList = samplePersonas
         personaListView.backgroundColor = Colors.NavigationBar.background
         personaListView.translatesAutoresizingMaskIntoConstraints = false
         return personaListView
+    }()
+
+    private lazy var expandedContentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(personaListView)
+
+        let bottomView = UIView()
+        bottomView.backgroundColor = .systemTeal
+        bottomView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bottomView)
+
+        NSLayoutConstraint.activate([
+            personaListView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            personaListView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            personaListView.topAnchor.constraint(equalTo: view.topAnchor),
+            personaListView.bottomAnchor.constraint(equalTo: bottomView.topAnchor),
+            bottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            bottomView.heightAnchor.constraint(equalToConstant: 75)
+        ])
+        return view
     }()
 
     private let headerView: UIView = {
@@ -127,6 +155,7 @@ class BottomSheetDemoController: UIViewController {
             DemoItem(title: "Should always fill width", type: .boolean, action: #selector(toggleFillWidth), isOn: bottomSheetViewController?.shouldAlwaysFillWidth ?? false),
             DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
             DemoItem(title: "Hide collapsed content", type: .boolean, action: #selector(toggleCollapsedContentHiding), isOn: collapsedContentHidingEnabled),
+            DemoItem(title: "Flexible sheet height", type: .boolean, action: #selector(toggleFlexibleSheetHeight), isOn: bottomSheetViewController?.isFlexibleHeight ?? false),
             DemoItem(title: "Use custom handle accessibility label", type: .boolean, action: #selector(toggleHandleUsingCustomAccessibilityLabel), isOn: isHandleUsingCustomAccessibilityLabel),
             DemoItem(title: "Full screen sheet content", type: .action, action: #selector(fullScreenSheetContent)),
             DemoItem(title: "Fixed height sheet content", type: .action, action: #selector(fixedHeightSheetContent))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -24,7 +24,7 @@ class BottomSheetDemoController: UIViewController {
         let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: expandedContentView)
         bottomSheetViewController.hostedScrollView = personaListView
         bottomSheetViewController.headerContentHeight = BottomSheetDemoController.headerHeight
-        bottomSheetViewController.collapsedContentHeight = 150
+        bottomSheetViewController.collapsedContentHeight = 70
         bottomSheetViewController.delegate = self
 
         self.bottomSheetViewController = bottomSheetViewController
@@ -100,9 +100,15 @@ class BottomSheetDemoController: UIViewController {
         view.addSubview(personaListView)
 
         let bottomView = UIView()
-        bottomView.backgroundColor = .systemTeal
+        bottomView.backgroundColor = Colors.surfaceQuaternary
         bottomView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomView)
+
+        let label = Label()
+        label.text = "Bottom view"
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        bottomView.addSubview(label)
 
         NSLayoutConstraint.activate([
             personaListView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -111,8 +117,10 @@ class BottomSheetDemoController: UIViewController {
             personaListView.bottomAnchor.constraint(equalTo: bottomView.topAnchor),
             bottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            bottomView.heightAnchor.constraint(equalToConstant: 75)
+            bottomView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            bottomView.heightAnchor.constraint(equalToConstant: 30),
+            label.centerXAnchor.constraint(equalTo: bottomView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: bottomView.centerYAnchor)
         ])
         return view
     }()
@@ -162,7 +170,7 @@ class BottomSheetDemoController: UIViewController {
         ]
     }
 
-    private static let headerHeight: CGFloat = 70
+    private static let headerHeight: CGFloat = 30
 
     private enum DemoItemType {
         case action

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -648,7 +648,8 @@ public class BottomSheetController: UIViewController {
             ? Constants.Spring.oscillatingDampingRatio
             : Constants.Spring.defaultDampingRatio
 
-        let springParams = UISpringTimingParameters(dampingRatio: damping, initialVelocity: CGVector(dx: springVelocity, dy: springVelocity))
+        let springParams = UISpringTimingParameters(dampingRatio: damping,
+                                                    initialVelocity: CGVector(dx: springVelocity, dy: springVelocity))
         let translationAnimator = UIViewPropertyAnimator(duration: Constants.Spring.animationDuration, timingParameters: springParams)
 
         self.targetExpansionState = targetExpansionState

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -97,6 +97,23 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// Indicates if the sheet height is flexible.
+    ///
+    /// When set to `false`, the sheet height is static and always corresponds to the height of the maximum expansion state.
+    /// Interacting with the sheet will only vertically translate it, moving it partially on/off-screen.
+    ///
+    /// When set to `true`, moving the sheet beyond the `.collapsed` state will resize it.
+    ///
+    /// Use flexible height if you have views attached to the bottom of `expandedContentView` that should always be visible.
+    @objc open var isFlexibleHeight: Bool = false {
+        didSet {
+            guard isViewLoaded else {
+                return
+            }
+            view.setNeedsLayout()
+        }
+    }
+
     /// Height of `headerContentView`.
     ///
     /// Setting this is required when the `headerContentView` is non-nil.
@@ -485,18 +502,21 @@ public class BottomSheetController: UIViewController {
             return
         }
 
-        let currentOffset = currentSheetVerticalOffset
-        let collapsedOffset = offset(for: .collapsed)
-        let expandedOffset = offset(for: .expanded)
-
         var targetAlpha: CGFloat = 0.0
-        if currentOffset <= expandedOffset {
-            targetAlpha = 1.0
-        } else if currentOffset >= collapsedOffset {
-            targetAlpha = 0.0
-        } else {
-            targetAlpha = abs(currentOffset - collapsedOffset) / (collapsedOffset - expandedOffset)
+        if isExpandable {
+            let currentOffset = currentSheetVerticalOffset
+            let collapsedOffset = offset(for: .collapsed)
+            let expandedOffset = offset(for: .expanded)
+
+            if currentOffset <= expandedOffset {
+                targetAlpha = 1.0
+            } else if currentOffset >= collapsedOffset {
+                targetAlpha = 0.0
+            } else {
+                targetAlpha = abs(currentOffset - collapsedOffset) / (collapsedOffset - expandedOffset)
+            }
         }
+
         dimmingView.alpha = targetAlpha
     }
 
@@ -539,9 +559,17 @@ public class BottomSheetController: UIViewController {
     private func sheetFrame(offset: CGFloat) -> CGRect {
         let availableWidth: CGFloat = view.bounds.width
         let sheetWidth = shouldAlwaysFillWidth ? availableWidth : min(Constants.maxSheetWidth, availableWidth)
+        let sheetHeight: CGFloat
+
+        if isFlexibleHeight {
+            let minSheetHeight = collapsedSheetHeight
+            sheetHeight = max(minSheetHeight, view.bounds.maxY - offset)
+        } else {
+            sheetHeight = expandedSheetHeight
+        }
 
         return CGRect(origin: CGPoint(x: (view.bounds.width - sheetWidth) / 2, y: offset),
-                      size: CGSize(width: sheetWidth, height: expandedSheetHeight))
+                      size: CGSize(width: sheetWidth, height: sheetHeight))
     }
 
     private func translationRubberBandFactor(for currentOffset: CGFloat) -> CGFloat {
@@ -620,7 +648,7 @@ public class BottomSheetController: UIViewController {
             ? Constants.Spring.oscillatingDampingRatio
             : Constants.Spring.defaultDampingRatio
 
-        let springParams = UISpringTimingParameters(dampingRatio: damping, initialVelocity: CGVector(dx: 0.0, dy: springVelocity))
+        let springParams = UISpringTimingParameters(dampingRatio: damping, initialVelocity: CGVector(dx: springVelocity, dy: springVelocity))
         let translationAnimator = UIViewPropertyAnimator(duration: Constants.Spring.animationDuration, timingParameters: springParams)
 
         self.targetExpansionState = targetExpansionState
@@ -685,8 +713,7 @@ public class BottomSheetController: UIViewController {
 
         switch expansionState {
         case .collapsed:
-            let desiredVisiblePortion = (collapsedContentHeight > 0) ? collapsedContentHeight : headerContentHeight
-            offset = view.frame.maxY - (desiredVisiblePortion + (isExpandable ? ResizingHandleView.height : 0.0) + view.safeAreaInsets.bottom)
+            offset = view.frame.maxY - collapsedSheetHeight
         case .expanded:
             offset = view.frame.maxY - expandedSheetHeight
         case .hidden:
@@ -741,20 +768,33 @@ public class BottomSheetController: UIViewController {
 
     // Height of the sheet in the fully expanded state
     private var expandedSheetHeight: CGFloat {
+        guard isExpandable else {
+            return collapsedSheetHeight
+        }
+
         let height: CGFloat
-        let minHeight = headerContentHeight + (isExpandable ? ResizingHandleView.height : 0.0)
-        let maxHeight: CGFloat = view.frame.height - view.safeAreaInsets.top - Constants.minimumTopExpandedPadding
+        let maxHeight = view.frame.height - view.safeAreaInsets.top - Constants.minimumTopExpandedPadding
 
         if preferredExpandedContentHeight == 0 {
             height = maxHeight
         } else {
-            let idealHeight = minHeight + preferredExpandedContentHeight + view.safeAreaInsets.bottom
+            let idealHeight = currentResizingHandleHeight + headerContentHeight + preferredExpandedContentHeight + view.safeAreaInsets.bottom
             height = min(maxHeight, idealHeight)
         }
 
-        // Min height is required for cases when view.frame is .zero (before the initial layout pass)
+        // One case when the lower bound is required is when view.frame is .zero (like before the initial layout pass)
         // This gives the sheet some space to layout in so the layout engine doesn't complain.
-        return max(minHeight, height)
+        return max(collapsedSheetHeight, height)
+    }
+
+    // Height of the sheet in collapsed state
+    private var collapsedSheetHeight: CGFloat {
+        let visibleContentHeight = (collapsedContentHeight > 0) ? collapsedContentHeight : headerContentHeight
+        return currentResizingHandleHeight + visibleContentHeight + view.safeAreaInsets.bottom
+    }
+
+    private var currentResizingHandleHeight: CGFloat {
+        (isExpandable ? ResizingHandleView.height : 0.0)
     }
 
     private lazy var panGestureRecognizer: UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently our bottom sheet works in a "rigid" mode where its height is static and dragging it just translates the sheet view vertically on or off-screen.
Some clients need to pin views to the bottom of the sheet that are always visible (like a text field) so we need a flexible mode where dragging actually resizes the sheet, so bottom of the sheet content is always visible.

This PR adds the `isFlexibleHeight` property which enables the flexible height mode. The sheet will resize anywhere above collapsed state and stay rigid anywhere below it (to make sure we're not forcing the content to layout in small or zero heights.

### Verification
Default rigid mode:

https://user-images.githubusercontent.com/3610850/151105447-757a9359-69ae-47ba-9cff-f638f6f99851.mov

Flexible mode:

https://user-images.githubusercontent.com/3610850/151105461-199ebd9d-c123-49f5-b522-b3ad5dddaec4.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/875)