### PR TITLE
Make CommandBar mutable and allow for multiple leading and trailing items.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -141,6 +141,8 @@ class CommandBarDemoController: DemoController {
         }
     }
 
+    var defaultCommandBar: CommandBar?
+
     let textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
@@ -156,6 +158,84 @@ class CommandBarDemoController: DemoController {
         container.layoutMargins.left = 0
         view.backgroundColor = Colors.surfaceSecondary
 
+        container.addArrangedSubview(createLabelWithText("Default"))
+
+        defaultCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        defaultCommandBar?.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(defaultCommandBar!)
+
+        let itemCustomizationContainer = UIStackView()
+        itemCustomizationContainer.spacing = 8.0
+        itemCustomizationContainer.axis = .vertical
+        itemCustomizationContainer.backgroundColor = Colors.navigationBarBackground
+
+        itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
+
+        let refreshButton = Button(style: .tertiaryOutline)
+        refreshButton.setTitle("Refresh 'Default' Bar", for: .normal)
+        refreshButton.addTarget(self, action: #selector(refreshDefaultBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(refreshButton)
+
+        let removeTrailingItemButton = Button(style: .tertiaryOutline)
+        removeTrailingItemButton.setTitle("Remove Trailing Button", for: .normal)
+        removeTrailingItemButton.addTarget(self, action: #selector(removeDefaultTrailingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(removeTrailingItemButton)
+
+        let refreshTrailingItemButton = Button(style: .tertiaryOutline)
+        refreshTrailingItemButton.setTitle("Refresh Trailing Button", for: .normal)
+        refreshTrailingItemButton.addTarget(self, action: #selector(refreshDefaultTrailingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(refreshTrailingItemButton)
+
+        let removeLeadingItemButton = Button(style: .tertiaryOutline)
+        removeLeadingItemButton.setTitle("Remove Leading Button", for: .normal)
+        removeLeadingItemButton.addTarget(self, action: #selector(removeDefaultLeadingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(removeLeadingItemButton)
+
+        let refreshLeadingItemButton = Button(style: .tertiaryOutline)
+        refreshLeadingItemButton.setTitle("Refresh Leading Button", for: .normal)
+        refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
+
+        let customizationStackView = UIStackView()
+        customizationStackView.axis = .horizontal
+        customizationStackView.alignment = .fill
+        customizationStackView.distribution = .fillProportionally
+        customizationStackView.addArrangedSubview(createLabelWithText("'+' Item Enabled"))
+        let itemEnabledSwitch: UISwitch = UISwitch()
+        itemEnabledSwitch.isOn = true
+        itemEnabledSwitch.addTarget(self, action: #selector(itemEnabledValueChanged), for: .valueChanged)
+        customizationStackView.addArrangedSubview(itemEnabledSwitch)
+        itemCustomizationContainer.addArrangedSubview(customizationStackView)
+
+        itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
+
+        container.addArrangedSubview(itemCustomizationContainer)
+
+        container.addArrangedSubview(createLabelWithText("With Fixed Button"))
+
+		let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+        fixedButtonCommandBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(fixedButtonCommandBar)
+
+        container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
+
+        let textFieldContainer = UIView()
+        textFieldContainer.backgroundColor = Colors.navigationBarBackground
+        textFieldContainer.addSubview(textField)
+        NSLayoutConstraint.activate([
+            textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
+            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 16.0),
+            textFieldContainer.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: 16.0),
+            textFieldContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 16.0)
+        ])
+
+        container.addArrangedSubview(textFieldContainer)
+
+        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
+        textField.inputAccessoryView = accessoryCommandBar
+    }
+
+    func createItemGroups() -> [CommandBarItemGroup] {
         let commandGroups: [[Command]] = [
             [
                 .add,
@@ -204,32 +284,7 @@ class CommandBarDemoController: DemoController {
                                           UIAction(title: "Copy Text", image: UIImage(named: "text24Regular"), handler: { _ in })])
         copyItem.showsMenuAsPrimaryAction = true
 
-        container.addArrangedSubview(createLabelWithText("Default"))
-
-        let defaultCommandBar = CommandBar(itemGroups: itemGroups)
-        container.addArrangedSubview(defaultCommandBar)
-
-        container.addArrangedSubview(createLabelWithText("With Fixed Button"))
-
-        let fixedButtonCommandBar = CommandBar(itemGroups: itemGroups, leadingItem: newItem(for: .copy), trailingItem: newItem(for: .keyboard))
-        container.addArrangedSubview(fixedButtonCommandBar)
-
-        container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
-
-        let textFieldContainer = UIView()
-        textFieldContainer.backgroundColor = Colors.navigationBarBackground
-        textFieldContainer.addSubview(textField)
-        NSLayoutConstraint.activate([
-            textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
-            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 16.0),
-            textFieldContainer.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: 16.0),
-            textFieldContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 16.0)
-        ])
-
-        container.addArrangedSubview(textFieldContainer)
-
-        let accessoryCommandBar = CommandBar(itemGroups: itemGroups, trailingItem: newItem(for: .keyboard))
-        textField.inputAccessoryView = accessoryCommandBar
+        return itemGroups
     }
 
     func createLabelWithText(_ text: String = "") -> Label {
@@ -273,5 +328,33 @@ class CommandBarDemoController: DemoController {
             alert.addAction(action)
             present(alert, animated: true)
         }
+    }
+
+    @objc func itemEnabledValueChanged(sender: UISwitch!) {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
+            return
+        }
+
+        item.isEnabled = sender.isOn
+    }
+
+    @objc func refreshDefaultBarItems(sender: UIButton!) {
+        defaultCommandBar?.itemGroups = createItemGroups()
+    }
+
+    @objc func removeDefaultTrailingBarItems(sender: UIButton!) {
+        defaultCommandBar?.trailingItemGroups = []
+    }
+
+    @objc func refreshDefaultTrailingBarItems(sender: UIButton!) {
+        defaultCommandBar?.trailingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    @objc func removeDefaultLeadingBarItems(sender: UIButton!) {
+        defaultCommandBar?.leadingItemGroups = []
+    }
+
+    @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
+        defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -160,9 +160,10 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("Default"))
 
-        defaultCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
-        defaultCommandBar?.backgroundColor = Colors.navigationBarBackground
-        container.addArrangedSubview(defaultCommandBar!)
+        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        commandBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(commandBar)
+        defaultCommandBar = commandBar
 
         let itemCustomizationContainer = UIStackView()
         itemCustomizationContainer.spacing = CommandBarDemoController.verticalStackViewSpacing
@@ -213,7 +214,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("With Fixed Button"))
 
-		let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
         fixedButtonCommandBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(fixedButtonCommandBar)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -357,6 +357,6 @@ class CommandBarDemoController: DemoController {
     @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
         defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
     }
