### PR TITLE
Fix bottom commanding dismissing VCs it doesn't own

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -294,6 +294,8 @@ open class BottomCommandingController: UIViewController {
 
         // Make sure we only reset our commanding style on iPad. On iPhone we only use the sheet style, so there's no need for unnecessary work.
         if newCollection.horizontalSizeClass != traitCollection.horizontalSizeClass && newCollection.userInterfaceIdiom == .pad {
+            dismissPresentedPopoverIfNeeded(with: .noUserAction, animated: false)
+
             // On a horizontal size class change the top level sheet / bar surfaces get recreated,
             // but the item views, containers and bindings persist and are reused during the individual setup functions.
             if let bottomSheetController = bottomSheetController {
@@ -318,18 +320,6 @@ open class BottomCommandingController: UIViewController {
 
     public override func viewSafeAreaInsetsDidChange() {
         updateSheetHeaderSizingParameters()
-    }
-
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-        if presentedViewController != nil {
-            dismiss(animated: false) { [weak self] in
-                guard let strongSelf = self else {
-                    return
-                }
-                strongSelf.delegate?.bottomCommandingController?(strongSelf, didDismissPopoverWith: .noUserAction)
-            }
-        }
     }
 
     private func setupCommandingLayout(traitCollection: UITraitCollection, forceLayoutPass: Bool = false) {
@@ -566,6 +556,7 @@ open class BottomCommandingController: UIViewController {
                 }
                 strongSelf.delegate?.bottomCommandingController?(strongSelf, didPresentPopoverWith: .moreButtonTap)
             }
+            presentedPopoverContentViewController = popoverContentViewController
         }
     }
 
@@ -577,6 +568,18 @@ open class BottomCommandingController: UIViewController {
             }
             if isFinished {
                 strongSelf.delegate?.bottomCommandingController?(strongSelf, sheetDidMoveTo: targetState, commandingInteraction: commandingInteraction, sheetInteraction: .noUserAction)
+            }
+        }
+    }
+
+    private func dismissPresentedPopoverIfNeeded(with interaction: BottomCommandingInteraction, animated: Bool) {
+        if let presentedViewController = presentedViewController, presentedViewController == presentedPopoverContentViewController {
+            dismiss(animated: animated) { [weak self] in
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.presentedPopoverContentViewController = nil
+                strongSelf.delegate?.bottomCommandingController?(strongSelf, didDismissPopoverWith: interaction)
             }
         }
     }
@@ -799,6 +802,8 @@ open class BottomCommandingController: UIViewController {
         isInSheetMode ? bottomSheetController?.view : bottomBarView
     }
 
+    private var presentedPopoverContentViewController: UIViewController?
+
     private var isTableViewLoaded: Bool = false
 
     private var isInSheetMode: Bool { bottomSheetController != nil }
@@ -955,14 +960,7 @@ extension BottomCommandingController: UITableViewDelegate {
         }
 
         if !binding.item.isToggleable {
-            if presentedViewController != nil {
-                dismiss(animated: true) { [weak self] in
-                    guard let strongSelf = self else {
-                        return
-                    }
-                    strongSelf.delegate?.bottomCommandingController?(strongSelf, didDismissPopoverWith: .commandTap)
-                }
-            }
+            dismissPresentedPopoverIfNeeded(with: .commandTap, animated: true)
             setSheetIsExpanded(to: false, commandingInteraction: .commandTap)
             binding.item.action?(binding.item)
         }
@@ -1044,6 +1042,7 @@ extension BottomCommandingController: BottomSheetControllerDelegate {
 
 extension BottomCommandingController: UIPopoverPresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        presentedPopoverContentViewController = nil
         delegate?.bottomCommandingController?(self, didDismissPopoverWith: .otherUserAction)
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Bottom commanding tries to dismiss any popover it presented when screen size / horizontal size class changes. I was using `presentedViewController` to check if a popover is presented, but I wasn't aware this will also include VCs presented by **any ancestor**. This causes bottom commanding to dismiss VCs it doesn't own on screen rotation, even full screen modals.

Changes in this PR:
- Only dismiss when we actually need it - iPad size class changes, not any size change.
- Keep a reference to the currently presented popover content and double check that is what we're dismissing.

### Verification

Manual bug repro, no repro after fix.
Show alert dialog - rotate screen, resize window - no alert dismissal.
Verify dismissals don't happen on iPhone rotation.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/995)