### PR TITLE
[Avatar] Apply SwiftUI animation modifier only when the state object property is set.

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -336,7 +336,9 @@ public struct Avatar: View {
 
         return avatarBody
             .pointerInteraction(state.hasPointerInteraction)
-            .animation(state.isAnimated ? .linear(duration: animationDuration) : .none)
+            .modifyIf(state.isAnimated, { thisView in
+                thisView.animation(.linear(duration: animationDuration))
+            })
             .accessibilityElement(children: .ignore)
             .accessibility(addTraits: state.hasButtonAccessibilityTrait ? .isButton : .isImage)
             .accessibility(label: Text(accessibilityLabel))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

One of our client apps reported that the animation was not behaving correctly when the isAnimated property was set to false.

The reason for that is because the Avatar always applies the animation modifier irrespective of that property value. What changes based on it is just the value passed to the modifier.

The fix for it is to apply the animation modifier only if the property is true. Otherwise it should just inherit the animation configuration defined by the Avatar's parent/container Views.

### Verification

Tested the demo app avatar scenarios to ensure the functionality is still intact.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/945)