### PR TITLE
Fix `BottomSheetController` not exiting .transitioning state

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -596,7 +596,10 @@ public class BottomSheetController: UIViewController {
         completeAnimationsIfNeeded()
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
-            let animator = stateChangeAnimator(to: targetExpansionState, velocity: velocity, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
+            let animator = stateChangeAnimator(to: targetExpansionState,
+                                               velocity: velocity,
+                                               interaction: interaction,
+                                               shouldNotifyDelegate: shouldNotifyDelegate)
             animator.addCompletion({ finalPosition in
                 completion?(finalPosition)
             })
@@ -666,7 +669,9 @@ public class BottomSheetController: UIViewController {
             }
             strongSelf.targetExpansionState = nil
             strongSelf.panGestureRecognizer.isEnabled = strongSelf.isExpandable
-            strongSelf.handleCompletedStateChange(to: finalPosition == .end ? targetExpansionState : originalExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
+            strongSelf.handleCompletedStateChange(to: finalPosition == .end ? targetExpansionState : originalExpansionState,
+                                                  interaction: interaction,
+                                                  shouldNotifyDelegate: shouldNotifyDelegate)
         })
 
         view.layoutIfNeeded()

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -508,8 +508,8 @@ public class BottomSheetController: UIViewController {
     @objc private func handlePan(_ sender: UIPanGestureRecognizer) {
         switch sender.state {
         case .began:
-            currentExpansionState = .transitioning
             completeAnimationsIfNeeded()
+            currentExpansionState = .transitioning
             fallthrough
         case .changed:
             translateSheet(by: sender.translation(in: view))
@@ -596,7 +596,7 @@ public class BottomSheetController: UIViewController {
         completeAnimationsIfNeeded()
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
-            let animator = stateChangeAnimator(to: targetExpansionState, velocity: velocity)
+            let animator = stateChangeAnimator(to: targetExpansionState, velocity: velocity, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
             animator.addCompletion({ finalPosition in
                 completion?(finalPosition)
             })
@@ -636,7 +636,6 @@ public class BottomSheetController: UIViewController {
         }
 
         // Animation might be reversed, so we need to remember the original state
-        let originalBottomSheetHiddenState = bottomSheetView.isHidden
         let originalExpansionState = currentExpansionState
 
         bottomSheetView.isHidden = false
@@ -667,15 +666,10 @@ public class BottomSheetController: UIViewController {
             }
             strongSelf.targetExpansionState = nil
             strongSelf.panGestureRecognizer.isEnabled = strongSelf.isExpandable
-
-            if finalPosition == .end {
-                strongSelf.handleCompletedStateChange(to: targetExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
-            } else if finalPosition == .start {
-                strongSelf.bottomSheetView.isHidden = originalBottomSheetHiddenState
-                strongSelf.currentExpansionState = originalExpansionState
-            }
+            strongSelf.handleCompletedStateChange(to: finalPosition == .end ? targetExpansionState : originalExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
         })
 
+        view.layoutIfNeeded()
         currentExpansionState = .transitioning
         translationAnimator.pauseAnimation()
         return translationAnimator


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`BottomSheetController` has a `.transitioning` state used during animation and user interaction to prevent the sheet frame from resetting during a layout pass.
The sheet can get stuck in the transitioning state when an animation gets cancelled, causing it to stop updating its frame until a new animation happens.

This PR does a few things to prevent this:
- make sure we get out of `.transitioning` state in the animation completion handler, regardless of how the animation ended
- `layoutIfNeeded` before an animation starts so we're in a good state if the animation cancels
- because the completion handler will now always get us out of transitioning state, make sure we reset back to it when a pan begins

Unrelated, but fixing it here:
- forward correct interaction data to `stateChangeAnimator` to fix incorrect delegate callbacks.

### Verification

Sanity checks in test app in cases that previously reproduced. Also tested in product.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/882)