### PR TITLE
syntax fix for variables of vmImage.

### DIFF
--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -28,10 +28,16 @@ jobs:
       packagesToPack: 'FluentUI.nuspec'
       buildProperties: buildNumber=$(sanitizedBuildNumber);commitId=$(Build.SourceVersion);repoUri=$(Build.Repository.Uri)
 
- - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-   displayName: 'Generation Task'
-   inputs:
-       BuildDropPath: '$(System.ArtifactsDirectory)/buildOutput'
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Generation Task'
+    inputs:
+      BuildDropPath: '$(System.DefaultWorkingDirectory)'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish Manifest'
+    inputs:
+      artifactName: SBom-$(System.JobAttempt)
+      targetPath: '$(System.DefaultWorkingDirectory)/_manifest'
 
   # push the package package
   - task: NuGetCommand@2

--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -28,6 +28,11 @@ jobs:
       packagesToPack: 'FluentUI.nuspec'
       buildProperties: buildNumber=$(sanitizedBuildNumber);commitId=$(Build.SourceVersion);repoUri=$(Build.Repository.Uri)
 
+ - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+   displayName: 'Generation Task'
+   inputs:
+       BuildDropPath: '$(System.ArtifactsDirectory)/buildOutput'
+
   # push the package package
   - task: NuGetCommand@2
     displayName: 'NuGet push'

--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -3,7 +3,7 @@ jobs:
   pool:
     vmImage: 'macos-11'
   variables:
-  - name:EOCompliance-macos
+  - name: EOCompliance-Mac
     value: true
   displayName: FluentUI Apple Publish NuGet
   timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/templates/fluentui-apple-publish-nuget-job.yml
+++ b/.ado/templates/fluentui-apple-publish-nuget-job.yml
@@ -45,5 +45,4 @@ jobs:
     inputs:
       command: push
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Microsoft.FluentUI.Apple.*.nupkg'
-      nuGetFeedType: external
-      publishFeedCredentials: Office
+      publishVstsFeed: Office


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes
syntax fix on agent pool variable name

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/901)