### PR TITLE
Fixing build warnings on the FluentUI Mac project.

### DIFF
--- a/macos/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/macos/FluentUITestApp/FluentUITestApp-Info.plist
@@ -20,6 +20,8 @@
 	<string>0.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>41</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainNibFile</key>

--- a/macos/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/macos/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -695,7 +695,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1200;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = "Microsoft Corporation";
 				TargetAttributes = {
 					8F41CC6C2447B60F0040B851 = {
@@ -1053,6 +1053,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8F41CC732447B66A0040B851 /* FluentUI_resources.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 			};
 			name = Debug;
 		};
@@ -1060,6 +1061,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8F41CC732447B66A0040B851 /* FluentUI_resources.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 			};
 			name = Release;
 		};
@@ -1067,6 +1069,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8F69C7B22295FABD009F69C0 /* FluentUI_testapp.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
 			};
 			name = Debug;
 		};
@@ -1074,6 +1078,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8F69C7B22295FABD009F69C0 /* FluentUI_testapp.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
 			};
 			name = Release;
 		};
@@ -1082,6 +1088,34 @@
 			baseConfigurationReference = E61C96D02295FA360006561F /* FluentUI_debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
@@ -1090,6 +1124,32 @@
 			baseConfigurationReference = E61C96D12295FA4E0006561F /* FluentUI_release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 			};
 			name = Release;
 		};
@@ -1097,6 +1157,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E61C96CE2295ED8A0006561F /* FluentUI_framework.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 			};
 			name = Debug;
 		};
@@ -1104,6 +1165,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E61C96CE2295ED8A0006561F /* FluentUI_framework.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 			};
 			name = Release;
 		};
@@ -1111,6 +1173,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8F931A6C22BD593300311764 /* FluentUI_unittest.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -1118,6 +1182,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8F931A6C22BD593300311764 /* FluentUI_unittest.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -1125,6 +1191,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E6A92D4D24BEAA0200562BCA /* FluentUI_testviewcontrollers.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 			};
 			name = Debug;
 		};
@@ -1132,6 +1199,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E6A92D4D24BEAA0200562BCA /* FluentUI_testviewcontrollers.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
 			};
 			name = Release;
 		};
@@ -1139,6 +1207,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E6A92D4C24BEAA0200562BCA /* FluentUI_swiftui_testapp.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
 			};
 			name = Debug;
 		};
@@ -1146,6 +1216,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E6A92D4C24BEAA0200562BCA /* FluentUI_swiftui_testapp.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
 			};
 			name = Release;
 		};

--- a/macos/xcode/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUI-macOS.xcscheme
+++ b/macos/xcode/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUI-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/macos/xcode/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUITestApp-macOS.xcscheme
+++ b/macos/xcode/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUITestApp-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1310"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

The Mac project currently issues the following build warnings:
![Screen Shot 2022-01-27 at 9 00 38 AM](https://user-images.githubusercontent.com/68076145/151410968-312d5441-a3ba-4da6-8c34-01c7451f5a54.png)
![Screen Shot 2022-01-27 at 9 00 47 AM](https://user-images.githubusercontent.com/68076145/151410980-d3529a99-ecb4-4851-bc0e-bfe11df10f51.png)

This change fixes those by:
- Setting the App category (**LSApplicationCategoryType**) to "developer tools" (**public.app-category.developer-tools**)
- Updating the Unit tests target deployment to 11.0 as Xcode now validates the test framework target deployment version with the unit test library being built.
- Changing the project with the recommended settings below:
![Screen Shot 2022-01-27 at 9 03 22 AM](https://user-images.githubusercontent.com/68076145/151411443-6a2b4c7c-c851-436c-98b5-ff42e834a955.png)


### Verification

- Built and archived the MacOS test app and ensured not build warnings were issued.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/884)