### PR TITLE
[vNext Tokens] Update Button to use new iOS 15 large content viewer

### DIFF
--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -40,6 +40,30 @@ extension View {
             .onPreferenceChange(SizePreferenceKey.self,
                                 perform: action)
     }
+
+    /// Adds a large content viewer for the view
+    /// - Parameters
+    ///  - text: Optional String to display in the large content viewer.
+    ///  - image: Optional UIImage to display in the large content viewer.
+    /// - Returns: The modified view.
+    func showsLargeContentViewer(text: String?, image: UIImage?) -> AnyView {
+        if #available(iOS 15.0, *) {
+            if text != nil || image != nil {
+                return AnyView(self.accessibilityShowsLargeContentViewer({
+                    if let image = image {
+                        Image(uiImage: image)
+                    }
+                    if let text = text {
+                        Text(text)
+                    }
+                }))
+            }
+
+            return AnyView(self.accessibilityShowsLargeContentViewer())
+        }
+
+        return AnyView(self)
+    }
 }
 
 /// PreferenceKey that will store the measured size of the view

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -76,14 +76,7 @@ public struct FluentButton: View, ConfigurableTokenizedControl {
         @ViewBuilder
         var largeContentButton: some View {
             if #available(iOS 15.0, *), state.style.isFloatingStyle {
-                button.accessibilityShowsLargeContentViewer({
-                    if let image = state.image {
-                        Image(uiImage: image)
-                    }
-                    if let text = state.text {
-                        Text(text)
-                    }
-                })
+                button.showsLargeContentViewer(text: state.text, image: state.image)
             } else {
                 button
             }

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -64,11 +64,31 @@ public struct FluentButton: View, ConfigurableTokenizedControl {
     }
 
     public var body: some View {
-        Button(action: state.action, label: {})
-            .buttonStyle(FluentButtonStyle(state: state,
-                                           tokensLookup: { tokens }))
-            .disabled(state.disabled ?? false)
-            .frame(maxWidth: .infinity)
+        @ViewBuilder
+        var button: some View {
+            Button(action: state.action, label: {})
+                .buttonStyle(FluentButtonStyle(state: state,
+                                               tokensLookup: { tokens }))
+                .disabled(state.disabled ?? false)
+                .frame(maxWidth: .infinity)
+        }
+
+        @ViewBuilder
+        var largeContentButton: some View {
+            if #available(iOS 15.0, *), state.style.isFloatingStyle {
+                button.accessibilityShowsLargeContentViewer({
+                    if let image = state.image {
+                        Image(uiImage: image)
+                    }
+                    if let text = state.text {
+                        Text(text)
+                    }
+                })
+            } else {
+                button
+            }
+        }
+        return largeContentButton
     }
 }
 

--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -75,7 +75,7 @@ public struct FluentButton: View, ConfigurableTokenizedControl {
 
         @ViewBuilder
         var largeContentButton: some View {
-            if #available(iOS 15.0, *), state.style.isFloatingStyle {
+            if state.style.isFloatingStyle {
                 button.showsLargeContentViewer(text: state.text, image: state.image)
             } else {
                 button

--- a/ios/FluentUI/Vnext/Button/MSFButton.swift
+++ b/ios/FluentUI/Vnext/Button/MSFButton.swift
@@ -58,27 +58,10 @@ import UIKit
 
             strongSelf.action?(strongSelf)
         }
-        setupLargeContentViewer()
     }
 
     required public init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    private func setupLargeContentViewer() {
-        let largeContentViewerInteraction = UILargeContentViewerInteraction()
-        self.addInteraction(largeContentViewerInteraction)
-        largeContentViewerInteraction.gestureRecognizerForExclusionRelationship.delegate = self
-        self.scalesLargeContentImage = true
-        self.showsLargeContentViewer = state.style.isFloatingStyle
-
-        imagePropertySubscriber = stateImpl.$image.sink { buttonImage in
-            self.largeContentImage = buttonImage
-        }
-
-        textPropertySubscriber = stateImpl.$text.sink { buttonText in
-            self.largeContentTitle = buttonText
-        }
     }
 
     private var textPropertySubscriber: AnyCancellable?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Removed our old UIKit large content viewer work around and added a new SwiftUI View modifier that will add a large content viewer with the provided text and image

### Verification

I was really struggling to get the large content viewer to even show up without the changes, so this change also made the large content viewer more reliable (in iOS 15.0+)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Button_largeContentViewer_before](https://user-images.githubusercontent.com/67026548/170794867-71b4ee8b-f522-4e15-911a-dc025b60f5cf.gif) | ![Button_largeContentViewer_after](https://user-images.githubusercontent.com/67026548/170794876-4dd3f1e2-0cad-49db-a5eb-1230e3abbcce.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)