### PR TITLE
[FHL] [vNext Tokens] Make SwiftUI control host be a `UIView` subclass, part 2

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -73,7 +73,7 @@ class ActivityIndicatorDemoController: DemoTableViewController {
             let activityIndicator = activityIndicatorDictionaries[activityIndicatorPath][activityIndicatorSize]
 
             cell.setup(title: activityIndicatorSize.description,
-                       customView: activityIndicator?.view)
+                       customView: activityIndicator)
             cell.titleNumberOfLines = 0
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -82,7 +82,7 @@ class AvatarDemoController: DemoTableViewController {
                 return cell
             }
 
-            let avatarView = avatar.view
+            let avatarView = avatar
 
             let titleLabel = Label(style: .body, colorStyle: .regular)
             titleLabel.text = row.title

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -84,9 +84,9 @@ class AvatarGroupDemoController: DemoTableViewController {
             let buttonView: [UIView] = {
                 switch row {
                 case .maxDisplayedAvatars:
-                    return [maxAvatarsTextField, maxAvatarButton.view]
+                    return [maxAvatarsTextField, maxAvatarButton]
                 case .overflow:
-                    return [overflowCountTextField, overflowCountButton.view]
+                    return [overflowCountTextField, overflowCountButton]
                 default:
                     return []
                 }
@@ -131,7 +131,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 return cell
             }
 
-            let avatarGroupView = avatarGroup.view
+            let avatarGroupView = avatarGroup
             avatarGroupView.translatesAutoresizingMaskIntoConstraints = false
 
             cell.contentView.addSubview(avatarGroupView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
@@ -33,11 +33,11 @@ class BadgeFieldDemoController: DemoController {
 
         addDescription(text: "Badge field with limited number of lines")
         container.addArrangedSubview(badgeField1)
-        container.addArrangedSubview(dividers[0].view)
+        container.addArrangedSubview(dividers[0])
         container.addArrangedSubview(UIView())
         addDescription(text: "Badge field with unlimited number of lines")
         container.addArrangedSubview(badgeField2)
-        container.addArrangedSubview(dividers[1].view)
+        container.addArrangedSubview(dividers[1])
     }
 
     private func setupBadgeField(label: String, dataSources: [BadgeViewDataSource]) -> BadgeField {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -78,7 +78,7 @@ class BadgeViewDemoController: DemoController {
 
         let dataSource: [(BadgeView.Size, UIView)] = [
             (.medium, imageView),
-            (.small, avatar.view)
+            (.small, avatar)
         ]
 
         for (size, customView) in dataSource {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -377,8 +377,8 @@ extension BottomCommandingDemoController: UITableViewDataSource {
             }
 
             let stackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-            stackView.addArrangedSubview(decrementHeroCommandCountButton.view)
-            stackView.addArrangedSubview(incrementHeroCommandCountButton.view)
+            stackView.addArrangedSubview(decrementHeroCommandCountButton)
+            stackView.addArrangedSubview(incrementHeroCommandCountButton)
             stackView.distribution = .fillEqually
             stackView.alignment = .center
             stackView.spacing = 4

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -100,7 +100,7 @@ class BottomSheetDemoController: UIViewController {
         }
         dismissButton.state.text = "Dismiss"
 
-        let dismissButtonView = dismissButton.view
+        let dismissButtonView = dismissButton
         dismissButtonView.translatesAutoresizingMaskIntoConstraints = false
         sheetContentView.addSubview(dismissButtonView)
 
@@ -113,7 +113,7 @@ class BottomSheetDemoController: UIViewController {
         }
         anotherOneButton.state.text = "Show another sheet"
 
-        let anotherOneButtonView = anotherOneButton.view
+        let anotherOneButtonView = anotherOneButton
         anotherOneButtonView.translatesAutoresizingMaskIntoConstraints = false
         sheetContentView.addSubview(anotherOneButtonView)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -62,7 +62,7 @@ class ButtonDemoController: DemoTableViewController {
             disabledButton.state.image = image
             disabledButton.state.text = text
 
-            let rowContentView = UIStackView(arrangedSubviews: [button.view, disabledButton.view])
+            let rowContentView = UIStackView(arrangedSubviews: [button, disabledButton])
             rowContentView.isLayoutMarginsRelativeArrangement = true
             rowContentView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 15, leading: 20, bottom: 15, trailing: 20)
             rowContentView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -54,7 +54,7 @@ class CardNudgeDemoController: DemoTableViewController {
              .outlineCard:
             let cell = tableView.dequeueReusableCell(withIdentifier: CardNudgeDemoController.controlReuseIdentifier, for: indexPath)
 
-            let view = cardNudges[indexPath.row].view
+            let view = cardNudges[indexPath.row]
             let contentView = cell.contentView
             contentView.addSubview(view)
             cell.selectionStyle = .none

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -107,7 +107,7 @@ class ColorDemoController: UIViewController {
         tableView.allowsSelection = false
         tableView.backgroundColor = Colors.tableBackground
 
-        let stackView = UIStackView(arrangedSubviews: [segmentedControl, divider.view, tableView])
+        let stackView = UIStackView(arrangedSubviews: [segmentedControl, divider, tableView])
         stackView.setCustomSpacing(8, after: segmentedControl)
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
@@ -43,7 +43,7 @@ class DateTimePickerDemoController: DemoController {
             }
 
             strongSelf.dateTimePicker.present(from: strongSelf, with: .date, startDate: strongSelf.startDate ?? Date(), datePickerType: strongSelf.datePickerType)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show date time picker", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -51,7 +51,7 @@ class DateTimePickerDemoController: DemoController {
             }
 
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateTime, startDate: strongSelf.startDate ?? Date(), datePickerType: strongSelf.datePickerType)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show date range picker (paged)", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -60,7 +60,7 @@ class DateTimePickerDemoController: DemoController {
 
             let (startDate, endDate, _) = strongSelf.calcDatePickerParams()
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show date range picker (tabbed)", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -69,7 +69,7 @@ class DateTimePickerDemoController: DemoController {
 
             let (startDate, endDate, _) = strongSelf.calcDatePickerParams()
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType, dateRangePresentation: .tabbed)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show date time range picker", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -78,7 +78,7 @@ class DateTimePickerDemoController: DemoController {
 
             let (startDate, endDate, _) = strongSelf.calcDatePickerParams()
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateTimeRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show picker with custom subtitles or tabs", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -87,7 +87,7 @@ class DateTimePickerDemoController: DemoController {
 
             let (startDate, endDate, titles) = strongSelf.calcDatePickerParams()
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType, titles: titles)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show picker with left bar-button", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -97,7 +97,7 @@ class DateTimePickerDemoController: DemoController {
             let (startDate, endDate, titles) = strongSelf.calcDatePickerParams()
             let leftBarButtonItem = strongSelf.cancelButton(target: strongSelf, action: #selector(strongSelf.handleDidTapCancel))
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType, titles: titles, leftBarButtonItem: leftBarButtonItem)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show picker with left and right bar-buttons", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -108,7 +108,7 @@ class DateTimePickerDemoController: DemoController {
             let leftBarButtonItem = strongSelf.confirmButton(target: strongSelf, action: #selector(strongSelf.handleDidTapDone))
             let rightBarButtonItem = strongSelf.cancelButton(target: strongSelf, action: #selector(strongSelf.handleDidTapCancel)) // or simply assign UIBarButtonItem() to hide the default confirm button
             strongSelf.dateTimePicker.present(from: strongSelf, with: .dateRange, startDate: startDate, endDate: endDate, datePickerType: strongSelf.datePickerType, titles: titles, leftBarButtonItem: leftBarButtonItem, rightBarButtonItem: rightBarButtonItem)
-        }).view)
+        }))
 
         container.addArrangedSubview(UIView())
         container.addArrangedSubview(createDatePickerTypeUI())
@@ -122,7 +122,7 @@ class DateTimePickerDemoController: DemoController {
             strongSelf.startDate = nil
             strongSelf.endDate = nil
             strongSelf.dateLabel.text = "No date selected"
-        }).view)
+        }))
     }
 
     func createDatePickerTypeUI() -> UIStackView {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -56,23 +56,23 @@ class DividerDemoController: DemoTableViewController {
             verticalStack.axis = .vertical
             verticalStack.isLayoutMarginsRelativeArrangement = true
             verticalStack.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
-            verticalStack.addArrangedSubview(makeDivider(spacing: spacing, customColor: useCustomColor).view)
+            verticalStack.addArrangedSubview(makeDivider(spacing: spacing, customColor: useCustomColor))
             verticalStack.distribution = .equalCentering
 
             let horizontalStack = UIStackView()
             horizontalStack.distribution = .equalCentering
-            horizontalStack.addArrangedSubview(makeDivider(orientation: .vertical, spacing: spacing, customColor: useCustomColor).view)
+            horizontalStack.addArrangedSubview(makeDivider(orientation: .vertical, spacing: spacing, customColor: useCustomColor))
             let text1 = Label(style: .subhead, colorStyle: .regular)
             text1.text = "Text 1"
             horizontalStack.addArrangedSubview(text1)
-            horizontalStack.addArrangedSubview(makeDivider(orientation: .vertical, spacing: spacing, customColor: useCustomColor).view)
+            horizontalStack.addArrangedSubview(makeDivider(orientation: .vertical, spacing: spacing, customColor: useCustomColor))
             let text2 = Label(style: .subhead, colorStyle: .regular)
             text2.text = "Text 2"
             horizontalStack.addArrangedSubview(text2)
-            horizontalStack.addArrangedSubview(makeDivider(orientation: .vertical, spacing: spacing, customColor: useCustomColor).view)
+            horizontalStack.addArrangedSubview(makeDivider(orientation: .vertical, spacing: spacing, customColor: useCustomColor))
             verticalStack.addArrangedSubview(horizontalStack)
 
-            verticalStack.addArrangedSubview(makeDivider(spacing: spacing, customColor: useCustomColor).view)
+            verticalStack.addArrangedSubview(makeDivider(spacing: spacing, customColor: useCustomColor))
 
             contentView.addSubview(verticalStack)
             NSLayoutConstraint.activate([

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -21,65 +21,65 @@ class DrawerDemoController: DemoController {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .down,
                                      presentationBackground: .none,
                                      contentView: strongSelf.containerForActionViews(),
                                      resizingBehavior: .dismissOrExpand)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .down,
                                      contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
                                      resizingBehavior: .expand,
                                      maxDrawerHeight: 350)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show non dismissable", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .down,
                                      contentView: strongSelf.containerForActionViews(),
                                      resizingBehavior: .expand)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .down,
                                      contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: true,
                                                                                      drawerHasToggleResizingBehaviorButton: true),
                                      resizingBehavior: .expand)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with no animation", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .down,
                                      contentView: strongSelf.containerForActionViews(),
                                      animated: false)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show from custom base with width on landscape", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            let buttonView = sender.view
