### PR TITLE
[vNext Tokens] Clean up missed custom ResizingHandle tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -474,12 +474,6 @@ class DrawerDemoController: DemoController {
         drawer.contentScrollView = personaListView
     }
 
-    private class CustomResizingHandleTokens: ResizingHandleTokens {
-        override var backgroundColor: DynamicColor {
-            return Colors.navigationBarBackground.dynamicColor ?? super.backgroundColor
-        }
-    }
-
     @objc private func handleScreenEdgePan(gesture: UIScreenEdgePanGestureRecognizer) {
         guard gesture.state == .began else {
             return


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Missed these when I was trying to undo adding them in the #966 

### Verification
Built and launched test app, everything is still working as expected

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/988)