### PR TITLE
Cardview large content viewer support

### DIFF
--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -489,7 +489,7 @@ open class CardView: UIView {
             largeContextText += "\n" + secondaryText
         }
         largeContentTitle = largeContextText
-	}
+    }
 
     @objc private func handleCardTapped(_ recognizer: UITapGestureRecognizer) {
         delegate?.didTapCard?(self)

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -487,11 +487,13 @@ open class CardView: UIView {
     }
 
     private func updateLargeContentTitle() {
-        var largeContextText = primaryText
-        if let secondaryText = secondaryText, !twoLineTitle {
-            largeContextText += "\n" + secondaryText
-        }
-        largeContentTitle = largeContextText
+        largeContentTitle = {
+            guard let secondaryText = secondaryText, !twoLineTitle else {
+                return primaryText
+            }
+
+            return  "\(primaryText)\n\(secondaryText)"
+        }()
     }
 
     private func updateLargeContentImage() {

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -179,6 +179,7 @@ open class CardView: UIView {
             if primaryText != oldValue {
                 primaryLabel.text = primaryText
                 setupLayoutConstraints()
+                setLargeContentTitle()
             }
         }
     }
@@ -189,6 +190,7 @@ open class CardView: UIView {
             if secondaryText != oldValue {
                 secondaryLabel.text = secondaryText
                 setupLayoutConstraints()
+                setLargeContentTitle()
             }
         }
     }
@@ -217,6 +219,7 @@ open class CardView: UIView {
             if twoLineTitle != oldValue {
                 primaryLabel.numberOfLines = Constants.twoLineTitle
                 setupLayoutConstraints()
+                setLargeContentTitle()
             }
         }
     }
@@ -356,6 +359,11 @@ open class CardView: UIView {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleCardTapped(_:)))
         addGestureRecognizer(tapGesture)
 
+        // Large content viewer
+        addInteraction(UILargeContentViewerInteraction())
+        showsLargeContentViewer = true
+        setLargeContentTitle()
+
         setupLayoutConstraints()
     }
 
@@ -474,6 +482,14 @@ open class CardView: UIView {
 
         NSLayoutConstraint.activate(layoutConstraints)
     }
+
+	private func setLargeContentTitle() {
+		var largeContextText = primaryText
+		if let secondaryText = secondaryText, !twoLineTitle {
+			largeContextText += "\n" + secondaryText
+		}
+		largeContentTitle = largeContextText
+	}
 
     @objc private func handleCardTapped(_ recognizer: UITapGestureRecognizer) {
         delegate?.didTapCard?(self)

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -179,7 +179,7 @@ open class CardView: UIView {
             if primaryText != oldValue {
                 primaryLabel.text = primaryText
                 setupLayoutConstraints()
-                setLargeContentTitle()
+                updateLargeContentTitle()
             }
         }
     }
@@ -190,7 +190,7 @@ open class CardView: UIView {
             if secondaryText != oldValue {
                 secondaryLabel.text = secondaryText
                 setupLayoutConstraints()
-                setLargeContentTitle()
+                updateLargeContentTitle()
             }
         }
     }
@@ -200,6 +200,7 @@ open class CardView: UIView {
         didSet {
             if icon != oldValue {
                 iconView.image = icon
+                updateLargeContentImage()
             }
         }
     }
@@ -219,7 +220,7 @@ open class CardView: UIView {
             if twoLineTitle != oldValue {
                 primaryLabel.numberOfLines = Constants.twoLineTitle
                 setupLayoutConstraints()
-                setLargeContentTitle()
+                updateLargeContentTitle()
             }
         }
     }
@@ -362,7 +363,9 @@ open class CardView: UIView {
         // Large content viewer
         addInteraction(UILargeContentViewerInteraction())
         showsLargeContentViewer = true
-        setLargeContentTitle()
+        scalesLargeContentImage = true
+        updateLargeContentTitle()
+        updateLargeContentImage()
 
         setupLayoutConstraints()
     }
@@ -483,12 +486,16 @@ open class CardView: UIView {
         NSLayoutConstraint.activate(layoutConstraints)
     }
 
-    private func setLargeContentTitle() {
+    private func updateLargeContentTitle() {
         var largeContextText = primaryText
         if let secondaryText = secondaryText, !twoLineTitle {
             largeContextText += "\n" + secondaryText
         }
         largeContentTitle = largeContextText
+    }
+
+    private func updateLargeContentImage() {
+        largeContentImage = icon
     }
 
     @objc private func handleCardTapped(_ recognizer: UITapGestureRecognizer) {

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -483,12 +483,12 @@ open class CardView: UIView {
         NSLayoutConstraint.activate(layoutConstraints)
     }
 
-	private func setLargeContentTitle() {
-		var largeContextText = primaryText
-		if let secondaryText = secondaryText, !twoLineTitle {
-			largeContextText += "\n" + secondaryText
-		}
-		largeContentTitle = largeContextText
+    private func setLargeContentTitle() {
+        var largeContextText = primaryText
+        if let secondaryText = secondaryText, !twoLineTitle {
+            largeContextText += "\n" + secondaryText
+        }
+        largeContentTitle = largeContextText
 	}
 
     @objc private func handleCardTapped(_ recognizer: UITapGestureRecognizer) {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Updated the accessibility of CardView. For dynamic text, the control will increase in height. It does not grow in width also though and this is so that it can keep a consistent layout when in a collectionView. To be able to view the title and subtitle for accessibility text sizes large content viewer is being used to allow users to read the text. 

### Verification

Tested manually 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| No support was available, so the title text would be cut off with no way to view | ![Screen Shot 2022-02-03 at 10 28 59 AM](https://user-images.githubusercontent.com/21343215/152406301-1b9db0f3-2f84-4731-af80-8a0b46482750.png)
| No support was available, so all title and subtitle text would be cut off with no way to view | ![Screen Shot 2022-02-03 at 10 28 57 AM](https://user-images.githubusercontent.com/21343215/152406388-4915ed47-8a1f-4af1-9e1a-36be7fc25f26.png)|




### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/890)