### PR TITLE
[vNext Tokens] Add new button tokens for minimum height and vertical padding

### DIFF
--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -116,6 +116,8 @@ struct FluentButtonBody: View {
         let isFocused = state.isFocused
         let isFloatingStyle = tokens.style.isFloatingStyle
         let shouldUsePressedShadow = isDisabled || isPressed
+        let verticalPadding = tokens.minVerticalPadding
+        let horizontalPadding = tokens.padding
         let iconColor: DynamicColor
         let textColor: DynamicColor
         let borderColor: DynamicColor
@@ -155,11 +157,14 @@ struct FluentButtonBody: View {
                         })
                 }
             }
-            .padding(tokens.padding)
+            .padding(EdgeInsets(top: verticalPadding,
+                                leading: horizontalPadding,
+                                bottom: verticalPadding,
+                                trailing: horizontalPadding))
             .modifyIf(isFloatingStyle && !(state.text?.isEmpty ?? true), { view in
                 view.padding(.horizontal, tokens.textAdditionalHorizontalPadding )
             })
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, minHeight: tokens.minHeight, maxHeight: .infinity)
             .foregroundColor(Color(dynamicColor: textColor))
         }
 

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -117,7 +117,7 @@ struct FluentButtonBody: View {
         let isFloatingStyle = tokens.style.isFloatingStyle
         let shouldUsePressedShadow = isDisabled || isPressed
         let verticalPadding = tokens.minVerticalPadding
-        let horizontalPadding = tokens.padding
+        let horizontalPadding = tokens.horizontalPadding
         let iconColor: DynamicColor
         let textColor: DynamicColor
         let borderColor: DynamicColor

--- a/ios/FluentUI/Vnext/Button/ButtonTokens.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokens.swift
@@ -283,7 +283,7 @@ open class ButtonTokens: ControlTokens {
     /// Defines the shadow used when a floating button is pressed.
     open var pressedShadow: ShadowInfo { aliasTokens.elevation[.interactiveElevation1Pressed] }
 
-    /// Defiens the minimum height of the button.
+    /// Defines the minimum height of the button.
     open var minHeight: CGFloat {
         switch style {
         case .primary, .secondary, .ghost:

--- a/ios/FluentUI/Vnext/Button/ButtonTokens.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokens.swift
@@ -268,4 +268,36 @@ open class ButtonTokens: ControlTokens {
     open var restShadow: ShadowInfo { aliasTokens.elevation[.interactiveElevation1Rest] }
 
     open var pressedShadow: ShadowInfo { aliasTokens.elevation[.interactiveElevation1Pressed] }
+
+    open var minHeight: CGFloat {
+        switch style {
+        case .primary, .secondary, .ghost:
+            switch size {
+            case .small:
+                return 28
+            case .medium:
+                return 40
+            case .large:
+                return 52
+            }
+        case .accentFloating, .subtleFloating:
+            switch size {
+            case .small, .medium:
+                return 48
+            case .large:
+                return 56
+            }
+        }
+    }
+
+    open var minVerticalPadding: CGFloat {
+        switch size {
+        case .small:
+            return 5
+        case .medium:
+            return 10
+        case .large:
+            return 15
+        }
+    }
 }

--- a/ios/FluentUI/Vnext/Button/ButtonTokens.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokens.swift
@@ -89,7 +89,7 @@ open class ButtonTokens: ControlTokens {
     }
 
     /// Defines the horizontal padding around the contents of the button.
-    open var padding: CGFloat {
+    open var horizontalPadding: CGFloat {
         switch style {
         case .primary, .secondary, .ghost:
             switch size {

--- a/ios/FluentUI/Vnext/Button/ButtonTokens.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokens.swift
@@ -37,6 +37,7 @@ open class ButtonTokens: ControlTokens {
     /// Defines the size of the button.
     public internal(set) var size: MSFButtonSize = .small
 
+    /// Defines the radius of the corners of the button.
     open var borderRadius: CGFloat {
         switch size {
         case .small, .medium:
@@ -46,6 +47,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the thickness of the border around the button.
     open var borderSize: CGFloat {
         switch style {
         case .primary, .ghost, .accentFloating, .subtleFloating:
@@ -55,6 +57,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the size of the icon in the button.
     open var iconSize: CGFloat {
         switch style {
         case .primary, .secondary, .ghost:
@@ -70,6 +73,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the space between the icon and text in the button.
     open var interspace: CGFloat {
         switch style {
         case .primary, .secondary, .ghost:
@@ -84,6 +88,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the horizontal padding around the contents of the button.
     open var padding: CGFloat {
         switch style {
         case .primary, .secondary, .ghost:
@@ -112,6 +117,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the font used for the text of the button.
     open var textFont: FontInfo {
         switch style {
         case .primary, .secondary, .ghost:
@@ -138,8 +144,10 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the minimum height of the text of the button.
     open var textMinimumHeight: CGFloat { globalTokens.iconSize[.medium] }
 
+    /// Defines the additional padding added when a floating style button has text.
     open var textAdditionalHorizontalPadding: CGFloat {
         switch size {
         case .small, .medium:
@@ -149,6 +157,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the color of the text of the button.
     open var textColor: ButtonDynamicColors {
         switch style {
         case .primary, .accentFloating:
@@ -178,6 +187,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the color of the border around the button.
     open var borderColor: ButtonDynamicColors {
         switch style {
         case .primary:
@@ -207,6 +217,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the color of the background of the button.
     open var backgroundColor: ButtonDynamicColors {
         switch style {
         case .primary, .accentFloating:
@@ -236,6 +247,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the color of the icon of the button.
     open var iconColor: ButtonDynamicColors {
         switch style {
         case .primary, .accentFloating:
@@ -265,10 +277,13 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the shadow used when a floating button is at rest.
     open var restShadow: ShadowInfo { aliasTokens.elevation[.interactiveElevation1Rest] }
 
+    /// Defines the shadow used when a floating button is pressed.
     open var pressedShadow: ShadowInfo { aliasTokens.elevation[.interactiveElevation1Pressed] }
 
+    /// Defiens the minimum height of the button.
     open var minHeight: CGFloat {
         switch style {
         case .primary, .secondary, .ghost:
@@ -290,6 +305,7 @@ open class ButtonTokens: ControlTokens {
         }
     }
 
+    /// Defines the minimum vertical padding around the content of the button.
     open var minVerticalPadding: CGFloat {
         switch size {
         case .small:


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Add new tokens to the FluentButton for the minimum height of the button and minimum vertical padding around the content.

### Verification

Button height comparisons: [Text+Icon, Text only, Icon only]

Before:
	Primary (small): [32, 31.6, 32]
	Primary (medium): [44, 39.6, 44]
	Primary (large): [60.3, 60.3, 60]
	FAB (small): [48, 48, 48]
	FAB (large): [56, 56, 56]

After:
	Primary (small): [28, 28, 28]
	Primary (medium): [40, 40, 40]
	Primary (large): [52, 52, 52]
	FAB (small): [48, 48, 48]
	FAB (large): [56, 56, 56]
	

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ButtonVerticalTokens_primary_before](https://user-images.githubusercontent.com/67026548/163080634-2e7bf952-972e-42d4-a11f-6b42023b1ddd.png) | ![ButtonVerticalTokens_primary_after](https://user-images.githubusercontent.com/67026548/163080648-af4bb607-5189-462d-8ba0-853740e8bbe5.png) |
| ![ButtonsVerticalTokens_floating_before](https://user-images.githubusercontent.com/67026548/163080639-23ed6b3f-65f0-45bf-8f0e-f01595fb8b29.png) | ![ButtonVerticalTokens_floating_after](https://user-images.githubusercontent.com/67026548/163080649-7e1f353e-995c-454b-84ea-8ed3aa448e8e.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/964)