### PR TITLE
[PreviewCard] Display PreviewCard view, add rounded box inside view

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */; };
 		C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */; };
 		CCC18C2F2501C75F00BE830E /* CardViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */; };
+		CE6045DC27FE149D00FFD972 /* PreviewCardDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6045DB27FE149D00FFD972 /* PreviewCardDemoController.swift */; };
 		E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842973247B672000A29C40 /* SceneDelegate.swift */; };
 		E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemes.swift */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
@@ -121,6 +122,7 @@
 		C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellShimmerDemoController.swift; sourceTree = "<group>"; };
 		C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerLinesViewDemoController.swift; sourceTree = "<group>"; };
 		CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewDemoController.swift; sourceTree = "<group>"; };
+		CE6045DB27FE149D00FFD972 /* PreviewCardDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCardDemoController.swift; sourceTree = "<group>"; };
 		E6842973247B672000A29C40 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E6842995247C350700A29C40 /* DemoColorThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoColorThemes.swift; sourceTree = "<group>"; };
 		FC414E3625888BC300069E73 /* CommandBarDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarDemoController.swift; sourceTree = "<group>"; };
@@ -275,10 +277,10 @@
 		A5CEC23220E452B80016922A /* Demos */ = {
 			isa = PBXGroup;
 			children = (
-				532FE3D926EA6D8D007539C0 /* ActivityIndicatorDemoController.swift */,
 				532FE3DA26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift */,
-				5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */,
+				532FE3D926EA6D8D007539C0 /* ActivityIndicatorDemoController.swift */,
 				5303259226B3198A00611D05 /* AvatarDemoController_SwiftUI.swift */,
+				5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */,
 				5306075826A1E73F002D49CF /* AvatarGroupDemoController.swift */,
 				B45EB79121A4D047008646A2 /* BadgeFieldDemoController.swift */,
 				B444D6B72183BA4B0002B4D4 /* BadgeViewDemoController.swift */,
@@ -292,8 +294,8 @@
 				FD7254EC21471A3F002F4069 /* DateTimePickerDemoController.swift */,
 				A5DCA75D211E3A92005F4CB7 /* DrawerDemoController.swift */,
 				B4E8F65121CD9579008A1598 /* HUDDemoController.swift */,
-				5328D97926FBA3E900F3723B /* IndeterminateProgressBarDemoController.swift */,
 				5328D97826FBA3E900F3723B /* IndeterminateProgressBarDemoController_SwiftUI.swift */,
+				5328D97926FBA3E900F3723B /* IndeterminateProgressBarDemoController.swift */,
 				A589F855211BA71000471C23 /* LabelDemoController.swift */,
 				FD41C8F322E28EEB0086F899 /* NavigationControllerDemoController.swift */,
 				A5B6617523A4227300E801DD /* NotificationViewDemoController.swift */,
@@ -305,6 +307,7 @@
 				B4EF53C4215C45C400573E8F /* PersonaListViewDemoController.swift */,
 				497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */,
 				A5961FA8218A61BB00E2A506 /* PopupMenuDemoController.swift */,
+				CE6045DB27FE149D00FFD972 /* PreviewCardDemoController.swift */,
 				2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */,
 				FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */,
 				C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */,
@@ -498,6 +501,7 @@
 				FD41C8F422E28EEB0086F899 /* NavigationControllerDemoController.swift in Sources */,
 				7DC2FB2B24C0F4FD00367A55 /* TableViewCellFileAccessoryViewDemoController.swift in Sources */,
 				E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */,
+				CE6045DC27FE149D00FFD972 /* PreviewCardDemoController.swift in Sources */,
 				A5CEC21020E436F10016922A /* AppDelegate.swift in Sources */,
 				B4414794228F6FDF0040E88E /* OtherCellsSampleData.swift in Sources */,
 				B444D6B82183BA4B0002B4D4 /* BadgeViewDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -24,7 +24,8 @@ struct Demos {
         DemoDescriptor("AvatarGroup", AvatarGroupDemoController.self),
         DemoDescriptor("CardNudge", CardNudgeDemoController.self),
         DemoDescriptor("IndeterminateProgressBar", IndeterminateProgressBarDemoController.self),
-        DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self)
+        DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
+        DemoDescriptor("PreviewCard", PreviewCardDemoController.self)
     ]
 
     static let controls: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PreviewCardDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PreviewCardDemoController.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+import SwiftUI
+
+class PreviewCardDemoController: DemoTableViewController {
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+    required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let previewCard = MSFPreviewCard(theme: nil)
+        let previewCardView = previewCard.view
+        view.addSubview(previewCardView)
+        previewCardView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            previewCardView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 16.0),
+            previewCardView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 16.0),
+            previewCardView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 16.0),
+            previewCardView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: 16.0)
+        ])
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PreviewCardDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PreviewCardDemoController.swift
@@ -14,10 +14,6 @@ class PreviewCardDemoController: DemoTableViewController {
     required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
-// MARK: - Constraint Constant Attribute Values
-    private struct Constants {
-        static let constantOffset: CGFloat = 16.0
-    }
     override func viewDidLoad() {
         super.viewDidLoad()
         let previewCard = MSFPreviewCard(theme: nil)
@@ -30,5 +26,9 @@ class PreviewCardDemoController: DemoTableViewController {
             previewCardView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: Constants.constantOffset),
             previewCardView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.constantOffset)
         ])
+    }
+// MARK: - Constraint Constant Attribute Values
+    private struct Constants {
+        static let constantOffset: CGFloat = 16.0
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PreviewCardDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PreviewCardDemoController.swift
@@ -14,6 +14,10 @@ class PreviewCardDemoController: DemoTableViewController {
     required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
+// MARK: - Constraint Constant Attribute Values
+    private struct Constants {
+        static let constantOffset: CGFloat = 16.0
+    }
     override func viewDidLoad() {
         super.viewDidLoad()
         let previewCard = MSFPreviewCard(theme: nil)
@@ -21,10 +25,10 @@ class PreviewCardDemoController: DemoTableViewController {
         view.addSubview(previewCardView)
         previewCardView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            previewCardView.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 16.0),
-            previewCardView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor, constant: 16.0),
-            previewCardView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 16.0),
-            previewCardView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: 16.0)
+            previewCardView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.constantOffset),
+            previewCardView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.constantOffset),
+            previewCardView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: Constants.constantOffset),
+            previewCardView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.constantOffset)
         ])
     }
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		C708B064260A87F7007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04EE25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
+		CE6045DA27FE147100FFD972 /* PreviewCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6045D927FE147100FFD972 /* PreviewCard.swift */; };
 		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
 		FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */; };
 /* End PBXBuildFile section */
