### PR TITLE
[vNext Tokens] Update rest and selected Pill Button tokens to match current design

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -243,21 +243,15 @@ extension PillButtonBarDemoController: DemoAppearanceDelegate {
 
     private class PerControlOverridePillButtonTokens: PillButtonTokens {
         override var backgroundColor: PillButtonDynamicColors {
-            return .init(rest: DynamicColor(light: ColorValue(r: CGFloat.random(in: 0.25...0.5),
-                                                              g: CGFloat.random(in: 0.25...0.5),
-                                                              b: CGFloat.random(in: 0.25...0.5),
-                                                              a: 0.75)),
-                         selected: DynamicColor(light: ColorValue(r: CGFloat.random(in: 0.75...1),
-                                                                  g: CGFloat.random(in: 0.75...1),
-                                                                  b: CGFloat.random(in: 0.75...1),
-                                                                  a: 1)),
+            return .init(rest: DynamicColor(light: globalTokens.sharedColors[.steel][.tint40], dark: globalTokens.sharedColors[.steel][.shade30]),
+                         selected: DynamicColor(light: globalTokens.sharedColors[.pumpkin][.tint40], dark: globalTokens.sharedColors[.pumpkin][.shade30]),
                          disabled: super.backgroundColor.disabled,
                          selectedDisabled: super.backgroundColor.selectedDisabled)
         }
 
         override var titleColor: PillButtonDynamicColors {
-            return .init(rest: DynamicColor(light: globalTokens.neutralColors[.white]),
-                         selected: DynamicColor(light: globalTokens.neutralColors[.black]),
+            return .init(rest: DynamicColor(light: globalTokens.sharedColors[.steel][.shade30], dark: globalTokens.sharedColors[.steel][.tint40]),
+                         selected: DynamicColor(light: globalTokens.sharedColors[.pumpkin][.shade30], dark: globalTokens.sharedColors[.pumpkin][.tint40]),
                          disabled: super.titleColor.disabled,
                          selectedDisabled: super.titleColor.selectedDisabled)
         }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -169,6 +169,8 @@ open class PillButton: UIButton, TokenizedControlInternal {
             ? UIColor(dynamicColor: tokens.enabledUnreadDotColor)
             : UIColor(dynamicColor: tokens.disabledUnreadDotColor)
         }
+
+        titleLabel?.font = UIFont.fluent(tokens.font, shouldScale: false)
     }
 
     private func updatePillButtonTokens() {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -183,7 +183,11 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
 
     @objc public let pillButtonStyle: PillButtonStyle
 
-    @objc public var pillButtonOverrideTokens: PillButtonTokens?
+    @objc public var pillButtonOverrideTokens: PillButtonTokens? {
+        didSet {
+            updatePillButtonTokens()
+        }
+    }
 
     /// If set to nil, the previously selected item will be deselected and there won't be any items selected
     @objc public var selectedItem: PillButtonBarItem? {
@@ -473,6 +477,12 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
 
     private func updatePillButtonBarTokens() {
         self.tokens = resolvedTokens
+    }
+
+    private func updatePillButtonTokens() {
+        for button in buttons {
+            button.overrideTokens = pillButtonOverrideTokens
+        }
     }
 
     private var leadingConstraint: NSLayoutConstraint?

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
@@ -32,7 +32,7 @@ open class PillButtonTokens: ControlTokens {
     open var backgroundColor: PillButtonDynamicColors {
         switch style {
         case .primary:
-            return .init(rest: aliasTokens.backgroundColors[.neutral4],
+            return .init(rest: aliasTokens.backgroundColors[.neutral3],
                          selected: aliasTokens.foregroundColors[.brandRest],
                          disabled: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey80], dark: globalTokens.neutralColors[.grey30]))

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
@@ -32,7 +32,7 @@ open class PillButtonTokens: ControlTokens {
     open var backgroundColor: PillButtonDynamicColors {
         switch style {
         case .primary:
-            return .init(rest: aliasTokens.backgroundColors[.neutral3],
+            return .init(rest: DynamicColor(light: aliasTokens.backgroundColors[.neutral4].light, dark: aliasTokens.backgroundColors[.neutral3].dark),
                          selected: aliasTokens.foregroundColors[.brandRest],
                          disabled: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey80], dark: globalTokens.neutralColors[.grey30]))

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
@@ -32,13 +32,13 @@ open class PillButtonTokens: ControlTokens {
     open var backgroundColor: PillButtonDynamicColors {
         switch style {
         case .primary:
-            return .init(rest: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8]),
-                         selected: globalTokens.brandColors[.primary],
+            return .init(rest: aliasTokens.backgroundColors[.neutral4],
+                         selected: DynamicColor(light: aliasTokens.foregroundColors[.brandRest].light, dark: aliasTokens.backgroundColors[.brandRest].dark),
                          disabled: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey80], dark: globalTokens.neutralColors[.grey30]))
         case .onBrand:
-            return .init(rest: DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.neutralColors[.grey8]),
-                         selected: DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.grey32]),
+            return .init(rest: DynamicColor(light: aliasTokens.backgroundColors[.brandHover].light, dark: aliasTokens.backgroundColors[.neutral3].dark),
+                         selected: DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: globalTokens.neutralColors[.grey32]),
                          disabled: DynamicColor(light: globalTokens.brandColors[.shade20].light, dark: globalTokens.neutralColors[.grey8]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.grey30]))
         }
@@ -48,13 +48,13 @@ open class PillButtonTokens: ControlTokens {
     open var titleColor: PillButtonDynamicColors {
         switch style {
         case .primary:
-            return .init(rest: DynamicColor(light: globalTokens.neutralColors[.grey38], dark: globalTokens.neutralColors[.grey84]),
-                         selected: DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.black]),
+            return .init(rest: DynamicColor(light: aliasTokens.foregroundColors[.neutral2].light, dark: aliasTokens.foregroundColors[.neutral2].dark),
+                         selected: DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: aliasTokens.foregroundColors[.neutralInverted].dark),
                          disabled: DynamicColor(light: globalTokens.neutralColors[.grey70], dark: globalTokens.neutralColors[.grey26]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey44]))
         case .onBrand:
-            return .init(rest: DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.grey84]),
-                         selected: DynamicColor(light: globalTokens.brandColors[.primary].light, dark: globalTokens.neutralColors[.white]),
+            return .init(rest: DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light, dark: aliasTokens.foregroundColors[.neutral2].dark),
+                         selected: DynamicColor(light: aliasTokens.foregroundColors[.brandRest].light, dark: aliasTokens.foregroundColors[.neutral1].dark),
                          disabled: DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.neutralColors[.grey26]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey74], dark: globalTokens.neutralColors[.grey44]))
         }
