### PR TITLE
Update the Fluent Button to change background colors when focus changes

### DIFF
--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -225,16 +225,11 @@ open class Button: UIButton {
     }
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
-        guard let window = window, style == .primaryFilled else {
+        guard style.isFilledStyle, (self == context.nextFocusedView || self == context.previouslyFocusedView) else {
             return
         }
-        let highlightedColor = UIColor(light: Colors.primaryTint10(for: window),
-                                     dark: Colors.primaryTint20(for: window))
-        if context.nextFocusedView == self {
-            backgroundColor = highlightedColor
-        } else if context.previouslyFocusedView == self {
-            backgroundColor = isHighlighted ? highlightedColor : Colors.primary(for: window)
-        }
+
+        updateBackgroundColor()
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -412,12 +407,14 @@ open class Button: UIButton {
             } else {
                 switch style {
                 case .primaryFilled:
-                    backgroundColor = isHighlighted ? UIColor(light: Colors.primaryTint10(for: window),
-                                                              dark: Colors.primaryTint20(for: window))
+                    backgroundColor = isHighlighted || isFocused
+                    ? UIColor(light: Colors.primaryTint10(for: window),
+                            dark: Colors.primaryTint20(for: window))
                     : Colors.primary(for: window)
                 case .dangerFilled:
-                    backgroundColor = isHighlighted ? UIColor(light: Colors.Palette.dangerTint10.color,
-                                                              dark: Colors.Palette.dangerTint20.color)
+                    backgroundColor = isHighlighted || isFocused
+                    ? UIColor(light: Colors.Palette.dangerTint10.color,
+                            dark: Colors.Palette.dangerTint20.color)
                     : Colors.Palette.dangerPrimary.color
                 case .primaryOutline,
                         .dangerOutline,

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -399,34 +399,36 @@ open class Button: UIButton {
     }
 
     private func updateBackgroundColor() {
-        if let window = window {
-            let backgroundColor: UIColor
-
-            if !isEnabled {
-                backgroundColor = style.isFilledStyle ? Colors.Button.backgroundFilledDisabled : Colors.Button.background
-            } else {
-                switch style {
-                case .primaryFilled:
-                    backgroundColor = isHighlighted || isFocused
-                    ? UIColor(light: Colors.primaryTint10(for: window),
-                            dark: Colors.primaryTint20(for: window))
-                    : Colors.primary(for: window)
-                case .dangerFilled:
-                    backgroundColor = isHighlighted || isFocused
-                    ? UIColor(light: Colors.Palette.dangerTint10.color,
-                            dark: Colors.Palette.dangerTint20.color)
-                    : Colors.Palette.dangerPrimary.color
-                case .primaryOutline,
-                        .dangerOutline,
-                        .secondaryOutline,
-                        .tertiaryOutline,
-                        .borderless:
-                    backgroundColor = Colors.Button.background
-                }
-            }
-
-            self.backgroundColor = backgroundColor
+        guard let window = window else {
+            return
         }
+
+        let backgroundColor: UIColor
+
+        if !isEnabled {
+            backgroundColor = style.isFilledStyle ? Colors.Button.backgroundFilledDisabled : Colors.Button.background
+        } else {
+            switch style {
+            case .primaryFilled:
+                backgroundColor = isHighlighted || isFocused
+                ? UIColor(light: Colors.primaryTint10(for: window),
+                          dark: Colors.primaryTint20(for: window))
+                : Colors.primary(for: window)
+            case .dangerFilled:
+                backgroundColor = isHighlighted || isFocused
+                ? UIColor(light: Colors.Palette.dangerTint10.color,
+                          dark: Colors.Palette.dangerTint20.color)
+                : Colors.Palette.dangerPrimary.color
+            case .primaryOutline,
+                    .dangerOutline,
+                    .secondaryOutline,
+                    .tertiaryOutline,
+                    .borderless:
+                backgroundColor = Colors.Button.background
+            }
+        }
+
+        self.backgroundColor = backgroundColor
     }
 
     private func updateBorderColor() {

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -399,9 +399,11 @@ open class Button: UIButton {
             } else {
                 switch style {
                 case .primaryFilled:
-                    backgroundColor = isHighlighted ? UIColor(light: Colors.primaryTint10(for: window),
-                                                              dark: Colors.primaryTint20(for: window))
-                    : Colors.primary(for: window)
+                    let highlightedColor = UIColor(light: Colors.primaryTint10(for: window),
+                                                 dark: Colors.primaryTint20(for: window))
+                    backgroundColor = isHighlighted ? highlightedColor : Colors.primary(for: window)
+                    focusBackgroundLayer.backgroundColor = highlightedColor.cgColor
+                    setBackgroundImage(focusBackgroundImage, for: .focused)
                 case .dangerFilled:
                     backgroundColor = isHighlighted ? UIColor(light: Colors.Palette.dangerTint10.color,
                                                               dark: Colors.Palette.dangerTint20.color)
@@ -437,5 +439,21 @@ open class Button: UIButton {
 
             layer.borderColor = borderColor.cgColor
         }
+    }
+
+    private lazy var focusBackgroundLayer: CALayer = {
+        let focusBackgroundLayer = CALayer()
+        focusBackgroundLayer.cornerRadius = style.cornerRadius
+        focusBackgroundLayer.cornerCurve = .continuous
+        return focusBackgroundLayer
+    }()
+
+    private var focusBackgroundImage: UIImage {
+            let renderer = UIGraphicsImageRenderer(size: intrinsicContentSize)
+            let image = renderer.image { (context) in
+                focusBackgroundLayer.bounds = context.format.bounds
+                focusBackgroundLayer.render(in: context.cgContext)
+            }
+            return image
     }
 }

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -224,6 +224,19 @@ open class Button: UIButton {
         update()
     }
 
+    open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        guard let window = window, style == .primaryFilled else {
+            return
+        }
+        let highlightedColor = UIColor(light: Colors.primaryTint10(for: window),
+                                     dark: Colors.primaryTint20(for: window))
+        if context.nextFocusedView == self {
+            backgroundColor = highlightedColor
+        } else if context.previouslyFocusedView == self {
+            backgroundColor = isHighlighted ? highlightedColor : Colors.primary(for: window)
+        }
+    }
+
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -399,11 +412,9 @@ open class Button: UIButton {
             } else {
                 switch style {
                 case .primaryFilled:
-                    let highlightedColor = UIColor(light: Colors.primaryTint10(for: window),
-                                                 dark: Colors.primaryTint20(for: window))
-                    backgroundColor = isHighlighted ? highlightedColor : Colors.primary(for: window)
-                    focusBackgroundLayer.backgroundColor = highlightedColor.cgColor
-                    setBackgroundImage(focusBackgroundImage, for: .focused)
+                    backgroundColor = isHighlighted ? UIColor(light: Colors.primaryTint10(for: window),
+                                                              dark: Colors.primaryTint20(for: window))
+                    : Colors.primary(for: window)
                 case .dangerFilled:
                     backgroundColor = isHighlighted ? UIColor(light: Colors.Palette.dangerTint10.color,
                                                               dark: Colors.Palette.dangerTint20.color)
@@ -439,21 +450,5 @@ open class Button: UIButton {
 
             layer.borderColor = borderColor.cgColor
         }
-    }
-
-    private lazy var focusBackgroundLayer: CALayer = {
-        let focusBackgroundLayer = CALayer()
-        focusBackgroundLayer.cornerRadius = style.cornerRadius
-        focusBackgroundLayer.cornerCurve = .continuous
-        return focusBackgroundLayer
-    }()
-
-    private var focusBackgroundImage: UIImage {
-            let renderer = UIGraphicsImageRenderer(size: intrinsicContentSize)
-            let image = renderer.image { (context) in
-                focusBackgroundLayer.bounds = context.format.bounds
-                focusBackgroundLayer.render(in: context.cgContext)
-            }
-            return image
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Since the collection view doesn't want to share the focus ring during keyboard navigation, we'll do some focus changes ourselves to make it more clear that the a primary button has focus.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ButtonFocus_keyboard_before](https://user-images.githubusercontent.com/67026548/158711152-e5dd81a8-6dd4-43c6-91f8-9c3d25d1f79d.gif) | ![ButtonFocus_keyboard_after](https://user-images.githubusercontent.com/67026548/158711164-35cd2d70-eab1-4190-be2e-add775dcc339.gif) |
| ![ButtonFocus_voiceover_before](https://user-images.githubusercontent.com/67026548/158711168-82785236-ed1e-4e65-87a6-6d03ffb3228d.gif) | ![ButtonFocus_voiceover_after](https://user-images.githubusercontent.com/67026548/158711171-e9e7cb6a-5d17-4841-b541-6d57676d57d9.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/947)