### PR TITLE
Manually update bottom sheet layout guide top edge

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -441,6 +441,7 @@ public class BottomSheetController: UIViewController {
         // so to avoid interfering we won't update the frame here.
         if currentExpansionState != .transitioning {
             bottomSheetView.frame = sheetFrame(offset: offset(for: currentExpansionState))
+            updateSheetLayoutGuideTopConstraint()
             updateExpandedContentAlpha()
             updateDimmingViewAlpha()
         }
@@ -525,6 +526,12 @@ public class BottomSheetController: UIViewController {
         dimmingView.alpha = targetAlpha
     }
 
+    private func updateSheetLayoutGuideTopConstraint() {
+        if sheetLayoutGuideTopConstraint.constant != currentSheetVerticalOffset {
+            sheetLayoutGuideTopConstraint.constant = currentSheetVerticalOffset
+        }
+    }
+
     @objc private func handlePan(_ sender: UIPanGestureRecognizer) {
         switch sender.state {
         case .began:
@@ -555,6 +562,7 @@ public class BottomSheetController: UIViewController {
         let targetOffset = min(max(bottomSheetView.frame.origin.y + offsetDelta, minOffset), maxOffset)
         bottomSheetView.frame = sheetFrame(offset: targetOffset)
 
+        updateSheetLayoutGuideTopConstraint()
         updateExpandedContentAlpha()
         updateDimmingViewAlpha()
     }
@@ -676,6 +684,7 @@ public class BottomSheetController: UIViewController {
                 return
             }
             strongSelf.bottomSheetView.frame = strongSelf.sheetFrame(offset: targetVerticalOffset)
+            strongSelf.sheetLayoutGuideTopConstraint.constant = targetVerticalOffset
             strongSelf.view.layoutIfNeeded()
         }
 
@@ -745,6 +754,10 @@ public class BottomSheetController: UIViewController {
         if targetExpansionState == .hidden {
             bottomSheetView.isHidden = true
         }
+
+        // UIKit doesn't properly handle interrupted constraint animations, so we need to
+        // detect and fix a possible desync here
+        updateSheetLayoutGuideTopConstraint()
     }
 
     private func completeAnimationsIfNeeded(skipToEnd: Bool = false) {
@@ -764,12 +777,15 @@ public class BottomSheetController: UIViewController {
             sheetLayoutGuide.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
         ]
 
+        // This constraint is used to align the top of the layout guide with the top of the bottomSheetView.
         // BottomSheetView will go off-screen when it's hidden, so this constraint is not always required.
-        let breakableConstraint = sheetLayoutGuide.topAnchor.constraint(equalTo: bottomSheetView.topAnchor)
-        breakableConstraint.priority = .defaultHigh
+        let breakableTopConstraint = sheetLayoutGuideTopConstraint
+        breakableTopConstraint.priority = .defaultHigh
 
-        return requiredConstraints + [breakableConstraint]
+        return requiredConstraints + [breakableTopConstraint]
     }
+
+    private lazy var sheetLayoutGuideTopConstraint: NSLayoutConstraint = sheetLayoutGuide.topAnchor.constraint(equalTo: view.topAnchor)
 
     // Height of the sheet in the fully expanded state
     private var expandedSheetHeight: CGFloat {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We use Auto Layout to fit the `sheetLayoutGuide` around the bottom sheet view. It turns out there is an Apple bug in place where if a `UIViewPropertyAnimator` animation is interrupted, Auto Layout does not update the layout guide to fit the current sheet frame. It instead jumps to the animation end location. I tried forcing a constraint update pass and a layout pass but even after this the layout guide wasn't updating. It only updates whenever the sheet frame changes again.
I think it's related to the sheet view's UIKit-generated autoresizing constraints also not updating when an animation interrupts. These constraints are likely what backs the anchors used to represent the view in Auto Layout world.

I'll submit an Apple bug for this, but in the meantime we have a good workaround. We are the ones setting the sheet frame, so we can instead use a constant constraint for the layout guide top constraint and keep it in sync with the sheet whenever we're changing the sheet offset.

### Verification

Force a repro in the test app by quickly cycling the isHidden value. Make sure the bug doesn't repro after the fix.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/898)