### PR TITLE
Adding AppCenter pre-build script.

### DIFF
--- a/ios/appcenter-pre-build.sh
+++ b/ios/appcenter-pre-build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo 'Replacing AppCenterSecret placeholder...'
+sed -i '' -e "s/$AppCenterSecretPlaceHolder/\"$AppCenterSecret\"/g" ./FluentUI.Demo/FluentUI.Demo/AppDelegate.swift


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change adds a pre-build script to be used by the AppCenter automated build feature.
It needs to be added in the same folder as the project being built as per the [AppCenter official documentation](https://docs.microsoft.com/en-us/appcenter/build/custom/scripts/).

The goal of this script is to replace the placeholder for the AppCenter secret in the AppDelegate.swift with the actual value that is stored as environment variables in the AppCenter Build configuration.

### Verification

Validated the newly created AppCenter build with the script and ensured build and distribution were successful.


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/928)