### PR TITLE
[vNext Tokens] Tokenize ResizingHandleView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -470,8 +470,14 @@ class DrawerDemoController: DemoController {
                                    contentController: contentController,
                                    resizingBehavior: .dismissOrExpand)
 
-        drawer.resizingHandleViewBackgroundColor = Colors.navigationBarBackground
+        drawer.resizingHandleViewOverrideTokens = CustomResizingHandleTokens()
         drawer.contentScrollView = personaListView
+    }
+
+    private class CustomResizingHandleTokens: ResizingHandleTokens {
+        override var backgroundColor: DynamicColor {
+            return Colors.navigationBarBackground.dynamicColor ?? super.backgroundColor
+        }
     }
 
     @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -470,7 +470,7 @@ class DrawerDemoController: DemoController {
                                    contentController: contentController,
                                    resizingBehavior: .dismissOrExpand)
 
-        drawer.resizingHandleViewOverrideTokens = CustomResizingHandleTokens()
+        drawer.resizingHandleViewBackgroundColor = Colors.navigationBarBackground
         drawer.contentScrollView = personaListView
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -104,7 +104,7 @@ class PopupMenuDemoController: DemoController {
             controller.addItems(items)
 
             controller.backgroundColor = menuBackgroundColor
-            controller.resizingHandleViewBackgroundColor = menuBackgroundColor
+            controller.resizingHandleViewOverrideTokens = CustomResizingHandleTokens()
             controller.separatorColor = .lightGray
 
             strongSelf.present(controller, animated: true)
@@ -137,7 +137,7 @@ class PopupMenuDemoController: DemoController {
             controller.addItems(items)
 
             controller.backgroundColor = menuBackgroundColor
-            controller.resizingHandleViewBackgroundColor = menuBackgroundColor
+            controller.resizingHandleViewOverrideTokens = CustomResizingHandleTokens()
             controller.separatorColor = .lightGray
 
             strongSelf.present(controller, animated: true)
@@ -205,5 +205,11 @@ class PopupMenuDemoController: DemoController {
         ])
 
         present(controller, animated: true)
+    }
+
+    private class CustomResizingHandleTokens: ResizingHandleTokens {
+        override var backgroundColor: DynamicColor {
+            return UIColor.darkGray.dynamicColor ?? super.backgroundColor
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -104,7 +104,7 @@ class PopupMenuDemoController: DemoController {
             controller.addItems(items)
 
             controller.backgroundColor = menuBackgroundColor
-            controller.resizingHandleViewOverrideTokens = CustomResizingHandleTokens()
+            controller.resizingHandleViewBackgroundColor = menuBackgroundColor
             controller.separatorColor = .lightGray
 
             strongSelf.present(controller, animated: true)
@@ -137,7 +137,7 @@ class PopupMenuDemoController: DemoController {
             controller.addItems(items)
 
             controller.backgroundColor = menuBackgroundColor
-            controller.resizingHandleViewOverrideTokens = CustomResizingHandleTokens()
+            controller.resizingHandleViewBackgroundColor = menuBackgroundColor
             controller.separatorColor = .lightGray
 
             strongSelf.present(controller, animated: true)
@@ -205,11 +205,5 @@ class PopupMenuDemoController: DemoController {
         ])
 
         present(controller, animated: true)
-    }
-
-    private class CustomResizingHandleTokens: ResizingHandleTokens {
-        override var backgroundColor: DynamicColor {
-            return UIColor.darkGray.dynamicColor ?? super.backgroundColor
-        }
     }
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		D6F4098F274F1A1C001B80D4 /* PillButtonBarTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F4098E274F1A1C001B80D4 /* PillButtonBarTokens.swift */; };
 		EC02A5F327472EF400E81B3E /* DividerTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F227472EF400E81B3E /* DividerTokens.swift */; };
 		EC02A5F5274DD19600E81B3E /* MSFDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F4274DD19500E81B3E /* MSFDivider.swift */; };
