### PR TITLE
Improve readability of the AvatarGroup body

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -532,8 +532,8 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, Identifiable, MSFAvatarSta
         if !isRingVisible {
             return avatarImageSize + (ringOuterGap * 2)
         } else {
-            let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
-            let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
+            let ringThickness: CGFloat = tokens.ringThickness
+            let ringInnerGap: CGFloat = hasRingInnerGap ? tokens.ringInnerGap : 0
             return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
         }
     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -179,8 +179,10 @@ public struct AvatarGroup: View {
         let avatars: [MSFAvatarStateImpl] = state.avatars
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
         let enumeratedAvatars = Array(avatars.enumerated())
-        let maxDisplayedAvatars: Int = avatars.prefix(state.maxDisplayedAvatars).count
-        let overflowCount: Int = (avatars.count > maxDisplayedAvatars ? avatars.count - maxDisplayedAvatars : 0) + state.overflowCount
+        let avatarCount: Int = avatars.count
+        let maxDisplayedAvatars: Int = state.maxDisplayedAvatars
+        let avatarsToDisplay: Int = min(maxDisplayedAvatars, avatarCount)
+        let overflowCount: Int = (avatarCount > maxDisplayedAvatars ? avatarCount - maxDisplayedAvatars : 0) + state.overflowCount
 
         let interspace: CGFloat = tokens.interspace
         let imageSize: CGFloat = tokens.size.size
@@ -193,7 +195,7 @@ public struct AvatarGroup: View {
         @ViewBuilder
         var avatarGroupContent: some View {
             HStack(spacing: 0) {
-                ForEach(enumeratedAvatars.prefix(maxDisplayedAvatars), id: \.1) { index, avatar in
+                ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
                     // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
                     let avatarView = avatarViews[index]
                     let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -210,8 +210,12 @@ public struct AvatarGroup: View {
                     let currentAvatarHasRing = avatar.isRingVisible
                     let nextAvatarHasRing = !isLastDisplayed ? avatars[nextIndex].isRingVisible : false
                     let avatarSizeDifference = avatarSize - nextAvatarSize
-                    let sizeDiff = !isLastDisplayed ? (currentAvatarHasRing ? avatarSizeDifference : avatarSizeDifference - ringGapOffset) :
-                    currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize
+                    let sizeDiff: CGFloat = {
+                        if isLastDisplayed {
+                            return avatarSize - imageSize - ringGapOffset - (currentAvatarHasRing ? 0 : ringGapOffset)
+                        }
+                        return avatarSizeDifference - (currentAvatarHasRing ? 0 : ringGapOffset)
+                    }()
 
                     // Calculating the different interspace scenarios considering rings.
                     let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -197,17 +197,18 @@ public struct AvatarGroup: View {
         var avatarGroupContent: some View {
             HStack(spacing: 0) {
                 ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
+                    let nextIndex = index + 1
                     // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
                     let avatarView = avatarViews[index]
-                    let needsCutout = tokens.style == .stack && (hasOverflow || index + 1 < maxDisplayedAvatars)
+                    let needsCutout = tokens.style == .stack && (hasOverflow || nextIndex < maxDisplayedAvatars)
                     let avatarSize: CGFloat = avatarView.state.totalSize()
-                    let nextAvatarSize: CGFloat = needsCutout ? avatarViews[index + 1].state.totalSize() : 0
+                    let nextAvatarSize: CGFloat = needsCutout ? avatarViews[nextIndex].state.totalSize() : 0
                     let isLastDisplayed = index == maxDisplayedAvatars - 1
 
                     // Calculating the size delta of the current and next avatar based off of ring visibility, which helps determine
                     // starting coordinates for the cutout.
                     let currentAvatarHasRing = avatar.isRingVisible
-                    let nextAvatarHasRing = index + 1 < maxDisplayedAvatars ? avatars[index + 1].isRingVisible : false
+                    let nextAvatarHasRing = nextIndex < maxDisplayedAvatars ? avatars[nextIndex].isRingVisible : false
                     let avatarSizeDifference = avatarSize - nextAvatarSize
                     let sizeDiff = !isLastDisplayed ? (currentAvatarHasRing ? avatarSizeDifference : avatarSizeDifference - ringGapOffset) :
                     currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -208,7 +208,6 @@ public struct AvatarGroup: View {
                     let avatarSizeDifference = avatarSize - nextAvatarSize
                     let sizeDiff = !isLastDisplayed ? (currentAvatarHasRing ? avatarSizeDifference : avatarSizeDifference - ringGapOffset) :
                     currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize
-                    let x = avatarSize + tokens.interspace - ringGapOffset
 
                     // Calculating the different interspace scenarios considering rings.
                     let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
@@ -221,7 +220,7 @@ public struct AvatarGroup: View {
                         if layoutDirection == .rightToLeft {
                             return -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
                         }
-                        return x - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
+                        return avatarSize + tokens.interspace - ringGapOffset - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
                     }()
                     let yOrigin = sizeDiff / 2
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -220,7 +220,7 @@ public struct AvatarGroup: View {
                         if layoutDirection == .rightToLeft {
                             return -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
                         }
-                        return avatarSize + tokens.interspace - ringGapOffset - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
+                        return avatarSize + interspace - ringGapOffset - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
                     }()
                     let yOrigin = sizeDiff / 2
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -198,17 +198,17 @@ public struct AvatarGroup: View {
             HStack(spacing: 0) {
                 ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
                     let nextIndex = index + 1
+                    let isLastDisplayed = nextIndex == avatarsToDisplay
                     // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
                     let avatarView = avatarViews[index]
-                    let needsCutout = tokens.style == .stack && (hasOverflow || nextIndex < maxDisplayedAvatars)
+                    let needsCutout = tokens.style == .stack && (hasOverflow || !isLastDisplayed)
                     let avatarSize: CGFloat = avatarView.state.totalSize()
                     let nextAvatarSize: CGFloat = needsCutout ? avatarViews[nextIndex].state.totalSize() : 0
-                    let isLastDisplayed = index == maxDisplayedAvatars - 1
 
                     // Calculating the size delta of the current and next avatar based off of ring visibility, which helps determine
                     // starting coordinates for the cutout.
                     let currentAvatarHasRing = avatar.isRingVisible
-                    let nextAvatarHasRing = nextIndex < maxDisplayedAvatars ? avatars[nextIndex].isRingVisible : false
+                    let nextAvatarHasRing = !isLastDisplayed ? avatars[nextIndex].isRingVisible : false
                     let avatarSizeDifference = avatarSize - nextAvatarSize
                     let sizeDiff = !isLastDisplayed ? (currentAvatarHasRing ? avatarSizeDifference : avatarSizeDifference - ringGapOffset) :
                     currentAvatarHasRing ? (avatarSize - ringGapOffset) - imageSize : (avatarSize - (ringGapOffset * 2)) - imageSize

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -184,6 +184,7 @@ public struct AvatarGroup: View {
         let avatarsToDisplay: Int = min(maxDisplayedAvatars, avatarCount)
         let overflowCount: Int = (avatarCount > maxDisplayedAvatars ? avatarCount - maxDisplayedAvatars : 0) + state.overflowCount
         let hasOverflow: Bool = overflowCount > 0
+        let isStackStyle = tokens.style == .stack
 
         let interspace: CGFloat = tokens.interspace
         let imageSize: CGFloat = tokens.size.size
@@ -201,7 +202,7 @@ public struct AvatarGroup: View {
                     let isLastDisplayed = nextIndex == avatarsToDisplay
                     // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
                     let avatarView = avatarViews[index]
-                    let needsCutout = tokens.style == .stack && (hasOverflow || !isLastDisplayed)
+                    let needsCutout = isStackStyle && (hasOverflow || !isLastDisplayed)
                     let avatarSize: CGFloat = avatarView.state.totalSize()
                     let nextAvatarSize: CGFloat = needsCutout ? avatarViews[nextIndex].state.totalSize() : 0
 
@@ -238,7 +239,7 @@ public struct AvatarGroup: View {
                                             .fill(style: FillStyle(eoFill: true)))
                             })
                     }
-                    .padding(.trailing, tokens.style == .stack ? stackPadding : interspace)
+                    .padding(.trailing, isStackStyle ? stackPadding : interspace)
                     .animation(Animation.linear(duration: animationDuration))
                     .transition(AnyTransition.move(edge: .leading))
                 }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -214,7 +214,7 @@ public struct AvatarGroup: View {
                     let stackPadding = interspace - (currentAvatarHasRing ? ringOffset : 0) - (nextAvatarHasRing ? ringOuterGap : 0)
 
                     // Finalized calculations for x and y coordinates of the Avatar if it needs a cutout, including RTL.
-                    let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize
+                    let cutoutSize = isLastDisplayed ? ringGapOffset + imageSize : nextAvatarSize
                     let xOrigin: CGFloat = {
                         if layoutDirection == .rightToLeft {
                             return -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -218,9 +218,7 @@ public struct AvatarGroup: View {
                     }()
 
                     // Calculating the different interspace scenarios considering rings.
-                    let ringPaddingInterspace = nextAvatarHasRing ? interspace - (ringOffset + ringOuterGap) : interspace - ringOffset
-                    let noRingPaddingInterspace = nextAvatarHasRing ? interspace - ringOuterGap : interspace
-                    let stackPadding = (currentAvatarHasRing ? ringPaddingInterspace : noRingPaddingInterspace)
+                    let stackPadding = interspace - (currentAvatarHasRing ? ringOffset : 0) - (nextAvatarHasRing ? ringOuterGap : 0)
 
                     // Finalized calculations for x and y coordinates of the Avatar if it needs a cutout, including RTL.
                     let cutoutSize = isLastDisplayed ? (ringOuterGap * 2) + imageSize : nextAvatarSize

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -183,6 +183,7 @@ public struct AvatarGroup: View {
         let maxDisplayedAvatars: Int = state.maxDisplayedAvatars
         let avatarsToDisplay: Int = min(maxDisplayedAvatars, avatarCount)
         let overflowCount: Int = (avatarCount > maxDisplayedAvatars ? avatarCount - maxDisplayedAvatars : 0) + state.overflowCount
+        let hasOverflow: Bool = overflowCount > 0
 
         let interspace: CGFloat = tokens.interspace
         let imageSize: CGFloat = tokens.size.size
@@ -198,7 +199,7 @@ public struct AvatarGroup: View {
                 ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
                     // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
                     let avatarView = avatarViews[index]
-                    let needsCutout = tokens.style == .stack && (overflowCount > 0 || index + 1 < maxDisplayedAvatars)
+                    let needsCutout = tokens.style == .stack && (hasOverflow || index + 1 < maxDisplayedAvatars)
                     let avatarSize: CGFloat = avatarView.state.totalSize()
                     let nextAvatarSize: CGFloat = needsCutout ? avatarViews[index + 1].state.totalSize() : 0
                     let isLastDisplayed = index == maxDisplayedAvatars - 1
@@ -244,7 +245,7 @@ public struct AvatarGroup: View {
                     .transition(AnyTransition.move(edge: .leading))
                 }
 
-                if overflowCount > 0 {
+                if hasOverflow {
                     VStack {
                         createOverflow(count: overflowCount)
                     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -209,13 +209,6 @@ public struct AvatarGroup: View {
                     // starting coordinates for the cutout.
                     let currentAvatarHasRing = avatar.isRingVisible
                     let nextAvatarHasRing = !isLastDisplayed ? avatars[nextIndex].isRingVisible : false
-                    let avatarSizeDifference = avatarSize - nextAvatarSize
-                    let sizeDiff: CGFloat = {
-                        if isLastDisplayed {
-                            return avatarSize - imageSize - ringGapOffset - (currentAvatarHasRing ? 0 : ringGapOffset)
-                        }
-                        return avatarSizeDifference - (currentAvatarHasRing ? 0 : ringGapOffset)
-                    }()
 
                     // Calculating the different interspace scenarios considering rings.
                     let stackPadding = interspace - (currentAvatarHasRing ? ringOffset : 0) - (nextAvatarHasRing ? ringOuterGap : 0)
@@ -228,6 +221,8 @@ public struct AvatarGroup: View {
                         }
                         return avatarSize + interspace - ringGapOffset - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
                     }()
+
+                    let sizeDiff = avatarSize - cutoutSize - (currentAvatarHasRing ? 0 : ringGapOffset)
                     let yOrigin = sizeDiff / 2
 
                     // Hand the rendering of the avatar to a helper function to appease Swift's


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Moved a bunch of variables around and tried to simplify some of the logic happening in the body of the AvatarGroup Body. Also removed some redundant logic from the avatar state impl totalSize method.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AvatarGroup_Body_LTRBefore](https://user-images.githubusercontent.com/67026548/153329212-dfe6bb32-6e43-498f-aa5e-bb93a20df63d.png) | ![AvatarGroup_Body_LTRAfter](https://user-images.githubusercontent.com/67026548/153329200-54b5757f-9893-4c79-b407-19ce6e866047.png) |
| ![AvatarGroup_Body_RTLBefore](https://user-images.githubusercontent.com/67026548/153329230-5ef49d1a-f58e-45f8-9873-50a129387f34.png) | ![AvatarGroup_Body_RTLAfter](https://user-images.githubusercontent.com/67026548/153329209-728a809c-cea4-4ed0-a69c-5271c11d449d.png) |
| ![AvatarGroup_animation_before](https://user-images.githubusercontent.com/67026548/153677801-25b4a112-ab3c-4d65-8561-0b38deb063a9.gif) | ![AvatarGroup_animation_afterRebase](https://user-images.githubusercontent.com/67026548/154160094-d351f14d-77f0-465b-af01-0cfce1a64a7f.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/899)