### PR TITLE
Support asynchronously loading of persona images

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -516,7 +516,7 @@ class AvatarDemoController: DemoTableViewController {
             switch self {
             case .defaultWithImage,
                  .defaultWithInitials:
-                return "Kat Larrson"
+                return "Kat Larsson"
             case .groupWithImage,
                  .groupWithInitials:
                  return "NorthWind Traders"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -29,7 +29,7 @@ struct AvatarDemoView: View {
     @State var isTransparent: Bool = true
     @State var hasPointerInteraction: Bool = false
     @State var hasRingInnerGap: Bool = true
-    @State var primaryText: String = "Kat Larrson"
+    @State var primaryText: String = "Kat Larsson"
     @State var secondaryText: String = ""
     @State var presence: MSFAvatarPresence = .none
     @State var showImage: Bool = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
@@ -11,7 +11,7 @@ class BadgeFieldDemoController: DemoController {
         super.viewDidLoad()
 
         let badgeDataSources1 = [
-            BadgeViewDataSource(text: "Kat Larrson", style: .default),
+            BadgeViewDataSource(text: "Kat Larsson", style: .default),
             BadgeViewDataSource(text: "Allan Munger", style: .default),
             BadgeViewDataSource(text: "Mona Kane", style: .default),
             BadgeViewDataSource(text: "Mauricio August", style: .default),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -49,7 +49,7 @@ class BadgeViewDemoController: DemoController {
     func addBadgeSection(title: String, style: BadgeView.Style, isEnabled: Bool = true, overrideColor: Bool = false) {
         addTitle(text: title)
         for size in BadgeView.Size.allCases.reversed() {
-            let badge = createBadge(text: "Kat Larrson", style: style, size: size, isEnabled: isEnabled)
+            let badge = createBadge(text: "Kat Larsson", style: style, size: size, isEnabled: isEnabled)
             if overrideColor {
                 if isEnabled {
                     badge.backgroundColor = Colors.Palette.blueMagenta20.color
@@ -83,7 +83,7 @@ class BadgeViewDemoController: DemoController {
 
         for (size, customView) in dataSource {
             let badge = createBadge(
-                text: "Kat Larrson",
+                text: "Kat Larsson",
                 style: .default,
                 size: size,
                 isEnabled: false,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -272,7 +272,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     var showsTopAccessoryView: Bool = false
 
     var personaData: PersonaData = {
-        let personaData = PersonaData(name: "Kat Larrson", image: UIImage(named: "avatar_kat_larsson"))
+        let personaData = PersonaData(name: "Kat Larsson", image: UIImage(named: "avatar_kat_larsson"))
         personaData.hasRingInnerGap = false
         return personaData
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -36,6 +36,13 @@ class PeoplePickerSampleData {
 }
 
 final class AsyncImageDemoPersona: PersonaData {
+    static var samples: [AsyncImageDemoPersona] = {
+        return samplePersonas.map { persona in
+            AsyncImageDemoPersona(name: persona.name,
+                                  email: persona.email,
+                                  subtitle: persona.subtitle)
+        }
+    }()
 
     public func fetchImage(completion: @escaping (UIImage?) -> Void) {
         // for demo purposes, the "fetched" image is not being cached. The image will be "re-fetched" every time the cell appears on the screen.
@@ -46,14 +53,6 @@ final class AsyncImageDemoPersona: PersonaData {
         }
     }
 }
-
-var asyncImagePersonas: [AsyncImageDemoPersona] = {
-    return samplePersonas.map { persona in
-        AsyncImageDemoPersona(name: persona.name,
-                              email: persona.email,
-                              subtitle: persona.subtitle)
-    }
-}()
 
 // MARK: - PeoplePickerDemoController
 
@@ -113,7 +112,7 @@ class PeoplePickerDemoController: DemoController {
 
     @objc private func onAsyncImageSwitchValueChanged() {
         for peoplePicker in peoplePickers {
-            peoplePicker.availablePersonas = asyncImageSwitch.isOn ? asyncImagePersonas : samplePersonas
+            peoplePicker.availablePersonas = asyncImageSwitch.isOn ? AsyncImageDemoPersona.samples : samplePersonas
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -36,13 +36,11 @@ class PeoplePickerSampleData {
 }
 
 final class AsyncImageDemoPersona: PersonaData {
-    static var samples: [AsyncImageDemoPersona] = {
-        return samplePersonas.map { persona in
-            AsyncImageDemoPersona(name: persona.name,
-                                  email: persona.email,
-                                  subtitle: persona.subtitle)
-        }
-    }()
+    static let samples: [AsyncImageDemoPersona] = samplePersonas.map { persona in
+        AsyncImageDemoPersona(name: persona.name,
+                              email: persona.email,
+                              subtitle: persona.subtitle)
+    }
 
     public func fetchImage(completion: @escaping (UIImage?) -> Void) {
         // for demo purposes, the "fetched" image is not being cached. The image will be "re-fetched" every time the cell appears on the screen.

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -29,19 +29,49 @@ class PeoplePickerSampleData {
 
     static let variants: [Variant] = [
         Variant(description: "Standard implementation with one line of picked personas", numberOfLines: 1, pickedPersonas: [samplePersonas[0], samplePersonas[4], samplePersonas[11], samplePersonas[14]]),
-        Variant(description: "Doesn't allow picked personas to appear as suggested", pickedPersonas: [samplePersonas[0], samplePersonas[9]], allowsPickedPersonasToAppearAsSuggested: false),
+        Variant(description: "Doesn't allow picked personas to appear as suggested", pickedPersonas: [samplePersonas[0], samplePersonas[8]], allowsPickedPersonasToAppearAsSuggested: false),
         Variant(description: "Hides search directory button", pickedPersonas: [samplePersonas[13]], showsSearchDirectoryButton: false, hidePersonaListViewWhenNoSuggestedPersonas: true),
         Variant(description: "Includes callback when picking a suggested persona")
     ]
 }
+
+final class AsyncImageDemoPersona: PersonaData {
+
+    public func fetchImage(completion: @escaping (UIImage?) -> Void) {
+        // for demo purposes, the "fetched" image is not being cached. The image will be "re-fetched" every time the cell appears on the screen.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            let avatarImageName = "avatar_\(self.name.lowercased().replacingOccurrences(of: " ", with: "_"))"
+            let image = UIImage(named: avatarImageName)
+            completion(image)
+        }
+    }
+}
+
+var asyncImagePersonas: [AsyncImageDemoPersona] = {
+    return samplePersonas.map { persona in
+        AsyncImageDemoPersona(name: persona.name,
+                              email: persona.email,
+                              subtitle: persona.subtitle)
+    }
+}()
 
 // MARK: - PeoplePickerDemoController
 
 class PeoplePickerDemoController: DemoController {
     var peoplePickers: [PeoplePicker] = []
 
+    private let asyncImageSwitch = UISwitch()
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        asyncImageSwitch.addTarget(self, action: #selector(onAsyncImageSwitchValueChanged), for: .valueChanged)
+        setupView()
+    }
+
+    private func setupView() {
+        container.addArrangedSubview(createAsyncImageToggle())
+        container.addArrangedSubview(Separator())
 
         for (index, variant) in PeoplePickerSampleData.variants.enumerated() {
             addDescription(text: variant.description)
@@ -52,7 +82,7 @@ class PeoplePickerDemoController: DemoController {
         }
     }
 
-    func addPeoplePicker(for variant: PeoplePickerSampleData.Variant) {
+    private func addPeoplePicker(for variant: PeoplePickerSampleData.Variant) {
         let peoplePicker = PeoplePicker()
         peoplePicker.label = "Send to:"
         peoplePicker.availablePersonas = samplePersonas
@@ -65,6 +95,26 @@ class PeoplePickerDemoController: DemoController {
         peoplePicker.delegate = self
         peoplePickers.append(peoplePicker)
         container.addArrangedSubview(peoplePicker)
+    }
+
+    private func createAsyncImageToggle() -> UIStackView {
+        let asyncImageRow = UIStackView()
+        asyncImageRow.axis = .horizontal
+        asyncImageRow.alignment = .center
+        asyncImageRow.distribution = .equalSpacing
+
+        let asyncImageLabel = Label(style: .subhead, colorStyle: .regular)
+        asyncImageLabel.text = "Load persona images asynchronously"
+
+        asyncImageRow.addArrangedSubview(asyncImageLabel)
+        asyncImageRow.addArrangedSubview(asyncImageSwitch)
+        return asyncImageRow
+    }
+
+    @objc private func onAsyncImageSwitchValueChanged() {
+        for peoplePicker in peoplePickers {
+            peoplePicker.availablePersonas = asyncImageSwitch.isOn ? asyncImagePersonas : samplePersonas
+        }
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -242,7 +242,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     private static let smallButtonReuseIdentifier: String = "smallButtonReuseIdentifier"
 
     private let personas: [PersonaData] = [
-        PersonaData(firstName: "Kat", lastName: "Larrson", image: UIImage(named: "avatar_kat_larsson")),
+        PersonaData(firstName: "Kat", lastName: "Larsson", image: UIImage(named: "avatar_kat_larsson")),
         PersonaData(firstName: "Ashley", lastName: "McCarthy", image: UIImage(named: "avatar_ashley_mccarthy")),
         PersonaData(firstName: "Allan", lastName: "Munger", image: UIImage(named: "avatar_allan_munger")),
         PersonaData(firstName: "Amanda", lastName: "Brady", image: UIImage(named: "avatar_amanda_brady")),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -7,7 +7,7 @@ import FluentUI
 import UIKit
 
 let samplePersonas: [PersonaData] = [
-    PersonaData(name: "Kat Larrson", email: "kat.larrson@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_kat_larsson")),
+    PersonaData(name: "Kat Larsson", email: "kat.larrson@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_kat_larsson")),
     PersonaData(name: "Kristin Patterson", email: "kristin.patterson@contoso.com", subtitle: "Software Engineer"),
     PersonaData(name: "Ashley McCarthy", image: UIImage(named: "avatar_ashley_mccarthy")),
     PersonaData(name: "Allan Munger", email: "allan.munger@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_allan_munger")),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -7,7 +7,7 @@ import FluentUI
 import UIKit
 
 let samplePersonas: [PersonaData] = [
-    PersonaData(name: "Kat Larsson", email: "kat.larrson@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_kat_larsson")),
+    PersonaData(name: "Kat Larsson", email: "kat.larsson@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_kat_larsson")),
     PersonaData(name: "Kristin Patterson", email: "kristin.patterson@contoso.com", subtitle: "Software Engineer"),
     PersonaData(name: "Ashley McCarthy", image: UIImage(named: "avatar_ashley_mccarthy")),
     PersonaData(name: "Allan Munger", email: "allan.munger@contoso.com", subtitle: "Designer", image: UIImage(named: "avatar_allan_munger")),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -13,7 +13,7 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
     }()
 
     private lazy var badgeView: UIView = {
-        let dataSource = BadgeViewDataSource(text: "Kat Larrson")
+        let dataSource = BadgeViewDataSource(text: "Kat Larsson")
         let badge = BadgeView(dataSource: dataSource)
         badge.disabledBackgroundColor = Colors.Palette.blueMagenta20.color
         badge.disabledLabelTextColor = .white

--- a/ios/FluentUI/Avatar/Persona.swift
+++ b/ios/FluentUI/Avatar/Persona.swift
@@ -42,6 +42,10 @@ public protocol Persona {
 
     /// The subtitle value for the persona.
     var subtitle: String { get }
+
+    /// Loads the image asynchronously. Implement this instead of use ``image``  property if it needs to be fetched asynchronously. Image caching should be handled in the implementation for optimial efficiency.
+    /// - Parameter completion: The completion block that returns the image
+    @objc optional func loadImageAsync(completion: @escaping (UIImage?) -> Void)
 }
 
 extension Persona {

--- a/ios/FluentUI/Avatar/Persona.swift
+++ b/ios/FluentUI/Avatar/Persona.swift
@@ -43,7 +43,8 @@ public protocol Persona {
     /// The subtitle value for the persona.
     var subtitle: String { get }
 
-    /// Loads the image asynchronously. Implement this instead of use ``image``  property if it needs to be fetched asynchronously. Image caching should be handled in the implementation for optimial efficiency.
+    /// Loads the image asynchronously. This is called when setting up Persona row for presentation. Image caching should be handled in the implementation for optimal efficiency.
+    /// If the ``image`` is provided, it will be overrided by the loaded image when completion block is called, acting like a custom placeholder.
     /// - Parameter completion: The completion block that returns the image
     @objc optional func loadImageAsync(completion: @escaping (UIImage?) -> Void)
 }

--- a/ios/FluentUI/Avatar/Persona.swift
+++ b/ios/FluentUI/Avatar/Persona.swift
@@ -43,10 +43,10 @@ public protocol Persona {
     /// The subtitle value for the persona.
     var subtitle: String { get }
 
-    /// Loads the image asynchronously. This is called when setting up Persona row for presentation. Image caching should be handled in the implementation for optimal efficiency.
-    /// If the ``image`` is provided, it will be overrided by the loaded image when completion block is called, acting like a custom placeholder.
+    /// Fetches the image asynchronously. This is called when setting up persona row for presentation. Image caching should be handled in the implementation for optimal efficiency.
+    /// If the ``image`` is provided, it will be overrided by the fetched image when completion block is called, acting like a custom placeholder.
     /// - Parameter completion: The completion block that returns the image
-    @objc optional func loadImageAsync(completion: @escaping (UIImage?) -> Void)
+    @objc optional func fetchImage(completion: @escaping (UIImage?) -> Void)
 }
 
 extension Persona {

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -30,11 +30,12 @@ open class PersonaCell: TableViewCell {
         }
 
         if let loadImageAsync = persona.loadImageAsync {
-            loadImageAsync { image in
-                guard let image = image else {
+            loadImageAsync { [weak avatar] image in
+                guard let avatar = avatar,
+                      let image = image else {
                     return
                 }
-                
+
                 if Thread.isMainThread {
                     avatar.state.image = image
                 } else {

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -29,8 +29,8 @@ open class PersonaCell: TableViewCell {
             avatar.state.image = image
         }
 
-        if let loadImageAsync = persona.loadImageAsync {
-            loadImageAsync { [weak avatar] image in
+        if let fetchImage = persona.fetchImage {
+            fetchImage { [weak avatar] image in
                 guard let avatar = avatar,
                       let image = image else {
                     return

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -29,6 +29,22 @@ open class PersonaCell: TableViewCell {
             avatar.state.image = image
         }
 
+        if let loadImageAsync = persona.loadImageAsync {
+            loadImageAsync { image in
+                guard let image = image else {
+                    return
+                }
+                
+                if Thread.isMainThread {
+                    avatar.state.image = image
+                } else {
+                    DispatchQueue.main.async {
+                        avatar.state.image = image
+                    }
+                }
+            }
+        }
+
         if let color = persona.color {
             avatar.state.backgroundColor = color
             avatar.state.ringColor = color


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Introduce a new function to Persona protocol to allow the clients to fetch image asynchronously.
The change does not modify the existing behavior, and should have no impact on the existing consumers of the library. 

### Verification
The change was tested manually on Planner app for add group members feature, where the Persona images are fetched from Graph API. 

Added change in PeoplePickerDemoController to demonstrate the change. 
![Simulator Screen Recording - iPhone 13 Pro - 2022-02-12 at 12 02 59](https://user-images.githubusercontent.com/3644377/153720835-f1ff1ecb-11d9-48fd-a859-777aaefc3045.gif)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/889)