### PR TITLE
Introducing capability to disable animation for avatar state transitions.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -47,6 +47,7 @@ class AvatarDemoController: DemoTableViewController {
             return cell
 
         case .alternateBackground,
+             .animating,
              .imageBasedRingColor,
              .outOfOffice,
              .pointerInteraction,
@@ -137,6 +138,16 @@ class AvatarDemoController: DemoTableViewController {
         }
     }
 
+    private var isAnimated: Bool = true {
+        didSet {
+            if oldValue != isAnimated {
+                allDemoAvatarsCombined.forEach { avatar in
+                    avatar.state.isAnimated = isAnimated
+                }
+            }
+        }
+    }
+
     private var isUsingAlternateBackgroundColor: Bool = false {
         didSet {
             updateBackgroundColor()
@@ -146,7 +157,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isPointerInteractionEnabled: Bool = false {
         didSet {
             if oldValue != isPointerInteractionEnabled {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.hasPointerInteraction = isPointerInteractionEnabled
                 }
             }
@@ -156,7 +167,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isShowingPresence: Bool = false {
         didSet {
             if oldValue != isShowingPresence {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.presence = isShowingPresence ? nextPresence() : .none
                 }
             }
@@ -166,7 +177,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isOutOfOffice: Bool = false {
         didSet {
             if oldValue != isOutOfOffice {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.isOutOfOffice = isOutOfOffice
                 }
             }
@@ -176,7 +187,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isShowingRings: Bool = false {
         didSet {
             if oldValue != isShowingRings {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.isRingVisible = isShowingRings
                 }
             }
@@ -186,7 +197,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
             if oldValue != isUsingImageBasedCustomColor {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
                 }
             }
@@ -196,7 +207,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isShowingRingInnerGap: Bool = true {
         didSet {
             if oldValue != isShowingRingInnerGap {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.hasRingInnerGap = isShowingRingInnerGap
                 }
             }
@@ -206,7 +217,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isTransparent: Bool = true {
         didSet {
             if oldValue != isTransparent {
-                for avatar in allDemoAvatarsCombined {
+                allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.isTransparent = isTransparent
                 }
             }
@@ -306,6 +317,8 @@ class AvatarDemoController: DemoTableViewController {
             return true
         case .alternateBackground:
             return self.isUsingAlternateBackgroundColor
+        case .animating:
+            return self.isAnimated
         case .imageBasedRingColor:
             return self.isUsingImageBasedCustomColor
         case .outOfOffice:
@@ -338,6 +351,8 @@ class AvatarDemoController: DemoTableViewController {
             return
         case .alternateBackground:
             self.isUsingAlternateBackgroundColor = isOn
+        case .animating:
+            self.isAnimated = isOn
         case .imageBasedRingColor:
             self.isUsingImageBasedCustomColor = isOn
         case .outOfOffice:
@@ -414,7 +429,8 @@ class AvatarDemoController: DemoTableViewController {
             case .swiftUI:
                 return [.swiftUIDemo]
             case .settings:
-                return [.alternateBackground,
+                return [.animating,
+                        .alternateBackground,
                         .pointerInteraction,
                         .transparency,
                         .presence,
@@ -443,6 +459,7 @@ class AvatarDemoController: DemoTableViewController {
 
     private enum AvatarDemoRow: CaseIterable {
         case accentWithFallback
+        case animating
         case alternateBackground
         case defaultWithImage
         case defaultWithInitials
@@ -474,6 +491,7 @@ class AvatarDemoController: DemoTableViewController {
                  .overflow:
                 return true
             case .alternateBackground,
+                 .animating,
                  .imageBasedRingColor,
                  .outOfOffice,
                  .pointerInteraction,
@@ -500,6 +518,7 @@ class AvatarDemoController: DemoTableViewController {
                  .outlinedWithFallback,
                  .overflow,
                  .alternateBackground,
+                 .animating,
                  .imageBasedRingColor,
                  .outOfOffice,
                  .pointerInteraction,
@@ -528,6 +547,7 @@ class AvatarDemoController: DemoTableViewController {
             case .overflow:
                 return "20"
             case .alternateBackground,
+                 .animating,
                  .imageBasedRingColor,
                  .outOfOffice,
                  .pointerInteraction,
@@ -558,6 +578,7 @@ class AvatarDemoController: DemoTableViewController {
             case .overflow:
                 return .overflow
             case .alternateBackground,
+                 .animating,
                  .imageBasedRingColor,
                  .outOfOffice,
                  .pointerInteraction,
@@ -576,6 +597,8 @@ class AvatarDemoController: DemoTableViewController {
                 return "Accent style (no initials, no image)"
             case .alternateBackground:
                 return "Use alternate background color"
+            case .animating:
+                return "Animate transitions"
             case.defaultWithImage:
                 return "Default style (image)"
             case .defaultWithInitials:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -24,6 +24,7 @@ class AvatarDemoControllerSwiftUI: UIHostingController<AvatarDemoView> {
 
 struct AvatarDemoView: View {
     @State var useAlternateBackground: Bool = false
+    @State var isAnimated: Bool = true
     @State var isOutOfOffice: Bool = false
     @State var isRingVisible: Bool = true
     @State var isTransparent: Bool = true
@@ -51,6 +52,7 @@ struct AvatarDemoView: View {
                 .presence(presence)
                 .isOutOfOffice(isOutOfOffice)
                 .hasPointerInteraction(hasPointerInteraction)
+                .isAnimated(isAnimated)
                 .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
                 .background(useAlternateBackground ? Color.gray : Color.clear)
 
@@ -78,6 +80,7 @@ struct AvatarDemoView: View {
                         FluentUIDemoToggle(titleKey: "Set alternate background", isOn: $useAlternateBackground)
                         FluentUIDemoToggle(titleKey: "Transparency", isOn: $isTransparent)
                         FluentUIDemoToggle(titleKey: "iPad Pointer interaction", isOn: $hasPointerInteraction)
+                        FluentUIDemoToggle(titleKey: "Animate transitions", isOn: $isAnimated)
                     }
 
                     Group {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -88,6 +88,9 @@ import SwiftUI
     /// The image used to fill the ring as a custom color.
     var imageBasedRingColor: UIImage? { get set }
 
+    /// Defines whether the avatar state transitions are animated or not. Animations are enabled by default.
+    var isAnimated: Bool { get set }
+
     /// Whether the presence status displays its "Out of office" or standard image.
     var isOutOfOffice: Bool { get set }
 
@@ -328,7 +331,7 @@ public struct Avatar: View {
 
         return avatarBody
             .pointerInteraction(state.hasPointerInteraction)
-            .animation(.linear(duration: animationDuration))
+            .animation(state.isAnimated ? .linear(duration: animationDuration) : .none)
             .accessibilityElement(children: .ignore)
             .accessibility(addTraits: state.hasButtonAccessibilityTrait ? .isButton : .isImage)
             .accessibility(label: Text(accessibilityLabel))
@@ -472,6 +475,7 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
     @Published var hasRingInnerGap: Bool = true
     @Published var image: UIImage?
     @Published var imageBasedRingColor: UIImage?
+    @Published var isAnimated: Bool = true
     @Published var isOutOfOffice: Bool = false
     @Published var isRingVisible: Bool = false
     @Published var isTransparent: Bool = true

--- a/ios/FluentUI/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Avatar/AvatarModifiers.swift
@@ -58,6 +58,14 @@ public extension Avatar {
         return self
     }
 
+    /// Defines whether the avatar state transitions are animated or not. Animations are enabled by default.
+    /// - Parameter isAnimated: Boolean value to set the property.
+    /// - Returns: The modified Avatar with the property set.
+    func isAnimated(_ isAnimated: Bool) -> Avatar {
+        state.isAnimated = isAnimated
+        return self
+    }
+
     /// Whether the presence status displays its "Out of office" or standard image.
     /// - Parameter isOutOfOffice: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Avatar transition animations are not always desired by the consuming apps.
This change introduces a state object that allows the calling code to disable animations for the Avatar.
The default value for the property is still true.

### Verification

- Introduced another configuration toggle in both demo controllers (UIKit and SwiftUI).
- Exercised state changes and ensured the new state property creates de desired behavior.


https://user-images.githubusercontent.com/68076145/152608653-f7dd834d-ef3e-414e-a602-4cfa876a7d53.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/892)