### PR TITLE
[vNext Tokens] Update PillButtonBar to update colors on theme change

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842973247B672000A29C40 /* SceneDelegate.swift */; };
 		E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemes.swift */; };
 		EC02A5F9274EED9200E81B3E /* DividerDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */; };
+		EC5982E027DC223C00FD048D /* ColoredBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982DF27DC223C00FD048D /* ColoredBackgroundView.swift */; };
 		EC6A71EC273DE6DF0076A586 /* DividerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
 		FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */; };
@@ -143,6 +144,7 @@
 		E6842973247B672000A29C40 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E6842995247C350700A29C40 /* DemoColorThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoColorThemes.swift; sourceTree = "<group>"; };
 		EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividerDemoController_SwiftUI.swift; sourceTree = "<group>"; };
+		EC5982DF27DC223C00FD048D /* ColoredBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredBackgroundView.swift; sourceTree = "<group>"; };
 		EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController.swift; sourceTree = "<group>"; };
 		EC8EA6AF2580D82A00F191CE /* ListDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDemoController.swift; sourceTree = "<group>"; };
 		FC414E3625888BC300069E73 /* CommandBarDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarDemoController.swift; sourceTree = "<group>"; };
@@ -365,6 +367,7 @@
 			isa = PBXGroup;
 			children = (
 				92E977B626C713F3008E10A8 /* ScrollView */,
+				EC5982DF27DC223C00FD048D /* ColoredBackgroundView.swift */,
 				B4414791228F6F740040E88E /* TableViewCellSampleData.swift */,
 				B4414793228F6FDF0040E88E /* OtherCellsSampleData.swift */,
 				B4EF66552295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift */,
@@ -518,6 +521,7 @@
 				5306075926A1E73F002D49CF /* AvatarGroupDemoController.swift in Sources */,
 				92561E732718AD090072ED00 /* DemoTableViewController.swift in Sources */,
 				497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */,
+				EC5982E027DC223C00FD048D /* ColoredBackgroundView.swift in Sources */,
 				B4EF53C5215C45C400573E8F /* PersonaListViewDemoController.swift in Sources */,
 				A5DCA75E211E3A92005F4CB7 /* DrawerDemoController.swift in Sources */,
 				B4414792228F6F740040E88E /* TableViewCellSampleData.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredBackgroundView.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+public enum ColoredBackgroundStyle: Int {
+    case neutral
+    case brand
+}
+
+class ColoredBackgroundView: UIView {
+    init(style: ColoredBackgroundStyle) {
+        self.style = style
+        super.init(frame: .zero)
+        updateBackgroundColor()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateBackgroundColor()
+    }
+
+    @objc func themeDidChange() {
+        updateBackgroundColor()
+    }
+
+    func updateBackgroundColor() {
+        let lightColor: UIColor
+        let darkColor: UIColor
+        switch style {
+        case .neutral:
+            if let fluentTheme = window?.fluentTheme {
+                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral1])
+                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
+            } else {
+                lightColor = Colors.navigationBarBackground
+                darkColor = Colors.navigationBarBackground
+            }
+        case .brand:
+            if let fluentTheme = window?.fluentTheme {
+                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.brandRest])
+                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
+            } else {
+                lightColor = Colors.communicationBlue
+                darkColor = Colors.navigationBarBackground
+            }
+        }
+
+        backgroundColor = UIColor(light: lightColor, dark: darkColor)
+    }
+
+    let style: ColoredBackgroundStyle
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -95,10 +95,6 @@ class PillButtonBarDemoController: DemoController {
             items.forEach { bar.disableItem($0) }
         }
 
-//        let backgroundView = UIView()
-//        if style == .primary {
-//            backgroundView.backgroundColor = Colors.navigationBarBackground
-//        }
         let backgroundStyle: ColoredBackgroundStyle = {
             switch style {
             case .primary:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -95,10 +95,19 @@ class PillButtonBarDemoController: DemoController {
             items.forEach { bar.disableItem($0) }
         }
 
-        let backgroundView = UIView()
-        if style == .primary {
-            backgroundView.backgroundColor = Colors.navigationBarBackground
-        }
+//        let backgroundView = UIView()
+//        if style == .primary {
+//            backgroundView.backgroundColor = Colors.navigationBarBackground
+//        }
+        let backgroundStyle: ColoredBackgroundStyle = {
+            switch style {
+            case .primary:
+                return .neutral
+            case .onBrand:
+                return .brand
+            }
+        }()
+        let backgroundView = ColoredBackgroundView(style: backgroundStyle)
 
         backgroundView.addSubview(bar)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0.0)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -79,7 +79,15 @@ class SegmentedControlDemoController: DemoController {
                               action: #selector(updateLabel(forControl:)),
                               for: .valueChanged)
 
-        let backgroundView = BackgroundView(style: style)
+        let backgroundStyle: ColoredBackgroundStyle = {
+            switch style {
+            case .primaryPill:
+                return .neutral
+            case .onBrandPill:
+                return .brand
+            }
+        }()
+        let backgroundView = ColoredBackgroundView(style: backgroundStyle)
         segmentedControls.append(pillControl)
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
@@ -145,57 +153,4 @@ extension SegmentedControlDemoController: DemoAppearanceDelegate {
             return FontInfo(name: "Papyrus", size: 10.0, weight: .regular)
         }
     }
-}
-
-class BackgroundView: UIView {
-    init(style: SegmentedControlStyle) {
-        self.style = style
-        super.init(frame: .zero)
-        updateBackgroundColor()
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateBackgroundColor()
-    }
-
-    @objc func themeDidChange() {
-        updateBackgroundColor()
-    }
-
-    func updateBackgroundColor() {
-        let lightColor: UIColor
-        let darkColor: UIColor
-        switch style {
-        case .primaryPill:
-            if let fluentTheme = window?.fluentTheme {
-                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral1])
-                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
-            } else {
-                lightColor = Colors.navigationBarBackground
-                darkColor = Colors.navigationBarBackground
-            }
-        case .onBrandPill:
-            if let fluentTheme = window?.fluentTheme {
-                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.brandRest])
-                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
-            } else {
-                lightColor = Colors.communicationBlue
-                darkColor = Colors.navigationBarBackground
-            }
-        }
-
-        backgroundColor = UIColor(light: lightColor, dark: darkColor)
-    }
-
-    let style: SegmentedControlStyle
 }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -105,6 +105,11 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
 
         let pointerInteraction = UIPointerInteraction(delegate: self)
         addInteraction(pointerInteraction)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -483,6 +488,14 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         for button in buttons {
             button.overrideTokens = pillButtonOverrideTokens
         }
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updatePillButtonBarTokens()
+        updatePillButtonTokens()
     }
 
     private var leadingConstraint: NSLayoutConstraint?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added an observer for themeDidChange so that the PillButtonBar would reload its colors when the theme changes. Also moved the BackgroundView from the SegmentedControlDemo to a new file and renamed it ColoredBackgroundView so I could use it in the PillButtonBar's demo also.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![PillButtonBar_before](https://user-images.githubusercontent.com/67026548/157996890-f3f0a14d-037f-4055-8682-3523ae8bac49.gif) | ![PillButtonBar_after](https://user-images.githubusercontent.com/67026548/157996898-f074dc7f-c044-47a4-88e6-03547749a393.gif) |
| ![SegmentedControl_before](https://user-images.githubusercontent.com/67026548/157996908-3915c89c-97bc-4da6-8560-f2189619b35b.gif) | ![SegmentedControl_after](https://user-images.githubusercontent.com/67026548/157996917-55d4ef90-dd57-48a0-9b56-915399f0ee61.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)