### PR TITLE
Create Release scheme for FluentUI demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
@@ -37,7 +37,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5CEC20B20E436F10016922A"
+               BuildableName = "FluentUI.Demo.app"
+               BlueprintName = "FluentUI.Demo"
+               ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8FD01165228A820600D25925"
+               BuildableName = "libFluentUI.a"
+               BlueprintName = "FluentUILib"
+               ReferencedContainer = "container:../FluentUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5CEC20B20E436F10016922A"
+            BuildableName = "FluentUI.Demo.app"
+            BlueprintName = "FluentUI.Demo"
+            ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5CEC15020D980B20016922A"
+            BuildableName = "FluentUI.framework"
+            BlueprintName = "FluentUI"
+            ReferencedContainer = "container:../FluentUI.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5CEC15920D980B30016922A"
+               BuildableName = "FluentUITests.xctest"
+               BlueprintName = "FluentUITests"
+               ReferencedContainer = "container:../FluentUI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5CEC20B20E436F10016922A"
+            BuildableName = "FluentUI.Demo.app"
+            BlueprintName = "FluentUI.Demo"
+            ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5CEC20B20E436F10016922A"
+            BuildableName = "FluentUI.Demo.app"
+            BlueprintName = "FluentUI.Demo"
+            ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This adds a new build scheme to the FluentUI demo app for `Release` builds. 

We already have GitHub and ADO tasks that generate release builds from the command line for both validation and shipping; this just makes it easier for developers to produce said builds on their local machines. 

This does not change or affect either of the existing schemes (`Debug` and `Dogfood`), and is mostly for the benefit of easier binary size comparisons.

### Verification

* Created some release builds locally and looked at them. Yep, they're release builds!
* Actually I've been using this scheme for months in the `vnext-tokens` branch for size comparisons, but it seems like something other folks might be able to use too.
* Other builds still work too. Which is not surprising since I'm not actually touching the build pipeline, but y'know, still good to check.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="247" alt="NoRelease" src="https://user-images.githubusercontent.com/4934719/151636057-eecb6f25-4134-4ab9-a12c-2aaab827efbc.png"> | <img width="247" alt="Release" src="https://user-images.githubusercontent.com/4934719/151636083-806da839-9e03-44e8-b6ed-e7c5d6911ca6.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/887)