### PR TITLE
Update MSFButton to change with keyboard focus

### DIFF
--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -76,7 +76,7 @@ class MSFButtonStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFB
     var action: () -> Void
     @Published var image: UIImage?
     @Published var disabled: Bool?
-    @Published var focused: Bool?
+    @Published var isFocused: Bool = false
     @Published var text: String?
     @Published var size: MSFButtonSize
     @Published var style: MSFButtonStyle
@@ -89,15 +89,6 @@ class MSFButtonStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFB
         }
         set {
             disabled = newValue
-        }
-    }
-
-    var isFocused: Bool {
-        get {
-            return focused ?? false
-        }
-        set {
-            focused = newValue
         }
     }
 

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -125,16 +125,11 @@ struct FluentButtonBody: View {
             textColor = tokens.textColor.disabled
             borderColor = tokens.borderColor.disabled
             backgroundColor = tokens.backgroundColor.disabled
-        } else if isPressed {
+        } else if isPressed || isFocused {
             iconColor = tokens.iconColor.pressed
             textColor = tokens.textColor.pressed
             borderColor = tokens.borderColor.pressed
             backgroundColor = tokens.backgroundColor.pressed
-        } else if isFocused {
-            iconColor = tokens.iconColor.hover
-            textColor = tokens.textColor.hover
-            borderColor = tokens.borderColor.hover
-            backgroundColor = tokens.backgroundColor.hover
         } else {
             iconColor = tokens.iconColor.rest
             textColor = tokens.textColor.rest

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -76,6 +76,7 @@ class MSFButtonStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFB
     var action: () -> Void
     @Published var image: UIImage?
     @Published var disabled: Bool?
+    @Published var focused: Bool?
     @Published var text: String?
     @Published var size: MSFButtonSize
     @Published var style: MSFButtonStyle
@@ -88,6 +89,15 @@ class MSFButtonStateImpl: NSObject, ObservableObject, ControlConfiguration, MSFB
         }
         set {
             disabled = newValue
+        }
+    }
+
+    var isFocused: Bool {
+        get {
+            return focused ?? false
+        }
+        set {
+            focused = newValue
         }
     }
 
