### PR TITLE
[FHL] Adding the AnimationCompletionModifier.

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		53097D212702890900A6E4DC /* ListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53097D132702890800A6E4DC /* ListHeader.swift */; };
 		53097D252702890900A6E4DC /* ListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53097D152702890900A6E4DC /* ListCell.swift */; };
 		53097D4727028B1200A6E4DC /* ButtonLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53097D4527028B1100A6E4DC /* ButtonLegacy.swift */; };
+		530D9C5327EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530D9C5227EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift */; };
 		5314E01625F00CF70099271A /* BarButtonItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52648DB2316F4F9003342A0 /* BarButtonItems.swift */; };
 		5314E02825F00DA80099271A /* BlurringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA1AF8B21484625001AE720 /* BlurringView.swift */; };
 		5314E03125F00DDD0099271A /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2B2501B22F00BE830E /* CardView.swift */; };
@@ -257,6 +258,7 @@
 		53097D132702890800A6E4DC /* ListHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListHeader.swift; sourceTree = "<group>"; };
 		53097D152702890900A6E4DC /* ListCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListCell.swift; sourceTree = "<group>"; };
 		53097D4527028B1100A6E4DC /* ButtonLegacy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonLegacy.swift; sourceTree = "<group>"; };
+		530D9C5227EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftUI+ViewAnimation.swift"; sourceTree = "<group>"; };
 		5328D96C26FBA3D600F3723B /* IndeterminateProgressBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarTokens.swift; sourceTree = "<group>"; };
 		5328D96D26FBA3D600F3723B /* IndeterminateProgressBarModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarModifiers.swift; sourceTree = "<group>"; };
 		5328D96F26FBA3D700F3723B /* IndeterminateProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBar.swift; sourceTree = "<group>"; };
@@ -982,6 +984,7 @@
 				A559BB82212B7D870055E107 /* FluentUIFramework.swift */,
 				535559E22711411E0094A871 /* FluentUIHostingController.swift */,
 				A5CEC16E20D98F340016922A /* Fonts.swift */,
+				530D9C5227EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift */,
 				5373D56F2694D66F0032A3B4 /* SwiftUI+ViewModifiers.swift */,
 				5373D56D2694D66F0032A3B4 /* UIKit+SwiftUI_interoperability.swift */,
 			);
@@ -1591,6 +1594,7 @@
 				5314E0E625F012C00099271A /* UIViewController+Navigation.swift in Sources */,
 				5314E29725F024760099271A /* String+Extension.swift in Sources */,
 				5314E12925F016230099271A /* PillButtonStyle.swift in Sources */,
+				530D9C5327EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift in Sources */,
 				EC5982DE27D2EA6100FD048D /* SegmentedControlTokens.swift in Sources */,
 				5306075726A1E6A4002D49CF /* AvatarGroup.swift in Sources */,
 				92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */,

--- a/ios/FluentUI/Core/SwiftUI+ViewAnimation.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewAnimation.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// Modifier that provides a completion closure for an animation on a given animatable value.
+struct AnimationCompletionModifier<Value>: AnimatableModifier where Value: VectorArithmetic {
+
+    func body(content: Content) -> some View {
+        content
+    }
+
+    init(animatableValue: Value, onComplete: @escaping () -> Void) {
+        self.onComplete = onComplete
+        self.animatableData = animatableValue
+        targetValue = animatableValue
+    }
+
+    var animatableData: Value {
+        didSet {
+            notifyCompletionIfFinished()
+        }
+    }
+
+    private var onComplete: () -> Void
+    private var targetValue: Value
+
+    private func notifyCompletionIfFinished() {
+        guard animatableData == targetValue else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            self.onComplete()
+        }
+    }
+}
+
+extension View {
+
+    /// Executes the `onComplete` closure when an animation is completed for a given animatable value.
+    /// - Parameters:
+    ///   - animatableValue: The animatable value that is bound to the animation.
+    ///   - completion: Closure that will be executed once the animation is completed.
+    /// - Returns: A modified `View` with the completion mechanism. No changes are made to the layout or rendering of the view.
+    func onAnimationComplete<Value: VectorArithmetic>(for animatableValue: Value,
+                                                      onComplete: @escaping () -> Void) -> ModifiedContent<Self, AnimationCompletionModifier<Value>> {
+        modifier(AnimationCompletionModifier(animatableValue: animatableValue,
+                                             onComplete: onComplete))
+    }
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

As part of the Heads-up Display (HUD) implementation in SwiftUI, a completion block for animations was needed to ensure the view would be set up to an initial state after it was dismissed, so that it'd be ready for a new presentation.

This modifier allows a SwiftUI View to observe animatable properties and fires a "callback" func that executes when the animation to a target value completes.

### Verification

The size (scale factor) of the HUD in the video below is animated from bigger to normal in the presentation, normal to smaller when it's dismissed.
Once it's dismissed we need to set its size to the bigger state again.

The slow animations mode illustrates that better than words:


https://user-images.githubusercontent.com/68076145/160211550-b711ad95-63d4-4e33-9e7f-82af8be10024.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/952)