-    
+
     private static let verticalStackViewSpacing: CGFloat = 8.0
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -165,7 +165,7 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(defaultCommandBar!)
 
         let itemCustomizationContainer = UIStackView()
-        itemCustomizationContainer.spacing = 8.0
+        itemCustomizationContainer.spacing = CommandBarDemoController.verticalStackViewSpacing
         itemCustomizationContainer.axis = .vertical
         itemCustomizationContainer.backgroundColor = Colors.navigationBarBackground
 
@@ -357,4 +357,6 @@ class CommandBarDemoController: DemoController {
     @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
         defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
     }
+    
+    private static let verticalStackViewSpacing: CGFloat = 8.0
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
+		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsStackView.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
@@ -268,6 +269,7 @@
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
+		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsStackView.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -1014,6 +1016,7 @@
 				FC414E4E2588B65C00069E73 /* CommandBarItem.swift */,
 				FC414E2A25887A4B00069E73 /* CommandBarButton.swift */,
 				FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */,
+				94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsStackView.swift */,
 			);
 			path = "Command Bar";
 			sourceTree = "<group>";
@@ -1513,6 +1516,7 @@
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,
 				5314E08925F00F2D0099271A /* CommandBarButtonGroupView.swift in Sources */,
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,
+				94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsStackView.swift in Sources */,
 				5314E21E25F022120099271A /* UIView+Extensions.swift in Sources */,
 				5314E0BD25F0106F0099271A /* HUD.swift in Sources */,
 				5314E06A25F00F100099271A /* GenericDateTimePicker.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
-		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsStackView.swift */; };
+		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
@@ -269,7 +269,7 @@
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
-		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsStackView.swift; sourceTree = "<group>"; };
+		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -1016,7 +1016,7 @@
 				FC414E4E2588B65C00069E73 /* CommandBarItem.swift */,
 				FC414E2A25887A4B00069E73 /* CommandBarButton.swift */,
 				FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */,
-				94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsStackView.swift */,
+				94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */,
 			);
 			path = "Command Bar";
 			sourceTree = "<group>";
@@ -1516,7 +1516,7 @@
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,
 				5314E08925F00F2D0099271A /* CommandBarButtonGroupView.swift in Sources */,
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,
-				94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsStackView.swift in Sources */,
+				94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */,
 				5314E21E25F022120099271A /* UIView+Extensions.swift in Sources */,
 				5314E0BD25F0106F0099271A /* HUD.swift in Sources */,
 				5314E06A25F00F100099271A /* GenericDateTimePicker.swift in Sources */,

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -7,14 +7,15 @@ import UIKit
 
 /**
  `CommandBar` is a horizontal scrollable list of icon buttons divided by groups.
- Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItem` and `trailingItem` add fixed buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
+ Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItemGroups` and `trailingItemGroups` add button in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  Set the `delegate` property to determine whether a button can be selected and deselected, and listen to selection changes.
  */
 @objc(MSFCommandBar)
 open class CommandBar: UIView {
     // Hierarchy:
     //
-    // leadingButton
+    // leadingCommandGroupsStackView
+    // |--buttons
     // containerView
     // |--layer.mask -> containerMaskLayer (fill containerView)
     // |--subviews
@@ -22,17 +23,26 @@ open class CommandBar: UIView {
     // |  |  |--subviews
     // |  |  |  |--stackView
     // |  |  |  |  |--buttons (fill scrollView content)
-    // trailingButton
+    // trailingCommandGroupsStackView
+    // |--buttons
 
     // MARK: - Public methods
 
-    @available(*, deprecated, renamed: "init(itemGroups:leadingItemGroups:trailingItemGroups:)")
+    @available(*, renamed: "init(itemGroups:leadingItemGroups:trailingItemGroups:)")
     @objc public init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
         self.itemGroups = itemGroups
 
-        self.leadingItemGroups = leadingItem != nil ? [[leadingItem!]] : []
+        if let leadingItem = leadingItem {
+            self.leadingItemGroups = [[leadingItem]]
+        }
 
-        self.trailingItemGroups = trailingItem != nil ? [[trailingItem!]] : []
+        if let trailingItem = trailingItem {
+            self.trailingItemGroups = [[trailingItem]]
+        }
+
+        self.leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.leadingItemGroups)
+        self.centerCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
+        self.trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.trailingItemGroups)
 
         super.init(frame: .zero)
 
@@ -44,10 +54,12 @@ open class CommandBar: UIView {
 
     @objc public init(itemGroups: [CommandBarItemGroup], leadingItemGroups: [CommandBarItemGroup]? = nil, trailingItemGroups: [CommandBarItemGroup]? = nil) {
         self.itemGroups = itemGroups
+        self.leadingItemGroups = leadingItemGroups
+        self.trailingItemGroups = trailingItemGroups
 
-        self.leadingItemGroups = leadingItemGroups != nil ? leadingItemGroups! : []
-
-        self.trailingItemGroups = trailingItemGroups != nil ? trailingItemGroups! : []
+        self.leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.leadingItemGroups)
+        self.centerCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
+        self.trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.trailingItemGroups)
 
         super.init(frame: .zero)
 
