### PR TITLE
Fix: Unwanted information being read out in BadgeView

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -144,7 +144,11 @@ open class BadgeView: UIView {
     @objc open var isSelected: Bool = false {
         didSet {
             updateColors()
-            updateAccessibility()
+            if isSelected {
+                accessibilityTraits.insert(.selected)
+            } else {
+                accessibilityTraits.remove(.selected)
+            }
         }
     }
 
@@ -364,7 +368,6 @@ open class BadgeView: UIView {
 
         isAccessibilityElement = true
         accessibilityTraits = .button
-        updateAccessibility()
 
         NotificationCenter.default.addObserver(self, selector: #selector(invalidateIntrinsicContentSize), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
@@ -436,16 +439,6 @@ open class BadgeView: UIView {
             return nil
         }
         return customView.bounds == .zero ? customView.sizeThatFits(size) : customView.bounds.size
-    }
-
-    private func updateAccessibility() {
-        if isSelected {
-            accessibilityValue = "Accessibility.Selected.Value".localized
-            accessibilityHint = "Accessibility.Selected.Hint".localized
-        } else {
-            accessibilityValue = nil
-            accessibilityHint = "Accessibility.Select.Hint".localized
-        }
     }
 
     private func updateColors() {

--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "اضغط ضغطاً مزدوجاً للتجاهل";
 "Accessibility.Done.Label" = "تم";
 "Accessibility.MultiSelect.Hint" = "اضغط ضغطاً مزدوجاً برفق لتبديل التحديد";
-"Accessibility.Select.Hint" = "اضغط ضغطاً مزدوجاً للتحديد";
-"Accessibility.Selected.Hint" = "اضغط ضغطاً مزدوجاً لمشاهدة التفاصيل.";
-"Accessibility.Selected.Value" = "محددة";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "التقويم";

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Toqueu dues vegades per descartar-ho.";
 "Accessibility.Done.Label" = "Fet";
 "Accessibility.MultiSelect.Hint" = "Toca dues vegades per commutar la selecció";
-"Accessibility.Select.Hint" = "Toqueu dues vegades per seleccionar-ho.";
-"Accessibility.Selected.Hint" = "Toqueu dues vegades per veure'n els detalls.";
-"Accessibility.Selected.Value" = "Seleccionat";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendari";

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Poklepáním zavřete.";
 "Accessibility.Done.Label" = "Hotovo";
 "Accessibility.MultiSelect.Hint" = "Výběr přepnete dvojitým poklepáním";
-"Accessibility.Select.Hint" = "Poklepáním vyberete.";
-"Accessibility.Selected.Hint" = "Poklepání zobrazíte podrobnosti.";
-"Accessibility.Selected.Value" = "Vybráno";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalendář";

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dobbelttryk for at afvise";
 "Accessibility.Done.Label" = "Udført";
 "Accessibility.MultiSelect.Hint" = "Dobbelttryk for at skifte valg ";
-"Accessibility.Select.Hint" = "Dobbelttryk for at vælge";
-"Accessibility.Selected.Hint" = "Dobbelttryk for at se detaljerne";
-"Accessibility.Selected.Value" = "Markeret";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalender";

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Zum Schließen doppeltippen.";
 "Accessibility.Done.Label" = "Fertig";
 "Accessibility.MultiSelect.Hint" = "Zum Umschalten der Auswahl doppelt tippen";
-"Accessibility.Select.Hint" = "Zum Auswählen doppeltippen";
-"Accessibility.Selected.Hint" = "Zum Anzeigen von Details doppeltippen.";
-"Accessibility.Selected.Value" = "Ausgewählt";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalender";

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Πατήστε δύο φορές για κλείσιμο";
 "Accessibility.Done.Label" = "Τέλος";
 "Accessibility.MultiSelect.Hint" = "Πατήστε δύο φορές για εναλλαγή της επιλογής";
-"Accessibility.Select.Hint" = "Πατήστε δύο φορές για επιλογή";
-"Accessibility.Selected.Hint" = "Πατήστε δύο φορές για εμφάνιση λεπτομερειών";
-"Accessibility.Selected.Value" = "Επιλεγμένο";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Ημερολόγιο";

--- a/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Double tap to dismiss";
 "Accessibility.Done.Label" = "Done";
 "Accessibility.MultiSelect.Hint" = "Double tap to toggle selection";
-"Accessibility.Select.Hint" = "Double tap to select";
-"Accessibility.Selected.Hint" = "Double tap to see details";
-"Accessibility.Selected.Value" = "Selected";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendar";

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Double tap to dismiss";
 "Accessibility.Done.Label" = "Done";
 "Accessibility.MultiSelect.Hint" = "Double tap to toggle selection";
-"Accessibility.Select.Hint" = "Double tap to select";
-"Accessibility.Selected.Hint" = "Double tap to see details";
-"Accessibility.Selected.Value" = "Selected";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendar";

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Pulsa dos veces para descartar";
 "Accessibility.Done.Label" = "Listo";
 "Accessibility.MultiSelect.Hint" = "Pulsa dos veces para alternar la selección";
-"Accessibility.Select.Hint" = "Pulsa dos veces para seleccionar";
-"Accessibility.Selected.Hint" = "Pulsa dos veces para ver los detalles";
-"Accessibility.Selected.Value" = "Seleccionado";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendario";

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Pulsa dos veces para descartar";
 "Accessibility.Done.Label" = "Listo";
 "Accessibility.MultiSelect.Hint" = "Pulse dos veces para alternar la selección";
-"Accessibility.Select.Hint" = "Pulsa dos veces para seleccionar";
-"Accessibility.Selected.Hint" = "Pulsa dos veces para agregar detalles";
-"Accessibility.Selected.Value" = "Seleccionado";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendario";

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Hylkää kaksoisnapauttamalla";
 "Accessibility.Done.Label" = "Valmis";
 "Accessibility.MultiSelect.Hint" = "Vaihda valintaa kaksoisnapauttamalla ";
-"Accessibility.Select.Hint" = "Valitse kaksoisnapauttamalla";
-"Accessibility.Selected.Hint" = "Näytä tiedot kaksoisnapauttamalla";
-"Accessibility.Selected.Value" = "Valittu";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalenteri";

--- a/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Appuyez deux fois pour masquer";
 "Accessibility.Done.Label" = "Terminé";
 "Accessibility.MultiSelect.Hint" = "Appuyez deux fois pour activer la sélection";
-"Accessibility.Select.Hint" = "Appuyez deux fois pour sélectionner";
-"Accessibility.Selected.Hint" = "Appuyez deux fois pour afficher les détails";
-"Accessibility.Selected.Value" = "Sélectionné";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendrier";

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "הקש פעמיים כדי לבטל";
 "Accessibility.Done.Label" = "בוצע";
 "Accessibility.MultiSelect.Hint" = "הקש פעמיים כדי להחליף מצב בחירה";
-"Accessibility.Select.Hint" = "הקש פעמיים כדי לבחור";
-"Accessibility.Selected.Hint" = "הקש פעמיים כדי להציג פרטים";
-"Accessibility.Selected.Value" = "נבחר";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "לוח שנה";

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "ख़ारिज करने के लिए डबल-टैप करें";
 "Accessibility.Done.Label" = "पूर्ण";
 "Accessibility.MultiSelect.Hint" = "चयन को टॉगल करने के लिए डबल टैप करें";
-"Accessibility.Select.Hint" = "चयन के लिए डबल टैप";
-"Accessibility.Selected.Hint" = "विवरण देखने के लिए डबल टैप करें";
-"Accessibility.Selected.Value" = "चयनित";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "कैलेंडर";

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dvaput dodirnite da biste odbacili";
 "Accessibility.Done.Label" = "Gotovo";
 "Accessibility.MultiSelect.Hint" = "Dvaput dodirnite za uključivanje/isključivanje odabira ";
-"Accessibility.Select.Hint" = "Dvaput dodirnite da biste odabrali";
-"Accessibility.Selected.Hint" = "Dvaput dodirnite da biste pogledali pojedinosti";
-"Accessibility.Selected.Value" = "Odabrano";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalendar";

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Koppintson duplán a bezáráshoz";
 "Accessibility.Done.Label" = "Kész";
 "Accessibility.MultiSelect.Hint" = "Koppintson duplán a kijelölés váltásához";
-"Accessibility.Select.Hint" = "Koppintson duplán a kijelöléshez";
-"Accessibility.Selected.Hint" = "Koppintson duplán a részletek megtekintéséhez";
-"Accessibility.Selected.Value" = "Kijelölve";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Naptár";

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Ketuk dua kali untuk menutup";
 "Accessibility.Done.Label" = "Selesai";
 "Accessibility.MultiSelect.Hint" = "Ketuk dua kali untuk mematikan/menghidupkan pilihan";
-"Accessibility.Select.Hint" = "Ketuk dua kali untuk memilih";
-"Accessibility.Selected.Hint" = "Ketuk dua kali untuk melihat detail";
-"Accessibility.Selected.Value" = "Dipilih";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalender";

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Effettua un doppio tocco per ignorare l'elemento";
 "Accessibility.Done.Label" = "Fine";
 "Accessibility.MultiSelect.Hint" = "Effettua un doppio tocco per attivare o disattivare la selezione";
-"Accessibility.Select.Hint" = "Effettua un doppio tocco per selezionare";
-"Accessibility.Selected.Hint" = "Effettua un doppio tocco per vedere i dettagli";
-"Accessibility.Selected.Value" = "Selezionato";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendario";

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "ダブルタップして閉じます";
 "Accessibility.Done.Label" = "完了";
 "Accessibility.MultiSelect.Hint" = "ダブルタップして、選択を切り替えます ";
-"Accessibility.Select.Hint" = "ダブルタップして選択します";
-"Accessibility.Selected.Hint" = "ダブルタップして詳細情報を表示します";
-"Accessibility.Selected.Value" = "選択済み";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "予定表";

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "해제하려면 두 번 탭하세요.";
 "Accessibility.Done.Label" = "완료";
 "Accessibility.MultiSelect.Hint" = "두 번 탭하여 선택을 전환할 수 있습니다. ";
-"Accessibility.Select.Hint" = "선택하려면 두 번 탭하세요.";
-"Accessibility.Selected.Hint" = "세부 정보를 보려면 두 번 탭하세요.";
-"Accessibility.Selected.Value" = "선택됨";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "일정";

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dwiketik untuk menolak";
 "Accessibility.Done.Label" = "Selesai";
 "Accessibility.MultiSelect.Hint" = "Dwiketik untuk togol pilihan";
-"Accessibility.Select.Hint" = "Dwiketik untuk memilih";
-"Accessibility.Selected.Hint" = "Dwiketik untuk melihat butiran";
-"Accessibility.Selected.Value" = "Dipilih";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalendar";

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dobbelttrykk for å lukke";
 "Accessibility.Done.Label" = "Fullført";
 "Accessibility.MultiSelect.Hint" = "Dobbelttrykk for å vise/skjule utvalg";
-"Accessibility.Select.Hint" = "Dobbelttrykk for å velge";
-"Accessibility.Selected.Hint" = "Dobbelttrykk for å se detaljene";
-"Accessibility.Selected.Value" = "Merket";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalender";

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dubbeltikken om te sluiten";
 "Accessibility.Done.Label" = "Gereed";
 "Accessibility.MultiSelect.Hint" = "Dubbeltikken om de selectie in of uit te schakelen";
-"Accessibility.Select.Hint" = "Dubbeltikken om te selecteren";
-"Accessibility.Selected.Hint" = "Dubbeltikken om details te zien";
-"Accessibility.Selected.Value" = "Geselecteerd";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Agenda";

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Naciśnij dwukrotnie, aby odrzucić";
 "Accessibility.Done.Label" = "Gotowe";
 "Accessibility.MultiSelect.Hint" = "Dotknij dwukrotnie, aby przełączyć zaznaczenie";
-"Accessibility.Select.Hint" = "Naciśnij dwukrotnie, aby zaznaczyć";
-"Accessibility.Selected.Hint" = "Naciśnij dwukrotnie, aby wyświetlić szczegóły";
-"Accessibility.Selected.Value" = "Zaznaczono";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalendarz";

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dê um toque duplo para ignorar";
 "Accessibility.Done.Label" = "Concluída";
 "Accessibility.MultiSelect.Hint" = "Dê um toque duplo para alternar a seleção";
-"Accessibility.Select.Hint" = "Dê um toque duplo para selecionar";
-"Accessibility.Selected.Hint" = "Dê um toque duplo para ver os detalhes";
-"Accessibility.Selected.Value" = "Selecionada";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendário";

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Faça duplo toque para dispensar";
 "Accessibility.Done.Label" = "Concluído";
 "Accessibility.MultiSelect.Hint" = "Toque duas vezes para ativar ou desativar a seleção";
-"Accessibility.Select.Hint" = "Faça duplo toque para selecionar";
-"Accessibility.Selected.Hint" = "Faça duplo toque para ver os detalhes";
-"Accessibility.Selected.Value" = "Selecionado";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendário";

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Atingeți de două ori pentru a îndepărta";
 "Accessibility.Done.Label" = "Gata";
 "Accessibility.MultiSelect.Hint" = "Atingeți de două ori pentru a comuta selecția";
-"Accessibility.Select.Hint" = "Atingeți de două ori pentru a selecta";
-"Accessibility.Selected.Hint" = "Atingeți de două ori pentru a vedea detaliile";
-"Accessibility.Selected.Value" = "Selectat";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendar";

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Дважды коснитесь, чтобы закрыть";
 "Accessibility.Done.Label" = "Готово";
 "Accessibility.MultiSelect.Hint" = "Дважды коснитесь, чтобы переключить выделение ";
-"Accessibility.Select.Hint" = "Дважды коснитесь, чтобы выбрать";
-"Accessibility.Selected.Hint" = "Дважды коснитесь, чтобы просмотреть сведения";
-"Accessibility.Selected.Value" = "Выбрано";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Календарь";

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Zrušíte dvojitým ťuknutím";
 "Accessibility.Done.Label" = "Hotovo";
 "Accessibility.MultiSelect.Hint" = "Výber prepnite dvojitým ťuknutím";
-"Accessibility.Select.Hint" = "Vyberte dvojitým ťuknutím";
-"Accessibility.Selected.Hint" = "Dvojitým ťuknutím zobrazíte podrobnosti.";
-"Accessibility.Selected.Value" = "Vybraté";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalendár";

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Dubbeltryck för att stänga";
 "Accessibility.Done.Label" = "Klart";
 "Accessibility.MultiSelect.Hint" = "Dubbelklicka för att växla markeringen";
-"Accessibility.Select.Hint" = "Dubbeltryck för att markera";
-"Accessibility.Selected.Hint" = "Dubbeltryck för att visa information";
-"Accessibility.Selected.Value" = "Markerad";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Kalender";

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "แตะสองครั้งเพื่อยกเลิก";
 "Accessibility.Done.Label" = "เสร็จสิ้น";
 "Accessibility.MultiSelect.Hint" = "แตะสองครั้งเพื่อสลับการเลือก ";
-"Accessibility.Select.Hint" = "แตะสองครั้งเพื่อเลือก";
-"Accessibility.Selected.Hint" = "แตะสองครั้งเพื่อดูรายละเอียด";
-"Accessibility.Selected.Value" = "เลือกแล้ว";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "ปฏิทิน";

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Kapatmak için iki kez dokunun";
 "Accessibility.Done.Label" = "Bitti";
 "Accessibility.MultiSelect.Hint" = "Seçimi değiştirmek için iki kez dokunun ";
-"Accessibility.Select.Hint" = "Seçmek için iki kez dokunun";
-"Accessibility.Selected.Hint" = "Ayrıntıları görmek için iki kez dokunun";
-"Accessibility.Selected.Value" = "Seçili";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Takvim";

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Торкніться двічі, щоб закрити";
 "Accessibility.Done.Label" = "Готово";
 "Accessibility.MultiSelect.Hint" = "Торкніться двічі, щоб перемкнути виділення ";
-"Accessibility.Select.Hint" = "Торкніться двічі, щоб вибрати";
-"Accessibility.Selected.Hint" = "Торкніться двічі, щоб переглянути відомості";
-"Accessibility.Selected.Value" = "Вибрано";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Календар";

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "Nhấn đúp để bỏ";
 "Accessibility.Done.Label" = "Đã xong";
 "Accessibility.MultiSelect.Hint" = "Nhấn đúp để chuyển đổi lựa chọn";
-"Accessibility.Select.Hint" = "Nhấn đúp để chọn";
-"Accessibility.Selected.Hint" = "Nhấn đúp để xem chi tiết";
-"Accessibility.Selected.Value" = "Đã chọn";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Lịch";

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "双击以关闭";
 "Accessibility.Done.Label" = "完成";
 "Accessibility.MultiSelect.Hint" = "双击以切换所选内容";
-"Accessibility.Select.Hint" = "双击进行选择";
-"Accessibility.Selected.Hint" = "双击以查看详细信息";
-"Accessibility.Selected.Value" = "已选择";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "日历";

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -12,9 +12,6 @@
 "Accessibility.Dismiss.Hint" = "點兩下以關閉";
 "Accessibility.Done.Label" = "完成";
 "Accessibility.MultiSelect.Hint" = "點兩下以切換選取項目";
-"Accessibility.Select.Hint" = "點兩下以選取";
-"Accessibility.Selected.Hint" = "點兩下以檢視詳細資料";
-"Accessibility.Selected.Value" = "已選取";
 
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "行事曆";


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

BadgeView was reading out unwanted information in VoiceOver when interacted with. "Double tap to see details" would be read out, even though there are no details. This changes removes this behavior and replaces it with default VoiceOver for selected buttons. As per the [accessibilityHint documentation](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint#:~:text=Purchase%20the%20item.”-,Don’t,-include%20the%20action), we want to avoid using any action statements in our hints.

### Verification

Ran changes on device with VoiceOver on. Observe changes in BadgeView/PeoplePicker Controller by selecting any badge.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Read: "Kat Larsson, button, double tap to see details" | Read:  "Selected, Kat Larsson, button" |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/972)