### PR TITLE
Combine AvatarCutout and PresenceCutout in to one struct

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		C708B064260A87F7007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04EE25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
+		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
 		FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -312,6 +313,7 @@
 		C77A04B625F03DD1001B3EB6 /* String+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
 		ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
 		FC414E1E258876FB00069E73 /* CommandBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBar.swift; sourceTree = "<group>"; };
 		FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarButtonGroupView.swift; sourceTree = "<group>"; };
@@ -920,6 +922,7 @@
 				5373D5612694D65C0032A3B4 /* Avatar.swift */,
 				5303259926B31B6B00611D05 /* AvatarModifiers.swift */,
 				5373D5602694D65C0032A3B4 /* AvatarTokens.swift */,
+				EC5982D927C703ED00FD048D /* CircleCutout.swift */,
 				5373D5632694D65C0032A3B4 /* MSFAvatarPresence.swift */,
 				5373D5622694D65C0032A3B4 /* MSFAvatarTokens.generated.swift */,
 				B4EF53C2215AF1AB00573E8F /* Persona.swift */,
@@ -1290,6 +1293,7 @@
 				6ED5E55126D3D39400D8BE81 /* BadgeLabelButton.swift in Sources */,
 				6ED5E55226D3D39400D8BE81 /* UIBarButtonItem+BadgeValue.swift in Sources */,
 				5314E0ED25F012C40099271A /* ContentScrollViewTraits.swift in Sources */,
+				EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */,
 				5314E03A25F00E3D0099271A /* BadgeView.swift in Sources */,
 				5314E1A325F01A7C0099271A /* TableViewHeaderFooterView.swift in Sources */,
 				5314E30325F0260E0099271A /* AccessibleViewDelegate.swift in Sources */,

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -309,9 +309,9 @@ public struct Avatar: View {
                              alignment: .center)
                     .modifyIf(shouldDisplayPresence, { thisView in
                             thisView
-                                .clipShape(PresenceCutout(originX: presenceCutoutOriginX,
-                                                          originY: presenceCutoutOriginY,
-                                                          presenceIconOutlineSize: presenceIconOutlineSize),
+                                .clipShape(CircleCutout(xOrigin: presenceCutoutOriginX,
+                                                          yOrigin: presenceCutoutOriginY,
+                                                          cutoutSize: presenceIconOutlineSize),
                                            style: FillStyle(eoFill: true))
                                 .overlay(Circle()
                                             .foregroundColor(Color(tokens.ringGapColor).opacity(isTransparent ? 0 : 1))
@@ -342,14 +342,14 @@ public struct Avatar: View {
                           with: windowProvider)
     }
 
-    /// `AvatarCutout`: Cutout shape for an Avatar
+    /// `CircleCutout`: Cutout shape for a circle
     ///
     /// `xOrigin`: beginning location of cutout on the x axis
     ///
     /// `yOrigin`: beginning location of cutout on the y axis
     ///
-    /// `cutoutSize`: dimensions of cutout shape of the Avatar
-    public struct AvatarCutout: Shape {
+    /// `cutoutSize`: diameter of the circle to cut out
+    public struct CircleCutout: Shape {
         var xOrigin: CGFloat
         var yOrigin: CGFloat
         var cutoutSize: CGFloat
@@ -376,33 +376,6 @@ public struct Avatar: View {
     }
 
     private let animationDuration: Double = 0.1
-
-    private struct PresenceCutout: Shape {
-        var originX: CGFloat
-        var originY: CGFloat
-        var presenceIconOutlineSize: CGFloat
-
-        var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
-            get {
-                AnimatablePair(AnimatablePair(originX, originY), presenceIconOutlineSize)
-            }
-
-            set {
-                originX = newValue.first.first
-                originY = newValue.first.second
-                presenceIconOutlineSize = newValue.second
-            }
-        }
-
-        func path(in rect: CGRect) -> Path {
-            var cutoutFrame = Rectangle().path(in: rect)
-            cutoutFrame.addPath(Circle().path(in: CGRect(x: originX,
-                                                         y: originY,
-                                                         width: presenceIconOutlineSize,
-                                                         height: presenceIconOutlineSize)))
-            return cutoutFrame
-        }
-    }
 
     private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
         var combined: String

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -304,28 +304,28 @@ public struct Avatar: View {
                                                         .clipShape(Circle())
                                                         .transition(.opacity),
                                                      alignment: .center)
-                                )
+                                        )
                                 .contentShape(Circle()),
                              alignment: .center)
                     .modifyIf(shouldDisplayPresence, { thisView in
-                            thisView
-                                .clipShape(CircleCutout(xOrigin: presenceCutoutOriginX,
-                                                          yOrigin: presenceCutoutOriginY,
-                                                          cutoutSize: presenceIconOutlineSize),
-                                           style: FillStyle(eoFill: true))
-                                .overlay(Circle()
-                                            .foregroundColor(Color(tokens.ringGapColor).opacity(isTransparent ? 0 : 1))
-                                            .frame(width: presenceIconOutlineSize, height: presenceIconOutlineSize, alignment: .center)
-                                            .overlay(presence.image(isOutOfOffice: isOutOfOffice)
-                                                        .interpolation(.high)
-                                                        .resizable()
-                                                        .frame(width: presenceIconSize, height: presenceIconSize, alignment: .center)
-                                                        .foregroundColor(presence.color(isOutOfOffice: isOutOfOffice)))
-                                            .contentShape(Circle())
-                                            .frame(width: presenceIconFrameSideRelativeToOuterRing, height: presenceIconFrameSideRelativeToOuterRing,
-                                                   alignment: .bottomTrailing),
-                                         alignment: .topLeading)
-                                .frame(width: overallFrameSide, height: overallFrameSide, alignment: .topLeading)
+                        thisView
+                            .clipShape(CircleCutout(xOrigin: presenceCutoutOriginX,
+                                                    yOrigin: presenceCutoutOriginY,
+                                                    cutoutSize: presenceIconOutlineSize),
+                                       style: FillStyle(eoFill: true))
+                            .overlay(Circle()
+                                        .foregroundColor(Color(tokens.ringGapColor).opacity(isTransparent ? 0 : 1))
+                                        .frame(width: presenceIconOutlineSize, height: presenceIconOutlineSize, alignment: .center)
+                                        .overlay(presence.image(isOutOfOffice: isOutOfOffice)
+                                                    .interpolation(.high)
+                                                    .resizable()
+                                                    .frame(width: presenceIconSize, height: presenceIconSize, alignment: .center)
+                                                    .foregroundColor(presence.color(isOutOfOffice: isOutOfOffice)))
+                                        .contentShape(Circle())
+                                        .frame(width: presenceIconFrameSideRelativeToOuterRing, height: presenceIconFrameSideRelativeToOuterRing,
+                                               alignment: .bottomTrailing),
+                                     alignment: .topLeading)
+                            .frame(width: overallFrameSide, height: overallFrameSide, alignment: .topLeading)
                     })
             }
         }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -342,39 +342,6 @@ public struct Avatar: View {
                           with: windowProvider)
     }
 