@@ -64,9 +76,9 @@ open class CommandBar: UIView {
 
     /// Apply `isEnabled` and `isSelected` state from `CommandBarItem` to the buttons
     @objc public func updateButtonsState() {
-        for button in itemsToButtonsMap.values {
-            button.updateState()
-        }
+		leadingCommandGroupsStackView.updateButtonsState()
+		centerCommandGroupsStackView.updateButtonsState()
+		trailingCommandGroupsStackView.updateButtonsState()
     }
 
     // MARK: Overrides
@@ -85,94 +97,50 @@ open class CommandBar: UIView {
     /// Scrollable items shown in the center of the CommandBar
     public var itemGroups: [CommandBarItemGroup] {
         didSet {
-            for view in stackView.arrangedSubviews {
-                view.removeFromSuperview()
-            }
-
-            _buttonGroupViews = nil
-            for view in buttonGroupViews {
-                stackView.addArrangedSubview(view)
-            }
+            centerCommandGroupsStackView.itemGroups = itemGroups
         }
     }
 
     /// Items pinned to the leading end of the CommandBar
-    public var leadingItemGroups: [CommandBarItemGroup] {
+    public var leadingItemGroups: [CommandBarItemGroup]? {
         didSet {
-            for view in leadingStackView.arrangedSubviews {
-                view.removeFromSuperview()
+            guard let leadingItemGroups = leadingItemGroups else {
+                return
             }
 
-            _leadingButtonGroupViews = nil
-            for view in leadingButtonGroupViews {
-                leadingStackView.addArrangedSubview(view)
-            }
+            leadingCommandGroupsStackView.itemGroups = leadingItemGroups
+            constrainLeadingCommandGroupsStackView()
         }
     }
 
     /// Items pinned to the trailing end of the CommandBar
-    public var trailingItemGroups: [CommandBarItemGroup] {
+    public var trailingItemGroups: [CommandBarItemGroup]? {
         didSet {
-            for view in trailingStackView.arrangedSubviews {
-                view.removeFromSuperview()
+            guard let trailingItemGroups = trailingItemGroups else {
+                return
             }
 
-            _trailingButtonGroupViews = nil
-            for view in trailingButtonGroupViews {
-                trailingStackView.addArrangedSubview(view)
-            }
+            trailingCommandGroupsStackView.itemGroups = trailingItemGroups
+            constrainTrailingCommandGroupsStackView()
         }
     }
 
     // MARK: - Private properties
 
-    private var _itemsToButtonsMap: [CommandBarItem: CommandBarButton]?
-    /// Mapping of `CommandBarItem`s to `CommandBarButton`s for items in `itemGroups`. Mapping is
-    /// refreshed when `buttonGroupViews` is set.
-    private var itemsToButtonsMap: [CommandBarItem: CommandBarButton] {
-        if _itemsToButtonsMap == nil {
-            let allButtons = itemGroups.flatMap({ $0 }).map({ button(forItem: $0) })
+    /// UIStackView holding the items pinned to the leading end of the CommandBar
+	private var leadingCommandGroupsStackView: CommandBarCommandGroupsStackView
 
-            _itemsToButtonsMap = Dictionary(uniqueKeysWithValues: allButtons.map { ($0.item, $0) })
-        }
-        return _itemsToButtonsMap!
-    }
+    /// UIStackView holding the items in the middle of the CommandBar
+	private var centerCommandGroupsStackView: CommandBarCommandGroupsStackView
 
-    private var _trailingItemsToButtonsMap: [CommandBarItem: CommandBarButton]?
-    /// Mapping of `CommandBarItem`s to `CommandBarButton`s for items in `trailingItemGroups`. Mapping is
-    /// refreshed when `trailingButtonGroupViews` is set.
-    private var trailingItemsToButtonsMap: [CommandBarItem: CommandBarButton] {
-        if _trailingItemsToButtonsMap == nil {
-            let trailingButtons = trailingItemGroups.flatMap({ $0 }).map({ button(forItem: $0) })
+    /// UIStackView holding the items pinned to the trailing end of the CommandBar
+	private var trailingCommandGroupsStackView: CommandBarCommandGroupsStackView
 
-            _trailingItemsToButtonsMap = Dictionary(uniqueKeysWithValues: trailingButtons.map { ($0.item, $0) })
-        }
-        return _trailingItemsToButtonsMap!
-    }
+    /// Leading constraint between the `containerView` and either the `leadingCommandGroupsStackView` or the parent view
+    private var leadingConstraint: NSLayoutConstraint?
 
-    private var _leadingItemsToButtonsMap: [CommandBarItem: CommandBarButton]?
-    /// Mapping of `CommandBarItem`s to `CommandBarButton`s for items in `leadingItemGroups`. Mapping is
-    /// refreshed when `leadingButtonGroupViews` is set.
-    private var leadingItemsToButtonsMap: [CommandBarItem: CommandBarButton] {
-        if _leadingItemsToButtonsMap == nil {
-            let leadingButtons = leadingItemGroups.flatMap({ $0 }).map({ button(forItem: $0) })
-
-            _leadingItemsToButtonsMap = Dictionary(uniqueKeysWithValues: leadingButtons.map { ($0.item, $0) })
-        }
-        return _leadingItemsToButtonsMap!
-    }
-
-    /// Checks each items-to-buttons map for given item, returns the corresponding button if found.
-    private func buttonFromButtonMaps(_ item: CommandBarItem) -> CommandBarButton? {
-        if itemsToButtonsMap[item] != nil {
-            return itemsToButtonsMap[item]
-        } else if leadingItemsToButtonsMap[item] != nil {
-            return leadingItemsToButtonsMap[item]
-        } else if trailingItemsToButtonsMap[item] != nil {
-            return trailingItemsToButtonsMap[item]
-        }
-        return nil
-    }
+    /// Trailing constraint between the `containerView` and either the `trailingCommandGroupsStackView` or the parent view
+    private var trailingConstraint: NSLayoutConstraint?
 
     // MARK: Views and Layers
 
@@ -197,123 +165,27 @@ open class CommandBar: UIView {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.contentInset = UIEdgeInsets(
             top: 0,
-            left: leadingStackView.arrangedSubviews.isEmpty ? CommandBar.insets.left : CommandBar.fixedButtonSpacing,
+            left: leadingCommandGroupsStackView.itemGroups.isEmpty ? CommandBar.insets.left : CommandBar.fixedButtonSpacing,
             bottom: 0,
-            right: trailingStackView.arrangedSubviews.isEmpty ? CommandBar.insets.right : CommandBar.fixedButtonSpacing
+            right: trailingCommandGroupsStackView.itemGroups.isEmpty ? CommandBar.insets.right : CommandBar.fixedButtonSpacing
         )
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
         scrollView.delegate = self
 
-        scrollView.addSubview(stackView)
+        scrollView.addSubview(centerCommandGroupsStackView)
         NSLayoutConstraint.activate([
             scrollView.contentLayoutGuide.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
 
-            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+            centerCommandGroupsStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            centerCommandGroupsStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: centerCommandGroupsStackView.bottomAnchor),
+            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: centerCommandGroupsStackView.trailingAnchor)
         ])
 
         return scrollView
     }()
-
-    /// UIStackView for holding `CommandBarButtonGroupView`s shown in the center of the CommandBar
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: buttonGroupViews)
-
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = CommandBar.buttonGroupSpacing
-
-        return stackView
-    }()
-
-    /// UIStackView for holding `CommandBarButtonGroupView`s shown at the leading end of the CommandBar
-    private lazy var leadingStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: leadingButtonGroupViews)
-
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = CommandBar.buttonGroupSpacing
-
-        return stackView
-    }()
-
-    /// UIStackView for holding `CommandBarButtonGroupView`s shown at the trailing end of the CommandBar
-    private lazy var trailingStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: trailingButtonGroupViews)
-
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = CommandBar.buttonGroupSpacing
-
-        return stackView
-    }()
-
-    private var _buttonGroupViews: [CommandBarButtonGroupView]?
-    /// Array of `CommandBarButtonGroupView`s for items shown in center of CommandBar. Set
-    /// `_buttonGroupViews` to `nil` to update the array on the next call.
-    private var buttonGroupViews: [CommandBarButtonGroupView] {
-        if _buttonGroupViews == nil {
-            _itemsToButtonsMap = nil
-            _buttonGroupViews = itemGroups.map { items in
-                CommandBarButtonGroupView(buttons: items.compactMap { item in
-                    item.delegate = self
-                    guard let button = itemsToButtonsMap[item] else {
-                        preconditionFailure("Button is not initialized in commandsToButtons")
-                    }
-
-                    return button
-                })
-            }
-        }
-        return _buttonGroupViews!
-    }
-
-    private var _leadingButtonGroupViews: [CommandBarButtonGroupView]?
-    /// Array of `CommandBarButtonGroupView`s for items shown at leading end of CommandBar. Set
-    /// `_leadingButtonGroupViews` to `nil` to update the array on the next call.
-    private var leadingButtonGroupViews: [CommandBarButtonGroupView] {
-        if _leadingButtonGroupViews == nil {
-            _leadingItemsToButtonsMap = nil
-            _leadingButtonGroupViews = leadingItemGroups.map { items in
-                CommandBarButtonGroupView(buttons: items.compactMap { item in
-                    item.delegate = self
-                    guard let button = leadingItemsToButtonsMap[item] else {
-                        preconditionFailure("Button is not initialized in commandsToButtons")
-                    }
-
-                    return button
-                })
-            }
-        }
-        return _leadingButtonGroupViews!
-    }
-
-    private var _trailingButtonGroupViews: [CommandBarButtonGroupView]?
-    /// Array of `CommandBarButtonGroupView`s for items shown at trailing end of CommandBar. Set
-    /// `_trailingButtonGroupViews` to `nil` to update the array on the next call.
-    private var trailingButtonGroupViews: [CommandBarButtonGroupView] {
-        if _trailingButtonGroupViews == nil {
-            _trailingItemsToButtonsMap = nil
-            _trailingButtonGroupViews = trailingItemGroups.map { items in
-                CommandBarButtonGroupView(buttons: items.compactMap { item in
-                    item.delegate = self
-                    guard let button = trailingItemsToButtonsMap[item] else {
-                        preconditionFailure("Button is not initialized in commandsToButtons")
-                    }
-
-                    return button
-                })
-            }
-        }
-        return _trailingButtonGroupViews!
-    }
-
-    private var leadingConstraint: NSLayoutConstraint?
-    private var trailingConstraint: NSLayoutConstraint?
 
     private let containerMaskLayer: CAGradientLayer = {
         // A mask layer using alpha color channel.
@@ -330,90 +202,96 @@ open class CommandBar: UIView {
         addSubview(containerView)
 
         // Constraint left and right item stack views
-        constrainLeadingAndTrailingStackViews()
+        constrainLeadingCommandGroupsStackView()
+        constrainTrailingCommandGroupsStackView()
 
         NSLayoutConstraint.activate([
             containerView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBar.insets.top),
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: CommandBar.insets.bottom)
         ])
 
