### PR TITLE
Fix small gap in between Avatar and ring when hasRingInnerGap is false

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -170,15 +170,15 @@ public struct Avatar: View {
         let isRingVisible = state.isRingVisible
         let hasRingInnerGap = state.hasRingInnerGap
         let ringThicknessToken: CGFloat = tokens.ringThickness
-        let ringInnerGapOffset = 0.5
         let isTransparent = state.isTransparent
         let isOutOfOffice = state.isOutOfOffice
         let initialsString: String = ((style == .overflow) ? state.primaryText ?? "" : Avatar.initialsText(fromPrimaryText: state.primaryText,
                                                                                                            secondaryText: state.secondaryText))
         let shouldUseCalculatedColors = !initialsString.isEmpty && style != .overflow
 
-        // Adding a 0.5 value offset to ringInnerGap & ringThickness to accommodate for a small space between
+        // Adding ringInnerGapOffset to ringInnerGap & ringThickness to accommodate for a small space between
         // the ring and avatar when the ring is visible and there is no inner ring gap
+        let ringInnerGapOffset = 0.5
         let ringInnerGap: CGFloat = isRingVisible ? (hasRingInnerGap ? tokens.ringInnerGap : -ringInnerGapOffset) : 0
         let ringThickness: CGFloat = isRingVisible ? (hasRingInnerGap ? ringThicknessToken : ringThicknessToken + ringInnerGapOffset) : 0
         let ringOuterGap: CGFloat = isRingVisible ? tokens.ringOuterGap : 0

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -170,6 +170,7 @@ public struct Avatar: View {
         let isRingVisible = state.isRingVisible
         let hasRingInnerGap = state.hasRingInnerGap
         let ringThicknessToken: CGFloat = tokens.ringThickness
+        let ringInnerGapOffset = 0.5
         let isTransparent = state.isTransparent
         let isOutOfOffice = state.isOutOfOffice
         let initialsString: String = ((style == .overflow) ? state.primaryText ?? "" : Avatar.initialsText(fromPrimaryText: state.primaryText,
@@ -178,8 +179,8 @@ public struct Avatar: View {
 
         // Adding a 0.5 value offset to ringInnerGap & ringThickness to accommodate for a small space between
         // the ring and avatar when the ring is visible and there is no inner ring gap
-        let ringInnerGap: CGFloat = isRingVisible ? (hasRingInnerGap ? tokens.ringInnerGap : -0.5) : 0
-        let ringThickness: CGFloat = isRingVisible ? (hasRingInnerGap ? ringThicknessToken : ringThicknessToken + 0.5) : 0
+        let ringInnerGap: CGFloat = isRingVisible ? (hasRingInnerGap ? tokens.ringInnerGap : -ringInnerGapOffset) : 0
+        let ringThickness: CGFloat = isRingVisible ? (hasRingInnerGap ? ringThicknessToken : ringThicknessToken + ringInnerGapOffset) : 0
         let ringOuterGap: CGFloat = isRingVisible ? tokens.ringOuterGap : 0
         let avatarImageSize: CGFloat = tokens.avatarSize!
         let ringInnerGapSize: CGFloat = avatarImageSize + (ringInnerGap * 2)

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -169,14 +169,17 @@ public struct Avatar: View {
         let shouldDisplayPresence = presence != .none
         let isRingVisible = state.isRingVisible
         let hasRingInnerGap = state.hasRingInnerGap
+        let ringThicknessToken: CGFloat = tokens.ringThickness
         let isTransparent = state.isTransparent
         let isOutOfOffice = state.isOutOfOffice
         let initialsString: String = ((style == .overflow) ? state.primaryText ?? "" : Avatar.initialsText(fromPrimaryText: state.primaryText,
                                                                                                            secondaryText: state.secondaryText))
         let shouldUseCalculatedColors = !initialsString.isEmpty && style != .overflow
 
-        let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
-        let ringThickness: CGFloat = isRingVisible ? tokens.ringThickness : 0
+        // Adding a 0.5 value offset to ringInnerGap & ringThickness to accommodate for a small space between
+        // the ring and avatar when the ring is visible and there is no inner ring gap
+        let ringInnerGap: CGFloat = isRingVisible ? (hasRingInnerGap ? tokens.ringInnerGap : -0.5) : 0
+        let ringThickness: CGFloat = isRingVisible ? (hasRingInnerGap ? ringThicknessToken : ringThicknessToken + 0.5) : 0
         let ringOuterGap: CGFloat = isRingVisible ? tokens.ringOuterGap : 0
         let avatarImageSize: CGFloat = tokens.avatarSize!
         let ringInnerGapSize: CGFloat = avatarImageSize + (ringInnerGap * 2)
@@ -260,7 +263,7 @@ public struct Avatar: View {
             if let imageBasedRingColor = state.imageBasedRingColor {
                 // The potentially maximum size of the ring view must be used in order to avoid abrupt
                 // transitions during the animation as the ImagePaint scale value is not animatable.
-                let ringMaxSize = avatarImageSize + (tokens.ringInnerGap + tokens.ringThickness) * 2
+                let ringMaxSize = avatarImageSize + (tokens.ringInnerGap + ringThicknessToken) * 2
                 let scaleFactor = ringMaxSize / imageBasedRingColor.size.width
 
                 // ImagePaint is being used as creating a Color struct from a UIColor created with


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When an Avatar has a ring but no inner ring gap, there is a small hairline gap that appears in between the Avatar and the ring, even though the `ringInnerGap` value is set to 0. Adding a small value offset of `-0.5` to `ringInnerGap`  and adding back `0.5` to `ringThickness` for when `isRingVisible && !hasRingInnerGap` should remove this gap and maintain ring thickness integrity.

### Verification
(Screenshots below are in demo controller & swift demo respectively on simulator iPhone 11 Pro iOS 14.5)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="434" alt="image" src="https://user-images.githubusercontent.com/22566866/156045864-d6c9a40b-6a53-47b2-b3b6-35af69d71659.png"> | <img width="422" alt="image" src="https://user-images.githubusercontent.com/22566866/156046127-ed082bc2-34d3-4838-b7a5-c84c4235ed94.png"> |
| <img width="139" alt="image" src="https://user-images.githubusercontent.com/22566866/156046034-7683ae7f-be45-4d22-8bb4-145f23660c00.png"> | <img width="142" alt="image" src="https://user-images.githubusercontent.com/22566866/156046170-32380085-a614-4925-9ebd-9d22e1899ee8.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/931)