### PR TITLE
[vNext Tokens] `ControlHostingView` should have an initial frame that matches its subview

### DIFF
--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -56,6 +56,11 @@ open class ControlHostingView: UIView {
         addSubview(hostedView)
         hostedView.translatesAutoresizingMaskIntoConstraints = false
 
+        // Initialize our frame with the hosted view's initial bounds so we don't start as a (0,0,0,0) view.
+        // Future updates will be handled by the autolayout constraints below.
+        hostedView.sizeToFit()
+        self.frame = hostedView.bounds
+
         let requiredConstraints = [
             hostedView.leadingAnchor.constraint(equalTo: leadingAnchor),
             hostedView.trailingAnchor.constraint(equalTo: trailingAnchor),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Previously, all views from `ControlHostingContainer` would be properly sized immediately upon initialization; clients often use this size info to inform their layouts. I did not account for this when switching to `ControlHostingView`, so I introduced the need for an additional layout pass before size information would be accurate. This is no problem in our demo app, since we rely heavily on autolayout, but any client that manually inspected our controls' frames would find that their layout would break.

Simple fix: match `ControlHostingView` initial size to the initial size of its contents, instead of waiting for a layout pass to complete.

### Verification

Verified in one of our clients that a broken `Avatar` layout now appears correct. Also did a quick sanity pass inside the test app to ensure no visible change.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/971)