### PR TITLE
[macOS DatePicker] Improve selected day button contrast

### DIFF
--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -128,7 +128,7 @@ class CalendarDayButton: NSButton {
 	override var wantsUpdateLayer: Bool {
 		return true
 	}
-	
+
 	override var allowsVibrancy: Bool {
 		return true
 	}

--- a/macos/FluentUI/DatePicker/CalendarDayButton.swift
+++ b/macos/FluentUI/DatePicker/CalendarDayButton.swift
@@ -128,6 +128,10 @@ class CalendarDayButton: NSButton {
 	override var wantsUpdateLayer: Bool {
 		return true
 	}
+	
+	override var allowsVibrancy: Bool {
+		return true
+	}
 
 	/// The day that is being displayed
 	var day: CalendarDay {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Override allowsVibrancy on CalendarDayButton to ensure that the DatePicker is visible with good contrast regardless of the material on which the calendar is placed. This PR will fix #930.

### Verification

Run through all the system default colors and ensure that the calendar renders properly and legibly in an NSMenu and in the standard material it's presented on in the test app when in light mode and dark mode, regardless of what color is behind the DatePicker.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="484" alt="Screen Shot 2022-02-28 at 11 06 28 AM" src="https://user-images.githubusercontent.com/658243/156047990-c872eecc-49ed-4712-97d2-c17b13ab9023.png"> | <img width="372" alt="Screen Shot 2022-02-28 at 11 26 14 AM" src="https://user-images.githubusercontent.com/658243/156048009-062d4caf-fb79-4c57-8135-afbac6f19c2c.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/932)