### PR TITLE
Fixing warnings caused by inconsistent documentation comments.

### DIFF
--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -159,7 +159,7 @@ public enum CardSize: Int, CaseIterable {
 /**
  `CardView` is a UIView used to display information in a card
  
- A card has a title, an optional subtitle, an icon, a style, and a color style
+ A card has a title, an optional subtitle, an icon, a size, and a color style
  
  Use `titleNumberOfLines` and `subtitleNumberOfLines`  to set the number of lines the title and subtitle should have respectively. When the string can not fit in the number of lines set, it will get truncated
  
@@ -173,7 +173,7 @@ open class CardView: UIView {
     /// Delegate to handle user interaction with the CardView
     @objc public weak var delegate: CardDelegate?
 
-    /// All card styles have a title. Setting `primaryText` will refresh the layout constraints
+    /// All card sizes have a title. Setting `primaryText` will refresh the layout constraints.
     @objc open var primaryText: String {
         didSet {
             if primaryText != oldValue {
@@ -193,7 +193,7 @@ open class CardView: UIView {
         }
     }
 
-    /// The card's icon. Announcement is the only card style that doesn't include an icon
+    /// The card's icon.
     @objc open var icon: UIImage {
         didSet {
             if icon != oldValue {
@@ -304,8 +304,8 @@ open class CardView: UIView {
 
     /**
      Initializes `CardView`
-     
-     - Parameter style: The style of the card
+
+     - Parameter size: The size of the card
      - Parameter title: The title of the card
      - Parameter subtitle: The subtitle of the card - optional
      - Parameter icon: The icon of the card


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Follow up on #878:
Fixing some warnings created by inconsistent documentation comments.

![Screen Shot 2022-01-25 at 5 35 15 PM](https://user-images.githubusercontent.com/68076145/151088710-af23f97e-d75d-4b65-a8fd-ee6f2c9b8946.png)


### Verification

Warnings are not issue upon build time.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/881)