-        stackView.layoutIfNeeded()
+        centerCommandGroupsStackView.layoutIfNeeded()
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
             let flipTransform = CGAffineTransform(scaleX: -1, y: 1)
             scrollView.transform = flipTransform
-            stackView.transform = flipTransform
+            centerCommandGroupsStackView.transform = flipTransform
             containerMaskLayer.setAffineTransform(flipTransform)
         }
     }
 
-    private func constrainLeadingAndTrailingStackViews() {
-        if !leadingStackView.arrangedSubviews.isEmpty {
-            addSubview(leadingStackView)
+    private func constrainLeadingCommandGroupsStackView() {
+        if !leadingCommandGroupsStackView.itemGroups.isEmpty {
+            addSubview(leadingCommandGroupsStackView)
             leadingConstraint?.isActive = false
-            leadingConstraint = containerView.leadingAnchor.constraint(equalTo: leadingStackView.trailingAnchor, constant: CommandBar.fixedButtonSpacing)
+            leadingConstraint = containerView.leadingAnchor.constraint(equalTo: leadingCommandGroupsStackView.trailingAnchor, constant: CommandBar.fixedButtonSpacing)
             NSLayoutConstraint.activate([
-                leadingStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: CommandBar.fixedButtonSpacing),
-                leadingStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
-                leadingStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+                leadingCommandGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: CommandBar.fixedButtonSpacing),
+                leadingCommandGroupsStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                leadingCommandGroupsStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
                 leadingConstraint!
             ])
         } else {
-            leadingStackView.removeFromSuperview()
+            leadingCommandGroupsStackView.removeFromSuperview()
+            leadingConstraint?.isActive = false
             leadingConstraint = containerView.leadingAnchor.constraint(equalTo: leadingAnchor)
             NSLayoutConstraint.activate([
                 leadingConstraint!
             ])
         }
 
-        if !trailingStackView.arrangedSubviews.isEmpty {
-            addSubview(trailingStackView)
+        updateScrollViewContentInset()
+    }
+
+    private func constrainTrailingCommandGroupsStackView() {
+        if !trailingCommandGroupsStackView.itemGroups.isEmpty {
+            addSubview(trailingCommandGroupsStackView)
             trailingConstraint?.isActive = false
-            trailingConstraint = trailingStackView.leadingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: CommandBar.fixedButtonSpacing)
+            trailingConstraint = trailingCommandGroupsStackView.leadingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: CommandBar.fixedButtonSpacing)
             NSLayoutConstraint.activate([
-                trailingStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
-                trailingStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-                trailingAnchor.constraint(equalTo: trailingStackView.trailingAnchor, constant: CommandBar.fixedButtonSpacing),
+                trailingCommandGroupsStackView.topAnchor.constraint(equalTo: containerView.topAnchor),
+                trailingCommandGroupsStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+                trailingAnchor.constraint(equalTo: trailingCommandGroupsStackView.trailingAnchor, constant: CommandBar.fixedButtonSpacing),
                 trailingConstraint!
             ])
         } else {
-            trailingStackView.removeFromSuperview()
+            trailingCommandGroupsStackView.removeFromSuperview()
+            trailingConstraint?.isActive = false
             trailingConstraint = containerView.trailingAnchor.constraint(equalTo: trailingAnchor)
             NSLayoutConstraint.activate([
                 trailingConstraint!
             ])
         }
+
+        updateScrollViewContentInset()
     }
 
