### PR TITLE
[FHL] Introducing the SquareShapedViewModifier.

### DIFF
--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -5,6 +5,38 @@
 
 import SwiftUI
 
+struct SquareShapedViewModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        let modifiedContent = HStack {
+            content
+                .alignmentGuide(HorizontalAlignment.center) { (viewDimensions) -> CGFloat in
+                    DispatchQueue.main.async {
+                        self.size = max(size, // ensures the View does not shrink
+                                        min(maxSize,
+                                            max(minSize,
+                                                max(viewDimensions.height,
+                                                    viewDimensions.width))))
+                    }
+
+                    return viewDimensions[HorizontalAlignment.center]
+                }
+        }
+
+        modifiedContent
+            .frame(width: size, height: size)
+    }
+
+    init(minSize: CGFloat, maxSize: CGFloat) {
+        self.size = minSize
+        self.minSize = minSize
+        self.maxSize = maxSize
+    }
+
+    @State var size: CGFloat
+    var minSize: CGFloat
+    var maxSize: CGFloat
+}
+
 extension View {
     /// Applies modifiers defined in a closure if a condition is met.
     /// - Parameters:
@@ -30,5 +62,17 @@ extension View {
         }
 
         return AnyView(self)
+    }
+
+    /// Ensures that the modified View has equal height and width values based on the
+    /// maximum of either dimension considering its dynamic content size.
+    /// Minimum and maximum cap values need to be specified.
+    /// - Parameters:
+    ///   - minSize: Minimum heigh/width value of the view.
+    ///   - maxSize: Maximum heigh/width value of the view.
+    /// - Returns: Modified view in a square shaped format.
+    func squareShaped(minSize: CGFloat, maxSize: CGFloat) -> some View {
+        modifier(SquareShapedViewModifier(minSize: minSize,
+                                          maxSize: maxSize))
     }
 }

--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -11,11 +11,19 @@ struct SquareShapedViewModifier: ViewModifier {
             content
                 .alignmentGuide(HorizontalAlignment.center) { (viewDimensions) -> CGFloat in
                     DispatchQueue.main.async {
-                        self.size = max(size, // ensures the View does not shrink
-                                        min(maxSize,
-                                            max(minSize,
-                                                max(viewDimensions.height,
-                                                    viewDimensions.width))))
+                        // Ensures the View does not shrink compared to its
+                        // previous size (calculated based on its content).
+                        size = max(size,
+                                   // Don't let the size be bigger than
+                                   // the maximum defined by the caller.
+                                   min(maxSize,
+                                       // Don't let the size be smaller than
+                                       // the minimum defined by the caller.
+                                       max(minSize,
+                                           // Sets the size the view with the
+                                           // longer side (width or height).
+                                           max(viewDimensions.height,
+                                               viewDimensions.width))))
                     }
 
                     return viewDimensions[HorizontalAlignment.center]
@@ -27,7 +35,7 @@ struct SquareShapedViewModifier: ViewModifier {
     }
 
     init(minSize: CGFloat, maxSize: CGFloat) {
-        self.size = minSize
+        size = minSize
         self.minSize = minSize
         self.maxSize = maxSize
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

One of the requirements of the HUD is that the view needs to remain with an aspect ratio of a square (equal values for its height and width).
It is also a requirement that the size of the HUD needs to adjust based on the text of its label with constraints of minimum and maximum constraints.

The **SquareShapedViewModifier** addresses these requirements by leveraging from the alignmentGuide modifier that provides the SwiftUI View dimensions once it's resized based on its contents.

### Verification

Note from the video below that the HUD has a minimum value that is used when no label is provided to it, and it grows to a limit as the label text becomes longer. Always keeping the width and height equal.

The view also does not shrink to avoid "jumps" on the size when the label is updated while the HUD is presented.


https://user-images.githubusercontent.com/68076145/160493083-7333727e-7830-4346-a751-1e3a35ac7cc4.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/954)