+            let buttonView = sender
             guard let rect = buttonView.superview?.convert(buttonView.frame, to: nil) else {
                 return
             }
@@ -89,19 +89,19 @@ class DrawerDemoController: DemoController {
                                      presentationDirection: .down,
                                      contentView: strongSelf.containerForActionViews(),
                                      customWidth: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show respecting safe area width", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .down,
                                      contentView: strongSelf.containerForActionViews(),
                                      resizingBehavior: .dismissOrExpand,
                                      respectSafeAreaWidth: true)
-        }).view)
+        }))
 
         addTitle(text: "Left/Right Drawer")
         addRow(
@@ -111,23 +111,23 @@ class DrawerDemoController: DemoController {
                         return
                     }
 
-                    strongSelf.presentDrawer(sourceView: sender.view,
+                    strongSelf.presentDrawer(sourceView: sender,
                                              presentationDirection: .fromLeading,
                                              presentationBackground: .none,
                                              contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
                                              resizingBehavior: .dismiss)
-                }).view,
+                }),
                 createButton(title: "Show from trailing with clear background", action: { [weak self] sender in
                     guard let strongSelf = self else {
                         return
                     }
 
-                    strongSelf.presentDrawer(sourceView: sender.view,
+                    strongSelf.presentDrawer(sourceView: sender,
                                              presentationDirection: .fromTrailing,
                                              presentationBackground: .none,
                                              contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
                                              resizingBehavior: .dismiss)
-                }).view
+                })
             ],
             itemSpacing: Constants.verticalSpacing,
             stretchItems: true
@@ -139,15 +139,15 @@ class DrawerDemoController: DemoController {
                         return
                     }
 
-                    strongSelf.presentDrawer(sourceView: sender.view, presentationDirection: .fromLeading, presentationBackground: .black, contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-                }).view,
+                    strongSelf.presentDrawer(sourceView: sender, presentationDirection: .fromLeading, presentationBackground: .black, contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+                }),
                 createButton(title: "Show from trailing with dimmed background", action: { [weak self] sender in
                     guard let strongSelf = self else {
                         return
                     }
 
-                    strongSelf.presentDrawer(sourceView: sender.view, presentationDirection: .fromTrailing, presentationBackground: .black, contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
-                }).view
+                    strongSelf.presentDrawer(sourceView: sender, presentationDirection: .fromTrailing, presentationBackground: .black, contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false), resizingBehavior: .dismiss)
+                })
             ],
             itemSpacing: Constants.verticalSpacing,
             stretchItems: true
@@ -161,53 +161,53 @@ class DrawerDemoController: DemoController {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .up,
                                      contentView: strongSelf.containerForActionViews(),
                                      resizingBehavior: .dismissOrExpand)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show resizable with max content height", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .up,
                                      contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: false),
                                      resizingBehavior: .dismissOrExpand,
                                      maxDrawerHeight: 350)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show changing resizing behaviour", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .up,
                                      contentView: strongSelf.containerForActionViews(drawerHasFlexibleHeight: true,
                                                                                      drawerHasToggleResizingBehaviorButton: true),
                                      resizingBehavior: .expand)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with no animation", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .up,
                                      contentView: strongSelf.containerForActionViews(),
                                      animated: false)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show from custom base", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            let buttonView = sender.view
+            let buttonView = sender
             guard let rect = buttonView.superview?.convert(buttonView.frame, to: nil) else {
                 return
             }
@@ -217,23 +217,23 @@ class DrawerDemoController: DemoController {
                                      presentationDirection: .up,
                                      contentView: strongSelf.containerForActionViews(),
                                      resizingBehavior: .dismissOrExpand)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with dimmed background", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.showBottomDrawerCustomContentController(sourceView: sender.view, presentationBackground: .black)
-        }).view)
+            strongSelf.showBottomDrawerCustomContentController(sourceView: sender, presentationBackground: .black)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show always as slideover, resizable with clear background", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.showBottomDrawerCustomContentController(sourceView: sender.view, presentationBackground: .none)
-        }).view)
+            strongSelf.showBottomDrawerCustomContentController(sourceView: sender, presentationBackground: .none)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with focusable content", action: { [weak self] sender in
             guard let strongSelf = self else {
@@ -259,9 +259,9 @@ class DrawerDemoController: DemoController {
             textField.delegate = self
             container.addArrangedSubview(textField)
 
-            container.addArrangedSubview(strongSelf.hideKeyboardButton.view)
+            container.addArrangedSubview(strongSelf.hideKeyboardButton)
 
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .up,
                                      permittedArrowDirections: .any,
                                      contentController: contentController,
@@ -269,7 +269,7 @@ class DrawerDemoController: DemoController {
                                      adjustHeightForKeyboard: true)
 
             textField.becomeFirstResponder()
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show dismiss blocking drawer", action: { [weak self] sender in
             guard let strongSelf = self else {
@@ -277,11 +277,11 @@ class DrawerDemoController: DemoController {
             }
 
             strongSelf.shouldConfirmDrawerDismissal = true
-            strongSelf.presentDrawer(sourceView: sender.view,
+            strongSelf.presentDrawer(sourceView: sender,
                                      presentationDirection: .up,
                                      contentView: strongSelf.containerForActionViews(),
                                      resizingBehavior: .dismissOrExpand)
-        }).view)
+        }))
 
         container.addArrangedSubview(UIView())
 
@@ -397,12 +397,12 @@ class DrawerDemoController: DemoController {
 
             self.expandButton = expandButton
             views.append(createButton(title: "Change content height", action: { sender in
-                if let spacer = (sender.view.superview as? UIStackView)?.arrangedSubviews.last,
+                if let spacer = (sender.superview as? UIStackView)?.arrangedSubviews.last,
                     let heightConstraint = spacer.constraints.first {
                     heightConstraint.constant = heightConstraint.constant == 20 ? 100 : 20
                 }
-            }).view)
-            views.append(expandButton.view)
+            }))
+            views.append(expandButton)
         }
 
         views.append(createButton(title: "Dismiss", action: { [weak self] _ in
@@ -411,7 +411,7 @@ class DrawerDemoController: DemoController {
             }
 
             strongSelf.dismiss(animated: true)
-        }).view)
+        }))
 
         views.append(createButton(title: "Dismiss (no animation)", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -419,7 +419,7 @@ class DrawerDemoController: DemoController {
             }
 
             strongSelf.dismiss(animated: false)
-        }).view)
+        }))
 
         if drawerHasToggleResizingBehaviorButton {
             views.append(createButton(title: "Resizing - None", action: { [weak self] sender in
@@ -434,7 +434,7 @@ class DrawerDemoController: DemoController {
                 let isResizingBehaviourNone = drawer.resizingBehavior == .none
                 drawer.resizingBehavior = isResizingBehaviourNone ? .expand : .none
                 sender.state.text = isResizingBehaviourNone ? "Resizing - None" : "Resizing - Expand"
-            }).view)
+            }))
         }
         views.append(spacer)
         return views
@@ -501,7 +501,7 @@ class DrawerDemoController: DemoController {
 
     private let hideKeyboardButton: MSFButton = {
         let button = MSFButton(style: .primary, size: .large) { sender in
-            if let stackView = sender.view.superview as? UIStackView {
+            if let stackView = sender.superview as? UIStackView {
                 let textField = stackView.arrangedSubviews.first(where: { $0 is UITextField })
                 textField?.resignFirstResponder()
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -18,7 +18,7 @@ class HUDDemoController: DemoController {
             strongSelf.showActivityHUD()
         })
         showActivityButton.state.text = "Show activity HUD"
-        container.addArrangedSubview(showActivityButton.view)
+        container.addArrangedSubview(showActivityButton)
 
         let showSuccessButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -28,7 +28,7 @@ class HUDDemoController: DemoController {
             strongSelf.showSuccessHUD()
         })
         showSuccessButton.state.text = "Show success HUD"
-        container.addArrangedSubview(showSuccessButton.view)
+        container.addArrangedSubview(showSuccessButton)
 
         let showFailureButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -38,7 +38,7 @@ class HUDDemoController: DemoController {
             strongSelf.showFailureHUD()
         })
         showFailureButton.state.text = "Show failure HUD"
-        container.addArrangedSubview(showFailureButton.view)
+        container.addArrangedSubview(showFailureButton)
 
         let showCustomButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -48,7 +48,7 @@ class HUDDemoController: DemoController {
             strongSelf.showCustomHUD()
         })
         showCustomButton.state.text = "Show custom HUD"
-        container.addArrangedSubview(showCustomButton.view)
+        container.addArrangedSubview(showCustomButton)
 
         let showCustomNonBlockingButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -58,7 +58,7 @@ class HUDDemoController: DemoController {
             strongSelf.showCustomNonBlockingHUD()
         })
         showCustomNonBlockingButton.state.text = "Show custom non-blocking HUD"
