### PR TITLE
Removing unwanted animation on List Cell label.

### DIFF
--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -293,7 +293,7 @@ struct MSFListCellView: View {
                 }
             }, label: {
                 HStack(spacing: 0) {
-                    let hasTitle: Bool = !state.title.isEmpty
+                    let title = state.title
                     let labelAccessoryInterspace: CGFloat = tokens.labelAccessoryInterspace
                     let labelAccessorySize: CGFloat = tokens.labelAccessorySize
                     let sublabelAccessorySize: CGFloat = tokens.sublabelAccessorySize
@@ -315,8 +315,9 @@ struct MSFListCellView: View {
                                     .frame(width: labelAccessorySize, height: labelAccessorySize)
                                     .padding(.trailing, labelAccessoryInterspace)
                             }
-                            if hasTitle {
-                                Text(state.title)
+                            if !title.isEmpty {
+                                Text(title)
+                                    .animation(nil, value: title)
                                     .scalableFont(font: tokens.labelFont)
                                     .foregroundColor(Color(tokens.labelColor))
                                     .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The List Cell has an unwanted animation that happens when the title (label) is set to a longer text that its current state.
This change remove the wipe animation in that scenario.

### Verification

**Before** (wipe animations on the label for longer text values):

https://user-images.githubusercontent.com/68076145/157980308-09ea1053-fa19-4732-a39c-3bff7507f85d.mov


After (no unwanted animations anymore):

https://user-images.githubusercontent.com/68076145/157980379-6dec02e2-4f0f-47ad-8f6f-69da452790f8.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/943)