### PR TITLE
Improve support for transient bottom sheets

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -11,7 +11,7 @@ class BottomCommandingDemoController: UIViewController {
     override func loadView() {
         view = UIView()
 
-        let optionTableViewController = UITableViewController(style: .plain)
+        let optionTableViewController = UITableViewController(style: .insetGrouped)
         mainTableViewController = optionTableViewController
 
         let optionTableView: UITableView = optionTableViewController.tableView
@@ -81,11 +81,16 @@ class BottomCommandingDemoController: UIViewController {
 
     private lazy var currentExpandedListSections: [CommandingSection] = shortCommandSectionList
 
-    private var demoOptionItems: [DemoItem] {
-        return [DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomCommandingController?.isHidden ?? false),
+    private var demoOptionItems: [[DemoItem]] {
+        return [
+            [
+                DemoItem(title: "Hidden", type: .boolean, action: #selector(toggleHidden), isOn: bottomCommandingController?.isHidden ?? false),
                 DemoItem(title: "Scroll to hide", type: .boolean, action: #selector(toggleScrollHiding), isOn: scrollHidingEnabled),
                 DemoItem(title: "Sheet more button", type: .boolean, action: #selector(toggleSheetMoreButton), isOn: bottomCommandingController?.prefersSheetMoreButtonVisible ?? true),
-                DemoItem(title: "Sheet should always fill width", type: .boolean, action: #selector(toggleFillWidth), isOn: bottomCommandingController?.sheetShouldAlwaysFillWidth ?? true),
+                DemoItem(title: "Sheet should always fill width", type: .boolean, action: #selector(toggleFillWidth), isOn: bottomCommandingController?.sheetShouldAlwaysFillWidth ?? true)
+            ],
+            [
+                DemoItem(title: "Hero command count", type: .stepper, action: nil),
                 DemoItem(title: "Expanded list items", type: .boolean, action: #selector(toggleExpandedItems), isOn: expandedItemsVisible),
                 DemoItem(title: "Additional expanded list items", type: .boolean, action: #selector(toggleAdditionalExpandedItems(_:)), isOn: additionalExpandedItemsVisible),
                 DemoItem(title: "Popover on hero command tap", type: .boolean, action: #selector(toggleHeroPopover)),
@@ -97,8 +102,8 @@ class BottomCommandingDemoController: UIViewController {
                 DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeHeroCommandTitle)),
                 DemoItem(title: "Change hero command images", type: .action, action: #selector(changeHeroCommandIcon)),
                 DemoItem(title: "Change list command titles", type: .action, action: #selector(changeListCommandTitle)),
-                DemoItem(title: "Change list command images", type: .action, action: #selector(changeListCommandIcon)),
-                DemoItem(title: "Hero command count", type: .stepper, action: nil)
+                DemoItem(title: "Change list command images", type: .action, action: #selector(changeListCommandIcon))
+            ]
         ]
     }
 
@@ -319,15 +324,26 @@ extension BottomCommandingDemoController: UITableViewDelegate {
 
 extension BottomCommandingDemoController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return demoOptionItems.count
     }
 
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return demoOptionItems[section].count
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        switch section {
+        case 0:
+            return "Settings"
+        case 1:
+            return "Command settings"
+        default:
+            return nil
+        }
+    }
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let item = demoOptionItems[indexPath.row]
+        let item = demoOptionItems[indexPath.section][indexPath.row]
 
         if item.type == .boolean {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -651,7 +651,7 @@ public class BottomSheetController: UIViewController {
                 animator.finishAnimation(at: .end)
             }
         } else {
-            currentExpansionState = targetExpansionState
+            handleCompletedStateChange(to: targetExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
         }
     }
 
@@ -709,14 +709,13 @@ public class BottomSheetController: UIViewController {
             }
             strongSelf.targetExpansionState = nil
             strongSelf.panGestureRecognizer.isEnabled = strongSelf.isExpandable
-            strongSelf.handleCompletedStateChange(to: finalPosition == .end ? targetExpansionState : originalExpansionState,
+            strongSelf.handleCompletedStateChange(to: finalPosition == .start ? originalExpansionState : targetExpansionState,
                                                   interaction: interaction,
-                                                  shouldNotifyDelegate: shouldNotifyDelegate)
+                                                  shouldNotifyDelegate: shouldNotifyDelegate && finalPosition != .current)
         })
 
         view.layoutIfNeeded()
         currentExpansionState = .transitioning
-        translationAnimator.pauseAnimation()
         return translationAnimator
     }
 
@@ -753,9 +752,7 @@ public class BottomSheetController: UIViewController {
             hostedScrollView?.setContentOffset(.zero, animated: true)
         }
 
-        if targetExpansionState == .hidden {
-            bottomSheetView.isHidden = true
-        }
+        bottomSheetView.isHidden = targetExpansionState == .hidden
 
         // UIKit doesn't properly handle interrupted constraint animations, so we need to
         // detect and fix a possible desync here


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The bottom sheet was originally created to support a persistent scenario where the sheet controller is always installed in the hierarchy and the sheet is almost always visible. However we also want to support transient scenarios where the sheet controller is created and placed in the hierarchy on demand, and removed after the sheet is dismissed.

Fortunately there are only very minor changes necessary in `BottomSheetController`. Most of the work in this PR is to add an example of transient presentation to the demo controller. Note the bottom sheet can't use UIKit's presentation API because this is only suitable for modal scenarios, while our desired usage is better described as semi-modal - main content needs to be interactable and accessible. This can only be achieved by manually installing the sheet view and view controller in the hierarchy on demand.

Small fixes to improve transient sheet support:
- Pausing a `UIViewPropertyAnimator` was breaking the unhiding animation if it was started right after a layout pass (which is is likely to happen in a transient presentation). Looks like an Apple bug. Luckily we don't need to pause the animator at all.
- Transient sheets highlighted a bug when a pan starts during an unhiding animation - the sheet would disappear because the animation interruption would cause it to go back to the original state. Let's change the animation interruption logic to use the target expansion state as a fallback when an animation is interrupted.
- If we skip a state change animation because the sheet offset is already there, let's call the full completion handler to ensure delegates are notified and `.isHidden` state is where it should be

Demo controller changes:
- Add a button to show a transient sheet
- For a more modern look, switch the main table view to `.insetGrouped` style (also in `BottomCommandingDemoController` for consistency)

### Verification

https://user-images.githubusercontent.com/3610850/153987274-62464915-602e-4b0e-a3c4-88cd99ad9ea0.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)