-        container.addArrangedSubview(showCustomNonBlockingButton.view)
+        container.addArrangedSubview(showCustomNonBlockingButton)
 
         let showNolabelButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -68,7 +68,7 @@ class HUDDemoController: DemoController {
             strongSelf.showNoLabelHUD()
         })
         showNolabelButton.state.text = "Show HUD with no label"
-        container.addArrangedSubview(showNolabelButton.view)
+        container.addArrangedSubview(showNolabelButton)
 
         let showGestureButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -78,7 +78,7 @@ class HUDDemoController: DemoController {
             strongSelf.showGestureHUD()
         })
         showGestureButton.state.text = "Show HUD with tap gesture callback"
-        container.addArrangedSubview(showGestureButton.view)
+        container.addArrangedSubview(showGestureButton)
 
         let showUpdatingButton = MSFButton(style: .secondary, size: .small, action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -88,7 +88,7 @@ class HUDDemoController: DemoController {
             strongSelf.showUpdateHUD()
         })
         showUpdatingButton.state.text = "Show HUD with updating caption"
-        container.addArrangedSubview(showUpdatingButton.view)
+        container.addArrangedSubview(showUpdatingButton)
     }
 
     @objc private func showActivityHUD() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
@@ -67,7 +67,7 @@ class IndeterminateProgressBarDemoController: DemoTableViewController {
         case.demoProgressBar:
             let cell = TableViewCell()
 
-            let rowContentView = UIStackView(arrangedSubviews: [indeterminateProgressBar.view])
+            let rowContentView = UIStackView(arrangedSubviews: [indeterminateProgressBar])
             rowContentView.isLayoutMarginsRelativeArrangement = true
             rowContentView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 15, leading: 0, bottom: 15, trailing: 0)
             rowContentView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -103,14 +103,6 @@ class LeftNavMenuViewController: UIViewController {
         view = leftNavView
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
-            sizeCategory != traitCollection.preferredContentSizeCategory {
-            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
-        }
-    }
-
     var menuAction: (() -> Void)?
 
     private func setPresence(presence: LeftNavPresence) {
@@ -131,8 +123,6 @@ class LeftNavMenuViewController: UIViewController {
     private var leftNavMenuList = MSFList()
 
     private var statusCell: MSFListCellState?
-
-    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
 
     private lazy var leftNavAccountView: UIView = {
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
@@ -289,11 +279,7 @@ class LeftNavMenuViewController: UIViewController {
         contentView.addSubview(accountView)
         contentView.addSubview(menuListView)
 
-        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
-        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
-
-        NSLayoutConstraint.activate([accountViewHeightConstraint,
-                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
+        NSLayoutConstraint.activate([accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
                                      accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
                                      accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
                                      menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
@@ -313,8 +299,8 @@ class LeftNavMenuViewController: UIViewController {
 
         container.backgroundColor = .systemBackground
 
+        // No bottom constraint means `contentView` will bind to the top of `container`.
         NSLayoutConstraint.activate([container.safeAreaLayoutGuide.topAnchor.constraint(equalTo: contentView.topAnchor),
-                                     container.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                                      container.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
                                      container.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
         return container

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -290,7 +290,6 @@ class LeftNavMenuViewController: UIViewController {
         contentView.addSubview(menuListView)
 
         let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
-        accountViewHeightConstraint.priority = .defaultHigh
         leftNavAccountViewHeightConstraint = accountViewHeightConstraint
 
         NSLayoutConstraint.activate([accountViewHeightConstraint,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -56,7 +56,7 @@ class LeftNavDemoController: DemoController {
                 return
             }
             strongSelf.showLeftNavButtonTapped()
-        }).view
+        })
     }()
 
     private lazy var drawerController: DrawerController = {
@@ -154,7 +154,7 @@ class LeftNavMenuViewController: UIViewController {
             })
         }
 
-        let personaView = persona.view
+        let personaView = persona
         personaView.translatesAutoresizingMaskIntoConstraints = false
         return personaView
     }()
@@ -261,7 +261,7 @@ class LeftNavMenuViewController: UIViewController {
         microsoftAccountCell.accessoryType = .checkmark
         let orgAvatar = MSFAvatar(style: .group, size: .large)
         orgAvatar.state.primaryText = "Kat Larrson"
-        microsoftAccountCell.leadingUIView = orgAvatar.view
+        microsoftAccountCell.leadingUIView = orgAvatar
         microsoftAccountCell.leadingViewSize = .large
 
         let msaAccountCell = accountsSection.createCell()
@@ -271,7 +271,7 @@ class LeftNavMenuViewController: UIViewController {
         msaAccountCell.subtitle = "kat.larrson@live.com"
         let msaAvatar = MSFAvatar(style: .group, size: .large)
         msaAvatar.state.primaryText = "kat.larrson@live.com"
-        msaAccountCell.leadingUIView = msaAvatar.view
+        msaAccountCell.leadingUIView = msaAvatar
         msaAccountCell.leadingViewSize = .large
 
         let addAccountCell = accountsSection.createCell()
@@ -283,7 +283,7 @@ class LeftNavMenuViewController: UIViewController {
         addAccountCell.onTapAction = defaultMenuAction
 
         let accountView = leftNavAccountView
-        let menuListView = leftNavMenuList.view
+        let menuListView = leftNavMenuList
         menuListView.translatesAutoresizingMaskIntoConstraints = false
 
         contentView.addSubview(accountView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -103,6 +103,14 @@ class LeftNavMenuViewController: UIViewController {
         view = leftNavView
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if let sizeCategory = previousTraitCollection?.preferredContentSizeCategory,
+            sizeCategory != traitCollection.preferredContentSizeCategory {
+            leftNavAccountViewHeightConstraint?.constant = leftNavAccountView.intrinsicContentSize.height
+        }
+    }
+
     var menuAction: (() -> Void)?
 
     private func setPresence(presence: LeftNavPresence) {
@@ -123,6 +131,8 @@ class LeftNavMenuViewController: UIViewController {
     private var leftNavMenuList = MSFList()
 
     private var statusCell: MSFListCellState?
+
+    private var leftNavAccountViewHeightConstraint: NSLayoutConstraint?
 
     private lazy var leftNavAccountView: UIView = {
         let chevron = UIImageView(image: UIImage(named: "ic_fluent_ios_chevron_right_20_filled"))
@@ -279,7 +289,12 @@ class LeftNavMenuViewController: UIViewController {
         contentView.addSubview(accountView)
         contentView.addSubview(menuListView)
 
-        NSLayoutConstraint.activate([accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
+        let accountViewHeightConstraint = accountView.heightAnchor.constraint(equalToConstant: accountView.intrinsicContentSize.height)
+        accountViewHeightConstraint.priority = .defaultHigh
+        leftNavAccountViewHeightConstraint = accountViewHeightConstraint
+
+        NSLayoutConstraint.activate([accountViewHeightConstraint,
+                                     accountView.topAnchor.constraint(equalTo: contentView.topAnchor),
                                      accountView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
                                      accountView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
                                      menuListView.topAnchor.constraint(equalTo: accountView.bottomAnchor),
@@ -299,8 +314,8 @@ class LeftNavMenuViewController: UIViewController {
 
         container.backgroundColor = .systemBackground
 
-        // No bottom constraint means `contentView` will bind to the top of `container`.
         NSLayoutConstraint.activate([container.safeAreaLayoutGuide.topAnchor.constraint(equalTo: contentView.topAnchor),
+                                     container.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                                      container.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
                                      container.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)])
         return container

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -67,7 +67,7 @@ class ListDemoController: DemoController {
             }
         }
 
-        let listView = list.view
+        let listView = list
         listView.translatesAutoresizingMaskIntoConstraints = false
 
         let demoControllerView: UIView = self.view
@@ -93,7 +93,7 @@ class ListDemoController: DemoController {
                                       image: personaData.image,
                                       style: .default)
         cellState.title = avatar.state.primaryText ?? ""
-        cellState.leadingUIView = avatar.view
+        cellState.leadingUIView = avatar
         cellState.isExpanded = personaDataNode.isExpanded
         cellState.hasDivider = true
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -18,7 +18,7 @@ class NavigationControllerDemoController: DemoController {
             }
 
             strongSelf.presentController(withLargeTitle: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -28,7 +28,7 @@ class NavigationControllerDemoController: DemoController {
             strongSelf.presentController(withLargeTitle: true,
                                          accessoryView: strongSelf.createAccessoryView(),
                                          contractNavigationBarOnScroll: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -38,7 +38,7 @@ class NavigationControllerDemoController: DemoController {
             strongSelf.presentController(withLargeTitle: true,
                                          accessoryView: strongSelf.createAccessoryView(),
                                          contractNavigationBarOnScroll: false)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show without an avatar", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -49,7 +49,7 @@ class NavigationControllerDemoController: DemoController {
                                          style: .primary,
                                          accessoryView: strongSelf.createAccessoryView(),
                                          showAvatar: false)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: { [weak self] _ in
             guard let strongSelf = self else {
@@ -73,7 +73,7 @@ class NavigationControllerDemoController: DemoController {
             strongSelf.presentController(withLargeTitle: true,
                                          accessoryView: stackView,
                                          contractNavigationBarOnScroll: false)
-        }).view)
+        }))
 
         addTitle(text: "Large Title with System style")
         container.addArrangedSubview(createButton(title: "Show without accessory", action: { [weak self] _ in
@@ -83,7 +83,7 @@ class NavigationControllerDemoController: DemoController {
 
             strongSelf.presentController(withLargeTitle: true,
                                          style: .system)
-        }).view)
+        }))
         container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: { [weak self] _ in
             guard let strongSelf = self else {
                 return
@@ -93,7 +93,7 @@ class NavigationControllerDemoController: DemoController {
                                          style: .system,
                                          contractNavigationBarOnScroll: false,
                                          showShadow: false)
-        }).view)
+        }))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: { [weak self] _ in
             guard let strongSelf = self else {
                 return
@@ -103,7 +103,7 @@ class NavigationControllerDemoController: DemoController {
                                          style: .system,
                                          accessoryView: strongSelf.createAccessoryView(with: .darkContent),
                                          contractNavigationBarOnScroll: true)
-        }).view)
+        }))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: { [weak self] _ in
             guard let strongSelf = self else {
                 return
@@ -113,7 +113,7 @@ class NavigationControllerDemoController: DemoController {
                                    style: .system,
                                    accessoryView: strongSelf.createAccessoryView(with: .darkContent),
                                    contractNavigationBarOnScroll: false)
-        }).view)
+        }))
 
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: { [weak self] _ in
@@ -125,7 +125,7 @@ class NavigationControllerDemoController: DemoController {
                                          style: .system,
                                          accessoryView: strongSelf.createAccessoryView(with: .darkContent),
                                          contractNavigationBarOnScroll: true)
-        }).view)
+        }))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: { [weak self] _ in
             guard let strongSelf = self else {
                 return
@@ -134,7 +134,7 @@ class NavigationControllerDemoController: DemoController {
             strongSelf.presentController(withLargeTitle: false,
                                          accessoryView: strongSelf.createAccessoryView(),
                                          contractNavigationBarOnScroll: false)
-        }).view)
+        }))
 
         addTitle(text: "Size Customization")
         container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: { [weak self] _ in
@@ -146,7 +146,7 @@ class NavigationControllerDemoController: DemoController {
                                                           accessoryView: strongSelf.createAccessoryView())
             controller.msfNavigationBar.avatarSize = .expanded
             controller.msfNavigationBar.titleSize = .contracted
-        }).view)
+        }))
 
         addTitle(text: "Custom Navigation Bar Color")
         container.addArrangedSubview(createButton(title: "Show with gradient navigation bar color", action: { [weak self] _ in
@@ -157,7 +157,7 @@ class NavigationControllerDemoController: DemoController {
             strongSelf.presentController(withLargeTitle: true,
                                          style: .custom,
                                          accessoryView: strongSelf.createAccessoryView())
-        }).view)
+        }))
 
         addTitle(text: "Top Accessory View")
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: { [weak self] _ in
@@ -170,7 +170,7 @@ class NavigationControllerDemoController: DemoController {
                                          accessoryView: strongSelf.createAccessoryView(with: .darkContent),
                                          showsTopAccessory: true,
                                          contractNavigationBarOnScroll: false)
-        }).view)
+        }))
 
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: { [weak self] _ in
@@ -184,7 +184,7 @@ class NavigationControllerDemoController: DemoController {
                                          showsTopAccessory: true,
                                          contractNavigationBarOnScroll: false,
                                          updateStylePeriodically: true)
-        }).view)
+        }))
     }
 
     @discardableResult

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -63,7 +63,7 @@ class NotificationViewDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show", action: { [weak self] _ in
             self?.navigationController?.pushViewController(NotificationViewDemoControllerSwiftUI(),
                                                            animated: true)
