### PR TITLE
Fix crash when calendar view is scrolling to an empty section.

### DIFF
--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -272,9 +272,10 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         // There may be no items in the 0th section if we are constraining the calendar to today's date.
         // Attempting to scroll in that case will throw an exception. But that's okay, there's no need
         // to scroll there anyway, since the view will start at that date.
-        if calendarView.collectionView.numberOfItems(inSection: targetIndexPath.section) > targetIndexPath.item {
-            calendarView.collectionView.scrollToItem(at: targetIndexPath, at: [.top], animated: animated)
+        guard targetIndexPath.item < calendarView.collectionView.numberOfItems(inSection: targetIndexPath.section) else {
+            return
         }
+        calendarView.collectionView.scrollToItem(at: targetIndexPath, at: [.top], animated: animated)
         // TODO: Notify of visible date?
     }
 

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -268,7 +268,13 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
             return
         }
         let targetIndexPath = IndexPath(item: 0, section: max(focusDateRow - rowOffset, 0))
-        calendarView.collectionView.scrollToItem(at: targetIndexPath, at: [.top], animated: animated)
+
+        // There may be no items in the 0th section if we are constraining the calendar to today's date.
+        // Attempting to scroll in that case will throw an exception. But that's okay, there's no need
+        // to scroll there anyway, since the view will start at that date.
+        if calendarView.collectionView.numberOfItems(inSection: targetIndexPath.section) > targetIndexPath.item {
+            calendarView.collectionView.scrollToItem(at: targetIndexPath, at: [.top], animated: animated)
+        }
         // TODO: Notify of visible date?
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixes #438

If you set the starting date of a calendar to today, then Fluent will crash when attempting to scroll to an empty starting date. This ensures that we only scroll if the 

### Verification

Added a line to `DateTimePickerDemoController`:
```swift
CalendarConfiguration.default.referenceStartDate = Date()
```

And then ensured that the date picker could be shown without crashing.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Crash 💣 | ![Simulator Screen Shot - iPhone 13 - 2022-03-01 at 15 46 12](https://user-images.githubusercontent.com/4934719/156268246-13ba63b0-6bfd-45a4-a17a-4baa97575c1d.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/933)