### PR TITLE
Move bottom sheet animator to active state before stopping it

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -647,7 +647,7 @@ public class BottomSheetController: UIViewController {
                 }
                 animator.startAnimation()
             } else {
-                animator.startAnimation()
+                animator.startAnimation() // moves the animator into active state so it can be stopped
                 animator.stopAnimation(false)
                 animator.finishAnimation(at: .end)
             }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -647,6 +647,7 @@ public class BottomSheetController: UIViewController {
                 }
                 animator.startAnimation()
             } else {
+                animator.startAnimation()
                 animator.stopAnimation(false)
                 animator.finishAnimation(at: .end)
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

TL;DR: App crashes during un-animated state changes because we are trying to stop an inactive animator.

In a previous change (2aaf64b8814a77a0ff21dd589dd4c7b24aa3577d) I removed code which paused the sheet state change animator before returning it. There are cases in which we skip to the end of an animation right after creating it, but `UIViewPropertyAnimator` is strict about needing to be in active state before being stopped. Pausing it used to move it to active state. To fix this, let's start the animator right before stopping it. This doesn't actually cause any animations to run, it just puts it in the right state to be stopped.

### Verification

Sanity checks that un-animated state changes work as expected.
Verify transient sheet animations still work as expected (which was the reason for the animator pause removal).

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/915)