### PR TITLE
[vNext Tokens] `state` -> `configuration`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -57,7 +57,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateToggleConfiguration()
-        configuration.isConfigured = true
+        configuration.isConfiguresd = true
     }
 
     private func updateToggleConfiguration() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -57,7 +57,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateToggleConfiguration()
-        configuration.isConfiguresd = true
+        configuration.isConfigured = true
     }
 
     private func updateToggleConfiguration() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
@@ -72,7 +72,7 @@ struct DemoAppearanceView: View {
 
     var body: some View {
         // Can't use `guard` in SwiftUI body, sadly
-        if configuration.isConfigured == false {
+        if configuration.isConfiguresd == false {
             FluentUI.ActivityIndicator(size: .xLarge)
                 .isAnimating(true)
         } else {
@@ -113,7 +113,7 @@ struct DemoAppearanceView: View {
         @Published var perControlOverride: Bool = false
 
         // Environment
-        @Published var isConfigured: Bool = false
+        @Published var isConfiguresd: Bool = false
 
         // Window-specific callbacks
         var onUserInterfaceStyleChanged: ((_ userInterfaceStyle: UIUserInterfaceStyle) -> Void)?

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
@@ -72,7 +72,7 @@ struct DemoAppearanceView: View {
 
     var body: some View {
         // Can't use `guard` in SwiftUI body, sadly
-        if configuration.isConfiguresd == false {
+        if configuration.isConfigured == false {
             FluentUI.ActivityIndicator(size: .xLarge)
                 .isAnimating(true)
         } else {
@@ -113,7 +113,7 @@ struct DemoAppearanceView: View {
         @Published var perControlOverride: Bool = false
 
         // Environment
-        @Published var isConfiguresd: Bool = false
+        @Published var isConfigured: Bool = false
 
         // Window-specific callbacks
         var onUserInterfaceStyleChanged: ((_ userInterfaceStyle: UIUserInterfaceStyle) -> Void)?

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -40,7 +40,7 @@ class DemoController: UIViewController {
 
     func createButton(title: String, action: (( MSFButton) -> Void)?) -> MSFButton {
         let button = MSFButton(style: .secondary, size: .small, action: action)
-        button.state.text = title
+        button.configuration.text = title
         return button
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -107,11 +107,11 @@ class ActivityIndicatorDemoController: DemoTableViewController {
         didSet {
             if oldValue != shouldHideWhenStopped {
                 defaultColorIndicators.values.forEach { indicator in
-                    indicator.state.hidesWhenStopped = shouldHideWhenStopped
+                    indicator.configuration.hidesWhenStopped = shouldHideWhenStopped
                 }
 
                 customColorIndicators.values.forEach { indicator in
-                    indicator.state.hidesWhenStopped = shouldHideWhenStopped
+                    indicator.configuration.hidesWhenStopped = shouldHideWhenStopped
                 }
             }
         }
@@ -121,11 +121,11 @@ class ActivityIndicatorDemoController: DemoTableViewController {
         didSet {
             if oldValue != isAnimating {
                 defaultColorIndicators.values.forEach { indicator in
-                    indicator.state.isAnimating = isAnimating
+                    indicator.configuration.isAnimating = isAnimating
                 }
 
                 customColorIndicators.values.forEach { indicator in
-                    indicator.state.isAnimating = isAnimating
+                    indicator.configuration.isAnimating = isAnimating
                 }
             }
         }
@@ -136,7 +136,7 @@ class ActivityIndicatorDemoController: DemoTableViewController {
 
         MSFActivityIndicatorSize.allCases.forEach { size in
             let indicator = MSFActivityIndicator(size: size)
-            indicator.state.isAnimating = true
+            indicator.configuration.isAnimating = true
             defaultColorIndicators.updateValue(indicator, forKey: size)
         }
 
@@ -148,8 +148,8 @@ class ActivityIndicatorDemoController: DemoTableViewController {
 
         MSFActivityIndicatorSize.allCases.forEach { size in
             let indicator = MSFActivityIndicator(size: size)
-            indicator.state.isAnimating = true
-            indicator.state.color = Colors.communicationBlue
+            indicator.configuration.isAnimating = true
+            indicator.configuration.color = Colors.communicationBlue
             customColorIndicators.updateValue(indicator, forKey: size)
         }
 
@@ -248,7 +248,7 @@ extension ActivityIndicatorDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         defaultColorIndicators.values.forEach { activityIndicator in
-            activityIndicator.state.overrideTokens = (isOverrideEnabled ? PerControlOverrideActivityIndicatorTokens() : nil)
+            activityIndicator.configuration.overrideTokens = (isOverrideEnabled ? PerControlOverrideActivityIndicatorTokens() : nil)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -142,7 +142,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isAnimated {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.isAnimated = isAnimated
+                    avatar.configuration.isAnimated = isAnimated
                 }
             }
         }
@@ -158,7 +158,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isPointerInteractionEnabled {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.hasPointerInteraction = isPointerInteractionEnabled
+                    avatar.configuration.hasPointerInteraction = isPointerInteractionEnabled
                 }
             }
         }
@@ -168,7 +168,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isShowingPresence {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.presence = isShowingPresence ? nextPresence() : .none
+                    avatar.configuration.presence = isShowingPresence ? nextPresence() : .none
                 }
             }
         }
@@ -178,7 +178,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isOutOfOffice {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.isOutOfOffice = isOutOfOffice
+                    avatar.configuration.isOutOfOffice = isOutOfOffice
                 }
             }
         }
@@ -188,7 +188,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isShowingRings {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.isRingVisible = isShowingRings
+                    avatar.configuration.isRingVisible = isShowingRings
                 }
             }
         }
@@ -198,7 +198,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isUsingImageBasedCustomColor {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
+                    avatar.configuration.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
                 }
             }
         }
@@ -208,7 +208,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isShowingRingInnerGap {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.hasRingInnerGap = isShowingRingInnerGap
+                    avatar.configuration.hasRingInnerGap = isShowingRingInnerGap
                 }
             }
         }
@@ -218,7 +218,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != isTransparent {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.isTransparent = isTransparent
+                    avatar.configuration.isTransparent = isTransparent
                 }
             }
         }
@@ -271,9 +271,9 @@ class AvatarDemoController: DemoTableViewController {
             }).forEach { row in
                 let avatar = MSFAvatar(style: row.avatarStyle,
                                        size: section.avatarSize)
-                let avatarState = avatar.state
-                avatarState.primaryText = row.avatarPrimaryText
-                avatarState.image = row.avatarImage
+                let avatarConfiguration = avatar.configuration
+                avatarConfiguration.primaryText = row.avatarPrimaryText
+                avatarConfiguration.image = row.avatarImage
 
                 avatarsForCurrentSection.updateValue(avatar, forKey: row)
                 allDemoAvatarsCombined.append(avatar)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -366,7 +366,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
 
                 for avatarGroup in allDemoAvatarGroupsCombined {
-                    avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
+                    avatarGroup.configuration.maxDisplayedAvatars = maxDisplayedAvatars
                 }
             }
         }
@@ -382,15 +382,15 @@ class AvatarGroupDemoController: DemoTableViewController {
             if let text = strongSelf.maxAvatarsTextField.text,
                let count = Int(text) {
                 strongSelf.maxDisplayedAvatars = count
-                button.state.isDisabled = true
+                button.configuration.isDisabled = true
             }
 
             strongSelf.maxAvatarsTextField.resignFirstResponder()
         }
 
-        let maxAvatarButtonState = maxAvatarButton.state
-        maxAvatarButtonState.text = "Set"
-        maxAvatarButtonState.isDisabled = true
+        let maxAvatarButtonConfiguration = maxAvatarButton.configuration
+        maxAvatarButtonConfiguration.text = "Set"
+        maxAvatarButtonConfiguration.isDisabled = true
 
         return maxAvatarButton
     }()
@@ -410,7 +410,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 overflowCountTextField.text = "\(overflowCount)"
 
                 for avatarGroup in allDemoAvatarGroupsCombined {
-                    avatarGroup.state.overflowCount = overflowCount
+                    avatarGroup.configuration.overflowCount = overflowCount
                 }
             }
         }
@@ -425,15 +425,15 @@ class AvatarGroupDemoController: DemoTableViewController {
             if let text = strongSelf.overflowCountTextField.text,
                let count = Int(text) {
                 strongSelf.overflowCount = count
-                button.state.isDisabled = true
+                button.configuration.isDisabled = true
             }
 
             strongSelf.overflowCountTextField.resignFirstResponder()
         }
 
-        let overflowCountButtonState = overflowCountButton.state
-        overflowCountButtonState.text = "Set"
-        overflowCountButtonState.isDisabled = true
+        let overflowCountButtonConfiguration = overflowCountButton.configuration
+        overflowCountButtonConfiguration.text = "Set"
+        overflowCountButtonConfiguration.isDisabled = true
 
         return overflowCountButton
     }()
@@ -462,16 +462,16 @@ class AvatarGroupDemoController: DemoTableViewController {
                 }).forEach { row in
                     let avatarGroup = demoAvatarGroupsBySection[section]![row]
                     if oldValue < avatarCount {
-                        let avatarState = avatarGroup?.state.createAvatar()
+                        let avatarConfiguration = avatarGroup?.configuration.createAvatar()
                         for index in 0..<avatarCount {
                             let samplePersona = samplePersonas[index]
-                            avatarState!.image = samplePersona.image
-                            avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
-                            avatarState!.primaryText = samplePersona.name
-                            avatarState!.secondaryText = samplePersona.email
+                            avatarConfiguration!.image = samplePersona.image
+                            avatarConfiguration!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                            avatarConfiguration!.primaryText = samplePersona.name
+                            avatarConfiguration!.secondaryText = samplePersona.email
                         }
                     } else {
-                        avatarGroup?.state.removeAvatar(at: avatarCount)
+                        avatarGroup?.configuration.removeAvatar(at: avatarCount)
                     }
 
                     avatarGroupsForCurrentSection.updateValue(avatarGroup!, forKey: row)
@@ -523,16 +523,16 @@ class AvatarGroupDemoController: DemoTableViewController {
                 let avatarGroup = MSFAvatarGroup(style: section.avatarStyle,
                                        size: row.avatarSize)
                 for index in 0..<avatarCount {
-                    let avatarState = avatarGroup.state.createAvatar()
+                    let avatarConfiguration = avatarGroup.configuration.createAvatar()
                     let samplePersona = samplePersonas[index]
-                    avatarState.image = samplePersona.image
-                    avatarState.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
-                    avatarState.primaryText = samplePersona.name
-                    avatarState.secondaryText = samplePersona.email
+                    avatarConfiguration.image = samplePersona.image
+                    avatarConfiguration.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                    avatarConfiguration.primaryText = samplePersona.name
+                    avatarConfiguration.secondaryText = samplePersona.email
                 }
 
-                avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
-                avatarGroup.state.overflowCount = overflowCount
+                avatarGroup.configuration.maxDisplayedAvatars = maxDisplayedAvatars
+                avatarGroup.configuration.overflowCount = overflowCount
                 avatarGroupsForCurrentSection.updateValue(avatarGroup, forKey: row)
                 allDemoAvatarGroupsCombined.append(avatarGroup)
             }
@@ -562,12 +562,12 @@ extension AvatarGroupDemoController: UITextFieldDelegate {
         let button = textField == maxAvatarsTextField ? maxAvatarButton : overflowCountButton
         if let count = UInt(text) {
             if textField == maxAvatarsTextField {
-                button.state.isDisabled = count <= 0 || count == maxDisplayedAvatars
+                button.configuration.isDisabled = count <= 0 || count == maxDisplayedAvatars
             } else {
-                button.state.isDisabled = count == overflowCount
+                button.configuration.isDisabled = count == overflowCount
             }
         } else {
-            button.state.isDisabled = true
+            button.configuration.isDisabled = true
         }
 
         return shouldChangeCharacters

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -74,7 +74,7 @@ class BadgeViewDemoController: DemoController {
         imageView.frame.size = CGSize(width: 20, height: 20)
 
         let avatar = MSFAvatar(style: .default, size: .xsmall)
-        avatar.state.image = UIImage(named: "avatar_kat_larsson")
+        avatar.configuration.image = UIImage(named: "avatar_kat_larsson")
 
         let dataSource: [(BadgeView.Size, UIView)] = [
             (.medium, imageView),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -243,7 +243,7 @@ class BottomCommandingDemoController: UIViewController {
                 strongSelf.bottomCommandingController?.heroItems = Array(strongSelf.heroItems[0..<newCount])
             }
         }
-        button.state.image = UIImage(named: "ic_fluent_add_20_regular")
+        button.configuration.image = UIImage(named: "ic_fluent_add_20_regular")
         button.accessibilityLabel = "Increment hero command count"
 
         return button
@@ -262,7 +262,7 @@ class BottomCommandingDemoController: UIViewController {
                 strongSelf.bottomCommandingController?.heroItems = Array(strongSelf.heroItems[0..<newCount])
             }
         }
-        button.state.image = UIImage(named: "ic_fluent_subtract_20_regular")
+        button.configuration.image = UIImage(named: "ic_fluent_subtract_20_regular")
         button.accessibilityLabel = "Decrement hero command count"
 
         return button

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -98,7 +98,7 @@ class BottomSheetDemoController: UIViewController {
                 secondarySheetController.view.removeFromSuperview()
             }
         }
-        dismissButton.state.text = "Dismiss"
+        dismissButton.configuration.text = "Dismiss"
 
         let dismissButtonView = dismissButton.view
         dismissButtonView.translatesAutoresizingMaskIntoConstraints = false
@@ -111,7 +111,7 @@ class BottomSheetDemoController: UIViewController {
 
             strongSelf.showTransientSheet()
         }
-        anotherOneButton.state.text = "Show another sheet"
+        anotherOneButton.configuration.text = "Show another sheet"
 
         let anotherOneButtonView = anotherOneButton.view
         anotherOneButtonView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -52,15 +52,15 @@ class ButtonDemoController: DemoTableViewController {
                                            style: section.buttonStyle,
                                            size: section.buttonSize,
                                            disabled: false)
-            button.state.image = image
-            button.state.text = text
+            button.configuration.image = image
+            button.configuration.text = text
 
             let disabledButton = dequeueDemoButton(indexPath: indexPath,
                                                    style: section.buttonStyle,
                                                    size: section.buttonSize,
                                                    disabled: true)
-            disabledButton.state.image = image
-            disabledButton.state.text = text
+            disabledButton.configuration.image = image
+            disabledButton.configuration.text = text
 
             let rowContentView = UIStackView(arrangedSubviews: [button.view, disabledButton.view])
             rowContentView.isLayoutMarginsRelativeArrangement = true
@@ -123,7 +123,7 @@ class ButtonDemoController: DemoTableViewController {
                                    size: size) { _ in
                 self.didPressButton()
             }
-            button.state.isDisabled = disabled
+            button.configuration.isDisabled = disabled
             buttons[key] = button
 
             return button
@@ -324,7 +324,7 @@ extension ButtonDemoController: DemoAppearanceDelegate {
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         self.buttons.forEach({ (_: String, value: MSFButton) in
             let tokens = isOverrideEnabled ? PerControlOverrideButtonTokens() : nil
-            value.state.overrideTokens = tokens
+            value.configuration.overrideTokens = tokens
         })
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -100,24 +100,24 @@ class CardNudgeDemoController: DemoTableViewController {
             break
         case .mainIcon:
             cardNudges.forEach { cardNudge in
-                cardNudge.state.mainIcon = (isOn ? UIImage(systemName: "gamecontroller") : nil)
+                cardNudge.configuration.mainIcon = (isOn ? UIImage(systemName: "gamecontroller") : nil)
             }
         case .subtitle:
             cardNudges.forEach { cardNudge in
-                cardNudge.state.subtitle = (isOn ? "Subtitle" : nil)
+                cardNudge.configuration.subtitle = (isOn ? "Subtitle" : nil)
             }
         case .accentIcon:
             cardNudges.forEach { cardNudge in
-                cardNudge.state.accentIcon = (isOn ? UIImage(named: "ic_fluent_presence_blocked_10_regular", in: FluentUIFramework.resourceBundle, with: nil) : nil)
+                cardNudge.configuration.accentIcon = (isOn ? UIImage(named: "ic_fluent_presence_blocked_10_regular", in: FluentUIFramework.resourceBundle, with: nil) : nil)
             }
         case .accentText:
             cardNudges.forEach { cardNudge in
-                cardNudge.state.accentText = (isOn ? "Accent" : nil)
+                cardNudge.configuration.accentText = (isOn ? "Accent" : nil)
             }
         case .dismissButton:
             cardNudges.forEach { cardNudge in
-                cardNudge.state.dismissButtonAction = (isOn ? { state in
-                    let alert = UIAlertController(title: "\(state.title) was dismissed", message: nil, preferredStyle: .alert)
+                cardNudge.configuration.dismissButtonAction = (isOn ? { configuration in
+                    let alert = UIAlertController(title: "\(configuration.title) was dismissed", message: nil, preferredStyle: .alert)
                     let action = UIAlertAction(title: "OK", style: .default, handler: nil)
                     alert.addAction(action)
                     self.present(alert, animated: true)
@@ -125,9 +125,9 @@ class CardNudgeDemoController: DemoTableViewController {
             }
         case .actionButton:
             cardNudges.forEach { cardNudge in
-                cardNudge.state.actionButtonTitle = (isOn ? "Action" : nil)
-                cardNudge.state.actionButtonAction = (isOn ? { state in
-                    let alert = UIAlertController(title: "\(state.title) action performed", message: nil, preferredStyle: .alert)
+                cardNudge.configuration.actionButtonTitle = (isOn ? "Action" : nil)
+                cardNudge.configuration.actionButtonAction = (isOn ? { configuration in
+                    let alert = UIAlertController(title: "\(configuration.title) action performed", message: nil, preferredStyle: .alert)
                     let action = UIAlertAction(title: "OK", style: .default, handler: nil)
                     alert.addAction(action)
                     self.present(alert, animated: true)
@@ -249,7 +249,7 @@ extension CardNudgeDemoController: DemoAppearanceDelegate {
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         self.cardNudges.forEach({ cardNudge in
             let tokens = isOverrideEnabled ? PerControlOverrideCardNudgeTokens() : nil
-            cardNudge.state.overrideTokens = tokens
+            cardNudge.configuration.overrideTokens = tokens
         })
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -115,7 +115,7 @@ class DividerDemoController: DemoTableViewController {
         if customColor {
             let color = Colors.communicationBlue
             let dividerTokens = customDividerTokens(spacing: spacing, color: color)
-            divider.state.overrideTokens = dividerTokens
+            divider.configuration.overrideTokens = dividerTokens
         }
 
         dividers.append(divider)
@@ -224,7 +224,7 @@ extension DividerDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         dividers.forEach { divider in
-            divider.state.overrideTokens = (isOverrideEnabled ? PerControlOverrideDividerTokens() : nil)
+            divider.configuration.overrideTokens = (isOverrideEnabled ? PerControlOverrideDividerTokens() : nil)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -433,7 +433,7 @@ class DrawerDemoController: DemoController {
 
                 let isResizingBehaviourNone = drawer.resizingBehavior == .none
                 drawer.resizingBehavior = isResizingBehaviourNone ? .expand : .none
-                sender.state.text = isResizingBehaviourNone ? "Resizing - None" : "Resizing - Expand"
+                sender.configuration.text = isResizingBehaviourNone ? "Resizing - None" : "Resizing - Expand"
             }).view)
         }
         views.append(spacer)
@@ -506,7 +506,7 @@ class DrawerDemoController: DemoController {
                 textField?.resignFirstResponder()
             }
         }
-        button.state.text = "Hide keyboard"
+        button.configuration.text = "Hide keyboard"
         return button
     }()
 }
@@ -520,11 +520,11 @@ extension DrawerDemoController: UITextFieldDelegate {
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        hideKeyboardButton.state.isDisabled = false
+        hideKeyboardButton.configuration.isDisabled = false
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        hideKeyboardButton.state.isDisabled = true
+        hideKeyboardButton.configuration.isDisabled = true
     }
 }
 
@@ -549,6 +549,6 @@ extension DrawerDemoController: DrawerControllerDelegate {
     }
 
     func drawerControllerDidChangeExpandedState(_ controller: DrawerController) {
-        expandButton?.state.text = controller.isExpanded ? "Return to normal" : "Expand"
+        expandButton?.configuration.text = controller.isExpanded ? "Return to normal" : "Expand"
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -17,7 +17,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showActivityHUD()
         })
-        showActivityButton.state.text = "Show activity HUD"
+        showActivityButton.configuration.text = "Show activity HUD"
         container.addArrangedSubview(showActivityButton.view)
 
         let showSuccessButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -27,7 +27,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showSuccessHUD()
         })
-        showSuccessButton.state.text = "Show success HUD"
+        showSuccessButton.configuration.text = "Show success HUD"
         container.addArrangedSubview(showSuccessButton.view)
 
         let showFailureButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -37,7 +37,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showFailureHUD()
         })
-        showFailureButton.state.text = "Show failure HUD"
+        showFailureButton.configuration.text = "Show failure HUD"
         container.addArrangedSubview(showFailureButton.view)
 
         let showCustomButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -47,7 +47,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showCustomHUD()
         })
-        showCustomButton.state.text = "Show custom HUD"
+        showCustomButton.configuration.text = "Show custom HUD"
         container.addArrangedSubview(showCustomButton.view)
 
         let showCustomNonBlockingButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -57,7 +57,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showCustomNonBlockingHUD()
         })
