### PR TITLE
[FHL] Introducing the SwiftUI PresentationModifier.

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		53097D212702890900A6E4DC /* ListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53097D132702890800A6E4DC /* ListHeader.swift */; };
 		53097D252702890900A6E4DC /* ListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53097D152702890900A6E4DC /* ListCell.swift */; };
 		53097D4727028B1200A6E4DC /* ButtonLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53097D4527028B1100A6E4DC /* ButtonLegacy.swift */; };
+		530D9C5127EE388200BDCBBF /* SwiftUI+ViewPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D9C5027EE388200BDCBBF /* SwiftUI+ViewPresentation.swift */; };
 		5314E01625F00CF70099271A /* BarButtonItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52648DB2316F4F9003342A0 /* BarButtonItems.swift */; };
 		5314E02825F00DA80099271A /* BlurringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA1AF8B21484625001AE720 /* BlurringView.swift */; };
 		5314E03125F00DDD0099271A /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2B2501B22F00BE830E /* CardView.swift */; };
@@ -257,6 +258,7 @@
 		53097D132702890800A6E4DC /* ListHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListHeader.swift; sourceTree = "<group>"; };
 		53097D152702890900A6E4DC /* ListCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListCell.swift; sourceTree = "<group>"; };
 		53097D4527028B1100A6E4DC /* ButtonLegacy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonLegacy.swift; sourceTree = "<group>"; };
+		530D9C5027EE388200BDCBBF /* SwiftUI+ViewPresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftUI+ViewPresentation.swift"; sourceTree = "<group>"; };
 		5328D96C26FBA3D600F3723B /* IndeterminateProgressBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarTokens.swift; sourceTree = "<group>"; };
 		5328D96D26FBA3D600F3723B /* IndeterminateProgressBarModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarModifiers.swift; sourceTree = "<group>"; };
 		5328D96F26FBA3D700F3723B /* IndeterminateProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBar.swift; sourceTree = "<group>"; };
@@ -983,6 +985,7 @@
 				535559E22711411E0094A871 /* FluentUIHostingController.swift */,
 				A5CEC16E20D98F340016922A /* Fonts.swift */,
 				5373D56F2694D66F0032A3B4 /* SwiftUI+ViewModifiers.swift */,
+				530D9C5027EE388200BDCBBF /* SwiftUI+ViewPresentation.swift */,
 				5373D56D2694D66F0032A3B4 /* UIKit+SwiftUI_interoperability.swift */,
 			);
 			path = Core;
@@ -1534,6 +1537,7 @@
 				5314E19625F019650099271A /* TabBarView.swift in Sources */,
 				C708B05F260A8778007190FA /* SegmentPillButton.swift in Sources */,
 				5314E13525F016370099271A /* PopupMenuItemCell.swift in Sources */,
+				530D9C5127EE388200BDCBBF /* SwiftUI+ViewPresentation.swift in Sources */,
 				5314E2A025F024860099271A /* NSLayoutConstraint+Extensions.swift in Sources */,
 				923DB9D5274CB65700D8E58A /* FluentTheme.swift in Sources */,
 				929DD257266ED3AC00E8175E /* PersonaButtonCarouselTokens.swift in Sources */,

