### PR TITLE
[vNext Tokens] Update List selection style to match PopupMenu selection

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListDemoController.swift
@@ -180,7 +180,7 @@ class ListDemoController: DemoController {
 
     let list: MSFList = {
         let list = MSFList()
-        list.state.isSelectable = true
+        list.state.allowsSelection = true
         return list
     }()
 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -165,7 +165,7 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
             preconditionFailure("Index is out of bounds")
         }
         let cell = MSFListCellStateImpl()
-        cells.insert(cell, at: index)
+        cell.selectionStyle = selectionStyle
         cell.onSelectAction = { [weak self] (selectedCell) in
             guard let strongSelf = self,
                   let onSelectAction = strongSelf.onSelectAction else {
@@ -173,6 +173,7 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
             }
             onSelectAction(selectedCell)
         }
+        cells.insert(cell, at: index)
         return cell
     }
 
@@ -231,6 +232,7 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
             preconditionFailure("Index is out of bounds")
         }
         let section = MSFListSectionStateImpl()
+        section.selectionStyle = selectionStyle
         section.onSelectAction = { [weak self] (selectedCell) in
             guard let strongSelf = self, strongSelf.allowsSelection else {
                 return

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -46,7 +46,7 @@ import SwiftUI
     var sectionCount: Int { get }
 
     /// Configures if the List allows selection.
-    var isSelectable: Bool { get set }
+    var allowsSelection: Bool { get set }
 
     /// Configures the selection style of the List.
     var selectionStyle: MSFListSelectionStyle { get set }
@@ -201,9 +201,9 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         return sections.count
     }
 
-    @Published var isSelectable: Bool = false {
+    @Published var allowsSelection: Bool = false {
         didSet {
-            if !isSelectable {
+            if !allowsSelection {
                 if let selectedCell = selectedCellState {
                     selectedCell.isSelected = false
                     selectedCellState = nil
@@ -232,7 +232,7 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         }
         let section = MSFListSectionStateImpl()
         section.onSelectAction = { [weak self] (selectedCell) in
-            guard let strongSelf = self, strongSelf.isSelectable else {
+            guard let strongSelf = self, strongSelf.allowsSelection else {
                 return
             }
 

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -45,8 +45,11 @@ import SwiftUI
     /// The number of Sections in the List.
     var sectionCount: Int { get }
 
-    /// Configures if the list allows selection
+    /// Configures if the List allows selection.
     var isSelectable: Bool { get set }
+
+    /// Configures the selection style of the List.
+    var selectionStyle: MSFListSelectionStyle { get set }
 
     /// Creates a new Section and appends it to the array of sections in a List.
     func createSection() -> MSFListSectionState
@@ -145,6 +148,14 @@ class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, Control
 
     var style: MSFHeaderStyle
 
+    var selectionStyle: MSFListSelectionStyle = .trailingCheckmark {
+        didSet {
+            for cell in cells {
+                cell.selectionStyle = selectionStyle
+            }
+        }
+    }
+
     func createCell() -> MSFListCellState {
         return createCell(at: cells.endIndex)
     }
@@ -200,6 +211,15 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
             }
         }
     }
+
+    @Published var selectionStyle: MSFListSelectionStyle = .trailingCheckmark {
+        didSet {
+            for section in sections {
+                section.selectionStyle = selectionStyle
+            }
+        }
+    }
+
     var selectedCellState: MSFListCellStateImpl?
 
     func createSection() -> MSFListSectionState {

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -202,7 +202,7 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         return sections.count
     }
 
-    @Published var allowsSelection: Bool = false {
+    var allowsSelection: Bool = false {
         didSet {
             if !allowsSelection {
                 if let selectedCell = selectedCellState {
@@ -213,7 +213,7 @@ class MSFListStateImpl: NSObject, ObservableObject, MSFListState {
         }
     }
 
-    @Published var selectionStyle: MSFListSelectionStyle = .trailingCheckmark {
+    var selectionStyle: MSFListSelectionStyle = .trailingCheckmark {
         didSet {
             for section in sections {
                 section.selectionStyle = selectionStyle

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -406,8 +406,7 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                     withAnimation {
                         state.isExpanded.toggle()
                     }
-                }
-                if let onSelectAction = state.onSelectAction {
+                } else if let onSelectAction = state.onSelectAction {
                     onSelectAction(state)
                 }
                 if let onTapAction = state.onTapAction {

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -268,6 +268,18 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
     }
 
     var body: some View {
+        let labelColor: Color
+        let sublabelColor: Color
+        let trailingItemColor: DynamicColor
+        if state.isSelected {
+            labelColor = Color(dynamicColor: tokens.labelSelectedColor)
+            sublabelColor = Color(dynamicColor: tokens.sublabelSelectedColor)
+            trailingItemColor = tokens.trailingItemSelectedForegroundColor
+        } else {
+            labelColor = Color(dynamicColor: tokens.labelColor)
+            sublabelColor = Color(dynamicColor: tokens.sublabelColor)
+            trailingItemColor = tokens.trailingItemForegroundColor
+        }
 
         @ViewBuilder
         var cellLabel: some View {
@@ -301,7 +313,7 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                         if !title.isEmpty {
                             Text(title)
                                 .font(.fluent(tokens.labelFont))
-                                .foregroundColor(Color(dynamicColor: tokens.labelColor))
+                                .foregroundColor(labelColor)
                                 .lineLimit(state.titleLineLimit == 0 ? nil : state.titleLineLimit)
                         }
                         if let titleTrailingAccessoryView = state.titleTrailingAccessoryView {
@@ -321,7 +333,7 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                             Text(state.subtitle)
                                 .font(.fluent(state.footnote.isEmpty ?
                                                             tokens.footnoteFont : tokens.sublabelFont))
-                                .foregroundColor(Color(dynamicColor: tokens.sublabelColor))
+                                .foregroundColor(sublabelColor)
                                 .lineLimit(state.subtitleLineLimit == 0 ? nil : state.subtitleLineLimit)
                         }
                         if let subtitleTrailingAccessoryView = state.subtitleTrailingAccessoryView {
@@ -340,7 +352,7 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                         if !state.footnote.isEmpty {
                             Text(state.footnote)
                                 .font(.fluent(tokens.footnoteFont))
-                                .foregroundColor(Color(dynamicColor: tokens.sublabelColor))
+                                .foregroundColor(sublabelColor)
                                 .lineLimit(state.footnoteLineLimit == 0 ? nil : state.footnoteLineLimit)
                         }
                         if let footnoteTrailingAccessoryView = state.footnoteTrailingAccessoryView {
@@ -366,7 +378,7 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                         Image(uiImage: accessoryIcon)
                             .resizable()
                             .foregroundColor(Color(dynamicColor: isDisclosure ?
-                                                   tokens.disclosureIconForegroundColor : tokens.trailingItemForegroundColor))
+                                                   tokens.disclosureIconForegroundColor : trailingItemColor))
                             .frame(width: isDisclosure ? disclosureSize : trailingItemSize,
                                    height: isDisclosure ? disclosureSize : trailingItemSize)
                             .padding(.leading, isDisclosure ? tokens.disclosureInterspace : tokens.iconInterspace)

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -223,6 +223,14 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
         return children.count
     }
 
+    var trailingItem: MSFListAccessoryType {
+        if isSelected {
+            return .checkmark
+        } else {
+            return accessoryType
+        }
+    }
+
     func createChildCell() -> MSFListCellState {
         return createChildCell(at: children.endIndex)
     }
@@ -372,7 +380,7 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                 }
 
                 HStack(spacing: 0) {
-                    if let accessoryType = state.accessoryType, accessoryType != .none, let accessoryIcon = accessoryType.icon {
+                    if let accessoryType = state.trailingItem, accessoryType != .none, let accessoryIcon = accessoryType.icon {
                         let isDisclosure = accessoryType == .disclosure
                         let disclosureSize = tokens.disclosureSize
                         Image(uiImage: accessoryIcon)

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -223,14 +223,6 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
         return children.count
     }
 
-    var trailingItem: MSFListAccessoryType {
-        if isSelected {
-            return .checkmark
-        } else {
-            return accessoryType
-        }
-    }
-
     func createChildCell() -> MSFListCellState {
         return createChildCell(at: children.endIndex)
     }
@@ -380,7 +372,8 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                 }
 
                 HStack(spacing: 0) {
-                    if let accessoryType = state.trailingItem, accessoryType != .none, let accessoryIcon = accessoryType.icon {
+                    let accessoryType = state.isSelected ? .checkmark : state.accessoryType
+                    if accessoryType != .none, let accessoryIcon = accessoryType.icon {
                         let isDisclosure = accessoryType == .disclosure
                         let disclosureSize = tokens.disclosureSize
                         Image(uiImage: accessoryIcon)

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -128,6 +128,7 @@ class MSFListCellStateImpl: NSObject, ObservableObject, Identifiable, ControlCon
     var id = UUID()
     var onSelectAction: ((MSFListCellStateImpl) -> Void)?
     @Published var isSelected: Bool = false
+    var selectionStyle: MSFListSelectionStyle = .trailingCheckmark
 
     var leadingUIView: UIView? {
         didSet {
@@ -372,7 +373,10 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
                 }
 
                 HStack(spacing: 0) {
-                    let accessoryType = state.isSelected ? .checkmark : state.accessoryType
+                    let accessoryType =
+                        state.isSelected && state.selectionStyle == .trailingCheckmark
+                        ? .checkmark
+                        : state.accessoryType
                     if accessoryType != .none, let accessoryIcon = accessoryType.icon {
                         let isDisclosure = accessoryType == .disclosure
                         let disclosureSize = tokens.disclosureSize

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -280,12 +280,12 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
             sublabelColor = Color(dynamicColor: tokens.sublabelColor)
             trailingItemColor = tokens.trailingItemForegroundColor
         }
+        let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
+        let leadingViewAreaSize: CGFloat = tokens.leadingViewAreaSize
 
         @ViewBuilder
         var cellLabel: some View {
-            let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
             let leadingViewSize: CGFloat = tokens.leadingViewSize
-            let leadingViewAreaSize: CGFloat = tokens.leadingViewAreaSize
 
             HStack(spacing: 0) {
                 let title = state.title
@@ -392,8 +392,6 @@ struct MSFListCellView: View, ConfigurableTokenizedControl {
         var cellContent: some View {
             let children: [MSFListCellStateImpl] = state.children
             let hasChildren: Bool = children.count > 0
-            let horizontalCellPadding: CGFloat = tokens.horizontalCellPadding
-            let leadingViewAreaSize: CGFloat = tokens.leadingViewAreaSize
 
             Button(action: {
                 if hasChildren {

--- a/ios/FluentUI/Vnext/List/ListCell.swift
+++ b/ios/FluentUI/Vnext/List/ListCell.swift
@@ -488,8 +488,7 @@ struct ListCellButtonStyle: ButtonStyle {
             return Color(stateBackgroundColor)
         }()
 
-        // TODO: Add correct selection styling
-        if isPressed || state.isSelected {
+        if isPressed && !state.isSelected {
             return highlightedBackgroundColor
         }
         return backgroundColor

--- a/ios/FluentUI/Vnext/List/ListTokens.swift
+++ b/ios/FluentUI/Vnext/List/ListTokens.swift
@@ -36,6 +36,12 @@ import SwiftUI
     }
 }
 
+/// Pre-defined styles for selection in the List.
+@objc public enum MSFListSelectionStyle: Int, CaseIterable {
+    case trailingCheckmark
+    // TODO: Add more styles, including a leading circle
+}
+
 // MARK: ListCell Tokens
 
 open class CellBaseTokens: ControlTokens {

--- a/ios/FluentUI/Vnext/List/ListTokens.swift
+++ b/ios/FluentUI/Vnext/List/ListTokens.swift
@@ -39,40 +39,58 @@ import SwiftUI
 // MARK: ListCell Tokens
 
 open class CellBaseTokens: ControlTokens {
+    /// Defines the size of the leading view of the Cell.
     public internal(set) var cellLeadingViewSize: MSFListCellLeadingViewSize = .medium
 
+    /// Defines the foreground color of the disclosure icon of the Cell.
     open var disclosureIconForegroundColor: DynamicColor { aliasTokens.foregroundColors[.neutral4] }
 
+    /// Defines the color of the label of the Cell.
     open var labelColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
+    /// Defines the color of the leading view of the Cell.
     open var leadingViewColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
+    /// Defines the color of the sublabel of the Cell.
     open var sublabelColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
+    /// Defines the foreground color of the trailing item of the Cell.
     open var trailingItemForegroundColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
+    /// Defines the color of the background when the Cell is at rest.
     open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.neutral1] }
 
+    /// Defines the color of the background when the Cell is highlighted.
     open var highlightedBackgroundColor: DynamicColor { aliasTokens.backgroundColors[.neutral5] }
 
+    /// Defines the height of the Cell with one line.
     open var cellHeightOneLine: CGFloat { globalTokens.spacing[.xxxLarge] }
 
+    /// Defines the height of the Cell with two lines.
     open var cellHeightTwoLines: CGFloat { 64 }
 
+    /// Defines the height of the Cell with three lines.
     open var cellHeightThreeLines: CGFloat { globalTokens.spacing[.xxxxLarge] }
 
+    /// Defines the padding on the leading side of the disclosure of the Cell.
     open var disclosureInterspace: CGFloat { globalTokens.spacing[.xxSmall] }
 
+    /// Defines the size of the disclosure of the Cell.
     open var disclosureSize: CGFloat { globalTokens.iconSize[.small] }
 
+    /// Defines the horizontal padding around the content of the Cell.
     open var horizontalCellPadding: CGFloat { globalTokens.spacing[.small] }
 
+    /// Defines the padding on the leading side of the non-disclosure accessory icons
     open var iconInterspace: CGFloat { globalTokens.spacing[.medium] }
 
+    /// Defines the space between a label and its accessory view
     open var labelAccessoryInterspace: CGFloat { globalTokens.spacing[.xSmall] }
 
+    /// Defines the size of the accessory view of a label
     open var labelAccessorySize: CGFloat { globalTokens.iconSize[.xxSmall] }
 
+    /// Defines the size of the leading view of the Cell.
     open var leadingViewSize: CGFloat {
         switch cellLeadingViewSize {
         case .small:
@@ -84,17 +102,24 @@ open class CellBaseTokens: ControlTokens {
         }
     }
 
+    /// Defines the size of the area aroudn the leading view of the Cell.
     open var leadingViewAreaSize: CGFloat { globalTokens.spacing[.xxxLarge] }
 
+    /// Defines the size of the accessories for the sublabel
     open var sublabelAccessorySize: CGFloat { globalTokens.iconSize[.xxSmall] }
 
+    /// Defines the size of the trailing item of the Cell.
     open var trailingItemSize: CGFloat { globalTokens.iconSize[.medium] }
 
+    /// Defines the vertical padding of the Cell.
     open var verticalCellPadding: CGFloat { globalTokens.spacing[.xSmall] }
 
+    /// Defines the font of the footnote of the Cell.
     open var footnoteFont: FontInfo { aliasTokens.typography[.caption1] }
 
+    /// Defiens the font of the sublabel of the Cell.
     open var sublabelFont: FontInfo { aliasTokens.typography[.body2] }
 
+    /// Defines the font of the label of the Cell.
     open var labelFont: FontInfo { aliasTokens.typography[.body1] }
 }

--- a/ios/FluentUI/Vnext/List/ListTokens.swift
+++ b/ios/FluentUI/Vnext/List/ListTokens.swift
@@ -48,14 +48,23 @@ open class CellBaseTokens: ControlTokens {
     /// Defines the color of the label of the Cell.
     open var labelColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
+    /// Defines the color of the label when the Cell is selected.
+    open var labelSelectedColor: DynamicColor { aliasTokens.foregroundColors[.brandRest] }
+
     /// Defines the color of the leading view of the Cell.
     open var leadingViewColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
     /// Defines the color of the sublabel of the Cell.
     open var sublabelColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
+    /// Defines the color of the sublabel when the Cell is selected.
+    open var sublabelSelectedColor: DynamicColor { aliasTokens.foregroundColors[.brandRest] }
+
     /// Defines the foreground color of the trailing item of the Cell.
     open var trailingItemForegroundColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
+
+    /// Defines the foreground color of the trailing item when the Cell is selected.
+    open var trailingItemSelectedForegroundColor: DynamicColor { aliasTokens.foregroundColors[.brandRest] }
 
     /// Defines the color of the background when the Cell is at rest.
     open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.neutral1] }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated the List to turn the text and trailing item Brand rest colored on selection and toggle a checkmark, rather than just toggle the highlighted background color.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ListSelectionStyle_before](https://user-images.githubusercontent.com/67026548/163507315-94c47690-c79e-4679-8679-f2194a5b8f88.gif) | ![ListSelectionStyle_after2](https://user-images.githubusercontent.com/67026548/164125054-4d78b879-9981-449c-829a-ebe7952fc1e4.gif) |

Also, it does turn green when the theme is set to green:
![ListSelectionStyle_after_green](https://user-images.githubusercontent.com/67026548/163507524-50bc86ad-3645-476b-ad00-ee9c9a4c776c.png)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/968)