-        showCustomNonBlockingButton.state.text = "Show custom non-blocking HUD"
+        showCustomNonBlockingButton.configuration.text = "Show custom non-blocking HUD"
         container.addArrangedSubview(showCustomNonBlockingButton.view)
 
         let showNolabelButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -67,7 +67,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showNoLabelHUD()
         })
-        showNolabelButton.state.text = "Show HUD with no label"
+        showNolabelButton.configuration.text = "Show HUD with no label"
         container.addArrangedSubview(showNolabelButton.view)
 
         let showGestureButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -77,7 +77,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showGestureHUD()
         })
-        showGestureButton.state.text = "Show HUD with tap gesture callback"
+        showGestureButton.configuration.text = "Show HUD with tap gesture callback"
         container.addArrangedSubview(showGestureButton.view)
 
         let showUpdatingButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
@@ -87,7 +87,7 @@ class HUDDemoController: DemoController {
 
             strongSelf.showUpdateHUD()
         })
-        showUpdatingButton.state.text = "Show HUD with updating caption"
+        showUpdatingButton.configuration.text = "Show HUD with updating caption"
         container.addArrangedSubview(showUpdatingButton.view)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
@@ -113,7 +113,7 @@ class IndeterminateProgressBarDemoController: DemoTableViewController {
     private var shouldHideWhenStopped: Bool = true {
         didSet {
             if oldValue != shouldHideWhenStopped {
-                indeterminateProgressBar.state.hidesWhenStopped = shouldHideWhenStopped
+                indeterminateProgressBar.configuration.hidesWhenStopped = shouldHideWhenStopped
             }
         }
     }
@@ -121,14 +121,14 @@ class IndeterminateProgressBarDemoController: DemoTableViewController {
     private var isAnimating: Bool = true {
         didSet {
             if oldValue != isAnimating {
-                indeterminateProgressBar.state.isAnimating = isAnimating
+                indeterminateProgressBar.configuration.isAnimating = isAnimating
             }
         }
     }
 
     private let indeterminateProgressBar: MSFIndeterminateProgressBar = {
         let indeterminateProgressBar = MSFIndeterminateProgressBar()
-        indeterminateProgressBar.state.isAnimating = true
+        indeterminateProgressBar.configuration.isAnimating = true
 
         return indeterminateProgressBar
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -114,7 +114,7 @@ class LeftNavMenuViewController: UIViewController {
     var menuAction: (() -> Void)?
 
     private func setPresence(presence: LeftNavPresence) {
-        persona.state.presence = presence.avatarPresence
+        persona.configuration.presence = presence.avatarPresence
 
         guard let statusCell = statusCell else {
             return
@@ -130,22 +130,22 @@ class LeftNavMenuViewController: UIViewController {
 
     private var leftNavMenuList = MSFList()
 
-    private var statusCell: MSFListCellState?
+    private var statusCell: MSFListCellConfiguration?
 
     private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
 
     private lazy var leftNavAccountView: UIView = {
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
         chevron.tintColor = Colors.textPrimary
-        let personaState = persona.state
+        let personaConfiguration = persona.configuration
 
-        personaState.presence = .available
-        personaState.primaryText = "Kat Larrson"
-        personaState.secondaryText = "Designer"
-        personaState.image = UIImage(named: "avatar_kat_larsson")
-        personaState.titleTrailingAccessoryUIView = chevron
-        personaState.backgroundColor = .systemBackground
-        personaState.onTapAction = {
+        personaConfiguration.presence = .available
+        personaConfiguration.primaryText = "Kat Larrson"
+        personaConfiguration.secondaryText = "Designer"
+        personaConfiguration.image = UIImage(named: "avatar_kat_larsson")
+        personaConfiguration.titleTrailingAccessoryUIView = chevron
+        personaConfiguration.backgroundColor = .systemBackground
+        personaConfiguration.onTapAction = {
             self.dismiss(animated: true, completion: { [weak self] in
                 guard let strongSelf = self else {
                     return
@@ -173,18 +173,18 @@ class LeftNavMenuViewController: UIViewController {
             strongSelf.menuAction?()
         }
 
-        let menuSection = leftNavMenuList.state.createSection()
+        let menuSection = leftNavMenuList.configuration.createSection()
 
-        let statusCellState = menuSection.createCell()
-        statusCell = statusCellState
+        let statusCellConfiguration = menuSection.createCell()
+        statusCell = statusCellConfiguration
 
-        statusCellState.title = LeftNavPresence.available.cellTitle
-        statusCellState.backgroundColor = .systemBackground
+        statusCellConfiguration.title = LeftNavPresence.available.cellTitle
+        statusCellConfiguration.backgroundColor = .systemBackground
         let statusImageView = LeftNavPresence.available.imageView
-        statusCellState.leadingUIView = statusImageView
+        statusCellConfiguration.leadingUIView = statusImageView
 
         for presence in LeftNavPresence.allCases {
-            let statusCellChild = statusCellState.createChildCell()
+            let statusCellChild = statusCellConfiguration.createChildCell()
             statusCellChild.leadingViewSize = .small
             statusCellChild.title = presence.cellTitle
             statusCellChild.leadingUIView = presence.imageView
@@ -201,7 +201,7 @@ class LeftNavMenuViewController: UIViewController {
         let tintDynamicColor = aliasTokens.foregroundColors[.neutral4]
         let tintColor = UIColor(dynamicColor: tintDynamicColor)
 
-        let resetStatusCell = statusCellState.createChildCell()
+        let resetStatusCell = statusCellConfiguration.createChildCell()
         resetStatusCell.title = "Reset status"
         resetStatusCell.leadingViewSize = .small
         resetStatusCell.backgroundColor = .systemBackground
@@ -249,7 +249,7 @@ class LeftNavMenuViewController: UIViewController {
         whatsNewCell.leadingUIView = whatsNewImageView
         whatsNewCell.onTapAction = defaultMenuAction
 
-        let accountsSection = leftNavMenuList.state.createSection()
+        let accountsSection = leftNavMenuList.configuration.createSection()
         accountsSection.title = "Accounts and Orgs"
         accountsSection.backgroundColor = .systemBackground
 
@@ -260,7 +260,7 @@ class LeftNavMenuViewController: UIViewController {
         microsoftAccountCell.subtitle = "kat.larrson@contoso.com"
         microsoftAccountCell.accessoryType = .checkmark
         let orgAvatar = MSFAvatar(style: .group, size: .large)
-        orgAvatar.state.primaryText = "Kat Larrson"
+        orgAvatar.configuration.primaryText = "Kat Larrson"
         microsoftAccountCell.leadingUIView = orgAvatar.view
         microsoftAccountCell.leadingViewSize = .large
 
@@ -270,7 +270,7 @@ class LeftNavMenuViewController: UIViewController {
         msaAccountCell.title = "Personal"
         msaAccountCell.subtitle = "kat.larrson@live.com"
         let msaAvatar = MSFAvatar(style: .group, size: .large)
-        msaAvatar.state.primaryText = "kat.larrson@live.com"
+        msaAvatar.configuration.primaryText = "kat.larrson@live.com"
         msaAccountCell.leadingUIView = msaAvatar.view
         msaAccountCell.leadingViewSize = .large
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -14,7 +14,7 @@ class ListDemoController: DemoController {
         var cell: TableViewCellSampleData.Item
         var showsLabelAccessoryView: Bool
 
-        var listCell: MSFListCellState
+        var listCell: MSFListCellConfiguration
 
         //PersonaDataNode creation
         let personaDataNodes: [PersonaDataNode] = [
@@ -28,7 +28,7 @@ class ListDemoController: DemoController {
         ]
 
         /// Custom Leading View with collapsible children items
-        let collapsibleSection = list.state.createSection()
+        let collapsibleSection = list.configuration.createSection()
         collapsibleSection.title = "AvatarSection"
         for node in personaDataNodes {
             let collapsibleCell = collapsibleSection.createCell()
@@ -38,14 +38,14 @@ class ListDemoController: DemoController {
 
         /// TableViewCell Sample Data Sections
         for (sectionIndex, section) in sections.enumerated() {
-            let sectionState = list.state.createSection()
-            sectionState.title = section.title
-            sectionState.style = MSFHeaderStyle.subtle
-            sectionState.hasDividers = true
+            let sectionConfiguration = list.configuration.createSection()
+            sectionConfiguration.title = section.title
+            sectionConfiguration.style = MSFHeaderStyle.subtle
+            sectionConfiguration.hasDividers = true
             for rowIndex in 0..<TableViewCellSampleData.numberOfItemsInSection {
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: IndexPath(row: rowIndex, section: sectionIndex))
                 cell = section.item
-                listCell = sectionState.createCell()
+                listCell = sectionConfiguration.createCell()
                 listCell.title = cell.text1
                 listCell.subtitle = cell.text2
                 listCell.footnote = cell.text3
@@ -85,14 +85,14 @@ class ListDemoController: DemoController {
         var isExpanded: Bool = false
     }
 
-    private func createSamplePersonaCell(cellState: MSFListCellState, personaDataNode: PersonaDataNode) {
+    private func createSamplePersonaCell(cellState: MSFListCellConfiguration, personaDataNode: PersonaDataNode) {
         let personaData = personaDataNode.personaData
         let personaChildren = personaDataNode.children
         let avatar = createAvatarView(size: .medium,
                                       name: personaData.name,
                                       image: personaData.image,
                                       style: .default)
-        cellState.title = avatar.state.primaryText ?? ""
+        cellState.title = avatar.configuration.primaryText ?? ""
         cellState.leadingUIView = avatar.view
         cellState.isExpanded = personaDataNode.isExpanded
         cellState.hasDivider = true
@@ -112,8 +112,8 @@ class ListDemoController: DemoController {
                                   style: MSFAvatarStyle) -> MSFAvatar {
         let avatarView = MSFAvatar(style: style,
                                    size: size)
-        avatarView.state.primaryText = name
-        avatarView.state.image = image
+        avatarView.configuration.primaryText = name
+        avatarView.configuration.image = image
 
         return avatarView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -663,19 +663,19 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
 extension RootViewController: SearchBarDelegate {
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
-        searchBar.progressSpinner.state.isAnimating = false
+        searchBar.progressSpinner.configuration.isAnimating = false
     }
 
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
     }
 
     func searchBarDidCancel(_ searchBar: SearchBar) {
-        searchBar.progressSpinner.state.isAnimating = false
+        searchBar.progressSpinner.configuration.isAnimating = false
     }
 
     func searchBarDidRequestSearch(_ searchBar: SearchBar) {
         if showSearchProgressSpinner {
-            searchBar.progressSpinner.state.isAnimating = true
+            searchBar.progressSpinner.configuration.isAnimating = true
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -83,7 +83,7 @@ class NotificationViewDemoController: DemoController {
                     $0.hide(after: variant.delayForHiding)
                 }
             })
-            showButton.state.text = "Show"
+            showButton.configuration.text = "Show"
             container.addArrangedSubview(showButton.view)
 
             container.alignment = .leading

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -268,7 +268,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
         didSet {
             if oldValue != notificationTitle {
                 notificationTitleTextField.text = "\(notificationTitle)"
-                notification.state.title = notificationTitle
+                notification.configuration.title = notificationTitle
             }
         }
     }
@@ -281,15 +281,15 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
 
             if let text = strongSelf.notificationTitleTextField.text {
                 strongSelf.notificationTitle = text
-                button.state.isDisabled = true
+                button.configuration.isDisabled = true
             }
 
             strongSelf.notificationTitleTextField.resignFirstResponder()
         }
 
-        let notificationTitleButtonState = notificationTitleButton.state
-        notificationTitleButtonState.text = "Set"
-        notificationTitleButtonState.isDisabled = true
+        let notificationTitleButtonConfiguration = notificationTitleButton.configuration
+        notificationTitleButtonConfiguration.text = "Set"
+        notificationTitleButtonConfiguration.isDisabled = true
 
         return notificationTitleButton
     }()
@@ -307,7 +307,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
         didSet {
             if oldValue != message {
                 messageTextField.text = "\(message)"
-                notification.state.message = message
+                notification.configuration.message = message
             }
         }
     }
@@ -320,13 +320,13 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
 
             if let text = strongSelf.messageTextField.text {
                 strongSelf.message = text
-                button.state.isDisabled = true
+                button.configuration.isDisabled = true
             }
 
             strongSelf.messageTextField.resignFirstResponder()
         }
 
-        let messageButtonState = messageButton.state
+        let messageButtonState = messageButton.configuration
         messageButtonState.text = "Set"
         messageButtonState.isDisabled = true
 
@@ -345,7 +345,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
     private var delayTime: TimeInterval = 2.0 {
         didSet {
             if oldValue != delayTime {
-                notification.state.delayTime = delayTime
+                notification.configuration.delayTime = delayTime
             }
         }
     }
@@ -358,13 +358,13 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
 
             if let text = strongSelf.delayTimeTextField.text, let textToTimeInterval = TimeInterval(text) {
                 strongSelf.delayTime = textToTimeInterval
-                button.state.isDisabled = true
+                button.configuration.isDisabled = true
             }
 
             strongSelf.delayTimeTextField.resignFirstResponder()
         }
 
-        let delayTimeButtonState = delayTimeButton.state
+        let delayTimeButtonState = delayTimeButton.configuration
         delayTimeButtonState.text = "Set"
         delayTimeButtonState.isDisabled = true
 
@@ -384,7 +384,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
         didSet {
             if oldValue != actionButtonTitle {
                 actionButtonTitleTextField.text = "\(actionButtonTitle)"
-                notification.state.actionButtonTitle = actionButtonTitle
+                notification.configuration.actionButtonTitle = actionButtonTitle
             }
         }
     }
@@ -397,13 +397,13 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
 
             if let text = strongSelf.actionButtonTitleTextField.text {
                 strongSelf.actionButtonTitle = text
-                button.state.isDisabled = true
+                button.configuration.isDisabled = true
             }
 
             strongSelf.actionButtonTitleTextField.resignFirstResponder()
         }
 
-        let actionButtonTitleButtonState = actionButtonTitleButton.state
+        let actionButtonTitleButtonState = actionButtonTitleButton.configuration
         actionButtonTitleButtonState.text = "Set"
         actionButtonTitleButtonState.isDisabled = true
 
@@ -422,7 +422,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
     private var setImage: Bool = false {
         didSet {
             if oldValue != setImage {
-                notification.state.image = setImage ? UIImage(named: "play-in-circle-24x24") : nil
+                notification.configuration.image = setImage ? UIImage(named: "play-in-circle-24x24") : nil
             }
         }
     }
@@ -430,7 +430,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
     private var hasActionButtonAction: Bool = true {
         didSet {
             if oldValue != hasActionButtonAction {
-                notification.state.actionButtonAction = hasActionButtonAction ? { [weak self] in
+                notification.configuration.actionButtonAction = hasActionButtonAction ? { [weak self] in
                     if let actionButtonTitle = self?.actionButtonTitle {
                         if actionButtonTitle.isEmpty {
                             self?.showMessage("`Dismiss` tapped")
@@ -446,7 +446,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
     private var hasMessageAction: Bool = false {
         didSet {
             if oldValue != hasMessageAction {
-                notification.state.messageButtonAction = hasMessageAction ? { [weak self] in
+                notification.configuration.messageButtonAction = hasMessageAction ? { [weak self] in
                     self?.showMessage("Message action tapped")
                 } : nil
             }
@@ -465,22 +465,22 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
     private var notification: MSFNotification = MSFNotification(style: .primaryToast, message: "Mail Archived", delayTime: 2.0) {
         didSet {
             if oldValue != notification {
-                notification.state.title = oldValue.state.title
-                notification.state.image = oldValue.state.image
-                notification.state.actionButtonTitle = oldValue.state.actionButtonTitle
-                notification.state.actionButtonAction = oldValue.state.actionButtonAction
-                notification.state.messageButtonAction = oldValue.state.messageButtonAction
-                notification.state.dismissAction = { self.notification.hide() }
+                notification.configuration.title = oldValue.configuration.title
+                notification.configuration.image = oldValue.configuration.image
+                notification.configuration.actionButtonTitle = oldValue.configuration.actionButtonTitle
+                notification.configuration.actionButtonAction = oldValue.configuration.actionButtonAction
+                notification.configuration.messageButtonAction = oldValue.configuration.messageButtonAction
+                notification.configuration.dismissAction = { self.notification.hide() }
                 tableView.reloadRows(at: [IndexPath(item: 0, section: 0)], with: .automatic)
             }
         }
     }
 
     private func initDemoNotification() {
-        let state = notification.state
-        state.title = notificationTitle
-        state.actionButtonTitle = actionButtonTitle
-        state.actionButtonAction = { [weak self] in
+        let configuration = notification.configuration
+        configuration.title = notificationTitle
+        configuration.actionButtonTitle = actionButtonTitle
+        configuration.actionButtonAction = { [weak self] in
             if let actionButtonTitle = self?.actionButtonTitle {
                 if actionButtonTitle.isEmpty {
                     self?.showMessage("`Dismiss` tapped")
@@ -489,21 +489,21 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
                 }
             }
         }
-        state.dismissAction = { [weak self] in
+        configuration.dismissAction = { [weak self] in
             self?.notification.hide() }
     }
 
     @objc private func showNotification() {
         // Create another instance of the demo notification to show
         let newNotification = MSFNotification(style: style, message: message, delayTime: delayTime)
-        newNotification.state.title = notification.state.title
-        newNotification.state.image = notification.state.image
-        newNotification.state.actionButtonTitle = notification.state.actionButtonTitle
-        newNotification.state.actionButtonAction = notification.state.actionButtonAction
-        newNotification.state.messageButtonAction = notification.state.messageButtonAction
-        newNotification.state.dismissAction = { newNotification.hide() }
+        newNotification.configuration.title = notification.configuration.title
+        newNotification.configuration.image = notification.configuration.image
+        newNotification.configuration.actionButtonTitle = notification.configuration.actionButtonTitle
+        newNotification.configuration.actionButtonAction = notification.configuration.actionButtonAction
+        newNotification.configuration.messageButtonAction = notification.configuration.messageButtonAction
+        newNotification.configuration.dismissAction = { newNotification.hide() }
         newNotification.showNotification(in: view) {
-            $0.hide(after: newNotification.state.delayTime)
+            $0.hide(after: newNotification.configuration.delayTime)
         }
     }
 }
@@ -514,14 +514,14 @@ extension NotificationViewDemoControllerSwiftUI: UITextFieldDelegate {
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let text = textField.text ?? ""
         if textField == notificationTitleTextField {
-            notificationTitleButton.state.isDisabled = text == notificationTitle
+            notificationTitleButton.configuration.isDisabled = text == notificationTitle
         } else if textField == messageTextField {
-            messageButton.state.isDisabled = text == message
+            messageButton.configuration.isDisabled = text == message
         } else if textField == actionButtonTitleTextField {
-            actionButtonTitleButton.state.isDisabled = text == actionButtonTitle
+            actionButtonTitleButton.configuration.isDisabled = text == actionButtonTitle
         } else if textField == delayTimeTextField {
             if let timeIntervalText = TimeInterval(text) {
-                delayTimeButton.state.isDisabled = timeIntervalText == delayTime
+                delayTimeButton.configuration.isDisabled = timeIntervalText == delayTime
             }
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -326,9 +326,9 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
             strongSelf.messageTextField.resignFirstResponder()
         }
 
-        let messageButtonState = messageButton.configuration
-        messageButtonState.text = "Set"
-        messageButtonState.isDisabled = true
+        let messageButtonConfiguration = messageButton.configuration
+        messageButtonConfiguration.text = "Set"
+        messageButtonConfiguration.isDisabled = true
 
         return messageButton
     }()
@@ -364,9 +364,9 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
             strongSelf.delayTimeTextField.resignFirstResponder()
         }
 
-        let delayTimeButtonState = delayTimeButton.configuration
-        delayTimeButtonState.text = "Set"
-        delayTimeButtonState.isDisabled = true
+        let delayTimeButtonConfiguration = delayTimeButton.configuration
+        delayTimeButtonConfiguration.text = "Set"
+        delayTimeButtonConfiguration.isDisabled = true
 
         return delayTimeButton
     }()
@@ -403,9 +403,9 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
             strongSelf.actionButtonTitleTextField.resignFirstResponder()
         }
 
-        let actionButtonTitleButtonState = actionButtonTitleButton.configuration
-        actionButtonTitleButtonState.text = "Set"
-        actionButtonTitleButtonState.isDisabled = true
+        let actionButtonTitleButtonConfiguration = actionButtonTitleButton.configuration
+        actionButtonTitleButtonConfiguration.text = "Set"
+        actionButtonTitleButtonConfiguration.isDisabled = true
 
         return actionButtonTitleButton
     }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -70,12 +70,12 @@
     [self.container addArrangedSubview:listVnextLabel];
 
     MSFList *testList = [[MSFList alloc] init];
-    id<MSFListSectionState> sectionState = [[testList state] createSection];
-    id<MSFListCellState> listCell1 = [sectionState createCell];
-    id<MSFListCellState> listCell2 = [sectionState createCell];
-    id<MSFListCellState> listCell3 = [sectionState createCell];
+    id<MSFListSectionConfiguration> sectionConfiguration = [[testList configuration] createSection];
+    id<MSFListCellConfiguration> listCell1 = [sectionConfiguration createCell];
+    id<MSFListCellConfiguration> listCell2 = [sectionConfiguration createCell];
+    id<MSFListCellConfiguration> listCell3 = [sectionConfiguration createCell];
 
-    id<MSFListCellState> childCell = [listCell1 createChildCell];
+    id<MSFListCellConfiguration> childCell = [listCell1 createChildCell];
     [childCell setTitle:@"Child Cell"];
 
     [listCell1 setTitle:@"SampleTitle1"];
@@ -107,24 +107,24 @@
 }
 
 - (void)enableButton {
-    id<MSFButtonState> state = [self->_testButton state];
-    [state setText:@"Enabled"];
-    [state setIsDisabled:NO];
-    [state setImage:[UIImage imageNamed:@"Placeholder_20"]];
+    id<MSFButtonConfiguration> configuration = [self->_testButton configuration];
+    [configuration setText:@"Enabled"];
+    [configuration setIsDisabled:NO];
+    [configuration setImage:[UIImage imageNamed:@"Placeholder_20"]];
 }
 
 - (void)disableButton {
-    id<MSFButtonState> state = [self->_testButton state];
-    [state setText:@"Disabled"];
-    [state setIsDisabled:YES];
-    [state setImage:nil];
+    id<MSFButtonConfiguration> configuration = [self->_testButton configuration];
+    [configuration setText:@"Disabled"];
+    [configuration setIsDisabled:YES];
+    [configuration setImage:nil];
 }
 
 - (void)resetButton {
-    id<MSFButtonState> state = [self->_testButton state];
-    [state setText:@"Button (Vnext)"];
-    [state setImage:nil];
-    [state setIsDisabled:NO];
+    id<MSFButtonConfiguration> configuration = [self->_testButton configuration];
+    [configuration setText:@"Button (Vnext)"];
+    [configuration setImage:nil];
+    [configuration setIsDisabled:NO];
 }
 
 - (MSFButtonLegacy *)createButtonWithTitle:(NSString *)title action:(SEL)action {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -96,7 +96,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
 
     // MARK: - Actions
 
-    private func didTap(on personaButtonState: MSFPersonaCarouselButtonState, at index: Int) {
+    private func didTap(on personaButtonState: MSFPersonaCarouselButtonConfiguration, at index: Int) {
         let primaryText: String = personaButtonState.primaryText ?? "n/a"
         let alert = UIAlertController(title: "\(primaryText) at index \(index) was selected", message: nil, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: nil)
@@ -112,7 +112,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
                 return (((persona.name.count > 0) ? persona.name : persona.email), nil)
             }
         }()
-        carousel.state.add(primaryText: text.0, secondaryText: text.1, image: persona.image)
+        carousel.configuration.add(primaryText: text.0, secondaryText: text.1, image: persona.image)
     }
 
     @objc private func handleAppendPersona() {
@@ -125,11 +125,11 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
 
     @objc private func handleRemovePersona() {
         carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
-            let state = carousel.state
-            let count = state.count
+            let configuration = carousel.configuration
+            let count = configuration.count
             if count > 0 {
                 let random = Int.random(in: 0...count - 1)
-                state.remove(at: random)
+                configuration.remove(at: random)
             }
         }
     }
@@ -171,7 +171,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
             add(persona, to: carousel)
         }
         carousels[size] = carousel
-        carousel.state.onTapAction = { [weak self] (personaButtonState: MSFPersonaCarouselButtonState, index: Int) in
+        carousel.configuration.onTapAction = { [weak self] (personaButtonState: MSFPersonaCarouselButtonConfiguration, index: Int) in
             self?.didTap(on: personaButtonState, at: index)
         }
 
@@ -205,13 +205,13 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
 
         // Create the PersonaButton to be displayed
         let personaButton = MSFPersonaButton(size: size)
-        let personaButtonState = personaButton.state
+        let personaButtonConfiguration = personaButton.configuration
         let persona = personas[indexPath.item]
-        personaButtonState.image = persona.image
-        personaButtonState.primaryText = persona.name
-        personaButtonState.secondaryText = persona.email
-        personaButtonState.onTapAction = { [weak self, weak personaButtonState] in
-            let alert = UIAlertController(title: nil, message: "PersonaButton tapped: \(personaButtonState?.primaryText ?? "(none)")", preferredStyle: .alert)
+        personaButtonConfiguration.image = persona.image
+        personaButtonConfiguration.primaryText = persona.name
+        personaButtonConfiguration.secondaryText = persona.email
+        personaButtonConfiguration.onTapAction = { [weak self, weak personaButtonConfiguration] in
+            let alert = UIAlertController(title: nil, message: "PersonaButton tapped: \(personaButtonConfiguration?.primaryText ?? "(none)")", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .default))
             self?.present(alert, animated: true)
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -96,8 +96,8 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
 
     // MARK: - Actions
 
-    private func didTap(on personaButtonState: MSFPersonaCarouselButtonConfiguration, at index: Int) {
-        let primaryText: String = personaButtonState.primaryText ?? "n/a"
+    private func didTap(on personaButtonConfiguration: MSFPersonaCarouselButtonConfiguration, at index: Int) {
+        let primaryText: String = personaButtonConfiguration.primaryText ?? "n/a"
         let alert = UIAlertController(title: "\(primaryText) at index \(index) was selected", message: nil, preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .default, handler: nil)
         alert.addAction(action)
@@ -171,8 +171,8 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
             add(persona, to: carousel)
         }
         carousels[size] = carousel
-        carousel.configuration.onTapAction = { [weak self] (personaButtonState: MSFPersonaCarouselButtonConfiguration, index: Int) in
-            self?.didTap(on: personaButtonState, at: index)
+        carousel.configuration.onTapAction = { [weak self] (personaButtonConfiguration: MSFPersonaCarouselButtonConfiguration, index: Int) in
+            self?.didTap(on: personaButtonConfiguration, at: index)
         }
 
         cell.contentView.addSubview(carousel.view)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -58,11 +58,11 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
     }
 
     func searchBarDidCancel(_ searchBar: SearchBar) {
-        searchBar.progressSpinner.state.isAnimating = false
+        searchBar.progressSpinner.configuration.isAnimating = false
     }
 
     func searchBarDidRequestSearch(_ searchBar: SearchBar) {
-        searchBar.progressSpinner.state.isAnimating = true
+        searchBar.progressSpinner.configuration.isAnimating = true
     }
 
     func searchBar(_ searchBar: SearchBar, didUpdateLeadingView leadingView: UIView?) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -50,8 +50,8 @@ class SideTabBarDemoController: DemoController {
 
             strongSelf.modifyBadgeNumbers(increment: 1)
         }
-        incrementBadgeButton.state.image = UIImage(named: "ic_fluent_add_20_regular")
-        incrementBadgeButton.state.accessibilityLabel = "Increment badge numbers"
+        incrementBadgeButton.configuration.image = UIImage(named: "ic_fluent_add_20_regular")
+        incrementBadgeButton.configuration.accessibilityLabel = "Increment badge numbers"
 
         return incrementBadgeButton
     }()
@@ -65,8 +65,8 @@ class SideTabBarDemoController: DemoController {
 
             strongSelf.modifyBadgeNumbers(increment: -1)
         }
-        decrementBadgeButton.state.image = UIImage(named: "ic_fluent_subtract_20_regular")
-        decrementBadgeButton.state.accessibilityLabel = "Decrement badge numbers"
+        decrementBadgeButton.configuration.image = UIImage(named: "ic_fluent_subtract_20_regular")
+        decrementBadgeButton.configuration.accessibilityLabel = "Decrement badge numbers"
 
         return decrementBadgeButton
     }()
@@ -182,10 +182,10 @@ class SideTabBarDemoController: DemoController {
         if let image = UIImage(named: "avatar_kat_larsson"), show {
             avatar = MSFAvatar(style: .accent,
                                size: .medium)
-            if let avatarState = avatar?.state {
-                avatarState.primaryText = "Kat Larson"
-                avatarState.image = image
-                avatarState.hasPointerInteraction = true
+            if let avatarConfiguration = avatar?.configuration {
+                avatarConfiguration.primaryText = "Kat Larson"
+                avatarConfiguration.image = image
+                avatarConfiguration.hasPointerInteraction = true
             }
         }
 
@@ -207,8 +207,8 @@ class SideTabBarDemoController: DemoController {
     }
 
     private func updateBadgeButtons() {
-        incrementBadgeButton.state.isDisabled = !showBadgeNumbers
-        decrementBadgeButton.state.isDisabled = !showBadgeNumbers
+        incrementBadgeButton.configuration.isDisabled = !showBadgeNumbers
+        decrementBadgeButton.configuration.isDisabled = !showBadgeNumbers
     }
 
     private func modifyBadgeNumbers(increment: Int) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -32,7 +32,7 @@ class TabBarViewDemoController: DemoController {
 
             strongSelf.incrementBadgeNumbers()
         })
-        button.state.text = "+"
+        button.configuration.text = "+"
 
         return button
     }()
@@ -45,7 +45,7 @@ class TabBarViewDemoController: DemoController {
 
             strongSelf.decrementBadgeNumbers()
         })
-        button.state.text = "-"
+        button.configuration.text = "-"
 
         return button
     }()
@@ -146,8 +146,8 @@ class TabBarViewDemoController: DemoController {
     }
 
     private func updateBadgeButtons() {
-        incrementBadgeButton.state.isDisabled = !showBadgeNumbers
-        decrementBadgeButton.state.isDisabled = !showBadgeNumbers
+        incrementBadgeButton.configuration.isDisabled = !showBadgeNumbers
+        decrementBadgeButton.configuration.isDisabled = !showBadgeNumbers
     }
 
     private func modifyBadgeNumbers(increment: Int) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -302,7 +302,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoTableViewController {
 
             strongSelf.perform(selector)
         }
-        button.state.image = UIImage(named: plus ? "ic_fluent_add_20_regular" : "ic_fluent_subtract_20_regular")
+        button.configuration.image = UIImage(named: plus ? "ic_fluent_add_20_regular" : "ic_fluent_subtract_20_regular")
 
         return button
     }

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
@@ -6,8 +6,8 @@
 import SwiftUI
 import UIKit
 
-/// Properties available to customize the state of the Activity Indicator state
-@objc public protocol MSFActivityIndicatorState {
+/// Properties available to customize the configuration of the Activity Indicator configuration
+@objc public protocol MSFActivityIndicatorConfiguration {
 
     /// Sets the accessibility label for the Activity Indicator.
     var accessibilityLabel: String? { get set }
@@ -34,25 +34,25 @@ public struct ActivityIndicator: View, ConfigurableTokenizedControl {
     /// Creates the ActivityIndicator.
     /// - Parameter size: The MSFActivityIndicatorSize value used by the Activity Indicator.
     public init(size: MSFActivityIndicatorSize) {
-        let state = MSFActivityIndicatorStateImpl(size: size)
-        self.state = state
+        let configuration = MSFActivityIndicatorConfigurationImpl(size: size)
+        self.configuration = configuration
     }
 
     public var body: some View {
         let side = tokens.side
         let color: Color = {
-            guard let stateUIColor = state.color else {
+            guard let configurationUIColor = configuration.color else {
                 return Color(dynamicColor: tokens.defaultColor)
             }
 
-            return Color(stateUIColor)
+            return Color(configurationUIColor)
         }()
         let accessibilityLabel: String = {
-            if let overriddenAccessibilityLabel = state.accessibilityLabel {
+            if let overriddenAccessibilityLabel = configuration.accessibilityLabel {
                 return overriddenAccessibilityLabel
             }
 
-            return state.isAnimating ?
+            return configuration.isAnimating ?
                 "Accessibility.ActivityIndicator.Animating.label".localized
                 :
                 "Accessibility.ActivityIndicator.Stopped.label".localized
@@ -61,20 +61,20 @@ public struct ActivityIndicator: View, ConfigurableTokenizedControl {
         SemiRing(color: color,
                  thickness: tokens.thickness,
                  accessibilityLabel: accessibilityLabel)
-            .modifyIf(state.isAnimating, { animatedView in
+            .modifyIf(configuration.isAnimating, { animatedView in
                 animatedView
                     .rotationEffect(.degrees(rotationAngle), anchor: .center)
                     .onAppear {
                         startAnimation()
                     }
             })
-            .modifyIf(!state.isAnimating) { staticView in
+            .modifyIf(!configuration.isAnimating) { staticView in
                 staticView
                     .onAppear {
                        stopAnimation()
                     }
             }
-            .modifyIf(!state.isAnimating && state.hidesWhenStopped, { view in
+            .modifyIf(!configuration.isAnimating && configuration.hidesWhenStopped, { view in
                 view.hidden()
             })
             .frame(width: side,
@@ -85,11 +85,11 @@ public struct ActivityIndicator: View, ConfigurableTokenizedControl {
     let defaultTokens: ActivityIndicatorTokens = .init()
     var tokens: ActivityIndicatorTokens {
         let tokens = resolvedTokens
-        tokens.size = state.size
+        tokens.size = configuration.size
         return tokens
     }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
-    @ObservedObject var state: MSFActivityIndicatorStateImpl
+    @ObservedObject var configuration: MSFActivityIndicatorConfigurationImpl
     @State var rotationAngle: Double = 0.0
 
     private struct SemiRing: View {
@@ -136,8 +136,8 @@ public struct ActivityIndicator: View, ConfigurableTokenizedControl {
     private let finalAnimationRotationAngle: Double = 360.0
 }
 
-/// Properties available to customize the state of the Activity Indicator
-class MSFActivityIndicatorStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFActivityIndicatorState {
+/// Properties available to customize the configuration of the Activity Indicator
+class MSFActivityIndicatorConfigurationImpl: NSObject, ObservableObject, ControlConfiguration, MSFActivityIndicatorConfiguration {
     @Published var overrideTokens: ActivityIndicatorTokens?
 
     @Published var color: UIColor?

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicatorModifiers.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicatorModifiers.swift
@@ -12,7 +12,7 @@ public extension ActivityIndicator {
     /// - Parameter accessibilityLabel: Accessibility label string.
     /// - Returns: The modified Activity Indicator with the property set.
     func accessibilityLabel(_ accessibilityLabel: String?) -> ActivityIndicator {
-        state.accessibilityLabel = accessibilityLabel
+        configuration.accessibilityLabel = accessibilityLabel
         return self
     }
 
@@ -20,7 +20,7 @@ public extension ActivityIndicator {
     /// - Parameter color: UIColor instance to be set.
     /// - Returns: The modified Activity Indicator with the property set.
     func color(_ color: UIColor?) -> ActivityIndicator {
-        state.color = color
+        configuration.color = color
         return self
     }
 
@@ -28,7 +28,7 @@ public extension ActivityIndicator {
     /// - Parameter isAnimating: Boolean value to set the property.
     /// - Returns: The modified Activity Indicator with the property set.
     func isAnimating(_ isAnimating: Bool) -> ActivityIndicator {
-        state.isAnimating = isAnimating
+        configuration.isAnimating = isAnimating
         return self
     }
 
@@ -36,13 +36,13 @@ public extension ActivityIndicator {
     /// - Parameter hidesWhenStopped: Boolean value to set the property.
     /// - Returns: The modified Activity Indicator with the property set.
     func hidesWhenStopped(_ hidesWhenStopped: Bool) -> ActivityIndicator {
-        state.hidesWhenStopped = hidesWhenStopped
+        configuration.hidesWhenStopped = hidesWhenStopped
         return self
     }
 
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: ActivityIndicatorTokens?) -> ActivityIndicator {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/ActivityIndicator/MSFActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/MSFActivityIndicator.swift
@@ -14,10 +14,10 @@ import UIKit
     ///   - size: The MSFActivityIndicatorSize value used by the Activity Indicator.
     @objc public init(size: MSFActivityIndicatorSize = .medium) {
         let activityIndicator = ActivityIndicator(size: size)
-        state = activityIndicator.state
+        configuration = activityIndicator.configuration
         super.init(AnyView(activityIndicator))
     }
 
     /// The object that groups properties that allow control over the Activity Indicator appearance.
-    @objc public let state: MSFActivityIndicatorState
+    @objc public let configuration: MSFActivityIndicatorConfiguration
 }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -19,7 +19,7 @@ import SwiftUI
     /// This property allows customizing the initials text color or the default image tint color.
     var foregroundColor: UIColor? { get set }
 
-    /// Configuress the Avatar with a button accessibility trait overriding its default image trait.
+    /// Configures the Avatar with a button accessibility trait overriding its default image trait.
     var hasButtonAccessibilityTrait: Bool { get set }
 
     /// Turns iPad Pointer interaction on/off.

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -103,8 +103,8 @@ public struct Avatar: View, ConfigurableTokenizedControl {
         let hasRingInnerGap = configuration.hasRingInnerGap
         let isTransparent = configuration.isTransparent
         let isOutOfOffice = configuration.isOutOfOffice
-        let initialsString: String = ((style == .overflow) ? configuration.primaryText ?? "" : Avatar.initialsText(fromPrimaryText: configuration.primaryText,
-                                                                                                           secondaryText: configuration.secondaryText))
+        let initialsString: String = ((style == .overflow) ? (configuration.primaryText ?? "") : Avatar.initialsText(fromPrimaryText: configuration.primaryText,
+                                                                                                                     secondaryText: configuration.secondaryText))
         let shouldUseCalculatedColors = !initialsString.isEmpty && style != .overflow
 
         let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
@@ -147,8 +147,8 @@ public struct Avatar: View, ConfigurableTokenizedControl {
         let ringGapColor = Color(dynamicColor: tokens.ringGapColor).opacity(isTransparent ? 0 : 1)
         let ringColor = !isRingVisible ? Color.clear :
         Color(dynamicColor: configuration.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
-                                                               tokens.ringDefaultColor :
-                                                                backgroundColor))
+                                                                       tokens.ringDefaultColor :
+                                                                        backgroundColor))
 
         let shouldUseDefaultImage = (configuration.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Properties that can be used to customize the appearance of the Avatar.
-@objc public protocol MSFAvatarState {
+@objc public protocol MSFAvatarConfiguration {
     /// Sets the accessibility label for the Avatar.
     var accessibilityLabel: String? { get set }
 
@@ -19,7 +19,7 @@ import SwiftUI
     /// This property allows customizing the initials text color or the default image tint color.
     var foregroundColor: UIColor? { get set }
 
-    /// Configures the Avatar with a button accessibility trait overriding its default image trait.
+    /// Configuress the Avatar with a button accessibility trait overriding its default image trait.
     var hasButtonAccessibilityTrait: Bool { get set }
 
     /// Turns iPad Pointer interaction on/off.
@@ -86,25 +86,25 @@ public struct Avatar: View, ConfigurableTokenizedControl {
                 image: UIImage? = nil,
                 primaryText: String? = nil,
                 secondaryText: String? = nil) {
-        let state = MSFAvatarStateImpl(style: style,
-                                       size: size)
-        state.image = image
-        state.primaryText = primaryText
-        state.secondaryText = secondaryText
+        let configuration = MSFAvatarConfigurationImpl(style: style,
+                                                       size: size)
+        configuration.image = image
+        configuration.primaryText = primaryText
+        configuration.secondaryText = secondaryText
 
-        self.state = state
+        self.configuration = configuration
     }
 
     public var body: some View {
         let style = tokens.style
-        let presence = state.presence
+        let presence = configuration.presence
         let shouldDisplayPresence = presence != .none
-        let isRingVisible = state.isRingVisible
-        let hasRingInnerGap = state.hasRingInnerGap
-        let isTransparent = state.isTransparent
-        let isOutOfOffice = state.isOutOfOffice
-        let initialsString: String = ((style == .overflow) ? state.primaryText ?? "" : Avatar.initialsText(fromPrimaryText: state.primaryText,
-                                                                                                           secondaryText: state.secondaryText))
+        let isRingVisible = configuration.isRingVisible
+        let hasRingInnerGap = configuration.hasRingInnerGap
+        let isTransparent = configuration.isTransparent
+        let isOutOfOffice = configuration.isOutOfOffice
+        let initialsString: String = ((style == .overflow) ? configuration.primaryText ?? "" : Avatar.initialsText(fromPrimaryText: configuration.primaryText,
+                                                                                                           secondaryText: configuration.secondaryText))
         let shouldUseCalculatedColors = !initialsString.isEmpty && style != .overflow
 
         let ringInnerGap: CGFloat = isRingVisible && hasRingInnerGap ? tokens.ringInnerGap : 0
@@ -134,40 +134,40 @@ public struct Avatar: View, ConfigurableTokenizedControl {
         let presenceIconFrameSideRelativeToOuterRing: CGFloat = presenceIconFrameSideRelativeToInnerRing + outerGapAndRingThicknesCombined
         let overallFrameSide = max(ringOuterGapSize, presenceIconFrameSideRelativeToOuterRing)
 
-        let foregroundColor = state.foregroundColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
+        let foregroundColor = configuration.foregroundColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                        tokens.foregroundDefaultColor :
-                                                                        initialsCalculatedColor(fromPrimaryText: state.primaryText,
-                                                                                                secondaryText: state.secondaryText,
+                                                                        initialsCalculatedColor(fromPrimaryText: configuration.primaryText,
+                                                                                                secondaryText: configuration.secondaryText,
                                                                                                 colorOptions: tokens.foregroundCalculatedColorOptions))
-        let backgroundColor = state.backgroundColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
+        let backgroundColor = configuration.backgroundColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                        tokens.backgroundDefaultColor :
-                                                                        initialsCalculatedColor(fromPrimaryText: state.primaryText,
-                                                                                                secondaryText: state.secondaryText,
+                                                                        initialsCalculatedColor(fromPrimaryText: configuration.primaryText,
+                                                                                                secondaryText: configuration.secondaryText,
                                                                                                 colorOptions: tokens.backgroundCalculatedColorOptions))
         let ringGapColor = Color(dynamicColor: tokens.ringGapColor).opacity(isTransparent ? 0 : 1)
         let ringColor = !isRingVisible ? Color.clear :
-        Color(dynamicColor: state.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
+        Color(dynamicColor: configuration.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                tokens.ringDefaultColor :
                                                                 backgroundColor))
 
-        let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
+        let shouldUseDefaultImage = (configuration.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
             if shouldUseDefaultImage {
                 let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
                 return (UIImage.staticImageNamed(isOutlinedStyle ? "person_48_regular" : "person_48_filled"), .template)
             }
 
-            return (state.image, .original)
+            return (configuration.image, .original)
         }()
         let avatarImageSizeRatio: CGFloat = (shouldUseDefaultImage) ? 0.7 : 1
 
         let accessibilityLabel: String = {
-            if let overriddenAccessibilityLabel = state.accessibilityLabel {
+            if let overriddenAccessibilityLabel = configuration.accessibilityLabel {
                 return overriddenAccessibilityLabel
             }
 
-            let defaultAccessibilityText = state.primaryText ?? state.secondaryText ?? ""
-            return (state.isOutOfOffice ?
+            let defaultAccessibilityText = configuration.primaryText ?? configuration.secondaryText ?? ""
+            return (configuration.isOutOfOffice ?
                         String.localizedStringWithFormat("Accessibility.AvatarView.LabelFormat".localized, defaultAccessibilityText, "Presence.OOF".localized) :
                         defaultAccessibilityText)
         }()
@@ -190,7 +190,7 @@ public struct Avatar: View, ConfigurableTokenizedControl {
         // This variable is not going to be computed in that scenario.
         @ViewBuilder
         var avatarRingView: some View {
-            if let imageBasedRingColor = state.imageBasedRingColor {
+            if let imageBasedRingColor = configuration.imageBasedRingColor {
                 // The potentially maximum size of the ring view must be used in order to avoid abrupt
                 // transitions during the animation as the ImagePaint scale value is not animatable.
                 let ringMaxSize = avatarImageSize + (tokens.ringInnerGap + tokens.ringThickness) * 2
@@ -264,10 +264,10 @@ public struct Avatar: View, ConfigurableTokenizedControl {
         }
 
         return avatarBody
-            .pointerInteraction(state.hasPointerInteraction)
-            .animation(state.isAnimated ? .linear(duration: animationDuration) : .none)
+            .pointerInteraction(configuration.hasPointerInteraction)
+            .animation(configuration.isAnimated ? .linear(duration: animationDuration) : .none)
             .accessibilityElement(children: .ignore)
-            .accessibility(addTraits: state.hasButtonAccessibilityTrait ? .isButton : .isImage)
+            .accessibility(addTraits: configuration.hasButtonAccessibilityTrait ? .isButton : .isImage)
             .accessibility(label: Text(accessibilityLabel))
             .accessibility(value: Text(presence.string() ?? ""))
     }
@@ -306,20 +306,20 @@ public struct Avatar: View, ConfigurableTokenizedControl {
     }
 
     // This initializer should be used by internal container views. These containers should first initialize
-    // MSFAvatarStateImpl using style and size, and then use that state and this initializer in their ViewBuilder.
-    init(_ avatarState: MSFAvatarStateImpl) {
-        state = avatarState
+    // MSFAvatarConfigurationImpl using style and size, and then use that configuration and this initializer in their ViewBuilder.
+    init(_ avatarConfiguration: MSFAvatarConfigurationImpl) {
+        configuration = avatarConfiguration
     }
 
     /// Calculates the size of the avatar, including ring spacing
     var totalSize: CGFloat {
         let avatarImageSize: CGFloat = tokens.avatarSize
         let ringOuterGap: CGFloat = tokens.ringOuterGap
-        if !state.isRingVisible {
+        if !configuration.isRingVisible {
             return avatarImageSize + (ringOuterGap * 2)
         } else {
             let ringThickness: CGFloat = tokens.ringThickness
-            let ringInnerGap: CGFloat = state.hasRingInnerGap ? tokens.ringInnerGap : 0
+            let ringInnerGap: CGFloat = configuration.hasRingInnerGap ? tokens.ringInnerGap : 0
             return ((ringInnerGap + ringThickness + ringOuterGap) * 2 + avatarImageSize)
         }
     }
@@ -333,11 +333,11 @@ public struct Avatar: View, ConfigurableTokenizedControl {
     let defaultTokens: AvatarTokens = .init()
     var tokens: AvatarTokens {
         let tokens = resolvedTokens
-        tokens.size = state.size
-        tokens.style = state.style
+        tokens.size = configuration.size
+        tokens.style = configuration.style
         return tokens
     }
-    @ObservedObject var state: MSFAvatarStateImpl
+    @ObservedObject var configuration: MSFAvatarConfigurationImpl
 
     private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
         var combined: String
@@ -442,8 +442,8 @@ public struct Avatar: View, ConfigurableTokenizedControl {
     private let animationDuration: Double = 0.1
 }
 
-/// Properties available to customize the state of the avatar
-class MSFAvatarStateImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFAvatarState {
+/// Properties available to customize the configuration of the avatar
+class MSFAvatarConfigurationImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFAvatarConfiguration {
     public var id = UUID()
 
     @Published var backgroundColor: UIColor?

--- a/ios/FluentUI/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Avatar/AvatarModifiers.swift
@@ -12,7 +12,7 @@ public extension Avatar {
     /// - Parameter accessibilityLabel: Accessibility label string.
     /// - Returns: The modified Avatar with the property set.
     func accessibilityLabel(_ accessibilityLabel: String?) -> Avatar {
-        state.accessibilityLabel = accessibilityLabel
+        configuration.accessibilityLabel = accessibilityLabel
         return self
     }
 
@@ -21,7 +21,7 @@ public extension Avatar {
     /// - Parameter backgroundColor: Background color.
     /// - Returns: The modified Avatar with the property set.
     func backgroundColor(_ backgroundColor: UIColor?) -> Avatar {
-        state.backgroundColor = backgroundColor
+        configuration.backgroundColor = backgroundColor
         return self
     }
 
@@ -30,7 +30,7 @@ public extension Avatar {
     /// - Parameter foregroundColor: Foreground color.
     /// - Returns: The modified Avatar with the property set.
     func foregroundColor(_ foregroundColor: UIColor?) -> Avatar {
-        state.foregroundColor = foregroundColor
+        configuration.foregroundColor = foregroundColor
         return self
     }
 
@@ -38,7 +38,7 @@ public extension Avatar {
     /// - Parameter hasPointerInteraction: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.
     func hasPointerInteraction(_ hasPointerInteraction: Bool) -> Avatar {
-        state.hasPointerInteraction = hasPointerInteraction
+        configuration.hasPointerInteraction = hasPointerInteraction
         return self
     }
 
@@ -46,7 +46,7 @@ public extension Avatar {
     /// - Parameter hasRingInnerGap: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.
     func hasRingInnerGap(_ hasRingInnerGap: Bool) -> Avatar {
-        state.hasRingInnerGap = hasRingInnerGap
+        configuration.hasRingInnerGap = hasRingInnerGap
         return self
     }
 
@@ -54,7 +54,7 @@ public extension Avatar {
     /// - Parameter imageBasedRingColor: Image to be used as a the ring fill pattern.
     /// - Returns: The modified Avatar with the property set.
     func imageBasedRingColor(_ imageBasedRingColor: UIImage?) -> Avatar {
-        state.imageBasedRingColor = imageBasedRingColor
+        configuration.imageBasedRingColor = imageBasedRingColor
         return self
     }
 
@@ -62,7 +62,7 @@ public extension Avatar {
     /// - Parameter isAnimated: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.
     func isAnimated(_ isAnimated: Bool) -> Avatar {
-        state.isAnimated = isAnimated
+        configuration.isAnimated = isAnimated
         return self
     }
 
@@ -70,7 +70,7 @@ public extension Avatar {
     /// - Parameter isOutOfOffice: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.
     func isOutOfOffice(_ isOutOfOffice: Bool) -> Avatar {
-        state.isOutOfOffice = isOutOfOffice
+        configuration.isOutOfOffice = isOutOfOffice
         return self
     }
 
@@ -79,7 +79,7 @@ public extension Avatar {
     /// - Parameter isRingVisible: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.
     func isRingVisible(_ isRingVisible: Bool) -> Avatar {
-        state.isRingVisible = isRingVisible
+        configuration.isRingVisible = isRingVisible
         return self
     }
 
@@ -88,13 +88,13 @@ public extension Avatar {
     /// - Parameter isTransparent: Boolean value to set the property.
     /// - Returns: The modified Avatar with the property set.
     func isTransparent(_ isTransparent: Bool) -> Avatar {
-        state.isTransparent = isTransparent
+        configuration.isTransparent = isTransparent
         return self
     }
 
     /// Provides a custom design token set to be used when drawing this control
     func overrideTokens(_ tokens: AvatarTokens?) -> Avatar {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 
@@ -104,7 +104,7 @@ public extension Avatar {
     /// - Parameter presence: The MSFAvatarPresence enum value.
     /// - Returns: The modified Avatar with the property set.
     func presence(_ presence: MSFAvatarPresence) -> Avatar {
-        state.presence = presence
+        configuration.presence = presence
         return self
     }
 
@@ -112,7 +112,7 @@ public extension Avatar {
     /// - Parameter ringColor: The color used to set the ring color.
     /// - Returns: The modified Avatar with the property set.
     func ringColor(_ ringColor: UIColor?) -> Avatar {
-        state.ringColor = ringColor
+        configuration.ringColor = ringColor
         return self
     }
 }

--- a/ios/FluentUI/Avatar/MSFAvatar.swift
+++ b/ios/FluentUI/Avatar/MSFAvatar.swift
@@ -17,10 +17,10 @@ import SwiftUI
                       size: MSFAvatarSize = .large) {
         let avatar = Avatar(style: style,
                             size: size)
-        state = avatar.state
+        configuration = avatar.configuration
         super.init(AnyView(avatar))
     }
 
     /// The object that groups properties that allow control over the Avatar appearance.
-    @objc public let state: MSFAvatarState
+    @objc public let configuration: MSFAvatarConfiguration
 }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Properties that can be used to customize the appearance of the AvatarGroup.
-@objc public protocol MSFAvatarGroupState {
+@objc public protocol MSFAvatarGroupConfiguration {
 
     /// Caps the number of displayed avatars and shows the remaining not displayed in the overflow avatar.
     var maxDisplayedAvatars: Int { get set }
@@ -23,14 +23,14 @@ import SwiftUI
     var size: MSFAvatarSize { get set }
 
     /// Creates a new Avatar within the AvatarGroup.
-    func createAvatar() -> MSFAvatarGroupAvatarState
+    func createAvatar() -> MSFAvatarGroupAvatarConfiguration
 
     /// Creates a new Avatar within the AvatarGroup at a specific index.
-    func createAvatar(at index: Int) -> MSFAvatarGroupAvatarState
+    func createAvatar(at index: Int) -> MSFAvatarGroupAvatarConfiguration
 
-    /// Retrieves the state object for a specific Avatar so its appearance can be customized.
+    /// Retrieves the configuration object for a specific Avatar so its appearance can be customized.
     /// - Parameter index: The zero-based index of the Avatar in the AvatarGroup.
-    func getAvatarState(at index: Int) -> MSFAvatarGroupAvatarState
+    func getAvatarConfiguration(at index: Int) -> MSFAvatarGroupAvatarConfiguration
 
     /// Remove an Avatar from the AvatarGroup.
     /// - Parameter index: The zero-based index of the Avatar that will be removed from the AvatarGroup.
@@ -49,7 +49,7 @@ import SwiftUI
 }
 
 /// Properties that can be used to customize the appearance of the Avatar in the AvatarGroup.
-@objc public protocol MSFAvatarGroupAvatarState {
+@objc public protocol MSFAvatarGroupAvatarConfiguration {
     /// Sets the accessibility label for the Avatar.
     var accessibilityLabel: String? { get set }
 
@@ -98,9 +98,9 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
     ///   - size: The size of the avatars displayed in the avatar group.
     init(style: MSFAvatarGroupStyle,
          size: MSFAvatarSize) {
-        let state = MSFAvatarGroupStateImpl(style: style,
+        let configuration = MSFAvatarGroupConfigurationImpl(style: style,
                                             size: size)
-        self.state = state
+        self.configuration = configuration
     }
 
     /// Renders the avatar with an optional cutout for the Stack group style.
@@ -121,13 +121,13 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
     }
 
     public var body: some View {
-        let avatars: [MSFAvatarStateImpl] = state.avatars
+        let avatars: [MSFAvatarConfigurationImpl] = configuration.avatars
         let avatarViews: [Avatar] = avatars.map { Avatar($0) }
         let enumeratedAvatars = Array(avatars.enumerated())
         let avatarCount: Int = avatars.count
-        let maxDisplayedAvatars: Int = state.maxDisplayedAvatars
+        let maxDisplayedAvatars: Int = configuration.maxDisplayedAvatars
         let avatarsToDisplay: Int = min(maxDisplayedAvatars, avatarCount)
-        let overflowCount: Int = (avatarCount > maxDisplayedAvatars ? avatarCount - maxDisplayedAvatars : 0) + state.overflowCount
+        let overflowCount: Int = (avatarCount > maxDisplayedAvatars ? avatarCount - maxDisplayedAvatars : 0) + configuration.overflowCount
         let hasOverflow: Bool = overflowCount > 0
         let isStackStyle = tokens.style == .stack
 
@@ -210,41 +210,41 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
     let defaultTokens: AvatarGroupTokens = .init()
     var tokens: AvatarGroupTokens {
         let tokens = resolvedTokens
-        tokens.size = state.size
-        tokens.style = state.style
+        tokens.size = configuration.size
+        tokens.style = configuration.style
         return tokens
     }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.layoutDirection) var layoutDirection: LayoutDirection
-    @ObservedObject var state: MSFAvatarGroupStateImpl
+    @ObservedObject var configuration: MSFAvatarGroupConfigurationImpl
 
     private let animationDuration: CGFloat = 0.1
 
     private func createOverflow(count: Int) -> Avatar {
-        var avatar = Avatar(style: .overflow, size: state.size)
-        let data = MSFAvatarStateImpl(style: .overflow, size: state.size)
+        var avatar = Avatar(style: .overflow, size: configuration.size)
+        let data = MSFAvatarConfigurationImpl(style: .overflow, size: configuration.size)
         data.primaryText = "\(count)"
         data.image = nil
-        avatar.state = data
+        avatar.configuration = data
         return avatar
     }
 }
 
-class MSFAvatarGroupStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFAvatarGroupState {
-    func createAvatar() -> MSFAvatarGroupAvatarState {
+class MSFAvatarGroupConfigurationImpl: NSObject, ObservableObject, ControlConfiguration, MSFAvatarGroupConfiguration {
+    func createAvatar() -> MSFAvatarGroupAvatarConfiguration {
         return createAvatar(at: avatars.endIndex)
     }
 
-    func createAvatar(at index: Int) -> MSFAvatarGroupAvatarState {
+    func createAvatar(at index: Int) -> MSFAvatarGroupAvatarConfiguration {
         guard index <= avatars.count && index >= 0 else {
             preconditionFailure("Index is out of bounds")
         }
-        let avatar = MSFAvatarGroupAvatarStateImpl(size: size)
+        let avatar = MSFAvatarGroupAvatarConfigurationImpl(size: size)
         avatars.insert(avatar, at: index)
         return avatar
     }
 
-    func getAvatarState(at index: Int) -> MSFAvatarGroupAvatarState {
+    func getAvatarConfiguration(at index: Int) -> MSFAvatarGroupAvatarConfiguration {
         guard avatars.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }
@@ -258,7 +258,7 @@ class MSFAvatarGroupStateImpl: NSObject, ObservableObject, ControlConfiguration,
         avatars.remove(at: index)
     }
 
-    @Published var avatars: [MSFAvatarGroupAvatarStateImpl] = []
+    @Published var avatars: [MSFAvatarGroupAvatarConfigurationImpl] = []
     @Published var maxDisplayedAvatars: Int = Int.max
     @Published var overflowCount: Int = 0
 
@@ -276,7 +276,7 @@ class MSFAvatarGroupStateImpl: NSObject, ObservableObject, ControlConfiguration,
     }
 }
 
-class MSFAvatarGroupAvatarStateImpl: MSFAvatarStateImpl, MSFAvatarGroupAvatarState {
+class MSFAvatarGroupAvatarConfigurationImpl: MSFAvatarConfigurationImpl, MSFAvatarGroupAvatarConfiguration {
     init(size: MSFAvatarSize) {
         super.init(style: .default, size: size)
     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroupModifiers.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroupModifiers.swift
@@ -9,7 +9,7 @@ import SwiftUI
 public extension AvatarGroup {
     /// Provides a custom design token set to be used when drawing this control
     func overrideTokens(_ tokens: AvatarGroupTokens?) -> AvatarGroup {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/AvatarGroup/MSFAvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/MSFAvatarGroup.swift
@@ -17,11 +17,11 @@ import SwiftUI
                       size: MSFAvatarSize) {
         let avatarGroup = AvatarGroup(style: style,
                                      size: size)
-        state = avatarGroup.state
+        configuration = avatarGroup.configuration
         super.init(AnyView(avatarGroup))
         view.backgroundColor = UIColor.clear
     }
 
     /// The object that groups properties that allow control over the AvatarGroup appearance.
-    @objc public let state: MSFAvatarGroupState
+    @objc public let configuration: MSFAvatarGroupConfiguration
 }

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -602,7 +602,7 @@ open class BadgeField: UIView {
         badge.isActive = isActive
         badges.append(badge)
         addSubview(badge)
-        // Configure drag gesture
+        // Configures drag gesture
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))
         longPressGestureRecognizer.minimumPressDuration = Constants.dragAndDropMinimumPressDuration
         badge.addGestureRecognizer(longPressGestureRecognizer)

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -602,7 +602,7 @@ open class BadgeField: UIView {
         badge.isActive = isActive
         badges.append(badge)
         addSubview(badge)
-        // Configures drag gesture
+        // Configure drag gesture
         let longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPressGesture(_:)))
         longPressGestureRecognizer.minimumPressDuration = Constants.dragAndDropMinimumPressDuration
         badge.addGestureRecognizer(longPressGestureRecognizer)

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -6,10 +6,10 @@
 import SwiftUI
 
 /// Type of callback for both action and dismiss buttons.
-public typealias CardNudgeButtonAction = ((_ state: MSFCardNudgeState) -> Void)
+public typealias CardNudgeButtonAction = ((_ state: MSFCardNudgeConfiguration) -> Void)
 
 /// Properties that can be used to customize the appearance of the `CardNudge`.
-@objc public protocol MSFCardNudgeState: NSObjectProtocol {
+@objc public protocol MSFCardNudgeConfiguration: NSObjectProtocol {
     /// Style to draw the control.
     @objc var style: MSFCardNudgeStyle { get set }
 
@@ -48,17 +48,17 @@ public typealias CardNudgeButtonAction = ((_ state: MSFCardNudgeState) -> Void)
 /// View that represents the CardNudge.
 public struct CardNudge: View, ConfigurableTokenizedControl {
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
-    @ObservedObject var state: MSFCardNudgeStateImpl
+    @ObservedObject var configuration: MSFCardNudgeConfigurationImpl
     let defaultTokens: CardNudgeTokens = .init()
     var tokens: CardNudgeTokens {
         let tokens = resolvedTokens
-        tokens.style = state.style
+        tokens.style = configuration.style
         return tokens
     }
 
     @ViewBuilder
     var icon: some View {
-        if let icon = state.mainIcon {
+        if let icon = configuration.mainIcon {
             ZStack {
                 RoundedRectangle(cornerRadius: tokens.circleRadius)
                     .frame(width: tokens.circleSize, height: tokens.circleSize)
@@ -73,13 +73,13 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
     }
 
     private var hasSecondTextRow: Bool {
-        state.accentIcon != nil || state.accentText != nil || state.subtitle != nil
+        configuration.accentIcon != nil || configuration.accentText != nil || configuration.subtitle != nil
     }
 
     @ViewBuilder
     var textContainer: some View {
         VStack(alignment: .leading, spacing: tokens.interTextVerticalPadding) {
-            Text(state.title)
+            Text(configuration.title)
                 .font(.subheadline)
                 .fontWeight(.medium)
                 .lineLimit(1)
@@ -87,20 +87,20 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
 
             if hasSecondTextRow {
                 HStack(spacing: tokens.accentPadding) {
-                    if let accentIcon = state.accentIcon {
+                    if let accentIcon = configuration.accentIcon {
                         Image(uiImage: accentIcon)
                             .renderingMode(.template)
                             .frame(width: tokens.accentIconSize, height: tokens.accentIconSize)
                             .foregroundColor(Color(dynamicColor: tokens.accentColor))
                     }
-                    if let accent = state.accentText {
+                    if let accent = configuration.accentText {
                         Text(accent)
                             .font(.subheadline)
                             .layoutPriority(1)
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.accentColor))
                     }
-                    if let subtitle = state.subtitle {
+                    if let subtitle = configuration.subtitle {
                         Text(subtitle)
                             .font(.subheadline)
                             .lineLimit(1)
@@ -114,10 +114,10 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
     @ViewBuilder
     var buttons: some View {
         HStack(spacing: 0) {
-            if let actionTitle = state.actionButtonTitle,
-                      let action = state.actionButtonAction {
+            if let actionTitle = configuration.actionButtonTitle,
+                      let action = configuration.actionButtonAction {
                 SwiftUI.Button(actionTitle) {
-                    action(state)
+                    action(configuration)
                 }
                 .lineLimit(1)
                 .padding(.horizontal, tokens.buttonInnerPaddingHorizontal)
@@ -128,9 +128,9 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                         .foregroundColor(Color(dynamicColor: tokens.buttonBackgroundColor))
                 )
             }
-            if let dismissAction = state.dismissButtonAction {
+            if let dismissAction = configuration.dismissButtonAction {
                 SwiftUI.Button(action: {
-                    dismissAction(state)
+                    dismissAction(configuration)
                 }, label: {
                     Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
                 })
@@ -172,12 +172,12 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
     }
 
     public init(style: MSFCardNudgeStyle, title: String) {
-        let state = MSFCardNudgeStateImpl(style: style, title: title)
-        self.state = state
+        let configuration = MSFCardNudgeConfigurationImpl(style: style, title: title)
+        self.configuration = configuration
     }
 }
 
-class MSFCardNudgeStateImpl: NSObject, ControlConfiguration, MSFCardNudgeState {
+class MSFCardNudgeConfigurationImpl: NSObject, ControlConfiguration, MSFCardNudgeConfiguration {
     @Published var title: String
     @Published var subtitle: String?
     @Published var mainIcon: UIImage?

--- a/ios/FluentUI/Card Nudge/CardNudgeModifiers.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeModifiers.swift
@@ -8,25 +8,25 @@ import SwiftUI
 public extension CardNudge {
     /// Optional subtext to draw below the main title area.
     func subtitle(_ subtitle: String?) -> CardNudge {
-        state.subtitle = subtitle
+        configuration.subtitle = subtitle
         return self
     }
 
     /// Optional icon to draw at the leading edge of the control.
     func mainIcon(_ mainIcon: UIImage?) -> CardNudge {
-        state.mainIcon = mainIcon
+        configuration.mainIcon = mainIcon
         return self
     }
 
     /// Optional accented text to draw below the main title area.
     func accentText(_ accentText: String?) -> CardNudge {
-        state.accentText = accentText
+        configuration.accentText = accentText
         return self
     }
 
     /// Optional small icon to draw at the leading edge of `accentText`.
     func accentIcon(_ accentIcon: UIImage?) -> CardNudge {
-        state.accentIcon = accentIcon
+        configuration.accentIcon = accentIcon
         return self
     }
 
@@ -34,7 +34,7 @@ public extension CardNudge {
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
     func actionButtonTitle(_ actionButtonTitle: String?) -> CardNudge {
-        state.actionButtonTitle = actionButtonTitle
+        configuration.actionButtonTitle = actionButtonTitle
         return self
     }
 
@@ -42,19 +42,19 @@ public extension CardNudge {
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
     func actionButtonAction(_ actionButtonAction: CardNudgeButtonAction?) -> CardNudge {
-        state.actionButtonAction = actionButtonAction
+        configuration.actionButtonAction = actionButtonAction
         return self
     }
 
     /// Action to be dispatched by the dismiss ("close") button on the trailing edge of the control.
     func dismissButtonAction(_ dismissButtonAction: CardNudgeButtonAction?) -> CardNudge {
-        state.dismissButtonAction = dismissButtonAction
+        configuration.dismissButtonAction = dismissButtonAction
         return self
     }
 
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: CardNudgeTokens?) -> CardNudge {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/Card Nudge/MSFCardNudge.swift
+++ b/ios/FluentUI/Card Nudge/MSFCardNudge.swift
@@ -17,10 +17,10 @@ import UIKit
     @objc public init(style: MSFCardNudgeStyle,
                       title: String) {
         let cardNudge = CardNudge(style: style, title: title)
-        state = cardNudge.state
+        configuration = cardNudge.configuration
         super.init(AnyView(cardNudge))
     }
 
     /// The object that groups properties that allow control over the Card Nudge appearance.
-    @objc public let state: MSFCardNudgeState
+    @objc public let configuration: MSFCardNudgeConfiguration
 }

--- a/ios/FluentUI/Core/Theme/Tokens/ConfigurableTokenizedControl.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ConfigurableTokenizedControl.swift
@@ -18,12 +18,12 @@ protocol ConfigurableTokenizedControl: TokenizedControlInternal {
     associatedtype ConfigurationType: ControlConfiguration where ConfigurationType.TokenType == TokenType
 
     /// Contains additional configuration information about the control.
-    var state: ConfigurationType { get }
+    var configuration: ConfigurationType { get }
 }
 
 // MARK: - Extensions
 
 /// This set of extensions implements the `TokenizedControlInternal` APIs for SwiftUI components.
 extension ConfigurableTokenizedControl {
-    var overrideTokens: TokenType? { state.overrideTokens }
+    var overrideTokens: TokenType? { configuration.overrideTokens }
 }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -497,7 +497,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // Configure the resizing handle view according to resizing behaviour and disable the gesture recogniser(if any) till view actually appears
+        // Configures the resizing handle view according to resizing behaviour and disable the gesture recogniser(if any) till view actually appears
         updateResizingHandleView()
         resizingGestureRecognizer?.isEnabled = false
 

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -497,7 +497,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // Configures the resizing handle view according to resizing behaviour and disable the gesture recogniser(if any) till view actually appears
+        // Configure the resizing handle view according to resizing behaviour and disable the gesture recogniser(if any) till view actually appears
         updateResizingHandleView()
         resizingGestureRecognizer?.isEnabled = false
 

--- a/ios/FluentUI/HUD/HUDView.swift
+++ b/ios/FluentUI/HUD/HUDView.swift
@@ -188,8 +188,8 @@ class HUDView: UIView {
         switch type {
         case .activity:
             let activityIndicator = MSFActivityIndicator(size: .xLarge)
-            activityIndicator.state.color = Colors.HUD.activityIndicator
-            activityIndicator.state.isAnimating = true
+            activityIndicator.configuration.color = Colors.HUD.activityIndicator
+            activityIndicator.configuration.isAnimating = true
             return activityIndicator.view
         case .success:
             let imageView = UIImageView(image: .staticImageNamed("checkmark-36x36"))

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -6,8 +6,8 @@
 import SwiftUI
 import UIKit
 
-/// Properties available to customize the state of the Indeterminate Progress Bar.
-@objc public protocol MSFIndeterminateProgressBarState {
+/// Properties available to customize the configuration of the Indeterminate Progress Bar.
+@objc public protocol MSFIndeterminateProgressBarConfiguration {
     /// Defines whether the Indeterminate Progress Bar is animating or stopped.
     var isAnimating: Bool { get set }
 
@@ -21,8 +21,8 @@ import UIKit
 public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
     /// Creates the Indeterminate Progress Bar.
     public init() {
-        let state = MSFIndeterminateProgressBarStateImpl()
-        self.state = state
+        let configuration = MSFIndeterminateProgressBarConfigurationImpl()
+        self.configuration = configuration
         startPoint = Constants.Coordinates(isRTLLanguage).initialStartPoint
         endPoint = Constants.Coordinates(isRTLLanguage).initialEndPoint
     }
@@ -42,19 +42,19 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
                    maxHeight: height,
                    alignment: .center)
             .background(backgroundColor)
-            .modifyIf(state.isAnimating, { view in
+            .modifyIf(configuration.isAnimating, { view in
                 view
                     .onAppear {
                         startAnimation()
                     }
             })
-            .modifyIf(!state.isAnimating) { view in
+            .modifyIf(!configuration.isAnimating) { view in
                 view
                     .onAppear {
                        stopAnimation()
                     }
             }
-            .modifyIf(!state.isAnimating && state.hidesWhenStopped, { view in
+            .modifyIf(!configuration.isAnimating && configuration.hidesWhenStopped, { view in
                 view.hidden()
             })
     }
@@ -65,7 +65,7 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
     }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.layoutDirection) var layoutDirection: LayoutDirection
-    @ObservedObject var state: MSFIndeterminateProgressBarStateImpl
+    @ObservedObject var configuration: MSFIndeterminateProgressBarConfigurationImpl
     @State var startPoint: UnitPoint = .zero
     @State var endPoint: UnitPoint = .zero
     var isRTLLanguage: Bool {
@@ -106,11 +106,11 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
     }
 }
 
-/// Properties available to customize the state of the Indeterminate Progress Bar
-class MSFIndeterminateProgressBarStateImpl: NSObject,
-                                            ObservableObject,
-                                            ControlConfiguration,
-                                            MSFIndeterminateProgressBarState {
+/// Properties available to customize the configuration of the Indeterminate Progress Bar
+class MSFIndeterminateProgressBarConfigurationImpl: NSObject,
+                                                    ObservableObject,
+                                                    ControlConfiguration,
+                                                    MSFIndeterminateProgressBarConfiguration {
     @Published var isAnimating: Bool = false
     @Published var hidesWhenStopped: Bool = true
 

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarModifiers.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarModifiers.swift
@@ -12,7 +12,7 @@ public extension IndeterminateProgressBar {
     /// - Parameter isAnimating: Boolean value to set the property.
     /// - Returns: The modified Indeterminate Progress Bar with the property set.
     func isAnimating(_ isAnimating: Bool) -> IndeterminateProgressBar {
-        state.isAnimating = isAnimating
+        configuration.isAnimating = isAnimating
         return self
     }
 
@@ -20,13 +20,13 @@ public extension IndeterminateProgressBar {
     /// - Parameter hidesWhenStopped: Boolean value to set the property.
     /// - Returns: The modified Indeterminate Progress Bar with the property set.
     func hidesWhenStopped(_ hidesWhenStopped: Bool) -> IndeterminateProgressBar {
-        state.hidesWhenStopped = hidesWhenStopped
+        configuration.hidesWhenStopped = hidesWhenStopped
         return self
     }
 
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: IndeterminateProgressBarTokens?) -> IndeterminateProgressBar {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/IndeterminateProgressBar/MSFIndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/MSFIndeterminateProgressBar.swift
@@ -12,10 +12,10 @@ import UIKit
     /// Creates a new MSFIndeterminateProgressBar instance.
     @objc public init() {
         let indeterminateProgressBar = IndeterminateProgressBar()
-        state = indeterminateProgressBar.state
+        configuration = indeterminateProgressBar.configuration
         super.init(AnyView(indeterminateProgressBar))
     }
 
     /// The object that groups properties that allow control over the Indeterminate Progress Bar appearance.
-    @objc public let state: MSFIndeterminateProgressBarState
+    @objc public let configuration: MSFIndeterminateProgressBarConfiguration
 }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -473,7 +473,7 @@ open class SearchBar: UIView {
         // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
-        progressSpinner.state.color = style.progressSpinnerColor
+        progressSpinner.configuration.color = style.progressSpinnerColor
         cancelButton.setTitleColor(style.cancelButtonColor, for: .normal)
         attributePlaceholderText()
     }

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -28,19 +28,19 @@ class LargeTitleView: UIView {
         didSet {
             updateProfileButtonVisibility()
 
-            if let avatarState = avatar?.state {
-                avatarState.primaryText = personaData?.name
-                avatarState.secondaryText = personaData?.email
-                avatarState.image = personaData?.image
-                avatarState.imageBasedRingColor = personaData?.imageBasedRingColor
-                avatarState.hasRingInnerGap = personaData?.hasRingInnerGap ?? true
-                avatarState.isRingVisible = personaData?.isRingVisible ?? false
-                avatarState.presence = personaData?.presence ?? .none
-                avatarState.isOutOfOffice = personaData?.isOutOfOffice ?? false
+            if let avatarConfiguration = avatar?.configuration {
+                avatarConfiguration.primaryText = personaData?.name
+                avatarConfiguration.secondaryText = personaData?.email
+                avatarConfiguration.image = personaData?.image
+                avatarConfiguration.imageBasedRingColor = personaData?.imageBasedRingColor
+                avatarConfiguration.hasRingInnerGap = personaData?.hasRingInnerGap ?? true
+                avatarConfiguration.isRingVisible = personaData?.isRingVisible ?? false
+                avatarConfiguration.presence = personaData?.presence ?? .none
+                avatarConfiguration.isOutOfOffice = personaData?.isOutOfOffice ?? false
 
                 let color = personaData?.color
-                avatarState.backgroundColor = color
-                avatarState.ringColor = color
+                avatarConfiguration.backgroundColor = color
+                avatarConfiguration.ringColor = color
             }
         }
     }
@@ -51,9 +51,9 @@ class LargeTitleView: UIView {
             case .automatic:
                 return
             case .contracted:
-                avatar?.state.size = Constants.compactAvatarSize
+                avatar?.configuration.size = Constants.compactAvatarSize
             case .expanded:
-                avatar?.state.size = Constants.avatarSize
+                avatar?.configuration.size = Constants.avatarSize
             }
         }
     }
@@ -72,7 +72,7 @@ class LargeTitleView: UIView {
         didSet {
             if let style = avatarOverrideStyle {
                 updateProfileButtonVisibility()
-                avatar?.state.style = style
+                avatar?.configuration.style = style
             }
         }
     }
@@ -80,7 +80,7 @@ class LargeTitleView: UIView {
     var style: Style = .light {
         didSet {
             titleButton.setTitleColor(colorForStyle, for: .normal)
-            avatar?.state.style = style == .light ? .default : .accent
+            avatar?.configuration.style = style == .light ? .default : .accent
         }
     }
 
@@ -177,14 +177,14 @@ class LargeTitleView: UIView {
         let preferredFallbackImageStyle: MSFAvatarStyle = style == .light ? .default : .accent
         let avatar = MSFAvatar(style: preferredFallbackImageStyle,
                                size: Constants.avatarSize)
-        let avatarState = avatar.state
-        avatarState.primaryText = personaData?.name
-        avatarState.secondaryText = personaData?.email
-        avatarState.image = personaData?.image
+        let avatarConfiguration = avatar.configuration
+        avatarConfiguration.primaryText = personaData?.name
+        avatarConfiguration.secondaryText = personaData?.email
+        avatarConfiguration.image = personaData?.image
 
         if let color = personaData?.color {
-            avatarState.backgroundColor = color
-            avatarState.ringColor = color
+            avatarConfiguration.backgroundColor = color
+            avatarConfiguration.ringColor = color
         }
 
         self.avatar = avatar
@@ -223,7 +223,7 @@ class LargeTitleView: UIView {
         }
 
         if avatarSize == .automatic {
-            avatar?.state.size = Constants.avatarSize
+            avatar?.configuration.size = Constants.avatarSize
         }
 
         layoutIfNeeded()
@@ -235,22 +235,22 @@ class LargeTitleView: UIView {
         }
 
         if avatarSize == .automatic {
-            avatar?.state.size = Constants.compactAvatarSize
+            avatar?.configuration.size = Constants.compactAvatarSize
         }
 
         layoutIfNeeded()
     }
 
     private func updateAvatarViewPointerInteraction() {
-        avatar?.state.hasPointerInteraction = onAvatarTapped != nil
+        avatar?.configuration.hasPointerInteraction = onAvatarTapped != nil
     }
 
     private func updateAvatarAccessibility() {
         if let avatar = avatar {
             let accessibilityLabel = avatarAccessibilityLabel
-            let avatarState = avatar.state
-            avatarState.accessibilityLabel = accessibilityLabel
-            avatarState.hasButtonAccessibilityTrait = onAvatarTapped != nil
+            let avatarConfiguration = avatar.configuration
+            avatarConfiguration.accessibilityLabel = accessibilityLabel
+            avatarConfiguration.hasButtonAccessibilityTrait = onAvatarTapped != nil
 
             let avatarView = avatar.view
             avatarView.showsLargeContentViewer = true

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -13,7 +13,7 @@ open class ActivityIndicatorCell: UITableViewCell {
 
     private let activityIndicator: MSFActivityIndicator = {
         let activityIndicator = MSFActivityIndicator(size: .small)
-        activityIndicator.state.isAnimating = true
+        activityIndicator.configuration.isAnimating = true
         return activityIndicator
     }()
 
@@ -36,7 +36,7 @@ open class ActivityIndicatorCell: UITableViewCell {
 
     open override func prepareForReuse() {
         super.prepareForReuse()
-        activityIndicator.state.isAnimating = true
+        activityIndicator.configuration.isAnimating = true
     }
 
     open override var intrinsicContentSize: CGSize {

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -23,10 +23,10 @@ open class PersonaCell: TableViewCell {
     @objc open func setup(persona: Persona, accessoryType: TableViewCellAccessoryType = .none) {
         let avatar = MSFAvatar(style: .accent, size: Constants.avatarSize)
 
-        avatar.state.primaryText = persona.name
-        avatar.state.secondaryText = persona.email
+        avatar.configuration.primaryText = persona.name
+        avatar.configuration.secondaryText = persona.email
         if let image = persona.image {
-            avatar.state.image = image
+            avatar.configuration.image = image
         }
 
         if let fetchImage = persona.fetchImage {
@@ -37,18 +37,18 @@ open class PersonaCell: TableViewCell {
                 }
 
                 if Thread.isMainThread {
-                    avatar.state.image = image
+                    avatar.configuration.image = image
                 } else {
                     DispatchQueue.main.async {
-                        avatar.state.image = image
+                        avatar.configuration.image = image
                     }
                 }
             }
         }
 
         if let color = persona.color {
-            avatar.state.backgroundColor = color
-            avatar.state.ringColor = color
+            avatar.configuration.backgroundColor = color
+            avatar.configuration.ringColor = color
         }
 
         let avatarView = avatar.view

--- a/ios/FluentUI/PersonaButton/MSFPersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/MSFPersonaButton.swift
@@ -14,10 +14,10 @@ import UIKit
     ///   - size: The MSFPersonaButtonSize value used by the PersonaButton.
     @objc public init(size: MSFPersonaButtonSize = .large) {
         let personaButton = PersonaButton(size: size)
-        state = personaButton.state
+        configuration = personaButton.configuration
         super.init(AnyView(personaButton))
     }
 
     /// The object that groups properties that allow control over the PersonaButton appearance.
-    @objc public let state: MSFPersonaButtonState
+    @objc public let configuration: MSFPersonaButtonConfiguration
 }

--- a/ios/FluentUI/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButton.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 
 /// Properties that define the appearance of a `PersonaButton`.
-@objc public protocol MSFPersonaButtonState {
+@objc public protocol MSFPersonaButtonConfiguration {
     /// Specifies whether to use small or large avatars.
     var buttonSize: MSFPersonaButtonSize { get set }
 
@@ -62,12 +62,12 @@ public struct PersonaButton: View, ConfigurableTokenizedControl {
     /// - Parameters:
     ///   - size: The` MSFPersonaButtonSize` value used by the `PersonaButton`.
     public init(size: MSFPersonaButtonSize) {
-        let state = MSFPersonaButtonStateImpl(size: size)
-        self.state = state
+        let configuration = MSFPersonaButtonConfigurationImpl(size: size)
+        self.configuration = configuration
     }
 
     public var body: some View {
-        let action = state.onTapAction ?? {}
+        let action = configuration.onTapAction ?? {}
         SwiftUI.Button(action: action) {
             VStack(spacing: 0) {
                 avatarView
@@ -81,29 +81,29 @@ public struct PersonaButton: View, ConfigurableTokenizedControl {
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.sizeCategory) var sizeCategory: ContentSizeCategory
-    @ObservedObject var state: MSFPersonaButtonStateImpl
+    @ObservedObject var configuration: MSFPersonaButtonConfigurationImpl
     let defaultTokens: PersonaButtonTokens = .init()
     var tokens: PersonaButtonTokens {
         let tokens = resolvedTokens
-        tokens.size = state.buttonSize
+        tokens.size = configuration.buttonSize
         return tokens
     }
 
-    init(state: MSFPersonaButtonStateImpl, action: (() -> Void)?) {
-        state.onTapAction = action
-        self.state = state
+    init(configuration: MSFPersonaButtonConfigurationImpl, action: (() -> Void)?) {
+        configuration.onTapAction = action
+        self.configuration = configuration
     }
 
     @ViewBuilder
     private var personaText: some View {
         Group {
-            Text(state.primaryText ?? "")
+            Text(configuration.primaryText ?? "")
                 .lineLimit(1)
                 .frame(alignment: .center)
                 .font(.fluent(tokens.labelFont))
                 .foregroundColor(Color(dynamicColor: tokens.labelColor))
-            if state.buttonSize.shouldShowSubtitle {
-                Text(state.secondaryText ?? "")
+            if configuration.buttonSize.shouldShowSubtitle {
+                Text(configuration.secondaryText ?? "")
                     .lineLimit(1)
                     .frame(alignment: .center)
                     .font(.fluent(tokens.sublabelFont))
@@ -114,7 +114,7 @@ public struct PersonaButton: View, ConfigurableTokenizedControl {
     }
 
     private var avatar: Avatar {
-        Avatar(state.avatarState)
+        Avatar(configuration.avatarConfiguration)
     }
 
     @ViewBuilder
@@ -134,18 +134,18 @@ public struct PersonaButton: View, ConfigurableTokenizedControl {
             .accessibilityExtraExtraExtraLarge: [ .large: 80, .small: 68 ]
         ]
 
-        return avatar.contentSize + (2 * tokens.horizontalAvatarPadding) + (accessibilityAdjustments[sizeCategory]?[state.buttonSize] ?? 0)
+        return avatar.contentSize + (2 * tokens.horizontalAvatarPadding) + (accessibilityAdjustments[sizeCategory]?[configuration.buttonSize] ?? 0)
     }
 }
 
 /// Properties that make up PersonaButton content
-class MSFPersonaButtonStateImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFPersonaButtonState {
-    /// Creates and initializes a `MSFPersonaButtonStateImpl`
+class MSFPersonaButtonConfigurationImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFPersonaButtonConfiguration {
+    /// Creates and initializes a `MSFPersonaButtonConfigurationImpl`
     /// - Parameters:
     ///   - size: The size of the persona button
     init(size: MSFPersonaButtonSize) {
         self.buttonSize = size
-        self.avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize)
+        self.avatarConfiguration = MSFAvatarConfigurationImpl(style: .default, size: size.avatarSize)
 
         super.init()
     }
@@ -154,141 +154,141 @@ class MSFPersonaButtonStateImpl: NSObject, ObservableObject, Identifiable, Contr
     @Published var onTapAction: (() -> Void)?
     @Published var overrideTokens: PersonaButtonTokens?
 
-    let avatarState: MSFAvatarStateImpl
+    let avatarConfiguration: MSFAvatarConfigurationImpl
     let id = UUID()
 
     var avatarBackgroundColor: UIColor? {
         get {
-            return avatarState.backgroundColor
+            return avatarConfiguration.backgroundColor
         }
         set {
-            avatarState.backgroundColor = newValue
+            avatarConfiguration.backgroundColor = newValue
         }
     }
 
     var avatarForegroundColor: UIColor? {
         get {
-            return avatarState.foregroundColor
+            return avatarConfiguration.foregroundColor
         }
         set {
-            avatarState.foregroundColor = newValue
+            avatarConfiguration.foregroundColor = newValue
         }
     }
 
     var hasPointerInteraction: Bool {
         get {
-            return avatarState.hasPointerInteraction
+            return avatarConfiguration.hasPointerInteraction
         }
         set {
-            avatarState.hasPointerInteraction = newValue
+            avatarConfiguration.hasPointerInteraction = newValue
         }
     }
 
     var hasRingInnerGap: Bool {
         get {
-            return avatarState.hasRingInnerGap
+            return avatarConfiguration.hasRingInnerGap
         }
         set {
-            avatarState.hasRingInnerGap = newValue
+            avatarConfiguration.hasRingInnerGap = newValue
         }
     }
 
     var image: UIImage? {
         get {
-            return avatarState.image
+            return avatarConfiguration.image
         }
         set {
-            avatarState.image = newValue
+            avatarConfiguration.image = newValue
         }
     }
 
     var imageBasedRingColor: UIImage? {
         get {
-            return avatarState.imageBasedRingColor
+            return avatarConfiguration.imageBasedRingColor
         }
         set {
-            avatarState.imageBasedRingColor = newValue
+            avatarConfiguration.imageBasedRingColor = newValue
         }
     }
 
     var isOutOfOffice: Bool {
         get {
-            return avatarState.isOutOfOffice
+            return avatarConfiguration.isOutOfOffice
         }
         set {
-            avatarState.isOutOfOffice = newValue
+            avatarConfiguration.isOutOfOffice = newValue
         }
     }
 
     var isRingVisible: Bool {
         get {
-            return avatarState.isRingVisible
+            return avatarConfiguration.isRingVisible
         }
         set {
-            avatarState.isRingVisible = newValue
+            avatarConfiguration.isRingVisible = newValue
         }
     }
 
     var isTransparent: Bool {
         get {
-            return avatarState.isTransparent
+            return avatarConfiguration.isTransparent
         }
         set {
-            avatarState.isTransparent = newValue
+            avatarConfiguration.isTransparent = newValue
         }
     }
 
     var presence: MSFAvatarPresence {
         get {
-            return avatarState.presence
+            return avatarConfiguration.presence
         }
         set {
-            avatarState.presence = newValue
+            avatarConfiguration.presence = newValue
         }
     }
 
     var primaryText: String? {
         get {
-            return avatarState.primaryText
+            return avatarConfiguration.primaryText
         }
         set {
-            avatarState.primaryText = newValue
+            avatarConfiguration.primaryText = newValue
         }
     }
 
     var ringColor: UIColor? {
         get {
-            return avatarState.ringColor
+            return avatarConfiguration.ringColor
         }
         set {
-            avatarState.ringColor = newValue
+            avatarConfiguration.ringColor = newValue
         }
     }
 
     var secondaryText: String? {
         get {
-            return avatarState.secondaryText
+            return avatarConfiguration.secondaryText
         }
         set {
-            avatarState.secondaryText = newValue
+            avatarConfiguration.secondaryText = newValue
         }
     }
 
     var size: MSFAvatarSize {
         get {
-            return avatarState.size
+            return avatarConfiguration.size
         }
         set {
-            avatarState.size = newValue
+            avatarConfiguration.size = newValue
         }
     }
 
     var style: MSFAvatarStyle {
         get {
-            return avatarState.style
+            return avatarConfiguration.style
         }
         set {
-            avatarState.style = newValue
+            avatarConfiguration.style = newValue
         }
     }
 }

--- a/ios/FluentUI/PersonaButton/PersonaButtonModifiers.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonModifiers.swift
@@ -8,7 +8,7 @@ import SwiftUI
 public extension PersonaButton {
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: PersonaButtonTokens?) -> PersonaButton {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -14,10 +14,10 @@ import UIKit
     ///   - size: The MSFPersonaButtonSize value used by the PersonaButtonCarousel.
     @objc public init(size: MSFPersonaButtonSize = .large) {
         let personaButtonCarousel = PersonaButtonCarousel(size: size)
-        state = personaButtonCarousel.state
+        configuration = personaButtonCarousel.configuration
         super.init(AnyView(personaButtonCarousel))
     }
 
     /// The object that groups properties that allow control over the PersonaButtonCarousel appearance.
-    @objc public let state: MSFPersonaButtonCarouselState
+    @objc public let configuration: MSFPersonaButtonCarouselConfiguration
 }

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselModifiers.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselModifiers.swift
@@ -8,7 +8,7 @@ import SwiftUI
 public extension PersonaButtonCarousel {
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: PersonaButtonCarouselTokens?) -> PersonaButtonCarousel {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -129,7 +129,7 @@ open class PopupMenuController: DrawerController {
     @objc open var separatorColor: UIColor = Colors.Separator.default {
         didSet {
             let customTokens = PopupMenuItemCell.CustomDividerTokens(separatorColor)
-            divider.state.overrideTokens = customTokens
+            divider.configuration.overrideTokens = customTokens
         }
     }
 
@@ -171,7 +171,7 @@ open class PopupMenuController: DrawerController {
         )
 
         let customTokens = PopupMenuItemCell.CustomDividerTokens(separatorColor)
-        divider.state.overrideTokens = customTokens
+        divider.configuration.overrideTokens = customTokens
         view.addSubview(divider.view)
         divider.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -9,7 +9,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     var customSeparatorColor: UIColor? {
         didSet {
-            bottomSeparator.state.overrideTokens = CustomDividerTokens(customSeparatorColor)
+            bottomSeparator.configuration.overrideTokens = CustomDividerTokens(customSeparatorColor)
         }
     }
 

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -28,7 +28,7 @@ open class SideTabBar: UIView {
     @objc public weak var delegate: SideTabBarDelegate? {
         didSet {
             if let avatar = avatar {
-                avatar.state.hasButtonAccessibilityTrait = delegate != nil
+                avatar.configuration.hasButtonAccessibilityTrait = delegate != nil
             }
         }
     }
@@ -43,15 +43,15 @@ open class SideTabBar: UIView {
         }
         didSet {
             if let avatar = avatar {
-                let avatarState = avatar.state
-                avatarState.size = .medium
-                avatarState.accessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
-                avatarState.hasButtonAccessibilityTrait = delegate != nil
+                let avatarConfiguration = avatar.configuration
+                avatarConfiguration.size = .medium
+                avatarConfiguration.accessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
+                avatarConfiguration.hasButtonAccessibilityTrait = delegate != nil
 
                 let avatarView = avatar.view
                 avatarView.translatesAutoresizingMaskIntoConstraints = false
                 avatarView.showsLargeContentViewer = true
-                avatarView.largeContentTitle = avatarState.accessibilityLabel
+                avatarView.largeContentTitle = avatarConfiguration.accessibilityLabel
                 addSubview(avatarView)
 
                 avatarView.addGestureRecognizer(avatarViewGestureRecognizer)

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1116,7 +1116,7 @@ open class TableViewCell: UITableViewCell {
         }
 
         layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
-        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.state.thickness)
+        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.configuration.thickness)
     }
 
     private func layoutLabelViews(label: UILabel, numberOfLines: Int, topOffset: CGFloat, leadingAccessoryView: UIView?, leadingAccessoryViewSize: CGSize, trailingAccessoryView: UIView?, trailingAccessoryViewSize: CGSize) {
@@ -1168,7 +1168,7 @@ open class TableViewCell: UITableViewCell {
             x: separatorLeadingInset(for: type),
             y: verticalOffset,
             width: frame.width - separatorLeadingInset(for: type),
-            height: separator.state.thickness
+            height: separator.configuration.thickness
         )
     }
 

--- a/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
@@ -12,12 +12,12 @@ public extension FluentButton {
     /// - Parameter accessibilityLabel: Accessibility label string.
     /// - Returns: The modified Button with the property set.
     func accessibilityLabel(_ accessibilityLabel: String?) -> FluentButton {
-        state.accessibilityLabel = accessibilityLabel
+        configuration.accessibilityLabel = accessibilityLabel
         return self
     }
 
     func overrideTokens(_ tokens: ButtonTokens?) -> FluentButton {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -15,7 +15,7 @@ import UIKit
     @objc public var action: ((_ sender: MSFButton) -> Void)?
 
     /// The object that groups properties that allow control over the button appearance.
-    @objc public let state: MSFButtonState
+    @objc public let configuration: MSFButtonConfiguration
 
     /// Creates a new MSFButton instance.
     /// - Parameters:
@@ -29,11 +29,11 @@ import UIKit
         let buttonView = FluentButton(style: style,
                                       size: size,
                                       action: {})
-        state = buttonView.state
+        configuration = buttonView.configuration
         super.init(AnyView(buttonView))
 
         // After initialization, set the new action to refer to our own.
-        buttonView.state.action = { [weak self] in
+        buttonView.configuration.action = { [weak self] in
             guard let strongSelf = self else {
                 return
             }
@@ -48,20 +48,20 @@ import UIKit
         view.addInteraction(largeContentViewerInteraction)
         largeContentViewerInteraction.gestureRecognizerForExclusionRelationship.delegate = self
         view.scalesLargeContentImage = true
-        view.showsLargeContentViewer = state.style.isFloatingStyle
+        view.showsLargeContentViewer = configuration.style.isFloatingStyle
 
-        // Unpleasant workaround to get the implementation of MSFButtonState.
+        // Unpleasant workaround to get the implementation of MSFButtonConfiguration.
         // Can be removed once we switch to Xcode 13.2 and can use
         // `.accessibilityShowsLargeContentViewerIfAvailable()`.
-        guard let stateImpl = state as? MSFButtonStateImpl else {
+        guard let configurationImpl = configuration as? MSFButtonConfigurationImpl else {
             return
         }
 
-        imagePropertySubscriber = stateImpl.$image.sink { buttonImage in
+        imagePropertySubscriber = configurationImpl.$image.sink { buttonImage in
             self.view.largeContentImage = buttonImage
         }
 
-        textPropertySubscriber = stateImpl.$text.sink { buttonText in
+        textPropertySubscriber = configurationImpl.$text.sink { buttonText in
             self.view.largeContentTitle = buttonText
         }
     }

--- a/ios/FluentUI/Vnext/Divider/Divider.swift
+++ b/ios/FluentUI/Vnext/Divider/Divider.swift
@@ -12,7 +12,7 @@ import SwiftUI
 }
 
 /// Properties that can be used to customize the appearance of the Divider.
-@objc public protocol MSFDividerState {
+@objc public protocol MSFDividerConfiguration {
     /// Defines the orientation of the Divider.
     var orientation: MSFDividerOrientation { get set }
 
@@ -35,19 +35,19 @@ public struct FluentDivider: View, ConfigurableTokenizedControl {
     ///   - spacing: The DividerSpacing used by the Divider.
     public init (orientation: MSFDividerOrientation = .horizontal,
                  spacing: MSFDividerSpacing = .none) {
-        let state = MSFDividerStateImpl(orientation: orientation, spacing: spacing)
+        let configuration = MSFDividerConfigurationImpl(orientation: orientation, spacing: spacing)
 
-        self.state = state
+        self.configuration = configuration
     }
 
     public var body: some View {
-        let isHorizontal = state.orientation == .horizontal
+        let isHorizontal = configuration.orientation == .horizontal
         let color = Color(dynamicColor: tokens.color)
 
         return Rectangle()
             .fill(color)
-            .frame(width: isHorizontal ? nil : state.thickness,
-                   height: isHorizontal ? state.thickness : nil)
+            .frame(width: isHorizontal ? nil : configuration.thickness,
+                   height: isHorizontal ? configuration.thickness : nil)
             .padding(isHorizontal ?
                      EdgeInsets(top: tokens.padding,
                                 leading: 0,
@@ -62,15 +62,15 @@ public struct FluentDivider: View, ConfigurableTokenizedControl {
     let defaultTokens: DividerTokens = .init()
     var tokens: DividerTokens {
         let tokens = resolvedTokens
-        tokens.spacing = state.spacing
+        tokens.spacing = configuration.spacing
         return tokens
     }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
-    @ObservedObject var state: MSFDividerStateImpl
+    @ObservedObject var configuration: MSFDividerConfigurationImpl
 }
 
 /// Properties available to customize the Divider.
-class MSFDividerStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFDividerState {
+class MSFDividerConfigurationImpl: NSObject, ObservableObject, ControlConfiguration, MSFDividerConfiguration {
     @Published var overrideTokens: DividerTokens?
 
     @Published var orientation: MSFDividerOrientation

--- a/ios/FluentUI/Vnext/Divider/DividerModifiers.swift
+++ b/ios/FluentUI/Vnext/Divider/DividerModifiers.swift
@@ -10,7 +10,7 @@ public extension FluentDivider {
 
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: DividerTokens?) -> FluentDivider {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/Vnext/Divider/MSFDivider.swift
+++ b/ios/FluentUI/Vnext/Divider/MSFDivider.swift
@@ -15,10 +15,10 @@ import SwiftUI
     @objc public init(orientation: MSFDividerOrientation = .horizontal,
                       spacing: MSFDividerSpacing = .none) {
         let divider = FluentDivider(orientation: orientation, spacing: spacing)
-        state = divider.state
+        configuration = divider.configuration
         super.init(AnyView(divider))
     }
 
     /// The object that groups properties that allow control over the Divider appearance.
-    @objc public let state: MSFDividerState
+    @objc public let configuration: MSFDividerConfiguration
 }

--- a/ios/FluentUI/Vnext/List/HeaderModifiers.swift
+++ b/ios/FluentUI/Vnext/List/HeaderModifiers.swift
@@ -9,7 +9,7 @@ import UIKit
 extension Header {
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: HeaderTokens?) -> Header {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Properties that can be used to customize the appearance of the List Section.
-@objc public protocol MSFListSectionState {
+@objc public protocol MSFListSectionConfiguration {
     /// Sets the Section title.
     var title: String? { get set }
 
@@ -15,25 +15,25 @@ import SwiftUI
     // TODO: Remove backgroundColor so that it will only be controlled by the tokens.
     var backgroundColor: UIColor? { get set }
 
-    /// Configures divider presence within the Section.
+    /// Configuress divider presence within the Section.
     var hasDividers: Bool { get set }
 
-    /// Configures the Section's `Header` style.
+    /// Configuress the Section's `Header` style.
     var style: MSFHeaderStyle { get set }
 
     /// The number of Cells in the Section.
     var cellCount: Int { get }
 
     /// Creates a new Cell and appends it to the array of cells in a Section.
-    func createCell() -> MSFListCellState
+    func createCell() -> MSFListCellConfiguration
 
     /// Creates a new Cell within the Section at a specific index.
     /// - Parameter index: The zero-based index of the Cell that will be inserted into the Section.
-    func createCell(at index: Int) -> MSFListCellState
+    func createCell(at index: Int) -> MSFListCellConfiguration
 
-    /// Retrieves the state object for a specific Cell so its appearance can be customized.
+    /// Retrieves the configuration object for a specific Cell so its appearance can be customized.
     /// - Parameter index: The zero-based index of the Cell in the Section.
-    func getCellState(at index: Int) -> MSFListCellState
+    func getCellConfiguration(at index: Int) -> MSFListCellConfiguration
 
     /// Remove a Cell from the Section.
     /// - Parameter index: The zero-based index of the Cell that will be removed from the Section.
@@ -41,20 +41,20 @@ import SwiftUI
 }
 
 /// Properties that can be used to customize the appearance of the List.
-@objc public protocol MSFListState {
+@objc public protocol MSFListConfiguration {
     /// The number of Sections in the List.
     var sectionCount: Int { get }
 
     /// Creates a new Section and appends it to the array of sections in a List.
-    func createSection() -> MSFListSectionState
+    func createSection() -> MSFListSectionConfiguration
 
     /// Creates a new Section within the List at a specific index.
     /// - Parameter index: The zero-based index of the Section that will be inserted into the List.
-    func createSection(at index: Int) -> MSFListSectionState
+    func createSection(at index: Int) -> MSFListSectionConfiguration
 
-    /// Retrieves the state object for a specific Section so its appearance can be customized.
+    /// Retrieves the configuration object for a specific Section so its appearance can be customized.
     /// - Parameter index: The zero-based index of the Section in the List.
-    func getSectionState(at index: Int) -> MSFListSectionState
+    func getSectionConfiguration(at index: Int) -> MSFListSectionConfiguration
 
     /// Remove a Section from the List.
     /// - Parameter index: The zero-based index of the Section that will be removed from the List.
@@ -63,7 +63,7 @@ import SwiftUI
 
 public struct FluentList: View {
     public init() {
-        self.state = MSFListStateImpl()
+        self.configuration = MSFListConfigurationImpl()
     }
 
     public var body: some View {
@@ -72,12 +72,12 @@ public struct FluentList: View {
             VStack(spacing: 0) {
                 ForEach(sections, id: \.self) { section in
                     if let sectionTitle = section.title, !sectionTitle.isEmpty {
-                        Header(state: section)
+                        Header(configuration: section)
                     }
 
                     ForEach(section.cells.indices, id: \.self) { index in
-                        let cellState = section.cells[index]
-                        MSFListCellView(state: cellState)
+                        let cellConfiguration = section.cells[index]
+                        MSFListCellView(configuration: cellConfiguration)
                             .frame(maxWidth: .infinity)
                     }
 
@@ -92,22 +92,22 @@ public struct FluentList: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    @ObservedObject var state: MSFListStateImpl
+    @ObservedObject var configuration: MSFListConfigurationImpl
 
     /// Finds the last cell directly adjacent to the end of a list section. This is used to remove the redundant separator that is
     /// inserted between each cell. Used as a fix until we are able to use the new List Separators in iOS 15.
-    private func findLastCell(_ lastCell: MSFListCellState) -> MSFListCellState {
+    private func findLastCell(_ lastCell: MSFListCellConfiguration) -> MSFListCellConfiguration {
         let childrenCellCount = lastCell.childrenCellCount
         if childrenCellCount > 0, lastCell.isExpanded {
-            let lastChild = lastCell.getChildCellState(at: childrenCellCount - 1)
+            let lastChild = lastCell.getChildCellConfiguration(at: childrenCellCount - 1)
             return findLastCell(lastChild)
         }
         return lastCell
     }
 
     /// Updates the status of dividers presence within the entire List.
-    private func updateCellDividers() -> [MSFListSectionStateImpl] {
-        state.sections.forEach { section in
+    private func updateCellDividers() -> [MSFListSectionConfigurationImpl] {
+        configuration.sections.forEach { section in
             section.cells.forEach { cell in
                 cell.hasDivider = section.hasDividers
             }
@@ -115,25 +115,25 @@ public struct FluentList: View {
                 findLastCell(lastCell).hasDivider = false
             }
         }
-        return state.sections
+        return configuration.sections
     }
 }
 
 /// Properties that make up section content
-class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFListSectionState {
+class MSFListSectionConfigurationImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFListSectionConfiguration {
     init(style: MSFHeaderStyle = .standard) {
         self.style = style
         super.init()
     }
 
     @Published var overrideTokens: HeaderTokens?
-    @Published private(set) var cells: [MSFListCellStateImpl] = []
+    @Published private(set) var cells: [MSFListCellConfigurationImpl] = []
     @Published var title: String?
     @Published var backgroundColor: UIColor?
     @Published var hasDividers: Bool = false
     var id = UUID()
 
-    // MARK: - MSFListSectionStateImpl accessors
+    // MARK: - MSFListSectionConfigurationImpl accessors
 
     var cellCount: Int {
         return cells.count
@@ -141,20 +141,20 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
 
     var style: MSFHeaderStyle
 
-    func createCell() -> MSFListCellState {
+    func createCell() -> MSFListCellConfiguration {
         return createCell(at: cells.endIndex)
     }
 
-    func createCell(at index: Int) -> MSFListCellState {
+    func createCell(at index: Int) -> MSFListCellConfiguration {
         guard index <= cells.count && index >= 0 else {
             preconditionFailure("Index is out of bounds")
         }
-        let cell = MSFListCellStateImpl()
+        let cell = MSFListCellConfigurationImpl()
         cells.insert(cell, at: index)
         return cell
     }
 
-    func getCellState(at index: Int) -> MSFListCellState {
+    func getCellConfiguration(at index: Int) -> MSFListCellConfiguration {
         guard cells.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }
@@ -170,29 +170,29 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
 }
 
 /// Properties that make up list content
-class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
-    @Published private(set) var sections: [MSFListSectionStateImpl] = []
+class MSFListConfigurationImpl: NSObject, ObservableObject, MSFListConfiguration {
+    @Published private(set) var sections: [MSFListSectionConfigurationImpl] = []
 
-    // MARK: - MSFListStateImpl accessors
+    // MARK: - MSFListConfigurationImpl accessors
 
     var sectionCount: Int {
         return sections.count
     }
 
-    func createSection() -> MSFListSectionState {
+    func createSection() -> MSFListSectionConfiguration {
         return createSection(at: sections.endIndex)
     }
 
-    func createSection(at index: Int) -> MSFListSectionState {
+    func createSection(at index: Int) -> MSFListSectionConfiguration {
         guard index <= sections.count && index >= 0 else {
             preconditionFailure("Index is out of bounds")
         }
-        let section = MSFListSectionStateImpl()
+        let section = MSFListSectionConfigurationImpl()
         sections.insert(section, at: index)
         return section
     }
 
-    func getSectionState(at index: Int) -> MSFListSectionState {
+    func getSectionConfiguration(at index: Int) -> MSFListSectionConfiguration {
         guard sections.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -15,10 +15,10 @@ import SwiftUI
     // TODO: Remove backgroundColor so that it will only be controlled by the tokens.
     var backgroundColor: UIColor? { get set }
 
-    /// Configuress divider presence within the Section.
+    /// Configures divider presence within the Section.
     var hasDividers: Bool { get set }
 
-    /// Configuress the Section's `Header` style.
+    /// Configures the Section's `Header` style.
     var style: MSFHeaderStyle { get set }
 
     /// The number of Cells in the Section.

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Properties that can be used to customize the appearance of the List Cell.
-@objc public protocol MSFListCellState {
+@objc public protocol MSFListCellConfiguration {
     /// Custom view on the leading side of the Cell.
     var leadingUIView: UIView? { get set }
 
@@ -53,22 +53,22 @@ import SwiftUI
     /// Sets a custom highlighed background color for the Cell.
     var highlightedBackgroundColor: UIColor? { get set }
 
-    /// Configures max number of lines in the title.
+    /// Configuress max number of lines in the title.
     var titleLineLimit: Int { get set }
 
-    /// Configures max number of lines in the subtitle.
+    /// Configuress max number of lines in the subtitle.
     var subtitleLineLimit: Int { get set }
 
-    /// Configures max number of lines in the footnote.
+    /// Configuress max number of lines in the footnote.
     var footnoteLineLimit: Int { get set }
 
-    /// Configures whether the cell is expanded or collapsed if it has children cells.
+    /// Configuress whether the cell is expanded or collapsed if it has children cells.
     var isExpanded: Bool { get set }
 
     /// Sets the cell as a one-line, two-line, or three-line layout type.
     var layoutType: MSFListCellLayoutType { get set }
 
-    /// Configures divider visibility, which is located under the cell.
+    /// Configuress divider visibility, which is located under the cell.
     var hasDivider: Bool { get set }
 
     /// Assigns an action to the cell when it is tapped.
@@ -78,23 +78,23 @@ import SwiftUI
     var childrenCellCount: Int { get }
 
     /// Creates a new child cell and appends it to the array of children cells in a Cell.
-    func createChildCell() -> MSFListCellState
+    func createChildCell() -> MSFListCellConfiguration
 
     /// Creates a new child cell within the array of children cells at a specific index.
     /// - Parameter index: The zero-based index of the child cell that will be inserted into the array of children cells.
-    func createChildCell(at index: Int) -> MSFListCellState
+    func createChildCell(at index: Int) -> MSFListCellConfiguration
 
-    /// Retrieves the state object for a specific child cell so its appearance can be customized.
+    /// Retrieves the configuration object for a specific child cell so its appearance can be customized.
     /// - Parameter index: The zero-based index of the child cell in the array of children cells.
-    func getChildCellState(at index: Int) -> MSFListCellState
+    func getChildCellConfiguration(at index: Int) -> MSFListCellConfiguration
 
     /// Remove a child cell from the Cell.
     /// - Parameter index: The zero-based index of the child cell that will be removed from the array of children cells.
     func removeChildCell(at index: Int)
 }
 
-/// `MSFListCellStateImpl` contains properties that make up a cell content.
-class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFListCellState {
+/// `MSFListCellConfigurationImpl` contains properties that make up a cell content.
+class MSFListCellConfigurationImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFListCellConfiguration {
     init(cellLeadingViewSize: MSFListCellLeadingViewSize = .medium) {
         self.leadingViewSize = cellLeadingViewSize
 
@@ -123,7 +123,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
     @Published var isExpanded: Bool = false
     @Published var layoutType: MSFListCellLayoutType = .automatic
     @Published var hasDivider: Bool = false
-    @Published private(set) var children: [MSFListCellStateImpl] = []
+    @Published private(set) var children: [MSFListCellConfigurationImpl] = []
     var onTapAction: (() -> Void)?
     var id = UUID()
 
@@ -221,20 +221,20 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
         return children.count
     }
 
-    func createChildCell() -> MSFListCellState {
+    func createChildCell() -> MSFListCellConfiguration {
         return createChildCell(at: children.endIndex)
     }
 
-    func createChildCell(at index: Int) -> MSFListCellState {
+    func createChildCell(at index: Int) -> MSFListCellConfiguration {
         guard index <= children.count && index >= 0 else {
             preconditionFailure("Index is out of bounds")
         }
-        let cell = MSFListCellStateImpl()
+        let cell = MSFListCellConfigurationImpl()
         children.insert(cell, at: index)
         return cell
     }
 
-    func getChildCellState(at index: Int) -> MSFListCellState {
+    func getChildCellConfiguration(at index: Int) -> MSFListCellConfiguration {
         guard children.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }
@@ -260,8 +260,8 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
 /// View for List Cells
 struct MSFListCellView: View, ConfigurableTokenizedControl {
 
-    init(state: MSFListCellStateImpl) {
-        self.state = state
+    init(configuration: MSFListCellConfigurationImpl) {
+        self.configuration = configuration
     }
 
     var body: some View {
@@ -273,13 +273,13 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
             let leadingViewAreaSize: CGFloat = tokens.leadingViewAreaSize
 
             HStack(spacing: 0) {
-                let hasTitle: Bool = !state.title.isEmpty
+                let hasTitle: Bool = !configuration.title.isEmpty
                 let labelAccessoryInterspace: CGFloat = tokens.labelAccessoryInterspace
                 let labelAccessorySize: CGFloat = tokens.labelAccessorySize
                 let sublabelAccessorySize: CGFloat = tokens.sublabelAccessorySize
                 let trailingItemSize: CGFloat = tokens.trailingItemSize
 
-                if let leadingView = state.leadingView {
+                if let leadingView = configuration.leadingView {
                     HStack(alignment: .center, spacing: 0) {
                         leadingView
                             .frame(width: leadingViewSize, height: leadingViewSize)
@@ -290,18 +290,18 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
 
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 0) {
-                        if let titleLeadingAccessoryView = state.titleLeadingAccessoryView {
+                        if let titleLeadingAccessoryView = configuration.titleLeadingAccessoryView {
                             titleLeadingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.trailing, labelAccessoryInterspace)
                         }
                         if hasTitle {
-                            Text(state.title)
+                            Text(configuration.title)
                                 .font(.fluent(tokens.labelFont))
                                 .foregroundColor(Color(dynamicColor: tokens.labelColor))
-                                .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)
+                                .lineLimit(configuration.titleLineLimit == 0 ? nil : configuration.titleLineLimit)
                         }
-                        if let titleTrailingAccessoryView = state.titleTrailingAccessoryView {
+                        if let titleTrailingAccessoryView = configuration.titleTrailingAccessoryView {
                             titleTrailingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.leading, labelAccessoryInterspace)
@@ -309,19 +309,19 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                     }
 
                     HStack(spacing: 0) {
-                        if let subtitleLeadingAccessoryView = state.subtitleLeadingAccessoryView {
+                        if let subtitleLeadingAccessoryView = configuration.subtitleLeadingAccessoryView {
                             subtitleLeadingAccessoryView
                                 .frame(width: sublabelAccessorySize, height: sublabelAccessorySize)
                                 .padding(.trailing, labelAccessoryInterspace)
                         }
-                        if !state.subtitle.isEmpty {
-                            Text(state.subtitle)
-                                .font(.fluent(state.footnote.isEmpty ?
+                        if !configuration.subtitle.isEmpty {
+                            Text(configuration.subtitle)
+                                .font(.fluent(configuration.footnote.isEmpty ?
                                                             tokens.footnoteFont : tokens.sublabelFont))
                                 .foregroundColor(Color(dynamicColor: tokens.sublabelColor))
-                                .lineLimit(state.subtitleLineLimit == 0 ? nil : state.subtitleLineLimit)
+                                .lineLimit(configuration.subtitleLineLimit == 0 ? nil : configuration.subtitleLineLimit)
                         }
-                        if let subtitleTrailingAccessoryView = state.subtitleTrailingAccessoryView {
+                        if let subtitleTrailingAccessoryView = configuration.subtitleTrailingAccessoryView {
                             subtitleTrailingAccessoryView
                                 .frame(width: sublabelAccessorySize, height: sublabelAccessorySize)
                                 .padding(.leading, labelAccessoryInterspace)
@@ -329,18 +329,18 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                     }
 
                     HStack(spacing: 0) {
-                        if let footnoteLeadingAccessoryView = state.footnoteLeadingAccessoryView {
+                        if let footnoteLeadingAccessoryView = configuration.footnoteLeadingAccessoryView {
                             footnoteLeadingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.trailing, labelAccessoryInterspace)
                         }
-                        if !state.footnote.isEmpty {
-                            Text(state.footnote)
+                        if !configuration.footnote.isEmpty {
+                            Text(configuration.footnote)
                                 .font(.fluent(tokens.footnoteFont))
                                 .foregroundColor(Color(dynamicColor: tokens.sublabelColor))
-                                .lineLimit(state.footnoteLineLimit == 0 ? nil : state.footnoteLineLimit)
+                                .lineLimit(configuration.footnoteLineLimit == 0 ? nil : configuration.footnoteLineLimit)
                         }
-                        if let footnoteTrailingAccessoryView = state.footnoteTrailingAccessoryView {
+                        if let footnoteTrailingAccessoryView = configuration.footnoteTrailingAccessoryView {
                             footnoteTrailingAccessoryView
                                 .frame(width: labelAccessorySize, height: labelAccessorySize)
                                 .padding(.leading, labelAccessoryInterspace)
@@ -350,14 +350,14 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
 
                 Spacer()
 
-                if let trailingView = state.trailingView {
+                if let trailingView = configuration.trailingView {
                     trailingView
                         .frame(width: trailingItemSize, height: trailingItemSize)
                         .fixedSize()
                 }
 
                 HStack(spacing: 0) {
-                    if let accessoryType = state.accessoryType, accessoryType != .none, let accessoryIcon = accessoryType.icon {
+                    if let accessoryType = configuration.accessoryType, accessoryType != .none, let accessoryIcon = accessoryType.icon {
                         let isDisclosure = accessoryType == .disclosure
                         let disclosureSize = tokens.disclosureSize
                         Image(uiImage: accessoryIcon)
@@ -375,32 +375,32 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
 
         @ViewBuilder
         var cellContent: some View {
-            let children: [MSFListCellStateImpl] = state.children
+            let children: [MSFListCellConfigurationImpl] = configuration.children
             let hasChildren: Bool = children.count > 0
             let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
             let leadingViewAreaSize: CGFloat = tokens.leadingViewAreaSize
 
-            Button(action: state.onTapAction ?? {
+            Button(action: configuration.onTapAction ?? {
                 if hasChildren {
                     withAnimation {
-                        state.isExpanded.toggle()
+                        configuration.isExpanded.toggle()
                     }
                 }
             }, label: {
                 cellLabel
             })
-            .buttonStyle(ListCellButtonStyle(tokens: tokens, state: state))
+            .buttonStyle(ListCellButtonStyle(tokens: tokens, configuration: configuration))
 
-            if state.hasDivider {
+            if configuration.hasDivider {
                 let padding = horizontalCellPadding +
-                    (state.leadingView != nil ? horizontalCellPadding + leadingViewAreaSize : 0)
+                    (configuration.leadingView != nil ? horizontalCellPadding + leadingViewAreaSize : 0)
                 FluentDivider()
                     .padding(.leading, padding)
             }
 
-            if hasChildren, state.isExpanded == true {
+            if hasChildren, configuration.isExpanded == true {
                 ForEach(children, id: \.self) { child in
-                    MSFListCellView(state: child)
+                    MSFListCellView(configuration: child)
                         .frame(maxWidth: .infinity)
                         .padding(.leading, (horizontalCellPadding + leadingViewAreaSize))
                 }
@@ -411,32 +411,32 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
     }
 
     func overrideTokens(_ tokens: CellBaseTokens?) -> MSFListCellView {
-        state.overrideTokens = tokens
+        configuration.overrideTokens = tokens
         return self
     }
 
     let defaultTokens: CellBaseTokens = .init()
     var tokens: CellBaseTokens {
         let tokens = resolvedTokens
-        tokens.cellLeadingViewSize = state.leadingViewSize
+        tokens.cellLeadingViewSize = configuration.leadingViewSize
         return tokens
     }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
-    @ObservedObject var state: MSFListCellStateImpl
+    @ObservedObject var configuration: MSFListCellConfigurationImpl
 }
 
 struct ListCellButtonStyle: ButtonStyle {
     let tokens: CellBaseTokens
-    let state: MSFListCellState
+    let configuration: MSFListCellConfiguration
 
     func makeBody(configuration: Self.Configuration) -> some View {
         let height: CGFloat
         let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
         let verticalCellPadding: CGFloat = tokens.verticalCellPadding
-        switch state.layoutType {
+        switch self.configuration.layoutType {
         case .automatic:
-            height = !state.footnote.isEmpty ? tokens.cellHeightThreeLines :
-                    (!state.subtitle.isEmpty ? tokens.cellHeightTwoLines : tokens.cellHeightOneLine)
+            height = !self.configuration.footnote.isEmpty ? tokens.cellHeightThreeLines :
+                    (!self.configuration.subtitle.isEmpty ? tokens.cellHeightTwoLines : tokens.cellHeightOneLine)
         case .oneLine:
             height = tokens.cellHeightOneLine
         case .twoLines:
@@ -456,17 +456,17 @@ struct ListCellButtonStyle: ButtonStyle {
 
     private func backgroundColor(_ isPressed: Bool = false) -> Color {
         let highlightedBackgroundColor: Color = {
-            guard let stateHighlightedBackgroundColor = state.highlightedBackgroundColor else {
+            guard let configurationHighlightedBackgroundColor = configuration.highlightedBackgroundColor else {
                 return Color(dynamicColor: tokens.highlightedBackgroundColor)
             }
-            return Color(stateHighlightedBackgroundColor)
+            return Color(configurationHighlightedBackgroundColor)
         }()
 
         let backgroundColor: Color = {
-            guard let stateBackgroundColor = state.backgroundColor else {
+            guard let configurationBackgroundColor = configuration.backgroundColor else {
                 return Color(dynamicColor: tokens.backgroundColor)
             }
-            return Color(stateBackgroundColor)
+            return Color(configurationBackgroundColor)
         }()
 
         if isPressed {

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -53,22 +53,22 @@ import SwiftUI
     /// Sets a custom highlighed background color for the Cell.
     var highlightedBackgroundColor: UIColor? { get set }
 
-    /// Configuress max number of lines in the title.
+    /// Configures max number of lines in the title.
     var titleLineLimit: Int { get set }
 
-    /// Configuress max number of lines in the subtitle.
+    /// Configures max number of lines in the subtitle.
     var subtitleLineLimit: Int { get set }
 
-    /// Configuress max number of lines in the footnote.
+    /// Configures max number of lines in the footnote.
     var footnoteLineLimit: Int { get set }
 
-    /// Configuress whether the cell is expanded or collapsed if it has children cells.
+    /// Configures whether the cell is expanded or collapsed if it has children cells.
     var isExpanded: Bool { get set }
 
     /// Sets the cell as a one-line, two-line, or three-line layout type.
     var layoutType: MSFListCellLayoutType { get set }
 
-    /// Configuress divider visibility, which is located under the cell.
+    /// Configures divider visibility, which is located under the cell.
     var hasDivider: Bool { get set }
 
     /// Assigns an action to the cell when it is tapped.

--- a/ios/FluentUI/Vnext/List/ListHeader.swift
+++ b/ios/FluentUI/Vnext/List/ListHeader.swift
@@ -7,20 +7,20 @@ import UIKit
 import SwiftUI
 
 struct Header: View, ConfigurableTokenizedControl {
-    init(state: MSFListSectionStateImpl) {
-        self.state = state
+    init(configuration: MSFListSectionConfigurationImpl) {
+        self.configuration = configuration
     }
 
     var body: some View {
         let backgroundColor: Color = {
-            guard let stateBackgroundColor = state.backgroundColor else {
+            guard let configurationBackgroundColor = configuration.backgroundColor else {
                 return Color(dynamicColor: tokens.backgroundColor)
             }
-            return Color(stateBackgroundColor)
+            return Color(configurationBackgroundColor)
         }()
 
         HStack(spacing: 0) {
-            if let title = state.title, !title.isEmpty {
+            if let title = configuration.title, !title.isEmpty {
                 Text(title)
                     .font(.fluent(tokens.textFont))
                     .foregroundColor(Color(dynamicColor: tokens.textColor))
@@ -40,5 +40,5 @@ struct Header: View, ConfigurableTokenizedControl {
         return resolvedTokens
     }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
-    @ObservedObject var state: MSFListSectionStateImpl
+    @ObservedObject var configuration: MSFListSectionConfigurationImpl
 }

--- a/ios/FluentUI/Vnext/List/MSFList.swift
+++ b/ios/FluentUI/Vnext/List/MSFList.swift
@@ -11,9 +11,9 @@ import SwiftUI
 
     @objc public init() {
         let list = FluentList()
-        state = list.state
+        configuration = list.configuration
         super.init(AnyView(list))
     }
 
-    @objc public let state: MSFListState
+    @objc public let configuration: MSFListConfiguration
 }

--- a/ios/FluentUI/Vnext/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Vnext/Notification/MSFNotificationView.swift
@@ -21,8 +21,8 @@ import UIKit
         super.init(AnyView(notification))
     }
 
-    @objc public var state: MSFNotificationState {
-        return notification.state
+    @objc public var configuration: MSFNotificationConfiguration {
+        return notification.configuration
     }
 
     // MARK: - Show/Hide Methods
@@ -90,7 +90,7 @@ import UIKit
 
     @objc public func hide(after delay: TimeInterval = 0, completion: (() -> Void)? = nil) {
         let hideDelay: TimeInterval = {
-            switch state.style {
+            switch configuration.style {
             case .primaryToast, .primaryBar, .primaryOutlineBar, .neutralBar:
                 return delay
             case .neutralToast, .dangerToast, .warningToast:

--- a/ios/FluentUI/Vnext/Persona/MSFPersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/MSFPersonaView.swift
@@ -11,9 +11,9 @@ import SwiftUI
 
     @objc public init() {
         let personaView = PersonaView()
-        state = personaView.state
+        configuration = personaView.configuration
         super.init(AnyView(personaView))
     }
 
-    @objc public let state: MSFPersonaViewState
+    @objc public let configuration: MSFPersonaViewConfiguration
 }

--- a/ios/FluentUI/Vnext/Persona/PersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaView.swift
@@ -6,221 +6,221 @@
 import UIKit
 import SwiftUI
 
-/// `MSFPersonaViewState` contains  PersonaView properties in addition to  MSFAvatarState protocol.
+/// `MSFPersonaViewConfiguration` contains  PersonaView properties in addition to  MSFAvatarConfiguration protocol.
 ///
 /// `TrailingAccessoryView` for `title` and `subtitle` allows for any custom UIView
 /// following each respective label.
 ///
 /// `onTapAction` provides tap gesture for PersonaView.
 ///
-@objc public protocol MSFPersonaViewState: MSFAvatarState {
+@objc public protocol MSFPersonaViewConfiguration: MSFAvatarConfiguration {
     var titleTrailingAccessoryUIView: UIView? { get set }
     var subtitleTrailingAccessoryUIView: UIView? { get set }
     var onTapAction: (() -> Void)? { get set }
 }
 
-public protocol PersonaViewState: MSFPersonaViewState {
+public protocol PersonaViewState: MSFPersonaViewConfiguration {
     var titleTrailingAccessoryView: AnyView? { get set }
     var subtitleTrailingAccessoryView: AnyView? { get set }
 }
 
 /// Properties that make up PersonaView content
-class MSFPersonaViewStateImpl: MSFListCellStateImpl, PersonaViewState {
+class MSFPersonaViewConfigurationImpl: MSFListCellConfigurationImpl, PersonaViewState {
     override var backgroundColor: UIColor? {
         get {
-            return avatarState.backgroundColor
+            return avatarConfiguration.backgroundColor
         }
 
         set {
-            avatarState.backgroundColor = newValue
+            avatarConfiguration.backgroundColor = newValue
         }
     }
 
     var foregroundColor: UIColor? {
         get {
-            return avatarState.foregroundColor
+            return avatarConfiguration.foregroundColor
         }
 
         set {
-            avatarState.foregroundColor = newValue
+            avatarConfiguration.foregroundColor = newValue
         }
     }
 
     var hasButtonAccessibilityTrait: Bool {
         get {
-            return avatarState.hasButtonAccessibilityTrait
+            return avatarConfiguration.hasButtonAccessibilityTrait
         }
 
         set {
-            avatarState.hasButtonAccessibilityTrait = newValue
+            avatarConfiguration.hasButtonAccessibilityTrait = newValue
         }
     }
 
     var hasPointerInteraction: Bool {
         get {
-            return avatarState.hasPointerInteraction
+            return avatarConfiguration.hasPointerInteraction
         }
 
         set {
-            avatarState.hasPointerInteraction = newValue
+            avatarConfiguration.hasPointerInteraction = newValue
         }
     }
 
     var hasRingInnerGap: Bool {
         get {
-            return avatarState.hasRingInnerGap
+            return avatarConfiguration.hasRingInnerGap
         }
 
         set {
-            avatarState.hasRingInnerGap = newValue
+            avatarConfiguration.hasRingInnerGap = newValue
         }
     }
 
     var image: UIImage? {
         get {
-            return avatarState.image
+            return avatarConfiguration.image
         }
 
         set {
-            avatarState.image = newValue
+            avatarConfiguration.image = newValue
         }
     }
 
     var imageBasedRingColor: UIImage? {
         get {
-            return avatarState.imageBasedRingColor
+            return avatarConfiguration.imageBasedRingColor
         }
 
         set {
-            avatarState.imageBasedRingColor = newValue
+            avatarConfiguration.imageBasedRingColor = newValue
         }
     }
 
     var isAnimated: Bool {
         get {
-            return avatarState.isAnimated
+            return avatarConfiguration.isAnimated
         }
 
         set {
-            avatarState.isAnimated = newValue
+            avatarConfiguration.isAnimated = newValue
         }
     }
 
     var isOutOfOffice: Bool {
         get {
-            return avatarState.isOutOfOffice
+            return avatarConfiguration.isOutOfOffice
         }
 
         set {
-            avatarState.isOutOfOffice = newValue
+            avatarConfiguration.isOutOfOffice = newValue
         }
     }
 
     var isRingVisible: Bool {
         get {
-            return avatarState.isRingVisible
+            return avatarConfiguration.isRingVisible
         }
 
         set {
-            avatarState.isRingVisible = newValue
+            avatarConfiguration.isRingVisible = newValue
         }
     }
 
     var isTransparent: Bool {
         get {
-            return avatarState.isTransparent
+            return avatarConfiguration.isTransparent
         }
 
         set {
-            avatarState.isTransparent = newValue
+            avatarConfiguration.isTransparent = newValue
         }
     }
 
     var presence: MSFAvatarPresence {
         get {
-            return avatarState.presence
+            return avatarConfiguration.presence
         }
 
         set {
-            avatarState.presence = newValue
+            avatarConfiguration.presence = newValue
         }
     }
 
     var primaryText: String? {
         get {
-            return avatarState.primaryText
+            return avatarConfiguration.primaryText
         }
 
         set {
-            avatarState.primaryText = newValue
+            avatarConfiguration.primaryText = newValue
             title = newValue ?? ""
         }
     }
 
     var ringColor: UIColor? {
         get {
-            return avatarState.ringColor
+            return avatarConfiguration.ringColor
         }
 
         set {
-            avatarState.ringColor = newValue
+            avatarConfiguration.ringColor = newValue
         }
     }
 
     var secondaryText: String? {
         get {
-            return avatarState.secondaryText
+            return avatarConfiguration.secondaryText
         }
 
         set {
-            avatarState.secondaryText = newValue
+            avatarConfiguration.secondaryText = newValue
             subtitle = newValue ?? ""
         }
     }
 
     var size: MSFAvatarSize {
         get {
-            return avatarState.size
+            return avatarConfiguration.size
         }
 
         set {
-            avatarState.size = newValue
+            avatarConfiguration.size = newValue
         }
     }
 
     var style: MSFAvatarStyle {
         get {
-            return avatarState.style
+            return avatarConfiguration.style
         }
 
         set {
-            avatarState.style = newValue
+            avatarConfiguration.style = newValue
         }
     }
 
-    init(avatarState: MSFAvatarState) {
-        self.avatarState = avatarState
+    init(avatarConfiguration: MSFAvatarConfiguration) {
+        self.avatarConfiguration = avatarConfiguration
 
         super.init()
     }
 
-    private var avatarState: MSFAvatarState
+    private var avatarConfiguration: MSFAvatarConfiguration
 }
 
 /// View for PersonaView
 public struct PersonaView: View {
     public init() {
         let avatar = Avatar(style: .default, size: .large)
-        state = MSFPersonaViewStateImpl(avatarState: avatar.state)
-        state.leadingView = AnyView(avatar)
-        state.leadingViewSize = .large
-        state.layoutType = .threeLines
-        state.overrideTokens = PersonaViewTokens()
+        configuration = MSFPersonaViewConfigurationImpl(avatarConfiguration: avatar.configuration)
+        configuration.leadingView = AnyView(avatar)
+        configuration.leadingViewSize = .large
+        configuration.layoutType = .threeLines
+        configuration.overrideTokens = PersonaViewTokens()
     }
 
     public var body: some View {
-        MSFListCellView(state: state)
+        MSFListCellView(configuration: configuration)
     }
 
-    @ObservedObject var state: MSFPersonaViewStateImpl
+    @ObservedObject var configuration: MSFPersonaViewConfigurationImpl
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

As part of our effort to consolidate and update our approach to our new Fluent controls, we've decided to formally swap the name for our SwiftUI controls' internal data structure from `state` to `configuration`.

The reasons for this change:
* `state` is a highly overloaded term in Apple-land, from `@State` in SwiftUI to `UIControl.State` for the interaction state of the control (e.g. highlighted, disabled), there is potential for confusion and conflict.
* On the other hand, `configuration` is only lightly used in either SwiftUI or UIKit, and only for buttons so far.
* `configuration` also more precisely describes the goal of the class/property: to describe how the control is "configured". This can include titles or images in buttons, or the sub-items in an aggregate control like `AvatarGroup`, along with custom token overrides for every other control. 

As for why now: this branch will result in a fair bit of churn to our clients when it merges, so might as well pull the bandage off now!

### Verification

Since this is a fairly wide-ranging change, the testing approach was more "bug bash" style than particularly focused on one area. My verification flow:
* Ensure every existing vNext control still displays in its demo controller.
* Verify the SwiftUI versions of vNext controls with support for that hosting environment.
* Verify custom tokens for controls with this view hooked up.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/939)