### PR TITLE
[vNext Tokens] Update AvatarGroup to get Avatar tokens from the overflow Avatar

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -115,14 +115,23 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
         let isStackStyle = tokens.style == .stack
 
         let overflowAvatar = createOverflow(count: overflowCount)
-        let imageSize: CGFloat = overflowAvatar.contentSize
 
         let interspace: CGFloat = tokens.interspace
-        let avatarTokens = overflowAvatar.tokens
-        let ringOuterGap: CGFloat = avatarTokens.ringOuterGap
-        let ringGapOffset: CGFloat = ringOuterGap * 2
-        let ringOffset: CGFloat = avatarTokens.ringThickness + avatarTokens.ringInnerGap + avatarTokens.ringOuterGap
-        let groupHeight: CGFloat = imageSize + (ringOffset * 2)
+
+        let groupHeight: CGFloat = {
+            let avatarMaxHeight: CGFloat
+            if let avatar = avatarViews.first {
+                let avatarTokens = avatar.tokens
+                avatarMaxHeight = avatarTokens.avatarSize + 2 * (avatarTokens.ringThickness + avatarTokens.ringInnerGap + avatarTokens.ringOuterGap)
+            } else {
+                avatarMaxHeight = 0
+            }
+
+            let overflowTokens = overflowAvatar.tokens
+            let overflowMaxHeight = overflowTokens.avatarSize + 2 * (overflowTokens.ringThickness + overflowTokens.ringInnerGap + overflowTokens.ringOuterGap)
+
+            return max(avatarMaxHeight, overflowMaxHeight)
+        }()
 
         @ViewBuilder
         var avatarGroupContent: some View {
@@ -142,10 +151,14 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                     let nextAvatarHasRing = !isLastDisplayed ? avatars[nextIndex].isRingVisible : false
 
                     // Calculating the different interspace scenarios considering rings.
+                    let currentTokens = avatarView.tokens
+                    let ringOuterGap = currentTokens.ringOuterGap
+                    let ringOffset = currentTokens.ringInnerGap + currentTokens.ringThickness + ringOuterGap
                     let stackPadding = interspace - (currentAvatarHasRing ? ringOffset : 0) - (nextAvatarHasRing ? ringOuterGap : 0)
 
                     // Finalized calculations for x and y coordinates of the Avatar if it needs a cutout, including RTL.
-                    let cutoutSize = isLastDisplayed ? ringGapOffset + imageSize : nextAvatarSize
+                    let cutoutSize = isLastDisplayed ? overflowAvatar.totalSize : nextAvatarSize
+                    let ringGapOffset = 2 * ringOuterGap
                     let xOrigin: CGFloat = {
                         if layoutDirection == .rightToLeft {
                             return -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -127,6 +127,7 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                 avatarMaxHeight = 0
             }
 
+            // Use the overflow tokens as a default in case we have no Avatars to show
             let overflowTokens = overflowAvatar.tokens
             let overflowMaxHeight = overflowTokens.avatarSize + 2 * (overflowTokens.ringThickness + overflowTokens.ringInnerGap + overflowTokens.ringOuterGap)
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -114,13 +114,14 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
         let hasOverflow: Bool = overflowCount > 0
         let isStackStyle = tokens.style == .stack
 
-        let interspace: CGFloat = tokens.interspace
-        let ringOuterGap: CGFloat = tokens.ringOuterGap
-        let ringGapOffset: CGFloat = ringOuterGap * 2
-        let ringOffset: CGFloat = tokens.ringThickness + tokens.ringInnerGap + tokens.ringOuterGap
-
         let overflowAvatar = createOverflow(count: overflowCount)
         let imageSize: CGFloat = overflowAvatar.contentSize
+
+        let interspace: CGFloat = tokens.interspace
+        let avatarTokens = overflowAvatar.tokens
+        let ringOuterGap: CGFloat = avatarTokens.ringOuterGap
+        let ringGapOffset: CGFloat = ringOuterGap * 2
+        let ringOffset: CGFloat = avatarTokens.ringThickness + avatarTokens.ringInnerGap + avatarTokens.ringOuterGap
         let groupHeight: CGFloat = imageSize + (ringOffset * 2)
 
         @ViewBuilder

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -143,7 +143,7 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                     let avatarView = avatarViews[index]
                     let needsCutout = isStackStyle && (hasOverflow || !isLastDisplayed)
                     let avatarSize: CGFloat = avatarView.totalSize
-                    let nextAvatarSize: CGFloat = needsCutout ? avatarViews[nextIndex].totalSize : 0
+                    let nextAvatarSize: CGFloat = isLastDisplayed ? overflowAvatar.totalSize : avatarViews[nextIndex].totalSize
 
                     // Calculating the size delta of the current and next avatar based off of ring visibility, which helps determine
                     // starting coordinates for the cutout.
@@ -157,16 +157,15 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                     let stackPadding = interspace - (currentAvatarHasRing ? ringOffset : 0) - (nextAvatarHasRing ? ringOuterGap : 0)
 
                     // Finalized calculations for x and y coordinates of the Avatar if it needs a cutout, including RTL.
-                    let cutoutSize = isLastDisplayed ? overflowAvatar.totalSize : nextAvatarSize
                     let ringGapOffset = 2 * ringOuterGap
                     let xOrigin: CGFloat = {
                         if layoutDirection == .rightToLeft {
-                            return -cutoutSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
+                            return -nextAvatarSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
                         }
                         return avatarSize + interspace - ringGapOffset - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
                     }()
 
-                    let sizeDiff = avatarSize - cutoutSize - (currentAvatarHasRing ? 0 : ringGapOffset)
+                    let sizeDiff = avatarSize - nextAvatarSize - (currentAvatarHasRing ? 0 : ringGapOffset)
                     let yOrigin = sizeDiff / 2
 
                     // Hand the rendering of the avatar to a helper function to appease Swift's
@@ -177,7 +176,7 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                             .modifyIf(needsCutout, { view in
                                 view.clipShape(CircleCutout(xOrigin: xOrigin,
                                                             yOrigin: yOrigin,
-                                                            cutoutSize: cutoutSize),
+                                                            cutoutSize: nextAvatarSize),
                                                style: FillStyle(eoFill: true))
                             })
                     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroupTokens.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroupTokens.swift
@@ -40,36 +40,4 @@ open class AvatarGroupTokens: ControlTokens {
             }
         }
     }