-    /// `CircleCutout`: Cutout shape for a circle
-    ///
-    /// `xOrigin`: beginning location of cutout on the x axis
-    ///
-    /// `yOrigin`: beginning location of cutout on the y axis
-    ///
-    /// `cutoutSize`: diameter of the circle to cut out
-    public struct CircleCutout: Shape {
-        var xOrigin: CGFloat
-        var yOrigin: CGFloat
-        var cutoutSize: CGFloat
-
-        public var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
-            get {
-                AnimatablePair(AnimatablePair(xOrigin, yOrigin), cutoutSize)
-            }
-            set {
-                xOrigin = newValue.first.first
-                yOrigin = newValue.first.second
-                cutoutSize = newValue.second
-            }
-        }
-
-        public func path(in rect: CGRect) -> Path {
-            var cutoutFrame = Rectangle().path(in: rect)
-            cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
-                                                         y: yOrigin,
-                                                         width: cutoutSize,
-                                                         height: cutoutSize)))
-            return cutoutFrame
-        }
-    }
-
     private let animationDuration: Double = 0.1
 
     private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {

--- a/ios/FluentUI/Avatar/CircleCutout.swift
+++ b/ios/FluentUI/Avatar/CircleCutout.swift
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import UIKit
 import SwiftUI
 
 /// `CircleCutout`: Cutout shape for a circle
@@ -14,11 +13,16 @@ import SwiftUI
 ///
 /// `cutoutSize`: diameter of the circle to cut out
 struct CircleCutout: Shape {
-    var xOrigin: CGFloat
-    var yOrigin: CGFloat
-    var cutoutSize: CGFloat
+    func path(in rect: CGRect) -> Path {
+        var cutoutFrame = Rectangle().path(in: rect)
+        cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
+                                                     y: yOrigin,
+                                                     width: cutoutSize,
+                                                     height: cutoutSize)))
+        return cutoutFrame
+    }
 
-    public var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
+    var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
         get {
             AnimatablePair(AnimatablePair(xOrigin, yOrigin), cutoutSize)
         }
@@ -29,12 +33,7 @@ struct CircleCutout: Shape {
         }
     }
 
-    public func path(in rect: CGRect) -> Path {
-        var cutoutFrame = Rectangle().path(in: rect)
-        cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
-                                                     y: yOrigin,
-                                                     width: cutoutSize,
-                                                     height: cutoutSize)))
-        return cutoutFrame
-    }
+    var xOrigin: CGFloat
+    var yOrigin: CGFloat
+    var cutoutSize: CGFloat
 }