@@ -64,9 +64,9 @@ open class PillButtonTokens: ControlTokens {
     open var enabledUnreadDotColor: DynamicColor {
         switch style {
         case .primary:
-            return globalTokens.brandColors[.primary]
+            return aliasTokens.foregroundColors[.brandRest]
         case .onBrand:
-            return DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
@@ -33,7 +33,7 @@ open class PillButtonTokens: ControlTokens {
         switch style {
         case .primary:
             return .init(rest: aliasTokens.backgroundColors[.neutral4],
-                         selected: DynamicColor(light: aliasTokens.foregroundColors[.brandRest].light, dark: aliasTokens.backgroundColors[.brandRest].dark),
+                         selected: aliasTokens.foregroundColors[.brandRest],
                          disabled: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey80], dark: globalTokens.neutralColors[.grey30]))
         case .onBrand:

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
@@ -48,7 +48,7 @@ open class PillButtonTokens: ControlTokens {
     open var titleColor: PillButtonDynamicColors {
         switch style {
         case .primary:
-            return .init(rest: DynamicColor(light: aliasTokens.foregroundColors[.neutral2].light, dark: aliasTokens.foregroundColors[.neutral2].dark),
+            return .init(rest: DynamicColor(light: aliasTokens.foregroundColors[.neutral3].light, dark: aliasTokens.foregroundColors[.neutral2].dark),
                          selected: DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: aliasTokens.foregroundColors[.neutralInverted].dark),
                          disabled: DynamicColor(light: globalTokens.neutralColors[.grey70], dark: globalTokens.neutralColors[.grey26]),
                          selectedDisabled: DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey44]))

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokens.swift
@@ -92,7 +92,7 @@ open class PillButtonTokens: ControlTokens {
     /// The distance of the unread dot from the trailing edge of the content of the `PillButton`.
     open var unreadDotOffsetX: CGFloat { 6.0 }
 
-    /// The distance of the unread dot from the bottom of the content of the `PillButton`.
+    /// The distance of the unread dot from the top of the content of the `PillButton`.
     open var unreadDotOffsetY: CGFloat { 3.0 }
 
     /// The size of the unread dot of the `PillButton`


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When we first tokenized the PillButtonBar, we did our best to match the colors we were using before. Now that the design has settled a bit, it looks like we were pretty close, but we were only using global tokens. This updates the Pill Button tokens to use the correct alias tokens. 

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![PillButtonTokens_before](https://user-images.githubusercontent.com/67026548/156851590-17afbbfa-a709-4e0b-82f4-630968039d2f.png) | ![PillButtonTokens_after](https://user-images.githubusercontent.com/67026548/157120857-18b9b368-a1a4-4248-90be-56b80beeec08.png)|
| ![PillButtonTokens_before_dark](https://user-images.githubusercontent.com/67026548/156852496-6fa1f661-2c74-4da2-ae92-c8b180ecad1f.png) | ![PillButtonTokens_after_dark](https://user-images.githubusercontent.com/67026548/157120874-d5fe8090-34c9-46d0-86b4-85805bfc95d8.png) |
|  | ![PillButton_after_themes](https://user-images.githubusercontent.com/67026548/157350618-1473d550-1650-49d6-b9e3-b23d833fc4e2.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/936)