+		EC27B8662807A63C00A40B9A /* ResizingHandleTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC27B8652807A63C00A40B9A /* ResizingHandleTokens.swift */; };
 		EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D727BF348700FD048D /* MSFAvatar.swift */; };
 		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
 		EC5982DC27CEC02100FD048D /* DrawerTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982DB27CEC02100FD048D /* DrawerTokens.swift */; };
@@ -393,6 +394,7 @@
 		D6F4098E274F1A1C001B80D4 /* PillButtonBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarTokens.swift; sourceTree = "<group>"; };
 		EC02A5F227472EF400E81B3E /* DividerTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerTokens.swift; sourceTree = "<group>"; };
 		EC02A5F4274DD19500E81B3E /* MSFDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFDivider.swift; sourceTree = "<group>"; };
+		EC27B8652807A63C00A40B9A /* ResizingHandleTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleTokens.swift; sourceTree = "<group>"; };
 		EC5982D727BF348700FD048D /* MSFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatar.swift; sourceTree = "<group>"; };
 		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
 		EC5982DB27CEC02100FD048D /* DrawerTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerTokens.swift; sourceTree = "<group>"; };
@@ -678,6 +680,7 @@
 			isa = PBXGroup;
 			children = (
 				A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */,
+				EC27B8652807A63C00A40B9A /* ResizingHandleTokens.swift */,
 			);
 			path = ResizingHandleView;
 			sourceTree = "<group>";
@@ -1664,6 +1667,7 @@
 				80AECC22263339E5005AF2F3 /* BottomSheetPassthroughView.swift in Sources */,
 				925728F9276D6B5800EE1019 /* FontInfo.swift in Sources */,
 				5314E1CD25F01B730099271A /* AnimationSynchronizer.swift in Sources */,
+				EC27B8662807A63C00A40B9A /* ResizingHandleTokens.swift in Sources */,
 				53097D252702890900A6E4DC /* ListCell.swift in Sources */,
 				92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */,
 				5314E13425F016370099271A /* PopupMenuItem.swift in Sources */,

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -250,7 +250,39 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     /// Set `resizingHandleViewBackgroundColor` to customize background color of resizingHandleView if it is shown
     @objc open var resizingHandleViewBackgroundColor: UIColor {
         didSet {
-            resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
+            updateResizingHandleTokens()
+        }
+    }
+
+    /// Set `resizingHandleViewMarkColor` to customize mark color of resizingHandleView if it is shown.
+    @objc open var resizingHandleViewMarkColor: UIColor? {
+        didSet {
+            updateResizingHandleTokens()
+        }
+    }
+
+    func updateResizingHandleTokens() {
+        resizingHandleView?.overrideTokens = CustomResizingHandleTokens(backgroundColor: resizingHandleViewBackgroundColor,
+                                                                        markColor: resizingHandleViewMarkColor)
+    }
+
+    class CustomResizingHandleTokens: ResizingHandleTokens {
+        var customBackgroundColor: UIColor?
+        var customMarkColor: UIColor?
+
+        override var markColor: DynamicColor {
+            return customMarkColor?.dynamicColor ?? super.markColor
+        }
+
+        override var backgroundColor: DynamicColor {
+            return customBackgroundColor?.dynamicColor ?? super.backgroundColor
+        }
+
+        convenience init(backgroundColor: UIColor?,
+                         markColor: UIColor?) {
+            self.init()
+            customBackgroundColor = backgroundColor
+            customMarkColor = markColor
         }
     }
 

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -248,41 +248,22 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     }
 
     /// Set `resizingHandleViewBackgroundColor` to customize background color of resizingHandleView if it is shown