-        }).view)
+        }))
 
         for (index, variant) in Variant.allCases.enumerated() {
             if index > 0 {
@@ -84,7 +84,7 @@ class NotificationViewDemoController: DemoController {
                 }
             })
             showButton.state.text = "Show"
-            container.addArrangedSubview(showButton.view)
+            container.addArrangedSubview(showButton)
 
             container.alignment = .leading
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -50,7 +50,7 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
         switch row {
         case .notification:
             let cell = UITableViewCell()
-            let notificationView = notification.view
+            let notificationView = notification
             let contentView = cell.contentView
             contentView.addSubview(notificationView)
             notificationView.translatesAutoresizingMaskIntoConstraints = false
@@ -83,13 +83,13 @@ class NotificationViewDemoControllerSwiftUI: DemoTableViewController, UIPickerVi
             let buttonView: [UIView] = {
                 switch row {
                 case .notificationTitle:
-                    return [notificationTitleTextField, notificationTitleButton.view]
+                    return [notificationTitleTextField, notificationTitleButton]
                 case .message:
-                    return [messageTextField, messageButton.view]
+                    return [messageTextField, messageButton]
                 case .actionButtonTitle:
-                    return [actionButtonTitleTextField, actionButtonTitleButton.view]
+                    return [actionButtonTitleTextField, actionButtonTitleButton]
                 case .delayTime:
-                    return [delayTimeTextField, delayTimeButton.view]
+                    return [delayTimeTextField, delayTimeButton]
                 default:
                     return []
                 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -54,7 +54,7 @@
                                               size:MSFButtonSizeMedium
                                             action:^(MSFButton *sender) {}];
     [self resetButton];
-    [self.container addArrangedSubview:[_testButton view]];
+    [self.container addArrangedSubview:_testButton];
 
     MSFButtonLegacy *enableButton = [self createButtonWithTitle:@"Enable Button" action:@selector(enableButton)];
     [self.container addArrangedSubview:enableButton];
@@ -98,12 +98,11 @@
         [self showAlertForCellTapped:@"Sample Title3"];
     }];
 
-    UIView *listView = [testList view];
-    listView.translatesAutoresizingMaskIntoConstraints = false;
+    testList.translatesAutoresizingMaskIntoConstraints = false;
 
-    [self.container addArrangedSubview:[testList view]];
+    [self.container addArrangedSubview:testList];
 
-    [[[listView heightAnchor] constraintEqualToConstant:250] setActive:YES];
+    [[[testList heightAnchor] constraintEqualToConstant:250] setActive:YES];
 }
 
 - (void)enableButton {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -77,7 +77,7 @@ class PeoplePickerDemoController: DemoController {
             if index != PeoplePickerSampleData.variants.count - 1 {
                 let divider = MSFDivider()
                 dividers.append(divider)
-                container.addArrangedSubview(divider.view)
+                container.addArrangedSubview(divider)
             }
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -175,17 +175,17 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
             self?.didTap(on: personaButtonState, at: index)
         }
 
-        cell.contentView.addSubview(carousel.view)
+        cell.contentView.addSubview(carousel)
         cell.selectionStyle = .none
         cell.backgroundColor = .tertiarySystemFill
         var constraints: [NSLayoutConstraint] = []
-        carousel.view.translatesAutoresizingMaskIntoConstraints = false
+        carousel.translatesAutoresizingMaskIntoConstraints = false
 
         constraints.append(contentsOf: [
-            carousel.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
-            carousel.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
-            carousel.view.leftAnchor.constraint(equalTo: cell.contentView.leftAnchor),
-            carousel.view.rightAnchor.constraint(equalTo: cell.contentView.rightAnchor)
+            carousel.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            carousel.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            carousel.leftAnchor.constraint(equalTo: cell.contentView.leftAnchor),
+            carousel.rightAnchor.constraint(equalTo: cell.contentView.rightAnchor)
         ])
 
         cell.contentView.addConstraints(constraints)
@@ -216,16 +216,16 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
             self?.present(alert, animated: true)
         }
 
-        cell.contentView.addSubview(personaButton.view)
+        cell.contentView.addSubview(personaButton)
         cell.selectionStyle = .none
         cell.backgroundColor = .tertiarySystemFill
         var constraints: [NSLayoutConstraint] = []
-        personaButton.view.translatesAutoresizingMaskIntoConstraints = false
+        personaButton.translatesAutoresizingMaskIntoConstraints = false
 
         constraints.append(contentsOf: [
-            personaButton.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
-            personaButton.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
-            personaButton.view.centerXAnchor.constraint(equalTo: cell.contentView.centerXAnchor)
+            personaButton.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
+            personaButton.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            personaButton.centerXAnchor.constraint(equalTo: cell.contentView.centerXAnchor)
         ])
 
         cell.contentView.addConstraints(constraints)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -38,7 +38,7 @@ class PopupMenuDemoController: DemoController {
                 return
             }
 
