### PR TITLE
[vNext] Fixing divider padding

### DIFF
--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -283,6 +283,7 @@ struct MSFListCellView: View {
             let hasChildren: Bool = children.count > 0
             let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
             let leadingViewSize: CGFloat = tokens.leadingViewSize
+            let leadingViewAreaSize: CGFloat = tokens.leadingViewAreaSize
 
             Button(action: state.onTapAction ?? {
                 if hasChildren {
@@ -392,7 +393,7 @@ struct MSFListCellView: View {
 
             if state.hasDivider {
                 let padding = horizontalCellPadding +
-                    (state.leadingView != nil ? (leadingViewSize + tokens.iconInterspace) : 0)
+                    (state.leadingView != nil ? horizontalCellPadding + leadingViewAreaSize : 0)
                 FluentDivider()
                     .padding(.leading, padding)
             }
@@ -401,7 +402,7 @@ struct MSFListCellView: View {
                 ForEach(children, id: \.self) { child in
                     MSFListCellView(state: child)
                         .frame(maxWidth: .infinity)
-                        .padding(.leading, (horizontalCellPadding + leadingViewSize))
+                        .padding(.leading, (horizontalCellPadding + leadingViewAreaSize))
                 }
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#854 brought token changes, and the Divider was not updated to the new changes, which caused misalignment. The tokens should be correctly updated now.

### Verification

| Before                                       | After                                      |
|------|------|
| ![Simulator Screen Shot - iPhone 11 Pro - 2022-03-02 at 15 22 00](https://user-images.githubusercontent.com/22566866/156466358-67826b53-30cb-4000-ba81-df793062e059.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2022-03-02 at 15 21 28](https://user-images.githubusercontent.com/22566866/156466329-c020fe37-fb35-47ef-b9aa-4a35c35d8bca.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/935)