### PR TITLE
[vNext] Tokenize Segmented Control

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -33,7 +33,8 @@ struct Demos {
         DemoDescriptor("List", ListDemoController.self),
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
-        DemoDescriptor("PillButtonBar", PillButtonBarDemoController.self)
+        DemoDescriptor("PillButtonBar", PillButtonBarDemoController.self),
+        DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self)
     ]
 
     static let controls: [DemoDescriptor] = [
@@ -53,7 +54,6 @@ struct Demos {
         DemoDescriptor("PersonaListView", PersonaListViewDemoController.self),
         DemoDescriptor("PopupMenuController", PopupMenuDemoController.self),
         DemoDescriptor("SearchBar", SearchBarDemoController.self),
-        DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
         DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TabBarView", TabBarViewDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -167,7 +167,7 @@ class ColorDemoController: UIViewController {
                 colorView.updateBackgroundColor()
             }
         }
-        segmentedControl.updateWindowSpecificColors()
+        segmentedControl.updateColors()
     }
 
     private let tableView = UITableView(frame: .zero, style: .grouped)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -147,7 +147,7 @@ extension SegmentedControlDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: FluentButton.self) != nil
+        return self.view.window?.fluentTheme.tokenOverride(for: SegmentedControl.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -55,6 +55,11 @@ class SegmentedControlDemoController: DemoController {
         addTitle(text: "Disabled On Brand Pill")
 
         addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, enabled: false)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     @objc func updateLabel(forControl control: SegmentedControl) {
@@ -71,8 +76,10 @@ class SegmentedControlDemoController: DemoController {
         if style == .primaryPill {
             backgroundView.backgroundColor = Colors.navigationBarBackground
         } else {
-            backgroundView.backgroundColor = UIColor(light: Colors.communicationBlue, dark: Colors.navigationBarBackground)
+            setOnBrandBackgroundColorFor(backgroundView)
+            onBrandSegmentedControlViews.append(backgroundView)
         }
+        segmentedControls.append(pillControl)
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
         pillControl.translatesAutoresizingMaskIntoConstraints = false
@@ -90,11 +97,30 @@ class SegmentedControlDemoController: DemoController {
         if enabled {
             controlLabels[pillControl] = addDescription(text: "", textAlignment: .center)
         }
+    }
 
-        segmentedControls.append(pillControl)
+    @objc func themeDidChange(_ notification: Notification) {
+        for background in onBrandSegmentedControlViews {
+            setOnBrandBackgroundColorFor(background)
+        }
+    }
+
+    func setOnBrandBackgroundColorFor(_ backgroundView: UIView) {
+        var lightColor: UIColor
+        var darkColor: UIColor
+        if let window = self.view.window {
+            lightColor = Colors.primary(for: window)
+            darkColor = UIColor(colorValue: window.fluentTheme.globalTokens.neutralColors[.grey12])
+        } else {
+            lightColor = Colors.communicationBlue
+            darkColor = Colors.navigationBarBackground
+        }
+
+        backgroundView.backgroundColor = UIColor(light: lightColor, dark: darkColor)
     }
 
     private var segmentedControls: [SegmentedControl] = []
+    private var onBrandSegmentedControlViews: [UIView] = []
 }
 
 extension SegmentedControlDemoController: DemoAppearanceDelegate {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -90,5 +90,51 @@ class SegmentedControlDemoController: DemoController {
         if enabled {
             controlLabels[pillControl] = addDescription(text: "", textAlignment: .center)
         }
+
+        segmentedControls.append(pillControl)
+    }
+
+    private var segmentedControls: [SegmentedControl] = []
+}
+
+extension SegmentedControlDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        var tokensClosure: ((SegmentedControl) -> SegmentedControlTokens)?
+        if isOverrideEnabled {
+            tokensClosure = { _ in
+                return ThemeWideOverrideSegmentedControlTokens()
+            }
+        }
+
+        fluentTheme.register(controlType: SegmentedControl.self, tokens: tokensClosure)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        self.segmentedControls.forEach({ segmentedControl in
+            let tokens = isOverrideEnabled ? PerControlOverrideSegmentedControlTokens() : nil
+            _ = segmentedControl.overrideTokens(tokens)
+        })
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokenOverride(for: FluentButton.self) != nil
+    }
+
+    // MARK: - Custom tokens
+
+    private class ThemeWideOverrideSegmentedControlTokens: SegmentedControlTokens {
+        override var font: FontInfo {
+            return FontInfo(name: "Times", size: 20.0, weight: .regular)
+        }
+    }
+
+    private class PerControlOverrideSegmentedControlTokens: SegmentedControlTokens {
+        override var font: FontInfo {
+            return FontInfo(name: "Papyrus", size: 10.0, weight: .regular)
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -159,8 +159,8 @@ class BackgroundView: UIView {
     }
 
     func updateBackgroundColor() {
-        var lightColor: UIColor
-        var darkColor: UIColor
+        let lightColor: UIColor
+        let darkColor: UIColor
         switch style {
         case .primaryPill:
             if let fluentTheme = window?.fluentTheme {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -29,32 +29,42 @@ class SegmentedControlDemoController: DemoController {
 
         addTitle(text: "Primary Pill")
 
-        addPillControl(items: Array(segmentItems.prefix(3)), style: .primaryPill)
+        addPillControl(items: Array(segmentItems.prefix(3)),
+                       style: .primaryPill)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Primary Pill with unequal buttons")
 
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .primaryPill, equalSegments: false)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .primaryPill,
+                       equalSegments: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Disabled Primary Pill")
 
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .primaryPill, enabled: false)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .primaryPill,
+                       enabled: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "On Brand Pill")
 
-        addPillControl(items: Array(segmentItems.prefix(4)), style: .onBrandPill)
+        addPillControl(items: Array(segmentItems.prefix(4)),
+                       style: .onBrandPill)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "On Brand Pill with unequal buttons")
 
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, equalSegments: false)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .onBrandPill,
+                       equalSegments: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Disabled On Brand Pill")
 
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, enabled: false)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .onBrandPill,
+                       enabled: false)
     }
 
     @objc func updateLabel(forControl control: SegmentedControl) {
@@ -65,7 +75,9 @@ class SegmentedControlDemoController: DemoController {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled
-        pillControl.addTarget(self, action: #selector(updateLabel(forControl:)), for: .valueChanged)
+        pillControl.addTarget(self,
+                              action: #selector(updateLabel(forControl:)),
+                              for: .valueChanged)
 
         let backgroundView = BackgroundView(style: style)
         segmentedControls.append(pillControl)
@@ -75,8 +87,10 @@ class SegmentedControlDemoController: DemoController {
         backgroundView.addSubview(pillControl)
         container.addArrangedSubview(backgroundView)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0)
-        var constraints = [backgroundView.topAnchor.constraint(equalTo: pillControl.topAnchor, constant: -margins.top),
-                           backgroundView.bottomAnchor.constraint(equalTo: pillControl.bottomAnchor, constant: margins.bottom)]
+        var constraints = [backgroundView.topAnchor.constraint(equalTo: pillControl.topAnchor,
+                                                               constant: -margins.top),
+                           backgroundView.bottomAnchor.constraint(equalTo: pillControl.bottomAnchor,
+                                                                  constant: margins.bottom)]
         if equalSegments {
             constraints.append(pillControl.centerXAnchor.constraint(equalTo: backgroundView.centerXAnchor))
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -61,7 +61,7 @@ class SegmentedControlDemoController: DemoController {
         controlLabels[control]?.text = "\"\(segmentItems[control.selectedSegmentIndex].title)\" segment is selected"
     }
 
-    func addPillControl(items: [SegmentItem], style: SegmentedControl.Style, equalSegments: Bool = true, enabled: Bool = true) {
+    func addPillControl(items: [SegmentItem], style: SegmentedControlStyle, equalSegments: Bool = true, enabled: Bool = true) {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -1125,9 +1125,9 @@
 			isa = PBXGroup;
 			children = (
 				ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */,
+				EC5982DD27D2EA6100FD048D /* SegmentedControlTokens.swift */,
 				C708B04B260A8696007190FA /* SegmentItem.swift */,
 				C708B055260A86FA007190FA /* SegmentPillButton.swift */,
-				EC5982DD27D2EA6100FD048D /* SegmentedControlTokens.swift */,
 			);
 			path = SegmentedControl;
 			sourceTree = "<group>";

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		EC02A5F5274DD19600E81B3E /* MSFDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F4274DD19500E81B3E /* MSFDivider.swift */; };
 		EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D727BF348700FD048D /* MSFAvatar.swift */; };
 		EC5982DC27CEC02100FD048D /* DrawerTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982DB27CEC02100FD048D /* DrawerTokens.swift */; };
+		EC5982DE27D2EA6100FD048D /* SegmentedControlTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982DD27D2EA6100FD048D /* SegmentedControlTokens.swift */; };
 		EC6A71EA273DBA520076A586 /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A71E9273DBA520076A586 /* Divider.swift */; };
 		ECA92184279A177D00B66117 /* DividerModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA92183279A177D00B66117 /* DividerModifiers.swift */; };
 		ECA9218627A3301C00B66117 /* MSFAvatarGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */; };
