### PR TITLE
[vNext Tokens] Re-tokenizing TabBar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -237,11 +237,11 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
     }
 
     private class PerControlOverrideTabBarItemTokens: TabBarTokens {
-        override var tabBarItemTitleLabelPortrait: FontInfo? {
+        override var tabBarItemTitleLabelFontPortrait: FontInfo? {
             return .init(size: 15, weight: .bold)
         }
 
-        override var tabBarItemTitleLabelLandscape: FontInfo? {
+        override var tabBarItemTitleLabelFontLandscape: FontInfo? {
             return .init(size: 15, weight: .bold)
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -222,13 +222,13 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
 
     // MARK: - Custom tokens
     private class ThemeWideOverrideTabBarTokens: TabBarTokens {
-        override var selectedColor: DynamicColor {
+        override var tabBarItemSelectedColor: DynamicColor {
             return .init(light: globalTokens.sharedColors[.burgundy][.tint10],
                          lightHighContrast: globalTokens.sharedColors[.pumpkin][.tint10],
                          dark: globalTokens.sharedColors[.darkTeal][.tint40],
                          darkHighContrast: globalTokens.sharedColors[.teal][.tint40])
         }
-        override var unselectedColor: DynamicColor {
+        override var tabBarItemUnselectedColor: DynamicColor {
             return .init(light: globalTokens.sharedColors[.darkTeal][.tint20],
                          lightHighContrast: globalTokens.sharedColors[.teal][.tint40],
                          dark: globalTokens.sharedColors[.pumpkin][.tint40],
@@ -237,27 +237,11 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
     }
 
     private class PerControlOverrideTabBarItemTokens: TabBarTokens {
-        override var portraitImageSize: CGFloat {
-            return 14.0
+        override var tabBarItemTitleLabelPortrait: FontInfo? {
+            return .init(size: 15, weight: .bold)
         }
 
-        override var portraitImageWithLabelSize: CGFloat {
-            return 14.0
-        }
-
-        override var landscapeImageSize: CGFloat {
-            return 14.0
-        }
-
-        override var phonePortraitHeight: CGFloat {
-            return 35.0
-        }
-
-        override var phoneLandscapeHeight: CGFloat {
-            return 35.0
-        }
-
-        override var titleLabelPortrait: FontInfo {
+        override var tabBarItemTitleLabelLandscape: FontInfo? {
             return .init(size: 15, weight: .bold)
         }
     }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		C708B064260A87F7007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04EE25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
+		D64D8E10283BFAEC00D8D7D1 /* TabBarItemTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64D8E0F283BFAEC00D8D7D1 /* TabBarItemTokens.swift */; };
 		D6A0124A2810764B00C90535 /* TabBarTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A012492810764B00C90535 /* TabBarTokens.swift */; };
 		D6F4098927470E7F001B80D4 /* PillButtonTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F4098827470E7F001B80D4 /* PillButtonTokens.swift */; };
 		D6F4098F274F1A1C001B80D4 /* PillButtonBarTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F4098E274F1A1C001B80D4 /* PillButtonBarTokens.swift */; };
@@ -391,6 +392,7 @@
 		C77A04B625F03DD1001B3EB6 /* String+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		D64D8E0F283BFAEC00D8D7D1 /* TabBarItemTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemTokens.swift; sourceTree = "<group>"; };
 		D6A012492810764B00C90535 /* TabBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarTokens.swift; sourceTree = "<group>"; };
 		D6F4098827470E7F001B80D4 /* PillButtonTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonTokens.swift; sourceTree = "<group>"; };
 		D6F4098E274F1A1C001B80D4 /* PillButtonBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarTokens.swift; sourceTree = "<group>"; };
@@ -561,6 +563,7 @@
 			children = (
 				7D0931C224AAAC8C0072458A /* SideTabBar.swift */,
 				118D9847230BBA2300BC0B72 /* TabBarItem.swift */,
+				D64D8E0F283BFAEC00D8D7D1 /* TabBarItemTokens.swift */,
 				1168630222E131CF0088B302 /* TabBarItemView.swift */,
 				D6A012492810764B00C90535 /* TabBarTokens.swift */,
 				1168630322E131CF0088B302 /* TabBarView.swift */,
@@ -1630,6 +1633,7 @@
 				5314E0A825F010070099271A /* DrawerPresentationController.swift in Sources */,
 				43488C46270FAD1300124C71 /* FluentNotification.swift in Sources */,
 				5314E06425F00EFD0099271A /* CalendarViewMonthBannerView.swift in Sources */,
+				D64D8E10283BFAEC00D8D7D1 /* TabBarItemTokens.swift in Sources */,
 				5314E18E25F0195C0099271A /* ShimmerLinesView.swift in Sources */,
 				53097D172702890900A6E4DC /* HeaderTokens.swift in Sources */,
 				EC02A5F5274DD19600E81B3E /* MSFDivider.swift in Sources */,

--- a/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,23 +1,25 @@
 {
-  "pins" : [
-    {
-      "identity" : "appcenter-sdk-apple",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
-      "state" : {
-        "revision" : "25f64229373de97ff3920941cd52203193e5d8be",
-        "version" : "4.3.0"
+  "object": {
+    "pins": [
+      {
+        "package": "AppCenter",
+        "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
+        "state": {
+          "branch": null,
+          "revision": "8354a50fe01a7e54e196d3b5493b5ab53dd5866a",
+          "version": "4.4.2"
+        }
+      },
+      {
+        "package": "PLCrashReporter",
+        "repositoryURL": "https://github.com/microsoft/PLCrashReporter.git",
+        "state": {
+          "branch": null,
+          "revision": "6b27393cad517c067dceea85fadf050e70c4ceaa",
+          "version": "1.10.1"
+        }
       }
-    },
-    {
-      "identity" : "plcrashreporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/PLCrashReporter.git",
-      "state" : {
-        "revision" : "59513acde6194d93617afcf7b2c81c88638a6af2",
-        "version" : "1.10.0"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "AppCenter",
-        "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
-        "state": {
-          "branch": null,
-          "revision": "8354a50fe01a7e54e196d3b5493b5ab53dd5866a",
-          "version": "4.4.2"
-        }
-      },
-      {
-        "package": "PLCrashReporter",
-        "repositoryURL": "https://github.com/microsoft/PLCrashReporter.git",
-        "state": {
-          "branch": null,
-          "revision": "6b27393cad517c067dceea85fadf050e70c4ceaa",
-          "version": "1.10.1"
-        }
+  "pins" : [
+    {
+      "identity" : "appcenter-sdk-apple",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
+      "state" : {
+        "revision" : "25f64229373de97ff3920941cd52203193e5d8be",
+        "version" : "4.3.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/PLCrashReporter.git",
+      "state" : {
+        "revision" : "59513acde6194d93617afcf7b2c81c88638a6af2",
+        "version" : "1.10.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/ios/FluentUI/Tab Bar/TabBarItemTokens.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokens.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Internal design token set for the `TabBarItem`.
+class TabBarItemTokens: ControlTokens {
+    /// Defines the background color of the  of the `TabBarItem` when selected.
+    open var selectedColor: DynamicColor {
+        return aliasTokens.foregroundColors[.brandRest]
+    }
+
+    /// Defines the background color of the  of the `TabBarItem` when not selected.
+    open var unselectedColor: DynamicColor {
+        DynamicColor(light: ColorValue(0x6E6E6E) /* gray500 */,
+                     lightHighContrast: ColorValue(0x303030) /* gray700 */,
+                     dark: ColorValue(0x919191) /* gray400 */,
+                     darkHighContrast: ColorValue(0xC8C8C8) /* gray200 */)
+    }
+
+    /// The vertical spacing of the `TabBarItem` within the TabBar
+    open var spacingVertical: CGFloat { 3.0 }
+
+    /// The horizontal spacing of the `TabBarItem` within the TabBar
+    open var spacingHorizontal: CGFloat { globalTokens.spacing[.xSmall] }
+
+    /// The size of the image associated with the `TabBarItem` when the device is in portrait mode
+    open var portraitImageSize: CGFloat { globalTokens.iconSize[.large] }
+
+    /// The size of the image associated with the `TabBarItem` when the device is in portrait mode and has a label
+    open var portraitImageWithLabelSize: CGFloat { globalTokens.iconSize[.medium] }
+
+    /// The size of the image associated with the `TabBarItem` when the device is in landscape mode
+    open var landscapeImageSize: CGFloat { globalTokens.iconSize[.medium] }
+
+    /// The vertical offset of the `Badge` associated with this `TabBarItem`
+    open var badgeVerticalOffset: CGFloat { -globalTokens.spacing[.xxSmall] }
+
+    /// The vertical offset of the `BadgeLabel` associated with this `TabBarItem` when the device is in portrait mode
+    open var badgePortraitTitleVerticalOffset: CGFloat { -globalTokens.spacing[.xxxSmall] }
+
+    /// The horizontal offset of the `BadgeLabel` associated with this `TabBarItem` when the bade value is a single digit
+    open var singleDigitBadgeHorizontalOffset: CGFloat { 14.0 }
+
+    /// The horizontal offset of the `BadgeLabel` associated with this `TabBarItem` when the bade value is multiple digits
+    open var multiDigitBadgeHorizontalOffset: CGFloat { globalTokens.spacing[.small] }
+
+    /// The  height of the `BadgeLabel` associated with this `TabBarItem`
+    open var badgeHeight: CGFloat { 16.0 }
+
+    /// The minimum width of the `BadgeLabel` associated with this `TabBarItem`
+    open var badgeMinWidth: CGFloat { 16.0 }
+
+    /// The default maximum width of the `BadgeLabel` associated with this `TabBarItem`, if not otherwise overridden
+    open var defaultBadgeMaxWidth: CGFloat { 42.0 }
+
+    /// The width of the `BadgeLabel` border
+    open var badgeBorderWidth: CGFloat { globalTokens.borderSize[.thick] }
+
+    /// The horizontal padding for the `BadgeLabel`
+    open var badgeHorizontalPadding: CGFloat { 10.0 }
+
+    /// The radii of the four corners of the `BadgeLabel`
+    open var badgeCornerRadii: CGFloat { 10.0 }
+
+    /// Font info for the title label when in portrait view
+    open var titleLabelPortrait: FontInfo { return .init(size: 10, weight: .medium) }
+
+    /// Font info for the title label when in landscape view
+    open var titleLabelLandscape: FontInfo { return .init(size: 13, weight: .medium) }
+}

--- a/ios/FluentUI/Tab Bar/TabBarItemTokens.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokens.swift
@@ -66,8 +66,8 @@ class TabBarItemTokens: ControlTokens {
     open var badgeCornerRadii: CGFloat { 10.0 }
 
     /// Font info for the title label when in portrait view
-    open var titleLabelPortrait: FontInfo { return .init(size: 10, weight: .medium) }
+    open var titleLabelFontPortrait: FontInfo { return .init(size: 10, weight: .medium) }
 
     /// Font info for the title label when in landscape view
-    open var titleLabelLandscape: FontInfo { return .init(size: 13, weight: .medium) }
+    open var titleLabelFontLandscape: FontInfo { return .init(size: 13, weight: .medium) }
 }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -6,15 +6,16 @@
 import UIKit
 
 class TabBarItemView: UIControl, TokenizedControlInternal {
-    public func overrideTokens(_ tokens: TabBarTokens?) -> Self {
+    public func overrideTokens(_ tokens: TabBarItemTokens?) -> Self {
         overrideTokens = tokens
         return self
     }
+
     let item: TabBarItem
 
-    var defaultTokens: TabBarTokens = .init()
-    var tokens: TabBarTokens = .init()
-    var overrideTokens: TabBarTokens? {
+    var defaultTokens: TabBarItemTokens = .init()
+    var tokens: TabBarItemTokens = .init()
+    var overrideTokens: TabBarItemTokens? {
         didSet {
             updateTabBarItemTokens()
             updateColors()

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -258,7 +258,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         if isInPortraitMode {
             container.axis = .vertical
             container.spacing = tokens.spacingVertical
-            titleLabel.font = UIFont.fluent(tokens.titleLabelPortrait, shouldScale: false)
+            titleLabel.font = UIFont.fluent(tokens.titleLabelFontPortrait, shouldScale: false)
 
             if canResizeImage {
                 suggestImageSize = titleLabel.isHidden ? tokens.portraitImageSize : tokens.portraitImageWithLabelSize
@@ -266,7 +266,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         } else {
             container.axis = .horizontal
             container.spacing = tokens.spacingHorizontal
-            titleLabel.font = UIFont.fluent(tokens.titleLabelLandscape, shouldScale: false)
+            titleLabel.font = UIFont.fluent(tokens.titleLabelFontLandscape, shouldScale: false)
             if canResizeImage {
                  suggestImageSize = tokens.landscapeImageSize
             }

--- a/ios/FluentUI/Tab Bar/TabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/TabBarTokens.swift
@@ -23,8 +23,8 @@ open class TabBarTokens: ControlTokens {
     open var tabBarItemUnselectedColor: DynamicColor? { nil }
 
     /// Font info for the title label when in portrait view
-    open var tabBarItemTitleLabelPortrait: FontInfo? { nil }
+    open var tabBarItemTitleLabelFontPortrait: FontInfo? { nil }
 
     /// Font info for the title label when in landscape view
-    open var tabBarItemTitleLabelLandscape: FontInfo? { nil }
+    open var tabBarItemTitleLabelFontLandscape: FontInfo? { nil }
 }

--- a/ios/FluentUI/Tab Bar/TabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/TabBarTokens.swift
@@ -17,66 +17,14 @@ open class TabBarTokens: ControlTokens {
     open var padHeight: CGFloat { 48.0 }
 
     /// Defines the background color of the  of the `TabBarItem` when selected.
-    open var selectedColor: DynamicColor {
-        return aliasTokens.foregroundColors[.brandRest]
-    }
+    open var tabBarItemSelectedColor: DynamicColor? { nil }
 
     /// Defines the background color of the  of the `TabBarItem` when not selected.
-    open var unselectedColor: DynamicColor {
-        DynamicColor(light: ColorValue(0x6E6E6E) /* gray500 */,
-                     lightHighContrast: ColorValue(0x303030) /* gray700 */,
-                     dark: ColorValue(0x919191) /* gray400 */,
-                     darkHighContrast: ColorValue(0xC8C8C8) /* gray200 */)
-    }
-
-    /// The vertical spacing of the `TabBarItem` within the TabBar
-    open var spacingVertical: CGFloat { 3.0 }
-
-    /// The horizontal spacing of the `TabBarItem` within the TabBar
-    open var spacingHorizontal: CGFloat { globalTokens.spacing[.xSmall] }
-
-    /// The size of the image associated with the `TabBarItem` when the device is in portrait mode
-    open var portraitImageSize: CGFloat { globalTokens.iconSize[.large] }
-
-    /// The size of the image associated with the `TabBarItem` when the device is in portrait mode and has a label
-    open var portraitImageWithLabelSize: CGFloat { globalTokens.iconSize[.medium] }
-
-    /// The size of the image associated with the `TabBarItem` when the device is in landscape mode
-    open var landscapeImageSize: CGFloat { globalTokens.iconSize[.medium] }
-
-    /// The vertical offset of the `Badge` associated with this `TabBarItem`
-    open var badgeVerticalOffset: CGFloat { -globalTokens.spacing[.xxSmall] }
-
-    /// The vertical offset of the `BadgeLabel` associated with this `TabBarItem` when the device is in portrait mode
-    open var badgePortraitTitleVerticalOffset: CGFloat { -globalTokens.spacing[.xxxSmall] }
-
-    /// The horizontal offset of the `BadgeLabel` associated with this `TabBarItem` when the bade value is a single digit
-    open var singleDigitBadgeHorizontalOffset: CGFloat { 14.0 }
-
-    /// The horizontal offset of the `BadgeLabel` associated with this `TabBarItem` when the bade value is multiple digits
-    open var multiDigitBadgeHorizontalOffset: CGFloat { globalTokens.spacing[.small] }
-
-    /// The  height of the `BadgeLabel` associated with this `TabBarItem`
-    open var badgeHeight: CGFloat { 16.0 }
-
-    /// The minimum width of the `BadgeLabel` associated with this `TabBarItem`
-    open var badgeMinWidth: CGFloat { 16.0 }
-
-    /// The default maximum width of the `BadgeLabel` associated with this `TabBarItem`, if not otherwise overridden
-    open var defaultBadgeMaxWidth: CGFloat { 42.0 }
-
-    /// The width of the `BadgeLabel` border
-    open var badgeBorderWidth: CGFloat { globalTokens.borderSize[.thick] }
-
-    /// The horizontal padding for the `BadgeLabel`
-    open var badgeHorizontalPadding: CGFloat { 10.0 }
-
-    /// The radii of the four corners of the `BadgeLabel`
-    open var badgeCornerRadii: CGFloat { 10.0 }
+    open var tabBarItemUnselectedColor: DynamicColor? { nil }
 
     /// Font info for the title label when in portrait view
-    open var titleLabelPortrait: FontInfo { return .init(size: 10, weight: .medium) }
+    open var tabBarItemTitleLabelPortrait: FontInfo? { nil }
 
     /// Font info for the title label when in landscape view
-    open var titleLabelLandscape: FontInfo { return .init(size: 13, weight: .medium) }
+    open var tabBarItemTitleLabelLandscape: FontInfo? { nil }
 }

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -191,13 +191,43 @@ open class TabBarView: UIView, TokenizedControlInternal {
         }
     }
 
+    private class CustomTabBarItemTokens: TabBarItemTokens {
+        var tabBarTokens: TabBarTokens = .init()
+
+        required init() {
+            super.init()
+        }
+
+        init (tabBarTokens: TabBarTokens) {
+            self.tabBarTokens = tabBarTokens
+            super.init()
+        }
+
+        override var selectedColor: DynamicColor {
+            tabBarTokens.tabBarItemSelectedColor ?? super.selectedColor
+        }
+
+        override var unselectedColor: DynamicColor {
+            tabBarTokens.tabBarItemUnselectedColor ?? super.unselectedColor
+        }
+
+        override var titleLabelPortrait: FontInfo {
+            tabBarTokens.tabBarItemTitleLabelPortrait ?? super.titleLabelPortrait
+        }
+
+        override var titleLabelLandscape: FontInfo {
+            tabBarTokens.tabBarItemTitleLabelLandscape ?? super.titleLabelLandscape
+        }
+
+    }
+
     private func updateTabBarTokens() {
         tokens = resolvedTokens
 
         let arrangedSubviews = stackView.arrangedSubviews
         for subview in arrangedSubviews {
             if let tabBarItemView = subview as? TabBarItemView {
-                tabBarItemView.overrideTokens = tokens
+                tabBarItemView.overrideTokens = CustomTabBarItemTokens.init(tabBarTokens: tokens)
             }
         }
     }

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -192,10 +192,11 @@ open class TabBarView: UIView, TokenizedControlInternal {
     }
 
     private class CustomTabBarItemTokens: TabBarItemTokens {
-        var tabBarTokens: TabBarTokens = .init()
+        var tabBarTokens: TabBarTokens
 
+        @available(*, unavailable)
         required init() {
-            super.init()
+            preconditionFailure("init() has not been implemented")
         }
 
         init (tabBarTokens: TabBarTokens) {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -211,12 +211,12 @@ open class TabBarView: UIView, TokenizedControlInternal {
             tabBarTokens.tabBarItemUnselectedColor ?? super.unselectedColor
         }
 
-        override var titleLabelPortrait: FontInfo {
-            tabBarTokens.tabBarItemTitleLabelPortrait ?? super.titleLabelPortrait
+        override var titleLabelFontPortrait: FontInfo {
+            tabBarTokens.tabBarItemTitleLabelFontPortrait ?? super.titleLabelFontPortrait
         }
 
-        override var titleLabelLandscape: FontInfo {
-            tabBarTokens.tabBarItemTitleLabelLandscape ?? super.titleLabelLandscape
+        override var titleLabelFontLandscape: FontInfo {
+            tabBarTokens.tabBarItemTitleLabelFontLandscape ?? super.titleLabelFontLandscape
         }
 
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change demonstrates the new strategy for handling tokenization of compound controls, where the "contained" control(s) is/are internal only. We expose only a small subset of tokens of the internal control to the public, via special nil-able values in the containing control's token set, which then sets the internal, private control's token set via a custom derived token class. This allows the public to change a subset of tokens, while still allowing our token system, and hence designers, to still have full control and access to all tokens of the internal class.

### Verification

Manually tested via Simulator.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![TokenizeTabBarAfter](https://user-images.githubusercontent.com/23249106/169892445-dba00147-a02b-43d6-89b0-1598a1cb062f.gif) | ![ReTokenizeTabBar](https://user-images.githubusercontent.com/23249106/169894080-d8569b00-4b0a-4989-b9f6-420cd88b2250.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/990)