### PR TITLE
[vNext Tokens] Add selection support to the Fluent List

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -42,7 +42,6 @@ class ListDemoController: DemoController {
             sectionState.title = section.title
             sectionState.style = MSFHeaderStyle.subtle
             sectionState.hasDividers = true
-            sectionState.allowsSelection = (sectionIndex % 2) == 0
             for rowIndex in 0..<TableViewCellSampleData.numberOfItemsInSection {
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: IndexPath(row: rowIndex, section: sectionIndex))
                 cell = section.item

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -42,6 +42,7 @@ class ListDemoController: DemoController {
             sectionState.title = section.title
             sectionState.style = MSFHeaderStyle.subtle
             sectionState.hasDividers = true
+            sectionState.allowsSelection = true
             for rowIndex in 0..<TableViewCellSampleData.numberOfItemsInSection {
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: IndexPath(row: rowIndex, section: sectionIndex))
                 cell = section.item

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -180,7 +180,7 @@ class ListDemoController: DemoController {
 
     let list: MSFList = {
         let list = MSFList()
-        list.state.allowsSelection = true
+        list.state.isSelectable = true
         return list
     }()
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -42,7 +42,7 @@ class ListDemoController: DemoController {
             sectionState.title = section.title
             sectionState.style = MSFHeaderStyle.subtle
             sectionState.hasDividers = true
-            sectionState.allowsSelection = true
+            sectionState.allowsSelection = (sectionIndex % 2) == 0
             for rowIndex in 0..<TableViewCellSampleData.numberOfItemsInSection {
                 showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: IndexPath(row: rowIndex, section: sectionIndex))
                 cell = section.item
@@ -179,5 +179,9 @@ class ListDemoController: DemoController {
         present(alert, animated: true)
     }
 
-    let list: MSFList = MSFList()
+    let list: MSFList = {
+        let list = MSFList()
+        list.state.allowsSelection = true
+        return list
+    }()
 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -46,7 +46,7 @@ import SwiftUI
     var sectionCount: Int { get }
 
     /// Configures if the list allows selection
-    var allowsSelection: Bool { get set }
+    var isSelectable: Bool { get set }
 
     /// Creates a new Section and appends it to the array of sections in a List.
     func createSection() -> MSFListSectionState
@@ -135,7 +135,7 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
     @Published var backgroundColor: UIColor?
     @Published var hasDividers: Bool = false
     var id = UUID()
-    var listSelectionAction: ((MSFListCellStateImpl) -> Void)?
+    var onSelectAction: ((MSFListCellStateImpl) -> Void)?
 
     // MARK: - MSFListSectionStateImpl accessors
 
@@ -155,12 +155,12 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
         }
         let cell = MSFListCellStateImpl()
         cells.insert(cell, at: index)
-        cell.selectionAction = { [weak self] (selectedCell) in
+        cell.onSelectAction = { [weak self] (selectedCell) in
             guard let strongSelf = self,
-                  let listSelectionAction = strongSelf.listSelectionAction else {
+                  let onSelectAction = strongSelf.onSelectAction else {
                 return
             }
-            listSelectionAction(selectedCell)
+            onSelectAction(selectedCell)
         }
         return cell
     }
@@ -190,9 +190,9 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         return sections.count
     }
 
-    @Published var allowsSelection: Bool = false {
+    @Published var isSelectable: Bool = false {
         didSet {
-            if !allowsSelection {
+            if !isSelectable {
                 if let selectedCell = selectedCellState {
                     selectedCell.isSelected = false
                     selectedCellState = nil
@@ -211,8 +211,8 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
             preconditionFailure("Index is out of bounds")
         }
         let section = MSFListSectionStateImpl()
-        section.listSelectionAction = { [weak self] (selectedCell) in
-            guard let strongSelf = self, strongSelf.allowsSelection else {
+        section.onSelectAction = { [weak self] (selectedCell) in
+            guard let strongSelf = self, strongSelf.isSelectable else {
                 return
             }
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -156,19 +156,17 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
         }
         let cell = MSFListCellStateImpl()
         cells.insert(cell, at: index)
-        if allowsSelection {
-            cell.selectionAction = { [weak self] (selectedCell) in
-                guard let strongSelf = self else {
-                    return
-                }
-
-                if let previousCell = strongSelf.selectedCellState,
-                   previousCell != selectedCell {
-                    previousCell.isSelected = false
-                }
-                selectedCell.isSelected.toggle()
-                strongSelf.selectedCellState = selectedCell
+        cell.selectionAction = { [weak self] (selectedCell) in
+            guard let strongSelf = self, strongSelf.allowsSelection else {
+                return
             }
+
+            if let previousCell = strongSelf.selectedCellState,
+               previousCell != selectedCell {
+                previousCell.isSelected = false
+            }
+            selectedCell.isSelected.toggle()
+            strongSelf.selectedCellState = selectedCell
         }
         return cell
     }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -24,6 +24,9 @@ import SwiftUI
     /// The number of Cells in the Section.
     var cellCount: Int { get }
 
+    /// Configures if the Section allows selection.
+    var allowsSelection: Bool { get set }
+
     /// Creates a new Cell and appends it to the array of cells in a Section.
     func createCell() -> MSFListCellState
 
@@ -131,7 +134,9 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
     @Published var title: String?
     @Published var backgroundColor: UIColor?
     @Published var hasDividers: Bool = false
+    @Published var allowsSelection: Bool = false
     var id = UUID()
+    var selectedCellState: MSFListCellStateImpl?
 
     // MARK: - MSFListSectionStateImpl accessors
 
@@ -151,6 +156,20 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
         }
         let cell = MSFListCellStateImpl()
         cells.insert(cell, at: index)
+        if allowsSelection {
+            cell.selectionAction = { [weak self] (selectedCell) in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                if let previousCell = strongSelf.selectedCellState,
+                   previousCell != selectedCell {
+                    previousCell.isSelected = false
+                }
+                selectedCell.isSelected.toggle()
+                strongSelf.selectedCellState = selectedCell
+            }
+        }
         return cell
     }
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -190,7 +190,7 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         return sections.count
     }
 
-    var allowsSelection: Bool = false {
+    @Published var allowsSelection: Bool = false {
         didSet {
             if !allowsSelection {
                 if let selectedCell = selectedCellState {

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -139,7 +139,7 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
     @Published var hasDividers: Bool = false
     var allowsSelection: Bool = false
     var id = UUID()
-    var listSelectionAction: ((MSFListCellStateImpl) -> Bool)?
+    var listSelectionAction: ((MSFListCellStateImpl) -> Void)?
 
     // MARK: - MSFListSectionStateImpl accessors
 
@@ -159,16 +159,14 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
         }
         let cell = MSFListCellStateImpl()
         cells.insert(cell, at: index)
-        cell.selectionAction = { [weak self] (selectedCell) -> Bool in
+        cell.selectionAction = { [weak self] (selectedCell) in
             guard let strongSelf = self, strongSelf.allowsSelection else {
-                return false
+                return
             }
 
-            var handledSelection = false
             if let listSelectionAction = strongSelf.listSelectionAction {
-                handledSelection = listSelectionAction(selectedCell)
+                listSelectionAction(selectedCell)
             }
-            return handledSelection
         }
         return cell
     }
@@ -210,9 +208,9 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
             preconditionFailure("Index is out of bounds")
         }
         let section = MSFListSectionStateImpl()
-        section.listSelectionAction = { [weak self] (selectedCell) -> Bool in
+        section.listSelectionAction = { [weak self] (selectedCell) in
             guard let strongSelf = self, strongSelf.allowsSelection else {
-                return false
+                return
             }
 
             if let previousCell = strongSelf.selectedCellState {
@@ -220,7 +218,6 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
             }
             selectedCell.isSelected.toggle()
             strongSelf.selectedCellState = selectedCell
-            return true
         }
         sections.insert(section, at: index)
         return section

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -190,7 +190,16 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         return sections.count
     }
 
-    var allowsSelection: Bool = false
+    var allowsSelection: Bool = false {
+        didSet {
+            if !allowsSelection {
+                if let selectedCell = selectedCellState {
+                    selectedCell.isSelected = false
+                    selectedCellState = nil
+                }
+            }
+        }
+    }
     var selectedCellState: MSFListCellStateImpl?
 
     func createSection() -> MSFListSectionState {

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -161,9 +161,8 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
                 return
             }
 
-            if let previousCell = strongSelf.selectedCellState,
-               previousCell != selectedCell {
-                previousCell.isSelected = false
+            if let previousCell = strongSelf.selectedCellState {
+                previousCell.isSelected.toggle()
             }
             selectedCell.isSelected.toggle()
             strongSelf.selectedCellState = selectedCell

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -24,9 +24,6 @@ import SwiftUI
     /// The number of Cells in the Section.
     var cellCount: Int { get }
 
-    /// Configures if the Section allows selection.
-    var allowsSelection: Bool { get set }
-
     /// Creates a new Cell and appends it to the array of cells in a Section.
     func createCell() -> MSFListCellState
 
@@ -48,7 +45,7 @@ import SwiftUI
     /// The number of Sections in the List.
     var sectionCount: Int { get }
 
-    /// Configures if the list allows selection, can be disabled at the Section level
+    /// Configures if the list allows selection
     var allowsSelection: Bool { get set }
 
     /// Creates a new Section and appends it to the array of sections in a List.
@@ -137,7 +134,6 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
     @Published var title: String?
     @Published var backgroundColor: UIColor?
     @Published var hasDividers: Bool = false
-    var allowsSelection: Bool = false
     var id = UUID()
     var listSelectionAction: ((MSFListCellStateImpl) -> Void)?
 
@@ -160,13 +156,11 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
         let cell = MSFListCellStateImpl()
         cells.insert(cell, at: index)
         cell.selectionAction = { [weak self] (selectedCell) in
-            guard let strongSelf = self, strongSelf.allowsSelection else {
+            guard let strongSelf = self,
+                  let listSelectionAction = strongSelf.listSelectionAction else {
                 return
             }
-
-            if let listSelectionAction = strongSelf.listSelectionAction {
-                listSelectionAction(selectedCell)
-            }
+            listSelectionAction(selectedCell)
         }
         return cell
     }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -208,9 +208,9 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
             }
 
             if let previousCell = strongSelf.selectedCellState {
-                previousCell.isSelected.toggle()
+                previousCell.isSelected = false
             }
-            selectedCell.isSelected.toggle()
+            selectedCell.isSelected = true
             strongSelf.selectedCellState = selectedCell
         }
         sections.insert(section, at: index)

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -48,6 +48,7 @@ import SwiftUI
     /// The number of Sections in the List.
     var sectionCount: Int { get }
 
+    /// Configures if the list allows selection, can be disabled at the Section level
     var allowsSelection: Bool { get set }
 
     /// Creates a new Section and appends it to the array of sections in a List.

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -126,7 +126,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
     @Published private(set) var children: [MSFListCellStateImpl] = []
     var onTapAction: (() -> Void)?
     var id = UUID()
-    var selectionAction: ((MSFListCellStateImpl) -> Void)?
+    var selectionAction: ((MSFListCellStateImpl) -> Bool)?
     @Published var isSelected: Bool = false
 
     var leadingUIView: UIView? {
@@ -232,6 +232,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
             preconditionFailure("Index is out of bounds")
         }
         let cell = MSFListCellStateImpl()
+        cell.selectionAction = selectionAction
         children.insert(cell, at: index)
         return cell
     }
@@ -388,10 +389,12 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                         state.isExpanded.toggle()
                     }
                 }
+
+                var handledSelection = false
                 if let selectionAction = state.selectionAction {
-                    selectionAction(state)
+                    handledSelection = selectionAction(state)
                 }
-                if let onTapAction = state.onTapAction {
+                if !handledSelection, let onTapAction = state.onTapAction {
                     onTapAction()
                 }
             }, label: {

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -126,7 +126,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
     @Published private(set) var children: [MSFListCellStateImpl] = []
     var onTapAction: (() -> Void)?
     var id = UUID()
-    var selectionAction: ((MSFListCellStateImpl) -> Bool)?
+    var selectionAction: ((MSFListCellStateImpl) -> Void)?
     @Published var isSelected: Bool = false
 
     var leadingUIView: UIView? {

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -126,7 +126,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
     @Published private(set) var children: [MSFListCellStateImpl] = []
     var onTapAction: (() -> Void)?
     var id = UUID()
-    var selectionAction: ((MSFListCellStateImpl) -> Void)?
+    var onSelectAction: ((MSFListCellStateImpl) -> Void)?
     @Published var isSelected: Bool = false
 
     var leadingUIView: UIView? {
@@ -232,7 +232,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
             preconditionFailure("Index is out of bounds")
         }
         let cell = MSFListCellStateImpl()
-        cell.selectionAction = selectionAction
+        cell.onSelectAction = onSelectAction
         children.insert(cell, at: index)
         return cell
     }
@@ -389,8 +389,8 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                         state.isExpanded.toggle()
                     }
                 }
-                if let selectionAction = state.selectionAction {
-                    selectionAction(state)
+                if let onSelectAction = state.onSelectAction {
+                    onSelectAction(state)
                 }
                 if let onTapAction = state.onTapAction {
                     onTapAction()

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -389,12 +389,10 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                         state.isExpanded.toggle()
                     }
                 }
-
-                var handledSelection = false
                 if let selectionAction = state.selectionAction {
-                    handledSelection = selectionAction(state)
+                    selectionAction(state)
                 }
-                if !handledSelection, let onTapAction = state.onTapAction {
+                if let onTapAction = state.onTapAction {
                     onTapAction()
                 }
             }, label: {

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -480,6 +480,7 @@ struct ListCellButtonStyle: ButtonStyle {
             return Color(stateBackgroundColor)
         }()
 
+        // TODO: Add correct selection styling
         if isPressed || state.isSelected {
             return highlightedBackgroundColor
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We're working towards making a new PopupMenu that will use the current UIKit Drawer and SwiftUI FluentList. This PR covers only adding support for selection to the list. A following PR will add styling to match the current PopupMenu.
In this PR I've added support for a single selection across the entire list, along with the ability to disable selection in specific sections.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ListSelection_before](https://user-images.githubusercontent.com/67026548/162531065-b083a739-f82d-4246-9c6c-497b9f855c31.gif) | ![ListSelection_after2](https://user-images.githubusercontent.com/67026548/163075029-b7d1e6ac-795c-4192-8fd3-2c8c8dd3d72f.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/962)