@@ -382,6 +383,7 @@
 		EC02A5F4274DD19500E81B3E /* MSFDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFDivider.swift; sourceTree = "<group>"; };
 		EC5982D727BF348700FD048D /* MSFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatar.swift; sourceTree = "<group>"; };
 		EC5982DB27CEC02100FD048D /* DrawerTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerTokens.swift; sourceTree = "<group>"; };
+		EC5982DD27D2EA6100FD048D /* SegmentedControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlTokens.swift; sourceTree = "<group>"; };
 		EC6A71E9273DBA520076A586 /* Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
 		ECA92183279A177D00B66117 /* DividerModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerModifiers.swift; sourceTree = "<group>"; };
 		ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatarGroup.swift; sourceTree = "<group>"; };
@@ -1125,6 +1127,7 @@
 				ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */,
 				C708B04B260A8696007190FA /* SegmentItem.swift */,
 				C708B055260A86FA007190FA /* SegmentPillButton.swift */,
+				EC5982DD27D2EA6100FD048D /* SegmentedControlTokens.swift */,
 			);
 			path = SegmentedControl;
 			sourceTree = "<group>";
@@ -1584,6 +1587,7 @@
 				5314E0E625F012C00099271A /* UIViewController+Navigation.swift in Sources */,
 				5314E29725F024760099271A /* String+Extension.swift in Sources */,
 				5314E12925F016230099271A /* PillButtonStyle.swift in Sources */,
+				EC5982DE27D2EA6100FD048D /* SegmentedControlTokens.swift in Sources */,
 				5306075726A1E6A4002D49CF /* AvatarGroup.swift in Sources */,
 				92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */,
 				5314E1C425F01B4E0099271A /* TwoLineTitleView.swift in Sources */,

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -94,7 +94,7 @@ class SegmentPillButton: UIButton {
                 xPos = anchor.minX - tokens.unreadDotOffsetX - tokens.unreadDotSize
             }
             unreadDotLayer.frame.origin = CGPoint(x: xPos, y: anchor.minY + tokens.unreadDotOffsetY)
-            let unreadDotColor = isEnabled ? tokens.enabledUnreadDotColor : tokens.disabledLabelColor
+            let unreadDotColor = isEnabled ? tokens.enabledUnreadDotColor : tokens.disabledUnreadDotColor
             unreadDotLayer.backgroundColor = UIColor(dynamicColor: unreadDotColor).cgColor
         }
     }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -37,7 +37,10 @@ class SegmentPillButton: UIButton {
         titleLabel?.font = UIFont.fluent(tokens.font, shouldScale: false)
         let verticalInset = tokens.verticalInset
         let horizontalInset = tokens.horizontalInset
-        contentEdgeInsets = UIEdgeInsets(top: verticalInset, left: horizontalInset, bottom: verticalInset, right: horizontalInset)
+        contentEdgeInsets = UIEdgeInsets(top: verticalInset,
+                                         left: horizontalInset,
+                                         bottom: verticalInset,
+                                         right: horizontalInset)
     }
 
     init(withItem item: SegmentItem, tokens: SegmentedControlTokens) {

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -17,8 +17,6 @@ class SegmentPillButton: UIButton {
         }
     }
 