@@ -313,6 +314,7 @@
 		C77A04B625F03DD1001B3EB6 /* String+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		CE6045D927FE147100FFD972 /* PreviewCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCard.swift; sourceTree = "<group>"; };
 		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
 		ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
 		FC414E1E258876FB00069E73 /* CommandBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBar.swift; sourceTree = "<group>"; };
@@ -743,15 +745,16 @@
 				5314DFEB25F002240099271A /* ActivityIndicator */,
 				C77A04F325F04CFB001B3EB6 /* Avatar */,
 				5306074E26A1E6A4002D49CF /* AvatarGroup */,
+				B4F118EA21C8270F00855942 /* Badge Field */,
 				5314DFF625F0079B0099271A /* BarButtonItems */,
 				80B52538264CA5BC00E3FD32 /* Bottom Commanding */,
 				80B1F6F52628CDEB004DFEE5 /* Bottom Sheet */,
 				5314DFEC25F0029C0099271A /* Button */,
-				CCC18C2A2501B1A900BE830E /* Card */,
-				B4F118EA21C8270F00855942 /* Badge Field */,
 				FDFB8AE921361C860046850A /* Calendar */,
+				CCC18C2A2501B1A900BE830E /* Card */,
 				92D5597C26A0FC9700328FD3 /* Card Nudge */,
 				FC414E1D258876D400069E73 /* Command Bar */,
+				A5CEC25720E6A64E0016922A /* Configuration */,
 				A5CEC16B20D98EBF0016922A /* Core */,
 				FD599D0021347FA0008845EE /* Date Time Pickers */,
 				5314DFEF25F003C60099271A /* DotView */,
@@ -771,7 +774,9 @@
 				497DC2D62418585D008D86F8 /* Pill Button Bar */,
 				A5961F9B218A251E00E2A506 /* Popup Menu */,
 				FD7254EE2147382D002F4069 /* Presenters */,
