### PR TITLE
Move Avatar size constants out of MSFAvatarSize

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -313,7 +313,7 @@ public struct Avatar: View, ConfigurableTokenizedControl {
 
     /// Calculates the size of the avatar, including ring spacing
     var totalSize: CGFloat {
-        let avatarImageSize: CGFloat = state.size.size
+        let avatarImageSize: CGFloat = tokens.avatarSize
         let ringOuterGap: CGFloat = tokens.ringOuterGap
         if !state.isRingVisible {
             return avatarImageSize + (ringOuterGap * 2)
@@ -322,6 +322,10 @@ public struct Avatar: View, ConfigurableTokenizedControl {
             let ringInnerGap: CGFloat = state.hasRingInnerGap ? tokens.ringInnerGap : 0
             return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
         }
+    }
+
+    var contentSize: CGFloat {
+        return tokens.avatarSize
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -12,7 +12,20 @@ open class AvatarTokens: ControlTokens {
 
     /// The size of the content of the `Avatar`.
     open var avatarSize: CGFloat {
-        return size.size
+        switch size {
+        case .xsmall:
+            return 16
+        case .small:
+            return 24
+        case .medium:
+            return 32
+        case .large:
+            return 40
+        case .xlarge:
+            return 52
+        case .xxlarge:
+            return 72
+        }
     }
 
     /// The radius of the corners of the `Avatar`.
@@ -253,21 +266,4 @@ open class AvatarTokens: ControlTokens {
     case large
     case xlarge
     case xxlarge
-
-    var size: CGFloat {
-        switch self {
-        case .xsmall:
-            return 16
-        case .small:
-            return 24
-        case .medium:
-            return 32
-        case .large:
-            return 40
-        case .xlarge:
-            return 52
-        case .xxlarge:
-            return 72
-        }
-    }
 }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -132,7 +132,7 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
         let isStackStyle = tokens.style == .stack
 
         let interspace: CGFloat = tokens.interspace
-        let imageSize: CGFloat = tokens.size.size
+        let imageSize: CGFloat = avatarViews[0].contentSize
         let ringOuterGap: CGFloat = tokens.ringOuterGap
         let ringGapOffset: CGFloat = ringOuterGap * 2
         let ringOffset: CGFloat = tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -132,11 +132,12 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
         let isStackStyle = tokens.style == .stack
 
         let interspace: CGFloat = tokens.interspace
-        let imageSize: CGFloat = avatarViews[0].contentSize
         let ringOuterGap: CGFloat = tokens.ringOuterGap
         let ringGapOffset: CGFloat = ringOuterGap * 2
         let ringOffset: CGFloat = tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap
 
+        let overflowAvatar = createOverflow(count: overflowCount)
+        let imageSize: CGFloat = overflowAvatar.contentSize
         let groupHeight: CGFloat = imageSize + (ringOffset * 2)
 
         @ViewBuilder
@@ -191,7 +192,7 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
 
                 if hasOverflow {
                     VStack {
-                        createOverflow(count: overflowCount)
+                        overflowAvatar
                     }
                     .animation(Animation.linear(duration: animationDuration))
                     .transition(AnyTransition.move(edge: .leading))
@@ -220,8 +221,8 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
     private let animationDuration: CGFloat = 0.1
 
     private func createOverflow(count: Int) -> Avatar {
-        var avatar = Avatar(style: .overflow, size: tokens.size)
-        let data = MSFAvatarStateImpl(style: .overflow, size: tokens.size)
+        var avatar = Avatar(style: .overflow, size: state.size)
+        let data = MSFAvatarStateImpl(style: .overflow, size: state.size)
         data.primaryText = "\(count)"
         data.image = nil
         avatar.state = data

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -199,28 +199,6 @@ class LargeTitleView: UIView {
 
         avatarView.centerYAnchor.constraint(equalTo: contentStackView.centerYAnchor).isActive = true
 
-        let avatarHeightConstraint = NSLayoutConstraint(item: avatarView,
-                                                        attribute: .height,
-                                                        relatedBy: .equal,
-                                                        toItem: nil,
-                                                        attribute: .notAnAttribute,
-                                                        multiplier: 1,
-                                                        constant: Constants.avatarSize.size)
-        avatarView.addConstraint(avatarHeightConstraint)
-        avatarHeightConstraint.isActive = true
-        self.avatarHeightConstraint = avatarHeightConstraint
-
-        let avatarWidthConstraint = NSLayoutConstraint(item: avatarView,
-                                                       attribute: .width,
-                                                       relatedBy: .equal,
-                                                       toItem: nil,
-                                                       attribute: .notAnAttribute,
-                                                       multiplier: 1,
-                                                       constant: Constants.avatarSize.size)
-        avatarView.addConstraint(avatarWidthConstraint)
-        avatarWidthConstraint.isActive = true
-        self.avatarWidthConstraint = avatarWidthConstraint
-
         // title button setup
         contentStackView.addArrangedSubview(titleButton)
         titleButton.setTitle(nil, for: .normal)
@@ -249,8 +227,6 @@ class LargeTitleView: UIView {
 
         if avatarSize == .automatic {
             avatar?.state.size = Constants.avatarSize
-            avatarWidthConstraint?.constant = Constants.avatarSize.size
-            avatarHeightConstraint?.constant = Constants.avatarSize.size
         }
 
         layoutIfNeeded()
@@ -263,8 +239,6 @@ class LargeTitleView: UIView {
 
         if avatarSize == .automatic {
             avatar?.state.size = Constants.compactAvatarSize
-            avatarWidthConstraint?.constant = Constants.compactAvatarSize.size
-            avatarHeightConstraint?.constant = Constants.compactAvatarSize.size
         }
 
         layoutIfNeeded()

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -58,9 +58,6 @@ class LargeTitleView: UIView {
         }
     }
 
-    var avatarHeightConstraint: NSLayoutConstraint?
-    var avatarWidthConstraint: NSLayoutConstraint?
-
     var avatarAccessibilityLabel: String? {
         return avatarCustomAccessibilityLabel ?? "Accessibility.LargeTitle.ProfileView".localized
     }

--- a/ios/FluentUI/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButton.swift
@@ -113,9 +113,13 @@ public struct PersonaButton: View, ConfigurableTokenizedControl {
         .padding(.horizontal, tokens.horizontalTextPadding)
     }
 
+    private var avatar: Avatar {
+        Avatar(state.avatarState)
+    }
+
     @ViewBuilder
     private var avatarView: some View {
-        Avatar(state.avatarState)
+        avatar
             .padding(.top, tokens.verticalPadding)
             .padding(.bottom, tokens.avatarInterspace)
     }
@@ -130,7 +134,7 @@ public struct PersonaButton: View, ConfigurableTokenizedControl {
             .accessibilityExtraExtraExtraLarge: [ .large: 80, .small: 68 ]
         ]
 
-        return state.avatarState.size.size + (2 * tokens.horizontalAvatarPadding) + (accessibilityAdjustments[sizeCategory]?[state.buttonSize] ?? 0)
+        return avatar.contentSize + (2 * tokens.horizontalAvatarPadding) + (accessibilityAdjustments[sizeCategory]?[state.buttonSize] ?? 0)
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Moving the size out of the enum as requested in https://github.com/microsoft/fluentui-apple/pull/919#discussion_r810401567

There were a few places where we would try to get the size of an Avatar by going through the MSFAvatarSize rather than the Avatar itself. 
One of those places was in some constraints for the LargeTitleView (added in https://github.com/microsoft/fluentui-apple/pull/535), but that seems to have no problems resizing without them.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AvatarSize_Group_before](https://user-images.githubusercontent.com/67026548/156272748-afc18ce9-9def-424f-867b-529f67116466.png) | ![AvatarSize_Group_after](https://user-images.githubusercontent.com/67026548/156272737-68e36f38-301e-47ce-854a-eaeef864c062.png) |
| ![AvatarSize_PersonaButton_before](https://user-images.githubusercontent.com/67026548/156272765-adac6055-1d81-40b4-847d-404df0131c3d.png) | ![AvatarSize_PersonaButton_after](https://user-images.githubusercontent.com/67026548/156272755-0e9f7428-b4ed-4c29-898d-1c76e97f8449.png) |
| ![AvatarSize_LargeTitle_before](https://user-images.githubusercontent.com/67026548/156272786-40f09534-714f-4e5e-b04b-62a6491ee340.gif) | ![AvatarSize_LargeTitle_after](https://user-images.githubusercontent.com/67026548/156272772-421c897c-dc53-446e-a7f9-f11f7fac6099.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/934)