-
-    /// CGFloat that defines the thickness of the space between the `Avatar` and its ring.
-    open var ringInnerGap: CGFloat {
-        switch size {
-        case .xsmall, .small, .medium, .large, .xlarge:
-            return globalTokens.borderSize[.thick]
-        case .xxlarge:
-            return globalTokens.borderSize[.thicker]
-        }
-    }
-
-    /// CGFloat that defines the thickness of the ring around the `Avatar`.
-    open var ringThickness: CGFloat {
-        switch size {
-        case .xsmall, .small:
-            return globalTokens.borderSize[.thin]
-        case .medium, .large, .xlarge:
-            return globalTokens.borderSize[.thick]
-        case .xxlarge:
-            return globalTokens.borderSize[.thicker]
-        }
-    }
-
-    /// CGFloat that defines the thickness of the space around the ring of the `Avatar`.
-    open var ringOuterGap: CGFloat {
-        switch size {
-        case .xsmall, .small, .medium, .large, .xlarge:
-            return globalTokens.borderSize[.thick]
-        case .xxlarge:
-            return globalTokens.borderSize[.thicker]
-        }
-    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Get the Avatar Tokens from the already initialized overflow avatar so we can remove the duplicate tokens from the AvatarGroup Tokens

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AvatarGroup_duplicateTokens_before](https://user-images.githubusercontent.com/67026548/157769198-3ff22ce7-e346-4e2d-9f99-f5691ae0635a.png) | ![AvatarGroup_duplicateTokens_after](https://user-images.githubusercontent.com/67026548/157769203-90eed9f6-53af-494b-9148-34fc25551351.png) |
| ![AvatarGroup_duplicateTokens_rtl_before](https://user-images.githubusercontent.com/67026548/157769212-c19aa228-ccbd-4791-93e5-fbdf52771f1f.png) | ![AvatarGroup_duplicateTokens_rtl_after](https://user-images.githubusercontent.com/67026548/157769217-a540ed1f-91a4-4cbb-af49-87deb9693e89.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/941)