### PR TITLE
Fix bug in calculation of available height for titleView in TableViewHeaderFooterView

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -396,7 +396,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         switch style {
         case .header, .footer, .headerPrimary:
             titleYOffset = style == .footer ? Constants.titleDefaultBottomMargin : Constants.titleDefaultTopMargin
-            titleHeight = contentView.frame.height - Constants.titleDefaultTopMargin - Constants.titleDefaultBottomMargin
+            titleHeight = contentView.frame.height - titleYOffset - Constants.titleDefaultBottomMargin
         case .divider, .dividerHighlighted:
             titleYOffset = Constants.titleDividerVerticalMargin
             titleHeight = contentView.frame.height - (Constants.titleDividerVerticalMargin * 2)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When the style is set to `.footer`, the `layoutSubviews` method uses a shorter top margin for the `titleYOffset` variable. However, when calculating the available height for the `titleView`, the code assumes that the default top and bottom margins are used regardless of the style. This change fixes the calculation to use the `titleYOffset` value which is set to the correct top margin instead.

### Verification

- Manual verification on iOS Simulator
- All unit tests were run.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="563" alt="Screen Shot 2022-05-05 at 8 41 43 PM" src="https://user-images.githubusercontent.com/21045490/167064132-2e474955-b0b4-4d44-a25d-7b56d7579822.png"> | <img width="628" alt="Screen Shot 2022-05-05 at 8 38 07 PM" src="https://user-images.githubusercontent.com/21045490/167064031-a659fdfb-68eb-4c8f-aaa5-df24dfc8b3dc.png">|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/982)