--- a/ios/FluentUI/Avatar/CircleCutout.swift
+++ b/ios/FluentUI/Avatar/CircleCutout.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+/// `CircleCutout`: Cutout shape for a circle
+///
+/// `xOrigin`: beginning location of cutout on the x axis
+///
+/// `yOrigin`: beginning location of cutout on the y axis
+///
+/// `cutoutSize`: diameter of the circle to cut out
+struct CircleCutout: Shape {
+    var xOrigin: CGFloat
+    var yOrigin: CGFloat
+    var cutoutSize: CGFloat
+
+    public var animatableData: AnimatablePair<AnimatablePair<CGFloat, CGFloat>, CGFloat> {
+        get {
+            AnimatablePair(AnimatablePair(xOrigin, yOrigin), cutoutSize)
+        }
+        set {
+            xOrigin = newValue.first.first
+            yOrigin = newValue.first.second
+            cutoutSize = newValue.second
+        }
+    }
+
+    public func path(in rect: CGRect) -> Path {
+        var cutoutFrame = Rectangle().path(in: rect)
+        cutoutFrame.addPath(Circle().path(in: CGRect(x: xOrigin,
+                                                     y: yOrigin,
+                                                     width: cutoutSize,
+                                                     height: cutoutSize)))
+        return cutoutFrame
+    }
+}

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -215,11 +215,10 @@ public struct AvatarGroup: View {
                         avatarView
                             .transition(.identity)
                             .modifyIf(needsCutout, { view in
-                                view.mask(Avatar.CircleCutout(
-                                    xOrigin: xOrigin,
-                                    yOrigin: yOrigin,
-                                    cutoutSize: cutoutSize)
-                                            .fill(style: FillStyle(eoFill: true)))
+                                view.clipShape(CircleCutout(xOrigin: xOrigin,
+                                                            yOrigin: yOrigin,
+                                                            cutoutSize: cutoutSize),
+                                               style: FillStyle(eoFill: true))
                             })
                     }
                     .padding(.trailing, isStackStyle ? stackPadding : interspace)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -158,23 +158,6 @@ public struct AvatarGroup: View {
         self.tokens = state.tokens
     }
 
-    /// Renders the avatar with an optional cutout for the Stack group style.
-    @ViewBuilder
-    private func avatarCutout(_ avatar: Avatar,
-                              _ needsCutout: Bool,
-                              _ xOrigin: CGFloat,
-                              _ yOrigin: CGFloat,
-                              _ cutoutSize: CGFloat,
-                              _ padding: CGFloat) -> some View {
-        avatar.modifyIf(needsCutout, { view in
-            view.clipShape(Avatar.AvatarCutout(xOrigin: xOrigin,
-                                               yOrigin: yOrigin,
-                                               cutoutSize: cutoutSize),
-                           style: FillStyle(eoFill: true))
-            })
-            .padding(.trailing, padding)
-    }
-
     public var body: some View {
         let avatars: [MSFAvatarStateImpl] = state.avatars
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
@@ -232,7 +215,7 @@ public struct AvatarGroup: View {
                         avatarView
                             .transition(.identity)
                             .modifyIf(needsCutout, { view in
-                                view.mask(Avatar.AvatarCutout(
+                                view.mask(Avatar.CircleCutout(
                                     xOrigin: xOrigin,
                                     yOrigin: yOrigin,
                                     cutoutSize: cutoutSize)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

AvatarCutout and PresenceCutout were pretty much the same struct, so I combined them in to CircleCutout.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AvatarStruct_Presence_before](https://user-images.githubusercontent.com/67026548/155245164-a995579f-aac5-4754-ae8e-5bd1fd025cf5.png) | ![AvatarStruct_Presence_after](https://user-images.githubusercontent.com/67026548/155245179-a0b69a62-fe86-4233-ada0-10cc169cbbae.png) |
| ![AvatarStruct_Presence_before_rtl](https://user-images.githubusercontent.com/67026548/155245620-5ec9da9f-2906-4757-99dd-1a80b3581268.png) | ![AvatarStruct_Presence_after_rtl](https://user-images.githubusercontent.com/67026548/155245629-355446d6-24f3-4c03-8d24-9dabe6c920b3.png) |
| ![AvatarStruct_Cutout_before](https://user-images.githubusercontent.com/67026548/155245168-d5c7b92b-66d0-4267-b5ce-46f54de8d085.png) | ![AvatarStruct_Cutout_after](https://user-images.githubusercontent.com/67026548/155245184-112346af-57c8-4944-8ce9-b59f52e43840.png) |
| ![AvatarStruct_Cutout_before_rtl](https://user-images.githubusercontent.com/67026548/155245605-7d5b6273-8a94-442b-8d69-b6c522e7dacd.png) | ![AvatarStruct_Cutout_after_rtl](https://user-images.githubusercontent.com/67026548/155245613-86969548-aeba-4525-b099-ee6ddb48c20a.png) |
### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/923)