### PR TITLE
Fix RTL Avatar Group spacing

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -208,9 +208,12 @@ public struct AvatarGroup: View {
                 let stackPadding = (currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace)
 
                 let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
-                let xPosition = currentAvatarHasRing ? x - ringOuterGap - ringOuterGap : x - ringOuterGap
-                let xPositionRTL = -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
-                let xOrigin = layoutDirection == .rightToLeft ? xPositionRTL : xPosition
+                let xOrigin: CGFloat = {
+                    if layoutDirection == .rightToLeft {
+                        return -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
+                    }
+                    return x - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
+                }()
                 let yOrigin = sizeDiff / 2
 
                 // Hand the rendering of the avatar to a helper function to appease Swift's

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -205,15 +205,13 @@ public struct AvatarGroup: View {
 
                 let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
                 let noRingPaddingInterspace = nextAvatarHasRing ? interspace - ringOuterGap : interspace
-                let rtlRingPaddingInterspace = (nextAvatarHasRing ? -x - ringOuterGap : -x + ringOffset)
-                let rtlNoRingPaddingInterspace = (nextAvatarHasRing ? -x - ringOffset - ringOuterGap : -x)
                 let stackPadding = (currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace)
 
+                let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
                 let xPosition = currentAvatarHasRing ? x - ringOuterGap - ringOuterGap : x - ringOuterGap
-                let xPositionRTL = currentAvatarHasRing ? rtlRingPaddingInterspace : rtlNoRingPaddingInterspace
+                let xPositionRTL = -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
                 let xOrigin = layoutDirection == .rightToLeft ? xPositionRTL : xPosition
                 let yOrigin = sizeDiff / 2
-                let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
 
                 // Hand the rendering of the avatar to a helper function to appease Swift's
                 // strict type-checking timeout.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update the RTL cutout origin to be based off the size of the cutout rather than the size of the current avatar

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AvatarGroup_RTLBefore](https://user-images.githubusercontent.com/67026548/152908791-760b6a0d-48e7-44ef-b5e2-3c52892d0188.png) | ![AvatarGroup_RTLAfter](https://user-images.githubusercontent.com/67026548/152908796-0a95983d-ec46-453b-b3f2-8339ec56a975.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/895)