@@ -112,6 +122,7 @@ struct FluentButtonBody: View {
 
     var body: some View {
         let isDisabled = !isEnabled
+        let isFocused = state.isFocused
         let isFloatingStyle = tokens.style.isFloatingStyle
         let shouldUsePressedShadow = isDisabled || isPressed
         let iconColor: DynamicColor
@@ -128,6 +139,11 @@ struct FluentButtonBody: View {
             textColor = tokens.textColor.pressed
             borderColor = tokens.borderColor.pressed
             backgroundColor = tokens.backgroundColor.pressed
+        } else if isFocused {
+            iconColor = tokens.iconColor.hover
+            textColor = tokens.textColor.hover
+            borderColor = tokens.borderColor.hover
+            backgroundColor = tokens.backgroundColor.hover
         } else {
             iconColor = tokens.iconColor.rest
             textColor = tokens.textColor.rest

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -17,7 +17,11 @@ import UIKit
             return
         }
 
-        stateImpl.isFocused = !stateImpl.isFocused
+        if subviews.contains(context.nextFocusedView!) {
+            stateImpl.isFocused = true
+        } else if subviews.contains(context.previouslyFocusedView!) {
+            stateImpl.isFocused = false
+        }
     }
 
     /// Closure that handles the button tap event.

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -13,7 +13,7 @@ import UIKit
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         let style = state.style
-        guard style == .primary || style == .accentFloating, let stateImpl = state as? MSFButtonStateImpl else {
+        guard style == .primary || style == .accentFloating else {
             return
         }
 
@@ -28,7 +28,9 @@ import UIKit
     @objc public var action: ((_ sender: MSFButton) -> Void)?
 
     /// The object that groups properties that allow control over the button appearance.
-    @objc public let state: MSFButtonState
+    @objc public var state: MSFButtonState {
+        return stateImpl
+    }
 
     /// Creates a new MSFButton instance.
     /// - Parameters:
@@ -42,7 +44,7 @@ import UIKit
         let buttonView = FluentButton(style: style,
                                       size: size,
                                       action: {})
-        state = buttonView.state
+        stateImpl = buttonView.state
         super.init(AnyView(buttonView))
 
         // After initialization, set the new action to refer to our own.
@@ -67,13 +69,6 @@ import UIKit
         view.scalesLargeContentImage = true
         view.showsLargeContentViewer = state.style.isFloatingStyle
 
-        // Unpleasant workaround to get the implementation of MSFButtonState.
-        // Can be removed once we switch to Xcode 13.2 and can use
-        // `.accessibilityShowsLargeContentViewerIfAvailable()`.
-        guard let stateImpl = state as? MSFButtonStateImpl else {
-            return
-        }
-
         imagePropertySubscriber = stateImpl.$image.sink { buttonImage in
             self.view.largeContentImage = buttonImage
         }
@@ -86,4 +81,6 @@ import UIKit
     private var textPropertySubscriber: AnyCancellable?
 
     private var imagePropertySubscriber: AnyCancellable?
+
+    private let stateImpl: MSFButtonStateImpl
 }

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -11,7 +11,8 @@ import UIKit
 @objc open class MSFButton: ControlHostingView,
                             UIGestureRecognizerDelegate {
 
-    open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+    open override func didUpdateFocus(in context: UIFocusUpdateContext,
+                                      with coordinator: UIFocusAnimationCoordinator) {
         let style = state.style
         guard style == .primary || style == .accentFloating else {
             return

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -11,6 +11,15 @@ import UIKit
 @objc open class MSFButton: ControlHostingView,
                             UIGestureRecognizerDelegate {
 
+    open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
+        let style = state.style
+        guard style == .primary || style == .accentFloating, let stateImpl = state as? MSFButtonStateImpl else {
+            return
+        }
+
+        stateImpl.isFocused = !stateImpl.isFocused
+    }
+
     /// Closure that handles the button tap event.
     @objc public var action: ((_ sender: MSFButton) -> Void)?
 

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -18,9 +18,11 @@ import UIKit
             return
         }
 
-        if subviews.contains(context.nextFocusedView!) {
+        if let nextFocusedView = context.nextFocusedView,
+           subviews.contains(nextFocusedView) {
             stateImpl.isFocused = true
-        } else if subviews.contains(context.previouslyFocusedView!) {
+        } else if let previouslyFocusedView = context.previouslyFocusedView,
+                  subviews.contains(previouslyFocusedView) {
             stateImpl.isFocused = false
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

I couldn't figure out a way to do this with just SwiftUI yet, so the pure SwiftUI FluentButton still doesn't support this, but at least UIKit usage of our FluentButton does. Looks like this approach only changes colors for keyboard focus, so VoiceOver is unchanged.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![MSFButtonFocus_before_light](https://user-images.githubusercontent.com/67026548/160942386-73716c06-095a-4028-92b8-8854071d1fa3.gif) | ![MSFButtonFocus_after_light_pressed](https://user-images.githubusercontent.com/67026548/161842874-9d40bdac-1936-458d-99a7-aa2a307500ad.gif) |
| ![MSFButtonFocus_before_light_vo](https://user-images.githubusercontent.com/67026548/160942403-60b489c0-6b2a-494d-ad21-a791502f404a.gif) | ![MSFButtonFocus_after_light_vo](https://user-images.githubusercontent.com/67026548/160942414-ba93b762-3da7-4dba-91d9-a556385b6b69.gif) |
| ![MSFButtonFocus_before_dark](https://user-images.githubusercontent.com/67026548/160942424-dbeddddb-871b-4ee3-9ee0-bc527a806f86.gif) | ![MSFButtonFocus_after_dark_pressed](https://user-images.githubusercontent.com/67026548/161842903-295101fa-400c-49f1-a9ce-3d3bce6509c8.gif) |
| ![MSFButtonFocus_before_dark_vo](https://user-images.githubusercontent.com/67026548/160942445-277e38fd-23db-4159-8847-62d247ecf9ff.gif) | ![MSFButtonFocus_after_dark_vo](https://user-images.githubusercontent.com/67026548/160942452-42baf20c-51b5-4cb5-bcda-a11b75e6fdde.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/958)