-    var unreadDotColor: UIColor = Colors.gray100
-
     override var isSelected: Bool {
         didSet {
             if oldValue != isSelected && isSelected == true {
@@ -28,23 +26,37 @@ class SegmentPillButton: UIButton {
         }
     }
 
-    init(withItem item: SegmentItem) {
-        self.item = item
-        super.init(frame: .zero)
+    var tokens: SegmentedControlTokens {
+        didSet {
+            updateTokenizedValues()
+            updateUnreadDot()
+        }
+    }
 
-        self.contentEdgeInsets = Constants.insets
+    private func updateTokenizedValues() {
+        titleLabel?.font = UIFont.fluent(tokens.font)
+        let verticalInset = tokens.verticalInset
+        let horizontalInset = tokens.horizontalInset
+        contentEdgeInsets = UIEdgeInsets(top: verticalInset, left: horizontalInset, bottom: verticalInset, right: horizontalInset)
+    }
+
+    init(withItem item: SegmentItem, tokens: SegmentedControlTokens) {
+        self.item = item
+        self.tokens = tokens
+        super.init(frame: .zero)
 
         let title = item.title
         self.setTitle(title, for: .normal)
         self.accessibilityLabel = title
         self.largeContentTitle = title
         self.showsLargeContentViewer = true
-        self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(isUnreadValueDidChange),
                                                name: SegmentItem.isUnreadValueDidChangeNotification,
                                                object: item)
+
+        updateTokenizedValues()
     }
 
     required init?(coder: NSCoder) {
@@ -58,12 +70,15 @@ class SegmentPillButton: UIButton {
 
     private let item: SegmentItem
 
-    private let unreadDotLayer: CALayer = {
+    private func initUnreadDotLayer() -> CALayer {
         let unreadDotLayer = CALayer()
-        unreadDotLayer.bounds.size = CGSize(width: Constants.unreadDotSize, height: Constants.unreadDotSize)
-        unreadDotLayer.cornerRadius = Constants.unreadDotSize / 2
+        let unreadDotSize = tokens.unreadDotSize
+        unreadDotLayer.bounds.size = CGSize(width: unreadDotSize, height: unreadDotSize)
+        unreadDotLayer.cornerRadius = unreadDotSize / 2
         return unreadDotLayer
-    }()
+    }
+
+    private lazy var unreadDotLayer: CALayer = initUnreadDotLayer()
 
     @objc private func isUnreadValueDidChange() {
         isUnreadDotVisible = item.isUnread
@@ -76,19 +91,13 @@ class SegmentPillButton: UIButton {
             let anchor = self.titleLabel?.frame ?? .zero
             let xPos: CGFloat
             if effectiveUserInterfaceLayoutDirection == .leftToRight {
-                xPos = anchor.maxX + Constants.unreadDotOffset.x
+                xPos = anchor.maxX + tokens.unreadDotOffsetX
             } else {
-                xPos = anchor.minX - Constants.unreadDotOffset.x - Constants.unreadDotSize
+                xPos = anchor.minX - tokens.unreadDotOffsetX - tokens.unreadDotSize
             }
-            unreadDotLayer.frame.origin = CGPoint(x: xPos, y: anchor.minY + Constants.unreadDotOffset.y)
-            unreadDotLayer.backgroundColor = unreadDotColor.cgColor
+            unreadDotLayer.frame.origin = CGPoint(x: xPos, y: anchor.minY + tokens.unreadDotOffsetY)
+            let unreadDotColor = isEnabled ? tokens.enabledUnreadDotColor : tokens.disabledLabelColor
+            unreadDotLayer.backgroundColor = UIColor(dynamicColor: unreadDotColor).cgColor
         }
-    }
-
-    private struct Constants {
-        static let fontSize: CGFloat = 16
-        static let unreadDotOffset = CGPoint(x: 6, y: 3)
-        static let unreadDotSize: CGFloat = 6
-        static let insets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -70,15 +70,13 @@ class SegmentPillButton: UIButton {
 
     private let item: SegmentItem
 
-    private func initUnreadDotLayer() -> CALayer {
+    private lazy var unreadDotLayer: CALayer = {
         let unreadDotLayer = CALayer()
         let unreadDotSize = tokens.unreadDotSize
         unreadDotLayer.bounds.size = CGSize(width: unreadDotSize, height: unreadDotSize)
         unreadDotLayer.cornerRadius = unreadDotSize / 2
         return unreadDotLayer
-    }
-
-    private lazy var unreadDotLayer: CALayer = initUnreadDotLayer()
+    }()
 
     @objc private func isUnreadValueDidChange() {
         isUnreadDotVisible = item.isUnread

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -34,7 +34,7 @@ class SegmentPillButton: UIButton {
     }
 
     private func updateTokenizedValues() {
-        titleLabel?.font = UIFont.fluent(tokens.font)
+        titleLabel?.font = UIFont.fluent(tokens.font, shouldScale: false)
         let verticalInset = tokens.verticalInset
         let horizontalInset = tokens.horizontalInset
         contentEdgeInsets = UIEdgeInsets(top: verticalInset, left: horizontalInset, bottom: verticalInset, right: horizontalInset)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -143,14 +143,22 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     }
 
     public func updateColors() {
-        pillMaskedLabelsContainerView.backgroundColor = isEnabled ? UIColor(dynamicColor: tokens.selectedTabColor) : UIColor(dynamicColor: tokens.disabledSelectedTabColor)
-        backgroundView.backgroundColor = isEnabled ? UIColor(dynamicColor: tokens.restTabColor) : UIColor(dynamicColor: tokens.disabledTabColor)
+        let tabColor: DynamicColor
+        let selectedTabColor: DynamicColor
+        let selectedLabelColor: DynamicColor
+        if isEnabled {
+            tabColor = tokens.restTabColor
+            selectedTabColor = tokens.selectedTabColor
+            selectedLabelColor = tokens.selectedLabelColor
+        } else {
+            tabColor = tokens.disabledTabColor
+            selectedTabColor = tokens.disabledSelectedTabColor
+            selectedLabelColor = tokens.disabledSelectedLabelColor
+        }
+        backgroundView.backgroundColor = UIColor(dynamicColor: tabColor)
+        pillMaskedLabelsContainerView.backgroundColor = UIColor(dynamicColor: selectedTabColor)
         for maskedLabel in pillMaskedLabels {
-            if isEnabled {
-                maskedLabel.textColor = UIColor(dynamicColor: tokens.selectedLabelColor)
-            } else {
-                maskedLabel.textColor = UIColor(dynamicColor: tokens.disabledSelectedLabelColor)
-            }
+            maskedLabel.textColor = UIColor(dynamicColor: selectedLabelColor)
         }
     }
 
@@ -361,11 +369,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     private func updateButtons() {
         for (index, button) in buttons.enumerated() {
             button.tokens = tokens
-            if isEnabled {
-                button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
-            } else {
-                button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
-            }
+            let labelColor = isEnabled ? tokens.restLabelColor : tokens.disabledLabelColor
+            button.setTitleColor(UIColor(dynamicColor: labelColor), for: .normal)
             pillMaskedLabels[index].font = button.titleLabel?.font
         }
     }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -26,6 +26,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         self.tokens = tokens
     }
 
+    var selectionChangeAnimationDuration: TimeInterval { return 0.2 }
+
     @objc(MSFSegmentedControlStyle)
     public enum Style: Int {
         /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
@@ -33,15 +35,6 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         /// Segments are shows as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
         /// Selection is indicated by a thumb under the selected label.
         case onBrandPill
-
-        var backgroundHasRoundedCorners: Bool { return self == .primaryPill || self == .onBrandPill }
-
-        var selectionChangeAnimationDuration: TimeInterval {
-            switch self {
-            case .primaryPill, .onBrandPill:
-                return 0.2
-            }
-        }
     }
 
     private struct Constants {
@@ -310,7 +303,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
         if animated {
             isAnimating = true
-            UIView.animate(withDuration: style.selectionChangeAnimationDuration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState], animations: {
+            UIView.animate(withDuration: selectionChangeAnimationDuration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState], animations: {
                 self.layoutSelectionView()
             }, completion: { _ in
                 self.isAnimating = false

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -4,27 +4,6 @@
 //
 import UIKit
 
-// MARK: SegmentedControl Colors
-
-private extension Colors {
-    struct SegmentedControl {
-        struct PrimaryPill {
-            static let background = UIColor(light: surfaceTertiary, dark: gray950)
-            static let backgroundDisabled: UIColor = background
-            static let segmentText = UIColor(light: textSecondary, dark: textPrimary)
-            static let selectionDisabled: UIColor = surfaceQuaternary
-        }
-
-        struct OnBrandPill {
-            static let background: UIColor = PrimaryPill.background
-            static let backgroundDisabled: UIColor = PrimaryPill.backgroundDisabled
-            static let segmentText = UIColor(light: textOnAccent, dark: textPrimary)
-            static let selection = UIColor(light: surfacePrimary, dark: surfaceQuaternary)
-            static let selectionDisabled = UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        }
-    }
-}
-
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.
 @objc(MSFSegmentedControl)
@@ -56,80 +35,6 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         case onBrandPill
 
         var backgroundHasRoundedCorners: Bool { return self == .primaryPill || self == .onBrandPill }
-
-        func backgroundColor(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.background
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.background)
-            }
-        }
-        func backgroundColorDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.backgroundDisabled
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.backgroundDisabled)
-            }
-        }
-        func selectionColor(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.primary(for: window)
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.selection
-            }
-        }
-        var selectionColorDisabled: UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.selectionDisabled
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.selectionDisabled
-            }
-        }
-        var segmentTextColor: UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.segmentText
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.segmentText
-            }
-        }
-        func segmentTextColorSelected(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.textOnAccent
-            case .onBrandPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
-            }
-        }
-        func segmentTextColorDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.textDisabled
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
-            }
-        }
-        func segmentTextColorSelectedAndDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
-            }
-        }
-
-        func segmentUnreadDotColor(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.gray100)
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.segmentText
-            }
-        }
 
         var selectionChangeAnimationDuration: TimeInterval {
             switch self {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -131,6 +131,11 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         addSubview(pillContainerView)
 
         setupLayoutConstraints()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -449,6 +454,15 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
         let button = buttons[index]
         button.isSelected = isSelected
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        if let window = self.window,
+           window.isEqual(notification.object) {
+            updateSegmentedControlTokens()
+            updateColors()
+            updateButtons()
+        }
     }
 
     private func layoutSelectionView() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -18,12 +18,23 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         didSet {
             updateSegmentedControlTokens()
             updateColors()
+            updateButtons()
         }
     }
     private func updateSegmentedControlTokens() {
         let tokens = resolvedTokens
         tokens.style = style
         self.tokens = tokens
+    }
+    private func updateButtons() {
+        for button in buttons {
+            button.tokens = tokens
+            if isEnabled {
+                button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
+            } else {
+                button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
+            }
+        }
     }
 
     var selectionChangeAnimationDuration: TimeInterval { return 0.2 }
