### PR TITLE
Fix sizing pass-through logic for `ControlHostingView`

### DIFF
--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -14,7 +14,19 @@ open class ControlHostingView: UIView {
         guard let hostedView = hostingController.view else {
             return super.intrinsicContentSize
         }
+
+        // Our desired size should always be the same as our hosted view.
         return hostedView.intrinsicContentSize
+    }
+
+    /// Asks the view to calculate and return the size that best fits the specified size.
+    @objc public override func sizeThatFits(_ size: CGSize) -> CGSize {
+        guard let hostedView = hostingController.view else {
+            return super.sizeThatFits(size)
+        }
+
+        // Our desired size should always be the same as our hosted view.
+        return hostedView.sizeThatFits(size)
     }
 
     /// Initializes and returns an instance of `ControlHostingContainer` that wraps `controlView`.
@@ -55,11 +67,6 @@ open class ControlHostingView: UIView {
 
         addSubview(hostedView)
         hostedView.translatesAutoresizingMaskIntoConstraints = false
-
-        // Initialize our frame with the hosted view's initial bounds so we don't start as a (0,0,0,0) view.
-        // Future updates will be handled by the autolayout constraints below.
-        hostedView.sizeToFit()
-        self.frame = hostedView.bounds
 
         let requiredConstraints = [
             hostedView.leadingAnchor.constraint(equalTo: leadingAnchor),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Reverting an earlier fix to an internal sizing issue, since it has unusual animation side-effects. Instead, simply allow clients to pass through their call to `sizeToFit()` by overriding `sizeThatFits(:)` to return the hosted view's value.

Original PR:
* #971

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/4934719/170602881-28a6194f-6aba-40af-8e40-1e503b6f6de3.gif) | ![After](https://user-images.githubusercontent.com/4934719/170602890-bd69b636-a3b1-46fc-b61c-0bd0c9c2864d.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/993)