### PR TITLE
Fix Pill Button Bar section toggle not responding on RTL with large text

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -24,7 +24,7 @@ class PillButtonBarDemoController: DemoController {
         disableOnBrandSwitchView.addTarget(self, action: #selector(toggleOnBrandPills(switchView:)), for: .valueChanged)
 
         container.addArrangedSubview(createLabelWithText("onBrand"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in onBrand Pill Bar"), disableOnBrandSwitchView], itemSpacing: 20, centerItems: true)
+        addSectionToggle(toggleTitle: createLabelWithText("Enable/Disable pills in onBrand Pill Bar"), switchView: disableOnBrandSwitchView)
         let onBrandBar = createBar(items: items, style: .onBrand)
         container.addArrangedSubview(onBrandBar)
         self.onBrandBar = onBrandBar
@@ -35,7 +35,7 @@ class PillButtonBarDemoController: DemoController {
         disableCustomOnBrandSwitchView.addTarget(self, action: #selector(toggleCustomOnBrandPills(switchView:)), for: .valueChanged)
 
         container.addArrangedSubview(createLabelWithText("onBrand With Custom Pills Background"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in custom onBrand Pill Bar"), disableCustomOnBrandSwitchView], itemSpacing: 20, centerItems: true)
+        addSectionToggle(toggleTitle: createLabelWithText("Enable/Disable pills in custom onBrand Pill Bar"), switchView: disableCustomOnBrandSwitchView)
         let customBar = createBar(items: items, style: .onBrand, useCustomPillsColors: true)
         container.addArrangedSubview(customBar)
         self.customBar = customBar
@@ -46,7 +46,7 @@ class PillButtonBarDemoController: DemoController {
         disablePrimarySwitchView.addTarget(self, action: #selector(togglePrimaryPills(switchView:)), for: .valueChanged)
 
         container.addArrangedSubview(createLabelWithText("Primary"))
-        addRow(items: [createLabelWithText("Enable/Disable pills in Primary Pill bar"), disablePrimarySwitchView], itemSpacing: 20, centerItems: true)
+        addSectionToggle(toggleTitle: createLabelWithText("Enable/Disable pills in Primary Pill bar"), switchView: disablePrimarySwitchView)
         let primaryBar = createBar(items: items)
         container.addArrangedSubview(primaryBar)
         self.primaryBar = primaryBar
@@ -115,6 +115,13 @@ class PillButtonBarDemoController: DemoController {
         label.text = text
         label.textAlignment = .center
         return label
+    }
+
+    func addSectionToggle(toggleTitle: Label, switchView: UISwitch) {
+        toggleTitle.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        switchView.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+        addRow(items: [toggleTitle, switchView], itemSpacing: 20, centerItems: true)
     }
 
     func fitViewIntoSuperview(_ view: UIView, margins: UIEdgeInsets) {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

The UISwitch we were using to toggle enabled/disabled for the sections of the PillButtonBar demo controller was getting squished by the label when RTL with large text. Increasing its resistance to compression fixed that.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![PillButton_Before](https://user-images.githubusercontent.com/67026548/151084435-c104b988-fe65-4fac-861e-c411c152f45f.gif) | ![PillButton_After](https://user-images.githubusercontent.com/67026548/151084446-402c3b9e-34e8-4e62-8a23-8145f1f5f5e3.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/880)