@@ -90,7 +101,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
         return view
     }()
-    private var buttons = [UIButton]()
+    private var buttons = [SegmentPillButton]()
     private let selectionView: UIView = {
         let view = UIView()
         view.layer.cornerCurve = .continuous
@@ -160,17 +171,6 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
                 maskedLabel.textColor = UIColor(dynamicColor: tokens.selectedLabelColor)
             } else {
                 maskedLabel.textColor = UIColor(dynamicColor: tokens.disabledSelectedLabelColor)
-            }
-        }
-        for button in buttons {
-            if isEnabled {
-                button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
-            } else {
-                button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
-            }
-
-            if let switchButton = button as? SegmentPillButton {
-                switchButton.unreadDotColor = isEnabled ? UIColor(dynamicColor: tokens.enabledUnreadDotColor) : UIColor(dynamicColor: tokens.disabledLabelColor)
             }
         }
     }
@@ -345,6 +345,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         super.didMoveToWindow()
         updateSegmentedControlTokens()
         updateColors()
+        updateButtons()
     }
 
     func intrinsicContentSizeInvalidatedForChildView() {
@@ -372,13 +373,13 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         }
     }
 
-    private func createPillButton(withItem item: SegmentItem) -> UIButton {
-        let button = SegmentPillButton(withItem: item)
+    private func createPillButton(withItem item: SegmentItem) -> SegmentPillButton {
+        let button = SegmentPillButton(withItem: item, tokens: tokens)
         button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
         return button
     }
 
-    private func addMaskedPillLabel(over button: UIButton, at index: Int) {
+    private func addMaskedPillLabel(over button: SegmentPillButton, at index: Int) {
         let maskedLabel = UILabel()
         maskedLabel.text = button.currentTitle
         maskedLabel.font = button.titleLabel?.font
@@ -397,7 +398,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         }
     }
 
-    @objc private func handleButtonTap(_ sender: UIButton) {
+    @objc private func handleButtonTap(_ sender: SegmentPillButton) {
         if let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index {
             selectSegment(at: index, animated: isAnimated)
             sendActions(for: .valueChanged)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -78,11 +78,11 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     // Hierarchy for pill styles:
     //
     // pillContainerView (used to create 16pt inset on either side)
-    // |--backgroundView (fill container view, uses customSegmentedControlBackgroundColor)
-    // |--buttons (uses customSegmentedControlButtonTextColor)
-    // |--pillMaskedLabelsContainerView (fill container view, uses customSegmentedControlSelectedButtonBackgroundColor)
+    // |--backgroundView (fill container view, uses restTabColor)
+    // |--buttons (uses restLabelColor)
+    // |--pillMaskedLabelsContainerView (fill container view, uses selectedTabColor)
     // |  |.mask -> selectionView
-    // |  |--pillMaskedLabels (uses customSelectedSegmentedControlButtonTextColor)
+    // |  |--pillMaskedLabels (uses selectedLabelColor)
 
     private let backgroundView: UIView = {
         let view = UIView()

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -67,10 +67,6 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     }
 
     private var _selectedSegmentIndex: Int = -1
-    private var customSegmentedControlBackgroundColor: UIColor?
-    private var customSegmentedControlSelectedButtonBackgroundColor: UIColor?
-    private var customSegmentedControlButtonTextColor: UIColor?
-    private var customSelectedSegmentedControlButtonTextColor: UIColor?
 
     private var items = [SegmentItem]()
     internal var style: SegmentedControlStyle {
@@ -129,34 +125,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     ///
     /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
-    @objc public convenience init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
-        self.init(items: items,
-                  style: style,
-                  customSegmentedControlBackgroundColor: nil,
-                  customSegmentedControlSelectedButtonBackgroundColor: nil,
-                  customSegmentedControlButtonTextColor: nil,
-                  customSelectedSegmentedControlButtonTextColor: nil)
-    }
-
-    /// Initializes a segmented control with the specified titles, style, and colors (colors are for pill styles only).
-    ///
-    /// - Parameter items: An array of Segmented Items representing the segments for this control.
-    /// - Parameter style: A style used for rendering of the control.
-    /// - Parameter customSegmentedControlBackgroundColor: UIColor to use as the background color
-    /// - Parameter customSegmentedControlSelectedButtonBackgroundColor: UIColor to use as the selected button background color
-    /// - Parameter customSegmentedControlButtonTextColor: UIColor to use as the unselected button text color
-    /// - Parameter customSelectedSegmentedControlButtonTextColor: UIColor to use as the selected button text color
-    @objc public init(items: [SegmentItem],
-                      style: SegmentedControlStyle = .primaryPill,
-                      customSegmentedControlBackgroundColor: UIColor? = nil,
-                      customSegmentedControlSelectedButtonBackgroundColor: UIColor? = nil,
-                      customSegmentedControlButtonTextColor: UIColor? = nil,
-                      customSelectedSegmentedControlButtonTextColor: UIColor? = nil) {
+    @objc public init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
         self.style = style
-        self.customSegmentedControlBackgroundColor = customSegmentedControlBackgroundColor
-        self.customSegmentedControlSelectedButtonBackgroundColor = customSegmentedControlSelectedButtonBackgroundColor
-        self.customSegmentedControlButtonTextColor = customSegmentedControlButtonTextColor
-        self.customSelectedSegmentedControlButtonTextColor = customSelectedSegmentedControlButtonTextColor
 
         super.init(frame: .zero)
 
@@ -187,26 +157,18 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
             return
         }
 
-        pillMaskedLabelsContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? UIColor(dynamicColor: tokens.selectedTabColor) : UIColor(dynamicColor: tokens.disabledSelectedTabColor))
-        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? UIColor(dynamicColor: tokens.restTabColor) : UIColor(dynamicColor: tokens.disabledTabColor))
+        pillMaskedLabelsContainerView.backgroundColor = isEnabled ? UIColor(dynamicColor: tokens.selectedTabColor) : UIColor(dynamicColor: tokens.disabledSelectedTabColor)
+        backgroundView.backgroundColor = isEnabled ? UIColor(dynamicColor: tokens.restTabColor) : UIColor(dynamicColor: tokens.disabledTabColor)
         for maskedLabel in pillMaskedLabels {
             if isEnabled {
-                if let customSelectedButtonTextColor = self.customSelectedSegmentedControlButtonTextColor {
-                    maskedLabel.textColor = customSelectedButtonTextColor
-                } else {
-                        maskedLabel.textColor = UIColor(dynamicColor: tokens.selectedLabelColor)
-                }
+                maskedLabel.textColor = UIColor(dynamicColor: tokens.selectedLabelColor)
             } else {
                     maskedLabel.textColor = UIColor(dynamicColor: tokens.disabledSelectedLabelColor)
             }
         }
         for button in buttons {
             if isEnabled {
-                if let customButtonTextColor = self.customSegmentedControlButtonTextColor {
-                    button.setTitleColor(customButtonTextColor, for: .normal)
-                } else {
-                    button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
-                }
+                button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
             } else {
                     button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
             }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -28,7 +28,25 @@ private extension Colors {
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.
 @objc(MSFSegmentedControl)
-open class SegmentedControl: UIControl {
+open class SegmentedControl: UIControl, TokenizedControlInternal {
+    public func overrideTokens(_ tokens: SegmentedControlTokens?) -> Self {
+        overrideTokens = tokens
+        return self
+    }
+    var defaultTokens: SegmentedControlTokens = .init()
+    var tokens: SegmentedControlTokens = .init()
+    var overrideTokens: SegmentedControlTokens? {
+        didSet {
+            updateSegmentedControlTokens()
+            updateWindowSpecificColors()
+        }
+    }
+    private func updateSegmentedControlTokens() {
+        let tokens = resolvedTokens
+        tokens.style = style
+        self.tokens = tokens
+    }
+
     @objc(MSFSegmentedControlStyle)
     public enum Style: Int {
         /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -28,15 +28,6 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
     var selectionChangeAnimationDuration: TimeInterval { return 0.2 }
 
-    @objc(MSFSegmentedControlStyle)
-    public enum Style: Int {
-        /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
-        case primaryPill
-        /// Segments are shows as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
-        /// Selection is indicated by a thumb under the selected label.
-        case onBrandPill
-    }
-
     private struct Constants {
         static let selectionBarHeight: CGFloat = 1.5
         static let pillContainerHorizontalInset: CGFloat = 16
@@ -82,7 +73,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     private var customSelectedSegmentedControlButtonTextColor: UIColor?
 
     private var items = [SegmentItem]()
-    internal var style: Style {
+    internal var style: SegmentedControlStyle {
         didSet {
             updateWindowSpecificColors()
         }
@@ -138,7 +129,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     ///
     /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
-    @objc public convenience init(items: [SegmentItem], style: Style = .primaryPill) {
+    @objc public convenience init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
         self.init(items: items,
                   style: style,
                   customSegmentedControlBackgroundColor: nil,
@@ -156,7 +147,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     /// - Parameter customSegmentedControlButtonTextColor: UIColor to use as the unselected button text color
     /// - Parameter customSelectedSegmentedControlButtonTextColor: UIColor to use as the selected button text color
     @objc public init(items: [SegmentItem],
-                      style: Style = .primaryPill,
+                      style: SegmentedControlStyle = .primaryPill,
                       customSegmentedControlBackgroundColor: UIColor? = nil,
                       customSegmentedControlSelectedButtonBackgroundColor: UIColor? = nil,
                       customSegmentedControlButtonTextColor: UIColor? = nil,

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -12,32 +12,6 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         overrideTokens = tokens
         return self
     }
-    var defaultTokens: SegmentedControlTokens = .init()
-    var tokens: SegmentedControlTokens = .init()
-    var overrideTokens: SegmentedControlTokens? {
-        didSet {
-            updateSegmentedControlTokens()
-            updateColors()
-            updateButtons()
-        }
-    }
-    private func updateSegmentedControlTokens() {
-        let tokens = resolvedTokens
-        tokens.style = style
-        self.tokens = tokens
-    }
-    private func updateButtons() {
-        for button in buttons {
-            button.tokens = tokens
-            if isEnabled {
-                button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
-            } else {
-                button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
-            }
-        }
-    }
-
-    var selectionChangeAnimationDuration: TimeInterval { return 0.2 }
 
     private struct Constants {
         static let selectionBarHeight: CGFloat = 1.5
@@ -359,6 +333,34 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         }
 
         return buttons[index] as UIView
+    }
+
+    var defaultTokens: SegmentedControlTokens = .init()
+    var tokens: SegmentedControlTokens = .init()
+    var overrideTokens: SegmentedControlTokens? {
+        didSet {
+            updateSegmentedControlTokens()
+            updateColors()
+            updateButtons()
+        }
+    }
+
+    var selectionChangeAnimationDuration: TimeInterval { return 0.2 }
+
+    private func updateSegmentedControlTokens() {
+        let tokens = resolvedTokens
+        tokens.style = style
+        self.tokens = tokens
+    }
+    private func updateButtons() {
+        for button in buttons {
+            button.tokens = tokens
+            if isEnabled {
+                button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
+            } else {
+                button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
+            }
+        }
     }
 
     private func addButtons(items: [SegmentItem]) {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -222,7 +222,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     ///   - index: The index of the segment to set as selected
     ///   - animated: Whether or not to animate the change in selected segment
     @objc open func selectSegment(at index: Int, animated: Bool) {
-        precondition(index >= 0 && index < buttons.count, "SegmentedControl > try to selected segment index with invalid index: \(index)")
+        precondition(index >= 0 && index < buttons.count,
+                     "SegmentedControl > try to selected segment index with invalid index: \(index)")
 
         if index == _selectedSegmentIndex {
             return
@@ -239,7 +240,10 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
         if animated {
             isAnimating = true
-            UIView.animate(withDuration: selectionChangeAnimationDuration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState], animations: {
+            UIView.animate(withDuration: selectionChangeAnimationDuration,
+                           delay: 0,
+                           options: [.curveEaseOut, .beginFromCurrentState],
+                           animations: {
                 self.layoutSelectionView()
             }, completion: { _ in
                 self.isAnimating = false
@@ -263,10 +267,14 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
             if shouldSetEqualWidthForSegments {
                 rightOffset = screen.roundToDevicePixels(CGFloat(index + 1) / CGFloat(buttons.count) * pillContainerView.frame.width)
             } else {
-                let maxSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+                let maxSize = CGSize(width: CGFloat.greatestFiniteMagnitude,
+                                     height: CGFloat.greatestFiniteMagnitude)
                 rightOffset = leftOffset + screen.roundToDevicePixels(button.sizeThatFits(maxSize).width)
             }
-            button.frame = CGRect(x: leftOffset, y: 0, width: rightOffset - leftOffset, height: pillContainerView.frame.height)
+            button.frame = CGRect(x: leftOffset,
+                                  y: 0,
+                                  width: rightOffset - leftOffset,
+                                  height: pillContainerView.frame.height)
             leftOffset = rightOffset
         }
 
@@ -278,7 +286,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     }
 
     open override var intrinsicContentSize: CGSize {
-        return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
+        return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude,
+                                   height: CGFloat.greatestFiniteMagnitude))
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -325,7 +334,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         }
         maxButtonHeight += (contentInset.top + contentInset.bottom)
 
-        return CGSize(width: min(maxButtonWidth, size.width), height: min(maxButtonHeight, size.height))
+        return CGSize(width: min(maxButtonWidth, size.width),
+                      height: min(maxButtonHeight, size.height))
     }
 
     open override func didMoveToWindow() {
@@ -425,10 +435,14 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         pillContainerView.translatesAutoresizingMaskIntoConstraints = false
         pillMaskedLabelsContainerView.translatesAutoresizingMaskIntoConstraints = false
 
-        let pillContainerViewTopConstraint = pillContainerView.topAnchor.constraint(equalTo: topAnchor, constant: contentInset.top)
-        let pillContainerViewBottomConstraint = pillContainerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -contentInset.bottom)
-        let pillContainerViewLeadingConstraint = pillContainerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: contentInset.leading)
-        let pillContainerViewTrailingConstraint = pillContainerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -contentInset.trailing)
+        let pillContainerViewTopConstraint = pillContainerView.topAnchor.constraint(equalTo: topAnchor,
+                                                                                    constant: contentInset.top)
+        let pillContainerViewBottomConstraint = pillContainerView.bottomAnchor.constraint(equalTo: bottomAnchor,
+                                                                                          constant: -contentInset.bottom)
+        let pillContainerViewLeadingConstraint = pillContainerView.leadingAnchor.constraint(equalTo: leadingAnchor,
+                                                                                            constant: contentInset.leading)
+        let pillContainerViewTrailingConstraint = pillContainerView.trailingAnchor.constraint(equalTo: trailingAnchor,
+                                                                                              constant: -contentInset.trailing)
         self.pillContainerViewTopConstraint = pillContainerViewTopConstraint
         self.pillContainerViewBottomConstraint = pillContainerViewBottomConstraint
         self.pillContainerViewLeadingConstraint = pillContainerViewLeadingConstraint
@@ -482,7 +496,8 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
     private func updateAccessibilityHints() {
         for (index, button) in buttons.enumerated() {
-            button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+            button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized,
+                                                                        index + 1, items.count)
         }
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -298,17 +298,17 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
             return
         }
 
-        pillMaskedLabelsContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(for: window) : style.selectionColorDisabled)
-        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(for: window) : style.backgroundColorDisabled(for: window))
+        pillMaskedLabelsContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? UIColor(dynamicColor: tokens.selectedTabColor) : UIColor(dynamicColor: tokens.disabledSelectedTabColor))
+        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? UIColor(dynamicColor: tokens.restTabColor) : UIColor(dynamicColor: tokens.disabledTabColor))
         for maskedLabel in pillMaskedLabels {
             if isEnabled {
                 if let customSelectedButtonTextColor = self.customSelectedSegmentedControlButtonTextColor {
                     maskedLabel.textColor = customSelectedButtonTextColor
                 } else {
-                        maskedLabel.textColor = style.segmentTextColorSelected(for: window)
+                        maskedLabel.textColor = UIColor(dynamicColor: tokens.selectedLabelColor)
                 }
             } else {
-                    maskedLabel.textColor = style.segmentTextColorSelectedAndDisabled(for: window)
+                    maskedLabel.textColor = UIColor(dynamicColor: tokens.disabledSelectedLabelColor)
             }
         }
         for button in buttons {
@@ -316,14 +316,14 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
                 if let customButtonTextColor = self.customSegmentedControlButtonTextColor {
                     button.setTitleColor(customButtonTextColor, for: .normal)
                 } else {
-                    button.setTitleColor(style.segmentTextColor, for: .normal)
+                    button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
                 }
             } else {
-                    button.setTitleColor(style.segmentTextColorDisabled(for: window), for: .normal)
+                    button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
             }
 
             if let switchButton = button as? SegmentPillButton {
-                switchButton.unreadDotColor = isEnabled ? style.segmentUnreadDotColor(for: window) : style.segmentTextColorDisabled(for: window)
+                switchButton.unreadDotColor = isEnabled ? UIColor(dynamicColor: tokens.enabledUnreadDotColor) : UIColor(dynamicColor: tokens.disabledLabelColor)
             }
         }
     }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -17,7 +17,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     var overrideTokens: SegmentedControlTokens? {
         didSet {
             updateSegmentedControlTokens()
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
     private func updateSegmentedControlTokens() {
@@ -39,7 +39,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
             for button in buttons {
                 button.isEnabled = isEnabled
             }
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
 
@@ -71,7 +71,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     private var items = [SegmentItem]()
     internal var style: SegmentedControlStyle {
         didSet {
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
 
@@ -152,25 +152,21 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    public func updateWindowSpecificColors() {
-        guard let window = window else {
-            return
-        }
-
+    public func updateColors() {
         pillMaskedLabelsContainerView.backgroundColor = isEnabled ? UIColor(dynamicColor: tokens.selectedTabColor) : UIColor(dynamicColor: tokens.disabledSelectedTabColor)
         backgroundView.backgroundColor = isEnabled ? UIColor(dynamicColor: tokens.restTabColor) : UIColor(dynamicColor: tokens.disabledTabColor)
         for maskedLabel in pillMaskedLabels {
             if isEnabled {
                 maskedLabel.textColor = UIColor(dynamicColor: tokens.selectedLabelColor)
             } else {
-                    maskedLabel.textColor = UIColor(dynamicColor: tokens.disabledSelectedLabelColor)
+                maskedLabel.textColor = UIColor(dynamicColor: tokens.disabledSelectedLabelColor)
             }
         }
         for button in buttons {
             if isEnabled {
                 button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
             } else {
-                    button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
+                button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
             }
 
             if let switchButton = button as? SegmentPillButton {
@@ -347,7 +343,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateWindowSpecificColors()
+        updateColors()
     }
 
     func intrinsicContentSizeInvalidatedForChildView() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -462,12 +462,12 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        if let window = self.window,
-           window.isEqual(notification.object) {
-            updateSegmentedControlTokens()
-            updateColors()
-            updateButtons()
+        guard let window = window, window.isEqual(notification.object) else {
+            return
         }
+        updateSegmentedControlTokens()
+        updateColors()
+        updateButtons()
     }
 
     private func layoutSelectionView() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -343,6 +343,7 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
+        updateSegmentedControlTokens()
         updateColors()
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -352,14 +352,16 @@ open class SegmentedControl: UIControl, TokenizedControlInternal {
         tokens.style = style
         self.tokens = tokens
     }
+
     private func updateButtons() {
-        for button in buttons {
+        for (index, button) in buttons.enumerated() {
             button.tokens = tokens
             if isEnabled {
                 button.setTitleColor(UIColor(dynamicColor: tokens.restLabelColor), for: .normal)
             } else {
                 button.setTitleColor(UIColor(dynamicColor: tokens.disabledLabelColor), for: .normal)
             }
+            pillMaskedLabels[index].font = button.titleLabel?.font
         }
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
@@ -14,9 +14,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var restTabColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: aliasTokens.backgroundColors[.neutral4].light, dark: aliasTokens.backgroundColors[.neutral3].dark)
+            return DynamicColor(light: aliasTokens.backgroundColors[.neutral4].light,
+                                dark: aliasTokens.backgroundColors[.neutral3].dark)
         case .onBrandPill:
-            return DynamicColor(light: aliasTokens.backgroundColors[.brandHover].light, dark: aliasTokens.backgroundColors[.neutral3].dark)
+            return DynamicColor(light: aliasTokens.backgroundColors[.brandHover].light,
+                                dark: aliasTokens.backgroundColors[.neutral3].dark)
         }
     }
 
@@ -26,7 +28,8 @@ open class SegmentedControlTokens: ControlTokens {
         case .primaryPill:
             return aliasTokens.foregroundColors[.brandRest]
         case .onBrandPill:
-            return DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: globalTokens.neutralColors[.grey32])
+            return DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light,
+                                dark: globalTokens.neutralColors[.grey32])
         }
     }
 
@@ -34,9 +37,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var disabledTabColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8])
+            return DynamicColor(light: globalTokens.neutralColors[.grey94],
+                                dark: globalTokens.neutralColors[.grey8])
         case .onBrandPill:
-            return DynamicColor(light: globalTokens.brandColors[.shade20].light, dark: globalTokens.neutralColors[.grey8])
+            return DynamicColor(light: globalTokens.brandColors[.shade20].light,
+                                dark: globalTokens.neutralColors[.grey8])
         }
     }
 
@@ -44,9 +49,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var disabledSelectedTabColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: globalTokens.neutralColors[.grey80], dark: globalTokens.neutralColors[.grey30])
+            return DynamicColor(light: globalTokens.neutralColors[.grey80],
+                                dark: globalTokens.neutralColors[.grey30])
         case .onBrandPill:
-            return DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.grey30])
+            return DynamicColor(light: globalTokens.neutralColors[.white],
+                                dark: globalTokens.neutralColors[.grey30])
         }
     }
 