-    private func button(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
-        let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection)
-        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
-
-        return button
+    private func updateScrollViewContentInset() {
+        scrollView.contentInset = UIEdgeInsets(
+            top: 0,
+            left: leadingCommandGroupsStackView.itemGroups.isEmpty ? CommandBar.insets.left : CommandBar.fixedButtonSpacing,
+            bottom: 0,
+            right: trailingCommandGroupsStackView.itemGroups.isEmpty ? CommandBar.insets.right : CommandBar.fixedButtonSpacing
+        )
     }
 
     private func updateShadow() {
         var locations: [CGFloat] = [0, 0, 1]
 
-        if !leadingStackView.arrangedSubviews.isEmpty {
+        if !leadingCommandGroupsStackView.itemGroups.isEmpty {
             let leadingOffset = max(0, scrollView.contentOffset.x)
             let percentage = min(1, leadingOffset / scrollView.contentInset.left)
             locations[1] = CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }
 
-        if !trailingStackView.arrangedSubviews.isEmpty {
-            let trailingOffset = max(0, stackView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
+        if !trailingCommandGroupsStackView.itemGroups.isEmpty {
+            let trailingOffset = max(0, centerCommandGroupsStackView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
             let percentage = min(1, trailingOffset / scrollView.contentInset.right)
             locations[2] = 1 - CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }
 
         containerMaskLayer.locations = locations.map { NSNumber(value: Float($0)) }
-    }
-
-    @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
-        sender.item.handleTapped(sender)
-        sender.updateState()
     }
 
     private static let fadeViewWidth: CGFloat = 16.0
@@ -428,39 +306,4 @@ extension CommandBar: UIScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateShadow()
     }
-}
-
-// MARK: - CommandBarItemDelegate
-
-extension CommandBar: CommandBarItemDelegate {
-    func commandBarItem(_ item: CommandBarItem, didChangeEnabledTo value: Bool) {
-        if let button: CommandBarButton = buttonFromButtonMaps(item) {
-            button.updateState()
-        }
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeSelectedTo value: Bool) {
-        if let button: CommandBarButton = buttonFromButtonMaps(item) {
-            button.updateState()
-        }
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeTitleTo value: String?) {
-        if let button: CommandBarButton = buttonFromButtonMaps(item) {
-            button.updateState()
-        }
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeTitleFontTo value: UIFont?) {
-        if let button: CommandBarButton = buttonFromButtonMaps(item) {
-            button.updateState()
-        }
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeIconImageTo value: UIImage?) {
-        if let button: CommandBarButton = buttonFromButtonMaps(item) {
-            button.updateState()
-        }
-    }
-
 }

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -33,16 +33,16 @@ open class CommandBar: UIView {
         self.itemGroups = itemGroups
 
         if let leadingItem = leadingItem {
-            self.leadingItemGroups = [[leadingItem]]
+            leadingItemGroups = [[leadingItem]]
         }
 
         if let trailingItem = trailingItem {
-            self.trailingItemGroups = [[trailingItem]]
+            trailingItemGroups = [[trailingItem]]
         }
 
-        self.leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.leadingItemGroups)
-        self.centerCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
-        self.trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.trailingItemGroups)
+        leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: leadingItemGroups)
+        mainCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
+        trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: trailingItemGroups)
 
         super.init(frame: .zero)
 
@@ -57,9 +57,9 @@ open class CommandBar: UIView {
         self.leadingItemGroups = leadingItemGroups
         self.trailingItemGroups = trailingItemGroups
 
-        self.leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.leadingItemGroups)
-        self.centerCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
-        self.trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.trailingItemGroups)
+        leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.leadingItemGroups)
+        mainCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
+        trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.trailingItemGroups)
 
         super.init(frame: .zero)
 
@@ -77,7 +77,7 @@ open class CommandBar: UIView {
     /// Apply `isEnabled` and `isSelected` state from `CommandBarItem` to the buttons
     @objc public func updateButtonsState() {
 		leadingCommandGroupsStackView.updateButtonsState()
-		centerCommandGroupsStackView.updateButtonsState()
+		mainCommandGroupsStackView.updateButtonsState()
 		trailingCommandGroupsStackView.updateButtonsState()
     }
 
@@ -97,7 +97,7 @@ open class CommandBar: UIView {
     /// Scrollable items shown in the center of the CommandBar
     public var itemGroups: [CommandBarItemGroup] {
         didSet {
-            centerCommandGroupsStackView.itemGroups = itemGroups
+            mainCommandGroupsStackView.itemGroups = itemGroups
         }
     }
 
@@ -128,13 +128,13 @@ open class CommandBar: UIView {
     // MARK: - Private properties
 
     /// UIStackView holding the items pinned to the leading end of the CommandBar
-	private var leadingCommandGroupsStackView: CommandBarCommandGroupsStackView
+    private var leadingCommandGroupsStackView: CommandBarCommandGroupsStackView
 
     /// UIStackView holding the items in the middle of the CommandBar
-	private var centerCommandGroupsStackView: CommandBarCommandGroupsStackView
+    private var mainCommandGroupsStackView: CommandBarCommandGroupsStackView
 
     /// UIStackView holding the items pinned to the trailing end of the CommandBar
-	private var trailingCommandGroupsStackView: CommandBarCommandGroupsStackView
+    private var trailingCommandGroupsStackView: CommandBarCommandGroupsStackView
 
     /// Leading constraint between the `containerView` and either the `leadingCommandGroupsStackView` or the parent view
     private var leadingConstraint: NSLayoutConstraint?
@@ -174,14 +174,14 @@ open class CommandBar: UIView {
         scrollView.alwaysBounceHorizontal = true
         scrollView.delegate = self
 
-        scrollView.addSubview(centerCommandGroupsStackView)
+        scrollView.addSubview(mainCommandGroupsStackView)
         NSLayoutConstraint.activate([
             scrollView.contentLayoutGuide.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
 
-            centerCommandGroupsStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            centerCommandGroupsStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: centerCommandGroupsStackView.bottomAnchor),
-            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: centerCommandGroupsStackView.trailingAnchor)
+            mainCommandGroupsStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            mainCommandGroupsStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: mainCommandGroupsStackView.bottomAnchor),
+            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: mainCommandGroupsStackView.trailingAnchor)
         ])
 
         return scrollView
@@ -210,13 +210,13 @@ open class CommandBar: UIView {
             bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: CommandBar.insets.bottom)
         ])
 
-        centerCommandGroupsStackView.layoutIfNeeded()
+        mainCommandGroupsStackView.layoutIfNeeded()
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
             let flipTransform = CGAffineTransform(scaleX: -1, y: 1)
             scrollView.transform = flipTransform
-            centerCommandGroupsStackView.transform = flipTransform
+            mainCommandGroupsStackView.transform = flipTransform
             containerMaskLayer.setAffineTransform(flipTransform)
         }
     }
