### PR TITLE
Fix bottom sheet state changes when frame is zero

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -642,6 +642,8 @@ public class BottomSheetController: UIViewController {
                 animator.stopAnimation(false)
                 animator.finishAnimation(at: .end)
             }
+        } else {
+            currentExpansionState = targetExpansionState
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Our current bottom sheet state changing code assumes that if we're at the target vertical offset, we are also in the target state. This assumption breaks when the frame is zero because zero offset is the only option for any state. This can cause us to miss state changes in the period of time after loadView and before our frame is set for the first time.

The fix is to just handle this the same way as when loadView hasn't happened yet - directly set `currentExpansionState` to `targetExpansionState`.

### Verification

Force a repro by changing state before the first layout pass, ensure it is fixed after the change.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/897)