@@ -54,9 +61,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var restLabelColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: aliasTokens.foregroundColors[.neutral3].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutral3].light,
+                                dark: aliasTokens.foregroundColors[.neutral2].dark)
         case .onBrandPill:
-            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light,
+                                dark: aliasTokens.foregroundColors[.neutral2].dark)
         }
     }
 
@@ -64,9 +73,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var selectedLabelColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: aliasTokens.foregroundColors[.neutralInverted].dark)
+            return DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light,
+                                dark: aliasTokens.foregroundColors[.neutralInverted].dark)
         case .onBrandPill:
-            return DynamicColor(light: aliasTokens.foregroundColors[.brandRest].light, dark: aliasTokens.foregroundColors[.neutral1].dark)
+            return DynamicColor(light: aliasTokens.foregroundColors[.brandRest].light,
+                                dark: aliasTokens.foregroundColors[.neutral1].dark)
         }
     }
 
@@ -74,9 +85,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var disabledLabelColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: globalTokens.neutralColors[.grey70], dark: globalTokens.neutralColors[.grey26])
+            return DynamicColor(light: globalTokens.neutralColors[.grey70],
+                                dark: globalTokens.neutralColors[.grey26])
         case .onBrandPill:
-            return DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.neutralColors[.grey26])
+            return DynamicColor(light: globalTokens.brandColors[.shade10].light,
+                                dark: globalTokens.neutralColors[.grey26])
         }
     }
 
