### PR TITLE
Cherry-picking AvatarGroup animation changes to main

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -138,7 +138,8 @@ class AvatarGroupDemoController: DemoTableViewController {
             NSLayoutConstraint.activate([
                 cell.contentView.leadingAnchor.constraint(equalTo: avatarGroupView.leadingAnchor, constant: -20),
                 cell.contentView.topAnchor.constraint(equalTo: avatarGroupView.topAnchor, constant: -15),
-                cell.contentView.bottomAnchor.constraint(equalTo: avatarGroupView.bottomAnchor, constant: 15)
+                cell.contentView.bottomAnchor.constraint(equalTo: avatarGroupView.bottomAnchor, constant: 15),
+                cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
             cell.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
@@ -359,7 +360,7 @@ class AvatarGroupDemoController: DemoTableViewController {
         }
     }
 
-    private var maxDisplayedAvatars: Int = 4 {
+    private var maxDisplayedAvatars: Int = 3 {
         didSet {
             if oldValue != maxDisplayedAvatars {
                 maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
@@ -439,8 +440,11 @@ class AvatarGroupDemoController: DemoTableViewController {
         return textField
     }()
 
-    private var avatarCount: Int = 5 {
+    private var avatarCount: Int = 4 {
         didSet {
+            guard oldValue != avatarCount && avatarCount >= 0 else {
+                return
+            }
             AvatarGroupDemoSection.allCases.filter({ section in
                 return section.isDemoSection
             }).forEach { section in
@@ -475,6 +479,10 @@ class AvatarGroupDemoController: DemoTableViewController {
     }
 
     @objc private func subtractAvatarCount(_ cell: ActionsCell) {
+        guard avatarCount > 0 else {
+            return
+        }
+
         avatarCount -= 1
     }
 

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -180,7 +180,7 @@ public struct Avatar: View {
         let ringOuterGap: CGFloat = isRingVisible ? tokens.ringOuterGap : 0
         let avatarImageSize: CGFloat = tokens.avatarSize!
         let ringInnerGapSize: CGFloat = avatarImageSize + (ringInnerGap * 2)
-        let ringSize: CGFloat = ringInnerGapSize + ( ringThickness * 2)
+        let ringSize: CGFloat = ringInnerGapSize + (ringThickness * 2)
         let ringOuterGapSize: CGFloat = ringSize + (ringOuterGap * 2)
         let presenceIconSize: CGFloat = tokens.presenceIconSize!
         let presenceIconOutlineSize: CGFloat = presenceIconSize + (tokens.presenceIconOutlineThickness * 2)
@@ -354,6 +354,17 @@ public struct Avatar: View {
         var yOrigin: CGFloat
         var cutoutSize: CGFloat
 
+        public var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
+            get {
+                AnimatablePair(AnimatablePair(xOrigin, yOrigin), cutoutSize)
+            }
+            set {
+                xOrigin = newValue.first.first
+                yOrigin = newValue.first.second
+                cutoutSize = newValue.second
+            }
+        }
+
         public func path(in rect: CGRect) -> Path {
             var cutoutFrame = Rectangle().path(in: rect)
             cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
@@ -468,7 +479,9 @@ public struct Avatar: View {
 }
 
 /// Properties available to customize the state of the avatar
-class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
+class MSFAvatarStateImpl: NSObject, ObservableObject, Identifiable, MSFAvatarState {
+    public var id = UUID()
+
     @Published var backgroundColor: UIColor?
     @Published var foregroundColor: UIColor?
     @Published var hasButtonAccessibilityTrait: Bool = false
@@ -520,7 +533,7 @@ class MSFAvatarStateImpl: NSObject, ObservableObject, MSFAvatarState {
             return avatarImageSize + (ringOuterGap * 2)
         } else {
             let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
-            let ringInnerGap: CGFloat = isRingVisible ? tokens.ringInnerGap : 0
+            let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
             return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
         }
     }


### PR DESCRIPTION
(cherry picked from commit 113cb1f8c39a4fb35ac0173c1a4118dc8f7e5008)

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picked #648 (see commit hash above) to main, and replaced old RTL logic with updated logic to support RTL pseudolanguages.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/905)