+				CE6663E927F114B700FD5DAD /* PreviewCard */,
 				5314DFF725F007FF0099271A /* ResizingHandleView */,
+				A5CEC17020D996120016922A /* Resources */,
 				ECEBA8F625EDEFF70048EE24 /* SegmentedControl */,
 				5314DFE625F000740099271A /* Separator */,
 				C0A0D75D233AEA9900F432FD /* Shimmer */,
@@ -781,8 +786,6 @@
 				5314DFF325F006060099271A /* TouchForwardingView */,
 				5314DFF825F008870099271A /* TwoLineTitleView */,
 				C0938E42235E8EAF00256251 /* Utilities */,
-				A5CEC17020D996120016922A /* Resources */,
-				A5CEC25720E6A64E0016922A /* Configuration */,
 			);
 			path = FluentUI;
 			sourceTree = "<group>";
@@ -936,6 +939,14 @@
 				CCC18C2B2501B22F00BE830E /* CardView.swift */,
 			);
 			path = Card;
+			sourceTree = "<group>";
+		};
+		CE6663E927F114B700FD5DAD /* PreviewCard */ = {
+			isa = PBXGroup;
+			children = (
+				CE6045D927FE147100FFD972 /* PreviewCard.swift */,
+			);
+			path = PreviewCard;
 			sourceTree = "<group>";
 		};
 		ECEBA8F625EDEFF70048EE24 /* SegmentedControl */ = {
@@ -1446,6 +1457,7 @@
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,
 				5314E21E25F022120099271A /* UIView+Extensions.swift in Sources */,
 				5314E0BD25F0106F0099271A /* HUD.swift in Sources */,
+				CE6045DA27FE147100FFD972 /* PreviewCard.swift in Sources */,
 				5314E06A25F00F100099271A /* GenericDateTimePicker.swift in Sources */,
 				5314E06025F00EFD0099271A /* CalendarViewWeekdayHeadingView.swift in Sources */,
 				5314E05A25F00EF50099271A /* CalendarViewLayout.swift in Sources */,

--- a/ios/FluentUI/PreviewCard/PreviewCard.swift
+++ b/ios/FluentUI/PreviewCard/PreviewCard.swift
@@ -1,0 +1,54 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+@objc open class MSFPreviewCard: NSObject, FluentUIWindowProvider {
+    @objc open var view: UIView {
+        return hostingController.view
+    }
+    @objc public init(theme: FluentUIStyle?) {
+        super.init()
+        previewCardView = PreviewCard()
+        hostingController = FluentUIHostingController(rootView: AnyView(previewCardView.windowProvider(self)))
+        hostingController.disableSafeAreaInsets()
+    }
+    var window: UIWindow? {
+        return self.view.window
+    }
+    private var hostingController: FluentUIHostingController!
+    private var previewCardView: PreviewCard!
+}
+
+public struct PreviewCard: View {
+
+    @Environment(\.theme) var theme: FluentUIStyle
+    @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+    private struct Constants {
+        static let boxMinWidth: CGFloat = 343
+        static let boxMinHeight: CGFloat = 200
+        static let boxRoundedTitle: String = "Rounded Box"
+        static let boxRadius: CGFloat = 8
+        static let boxLineWidth: CGFloat = 0.5
+    }
+    @ViewBuilder
+    var innerContents: some View {
+        VStack {
+            Text(Constants.boxRoundedTitle)
+                .frame(minWidth: Constants.boxMinWidth, minHeight: Constants.boxMinHeight)
+        }
+    }
+    public var body: some View {
+        innerContents
+            .background(
+                RoundedRectangle(cornerRadius: Constants.boxRadius)
+                    .strokeBorder(Color(.black), lineWidth: Constants.boxLineWidth)
+                    .background(
+                        RoundedRectangle(cornerRadius: Constants.boxRadius)
+                            .fill(.white)
+                    )
+    )}
+}

--- a/ios/FluentUI/PreviewCard/PreviewCard.swift
+++ b/ios/FluentUI/PreviewCard/PreviewCard.swift
@@ -6,10 +6,15 @@
 import UIKit
 import SwiftUI
 
+/// UIKit wrapper that exposes the SwiftUI PreviewCard implementation.
 @objc open class MSFPreviewCard: NSObject, FluentUIWindowProvider {
+    /// The UIView representing the Activity Indicator.
     @objc open var view: UIView {
         return hostingController.view
     }
+    /// Creates a new MSFPreviewCard instance.
+    /// - Parameters:
+    ///   - theme: The FluentUIStyle instance representing the theme to be overriden for this PreviewCard.
     @objc public init(theme: FluentUIStyle?) {
         super.init()
         previewCardView = PreviewCard()
@@ -23,24 +28,28 @@ import SwiftUI
     private var previewCardView: PreviewCard!
 }
 
+/// View that represents the PreviewCard.
 public struct PreviewCard: View {
 
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
+// MARK: - PreviewCard Box Properties
+    // TODO: - Update the hard values with tokens
     private struct Constants {
         static let boxMinWidth: CGFloat = 343
-        static let boxMinHeight: CGFloat = 200
-        static let boxRoundedTitle: String = "Rounded Box"
+        static let boxMinHeight: CGFloat = 147
         static let boxRadius: CGFloat = 8
         static let boxLineWidth: CGFloat = 0.5
     }
+    /// Creates inner PreviewCard view.
     @ViewBuilder
     var innerContents: some View {
-        VStack {
-            Text(Constants.boxRoundedTitle)
+        HStack {
+            Spacer()
                 .frame(minWidth: Constants.boxMinWidth, minHeight: Constants.boxMinHeight)
         }
     }
+    /// Creates the PreviewCard.
     public var body: some View {
         innerContents
             .background(

--- a/ios/FluentUI/PreviewCard/PreviewCard.swift
+++ b/ios/FluentUI/PreviewCard/PreviewCard.swift
@@ -33,31 +33,33 @@ public struct PreviewCard: View {
 
     @Environment(\.theme) var theme: FluentUIStyle
     @Environment(\.windowProvider) var windowProvider: FluentUIWindowProvider?
-// MARK: - PreviewCard Box Properties
-    // TODO: - Update the hard values with tokens
-    private struct Constants {
-        static let boxMinWidth: CGFloat = 343
-        static let boxMinHeight: CGFloat = 147
-        static let boxRadius: CGFloat = 8
-        static let boxLineWidth: CGFloat = 0.5
-    }
     /// Creates inner PreviewCard view.
     @ViewBuilder
     var innerContents: some View {
         HStack {
             Spacer()
-                .frame(minWidth: Constants.boxMinWidth, minHeight: Constants.boxMinHeight)
+                .frame(minWidth: Constants.cardMinWidth, minHeight: Constants.cardMinHeight)
         }
     }
     /// Creates the PreviewCard.
     public var body: some View {
+// TODO: - Implement elevated card
+// TODO: - Update to implement light and dark mode
         innerContents
             .background(
-                RoundedRectangle(cornerRadius: Constants.boxRadius)
-                    .strokeBorder(Color(.black), lineWidth: Constants.boxLineWidth)
+                RoundedRectangle(cornerRadius: Constants.cardCornerRadius)
+                    .strokeBorder(Color(.black), lineWidth: Constants.cardLineWidth)
                     .background(
-                        RoundedRectangle(cornerRadius: Constants.boxRadius)
+                        RoundedRectangle(cornerRadius: Constants.cardCornerRadius)
                             .fill(.white)
                     )
     )}
+// MARK: - PreviewCard Box Properties
+    // TODO: - Update the hard values with tokens
+    private struct Constants {
+        static let cardMinWidth: CGFloat = 343
+        static let cardMinHeight: CGFloat = 147
+        static let cardCornerRadius: CGFloat = 8
+        static let cardLineWidth: CGFloat = 0.5
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR introduces the SwiftUI implementation of a Preview Card.
Included within the view is a rounded, bordered box. The box's properties are defined with non-tokenized values and tentative for now. 

Questions for the design/general:

1. Center the box?
2. ~~Move the box title below the box instead of inside?~~
3. Move the Constants variables into another file?

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![all controls2](https://user-images.githubusercontent.com/65370736/163281235-0ff957e9-9fa4-44cf-a6c3-f9856fab0cda.png) | ![previewcard_box_display_updated resized](https://user-images.githubusercontent.com/65370736/163280842-95d081a2-b934-4929-9026-9c294f8fba0b.png) |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/963)