@@ -84,9 +97,11 @@ open class SegmentedControlTokens: ControlTokens {
     open var disabledSelectedLabelColor: DynamicColor {
         switch style {
         case .primaryPill:
-            return DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey44])
+            return DynamicColor(light: globalTokens.neutralColors[.grey94],
+                                dark: globalTokens.neutralColors[.grey44])
         case .onBrandPill:
-            return DynamicColor(light: globalTokens.neutralColors[.grey74], dark: globalTokens.neutralColors[.grey44])
+            return DynamicColor(light: globalTokens.neutralColors[.grey74],
+                                dark: globalTokens.neutralColors[.grey44])
         }
     }
 
@@ -96,7 +111,8 @@ open class SegmentedControlTokens: ControlTokens {
         case .primaryPill:
             return aliasTokens.foregroundColors[.brandRest]
         case .onBrandPill:
-            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light,
+                                dark: aliasTokens.foregroundColors[.neutral2].dark)
         }
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
@@ -100,6 +100,11 @@ open class SegmentedControlTokens: ControlTokens {
         }
     }
 
+    /// The color of the unread dot when the `SegmentedControl` is disabled.
+    open var disabledUnreadDotColor: DynamicColor {
+        return disabledLabelColor
+    }
+
     /// The distance of the content from the top and bottom of the `SegmentedControl`.
     open var verticalInset: CGFloat { 6.0 }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