-    @objc open var resizingHandleViewBackgroundColor: UIColor {
+    @available(*, deprecated, message: "Customization of the resizing handle view should be done through the resizingHandleViewOverrideTokens")
+    @objc open var resizingHandleViewBackgroundColor: UIColor? {
         didSet {
-            updateResizingHandleTokens()
+            guard let resizingHandleView = resizingHandleView else {
+                return
+            }
+            resizingHandleView.customBackgroundColor = resizingHandleViewBackgroundColor
         }
     }
 
-    /// Set `resizingHandleViewMarkColor` to customize mark color of resizingHandleView if it is shown.
-    @objc open var resizingHandleViewMarkColor: UIColor? {
+    @objc public var resizingHandleViewOverrideTokens: ResizingHandleTokens? {
         didSet {
-            updateResizingHandleTokens()
-        }
-    }
-
-    func updateResizingHandleTokens() {
-        resizingHandleView?.overrideTokens = CustomResizingHandleTokens(backgroundColor: resizingHandleViewBackgroundColor,
-                                                                        markColor: resizingHandleViewMarkColor)
-    }
-
-    class CustomResizingHandleTokens: ResizingHandleTokens {
-        var customBackgroundColor: UIColor?
-        var customMarkColor: UIColor?
-
-        override var markColor: DynamicColor {
-            return customMarkColor?.dynamicColor ?? super.markColor
-        }
-
-        override var backgroundColor: DynamicColor {
-            return customBackgroundColor?.dynamicColor ?? super.backgroundColor
-        }
-
-        convenience init(backgroundColor: UIColor?,
-                         markColor: UIColor?) {
-            self.init()
-            customBackgroundColor = backgroundColor
-            customMarkColor = markColor
+            guard let resizingHandleView = resizingHandleView else {
+                return
+            }
+            resizingHandleView.overrideTokens = resizingHandleViewOverrideTokens
         }
     }
 
@@ -454,7 +435,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         self.presentationDirection = presentationDirection
         self.preferredMaximumExpansionHeight = preferredMaximumHeight
         self.backgroundColor = UIColor(dynamicColor: tokens.drawerContentBackground)
-        self.resizingHandleViewBackgroundColor = UIColor(dynamicColor: tokens.drawerContentBackground)
 
         super.init(nibName: nil, bundle: nil)
 
@@ -476,7 +456,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         self.presentationDirection = presentationDirection
         self.preferredMaximumExpansionHeight = preferredMaximumHeight
         self.backgroundColor = UIColor(dynamicColor: tokens.drawerContentBackground)
-        self.resizingHandleViewBackgroundColor = UIColor(dynamicColor: tokens.drawerContentBackground)
 
         super.init(nibName: nil, bundle: nil)
 
@@ -768,7 +747,8 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
            if showsResizingHandle {
                if resizingHandleView == nil {
                    resizingHandleView = ResizingHandleView()
-                   resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
+                   resizingHandleView?.customBackgroundColor = resizingHandleViewBackgroundColor
+                   resizingHandleView?.overrideTokens = resizingHandleViewOverrideTokens
                }
            } else {
                resizingHandleView = nil
@@ -796,7 +776,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
 
     private func updateAppearance() {
         view.backgroundColor = backgroundColor
-        resizingHandleView?.backgroundColor = resizingHandleViewBackgroundColor
         // if DrawerController is shown in UIPopoverPresentationController then we want to show different darkElevated color
         if !useCustomBackgroundColor {
             if presentationController is UIPopoverPresentationController {

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -248,22 +248,13 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     }
 
     /// Set `resizingHandleViewBackgroundColor` to customize background color of resizingHandleView if it is shown
-    @available(*, deprecated, message: "Customization of the resizing handle view should be done through the resizingHandleViewOverrideTokens")
     @objc open var resizingHandleViewBackgroundColor: UIColor? {
         didSet {
+            // TODO: Update this to conform to the new pattern after the conclusion of the sub-token discussion
             guard let resizingHandleView = resizingHandleView else {
                 return
             }
             resizingHandleView.customBackgroundColor = resizingHandleViewBackgroundColor
-        }
-    }
-
-    @objc public var resizingHandleViewOverrideTokens: ResizingHandleTokens? {
-        didSet {
-            guard let resizingHandleView = resizingHandleView else {
-                return
-            }
-            resizingHandleView.overrideTokens = resizingHandleViewOverrideTokens
         }
     }
 
@@ -748,7 +739,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
                if resizingHandleView == nil {
                    resizingHandleView = ResizingHandleView()
                    resizingHandleView?.customBackgroundColor = resizingHandleViewBackgroundColor
-                   resizingHandleView?.overrideTokens = resizingHandleViewOverrideTokens
                }
            } else {
                resizingHandleView = nil

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleTokens.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleTokens.swift
@@ -10,7 +10,6 @@ import SwiftUI
 open class ResizingHandleTokens: ControlTokens {
     /// Defines the color of the mark of the `ResizingHandle`.
     open var markColor: DynamicColor {
-        // TODO: Update to aliasTokens.strokeColors[.neutral1] with Fluent 2 colors
         return DynamicColor(light: ColorValue(0x919191) /* gray400 */,
                             lightHighContrast: ColorValue(0x404040) /* gray600 */,
                             dark: ColorValue(0x6E6E6E) /* gray500 */,

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleTokens.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleTokens.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+import SwiftUI
+
+/// Design token set for the `ResizingHandleView` control.
+open class ResizingHandleTokens: ControlTokens {
+    /// Defines the color of the mark of the `ResizingHandle`.
+    open var markColor: DynamicColor {
+        // TODO: Update to aliasTokens.strokeColors[.neutral1] with Fluent 2 colors
+        return DynamicColor(light: ColorValue(0x919191) /* gray400 */,
+                            lightHighContrast: ColorValue(0x404040) /* gray600 */,
+                            dark: ColorValue(0x6E6E6E) /* gray500 */,
+                            darkHighContrast: ColorValue(0x919191) /* gray400 */)
+    }
+}

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleTokens.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleTokens.swift
@@ -16,4 +16,9 @@ open class ResizingHandleTokens: ControlTokens {
                             dark: ColorValue(0x6E6E6E) /* gray500 */,
                             darkHighContrast: ColorValue(0x919191) /* gray400 */)
     }
+
+    /// Defines the background color of the `ResizingHandle`.
+    open var backgroundColor: DynamicColor {
+        return DynamicColor(light: ColorValue.clear)
+    }
 }

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -67,7 +67,7 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
     var overrideTokens: ResizingHandleTokens? {
         didSet {
             updateResizingHandleTokens()
-            updateMarkColor()
+            updateColors()
         }
     }
 
@@ -75,8 +75,9 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
         self.tokens = resolvedTokens
     }
 
-    private func updateMarkColor() {
+    private func updateColors() {
         markLayer.backgroundColor = UIColor(dynamicColor: tokens.markColor).cgColor
+        backgroundColor = UIColor(dynamicColor: tokens.backgroundColor)
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
@@ -84,6 +85,6 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
             return
         }
         updateResizingHandleTokens()
-        updateMarkColor()
+        updateColors()
     }
 }

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -16,7 +16,7 @@ private extension Colors {
 // MARK: - ResizingHandleView
 
 @objc(MSFResizingHandleView)
-open class ResizingHandleView: UIView {
+open class ResizingHandleView: UIView, TokenizedControlInternal {
     private struct Constants {
         static let markSize = CGSize(width: 36, height: 4)
         static let markCornerRadius: CGFloat = 2
@@ -58,5 +58,27 @@ open class ResizingHandleView: UIView {
     open override func layoutSubviews() {
         super.layoutSubviews()
         markLayer.position = CGPoint(x: bounds.midX, y: bounds.midY)
+    }
+
+    public func overrideTokens(_ tokens: ResizingHandleTokens?) -> Self {
+        overrideTokens = tokens
+        return self
+    }
+
+    var defaultTokens: ResizingHandleTokens = .init()
+    var tokens: ResizingHandleTokens = .init()
+    var overrideTokens: ResizingHandleTokens? {
+        didSet {
+            updateResizingHandleTokens()
+            updateMarkColor()
+        }
+    }
+
+    private func updateResizingHandleTokens() {
+        self.tokens = resolvedTokens
+    }
+
+    private func updateMarkColor() {
+        markLayer.backgroundColor = UIColor(dynamicColor: tokens.markColor).cgColor
     }
 }

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -26,7 +26,7 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        backgroundColor = .clear
+        backgroundColor = UIColor(dynamicColor: tokens.backgroundColor)
         self.frame.size.height = ResizingHandleView.height
         autoresizingMask = .flexibleWidth
         setContentHuggingPriority(.required, for: .vertical)

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -33,6 +33,11 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
         setContentCompressionResistancePriority(.required, for: .vertical)
         isUserInteractionEnabled = false
         layer.addSublayer(markLayer)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -72,5 +77,13 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
 
     private func updateMarkColor() {
         markLayer.backgroundColor = UIColor(dynamicColor: tokens.markColor).cgColor
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateResizingHandleTokens()
+        updateMarkColor()
     }
 }

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -62,6 +62,13 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
         return self
     }
 
+    /// Internal custom color to preserve deprecated Drawer API (resizingHandleViewBackgroundColor)
+    var customBackgroundColor: UIColor? {
+        didSet {
+            updateColors()
+        }
+    }
+
     var defaultTokens: ResizingHandleTokens = .init()
     var tokens: ResizingHandleTokens = .init()
     var overrideTokens: ResizingHandleTokens? {
@@ -77,7 +84,7 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
 
     private func updateColors() {
         markLayer.backgroundColor = UIColor(dynamicColor: tokens.markColor).cgColor
-        backgroundColor = UIColor(dynamicColor: tokens.backgroundColor)
+        backgroundColor = customBackgroundColor ?? UIColor(dynamicColor: tokens.backgroundColor)
     }
 
     @objc private func themeDidChange(_ notification: Notification) {

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -5,14 +5,6 @@
 
 import UIKit
 
-// MARK: ResizingHandle Colors
-
-private extension Colors {
-    struct ResizingHandle {
-        public static var mark: UIColor = iconSecondary
-    }
-}
-
 // MARK: - ResizingHandleView
 
 @objc(MSFResizingHandleView)
@@ -24,11 +16,11 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
 
     @objc public static let height: CGFloat = 20
 
-    private let markLayer: CALayer = {
+    private lazy var markLayer: CALayer = {
         let markLayer = CALayer()
         markLayer.bounds.size = Constants.markSize
         markLayer.cornerRadius = Constants.markCornerRadius
-        markLayer.backgroundColor = Colors.ResizingHandle.mark.cgColor
+        markLayer.backgroundColor = UIColor(dynamicColor: tokens.markColor).cgColor
         return markLayer
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add a token for the color of the mark of the ReisizingHandleView
The old colors were gray400, gray500, and gray600. The new colors are neutral stroke 1. But, since gray4/5/600 all don't map to a new grey token, I just put in the hex values.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ResizingHandle_before_light](https://user-images.githubusercontent.com/67026548/163298318-2829fb61-0589-487d-a277-da3ef1319672.png) | ![ResizingHandle_after_light](https://user-images.githubusercontent.com/67026548/163298329-d27ea07b-e6a8-4ef1-91c5-3a10841b34c5.png) |
| ![ResizingHandle_before_dark](https://user-images.githubusercontent.com/67026548/163298341-e12f4c55-dce7-4109-a8dd-d43ce61d87bc.png) | ![ResizingHandle_after_dark](https://user-images.githubusercontent.com/67026548/163298349-1c088b76-391c-49bd-af15-0a410b7daf91.png) |
| ![ResizingHandle_PopupMenu_before](https://user-images.githubusercontent.com/67026548/167971657-652720ae-6a43-4320-a716-a28bd66c0995.png) | ![ResizingHandle_PopupMenu_after](https://user-images.githubusercontent.com/67026548/167971664-07aa952a-22f9-40a3-a237-b4e7f2a57c34.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/966)