--- a/ios/FluentUI/Core/SwiftUI+ViewPresentation.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewPresentation.swift
@@ -29,14 +29,14 @@ struct PresentationModifier<PresentedView: View>: ViewModifier {
 
     var hasDimmedBackground: Bool
     var dimmedBackgroundColor: Color
-    var dimmedBackgroundColroOpacity: Double
+    var dimmedBackgroundColorOpacity: Double
     var isBlocking: Bool
     @Binding var isPresented: Bool
     @ViewBuilder var presentedView: PresentedView
 
     var backgroundColor: Color {
         if hasDimmedBackground {
-            return dimmedBackgroundColor.opacity(dimmedBackgroundColroOpacity)
+            return dimmedBackgroundColor.opacity(dimmedBackgroundColorOpacity)
         } else if isBlocking {
             // A clear color won't allow the background
             // view to block the underlying view
@@ -52,6 +52,8 @@ extension View {
     /// Presents a View as a layer on top of this View.
     /// - Parameters:
     ///   - isPresented: Binding boolean value that determines whehter the `presentedView` is presented on top of this view..
+    ///   - dimmedBackgroundColor: Defines the color of the dimmed background presented with the `presentedView`. The default color is black.
+    ///   - dimmedBackgroundColorOpacity: Defines the opacity color of the dimmed background presented with the `presentedView`. The default color is 0.1.
     ///   - hasDimmedBackground: Defines whether the `presentedView` has a dimmed backdrop. The default value is false which renders a transparent backdrop.
     ///   - isBlocking: Defines whether the user can interact with this view while the `presentedView` is being presented on top of it.
     ///   - presentedView: The SwiftUI View that will be presented on top of this view.
@@ -65,7 +67,7 @@ extension View {
                                              @ViewBuilder presentedView: @escaping () -> PresentedView) -> some View {
         modifier(PresentationModifier(hasDimmedBackground: hasDimmedBackground,
                                       dimmedBackgroundColor: dimmedBackgroundColor,
-                                      dimmedBackgroundColroOpacity: dimmedBackgroundColorOpacity,
+                                      dimmedBackgroundColorOpacity: dimmedBackgroundColorOpacity,
                                       isBlocking: isBlocking,
                                       isPresented: isPresented,
                                       presentedView: presentedView))

--- a/ios/FluentUI/Core/SwiftUI+ViewPresentation.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewPresentation.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// Modifier that presents a SwiftUI View as an additional layer on top of the content View.
+struct PresentationModifier<PresentedView: View>: ViewModifier {
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+
+            // Backdrop for the presented view which overlays the
+            // content where it's being presented from.
+            Rectangle()
+            .frame(maxWidth: .infinity,
+                   maxHeight: .infinity,
+                   alignment: .center)
+            .foregroundColor(isPresented ? backgroundColor : Color.clear)
+            .allowsHitTesting(isPresented && isBlocking)
+
+            presentedView
+        }
+        .frame(maxWidth: .infinity,
+               maxHeight: .infinity,
+               alignment: .center)
+    }
+
+    var hasDimmedBackground: Bool
+    var dimmedBackgroundColor: Color
+    var dimmedBackgroundColroOpacity: Double
+    var isBlocking: Bool
+    @Binding var isPresented: Bool
+    @ViewBuilder var presentedView: PresentedView
+
+    var backgroundColor: Color {
+        if hasDimmedBackground {
+            return dimmedBackgroundColor.opacity(dimmedBackgroundColroOpacity)
+        } else if isBlocking {
+            // A clear color won't allow the background
+            // view to block the underlying view
+            return Color.black.opacity(Double.ulpOfOne)
+        }
+
+        return Color.clear
+    }
+}
+
+extension View {
+
+    /// Presents a View as a layer on top of this View.
+    /// - Parameters:
+    ///   - isPresented: Binding boolean value that determines whehter the `presentedView` is presented on top of this view..
+    ///   - hasDimmedBackground: Defines whether the `presentedView` has a dimmed backdrop. The default value is false which renders a transparent backdrop.
+    ///   - isBlocking: Defines whether the user can interact with this view while the `presentedView` is being presented on top of it.
+    ///   - presentedView: The SwiftUI View that will be presented on top of this view.
+    /// - Returns: Returns the modified view with its overlay according to the passed parameters.
+    @ViewBuilder
+    func presentingView<PresentedView: View>(isPresented: Binding<Bool>,
+                                             dimmedBackgroundColor: Color = Color.black,
+                                             dimmedBackgroundColorOpacity: Double = 0.1,
+                                             hasDimmedBackground: Bool = false,
+                                             isBlocking: Bool = false,
+                                             @ViewBuilder presentedView: @escaping () -> PresentedView) -> some View {
+        modifier(PresentationModifier(hasDimmedBackground: hasDimmedBackground,
+                                      dimmedBackgroundColor: dimmedBackgroundColor,
+                                      dimmedBackgroundColroOpacity: dimmedBackgroundColorOpacity,
+                                      isBlocking: isBlocking,
+                                      isPresented: isPresented,
+                                      presentedView: presentedView))
+    }
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

SwiftUI controls that will need to be presented on top of Views will leverage from this modifier to overlay their contents on top of the SwiftUI View that is modified with it.

It allows optionally blocking the underlying view and providing a backdrop to it as well.

The Heads-up Display (HUD) and NotificationView are the first controls that will use that modifier.

### Verification

Tested it as part of the ongoing HUD implementation in the purely SwiftUI environment:

https://user-images.githubusercontent.com/68076145/160185951-0a88f7db-ac7c-4f93-87f2-41c1401a7315.mov


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/951)