### PR TITLE
[Swift Package Manager] Remove file exclude for deleted Info.plist

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,6 @@ let package = Package(
                 "Bottom Commanding/BottomCommanding.resources.xcfilelist",
                 "Core/Core.resources.xcfilelist",
                 "HUD/HUD.resources.xcfilelist",
-                "Info.plist",
                 "Navigation/Navigation.resources.xcfilelist",
                 "Notification/Notification.resources.xcfilelist",
                 "Other Cells/OtherCells.resources.xcfilelist",


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Remove a file exclude that is no longer necessary and is creating a warning when consuming Fluent UI via Swift Package Manager.

The file was deleted by commit 20faebca51c0311d6174eaaa412dd1f2eec8b104 in https://github.com/microsoft/fluentui-apple/pull/757 and no longer needs to be excluded.

### Verification

Before the change, ensure that we see the warning. Manually confirm that the file referenced by the warning truly doesn't exist in the repo. After the change, ensure that the warning goes away.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="650" alt="Info Plist Warning" src="https://user-images.githubusercontent.com/658243/155238694-d651d896-7cde-4f1a-a5a5-443b050846aa.png"> | <img width="198" alt="image" src="https://user-images.githubusercontent.com/658243/155238758-09d10630-eee4-4516-8a62-f97b06ce0288.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/922)