### PR TITLE
Update SegmentedControl to support images

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -9,7 +9,7 @@ import UIKit
 class SegmentedControlDemoController: DemoController {
     let segmentItems: [SegmentItem] = [
         SegmentItem(title: "First"),
-        SegmentItem(title: "Second"),
+        SegmentItem(title: "Second", image: UIImage(named: "Placeholder_20")),
         SegmentItem(title: "Third", isUnread: true),
         SegmentItem(title: "Fourth")
     ]

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -22,7 +22,7 @@ public class SegmentItem: NSObject {
    }
 
     @objc public convenience init(title: String, isUnread: Bool = false) {
-        self.init(title: title, isUnread: isUnread)
+        self.init(title: title, image: nil, isUnread: isUnread)
     }
 
     @objc public init(title: String,

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -3,11 +3,14 @@
 //  Licensed under the MIT License.
 //
 import Foundation
+import UIKit
 
 /// Used for SegmentedControl array of views
 @objc(MSFSegmentItem)
 public class SegmentItem: NSObject {
     public let title: String
+    public let image: UIImage?
+    public let isTemplateImage: Bool
 
     /// This value will determine whether or not to show dot next to the pill button label
     public var isUnread: Bool {
@@ -18,8 +21,13 @@ public class SegmentItem: NSObject {
        }
    }
 
-    @objc public init(title: String, isUnread: Bool = false) {
+    @objc public init(title: String,
+                      image: UIImage? = nil,
+                      isTemplateImage: Bool = true,
+                      isUnread: Bool = false) {
         self.title = title
+        self.image = image
+        self.isTemplateImage = isTemplateImage
         self.isUnread = isUnread
         super.init()
     }

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -20,12 +20,21 @@ public class SegmentItem: NSObject {
        }
    }
 
+    /// Creates a new instance of a `SegmentItem` that holds data used to create a segment in the `SegmentedControl`.
+    /// - Parameters
+    ///   - title: Title that will be displayed by the segment and used as the accessibility label and large content viewer title.
+    ///   - isUnread:  Whether the segment shows the mark that represents the "unread" state.
     @objc public convenience init(title: String, isUnread: Bool = false) {
         self.init(title: title,
                   image: nil,
                   isUnread: isUnread)
     }
 
+    /// Creates a new instance of a `SegmentItem` that holds data used to create a segment in the `SegmentedControl`.
+    /// - Parameters
+    ///   - title: Title that will be displayed by the segment if the image is nil, and used as the accessibility label and large content viewer title.
+    ///   - image: Image that will display instead of the title if not nil.
+    ///   - isUnread:  Whether the segment shows the mark that represents the "unread" state.
     @objc public init(title: String,
                       image: UIImage? = nil,
                       isUnread: Bool = false) {

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -21,6 +21,10 @@ public class SegmentItem: NSObject {
        }
    }
 
+    @objc public convenience init(title: String, isUnread: Bool = false) {
+        self.init(title: title, isUnread: isUnread)
+    }
+
     @objc public init(title: String,
                       image: UIImage? = nil,
                       isTemplateImage: Bool = true,

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -10,7 +10,6 @@ import UIKit
 public class SegmentItem: NSObject {
     public let title: String
     public let image: UIImage?
-    public let isTemplateImage: Bool
 
     /// This value will determine whether or not to show dot next to the pill button label
     public var isUnread: Bool {
@@ -22,16 +21,16 @@ public class SegmentItem: NSObject {
    }
 
     @objc public convenience init(title: String, isUnread: Bool = false) {
-        self.init(title: title, image: nil, isUnread: isUnread)
+        self.init(title: title,
+                  image: nil,
+                  isUnread: isUnread)
     }
 
     @objc public init(title: String,
                       image: UIImage? = nil,
-                      isTemplateImage: Bool = true,
                       isUnread: Bool = false) {
         self.title = title
         self.image = image
-        self.isTemplateImage = isTemplateImage
         self.isUnread = isUnread
         super.init()
     }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -35,10 +35,10 @@ class SegmentPillButton: UIButton {
         self.contentEdgeInsets = Constants.insets
 
         let title = item.title
-        self.accessibilityLabel = title
-        self.largeContentTitle = title
         if let image = item.image {
             self.setImage(image, for: .normal)
+            self.accessibilityLabel = title
+            self.largeContentTitle = title
         } else {
             self.setTitle(title, for: .normal)
         }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -38,7 +38,7 @@ class SegmentPillButton: UIButton {
         self.accessibilityLabel = title
         self.largeContentTitle = title
         if let image = item.image {
-            self.setImage(image.withRenderingMode(item.isTemplateImage ? .alwaysTemplate : .automatic), for: .normal)
+            self.setImage(image, for: .normal)
         } else {
             self.setTitle(title, for: .normal)
         }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -35,9 +35,13 @@ class SegmentPillButton: UIButton {
         self.contentEdgeInsets = Constants.insets
 
         let title = item.title
-        self.setTitle(title, for: .normal)
         self.accessibilityLabel = title
         self.largeContentTitle = title
+        if let image = item.image {
+            self.setImage(image.withRenderingMode(item.isTemplateImage ? .alwaysTemplate : .automatic), for: .normal)
+        } else {
+            self.setTitle(title, for: .normal)
+        }
         self.showsLargeContentViewer = true
         self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -284,7 +284,7 @@ open class SegmentedControl: UIControl {
 
         pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(for: window) : style.selectionColorDisabled)
         backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(for: window) : style.backgroundColorDisabled(for: window))
-        let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(for: window)) : style.segmentTextColorDisabled(for: window)
+        let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(for: window)) : style.segmentTextColorSelectedAndDisabled(for: window)
         for maskedLabel in pillMaskedLabels {
             guard let maskedLabel = maskedLabel else {
                 continue

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -125,6 +125,7 @@ open class SegmentedControl: UIControl {
         static let selectionBarHeight: CGFloat = 1.5
         static let pillContainerHorizontalInset: CGFloat = 16
         static let pillButtonCornerRadius: CGFloat = 16
+        static let iPadMinimumWidth: CGFloat = 375
     }
 
     open override var isEnabled: Bool {
@@ -469,7 +470,7 @@ open class SegmentedControl: UIControl {
             let windowSafeAreaInsets = window.safeAreaInsets
             let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
             if traitCollection.userInterfaceIdiom == .pad {
-                maxButtonWidth = max(windowWidth / 2, 375.0)
+                maxButtonWidth = max(windowWidth / 2, Constants.iPadMinimumWidth)
             } else {
                 maxButtonWidth = windowWidth
             }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -404,13 +404,12 @@ open class SegmentedControl: UIControl {
     open override func layoutSubviews() {
         super.layoutSubviews()
 
-        if isAnimating {
+        guard let screen = window?.windowScene?.screen, !isAnimating else {
             return
         }
 
         var rightOffset: CGFloat = 0
         var leftOffset: CGFloat = 0
-        let screen = window?.windowScene?.screen ?? UIScreen.main
         for (index, button) in buttons.enumerated() {
             if shouldSetEqualWidthForSegments {
                 rightOffset = screen.roundToDevicePixels(CGFloat(index + 1) / CGFloat(buttons.count) * pillContainerView.frame.width)
@@ -442,10 +441,10 @@ open class SegmentedControl: UIControl {
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        guard let window = window else {
+        guard let window = window,
+              let screen = window.windowScene?.screen else {
             return CGSize.zero
         }
-        let screen = window.windowScene?.screen ?? UIScreen.main
         var maxButtonHeight: CGFloat = 0.0
         var maxButtonWidth: CGFloat = 0.0
         var buttonsWidth: CGFloat = 0.0


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Added an optional image to the SegmentedItem. If the image is set, we'll only display the image and not the text, but we'll still use the text for accessibility.
Changed pillMaskedLabelsContainerView's name to pillMaskedContentContainerView, since now it holds more than just labels.
Changed the maskedLabels array to be an array of optionals, since I'm also adding an array for the maskedImages, and we don't need the label/image that isn't being used.
Also updated the logic in sizeThatFits, since I was getting weird results where the window's layout guide was nil or something and just returning zero. (the before iPhone portrait picture shows what I'm talking about)
Moved some logic out of for loops, since there were a few places we were doing things every loop when it was never going to change during the loop.

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_images_iPad_before](https://user-images.githubusercontent.com/67026548/170371893-946ef669-6d01-4aca-8cd3-077e8c4278b7.png) | ![SegmentedControl_images_iPad_after](https://user-images.githubusercontent.com/67026548/170371903-072d85cc-b636-499b-9800-4544d9348652.png) |
| ![SegmentedControl_images_iPhone_before](https://user-images.githubusercontent.com/67026548/170371913-2f964d2e-3b6d-414d-8257-dd397f9ca81f.png) | ![SegmentedControl_images_iPhone_after](https://user-images.githubusercontent.com/67026548/170371922-c2034520-96bc-4ccd-8b2a-e465f6cc35ef.png) |
| ![SegmentedControl_images_iPhone_dark_before](https://user-images.githubusercontent.com/67026548/170583137-61e4ae2d-46e0-4162-bdf1-ffd5c75ae0da.png) | ![SegmentedControl_images_iPhone_dark_after](https://user-images.githubusercontent.com/67026548/170583152-c2e4c520-67e2-46f7-afa1-8fe50432d5b7.png) |
| ![SegmentedControl_images_iPhone_landscape_before](https://user-images.githubusercontent.com/67026548/170371928-8d394193-c1c6-43d3-8268-0579432a9993.png) | ![SegmentedControl_images_iPhone_landscape_after](https://user-images.githubusercontent.com/67026548/170371938-0e80c40f-3475-48da-9c89-168b28c5774e.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/992)