-            let buttonView = sender.view
+            let buttonView = sender
             let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
 
             controller.addSections([
@@ -61,28 +61,28 @@ class PopupMenuDemoController: DemoController {
             }
 
             strongSelf.present(controller, animated: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show with scrollable items and no icons", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            let buttonView = sender.view
+            let buttonView = sender
             let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
 
             let items = samplePersonas.map { PopupMenuItem(title: !$0.name.isEmpty ? $0.name : $0.email) }
             controller.addItems(items)
 
             strongSelf.present(controller, animated: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show items with custom colors", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            let buttonView = sender.view
+            let buttonView = sender
             let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
 
             let items = [
@@ -108,14 +108,14 @@ class PopupMenuDemoController: DemoController {
             controller.separatorColor = .lightGray
 
             strongSelf.present(controller, animated: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(createButton(title: "Show items without dismissal after being tapped", action: { [weak self] sender in
             guard let strongSelf = self else {
                 return
             }
 
-            let buttonView = sender.view
+            let buttonView = sender
             let controller = PopupMenuController(sourceView: buttonView, sourceRect: buttonView.bounds, presentationDirection: .down)
 
             let items = [
@@ -141,7 +141,7 @@ class PopupMenuDemoController: DemoController {
             controller.separatorColor = .lightGray
 
             strongSelf.present(controller, animated: true)
-        }).view)
+        }))
 
         container.addArrangedSubview(UIView())
         addTitle(text: "Show with...")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -60,27 +60,27 @@ class ShimmerViewDemoController: DemoController {
         }
 
         container.addArrangedSubview(shimmerViewLabel("A ShimmerLinesView needs no containerview or subviews"))
-        container.addArrangedSubview(dividers[0].view)
+        container.addArrangedSubview(dividers[0])
         container.addArrangedSubview(ShimmerLinesView())
-        container.addArrangedSubview(dividers[1].view)
+        container.addArrangedSubview(dividers[1])
 
         container.addArrangedSubview(shimmerViewLabel("ShimmerView shimmers all the top level subviews of its container view"))
-        container.addArrangedSubview(dividers[2].view)
+        container.addArrangedSubview(dividers[2])
         container.addArrangedSubview(shimmeringContentView(false))
-        container.addArrangedSubview(dividers[3].view)
+        container.addArrangedSubview(dividers[3])
 
         container.addArrangedSubview(shimmerViewLabel("With shimmersLeafViews set, the ShimmerView will shimmer the labels inside the stackview"))
-        container.addArrangedSubview(dividers[4].view)
+        container.addArrangedSubview(dividers[4])
         container.addArrangedSubview(shimmeringContentView(true))
-        container.addArrangedSubview(dividers[5].view)
+        container.addArrangedSubview(dividers[5])
 
         container.addArrangedSubview(shimmerViewLabel("Revealing style shimmer on an image: the gradient reveals its container view as it moves"))
-        container.addArrangedSubview(dividers[6].view)
+        container.addArrangedSubview(dividers[6])
         container.addArrangedSubview(shimmeringImageView(.revealing))
 
-        container.addArrangedSubview(dividers[7].view)
+        container.addArrangedSubview(dividers[7])
         container.addArrangedSubview(shimmerViewLabel("Concealing style shimmer on an image: the gradient conceals its container view as it moves"))
-        container.addArrangedSubview(dividers[8].view)
+        container.addArrangedSubview(dividers[8])
         container.addArrangedSubview(shimmeringImageView(.concealing))
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -300,8 +300,8 @@ extension SideTabBarDemoController: UITableViewDataSource {
             }
 
             let stackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 100, height: 40))
-            stackView.addArrangedSubview(decrementBadgeButton.view)
-            stackView.addArrangedSubview(incrementBadgeButton.view)
+            stackView.addArrangedSubview(decrementBadgeButton)
+            stackView.addArrangedSubview(incrementBadgeButton)
             stackView.distribution = .fillEqually
             stackView.alignment = .center
             stackView.spacing = 4

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -72,7 +72,7 @@ class TabBarViewDemoController: DemoController {
                                 preferredArrowDirection: .down,
                                 offset: .init(x: 0, y: 6),
                                 dismissOn: .tapAnywhere)
-        }).view)
+        }))
 
         container.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
 
@@ -85,7 +85,7 @@ class TabBarViewDemoController: DemoController {
         addRow(text: "Use higher badge numbers", items: [useHigherBadgeNumbersSwitch], textWidth: Constants.switchSettingTextWidth)
         useHigherBadgeNumbersSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
 
-        let buttonsStackView = UIStackView(arrangedSubviews: [incrementBadgeButton.view, decrementBadgeButton.view])
+        let buttonsStackView = UIStackView(arrangedSubviews: [incrementBadgeButton, decrementBadgeButton])
         buttonsStackView.spacing = 20
         addRow(text: "Modify badge numbers", items: [buttonsStackView], textWidth: Constants.buttonSettingTextWidth)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -286,12 +286,12 @@ class TableViewCellFileAccessoryViewDemoController: DemoTableViewController {
         }
     }
 
-    private lazy var plusMinActionsButton: UIView = createPlusMinusButton(plus: true, #selector(incrementMinimumActionsCount)).view
-    private lazy var minusMinActionsButton: UIView = createPlusMinusButton(plus: false, #selector(decrementMinimumActionsCount)).view
-    private lazy var plusTopOverlapButton: UIView = createPlusMinusButton(plus: true, #selector(incrementTopActionsOverlap)).view
-    private lazy var minusTopOverlapButton: UIView = createPlusMinusButton(plus: false, #selector(decrementTopActionsOverlap)).view
-    private lazy var plusBottomOverlapButton: UIView = createPlusMinusButton(plus: true, #selector(incrementBottomActionsOverlap)).view
-    private lazy var minusBottomOverlapButton: UIView = createPlusMinusButton(plus: false, #selector(decrementBottomActionsOverlap)).view
+    private lazy var plusMinActionsButton: UIView = createPlusMinusButton(plus: true, #selector(incrementMinimumActionsCount))
+    private lazy var minusMinActionsButton: UIView = createPlusMinusButton(plus: false, #selector(decrementMinimumActionsCount))
+    private lazy var plusTopOverlapButton: UIView = createPlusMinusButton(plus: true, #selector(incrementTopActionsOverlap))
+    private lazy var minusTopOverlapButton: UIView = createPlusMinusButton(plus: false, #selector(decrementTopActionsOverlap))
+    private lazy var plusBottomOverlapButton: UIView = createPlusMinusButton(plus: true, #selector(incrementBottomActionsOverlap))
+    private lazy var minusBottomOverlapButton: UIView = createPlusMinusButton(plus: false, #selector(decrementBottomActionsOverlap))
 
     private func createPlusMinusButton(plus: Bool, _ selector: Selector) -> MSFButton {
         let button = MSFButton(style: .secondary,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -34,7 +34,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         container.setCustomSpacing(8, after: segmentedControl)
         container.backgroundColor = Colors.navigationBarBackground
 
-        container.addArrangedSubview(divider.view)
+        container.addArrangedSubview(divider)
 
         container.addArrangedSubview(groupedTableView)
         container.addArrangedSubview(plainTableView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
@@ -20,21 +20,21 @@ class TooltipDemoController: DemoController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Show on title", style: .plain, target: self, action: #selector(showTitleTooltip))
 
         container.addArrangedSubview(createButton(title: "Show single-line tooltip below", action: { sender in
-            Tooltip.shared.show(with: "This is pointing up.", for: sender.view, preferredArrowDirection: .up)
-        }).view)
+            Tooltip.shared.show(with: "This is pointing up.", for: sender, preferredArrowDirection: .up)
+        }))
         container.addArrangedSubview(createButton(title: "Show double-line tooltip above", action: { sender in
-            Tooltip.shared.show(with: "This is a very long message, and this is also pointing down.", for: sender.view)
-        }).view)
+            Tooltip.shared.show(with: "This is a very long message, and this is also pointing down.", for: sender)
+        }))
         container.addArrangedSubview(createButton(title: "Show with tap on tooltip dismissal", action: { sender in
-            Tooltip.shared.show(with: "Tap on this tooltip to dismiss.", for: sender.view, preferredArrowDirection: .up, dismissOn: .tapOnTooltip)
-        }).view)
+            Tooltip.shared.show(with: "Tap on this tooltip to dismiss.", for: sender, preferredArrowDirection: .up, dismissOn: .tapOnTooltip)
+        }))
         container.addArrangedSubview(createButton(title: "Show with tap on tooltip or anchor dismissal", action: { [weak self] _ in
             guard let strongSelf = self else {
                 return
             }
 
             Tooltip.shared.show(with: "Tap on this tooltip or this title button to dismiss.", for: strongSelf.titleView, dismissOn: .tapOnTooltipOrAnchor)
-        }).view)
+        }))
         container.addArrangedSubview(createLeftRightButtons())
 
         edgeCaseStackView = createEdgeCaseButtons()
@@ -52,15 +52,15 @@ class TooltipDemoController: DemoController {
         container.spacing = 16.0
 
         let leftButton = createButton(title: "Show tooltip\n(with arrow left)", action: { sender in
-            Tooltip.shared.show(with: "This is pointing left.", for: sender.view, preferredArrowDirection: .left)
+            Tooltip.shared.show(with: "This is pointing left.", for: sender, preferredArrowDirection: .left)
         })
 
         let rightButton = createButton(title: "Show tooltip\n(with arrow right)", action: { sender in
-            Tooltip.shared.show(with: "This is pointing right.", for: sender.view, preferredArrowDirection: .right)
+            Tooltip.shared.show(with: "This is pointing right.", for: sender, preferredArrowDirection: .right)
         })
 
-        container.addArrangedSubview(leftButton.view)
-        container.addArrangedSubview(rightButton.view)
+        container.addArrangedSubview(leftButton)
+        container.addArrangedSubview(rightButton)
         return container
     }
 
@@ -71,8 +71,8 @@ class TooltipDemoController: DemoController {
         container.alignment = .fill
 
         let topleftButton = createButton(title: " ", action: { sender in
-            Tooltip.shared.show(with: "This is an offset tooltip.", for: sender.view, preferredArrowDirection: .up)
-        }).view
+            Tooltip.shared.show(with: "This is an offset tooltip.", for: sender, preferredArrowDirection: .up)
+        })
 
         let topRightButton = createButton(title: "", action: { [weak self] sender in
             guard let strongSelf = self else {
@@ -87,8 +87,8 @@ class TooltipDemoController: DemoController {
             var margins = Tooltip.defaultScreenMargins
             margins.top = edgeCaseStackView.convert(edgeCaseStackView.bounds, to: window).minY - window.safeAreaInsets.top
             margins.left = window.frame.inset(by: window.safeAreaInsets).midX
-            Tooltip.shared.show(with: "This is a very long, offset message.", for: sender.view, preferredArrowDirection: .right, screenMargins: margins)
-        }).view
+            Tooltip.shared.show(with: "This is a very long, offset message.", for: sender, preferredArrowDirection: .right, screenMargins: margins)
+        })
 
         let bottomLeftButton = createButton(title: "", action: { [weak self] sender in
             guard let strongSelf = self else {
@@ -100,12 +100,12 @@ class TooltipDemoController: DemoController {
             }
             var margins = Tooltip.defaultScreenMargins
             margins.right = window.frame.inset(by: window.safeAreaInsets).midX
-            Tooltip.shared.show(with: "This is a very long, offset message.", for: sender.view, preferredArrowDirection: .left, screenMargins: margins)
-        }).view
+            Tooltip.shared.show(with: "This is a very long, offset message.", for: sender, preferredArrowDirection: .left, screenMargins: margins)
+        })
 
         let bottomRightButton = createButton(title: "", action: { sender in
-            Tooltip.shared.show(with: "This is an offset tooltip.", for: sender.view)
-        }).view
+            Tooltip.shared.show(with: "This is an offset tooltip.", for: sender)
+        })
 
         for button in [topleftButton, topRightButton, bottomLeftButton, bottomRightButton] {
             button.widthAnchor.constraint(equalToConstant: 32.0).isActive = true

--- a/ios/FluentUI/AvatarGroup/MSFAvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/MSFAvatarGroup.swift
@@ -19,7 +19,6 @@ import SwiftUI
                                      size: size)
         state = avatarGroup.state
         super.init(AnyView(avatarGroup))
