### PR TITLE
[vNext Tokens] Make `ControlHostingContainer` classes open

### DIFF
--- a/ios/FluentUI/ActivityIndicator/MSFActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/MSFActivityIndicator.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI Activity Indicator implementation
-@objc public class MSFActivityIndicator: ControlHostingContainer {
+@objc open class MSFActivityIndicator: ControlHostingContainer {
 
     /// Creates a new MSFActivityIndicator instance.
     /// - Parameters:

--- a/ios/FluentUI/Avatar/MSFAvatar.swift
+++ b/ios/FluentUI/Avatar/MSFAvatar.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// UIKit wrapper that exposes the SwiftUI Avatar implementation.
-@objc public class MSFAvatar: ControlHostingContainer {
+@objc open class MSFAvatar: ControlHostingContainer {
 
     /// Creates a new MSFAvatar instance.
     /// - Parameters:

--- a/ios/FluentUI/AvatarGroup/MSFAvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/MSFAvatarGroup.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// UIKit wrapper that exposes the SwiftUI AvatarGroup implementation.
-@objc public class MSFAvatarGroup: ControlHostingContainer {
+@objc open class MSFAvatarGroup: ControlHostingContainer {
 
     /// Creates a new MSFAvatarGroup instance.
     /// - Parameters:

--- a/ios/FluentUI/Card Nudge/MSFCardNudge.swift
+++ b/ios/FluentUI/Card Nudge/MSFCardNudge.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI `CardNudge` implementation
-@objc public class MSFCardNudge: ControlHostingContainer {
+@objc open class MSFCardNudge: ControlHostingContainer {
 
     /// Creates a new MSFCardNudge instance.
     /// - Parameters:

--- a/ios/FluentUI/Core/ControlHostingContainer.swift
+++ b/ios/FluentUI/Core/ControlHostingContainer.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// Common wrapper for hosting and exposing SwiftUI components to UIKit-based clients.
-public class ControlHostingContainer: NSObject {
+open class ControlHostingContainer: NSObject {
 
     /// The UIView representing the wrapped SwiftUI view.
     @objc public var view: UIView {

--- a/ios/FluentUI/IndeterminateProgressBar/MSFIndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/MSFIndeterminateProgressBar.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI Indeterminate Progress Bar implementation
-@objc public class MSFIndeterminateProgressBar: ControlHostingContainer {
+@objc open class MSFIndeterminateProgressBar: ControlHostingContainer {
 
     /// Creates a new MSFIndeterminateProgressBar instance.
     @objc public init() {

--- a/ios/FluentUI/PersonaButton/MSFPersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/MSFPersonaButton.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI PersonaButton implementation
-@objc public class MSFPersonaButton: ControlHostingContainer {
+@objc open class MSFPersonaButton: ControlHostingContainer {
 
     /// Creates a new MSFPersonaButton instance.
     /// - Parameters:

--- a/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI PersonaButtonCarousel implementation
-@objc public class MSFPersonaButtonCarousel: ControlHostingContainer {
+@objc open class MSFPersonaButtonCarousel: ControlHostingContainer {
 
     /// Creates a new MSFPersonaButtonCarousel instance.
     /// - Parameters:

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -8,8 +8,8 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI Button implementation
-@objc public class MSFButton: ControlHostingContainer,
-                              UIGestureRecognizerDelegate {
+@objc open class MSFButton: ControlHostingContainer,
+                            UIGestureRecognizerDelegate {
 
     /// Closure that handles the button tap event.
     @objc public var action: ((_ sender: MSFButton) -> Void)?

--- a/ios/FluentUI/Vnext/Divider/MSFDivider.swift
+++ b/ios/FluentUI/Vnext/Divider/MSFDivider.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// UIKit wrapper that exposes the SwiftUI Divider implementation.
-@objc public class MSFDivider: ControlHostingContainer {
+@objc open class MSFDivider: ControlHostingContainer {
     /// Creates a new MSFDivider instance.
     ///  - Parameters:
     ///   - orientation: The DividerOrientation used by the Divider.

--- a/ios/FluentUI/Vnext/List/MSFList.swift
+++ b/ios/FluentUI/Vnext/List/MSFList.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// UIKit wrapper that exposes the SwiftUI List implementation
-@objc public class MSFList: ControlHostingContainer {
+@objc open class MSFList: ControlHostingContainer {
 
     @objc public init() {
         let list = FluentList()

--- a/ios/FluentUI/Vnext/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Vnext/Notification/MSFNotificationView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import UIKit
 
 /// UIKit wrapper that exposes the SwiftUI `Notification` implementation
-@objc public class MSFNotification: ControlHostingContainer {
+@objc open class MSFNotification: ControlHostingContainer {
 
     /// Creates a new MSFNotification instance.
     /// - Parameters:

--- a/ios/FluentUI/Vnext/Persona/MSFPersonaView.swift
+++ b/ios/FluentUI/Vnext/Persona/MSFPersonaView.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// UIKit wrapper that exposes the SwiftUI PersonaView implementation
-@objc public class MSFPersonaView: ControlHostingContainer {
+@objc open class MSFPersonaView: ControlHostingContainer {
 
     @objc public init() {
         let personaView = PersonaView()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Some of our clients expect our `ControlHostingContainer` subclasses to be themselves subclassable. They're `open` in `main` but not in `vnext-tokens`. Fix that!

### Verification

No functional changes. Verified no binary size impact.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/942)