@@ -286,7 +286,7 @@ open class CommandBar: UIView {
         }
 
         if !trailingCommandGroupsStackView.itemGroups.isEmpty {
-            let trailingOffset = max(0, centerCommandGroupsStackView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
+            let trailingOffset = max(0, mainCommandGroupsStackView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
             let percentage = min(1, trailingOffset / scrollView.contentInset.right)
             locations[2] = 1 - CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -29,27 +29,19 @@ open class CommandBar: UIView {
     // MARK: - Public methods
 
     @available(*, renamed: "init(itemGroups:leadingItemGroups:trailingItemGroups:)")
-    @objc public init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
-        self.itemGroups = itemGroups
+    @objc public convenience init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
+        var leadingItems: [CommandBarItemGroup] = []
+        var trailingItems: [CommandBarItemGroup] = []
 
         if let leadingItem = leadingItem {
-            leadingItemGroups = [[leadingItem]]
+            leadingItems = [[leadingItem]]
         }
 
         if let trailingItem = trailingItem {
-            trailingItemGroups = [[trailingItem]]
+            trailingItems = [[trailingItem]]
         }
 
-        leadingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: leadingItemGroups)
-        mainCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: self.itemGroups)
-        trailingCommandGroupsStackView = CommandBarCommandGroupsStackView(itemGroups: trailingItemGroups)
-
-        super.init(frame: .zero)
-
-        translatesAutoresizingMaskIntoConstraints = false
-
-        configureHierarchy()
-        updateButtonsState()
+        self.init(itemGroups: itemGroups, leadingItemGroups: leadingItems.isEmpty ? nil : leadingItems, trailingItemGroups: trailingItems.isEmpty ? nil : trailingItems)
     }
 
     @objc public init(itemGroups: [CommandBarItemGroup], leadingItemGroups: [CommandBarItemGroup]? = nil, trailingItemGroups: [CommandBarItemGroup]? = nil) {
@@ -66,19 +58,11 @@ open class CommandBar: UIView {
         translatesAutoresizingMaskIntoConstraints = false
 
         configureHierarchy()
-        updateButtonsState()
     }
 
     @available(*, unavailable)
     public required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    /// Apply `isEnabled` and `isSelected` state from `CommandBarItem` to the buttons
-    @objc public func updateButtonsState() {
-		leadingCommandGroupsStackView.updateButtonsState()
-		mainCommandGroupsStackView.updateButtonsState()
-		trailingCommandGroupsStackView.updateButtonsState()
     }
 
     // MARK: Overrides

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsStackView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsStackView.swift
@@ -19,25 +19,18 @@ class CommandBarCommandGroupsStackView: UIStackView {
         axis = .horizontal
         spacing = CommandBarCommandGroupsStackView.buttonGroupSpacing
 
-        refreshButtonLayout()
+        updateButtonsShown()
     }
 
     required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     public var itemGroups: [CommandBarItemGroup] {
         didSet {
             if itemGroups != oldValue {
-                refreshButtonLayout()
+                updateButtonsShown()
             }
-        }
-    }
-
-    /// Updates the state of all buttons in the group
-    public func updateButtonsState() {
-        for button in itemsToButtonsMap.values {
-            button.updateState()
         }
     }
 
@@ -49,7 +42,7 @@ class CommandBarCommandGroupsStackView: UIStackView {
     // MARK: View Updates
 
     /// Refreshes the buttons shown in the `arrangedSubviews`
-    private func refreshButtonLayout() {
+    private func updateButtonsShown() {
         for view in arrangedSubviews {
             view.removeFromSuperview()
         }
@@ -65,9 +58,11 @@ class CommandBarCommandGroupsStackView: UIStackView {
         updateItemsToButtonsMap()
         buttonGroupViews = itemGroups.map { items in
                 CommandBarButtonGroupView(buttons: items.compactMap { item in
-                    item.delegate = self
                     guard let button = itemsToButtonsMap[item] else {
                         preconditionFailure("Button is not initialized in commandsToButtons")
+                    }
+                    item.propertyChangedUpdateBlock = { _ in
+                        button.updateState()
                     }
                     return button
                 })
@@ -93,12 +88,4 @@ class CommandBarCommandGroupsStackView: UIStackView {
     }
 
     private static let buttonGroupSpacing: CGFloat = 16
-}
-
-// MARK: - CommandBarItemDelegate
-
-extension CommandBarCommandGroupsStackView: CommandBarItemDelegate {
-    func commandBarItemPropertyDidChange(_ item: CommandBarItem) {
-        itemsToButtonsMap[item]?.updateState()
-    }
 }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsStackView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsStackView.swift
@@ -98,23 +98,7 @@ class CommandBarCommandGroupsStackView: UIStackView {
 // MARK: - CommandBarItemDelegate
 
 extension CommandBarCommandGroupsStackView: CommandBarItemDelegate {
-    func commandBarItem(_ item: CommandBarItem, didChangeEnabledTo value: Bool) {
-        itemsToButtonsMap[item]?.updateState()
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeSelectedTo value: Bool) {
-        itemsToButtonsMap[item]?.updateState()
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeTitleTo value: String?) {
-        itemsToButtonsMap[item]?.updateState()
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeTitleFontTo value: UIFont?) {
-        itemsToButtonsMap[item]?.updateState()
-    }
-
-    func commandBarItem(_ item: CommandBarItem, didChangeIconImageTo value: UIImage?) {
+    func commandBarItemPropertyDidChange(_ item: CommandBarItem) {
         itemsToButtonsMap[item]?.updateState()
     }
 }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsStackView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsStackView.swift
@@ -1,0 +1,120 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+class CommandBarCommandGroupsStackView: UIStackView {
+    init(itemGroups: [CommandBarItemGroup]? = nil) {
+        if let itemGroups = itemGroups {
+            self.itemGroups = itemGroups
+        } else {
+            self.itemGroups = []
+        }
+
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        axis = .horizontal
+        spacing = CommandBarCommandGroupsStackView.buttonGroupSpacing
+
+        refreshButtonLayout()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public var itemGroups: [CommandBarItemGroup] {
+        didSet {
+            if itemGroups != oldValue {
+                refreshButtonLayout()
+            }
+        }
+    }
+
+    /// Updates the state of all buttons in the group
+    public func updateButtonsState() {
+        for button in itemsToButtonsMap.values {
+            button.updateState()
+        }
+    }
+
+    // MARK: - Private properties
+
+    private var buttonGroupViews: [CommandBarButtonGroupView] = []
+    private var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = [:]
+
+    // MARK: View Updates
+
+    /// Refreshes the buttons shown in the `arrangedSubviews`
+    private func refreshButtonLayout() {
+        for view in arrangedSubviews {
+            view.removeFromSuperview()
+        }
+
+        updateButtonGroupViews()
+        for view in buttonGroupViews {
+            addArrangedSubview(view)
+        }
+    }
+
+    /// Refreshes the `buttonGroupViews` array of `CommandBarButtonGroupView`s that are displayed in the view
+    private func updateButtonGroupViews() {
+        updateItemsToButtonsMap()
+        buttonGroupViews = itemGroups.map { items in
+                CommandBarButtonGroupView(buttons: items.compactMap { item in
+                    item.delegate = self
+                    guard let button = itemsToButtonsMap[item] else {
+                        preconditionFailure("Button is not initialized in commandsToButtons")
+                    }
+                    return button
+                })
+        }
+    }
+
+    /// Refreshes the `itemsToButtonsMap` of `CommandBarItem`s to their corresponding `CommandBarButton`
+    private func updateItemsToButtonsMap() {
+        let allButtons = itemGroups.flatMap({ $0 }).map({ button(forItem: $0) })
+        itemsToButtonsMap = Dictionary(uniqueKeysWithValues: allButtons.map { ($0.item, $0) })
+    }
+
+    private func button(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
+        let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection)
+        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
+
+        return button
+    }
+
+    @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
+        sender.item.handleTapped(sender)
+        sender.updateState()
+    }
+
+    private static let buttonGroupSpacing: CGFloat = 16
+}
+
+// MARK: - CommandBarItemDelegate
+
+extension CommandBarCommandGroupsStackView: CommandBarItemDelegate {
+    func commandBarItem(_ item: CommandBarItem, didChangeEnabledTo value: Bool) {
+        itemsToButtonsMap[item]?.updateState()
+    }
+
+    func commandBarItem(_ item: CommandBarItem, didChangeSelectedTo value: Bool) {
+        itemsToButtonsMap[item]?.updateState()
+    }
+
+    func commandBarItem(_ item: CommandBarItem, didChangeTitleTo value: String?) {
+        itemsToButtonsMap[item]?.updateState()
+    }
+
+    func commandBarItem(_ item: CommandBarItem, didChangeTitleFontTo value: UIFont?) {
+        itemsToButtonsMap[item]?.updateState()
+    }
+
+    func commandBarItem(_ item: CommandBarItem, didChangeIconImageTo value: UIImage?) {
+        itemsToButtonsMap[item]?.updateState()
+    }
+}

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -5,17 +5,21 @@
 
 import UIKit
 
-class CommandBarCommandGroupsStackView: UIStackView {
+class CommandBarCommandGroupsView: UIView {
     init(itemGroups: [CommandBarItemGroup]? = nil, buttonsPersistSelection: Bool = true) {
         self.itemGroups = itemGroups ?? []
 
         self.buttonsPersistSelection = buttonsPersistSelection
 
+        buttonGroupsStackView = UIStackView()
+
         super.init(frame: .zero)
 
-        axis = .horizontal
-        spacing = CommandBarCommandGroupsStackView.buttonGroupSpacing
+        buttonGroupsStackView.translatesAutoresizingMaskIntoConstraints = false
+        buttonGroupsStackView.axis = .horizontal
+        buttonGroupsStackView.spacing = CommandBarCommandGroupsView.buttonGroupSpacing
 
+        configureHierarchy()
         updateButtonsShown()
     }
 
@@ -40,21 +44,33 @@ class CommandBarCommandGroupsStackView: UIStackView {
 
     // MARK: - Private properties
 
+    private var buttonGroupsStackView: UIStackView
     private var buttonGroupViews: [CommandBarButtonGroupView] = []
     private var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = [:]
     private var buttonsPersistSelection: Bool
 
     // MARK: View Updates
 
+    private func configureHierarchy() {
+        addSubview(buttonGroupsStackView)
+
+        NSLayoutConstraint.activate([
+            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
     /// Refreshes the buttons shown in the `arrangedSubviews`
     private func updateButtonsShown() {
-        for view in arrangedSubviews {
+        for view in buttonGroupsStackView.arrangedSubviews {
             view.removeFromSuperview()
         }
 
         updateButtonGroupViews()
         for view in buttonGroupViews {
-            addArrangedSubview(view)
+            buttonGroupsStackView.addArrangedSubview(view)
         }
     }
 
@@ -93,4 +109,5 @@ class CommandBarCommandGroupsStackView: UIStackView {
     }
 
     private static let buttonGroupSpacing: CGFloat = 16
+    private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
 }

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -65,7 +65,7 @@ open class CommandBarItem: NSObject {
     @objc public var iconImage: UIImage? {
         didSet {
             if iconImage != oldValue {
-                delegate?.commandBarItem(self, didChangeIconImageTo: iconImage)
+                delegate?.commandBarItemPropertyDidChange(self)
             }
         }
     }
@@ -74,7 +74,7 @@ open class CommandBarItem: NSObject {
     @objc public var title: String? {
         didSet {
             if title != oldValue {
-                delegate?.commandBarItem(self, didChangeTitleTo: title)
+                delegate?.commandBarItemPropertyDidChange(self)
             }
         }
     }
@@ -82,7 +82,7 @@ open class CommandBarItem: NSObject {
     @objc public var titleFont: UIFont? {
         didSet {
             if titleFont != oldValue {
-                delegate?.commandBarItem(self, didChangeTitleFontTo: titleFont)
+                delegate?.commandBarItemPropertyDidChange(self)
             }
         }
     }
@@ -90,7 +90,7 @@ open class CommandBarItem: NSObject {
     @objc public var isEnabled: Bool {
         didSet {
             if isEnabled != oldValue {
-                delegate?.commandBarItem(self, didChangeEnabledTo: isEnabled)
+                delegate?.commandBarItemPropertyDidChange(self)
             }
         }
     }
@@ -99,7 +99,7 @@ open class CommandBarItem: NSObject {
     @objc public var isSelected: Bool {
         didSet {
             if isSelected != oldValue {
-                delegate?.commandBarItem(self, didChangeSelectedTo: isSelected)
+                delegate?.commandBarItemPropertyDidChange(self)
             }
         }
     }
@@ -125,14 +125,6 @@ open class CommandBarItem: NSObject {
 }
 
 protocol CommandBarItemDelegate: AnyObject {
-    /// Called after the `isEnabled` property is changed
-    func commandBarItem(_ item: CommandBarItem, didChangeEnabledTo value: Bool)
-    /// Called after the `isSelected` property is changed
-    func commandBarItem(_ item: CommandBarItem, didChangeSelectedTo value: Bool)
-    /// Called after the `title` property is changed
-    func commandBarItem(_ item: CommandBarItem, didChangeTitleTo value: String?)
-    /// Called after the `titleFont` property is changed
-    func commandBarItem(_ item: CommandBarItem, didChangeTitleFontTo value: UIFont?)
-    /// Called after the `iconImage` property is changed
-    func commandBarItem(_ item: CommandBarItem, didChangeIconImageTo value: UIImage?)
+    /// To be called after a `CommandBarItem` property changes
+    func commandBarItemPropertyDidChange(_ item: CommandBarItem)
 }

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -65,7 +65,7 @@ open class CommandBarItem: NSObject {
     @objc public var iconImage: UIImage? {
         didSet {
             if iconImage != oldValue {
-                delegate?.commandBarItemPropertyDidChange(self)
+                propertyChangedUpdateBlock?(self)
             }
         }
     }
@@ -74,23 +74,17 @@ open class CommandBarItem: NSObject {
     @objc public var title: String? {
         didSet {
             if title != oldValue {
-                delegate?.commandBarItemPropertyDidChange(self)
+                propertyChangedUpdateBlock?(self)
             }
         }
     }
 
-    @objc public var titleFont: UIFont? {
-        didSet {
-            if titleFont != oldValue {
-                delegate?.commandBarItemPropertyDidChange(self)
-            }
-        }
-    }
+    @objc public var titleFont: UIFont?
 
     @objc public var isEnabled: Bool {
         didSet {
             if isEnabled != oldValue {
-                delegate?.commandBarItemPropertyDidChange(self)
+                propertyChangedUpdateBlock?(self)
             }
         }
     }
@@ -99,7 +93,7 @@ open class CommandBarItem: NSObject {
     @objc public var isSelected: Bool {
         didSet {
             if isSelected != oldValue {
-                delegate?.commandBarItemPropertyDidChange(self)
+                propertyChangedUpdateBlock?(self)
             }
         }
     }
@@ -121,10 +115,6 @@ open class CommandBarItem: NSObject {
         itemTappedHandler(sender, self)
     }
 
-    weak var delegate: CommandBarItemDelegate?
-}
-
-protocol CommandBarItemDelegate: AnyObject {
-    /// To be called after a `CommandBarItem` property changes
-    func commandBarItemPropertyDidChange(_ item: CommandBarItem)
+    /// Call after a property is changed to trigger the update of a corresponding button
+    var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
 }

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -115,6 +115,6 @@ open class CommandBarItem: NSObject {
         itemTappedHandler(sender, self)
     }
 
-    /// Call after a property is changed to trigger the update of a corresponding button
+    /// Called after a property is changed to trigger the update of a corresponding button
     var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
 }

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -62,17 +62,47 @@ open class CommandBarItem: NSObject {
         self.accessibilityHint = accessibilityHint
     }
 
-    @objc public var iconImage: UIImage?
+    @objc public var iconImage: UIImage? {
+        didSet {
+            if iconImage != oldValue {
+                delegate?.commandBarItem(self, didChangeIconImageTo: iconImage)
+            }
+        }
+    }
 
     /// Title for the item. Only valid when `iconImage` is `nil`.
-    @objc public var title: String?
+    @objc public var title: String? {
+        didSet {
+            if title != oldValue {
+                delegate?.commandBarItem(self, didChangeTitleTo: title)
+            }
+        }
+    }
 
-    @objc public var titleFont: UIFont?
+    @objc public var titleFont: UIFont? {
+        didSet {
+            if titleFont != oldValue {
+                delegate?.commandBarItem(self, didChangeTitleFontTo: titleFont)
+            }
+        }
+    }
 
-    @objc public var isEnabled: Bool
+    @objc public var isEnabled: Bool {
+        didSet {
+            if isEnabled != oldValue {
+                delegate?.commandBarItem(self, didChangeEnabledTo: isEnabled)
+            }
+        }
+    }
 
     /// If `isPersistSelection` is `true`, this value would be changed to reflect the selection state of the button. Setting this value before providing to `CommandBar` would set the initial selection state.
-    @objc public var isSelected: Bool
+    @objc public var isSelected: Bool {
+        didSet {
+            if isSelected != oldValue {
+                delegate?.commandBarItem(self, didChangeSelectedTo: isSelected)
+            }
+        }
+    }
 
     /// Set `isSelected` to desired value in this handler. Default implementation is toggling `isSelected` property.
     @objc public var itemTappedHandler: ItemTappedHandler
@@ -90,4 +120,19 @@ open class CommandBarItem: NSObject {
     func handleTapped(_ sender: CommandBarButton) {
         itemTappedHandler(sender, self)
     }
+
+    weak var delegate: CommandBarItemDelegate?
+}
+
+protocol CommandBarItemDelegate: AnyObject {
+    /// Called after the `isEnabled` property is changed
+    func commandBarItem(_ item: CommandBarItem, didChangeEnabledTo value: Bool)
+    /// Called after the `isSelected` property is changed
+    func commandBarItem(_ item: CommandBarItem, didChangeSelectedTo value: Bool)
+    /// Called after the `title` property is changed
+    func commandBarItem(_ item: CommandBarItem, didChangeTitleTo value: String?)
+    /// Called after the `titleFont` property is changed
+    func commandBarItem(_ item: CommandBarItem, didChangeTitleFontTo value: UIFont?)
+    /// Called after the `iconImage` property is changed
+    func commandBarItem(_ item: CommandBarItem, didChangeIconImageTo value: UIImage?)
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change aims to address a few different limitations of the existing CommandBar implementation:
1. The existing CommandBar implementation does not allow for items to be added or removed after initialization, making it impossible to update the items shown without creating an entirely new bar. To fix this, the itemGroups property was made public and a didSet property observer was added which triggers a refresh of the views shown in the stackView. The maps holding the items and their corresponding buttons have to be refreshed when this happens.
2. Any changes made to CommandBarItems will only be reflected in the UI if CommandBar.updateButtonState() is called. Calling this iterates over and updates all of the buttons shown. Ideally, buttons can be updated individually without having to update all of the buttons. To solve this, I've added CommandBarItemDelegate protocol that is implemented by the CommandBar and allows for buttons to be updated individually after properties on the their corresponding CommandBarItem changes.
3. Expand the leadingButton and trailingButton areas to allow for multiple items. To do this, UIStackViews were used and implemented in a similar manner to that of the UIStackView used for the center items in itemGroups. New item-to-button mappings are created to store the items and their corresponding buttons. The CommandBar.leadingItemGroups and CommandBar.trailingItemGroups properties are exposed and work in the same way that itemsGroup property works. The biggest downside that I see to this approach is that there are now 3 mappings being maintained for the CommandBar (leading items, center items, trailing items).

### Verification

Before         
![Before](https://user-images.githubusercontent.com/10938746/169105437-b0d534b1-53f6-4b68-a80e-5d6b46b83352.png)

After

https://user-images.githubusercontent.com/10938746/169106813-ed886694-f422-41a0-8cd8-15614d9d6327.mov
The video above demos of how the items in the the CommandBar can be refreshed after initialization.

https://user-images.githubusercontent.com/10938746/169105547-6983c781-c982-4b14-96c2-dc766910819f.mov
The video above shows how the the new CommandBarItemDelegate can be used to update individual items without doing a refresh of all the items in the bar.

https://user-images.githubusercontent.com/10938746/169106904-dbb01896-04e1-4031-ab74-79c4cade848d.mov
The video above shows how the items in the leading and trailing sections can be refreshed after initialization.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/987)