-        view.backgroundColor = UIColor.clear
     }
 
     required public init?(coder: NSCoder) {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -455,7 +455,7 @@ open class BottomCommandingController: UIViewController {
 
     private func makeSheetExpandedContent(with tableView: UITableView) -> UIView {
         let view = UIView()
-        let dividerView = divider.view
+        let dividerView = divider
         dividerView.translatesAutoresizingMaskIntoConstraints = false
         tableView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -46,11 +46,11 @@ class CalendarView: UIView {
 
         addSubview(weekdayHeadingView)
         addSubview(collectionView)
-        addSubview(collectionViewDivider.view)
+        addSubview(collectionViewDivider)
         addInteraction(UILargeContentViewerInteraction())
 
         if headerStyle == .light {
-            addSubview(headingViewDivider.view)
+            addSubview(headingViewDivider)
         }
     }
 
@@ -70,11 +70,11 @@ class CalendarView: UIView {
             height: weekdayHeadingViewSize.height
         )
 
-        headingViewDivider.view.frame = CGRect(
+        headingViewDivider.frame = CGRect(
             x: 0.0,
             y: weekdayHeadingView.frame.height,
             width: bounds.size.width,
-            height: headingViewDivider.view.frame.height
+            height: headingViewDivider.frame.height
         )
 
         // Collection view
@@ -91,11 +91,11 @@ class CalendarView: UIView {
         )
         collectionView.contentOffset = originalContentOffset
 
-        collectionViewDivider.view.frame = CGRect(
+        collectionViewDivider.frame = CGRect(
             x: 0.0,
-            y: collectionView.frame.maxY - collectionViewDivider.view.frame.height,
+            y: collectionView.frame.maxY - collectionViewDivider.frame.height,
             width: bounds.size.width,
-            height: collectionViewDivider.view.frame.height
+            height: collectionViewDivider.frame.height
         )
     }
 

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -9,11 +9,7 @@ import UIKit
 /// Common wrapper for hosting and exposing SwiftUI components to UIKit-based clients.
 open class ControlHostingView: UIView {
 
-    /// The UIView representing the wrapped SwiftUI view.
-    @objc public var view: UIView {
-        return self
-    }
-
+    /// The intrinsic content size of the wrapped SwiftUI view.
     @objc public override var intrinsicContentSize: CGSize {
         guard let hostedView = hostingController.view else {
             return super.intrinsicContentSize

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -62,9 +62,6 @@ open class ControlHostingView: UIView {
             hostedView.bottomAnchor.constraint(equalTo: bottomAnchor),
             hostedView.topAnchor.constraint(equalTo: topAnchor)
         ]
-        requiredConstraints.forEach {
-            $0.priority = .defaultHigh
-        }
         self.addConstraints(requiredConstraints)
     }
 

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -62,6 +62,9 @@ open class ControlHostingView: UIView {
             hostedView.bottomAnchor.constraint(equalTo: bottomAnchor),
             hostedView.topAnchor.constraint(equalTo: topAnchor)
         ]
+        requiredConstraints.forEach {
+            $0.priority = .defaultHigh
+        }
         self.addConstraints(requiredConstraints)
     }
 
@@ -74,7 +77,7 @@ open class ControlHostingView: UIView {
     }
 
     private var currentFluentTheme: FluentTheme {
-        if let windowFluentTheme = self.view.window?.fluentTheme {
+        if let windowFluentTheme = self.window?.fluentTheme {
             return windowFluentTheme
         } else {
             return FluentThemeKey.defaultValue

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -75,8 +75,8 @@ class DateTimePickerView: UIControl {
         }
 
         layer.addSublayer(gradientLayer)
-        addSubview(selectionTopDivider.view)
-        addSubview(selectionBottomDivider.view)
+        addSubview(selectionTopDivider)
+        addSubview(selectionBottomDivider)
         addInteraction(UILargeContentViewerInteraction())
 
         backgroundColor = Colors.DateTimePicker.background
@@ -153,9 +153,9 @@ class DateTimePickerView: UIControl {
             x += viewWidth
         }
 
-        let selectionTopDividerView = selectionTopDivider.view
+        let selectionTopDividerView = selectionTopDivider
         let selectionTopDividerHeight = selectionTopDividerView.frame.height
-        let selectionBottomDividerView = selectionBottomDivider.view
+        let selectionBottomDividerView = selectionBottomDivider
         let selectionBottomDividerHeight = selectionTopDividerView.frame.height
         let frameWidth = frame.width
         let frameHeight = frame.height

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -102,8 +102,8 @@ class DrawerPresentationController: UIPresentationController {
             // Clipping is added to prevent any animation bug sliding over the navigation bar
             contentView.clipsToBounds = true
             if presentationDirection.isVertical && actualPresentationOffset == 0 {
-                divider.view.translatesAutoresizingMaskIntoConstraints = false
-                containerView.addSubview(divider.view)
+                divider.translatesAutoresizingMaskIntoConstraints = false
+                containerView.addSubview(divider)
             }
         }
         updateLayout()
@@ -142,7 +142,7 @@ class DrawerPresentationController: UIPresentationController {
             UIAccessibility.post(notification: .screenChanged, argument: focusElement)
             UIAccessibility.post(notification: .announcement, argument: "Accessibility.Alert".localized)
         } else {
-            divider.view.removeFromSuperview()
+            divider.removeFromSuperview()
             removePresentedViewMask()
             shadowView.owner = nil
         }
@@ -162,7 +162,7 @@ class DrawerPresentationController: UIPresentationController {
 
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         if completed {
-            divider.view.removeFromSuperview()
+            divider.removeFromSuperview()
             removePresentedViewMask()
             shadowView.owner = nil
             UIAccessibility.post(notification: .screenChanged, argument: drawerPresentationControllerDelegate?.sourceObject)
@@ -243,7 +243,7 @@ class DrawerPresentationController: UIPresentationController {
         didSet {
             if keyboardHeight != oldValue {
                 updateContentViewFrame(animated: true, animationDuration: keyboardAnimationDuration)
-                divider.view.isHidden = keyboardHeight != 0
+                divider.isHidden = keyboardHeight != 0
             }
         }
     }
@@ -255,7 +255,7 @@ class DrawerPresentationController: UIPresentationController {
         super.containerViewWillLayoutSubviews()
         updateLayout()
         // In non-animated presentations presented view will be force-placed into containerView by UIKit after separator thus hiding it
-        containerView?.bringSubviewToFront(divider.view)
+        containerView?.bringSubviewToFront(divider)
     }
 
     func setExtraContentSize(_ extraContentSize: CGFloat, updatingLayout updateLayout: Bool = true, animated: Bool = false) {
@@ -319,8 +319,8 @@ class DrawerPresentationController: UIPresentationController {
             presentedView.frame = presentedViewFrame
         }
 
-        if divider.view.superview != nil {
-            divider.view.frame = frameForDivider(in: contentView.frame, withThickness: divider.view.frame.height)
+        if divider.superview != nil {
+            divider.frame = frameForDivider(in: contentView.frame, withThickness: divider.frame.height)
         }
         updateBackgroundAccessibilityFrame()
     }

--- a/ios/FluentUI/HUD/HUDView.swift
+++ b/ios/FluentUI/HUD/HUDView.swift
@@ -190,7 +190,7 @@ class HUDView: UIView {
             let activityIndicator = MSFActivityIndicator(size: .xLarge)
             activityIndicator.state.color = Colors.HUD.activityIndicator
             activityIndicator.state.isAnimating = true
-            return activityIndicator.view
+            return activityIndicator
         case .success:
             let imageView = UIImageView(image: .staticImageNamed("checkmark-36x36"))
             imageView.tintColor = Colors.HUD.activityIndicator

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -414,7 +414,7 @@ open class SearchBar: UIView {
         textFieldLeadingConstraint = constraints.last
 
         // progressSpinner
-        let progressSpinnerView = progressSpinner.view
+        let progressSpinnerView = progressSpinner
         searchTextFieldBackgroundView.addSubview(progressSpinnerView)
         progressSpinnerView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -170,7 +170,7 @@ class ShyHeaderView: UIView {
             if showsShadow {
                 initShadow()
             } else {
-                shadow.view.removeFromSuperview()
+                shadow.removeFromSuperview()
             }
         }
     }
@@ -194,7 +194,7 @@ class ShyHeaderView: UIView {
     }
 
     private func initShadow() {
-        let shadowView = shadow.view
+        let shadowView = shadow
         shadowView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(shadowView)
         NSLayoutConstraint.activate([

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -109,7 +109,7 @@ class LargeTitleView: UIView {
             return nil
         }
 
-        return avatar?.view
+        return avatar
     }
 
     private var colorForStyle: UIColor {
@@ -131,7 +131,7 @@ class LargeTitleView: UIView {
 
     private var showsProfileButton: Bool = true { // whether to display the customizable profile button
         didSet {
-            avatar?.view.isHidden = !showsProfileButton
+            avatar?.isHidden = !showsProfileButton
             setupAccessibility()
         }
     }
@@ -188,7 +188,7 @@ class LargeTitleView: UIView {
         }
 
         self.avatar = avatar
-        let avatarView = avatar.view
+        let avatarView = avatar
 
         avatarView.translatesAutoresizingMaskIntoConstraints = false
         avatarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleAvatarViewTapped)))
@@ -252,7 +252,7 @@ class LargeTitleView: UIView {
             avatarState.accessibilityLabel = accessibilityLabel
             avatarState.hasButtonAccessibilityTrait = onAvatarTapped != nil
 
-            let avatarView = avatar.view
+            let avatarView = avatar
             avatarView.showsLargeContentViewer = true
             avatarView.largeContentTitle = accessibilityLabel
         }

--- a/ios/FluentUI/Notification/NotificationView.swift
+++ b/ios/FluentUI/Notification/NotificationView.swift
@@ -134,8 +134,8 @@ open class NotificationView: UIView, TokenizedControlInternal {
     }
 
     @objc open func initialize() {
-        addSubview(divider.view)
-        divider.view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(divider)
+        divider.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(container)
         container.translatesAutoresizingMaskIntoConstraints = false
@@ -148,9 +148,9 @@ open class NotificationView: UIView, TokenizedControlInternal {
 
         let horizontalPadding: CGFloat! = tokens.horizontalPadding
         NSLayoutConstraint.activate([
-            divider.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-            divider.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-            divider.view.bottomAnchor.constraint(equalTo: topAnchor),
+            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: trailingAnchor),
+            divider.bottomAnchor.constraint(equalTo: topAnchor),
             container.topAnchor.constraint(equalTo: topAnchor),
             container.bottomAnchor.constraint(equalTo: bottomAnchor),
             container.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: horizontalPadding),
@@ -471,7 +471,7 @@ open class NotificationView: UIView, TokenizedControlInternal {
         ambientShadow.shadowOffset = CGSize(width: tokens.ambientShadowOffsetX, height: tokens.ambientShadowOffsetY)
         ambientShadow.shadowOpacity = 1.0
 
-        divider.view.isHidden = !tokens.style.needsSeparator
+        divider.isHidden = !tokens.style.needsSeparator
 
         updateWindowSpecificColors()
     }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -104,9 +104,9 @@ open class ActionsCell: UITableViewCell {
 
         contentView.addSubview(action1Button)
         contentView.addSubview(action2Button)
-        contentView.addSubview(verticalSeparator.view)
-        addSubview(topSeparator.view)
-        addSubview(bottomSeparator.view)
+        contentView.addSubview(verticalSeparator)
+        addSubview(topSeparator)
+        addSubview(bottomSeparator)
 
         hideSystemSeparator()
         updateHorizontalSeparator(topSeparator, with: topSeparatorType)
@@ -139,7 +139,7 @@ open class ActionsCell: UITableViewCell {
             self.action2Type = action2Type
         }
         action2Button.isHidden = !hasAction
-        verticalSeparator.view.isHidden = !hasAction
+        verticalSeparator.isHidden = !hasAction
 
         updateActionTitleColors()
     }
@@ -161,11 +161,11 @@ open class ActionsCell: UITableViewCell {
 
         if actionCount > 1 {
             action2Button.frame = CGRect(x: left, y: 0, width: frame.width - left, height: frame.height)
-            verticalSeparator.view.frame = CGRect(x: left, y: 0, width: verticalSeparator.view.frame.width, height: frame.height)
+            verticalSeparator.frame = CGRect(x: left, y: 0, width: verticalSeparator.frame.width, height: frame.height)
         }
 
         layoutHorizontalSeparator(topSeparator, with: topSeparatorType, at: 0)
-        layoutHorizontalSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.view.frame.height)
+        layoutHorizontalSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
@@ -210,17 +210,17 @@ open class ActionsCell: UITableViewCell {
     private func layoutHorizontalSeparator(_ separator: MSFDivider, with type: TableViewCell.SeparatorType, at verticalOffset: CGFloat) {
         let horizontalOffset = type == .inset ? safeAreaInsets.left + Constants.horizontalSpacing : 0
 
-        separator.view.frame = CGRect(
+        separator.frame = CGRect(
             x: horizontalOffset,
             y: verticalOffset,
             width: frame.width - horizontalOffset,
-            height: separator.view.frame.height
+            height: separator.frame.height
         )
-        separator.view.flipForRTL()
+        separator.flipForRTL()
     }
 
     private func updateHorizontalSeparator(_ separator: MSFDivider, with type: TableViewCell.SeparatorType) {
-        separator.view.isHidden = type == .none
+        separator.isHidden = type == .none
         setNeedsLayout()
     }
 

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -19,7 +19,7 @@ open class ActivityIndicatorCell: UITableViewCell {
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        contentView.addSubview(activityIndicator.view)
+        contentView.addSubview(activityIndicator)
         backgroundColor = Colors.Table.Cell.background
     }
 
@@ -29,7 +29,7 @@ open class ActivityIndicatorCell: UITableViewCell {
 
     open override func layoutSubviews() {
         super.layoutSubviews()
-        let activityIndicatorView = activityIndicator.view
+        let activityIndicatorView = activityIndicator
         activityIndicatorView.sizeToFit()
         activityIndicatorView.center = CGPoint(x: UIScreen.main.roundToDevicePixels(contentView.frame.width / 2), y: UIScreen.main.roundToDevicePixels(contentView.frame.height / 2))
     }

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -142,7 +142,7 @@ open class PeoplePicker: BadgeField {
 
     func initialize() {
         personaSuggestionsView.addSubview(personaListView)
-        personaSuggestionsView.addSubview(divider.view)
+        personaSuggestionsView.addSubview(divider)
 
         personaListView.onPersonaSelected = { [unowned self] persona in
             self.pickPersona(persona: persona)
@@ -241,7 +241,7 @@ open class PeoplePicker: BadgeField {
 
         personaListView.frame = personaSuggestionsView.bounds
 
-        divider.view.frame = CGRect(x: 0, y: separatorY, width: personaSuggestionsView.frame.width, height: divider.view.frame.height)
+        divider.frame = CGRect(x: 0, y: separatorY, width: personaSuggestionsView.frame.width, height: divider.frame.height)
     }
 
     // MARK: Personas

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -51,7 +51,7 @@ open class PersonaCell: TableViewCell {
             avatar.state.ringColor = color
         }
 
-        let avatarView = avatar.view
+        let avatarView = avatar
         avatarView.accessibilityElementsHidden = true
         // Attempt to use email if name is empty
         let title = !persona.name.isEmpty ? persona.name : persona.email

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -172,12 +172,12 @@ open class PopupMenuController: DrawerController {
 
         let customTokens = PopupMenuItemCell.CustomDividerTokens(separatorColor)
         divider.state.overrideTokens = customTokens
-        view.addSubview(divider.view)
-        divider.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(divider)
+        divider.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            divider.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            divider.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            divider.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            divider.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            divider.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
         return view

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -38,8 +38,8 @@ open class SideTabBar: UIView {
     /// Remember to enable pointer interactions on the avatar view if it handles pointer interactions.
     @objc open var avatar: MSFAvatar? {
         willSet {
-            avatar?.view.removeGestureRecognizer(avatarViewGestureRecognizer)
-            avatar?.view.removeFromSuperview()
+            avatar?.removeGestureRecognizer(avatarViewGestureRecognizer)
+            avatar?.removeFromSuperview()
         }
         didSet {
             if let avatar = avatar {
@@ -48,7 +48,7 @@ open class SideTabBar: UIView {
                 avatarState.accessibilityLabel = "Accessibility.LargeTitle.ProfileView".localized
                 avatarState.hasButtonAccessibilityTrait = delegate != nil
 
-                let avatarView = avatar.view
+                let avatarView = avatar
                 avatarView.translatesAutoresizingMaskIntoConstraints = false
                 avatarView.showsLargeContentViewer = true
                 avatarView.largeContentTitle = avatarState.accessibilityLabel
@@ -117,8 +117,8 @@ open class SideTabBar: UIView {
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
         contain(view: backgroundView)
 
-        borderLine.view.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(borderLine.view)
+        borderLine.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(borderLine)
 
         addSubview(topStackView)
         addSubview(bottomStackView)
@@ -129,9 +129,9 @@ open class SideTabBar: UIView {
         shouldGroupAccessibilityChildren = true
 
         NSLayoutConstraint.activate([widthAnchor.constraint(equalToConstant: Constants.viewWidth),
-                                     borderLine.view.leadingAnchor.constraint(equalTo: trailingAnchor),
-                                     borderLine.view.bottomAnchor.constraint(equalTo: bottomAnchor),
-                                     borderLine.view.topAnchor.constraint(equalTo: topAnchor)])
+                                     borderLine.leadingAnchor.constraint(equalTo: trailingAnchor),
+                                     borderLine.bottomAnchor.constraint(equalTo: bottomAnchor),
+                                     borderLine.topAnchor.constraint(equalTo: topAnchor)])
     }
 
     @available(*, unavailable)
@@ -193,7 +193,7 @@ open class SideTabBar: UIView {
             // The avatar view's distance from the top of the side tab bar depends on safe layout guides.
             // There is a minimum spacing. If the layout guide spacing is large than the minimum spacing,
             // then the spacing will be layoutGuideSpacing + safeTopSpacing.
-            let avatarView = avatar.view
+            let avatarView = avatar
             let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewSafeTopSpacing)
             topSafeConstraint.priority = .defaultHigh
 
@@ -273,7 +273,7 @@ open class SideTabBar: UIView {
             }
 
             var previousSectionCount: Int = 0
-            if let avatar = avatar, !avatar.view.isHidden {
+            if let avatar = avatar, !avatar.isHidden {
                 totalCount += 1
                 previousSectionCount += 1
             }

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -87,14 +87,14 @@ open class TabBarView: UIView {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         contain(view: stackView, withInsets: .zero, respectingSafeAreaInsets: true)
 
-        topBorderLine.view.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(topBorderLine.view)
+        topBorderLine.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(topBorderLine)
 
         heightConstraint = stackView.heightAnchor.constraint(equalToConstant: traitCollection.userInterfaceIdiom == .phone ? Constants.phonePortraitHeight : Constants.padHeight)
         NSLayoutConstraint.activate([heightConstraint!,
-                                     topBorderLine.view.bottomAnchor.constraint(equalTo: topAnchor),
-                                     topBorderLine.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-                                     topBorderLine.view.trailingAnchor.constraint(equalTo: trailingAnchor)])
+                                     topBorderLine.bottomAnchor.constraint(equalTo: topAnchor),
+                                     topBorderLine.leadingAnchor.constraint(equalTo: leadingAnchor),
+                                     topBorderLine.trailingAnchor.constraint(equalTo: trailingAnchor)])
 
         addInteraction(UILargeContentViewerInteraction())
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -950,8 +950,8 @@ open class TableViewCell: UITableViewCell {
         contentView.addSubview(subtitleLabel)
         contentView.addSubview(footerLabel)
         contentView.addSubview(selectionImageView)
-        contentView.addSubview(topSeparator.view)
-        contentView.addSubview(bottomSeparator.view)
+        contentView.addSubview(topSeparator)
+        contentView.addSubview(bottomSeparator)
 
         setupBackgroundColors()
 
@@ -1164,7 +1164,7 @@ open class TableViewCell: UITableViewCell {
     }
 
     private func layoutSeparator(_ separator: MSFDivider, with type: SeparatorType, at verticalOffset: CGFloat) {
-        separator.view.frame = CGRect(
+        separator.frame = CGRect(
             x: separatorLeadingInset(for: type),
             y: verticalOffset,
             width: frame.width - separatorLeadingInset(for: type),
@@ -1402,7 +1402,7 @@ open class TableViewCell: UITableViewCell {
     }
 
     private func updateSeparator(_ separator: MSFDivider, with type: SeparatorType) {
-        separator.view.isHidden = type == .none
+        separator.isHidden = type == .none
         setNeedsLayout()
     }
 

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -49,10 +49,10 @@ import UIKit
 
     private func setupLargeContentViewer() {
         let largeContentViewerInteraction = UILargeContentViewerInteraction()
-        view.addInteraction(largeContentViewerInteraction)
+        self.addInteraction(largeContentViewerInteraction)
         largeContentViewerInteraction.gestureRecognizerForExclusionRelationship.delegate = self
-        view.scalesLargeContentImage = true
-        view.showsLargeContentViewer = state.style.isFloatingStyle
+        self.scalesLargeContentImage = true
+        self.showsLargeContentViewer = state.style.isFloatingStyle
 
         // Unpleasant workaround to get the implementation of MSFButtonState.
         // Can be removed once we switch to Xcode 13.2 and can use
@@ -62,11 +62,11 @@ import UIKit
         }
 
         imagePropertySubscriber = stateImpl.$image.sink { buttonImage in
-            self.view.largeContentImage = buttonImage
+            self.largeContentImage = buttonImage
         }
 
         textPropertySubscriber = stateImpl.$text.sink { buttonText in
-            self.view.largeContentTitle = buttonText
+            self.largeContentTitle = buttonText
         }
     }
 

--- a/ios/FluentUI/Vnext/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Vnext/Notification/MSFNotificationView.swift
@@ -32,38 +32,38 @@ import UIKit
     // MARK: - Show/Hide Methods
 
     public func showNotification(in view: UIView, completion: ((MSFNotification) -> Void)? = nil) {
-        guard self.view.window == nil else {
+        guard self.window == nil else {
             return
         }
 
         let style = notification.tokens.style
         let presentationOffset: CGFloat! = notification.tokens.presentationOffset
-        if style.isToast, let currentToast = MSFNotification.currentToast, currentToast.view.window != nil {
+        if style.isToast, let currentToast = MSFNotification.currentToast, currentToast.window != nil {
             currentToast.hide {
                 self.showNotification(in: view, completion: completion)
             }
             return
         }
 
-        self.view.translatesAutoresizingMaskIntoConstraints = false
+        self.translatesAutoresizingMaskIntoConstraints = false
         if let anchorView = anchorView, anchorView.superview == view {
-            view.insertSubview(self.view, belowSubview: anchorView)
+            view.insertSubview(self, belowSubview: anchorView)
         } else {
-            view.addSubview(self.view)
+            view.addSubview(self)
         }
 
         let anchor = anchorView?.topAnchor ?? view.safeAreaLayoutGuide.bottomAnchor
-        constraintWhenHidden = self.view.topAnchor.constraint(equalTo: anchor)
-        constraintWhenShown = self.view.bottomAnchor.constraint(equalTo: anchor, constant: -presentationOffset)
+        constraintWhenHidden = self.topAnchor.constraint(equalTo: anchor)
+        constraintWhenShown = self.bottomAnchor.constraint(equalTo: anchor, constant: -presentationOffset)
 
         var constraints = [NSLayoutConstraint]()
         constraints.append(animated ? constraintWhenHidden : constraintWhenShown)
         if style.needsFullWidth {
-            constraints.append(self.view.leadingAnchor.constraint(equalTo: view.leadingAnchor))
-            constraints.append(self.view.trailingAnchor.constraint(equalTo: view.trailingAnchor))
+            constraints.append(self.leadingAnchor.constraint(equalTo: view.leadingAnchor))
+            constraints.append(self.trailingAnchor.constraint(equalTo: view.trailingAnchor))
         } else {
-            constraints.append(self.view.centerXAnchor.constraint(equalTo: view.centerXAnchor))
-            constraints.append(self.view.widthAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.widthAnchor, constant: -2 * presentationOffset))
+            constraints.append(self.centerXAnchor.constraint(equalTo: view.centerXAnchor))
+            constraints.append(self.widthAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.widthAnchor, constant: -2 * presentationOffset))
         }
         NSLayoutConstraint.activate(constraints)
 
@@ -72,7 +72,7 @@ import UIKit
         }
 
         let completionForShow = { (_: Bool) in
-            UIAccessibility.post(notification: .layoutChanged, argument: self.view)
+            UIAccessibility.post(notification: .layoutChanged, argument: self)
             completion?(self)
         }
 
@@ -102,7 +102,7 @@ import UIKit
             }
         }()
 
-        guard self.view.window != nil && constraintWhenHidden != nil && hideDelay != .infinity else {
+        guard self.window != nil && constraintWhenHidden != nil && hideDelay != .infinity else {
             return
         }
 
@@ -117,7 +117,7 @@ import UIKit
             completionsForHide.append(completion)
         }
         let completionForHide = {
-            self.view.removeFromSuperview()
+            self.removeFromSuperview()
             if MSFNotification.currentToast == self {
                 MSFNotification.currentToast = nil
             }
@@ -131,7 +131,7 @@ import UIKit
             UIView.animate(withDuration: notification.tokens.style.animationDurationForHide, animations: {
                 self.constraintWhenShown.isActive = false
                 self.constraintWhenHidden.isActive = true
-                self.view.superview?.layoutIfNeeded()
+                self.superview?.layoutIfNeeded()
             }, completion: { _ in
                 self.isHiding = false
                 completionForHide()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In [[FHL] [vNext Tokens] Make SwiftUI control host be a `UIView` subclass, part 1](https://github.com/microsoft/fluentui-apple/pull/949), the `ControlHostingContainer` was converted to a `ControlHostingView`, which can now be placed directly into the view hierarchy.

This change removes the `view` property from `ControlHostingView` and updates all demo controllers and internal callers to simply embed the view directly.

### Verification

Because the `view` property already returned `self`, this PR introduces no functional changes. Nevertheless, it's a big change, so I've still performed a sanity pass to ensure that the trickiest controls behave as expected (and that I didn't mistype anything).

Here are a few:

https://user-images.githubusercontent.com/4934719/160943011-9d85bf4d-d553-48d1-a577-0e8adf6929df.mp4


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/957)