### PR TITLE
[vNext] Adopting to protocol in ListCell vNext

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -106,7 +106,7 @@ class LeftNavMenuViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
-            sizeCategory != self.traitCollection.preferredContentSizeCategory {
+            sizeCategory != traitCollection.preferredContentSizeCategory {
             leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
         }
     }
@@ -114,11 +114,11 @@ class LeftNavMenuViewController: UIViewController {
     var menuAction: (() -> Void)?
 
     private func setPresence(presence: LeftNavPresence) {
-        self.persona.state.presence = presence.avatarPresence()
-        let statusCell = self.leftNavMenuList.state.getSectionState(at: 0).getCellState(at: 0)
+        persona.state.presence = presence.avatarPresence
+        let statusCell = leftNavMenuList.state.getSectionState(at: 0).getCellState(at: 0)
         statusCell.isExpanded = false
-        statusCell.title = presence.cellTitle()
-        statusCell.leadingUIView = presence.imageView()
+        statusCell.title = presence.cellTitle
+        statusCell.leadingUIView = presence.imageView
     }
 
     private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
@@ -171,17 +171,16 @@ class LeftNavMenuViewController: UIViewController {
         let menuSection = leftNavMenuList.state.createSection()
 
         let statusCell = menuSection.createCell()
-        statusCell.title = LeftNavPresence.available.cellTitle()
+        statusCell.title = LeftNavPresence.available.cellTitle
         statusCell.backgroundColor = .systemBackground
-        let statusImageView = LeftNavPresence.available.imageView()
-        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+        let statusImageView = LeftNavPresence.available.imageView
         statusCell.leadingUIView = statusImageView
 
         for presence in LeftNavPresence.allCases {
             let statusCellChild = statusCell.createChildCell()
             statusCellChild.leadingViewSize = MSFListCellLeadingViewSize.small
-            statusCellChild.title = presence.cellTitle()
-            statusCellChild.leadingUIView = presence.imageView()
+            statusCellChild.title = presence.cellTitle
+            statusCellChild.leadingUIView = presence.imageView
             statusCellChild.backgroundColor = .systemBackground
             statusCellChild.onTapAction = {
                 self.setPresence(presence: presence)
@@ -190,7 +189,7 @@ class LeftNavMenuViewController: UIViewController {
 
         let resetStatusCell = statusCell.createChildCell()
         resetStatusCell.title = "Reset status"
-        resetStatusCell.leadingViewSize = MSFListCellLeadingViewSize.small
+        resetStatusCell.leadingViewSize = .small
         resetStatusCell.backgroundColor = .systemBackground
         let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
@@ -318,9 +317,8 @@ enum LeftNavPresence: Int, CaseIterable {
     case away
     case offline
 
-    func imageView() -> UIImageView {
+    var imageView: UIImageView {
         let imageView: UIImageView
-
         switch self {
         case .available:
             imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_available_16_filled"))
@@ -338,11 +336,10 @@ enum LeftNavPresence: Int, CaseIterable {
             imageView = UIImageView(image: UIImage(named: "ic_fluent_presence_offline_16_regular"))
             imageView.tintColor = FluentUIThemeManager.S.Colors.Presence.offline
         }
-
         return imageView
     }
 
-    func cellTitle() -> String {
+    var cellTitle: String {
         let cellTitle: String
         switch self {
         case .available:
@@ -362,7 +359,7 @@ enum LeftNavPresence: Int, CaseIterable {
         return cellTitle
     }
 
-    func avatarPresence() -> MSFAvatarPresence {
+    var avatarPresence: MSFAvatarPresence {
         switch self {
         case .available:
             return .available

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -177,7 +177,7 @@ class LeftNavMenuViewController: UIViewController {
 
         for presence in LeftNavPresence.allCases {
             let statusCellChild = statusCell.createChildCell()
-            statusCellChild.leadingViewSize = MSFListCellLeadingViewSize.small
+            statusCellChild.leadingViewSize = .small
             statusCellChild.title = presence.cellTitle
             statusCellChild.leadingUIView = presence.imageView
             statusCellChild.backgroundColor = .systemBackground

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -113,9 +113,8 @@ class LeftNavMenuViewController: UIViewController {
 
     var menuAction: (() -> Void)?
 
-    private func setPresence(presence: LeftNavPresence) {
+    private func setPresence(statusCell: MSFListCellState, presence: LeftNavPresence) {
         persona.state.presence = presence.avatarPresence
-        let statusCell = leftNavMenuList.state.getSectionState(at: 0).getCellState(at: 0)
         statusCell.isExpanded = false
         statusCell.title = presence.cellTitle
         statusCell.leadingUIView = presence.imageView
@@ -183,7 +182,7 @@ class LeftNavMenuViewController: UIViewController {
             statusCellChild.leadingUIView = presence.imageView
             statusCellChild.backgroundColor = .systemBackground
             statusCellChild.onTapAction = {
-                self.setPresence(presence: presence)
+                self.setPresence(statusCell: statusCell, presence: presence)
             }
         }
 
@@ -195,7 +194,7 @@ class LeftNavMenuViewController: UIViewController {
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
         resetStatusCell.leadingUIView = resetStatusImageView
         resetStatusCell.onTapAction = {
-            self.setPresence(presence: .available)
+            self.setPresence(statusCell: statusCell, presence: .available)
         }
 
         let statusMessageCell = menuSection.createCell()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -115,16 +115,15 @@ class LeftNavMenuViewController: UIViewController {
 
     private func setPresence(presence: LeftNavPresence) {
         self.persona.state.presence = presence.avatarPresence()
-        self.statusCell.isExpanded = false
-        self.statusCell.title = presence.cellTitle()
-        self.statusCell.leadingUIView = presence.imageView()
+        let statusCell = self.leftNavMenuList.state.getSectionState(at: 0).getCellState(at: 0)
+        statusCell.isExpanded = false
+        statusCell.title = presence.cellTitle()
+        statusCell.leadingUIView = presence.imageView()
     }
 
     private var leftNavAvatar = MSFAvatar(style: .default, size: .xlarge)
 
     private var persona = MSFPersonaView()
-
-    private var statusCell = MSFListCellState()
 
     private var leftNavMenuList = MSFList()
 
@@ -169,24 +168,29 @@ class LeftNavMenuViewController: UIViewController {
             menuAction()
         }
 
-        var statusCellChildren: [MSFListCellState] = []
+        let menuSection = leftNavMenuList.state.createSection()
+
+        let statusCell = menuSection.createCell()
+        statusCell.title = LeftNavPresence.available.cellTitle()
+        statusCell.backgroundColor = .systemBackground
+        let statusImageView = LeftNavPresence.available.imageView()
+        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
+        statusCell.leadingUIView = statusImageView
 
         for presence in LeftNavPresence.allCases {
-            let statusCellChild = MSFListCellState()
-            statusCellChild.leadingViewSize = .small
+            let statusCellChild = statusCell.createChildCell()
+            statusCellChild.leadingViewSize = MSFListCellLeadingViewSize.small
             statusCellChild.title = presence.cellTitle()
             statusCellChild.leadingUIView = presence.imageView()
             statusCellChild.backgroundColor = .systemBackground
             statusCellChild.onTapAction = {
                 self.setPresence(presence: presence)
             }
-
-            statusCellChildren.append(statusCellChild)
         }
 
-        let resetStatusCell = MSFListCellState()
+        let resetStatusCell = statusCell.createChildCell()
         resetStatusCell.title = "Reset status"
-        resetStatusCell.leadingViewSize = .small
+        resetStatusCell.leadingViewSize = MSFListCellLeadingViewSize.small
         resetStatusCell.backgroundColor = .systemBackground
         let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
@@ -194,17 +198,6 @@ class LeftNavMenuViewController: UIViewController {
         resetStatusCell.onTapAction = {
             self.setPresence(presence: .available)
         }
-        statusCellChildren.append(resetStatusCell)
-
-        let menuSection = leftNavMenuList.state.createSection()
-
-        statusCell = menuSection.createCell()
-        statusCell.title = LeftNavPresence.available.cellTitle()
-        statusCell.backgroundColor = .systemBackground
-        let statusImageView = LeftNavPresence.available.imageView()
-        statusImageView.tintColor = FluentUIThemeManager.S.Colors.Presence.available
-        statusCell.leadingUIView = statusImageView
-        statusCell.children = statusCellChildren
 
         let statusMessageCell = menuSection.createCell()
         statusMessageCell.backgroundColor = .systemBackground

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -166,46 +166,50 @@ class LeftNavMenuViewController: UIViewController {
                                                  left: Constant.margin,
                                                  bottom: Constant.margin,
                                                  right: Constant.margin)
-        let defaultMenuAction = {
-            guard let menuAction = self.menuAction else {
+        let defaultMenuAction = { [weak self] in
+            guard let strongSelf = self else {
                 return
             }
-            menuAction()
+            strongSelf.menuAction?()
         }
 
         let menuSection = leftNavMenuList.state.createSection()
 
-        statusCell = menuSection.createCell()
-        guard let statusCell = statusCell else {
-            return contentView
-        }
+        let statusCellState = menuSection.createCell()
 
-        statusCell.title = LeftNavPresence.available.cellTitle
-        statusCell.backgroundColor = .systemBackground
+        statusCellState.title = LeftNavPresence.available.cellTitle
+        statusCellState.backgroundColor = .systemBackground
         let statusImageView = LeftNavPresence.available.imageView
-        statusCell.leadingUIView = statusImageView
+        statusCellState.leadingUIView = statusImageView
 
         for presence in LeftNavPresence.allCases {
-            let statusCellChild = statusCell.createChildCell()
+            let statusCellChild = statusCellState.createChildCell()
             statusCellChild.leadingViewSize = .small
             statusCellChild.title = presence.cellTitle
             statusCellChild.leadingUIView = presence.imageView
             statusCellChild.backgroundColor = .systemBackground
-            statusCellChild.onTapAction = {
-                self.setPresence(presence: presence)
+            statusCellChild.onTapAction = { [weak self] in
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.setPresence(presence: presence)
             }
         }
 
-        let resetStatusCell = statusCell.createChildCell()
+        let resetStatusCell = statusCellState.createChildCell()
         resetStatusCell.title = "Reset status"
         resetStatusCell.leadingViewSize = .small
         resetStatusCell.backgroundColor = .systemBackground
         let resetStatusImageView = UIImageView(image: UIImage(named: "ic_fluent_arrow_sync_24_regular"))
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
         resetStatusCell.leadingUIView = resetStatusImageView
-        resetStatusCell.onTapAction = {
-            self.setPresence(presence: .available)
+        resetStatusCell.onTapAction = { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.setPresence(presence: .available)
         }
+        statusCell = statusCellState
 
         let statusMessageCell = menuSection.createCell()
         statusMessageCell.backgroundColor = .systemBackground

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -176,6 +176,7 @@ class LeftNavMenuViewController: UIViewController {
         let menuSection = leftNavMenuList.state.createSection()
 
         let statusCellState = menuSection.createCell()
+        statusCell = statusCellState
 
         statusCellState.title = LeftNavPresence.available.cellTitle
         statusCellState.backgroundColor = .systemBackground
@@ -209,7 +210,6 @@ class LeftNavMenuViewController: UIViewController {
             }
             strongSelf.setPresence(presence: .available)
         }
-        statusCell = statusCellState
 
         let statusMessageCell = menuSection.createCell()
         statusMessageCell.backgroundColor = .systemBackground

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -61,8 +61,8 @@ class LeftNavDemoController: DemoController {
 
     private lazy var drawerController: DrawerController = {
         let drawerController = DrawerController(sourceView: navigationButton,
-                                            sourceRect: navigationButton.bounds,
-                                            presentationDirection: .fromLeading)
+                                                sourceRect: navigationButton.bounds,
+                                                presentationDirection: .fromLeading)
         drawerController.presentationBackground = .black
         drawerController.preferredContentSize.width = 360
         drawerController.resizingBehavior = .dismiss
@@ -113,8 +113,12 @@ class LeftNavMenuViewController: UIViewController {
 
     var menuAction: (() -> Void)?
 
-    private func setPresence(statusCell: MSFListCellState, presence: LeftNavPresence) {
+    private func setPresence(presence: LeftNavPresence) {
         persona.state.presence = presence.avatarPresence
+
+        guard let statusCell = statusCell else {
+            return
+        }
         statusCell.isExpanded = false
         statusCell.title = presence.cellTitle
         statusCell.leadingUIView = presence.imageView
@@ -125,6 +129,8 @@ class LeftNavMenuViewController: UIViewController {
     private var persona = MSFPersonaView()
 
     private var leftNavMenuList = MSFList()
+
+    private var statusCell: MSFListCellState?
 
     private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
 
@@ -169,7 +175,11 @@ class LeftNavMenuViewController: UIViewController {
 
         let menuSection = leftNavMenuList.state.createSection()
 
-        let statusCell = menuSection.createCell()
+        statusCell = menuSection.createCell()
+        guard let statusCell = statusCell else {
+            return contentView
+        }
+
         statusCell.title = LeftNavPresence.available.cellTitle
         statusCell.backgroundColor = .systemBackground
         let statusImageView = LeftNavPresence.available.imageView
@@ -182,7 +192,7 @@ class LeftNavMenuViewController: UIViewController {
             statusCellChild.leadingUIView = presence.imageView
             statusCellChild.backgroundColor = .systemBackground
             statusCellChild.onTapAction = {
-                self.setPresence(statusCell: statusCell, presence: presence)
+                self.setPresence(presence: presence)
             }
         }
 
@@ -194,7 +204,7 @@ class LeftNavMenuViewController: UIViewController {
         resetStatusImageView.tintColor = FluentUIThemeManager.S.Colors.Foreground.neutral4
         resetStatusCell.leadingUIView = resetStatusImageView
         resetStatusCell.onTapAction = {
-            self.setPresence(statusCell: statusCell, presence: .available)
+            self.setPresence(presence: .available)
         }
 
         let statusMessageCell = menuSection.createCell()
@@ -282,7 +292,7 @@ class LeftNavMenuViewController: UIViewController {
                                      menuListView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                                      menuListView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
                                      menuListView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-        ])
+                                    ])
 
         return contentView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -29,59 +29,54 @@ class ListDemoController: DemoController {
 
         var avatar: MSFAvatar
 
-        /// Subchildren list items
-        var subchildren: [MSFListCellState] = []
-        listCell = MSFListCellState()
-        avatar = createAvatarView(size: .medium,
-                                  name: samplePersonas[4].name,
-                                  image: samplePersonas[4].image,
-                                  style: .default)
-        listCell.title = avatar.state.primaryText ?? ""
-        listCell.leadingUIView = avatar.view
-        listCell.onTapAction = {
-            self.showAlertForAvatarTapped(name: samplePersonas[4].name)
-        }
-        listCell.hasDivider = true
-        subchildren.append(listCell)
-
-        /// Children list items
-        var children: [MSFListCellState] = []
-        for index in 2...3 {
-            listCell = MSFListCellState()
-            avatar = createAvatarView(size: .medium,
-                                      name: samplePersonas[index].name,
-                                      image: samplePersonas[index].image,
-                                      style: .default)
-            listCell.title = avatar.state.primaryText ?? ""
-            listCell.leadingUIView = avatar.view
-            children.append(listCell)
-            listCell.hasDivider = true
-        }
-        children[0].children = subchildren
-        children[0].isExpanded = true
-        children[1].onTapAction = {
-            self.showAlertForAvatarTapped(name: samplePersonas[3].name)
-        }
-
         /// Custom Leading View with collapsible children items
         let collapsibleSection = list.state.createSection()
         collapsibleSection.title = "AvatarSection"
         for index in 0...1 {
-            listCell = collapsibleSection.createCell()
-            avatar = createAvatarView(size: .medium,
-                                      name: samplePersonas[index].name,
-                                      image: samplePersonas[index].image,
-                                      style: .default)
-            listCell.title = avatar.state.primaryText ?? ""
-            listCell.leadingUIView = avatar.view
-        collapsibleSection.hasDividers = true
+            let collapsibleCell = collapsibleSection.createCell()
+            let avatar = createAvatarView(size: .medium,
+                                          name: samplePersonas[index].name,
+                                          image: samplePersonas[index].image,
+                                          style: .default)
+            collapsibleCell.title = avatar.state.primaryText ?? ""
+            collapsibleCell.leadingUIView = avatar.view
+            collapsibleSection.hasDividers = true
         }
-        let firstCellState = collapsibleSection.getCellState(at: 0)
-        firstCellState.children = children
-        firstCellState.isExpanded = true
         collapsibleSection.getCellState(at: 1).onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }
+
+        /// Children list items
+        let firstCellState = collapsibleSection.getCellState(at: 0)
+        for index in 2...3 {
+            let childCell = firstCellState.createChildCell()
+            avatar = createAvatarView(size: .medium,
+                                           name: samplePersonas[index].name,
+                                           image: samplePersonas[index].image,
+                                           style: .default)
+            childCell.title = avatar.state.primaryText ?? ""
+            childCell.leadingUIView = avatar.view
+            childCell.hasDivider = true
+        }
+        firstCellState.isExpanded = true
+        firstCellState.getChildCellState(at: 1).onTapAction = {
+            self.showAlertForAvatarTapped(name: samplePersonas[3].name)
+        }
+
+        /// Subchildren list items
+        let firstChildState = firstCellState.getChildCellState(at: 0)
+        firstChildState.isExpanded = true
+        let firstSubChildState = firstChildState.createChildCell()
+        avatar = createAvatarView(size: .medium,
+                                  name: samplePersonas[4].name,
+                                  image: samplePersonas[4].image,
+                                  style: .default)
+        firstSubChildState.title = avatar.state.primaryText ?? ""
+        firstSubChildState.leadingUIView = avatar.view
+        firstSubChildState.onTapAction = {
+            self.showAlertForAvatarTapped(name: samplePersonas[4].name)
+        }
+        firstSubChildState.hasDivider = true
 
         /// TableViewCell Sample Data Sections
         for sectionIndex in 0..<sections.count {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -21,17 +21,11 @@ class ListDemoController: DemoController {
         let personaDataNodes: [PersonaDataNode] = [
             PersonaDataNode(personaData: samplePersonas[0],
                             children: [ PersonaDataNode(personaData: samplePersonas[1],
-                                                        children: [ PersonaDataNode(personaData: samplePersonas[2],
-                                                                                    children: [],
-                                                                                    isExpanded: false) ],
+                                                        children: [ PersonaDataNode(personaData: samplePersonas[2]) ],
                                                         isExpanded: true),
-                                        PersonaDataNode(personaData: samplePersonas[3],
-                                                        children: [],
-                                                        isExpanded: false) ],
+                                        PersonaDataNode(personaData: samplePersonas[3]) ],
                             isExpanded: true),
-            PersonaDataNode(personaData: samplePersonas[4],
-                            children: [],
-                            isExpanded: false)
+            PersonaDataNode(personaData: samplePersonas[4])
         ]
 
         /// Custom Leading View with collapsible children items
@@ -88,8 +82,8 @@ class ListDemoController: DemoController {
 
     struct PersonaDataNode {
         var personaData: PersonaData
-        var children: [PersonaDataNode]
-        var isExpanded: Bool
+        var children: [PersonaDataNode] = []
+        var isExpanded: Bool = false
     }
 
     private func createSamplePersonaCell(cellState: MSFListCellState, personaDataNode: PersonaDataNode) {
@@ -105,8 +99,8 @@ class ListDemoController: DemoController {
         cellState.hasDivider = true
 
         cellState.onTapAction = personaChildren.isEmpty ? {
-                    self.showAlertForAvatarTapped(name: personaData.name)
-                } : nil
+            self.showAlertForAvatarTapped(name: personaData.name)
+        } : nil
 
         for persona in personaChildren {
             createSamplePersonaCell(cellState: cellState.createChildCell(), personaDataNode: persona)
@@ -118,7 +112,7 @@ class ListDemoController: DemoController {
                                   image: UIImage? = nil,
                                   style: MSFAvatarStyle) -> MSFAvatar {
         let avatarView = MSFAvatar(style: style,
-                                        size: size)
+                                   size: size)
         avatarView.state.primaryText = name
         avatarView.state.image = image
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -19,20 +19,12 @@ class ListDemoController: DemoController {
         let list: MSFList = MSFList()
         var listCell: MSFListCellState
 
-        let samplePersonas: [PersonaData] = [
-            PersonaData(name: "Kat Larrson", email: "kat.larrson@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_kat_larsson"), color: Colors.Palette.cyanBlue10.color),
-            PersonaData(name: "Kristin Patterson", email: "kristin.patterson@contoso.com", subtitle: "Software Engineer", color: Colors.Palette.red10.color),
-            PersonaData(name: "Ashley McCarthy", image: UIImage(named: "avatar_ashley_mccarthy"), color: Colors.Palette.magenta20.color),
-            PersonaData(name: "Allan Munger", email: "allan.munger@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_allan_munger"), color: Colors.Palette.green10.color),
-            PersonaData(name: "Amanda Brady", subtitle: "Program Manager", image: UIImage(named: "avatar_amanda_brady"), color: Colors.Palette.magentaPink10.color)
-        ]
-
         /// Custom Leading View with collapsible children items
         let collapsibleSection = list.state.createSection()
         collapsibleSection.title = "AvatarSection"
         for samplePersonaIndex in 0...1 {
             let collapsibleCell = collapsibleSection.createCell()
-            createSamplePersonaCell(cellState: collapsibleCell, samplePersonaIndex: samplePersonaIndex)
+            createSamplePersonaCell(cellState: collapsibleCell, samplePersona: samplePersonas[samplePersonaIndex])
         }
         collapsibleSection.hasDividers = true
         collapsibleSection.getCellState(at: 1).onTapAction = {
@@ -43,7 +35,7 @@ class ListDemoController: DemoController {
         let firstCellState = collapsibleSection.getCellState(at: 0)
         for samplePersonaIndex in 2...3 {
             let childCell = firstCellState.createChildCell()
-            createSamplePersonaCell(cellState: childCell, samplePersonaIndex: samplePersonaIndex)
+            createSamplePersonaCell(cellState: childCell, samplePersona: samplePersonas[samplePersonaIndex])
         }
         firstCellState.isExpanded = true
         firstCellState.getChildCellState(at: 1).onTapAction = {
@@ -54,7 +46,7 @@ class ListDemoController: DemoController {
         let firstChildState = firstCellState.getChildCellState(at: 0)
         firstChildState.isExpanded = true
         let firstSubChildState = firstChildState.createChildCell()
-        createSamplePersonaCell(cellState: firstSubChildState, samplePersonaIndex: 4)
+        createSamplePersonaCell(cellState: firstSubChildState, samplePersona: samplePersonas[4])
         firstSubChildState.onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[4].name)
         }
@@ -109,10 +101,16 @@ class ListDemoController: DemoController {
                                      demoControllerView.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: listView.trailingAnchor)])
     }
 
-    private func createSamplePersonaCell(cellState: MSFListCellState, samplePersonaIndex: Int) {
+    struct PersonaDataNode {
+        let personaData: PersonaData
+        let children: [PersonaData]
+        let isCollapsed: Bool
+    }
+
+    private func createSamplePersonaCell(cellState: MSFListCellState, samplePersona: PersonaData) {
         let avatar = createAvatarView(size: .medium,
-                                      name: samplePersonas[samplePersonaIndex].name,
-                                      image: samplePersonas[samplePersonaIndex].image,
+                                      name: samplePersona.name,
+                                      image: samplePersona.image,
                                       style: .default)
         cellState.title = avatar.state.primaryText ?? ""
         cellState.leadingUIView = avatar.view

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -27,36 +27,23 @@ class ListDemoController: DemoController {
             PersonaData(name: "Amanda Brady", subtitle: "Program Manager", image: UIImage(named: "avatar_amanda_brady"), color: Colors.Palette.magentaPink10.color)
         ]
 
-        var avatar: MSFAvatar
-
         /// Custom Leading View with collapsible children items
         let collapsibleSection = list.state.createSection()
         collapsibleSection.title = "AvatarSection"
-        for index in 0...1 {
+        for samplePersonaIndex in 0...1 {
             let collapsibleCell = collapsibleSection.createCell()
-            let avatar = createAvatarView(size: .medium,
-                                          name: samplePersonas[index].name,
-                                          image: samplePersonas[index].image,
-                                          style: .default)
-            collapsibleCell.title = avatar.state.primaryText ?? ""
-            collapsibleCell.leadingUIView = avatar.view
-            collapsibleSection.hasDividers = true
+            createSamplePersonaCell(cellState: collapsibleCell, samplePersonaIndex: samplePersonaIndex)
         }
+        collapsibleSection.hasDividers = true
         collapsibleSection.getCellState(at: 1).onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[1].name)
         }
 
         /// Children list items
         let firstCellState = collapsibleSection.getCellState(at: 0)
-        for index in 2...3 {
+        for samplePersonaIndex in 2...3 {
             let childCell = firstCellState.createChildCell()
-            avatar = createAvatarView(size: .medium,
-                                           name: samplePersonas[index].name,
-                                           image: samplePersonas[index].image,
-                                           style: .default)
-            childCell.title = avatar.state.primaryText ?? ""
-            childCell.leadingUIView = avatar.view
-            childCell.hasDivider = true
+            createSamplePersonaCell(cellState: childCell, samplePersonaIndex: samplePersonaIndex)
         }
         firstCellState.isExpanded = true
         firstCellState.getChildCellState(at: 1).onTapAction = {
@@ -67,12 +54,7 @@ class ListDemoController: DemoController {
         let firstChildState = firstCellState.getChildCellState(at: 0)
         firstChildState.isExpanded = true
         let firstSubChildState = firstChildState.createChildCell()
-        avatar = createAvatarView(size: .medium,
-                                  name: samplePersonas[4].name,
-                                  image: samplePersonas[4].image,
-                                  style: .default)
-        firstSubChildState.title = avatar.state.primaryText ?? ""
-        firstSubChildState.leadingUIView = avatar.view
+        createSamplePersonaCell(cellState: firstSubChildState, samplePersonaIndex: 4)
         firstSubChildState.onTapAction = {
             self.showAlertForAvatarTapped(name: samplePersonas[4].name)
         }
@@ -125,6 +107,16 @@ class ListDemoController: DemoController {
                                      demoControllerView.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: listView.bottomAnchor),
                                      demoControllerView.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: listView.leadingAnchor),
                                      demoControllerView.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: listView.trailingAnchor)])
+    }
+
+    private func createSamplePersonaCell(cellState: MSFListCellState, samplePersonaIndex: Int) {
+        let avatar = createAvatarView(size: .medium,
+                                      name: samplePersonas[samplePersonaIndex].name,
+                                      image: samplePersonas[samplePersonaIndex].image,
+                                      style: .default)
+        cellState.title = avatar.state.primaryText ?? ""
+        cellState.leadingUIView = avatar.view
+        cellState.hasDivider = true
     }
 
     private func createAvatarView(size: MSFAvatarSize,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -71,17 +71,15 @@
 
     MSFList *testList = [[MSFList alloc] initWithTheme:nil];
     id<MSFListSectionState> sectionState = [[testList state] createSection];
-    MSFListCellState *listCell1 = [sectionState createCell];
-    MSFListCellState *listCell2 = [sectionState createCell];
-    MSFListCellState *listCell3 = [sectionState createCell];
+    id<MSFListCellState> listCell1 = [sectionState createCell];
+    id<MSFListCellState> listCell2 = [sectionState createCell];
+    id<MSFListCellState> listCell3 = [sectionState createCell];
 
-    MSFListCellState *childCell = [[MSFListCellState alloc] init];
+    id<MSFListCellState> childCell = [listCell1 createChildCell];
     [childCell setTitle:@"Child Cell"];
-    NSArray *children = [NSArray arrayWithObject:childCell];
 
     [listCell1 setTitle:@"SampleTitle1"];
     [listCell1 setIsExpanded:TRUE];
-    [listCell1 setChildren:children];
 
     [listCell2 setTitle:@"SampleTitle2"];
     [listCell2 setSubtitle:@"SampleTitle2"];

--- a/ios/FluentUI/Vnext/List/HeaderFooterTokens.swift
+++ b/ios/FluentUI/Vnext/List/HeaderFooterTokens.swift
@@ -25,12 +25,12 @@ class MSFHeaderFooterTokens: MSFTokensBase, ObservableObject {
     @Published public var textFont: UIFont!
 
     var style: MSFHeaderFooterStyle {
-            didSet {
-                if oldValue != style {
-                    updateForCurrentTheme()
-                }
+        didSet {
+            if oldValue != style {
+                updateForCurrentTheme()
             }
         }
+    }
 
     init(style: MSFHeaderFooterStyle) {
         self.style = style

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -226,7 +226,7 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         super.init()
     }
 
-    // MARK: - MSFListStateImpl accessors and modifiers
+    // MARK: - MSFListStateImpl accessors
 
     var sectionCount: Int {
         return sections.count

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -173,7 +173,7 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, MSFList
         super.init()
     }
 
-    // MARK: - MSFListSectionStateImpl accessors and modifiers
+    // MARK: - MSFListSectionStateImpl accessors
 
     var cellCount: Int {
         return cells.count

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -101,31 +101,31 @@ public struct MSFListView: View {
 
     public var body: some View {
         let sections = self.updateCellDividers()
-            ScrollView {
-                VStack(spacing: 0) {
-                    ForEach(sections, id: \.self) { section in
-                        if let sectionTitle = section.title, !sectionTitle.isEmpty {
-                            Header(state: section)
-                        }
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(sections, id: \.self) { section in
+                    if let sectionTitle = section.title, !sectionTitle.isEmpty {
+                        Header(state: section)
+                    }
 
-                        ForEach(section.cells.indices, id: \.self) { index in
-                            let cellState = section.cells[index]
-                            MSFListCellView(state: cellState)
-                                .frame(maxWidth: .infinity)
-                        }
+                    ForEach(section.cells.indices, id: \.self) { index in
+                        let cellState = section.cells[index]
+                        MSFListCellView(state: cellState)
+                            .frame(maxWidth: .infinity)
+                    }
 
-                        if section.hasDividers {
-                            FluentDivider()
-                        }
+                    if section.hasDividers {
+                        FluentDivider()
                     }
                 }
             }
-            .animation(.default)
-            .environment(\.defaultMinListRowHeight, 0)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .designTokens(tokens,
-                          from: theme,
-                          with: windowProvider)
+        }
+        .animation(.default)
+        .environment(\.defaultMinListRowHeight, 0)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .designTokens(tokens,
+                      from: theme,
+                      with: windowProvider)
     }
 
     @Environment(\.theme) var theme: FluentUIStyle

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -139,10 +139,10 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, MSFListCel
 
     @Published var leadingViewSize: MSFListCellLeadingViewSize = .medium {
         didSet {
-            if leadingViewSize != oldValue {
-                tokens.cellLeadingViewSize = leadingViewSize
-                tokens.updateForCurrentTheme()
+            guard leadingViewSize != oldValue else {
+                return
             }
+            tokens.cellLeadingViewSize = leadingViewSize
         }
     }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -6,42 +6,108 @@
 import UIKit
 import SwiftUI
 
-/// `MSFListCellState` contains properties that make up a cell content.
-///
-/// `title` is the first line of text, subsequently followed by `subtitle` on the second line and `footnote` on the third line.
-/// Set line limits for text using `titleLineLimit`, `subtitleLineLimit`, and `footnoteLineLimit`.
-///
-/// Any label`AccessoryView` property is a custom view at the leading/trailing end of a label, including the title, subtitle, or footnote.
-/// Currently only supports square views (width & height must be the same).
-///
-/// All `AnyView?` properties will be overwritten by its UIView equivalent. Used for SwiftUI environments.
-///
-/// `leadingView` and `trailingView` allows any custom views. Currently only supports square views (width & height must be the same).
-/// `leadingViewSize` can be specified using `MSFListCellLeadingViewSize`.
-///
-/// Set `accessoryType` using the variations specified in `MSFListAccessoryType`. This is displayed in the very trailing end of a cell.
-///
-/// `children`: define nested cells. `isExpanded` will determine if the children are initially expanded or collapsed.
-///
-/// `layoutType`:  override the default cell height.
-///
-/// `onTapAction`: perform an action on a cell tap.
-///
-/// `hasDivider`:  displays a separator beneath the cell. Default is set to `false`.
-///
-@objc public class MSFListCellState: NSObject, ObservableObject, Identifiable {
-    public var id = UUID()
+/// Properties that can be used to customize the appearance of the List Section.
+@objc public protocol MSFListCellState {
+    /// Custom view on the leading side of the Cell.
+    var leadingUIView: UIView? { get set }
 
-    @Published public var leadingView: AnyView?
-    @Published public var titleLeadingAccessoryView: AnyView?
-    @Published public var titleTrailingAccessoryView: AnyView?
-    @Published public var subtitleLeadingAccessoryView: AnyView?
-    @Published public var subtitleTrailingAccessoryView: AnyView?
-    @Published public var footnoteLeadingAccessoryView: AnyView?
-    @Published public var footnoteTrailingAccessoryView: AnyView?
-    @Published public var trailingView: AnyView?
+    /// Custom view on the leading side of the Cell title.
+    var titleLeadingAccessoryUIView: UIView? { get set }
 
-    @objc @Published public var leadingViewSize: MSFListCellLeadingViewSize = .medium {
+    /// Custom view on the trailing side of the Cell title.
+    var titleTrailingAccessoryUIView: UIView? { get set }
+
+    /// Custom view on the leading side of the Cell subtitle.
+    var subtitleLeadingAccessoryUIView: UIView? { get set }
+
+    /// Custom view on the trailing side of the Cell subtitle.
+    var subtitleTrailingAccessoryUIView: UIView? { get set }
+
+    /// Custom view on the leading side of the Cell footnote.
+    var footnoteLeadingAccessoryUIView: UIView? { get set }
+
+    /// Custom view on the trailing side of the Cell footnote.
+    var footnoteTrailingAccessoryUIView: UIView? { get set }
+
+    /// Custom view on the trailing side of the Cell.
+    var trailingUIView: UIView? { get set }
+
+    /// Size of the `leadingView`.
+    var leadingViewSize: MSFListCellLeadingViewSize { get set }
+
+    /// The first line of the Cell.
+    var title: String { get set }
+
+    /// The second line of the Cell.
+    var subtitle: String { get set }
+
+    /// The third line of the Cell.
+    var footnote: String { get set }
+
+    /// Type of List accessory, located on the Cell's trailing side.
+    var accessoryType: MSFListAccessoryType { get set }
+
+    /// Sets a custom background color for the Cell.
+    var backgroundColor: UIColor? { get set }
+
+    /// Sets a custom highlighed background color for the Cell.
+    var highlightedBackgroundColor: UIColor? { get set }
+
+    /// Configures max number of lines in the title.
+    var titleLineLimit: Int { get set }
+
+    /// Configures max number of lines in the subtitle.
+    var subtitleLineLimit: Int { get set }
+
+    /// Configures max number of lines in the footnote.
+    var footnoteLineLimit: Int { get set }
+
+    /// Configures whether the cell is expanded or collapsed if it has children cells.
+    var isExpanded: Bool { get set }
+
+    /// Sets the cell as a one-line, two-line, or three-line layout type.
+    var layoutType: MSFListCellLayoutType { get set }
+
+    /// Configures divider visibility, which is located under the cell.
+    var hasDivider: Bool { get set }
+
+    /// Assigns an action to the cell when it is tapped.
+    var onTapAction: (() -> Void)? { get set }
+
+    /// The number of children cells in the Cell.
+    var childrenCellCount: Int { get }
+
+    /// Creates a new child cell and appends it to the array of children cells in a Cell.
+    func createChildCell() -> MSFListCellState
+
+    /// Creates a new child cell within the array of children cells at a specific index.
+    /// - Parameter index: The zero-based index of the child cell that will be inserted into the array of children cells.
+    func createChildCell(at index: Int) -> MSFListCellState
+
+    /// Retrieves the state object for a specific child cell so its appearance can be customized.
+    /// - Parameter index: The zero-based index of the child cell in the array of children cells.
+    func getChildCellState(at index: Int) -> MSFListCellState
+
+    /// Remove a child cell from the Cell.
+    /// - Parameter index: The zero-based index of the child cell that will be removed from the array of children cells.
+    func removeChildCell(at index: Int)
+}
+
+/// `MSFListCellStateImpl` contains properties that make up a cell content.
+class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, MSFListCellState {
+    var tokens: MSFCellBaseTokens
+    var id = UUID()
+
+    @Published var leadingView: AnyView?
+    @Published var titleLeadingAccessoryView: AnyView?
+    @Published var titleTrailingAccessoryView: AnyView?
+    @Published var subtitleLeadingAccessoryView: AnyView?
+    @Published var subtitleTrailingAccessoryView: AnyView?
+    @Published var footnoteLeadingAccessoryView: AnyView?
+    @Published var footnoteTrailingAccessoryView: AnyView?
+    @Published var trailingView: AnyView?
+
+    @Published var leadingViewSize: MSFListCellLeadingViewSize = .medium {
         didSet {
             if leadingViewSize != oldValue {
                 tokens.cellLeadingViewSize = leadingViewSize
@@ -50,22 +116,26 @@ import SwiftUI
         }
     }
 
-    @objc @Published public var title: String = ""
-    @objc @Published public var subtitle: String = ""
-    @objc @Published public var footnote: String = ""
-    @objc @Published public var accessoryType: MSFListAccessoryType = .none
-    @objc @Published public var backgroundColor: UIColor?
-    @objc @Published public var highlightedBackgroundColor: UIColor?
-    @objc @Published public var titleLineLimit: Int = 0
-    @objc @Published public var subtitleLineLimit: Int = 0
-    @objc @Published public var footnoteLineLimit: Int = 0
-    @objc @Published public var children: [MSFListCellState]?
-    @objc @Published public var isExpanded: Bool = false
-    @objc @Published public var layoutType: MSFListCellLayoutType = .automatic
-    @objc @Published public var hasDivider: Bool = false
-    @objc public var onTapAction: (() -> Void)?
+    @Published var title: String = ""
+    @Published var subtitle: String = ""
+    @Published var footnote: String = ""
+    @Published var accessoryType: MSFListAccessoryType = .none
+    @Published var backgroundColor: UIColor?
+    @Published var highlightedBackgroundColor: UIColor?
+    @Published var titleLineLimit: Int = 0
+    @Published var subtitleLineLimit: Int = 0
+    @Published var footnoteLineLimit: Int = 0
+    @Published var isExpanded: Bool = false
+    @Published var layoutType: MSFListCellLayoutType = .automatic
+    @Published var hasDivider: Bool = false
+    @Published private(set) var children: [MSFListCellStateImpl] = []
+    var onTapAction: (() -> Void)?
 
-    @objc public var leadingUIView: UIView? {
+    init(cellLeadingViewSize: MSFListCellLeadingViewSize = .medium) {
+        self.tokens = MSFListCellTokens(cellLeadingViewSize: cellLeadingViewSize)
+    }
+
+    var leadingUIView: UIView? {
         didSet {
             guard let view = leadingUIView else {
                 leadingView = nil
@@ -76,7 +146,7 @@ import SwiftUI
         }
     }
 
-    @objc public var titleLeadingAccessoryUIView: UIView? {
+    var titleLeadingAccessoryUIView: UIView? {
         didSet {
             guard let view = titleLeadingAccessoryUIView else {
                 titleLeadingAccessoryView = nil
@@ -87,7 +157,7 @@ import SwiftUI
         }
     }
 
-    @objc public var titleTrailingAccessoryUIView: UIView? {
+    var titleTrailingAccessoryUIView: UIView? {
         didSet {
             guard let view = titleTrailingAccessoryUIView else {
                 titleTrailingAccessoryView = nil
@@ -98,7 +168,7 @@ import SwiftUI
         }
     }
 
-    @objc public var subtitleLeadingAccessoryUIView: UIView? {
+    var subtitleLeadingAccessoryUIView: UIView? {
         didSet {
             guard let view = subtitleLeadingAccessoryUIView else {
                 subtitleLeadingAccessoryView = nil
@@ -109,7 +179,7 @@ import SwiftUI
         }
     }
 
-    @objc public var subtitleTrailingAccessoryUIView: UIView? {
+    var subtitleTrailingAccessoryUIView: UIView? {
         didSet {
             guard let view = subtitleTrailingAccessoryUIView else {
                 subtitleTrailingAccessoryView = nil
@@ -120,7 +190,7 @@ import SwiftUI
         }
     }
 
-    @objc public var footnoteLeadingAccessoryUIView: UIView? {
+    var footnoteLeadingAccessoryUIView: UIView? {
         didSet {
             guard let view = footnoteLeadingAccessoryUIView else {
                 footnoteLeadingAccessoryView = nil
@@ -131,7 +201,7 @@ import SwiftUI
         }
     }
 
-    @objc public var footnoteTrailingAccessoryUIView: UIView? {
+    var footnoteTrailingAccessoryUIView: UIView? {
         didSet {
             guard let view = footnoteTrailingAccessoryUIView else {
                 footnoteTrailingAccessoryView = nil
@@ -142,7 +212,7 @@ import SwiftUI
         }
     }
 
-    @objc public var trailingUIView: UIView? {
+    var trailingUIView: UIView? {
         didSet {
             guard let view = trailingUIView else {
                 trailingView = nil
@@ -153,7 +223,36 @@ import SwiftUI
         }
     }
 
-    var tokens: MSFCellBaseTokens = MSFListCellTokens(cellLeadingViewSize: .medium)
+    var childrenCellCount: Int {
+        return children.count
+    }
+
+    func createChildCell() -> MSFListCellState {
+        return createChildCell(at: children.endIndex)
+    }
+
+    func createChildCell(at index: Int) -> MSFListCellState {
+        guard index <= children.count && index >= 0 else {
+            preconditionFailure("Index is out of bounds")
+        }
+        let cell = MSFListCellStateImpl()
+        children.insert(cell, at: index)
+        return cell
+    }
+
+    func getChildCellState(at index: Int) -> MSFListCellState {
+        guard children.indices.contains(index) else {
+            preconditionFailure("Index is out of bounds")
+        }
+        return children[index]
+    }
+
+    func removeChildCell(at index: Int) {
+        guard children.indices.contains(index) else {
+            preconditionFailure("Index is out of bounds")
+        }
+        children.remove(at: index)
+    }
 }
 
 /// Pre-defined layout heights of cells
@@ -169,9 +268,9 @@ struct MSFListCellView: View {
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
     @ObservedObject var tokens: MSFCellBaseTokens
-    @ObservedObject var state: MSFListCellState
+    @ObservedObject var state: MSFListCellStateImpl
 
-    init(state: MSFListCellState) {
+    init(state: MSFListCellStateImpl) {
         self.state = state
         self.tokens = state.tokens
     }
@@ -180,8 +279,13 @@ struct MSFListCellView: View {
 
         @ViewBuilder
         var cellContent: some View {
+            let children: [MSFListCellStateImpl] = state.children
+            let hasChildren: Bool = children.count > 0
+            let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
+            let leadingViewSize: CGFloat = tokens.leadingViewSize
+
             Button(action: state.onTapAction ?? {
-                if state.children != nil {
+                if hasChildren {
                     withAnimation {
                         state.isExpanded.toggle()
                     }
@@ -192,14 +296,15 @@ struct MSFListCellView: View {
                     let labelAccessoryInterspace: CGFloat = tokens.labelAccessoryInterspace
                     let labelAccessorySize: CGFloat = tokens.labelAccessorySize
                     let sublabelAccessorySize: CGFloat = tokens.sublabelAccessorySize
+                    let trailingItemSize: CGFloat = tokens.trailingItemSize
 
                     if let leadingView = state.leadingView {
                         HStack(alignment: .center, spacing: 0) {
                             leadingView
-                                .frame(width: tokens.leadingViewSize, height: tokens.leadingViewSize)
+                                .frame(width: leadingViewSize, height: leadingViewSize)
                         }
                         .frame(width: tokens.leadingViewAreaSize)
-                        .padding(.trailing, tokens.horizontalCellPadding)
+                        .padding(.trailing, horizontalCellPadding)
                     }
 
                     VStack(alignment: .leading, spacing: 0) {
@@ -265,7 +370,7 @@ struct MSFListCellView: View {
 
                     if let trailingView = state.trailingView {
                         trailingView
-                            .frame(width: tokens.trailingItemSize, height: tokens.trailingItemSize)
+                            .frame(width: trailingItemSize, height: trailingItemSize)
                             .fixedSize()
                     }
 
@@ -276,7 +381,7 @@ struct MSFListCellView: View {
                             Image(uiImage: accessoryIcon)
                                 .resizable()
                                 .foregroundColor(Color(isDisclosure ? tokens.disclosureIconForegroundColor : tokens.trailingItemForegroundColor))
-                                .frame(width: isDisclosure ? disclosureSize : tokens.trailingItemSize, height: isDisclosure ? disclosureSize : tokens.trailingItemSize)
+                                .frame(width: isDisclosure ? disclosureSize : trailingItemSize, height: isDisclosure ? disclosureSize : trailingItemSize)
                                 .padding(.leading, isDisclosure ? tokens.disclosureInterspace : tokens.iconInterspace)
                         }
                     }
@@ -285,17 +390,17 @@ struct MSFListCellView: View {
             .buttonStyle(ListCellButtonStyle(tokens: tokens, state: state))
 
             if state.hasDivider {
-                let padding = tokens.horizontalCellPadding +
-                    (state.leadingView != nil ? (tokens.leadingViewSize + tokens.iconInterspace) : 0)
+                let padding = horizontalCellPadding +
+                    (state.leadingView != nil ? (leadingViewSize + tokens.iconInterspace) : 0)
                 FluentDivider()
                     .padding(.leading, padding)
             }
 
-            if let children = state.children, state.isExpanded == true {
+            if hasChildren, state.isExpanded == true {
                 ForEach(children, id: \.self) { child in
                     MSFListCellView(state: child)
                         .frame(maxWidth: .infinity)
-                        .padding(.leading, (tokens.horizontalCellPadding + tokens.leadingViewSize))
+                        .padding(.leading, (horizontalCellPadding + leadingViewSize))
                 }
             }
         }

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -6,10 +6,16 @@
 import UIKit
 import SwiftUI
 
-/// Properties that can be used to customize the appearance of the List Section.
+/// Properties that can be used to customize the appearance of the List Cell.
 @objc public protocol MSFListCellState {
     /// Custom view on the leading side of the Cell.
     var leadingUIView: UIView? { get set }
+
+    /// Size of the `leadingView`.
+    var leadingViewSize: MSFListCellLeadingViewSize { get set }
+
+    /// Custom view on the trailing side of the Cell.
+    var trailingUIView: UIView? { get set }
 
     /// Custom view on the leading side of the Cell title.
     var titleLeadingAccessoryUIView: UIView? { get set }
@@ -28,12 +34,6 @@ import SwiftUI
 
     /// Custom view on the trailing side of the Cell footnote.
     var footnoteTrailingAccessoryUIView: UIView? { get set }
-
-    /// Custom view on the trailing side of the Cell.
-    var trailingUIView: UIView? { get set }
-
-    /// Size of the `leadingView`.
-    var leadingViewSize: MSFListCellLeadingViewSize { get set }
 
     /// The first line of the Cell.
     var title: String { get set }
@@ -107,15 +107,6 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, MSFListCel
     @Published var footnoteTrailingAccessoryView: AnyView?
     @Published var trailingView: AnyView?
 
-    @Published var leadingViewSize: MSFListCellLeadingViewSize = .medium {
-        didSet {
-            if leadingViewSize != oldValue {
-                tokens.cellLeadingViewSize = leadingViewSize
-                tokens.updateForCurrentTheme()
-            }
-        }
-    }
-
     @Published var title: String = ""
     @Published var subtitle: String = ""
     @Published var footnote: String = ""
@@ -143,6 +134,26 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, MSFListCel
             }
 
             leadingView = AnyView(UIViewAdapter(view))
+        }
+    }
+
+    @Published var leadingViewSize: MSFListCellLeadingViewSize = .medium {
+        didSet {
+            if leadingViewSize != oldValue {
+                tokens.cellLeadingViewSize = leadingViewSize
+                tokens.updateForCurrentTheme()
+            }
+        }
+    }
+
+    var trailingUIView: UIView? {
+        didSet {
+            guard let view = trailingUIView else {
+                trailingView = nil
+                return
+            }
+
+            trailingView = AnyView(UIViewAdapter(view))
         }
     }
 
@@ -209,17 +220,6 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, MSFListCel
             }
 
             footnoteTrailingAccessoryView = AnyView(UIViewAdapter(view))
-        }
-    }
-
-    var trailingUIView: UIView? {
-        didSet {
-            guard let view = trailingUIView else {
-                trailingView = nil
-                return
-            }
-
-            trailingView = AnyView(UIViewAdapter(view))
         }
     }
 

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -381,7 +381,8 @@ struct MSFListCellView: View {
                             Image(uiImage: accessoryIcon)
                                 .resizable()
                                 .foregroundColor(Color(isDisclosure ? tokens.disclosureIconForegroundColor : tokens.trailingItemForegroundColor))
-                                .frame(width: isDisclosure ? disclosureSize : trailingItemSize, height: isDisclosure ? disclosureSize : trailingItemSize)
+                                .frame(width: isDisclosure ? disclosureSize : trailingItemSize,
+                                       height: isDisclosure ? disclosureSize : trailingItemSize)
                                 .padding(.leading, isDisclosure ? tokens.disclosureInterspace : tokens.iconInterspace)
                         }
                     }

--- a/ios/FluentUI/Vnext/List/ListTokens.swift
+++ b/ios/FluentUI/Vnext/List/ListTokens.swift
@@ -82,7 +82,6 @@ class MSFCellBaseTokens: MSFTokensBase, ObservableObject {
     @Published public var iconInterspace: CGFloat!
     @Published public var labelAccessoryInterspace: CGFloat!
     @Published public var labelAccessorySize: CGFloat!
-    @Published public var cellLeadingViewSize: MSFListCellLeadingViewSize!
     @Published public var leadingViewSize: CGFloat!
     @Published public var leadingViewAreaSize: CGFloat!
     @Published public var sublabelAccessorySize: CGFloat!
@@ -92,6 +91,14 @@ class MSFCellBaseTokens: MSFTokensBase, ObservableObject {
     @Published public var footnoteFont: UIFont!
     @Published public var sublabelFont: UIFont!
     @Published public var labelFont: UIFont!
+
+    var cellLeadingViewSize: MSFListCellLeadingViewSize! {
+        didSet {
+            if oldValue != cellLeadingViewSize {
+                updateForCurrentTheme()
+            }
+        }
+    }
 }
 
 class MSFListCellTokens: MSFCellBaseTokens {

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -25,7 +25,7 @@ public protocol PersonaViewState: MSFPersonaViewState {
 }
 
 /// Properties that make up PersonaView content
-class MSFPersonaViewStateImpl: MSFListCellState, PersonaViewState {
+class MSFPersonaViewStateImpl: MSFListCellStateImpl, PersonaViewState {
     override var backgroundColor: UIColor? {
         get {
             return avatarState.backgroundColor


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Follow-up of #865. This PR adds a protocol to ListCell, which affected List & PersonaView controls. There is also some further file organization (rearranging properties/methods & adding documentation).

### Verification

Tested on iOS 14/15, Dark/Light, verified that List works the same in List/LeftNav/ObjC demo controllers.

Demo:

https://user-images.githubusercontent.com/22566866/150446782-68d20aff-644d-4e76-9da2-d1c85c8d5e69.mov


Theming validation:

https://user-images.githubusercontent.com/22566866/150446807-8459c78c-b657-4565-860b-7bc76db30c0d.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/877)