@@ -8,7 +8,7 @@ import UIKit
 /// Design token set for the `SegmentedControl`.
 open class SegmentedControlTokens: ControlTokens {
     /// Defines the style of the `SegmentedControl`.
-    public internal(set) var style: SegmentedControl.Style = .primaryPill
+    public internal(set) var style: SegmentedControlStyle = .primaryPill
 
     /// Defines the background color of the unselected segments of the `SegmentedControl`.
     open var restTabColor: DynamicColor {
@@ -117,4 +117,13 @@ open class SegmentedControlTokens: ControlTokens {
 
     /// The font used for the label of the `SegmentedControl`.
     open var font: FontInfo { aliasTokens.typography[.body2] }
+}
+
+@objc(MSFSegmentedControlStyle)
+public enum SegmentedControlStyle: Int {
+    /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
+    case primaryPill
+    /// Segments are shows as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
+    /// Selection is indicated by a thumb under the selected label.
+    case onBrandPill
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
@@ -104,7 +104,7 @@ open class SegmentedControlTokens: ControlTokens {
     open var verticalInset: CGFloat { 6.0 }
 
     /// The distance of the content from the leading and trailing edges of the `SegmentedControl`.
-    open var horizontalInset: CGFloat { 16.0 }
+    open var horizontalInset: CGFloat { globalTokens.spacing[.medium] }
 
     /// The distance of the unread dot from the trailing edge of the content of the `SegmentedControl`.
     open var unreadDotOffsetX: CGFloat { 6.0 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokens.swift
@@ -1,0 +1,120 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Design token set for the `SegmentedControl`.
+open class SegmentedControlTokens: ControlTokens {
+    /// Defines the style of the `SegmentedControl`.
+    public internal(set) var style: SegmentedControl.Style = .primaryPill
+
+    /// Defines the background color of the unselected segments of the `SegmentedControl`.
+    open var restTabColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: aliasTokens.backgroundColors[.neutral4].light, dark: aliasTokens.backgroundColors[.neutral3].dark)
+        case .onBrandPill:
+            return DynamicColor(light: aliasTokens.backgroundColors[.brandHover].light, dark: aliasTokens.backgroundColors[.neutral3].dark)
+        }
+    }
+
+    /// Defines the background color of the selected segments of the `SegmentedControl`.
+    open var selectedTabColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return aliasTokens.foregroundColors[.brandRest]
+        case .onBrandPill:
+            return DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: globalTokens.neutralColors[.grey32])
+        }
+    }
+
+    /// Defines the background color of the unselected segments of the `SegmentedControl` when disabled.
+    open var disabledTabColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey8])
+        case .onBrandPill:
+            return DynamicColor(light: globalTokens.brandColors[.shade20].light, dark: globalTokens.neutralColors[.grey8])
+        }
+    }
+
+    /// Defines the background color of the selected segments of the `SegmentedControl` when disabled.
+    open var disabledSelectedTabColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: globalTokens.neutralColors[.grey80], dark: globalTokens.neutralColors[.grey30])
+        case .onBrandPill:
+            return DynamicColor(light: globalTokens.neutralColors[.white], dark: globalTokens.neutralColors[.grey30])
+        }
+    }
+
+    /// Defines the label color of the unselected segments of the `SegmentedControl`.
+    open var restLabelColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutral3].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
+        case .onBrandPill:
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
+        }
+    }
+
+    /// Defines the label color of the selected segments of the `SegmentedControl`.
+    open var selectedLabelColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: aliasTokens.backgroundColors[.neutral1].light, dark: aliasTokens.foregroundColors[.neutralInverted].dark)
+        case .onBrandPill:
+            return DynamicColor(light: aliasTokens.foregroundColors[.brandRest].light, dark: aliasTokens.foregroundColors[.neutral1].dark)
+        }
+    }
+
+    /// Defines the label color of the unselected segments of the `SegmentedControl` when disabled.
+    open var disabledLabelColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: globalTokens.neutralColors[.grey70], dark: globalTokens.neutralColors[.grey26])
+        case .onBrandPill:
+            return DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.neutralColors[.grey26])
+        }
+    }
+
+    /// Defines the label color of the selected segments of the `SegmentedControl` when disabled.
+    open var disabledSelectedLabelColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return DynamicColor(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey44])
+        case .onBrandPill:
+            return DynamicColor(light: globalTokens.neutralColors[.grey74], dark: globalTokens.neutralColors[.grey44])
+        }
+    }
+
+    /// The color of the unread dot when the `SegmentedControl` is enabled.
+    open var enabledUnreadDotColor: DynamicColor {
+        switch style {
+        case .primaryPill:
+            return aliasTokens.foregroundColors[.brandRest]
+        case .onBrandPill:
+            return DynamicColor(light: aliasTokens.foregroundColors[.neutralInverted].light, dark: aliasTokens.foregroundColors[.neutral2].dark)
+        }
+    }
+
+    /// The distance of the content from the top and bottom of the `SegmentedControl`.
+    open var verticalInset: CGFloat { 6.0 }
+
+    /// The distance of the content from the leading and trailing edges of the `SegmentedControl`.
+    open var horizontalInset: CGFloat { 16.0 }
+
+    /// The distance of the unread dot from the trailing edge of the content of the `SegmentedControl`.
+    open var unreadDotOffsetX: CGFloat { 6.0 }
+
+    /// The distance of the unread dot from the top of the content of the `SegmentedControl`.
+    open var unreadDotOffsetY: CGFloat { 3.0 }
+
+    /// The size of the unread dot of the `SegmentedControl`
+    open var unreadDotSize: CGFloat { 6.0 }
+
+    /// The font used for the label of the `SegmentedControl`.
+    open var font: FontInfo { aliasTokens.typography[.body2] }
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Convert the Segmented Control to a tokenized control. Also update the demo controller to support the new theme/token overrides.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_before_light](https://user-images.githubusercontent.com/67026548/157349137-2c1f05e0-dc4e-4d50-9ec4-b8e4eaad9536.png) | ![SegmentedControl_after_light](https://user-images.githubusercontent.com/67026548/157349145-a166400f-9c10-49ad-a5ed-9c1f1defc4b4.png) |
| ![SegmentedControl_before_dark](https://user-images.githubusercontent.com/67026548/157349156-45449201-6db0-42aa-8c61-d29ebc8233a0.png) | ![SegmentedControl_after_dark](https://user-images.githubusercontent.com/67026548/157349168-16e385a2-3661-4e09-b30e-f5d037478bf5.png) |
| ![SegmentedControl_before_color](https://user-images.githubusercontent.com/67026548/157349186-1548bc6b-ac84-47c2-893b-d12764f9cd95.gif) | ![SegmentedControl_after_color](https://user-images.githubusercontent.com/67026548/157349198-547482c3-ec82-4ccf-8c28-19464a06145b.gif) |
| ![SegmentedControl_rtl_before](https://user-images.githubusercontent.com/67026548/157543486-87487565-79a5-412a-a10d-310c5a1d4fcf.png) | ![SegmentedControl_rtl_after](https://user-images.githubusercontent.com/67026548/157543498-da84cad2-a729-4ccd-92c7-7d88ef1ee0ef.png) |
|  | ![SegmentedControl_after_themes](https://user-images.githubusercontent.com/67026548/157349209-8839113e-ee0b-4404-bf93-7884393b01df.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/940)