### PR TITLE
[vNext Tokens] SideTabBar Tokenization

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -168,13 +168,22 @@ class DemoController: UIViewController {
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "ic_fluent_settings_24_regular"),
                                                             style: .plain,
                                                             target: self,
-                                                            action: #selector(showAppearancePopover))
+                                                            action: #selector(showAppearancePopover(_:)))
     }
 
-    @objc func showAppearancePopover(_ sender: UIBarButtonItem) {
-        appearanceController.popoverPresentationController?.barButtonItem = sender
+    @objc func showAppearancePopover(_ sender: AnyObject, presenter: UIViewController) {
+        if let barButtonItem = sender as? UIBarButtonItem {
+            appearanceController.popoverPresentationController?.barButtonItem = barButtonItem
+        } else if let sourceView = sender as? UIView {
+            appearanceController.popoverPresentationController?.sourceView = sourceView
+            appearanceController.popoverPresentationController?.sourceRect = sourceView.bounds
+        }
         appearanceController.popoverPresentationController?.delegate = self
-        self.present(appearanceController, animated: true, completion: nil)
+        presenter.present(appearanceController, animated: true, completion: nil)
+    }
+
+    @objc func showAppearancePopover(_ sender: AnyObject) {
+        showAppearancePopover(sender, presenter: self)
     }
 
     private lazy var appearanceController: DemoAppearanceController = .init(delegate: self as? DemoAppearanceDelegate)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -36,6 +36,7 @@ struct Demos {
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
         DemoDescriptor("PillButtonBar", PillButtonBarDemoController.self),
         DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
+        DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TabBarView", TabBarViewDemoController.self)
     ]
 
@@ -56,7 +57,6 @@ struct Demos {
         DemoDescriptor("PopupMenuController", PopupMenuDemoController.self),
         DemoDescriptor("SearchBar", SearchBarDemoController.self),
         DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
-        DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
         DemoDescriptor("TableViewCellFileAccessoryView", TableViewCellFileAccessoryViewDemoController.self),
         DemoDescriptor("TableViewCellShimmer", TableViewCellShimmerDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -315,6 +315,59 @@ extension SideTabBarDemoController: UITableViewDataSource {
     }
 }
 
+// MARK: - SideTabBarDemoController: DemoAppearanceDelegate
+extension SideTabBarDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        var tokensClosure: ((SideTabBar) -> SideTabBarTokens)?
+        if isOverrideEnabled {
+            tokensClosure = { _ in
+                return ThemeWideOverrideSideTabBarTokens()
+            }
+        }
+
+        fluentTheme.register(controlType: SideTabBar.self, tokens: tokensClosure)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        let tokens = (isOverrideEnabled ? PerControlOverrideSideTabBarItemTokens() : nil)
+        _ = sideTabBar.overrideTokens(tokens)
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokenOverride(for: SideTabBar.self) != nil
+    }
+
+    // MARK: - Custom tokens
+    private class ThemeWideOverrideSideTabBarTokens: SideTabBarTokens {
+        override var tabBarItemSelectedColor: DynamicColor {
+            return .init(light: globalTokens.sharedColors[.burgundy][.tint10],
+                         lightHighContrast: globalTokens.sharedColors[.pumpkin][.tint10],
+                         dark: globalTokens.sharedColors[.darkTeal][.tint40],
+                         darkHighContrast: globalTokens.sharedColors[.teal][.tint40])
+        }
+        override var tabBarItemUnselectedColor: DynamicColor {
+            return .init(light: globalTokens.sharedColors[.darkTeal][.tint20],
+                         lightHighContrast: globalTokens.sharedColors[.teal][.tint40],
+                         dark: globalTokens.sharedColors[.pumpkin][.tint40],
+                         darkHighContrast: globalTokens.sharedColors[.burgundy][.tint40])
+        }
+    }
+
+    private class PerControlOverrideSideTabBarItemTokens: SideTabBarTokens {
+        override var tabBarItemTitleLabelFontPortrait: FontInfo? {
+            return .init(size: 15, weight: .bold)
+        }
+
+        override var tabBarItemTitleLabelFontLandscape: FontInfo? {
+            return .init(size: 15, weight: .bold)
+        }
+    }
+}
+
 extension SideTabBarDemoController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
        return false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -231,6 +231,14 @@ class SideTabBarDemoController: DemoController {
         updateBadgeNumbers()
     }
 
+    /// Custom presentation logic to let `contentViewController` present the appearance popover.
+    @objc private func showAppearancePopoverLocal(_ sender: AnyObject) {
+        guard let contentViewController = contentViewController else {
+            return
+        }
+        super.showAppearancePopover(sender, presenter: contentViewController)
+    }
+
     private let optionsCellItems: [CellItem] = {
         return [CellItem(title: "Show Avatar View", type: .boolean, action: #selector(toggleAvatarView(_:)), isOn: true),
                 CellItem(title: "Show top item titles", type: .boolean, action: #selector(toggleShowTopItemTitles(_:))),
@@ -239,7 +247,8 @@ class SideTabBarDemoController: DemoController {
                 CellItem(title: "Use higher badge numbers", type: .boolean, action: #selector(toggleUseHigherBadgeNumbers(_:))),
                 CellItem(title: "Modify badge numbers", type: .stepper, action: nil),
                 CellItem(title: "Show tooltip for Home button", type: .action, action: #selector(showTooltipForHomeButton)),
-                CellItem(title: "Dismiss", type: .action, action: #selector(dismissSideTabBar))
+                CellItem(title: "Dismiss", type: .action, action: #selector(dismissSideTabBar)),
+                CellItem(title: "Show Appearance Popover", type: .action, action: #selector(showAppearancePopoverLocal(_:)))
         ]
     }()
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04EE25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
 		D64D8E10283BFAEC00D8D7D1 /* TabBarItemTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64D8E0F283BFAEC00D8D7D1 /* TabBarItemTokens.swift */; };
+		D64D8E12283D798D00D8D7D1 /* SideTabBarTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64D8E11283D798D00D8D7D1 /* SideTabBarTokens.swift */; };
 		D6A0124A2810764B00C90535 /* TabBarTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A012492810764B00C90535 /* TabBarTokens.swift */; };
 		D6F4098927470E7F001B80D4 /* PillButtonTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F4098827470E7F001B80D4 /* PillButtonTokens.swift */; };
 		D6F4098F274F1A1C001B80D4 /* PillButtonBarTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F4098E274F1A1C001B80D4 /* PillButtonBarTokens.swift */; };
@@ -393,6 +394,7 @@
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		D64D8E0F283BFAEC00D8D7D1 /* TabBarItemTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItemTokens.swift; sourceTree = "<group>"; };
+		D64D8E11283D798D00D8D7D1 /* SideTabBarTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabBarTokens.swift; sourceTree = "<group>"; };
 		D6A012492810764B00C90535 /* TabBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarTokens.swift; sourceTree = "<group>"; };
 		D6F4098827470E7F001B80D4 /* PillButtonTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonTokens.swift; sourceTree = "<group>"; };
 		D6F4098E274F1A1C001B80D4 /* PillButtonBarTokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarTokens.swift; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 			isa = PBXGroup;
 			children = (
 				7D0931C224AAAC8C0072458A /* SideTabBar.swift */,
+				D64D8E11283D798D00D8D7D1 /* SideTabBarTokens.swift */,
 				118D9847230BBA2300BC0B72 /* TabBarItem.swift */,
 				D64D8E0F283BFAEC00D8D7D1 /* TabBarItemTokens.swift */,
 				1168630222E131CF0088B302 /* TabBarItemView.swift */,
@@ -1676,6 +1679,7 @@
 				5314E11625F015EA0099271A /* PersonaBadgeViewDataSource.swift in Sources */,
 				0ACD82192620453B0035CD9F /* PersonaViewTokens.swift in Sources */,
 				5314E2DA25F025370099271A /* Fonts.swift in Sources */,
+				D64D8E12283D798D00D8D7D1 /* SideTabBarTokens.swift in Sources */,
 				5373D5772694D66F0032A3B4 /* SwiftUI+ViewModifiers.swift in Sources */,
 				5314E07F25F00F1A0099271A /* DateTimePickerViewComponentCell.swift in Sources */,
 				0AA874162600237A00D47421 /* PersonaView.swift in Sources */,

--- a/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,23 +1,25 @@
 {
-  "pins" : [
-    {
-      "identity" : "appcenter-sdk-apple",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
-      "state" : {
-        "revision" : "25f64229373de97ff3920941cd52203193e5d8be",
-        "version" : "4.3.0"
+  "object": {
+    "pins": [
+      {
+        "package": "AppCenter",
+        "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
+        "state": {
+          "branch": null,
+          "revision": "8354a50fe01a7e54e196d3b5493b5ab53dd5866a",
+          "version": "4.4.2"
+        }
+      },
+      {
+        "package": "PLCrashReporter",
+        "repositoryURL": "https://github.com/microsoft/PLCrashReporter.git",
+        "state": {
+          "branch": null,
+          "revision": "6b27393cad517c067dceea85fadf050e70c4ceaa",
+          "version": "1.10.1"
+        }
       }
-    },
-    {
-      "identity" : "plcrashreporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/PLCrashReporter.git",
-      "state" : {
-        "revision" : "59513acde6194d93617afcf7b2c81c88638a6af2",
-        "version" : "1.10.0"
-      }
-    }
-  ],
-  "version" : 2
+    ]
+  },
+  "version": 1
 }

--- a/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/FluentUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "AppCenter",
-        "repositoryURL": "https://github.com/microsoft/appcenter-sdk-apple.git",
-        "state": {
-          "branch": null,
-          "revision": "8354a50fe01a7e54e196d3b5493b5ab53dd5866a",
-          "version": "4.4.2"
-        }
-      },
-      {
-        "package": "PLCrashReporter",
-        "repositoryURL": "https://github.com/microsoft/PLCrashReporter.git",
-        "state": {
-          "branch": null,
-          "revision": "6b27393cad517c067dceea85fadf050e70c4ceaa",
-          "version": "1.10.1"
-        }
+  "pins" : [
+    {
+      "identity" : "appcenter-sdk-apple",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/appcenter-sdk-apple.git",
+      "state" : {
+        "revision" : "25f64229373de97ff3920941cd52203193e5d8be",
+        "version" : "4.3.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/PLCrashReporter.git",
+      "state" : {
+        "revision" : "59513acde6194d93617afcf7b2c81c88638a6af2",
+        "version" : "1.10.0"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -372,6 +372,8 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         }
     }
 
+    // This custom tokens class is used to override only the four TabBarItemToken values
+    // that we want to expose publicly to consumers of the SideTabBar.
     private class CustomSideTabBarItemTokens: TabBarItemTokens {
         @available(*, unavailable)
         required init() {

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -409,7 +409,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     }
 
     private func updateSideTabBarTokensForSection(in section: Section) {
-        var customSideTabBarItemTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
+        let customSideTabBarItemTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
         for subview in stackView(in: section).arrangedSubviews {
             if let tabBarItemView = subview as? TabBarItemView {
                 tabBarItemView.overrideTokens = customSideTabBarItemTokens

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -409,7 +409,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     }
 
     private func updateSideTabBarTokensForSection(in section: Section) {
-        customSideTabBarItemTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
+        var customSideTabBarItemTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
         for subview in stackView(in: section).arrangedSubviews {
             if let tabBarItemView = subview as? TabBarItemView {
                 tabBarItemView.overrideTokens = customSideTabBarItemTokens

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -373,8 +373,6 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     }
 
     private class CustomSideTabBarItemTokens: TabBarItemTokens {
-        var sideTabBarTokens: SideTabBarTokens
-
         @available(*, unavailable)
         required init() {
             preconditionFailure("init() has not been implemented")
@@ -400,6 +398,8 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         override var titleLabelFontLandscape: FontInfo {
             sideTabBarTokens.tabBarItemTitleLabelFontLandscape ?? super.titleLabelFontLandscape
         }
+
+        var sideTabBarTokens: SideTabBarTokens
     }
 
     private func updateSideTabBarTokens() {
@@ -409,9 +409,10 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     }
 
     private func updateSideTabBarTokensForSection(in section: Section) {
+        customSideTabBarItemTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
         for subview in stackView(in: section).arrangedSubviews {
             if let tabBarItemView = subview as? TabBarItemView {
-                tabBarItemView.overrideTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
+                tabBarItemView.overrideTokens = customSideTabBarItemTokens
             }
         }
     }

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -368,7 +368,8 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     var tokens: SideTabBarTokens = .init()
     var overrideTokens: SideTabBarTokens? {
         didSet {
-            updateSideTabBarTokens()        }
+            updateSideTabBarTokens()
+        }
     }
 
     private class CustomSideTabBarItemTokens: TabBarItemTokens {

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -165,11 +165,11 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     }()
 
     private lazy var topStackView: UIStackView = {
-        return createStackView(spacing: tokens.topTabBarItemSpacing)
+        return SideTabBar.createStackView(spacing: tokens.topTabBarItemSpacing)
     }()
 
     private lazy var bottomStackView: UIStackView = {
-        return createStackView(spacing: tokens.bottomTabBarItemSpacing)
+        return SideTabBar.createStackView(spacing: tokens.bottomTabBarItemSpacing)
     }()
 
     private lazy var avatarViewGestureRecognizer: UITapGestureRecognizer = {
@@ -326,7 +326,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         return itemView(with: item, in: .bottom)
     }
 
-    private func createStackView(spacing: CGFloat) -> UIStackView {
+    private class func createStackView(spacing: CGFloat) -> UIStackView {
         let stackView = UIStackView(frame: .zero)
         stackView.axis = .vertical
         stackView.distribution = .fillEqually

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -23,7 +23,7 @@ public protocol SideTabBarDelegate {
 /// View for a vertical side tab bar that can be used for app navigation.
 /// Optimized for horizontal regular + vertical regular size class configuration. Prefer using TabBarView for other size class configurations.
 @objc(MSFSideTabBar)
-open class SideTabBar: UIView {
+open class SideTabBar: UIView, TokenizedControlInternal {
     /// Delegate to handle user interactions in the side tab bar.
     @objc public weak var delegate: SideTabBarDelegate? {
         didSet {
@@ -128,10 +128,15 @@ open class SideTabBar: UIView {
         accessibilityTraits = .tabBar
         shouldGroupAccessibilityChildren = true
 
-        NSLayoutConstraint.activate([widthAnchor.constraint(equalToConstant: Constants.viewWidth),
+        NSLayoutConstraint.activate([widthAnchor.constraint(equalToConstant: tokens.sideTabBarWidth),
                                      borderLine.leadingAnchor.constraint(equalTo: trailingAnchor),
                                      borderLine.bottomAnchor.constraint(equalTo: bottomAnchor),
                                      borderLine.topAnchor.constraint(equalTo: topAnchor)])
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     @available(*, unavailable)
@@ -146,18 +151,6 @@ open class SideTabBar: UIView {
 
     private struct Constants {
         static let maxTabCount: Int = 5
-        static let viewWidth: CGFloat = 62
-        static let avatarViewSafeTopSpacing: CGFloat = 18
-        static let avatarViewMinTopSpacing: CGFloat = 36
-        static let avatarViewTopStackViewSpacing: CGFloat = 34
-        static let bottomStackViewSafeSpacing: CGFloat = 14
-        static let bottomStackViewMinSpacing: CGFloat = 24
-        static let topItemSpacing: CGFloat = 32
-        static let bottomItemSpacing: CGFloat = 24
-        static let topItemSize: CGFloat = 28
-        static let bottomItemSize: CGFloat = 24
-        static let badgeTopSectionPadding: CGFloat = 2
-        static let badgeBottomSectionPadding: CGFloat = 4
         static let numberOfTitleLines: Int = 2
     }
 
@@ -171,12 +164,12 @@ open class SideTabBar: UIView {
         return UIVisualEffectView(effect: UIBlurEffect(style: style))
     }()
 
-    private let topStackView: UIStackView = {
-        return createStackView(spacing: Constants.topItemSpacing)
+    private lazy var topStackView: UIStackView = {
+        return createStackView(spacing: tokens.topTabBarItemSpacing)
     }()
 
-    private let bottomStackView: UIStackView = {
-        return createStackView(spacing: Constants.bottomItemSpacing)
+    private lazy var bottomStackView: UIStackView = {
+        return createStackView(spacing: tokens.bottomTabBarItemSpacing)
     }()
 
     private lazy var avatarViewGestureRecognizer: UITapGestureRecognizer = {
@@ -191,23 +184,23 @@ open class SideTabBar: UIView {
 
         if let avatar = avatar {
             // The avatar view's distance from the top of the side tab bar depends on safe layout guides.
-            // There is a minimum spacing. If the layout guide spacing is large than the minimum spacing,
+            // There is a minimum spacing. If the layout guide spacing is larger than the minimum spacing,
             // then the spacing will be layoutGuideSpacing + safeTopSpacing.
             let avatarView = avatar
-            let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.avatarViewSafeTopSpacing)
+            let topSafeConstraint = avatarView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: tokens.avatarViewSafeTopSpacing)
             topSafeConstraint.priority = .defaultHigh
 
             layoutConstraints.append(contentsOf: [
                 topSafeConstraint,
-                avatarView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: Constants.avatarViewMinTopSpacing),
+                avatarView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: tokens.avatarViewMinTopSpacing),
                 avatarView.centerXAnchor.constraint(equalTo: centerXAnchor),
-                topStackView.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: Constants.avatarViewTopStackViewSpacing)
+                topStackView.topAnchor.constraint(equalTo: avatarView.bottomAnchor, constant: tokens.avatarViewTopStackViewSpacing)
             ])
         } else {
-            layoutConstraints.append(topStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: Constants.topItemSpacing))
+            layoutConstraints.append(topStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: tokens.topTabBarItemSpacing))
         }
 
-        let bottomSafeConstraint = bottomStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -Constants.bottomStackViewSafeSpacing)
+        let bottomSafeConstraint = bottomStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -tokens.bottomStackViewSafeSpacing)
         bottomSafeConstraint.priority = .defaultHigh
 
         layoutConstraints.append(contentsOf: [
@@ -216,7 +209,7 @@ open class SideTabBar: UIView {
             bottomStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             bottomStackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor),
             bottomSafeConstraint,
-            bottomStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -Constants.bottomStackViewMinSpacing)
+            bottomStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -tokens.bottomStackViewMinSpacing)
         ])
 
         NSLayoutConstraint.activate(layoutConstraints)
@@ -234,7 +227,7 @@ open class SideTabBar: UIView {
         }
 
         let stackView = self.stackView(in: section)
-        let badgePadding = section == .top ? Constants.badgeTopSectionPadding : Constants.badgeBottomSectionPadding
+        let badgePadding = section == .top ? tokens.badgeTopSectionPadding : tokens.badgeBottomSectionPadding
         let showItemTitles = section == .top ? showTopItemTitles : showBottomItemTitles
         var didRestoreSelection = false
 
@@ -242,7 +235,7 @@ open class SideTabBar: UIView {
             let tabBarItemView = TabBarItemView(item: item, showsTitle: showItemTitles, canResizeImage: false)
             tabBarItemView.translatesAutoresizingMaskIntoConstraints = false
             tabBarItemView.alwaysShowTitleBelowImage = true
-            tabBarItemView.maxBadgeWidth = Constants.viewWidth / 2 - badgePadding
+            tabBarItemView.maxBadgeWidth = tokens.sideTabBarWidth / 2 - badgePadding
             tabBarItemView.numberOfTitleLines = Constants.numberOfTitleLines
 
             if itemView(with: item, in: section) != nil && section == .top && item == selectedTopItem {
@@ -333,7 +326,7 @@ open class SideTabBar: UIView {
         return itemView(with: item, in: .bottom)
     }
 
-    private class func createStackView(spacing: CGFloat) -> UIStackView {
+    private func createStackView(spacing: CGFloat) -> UIStackView {
         let stackView = UIStackView(frame: .zero)
         stackView.axis = .vertical
         stackView.distribution = .fillEqually
@@ -364,5 +357,68 @@ open class SideTabBar: UIView {
         if let item = (recognizer.view as? TabBarItemView)?.item {
             delegate?.sideTabBar?(self, didSelect: item, fromTop: false)
         }
+    }
+
+    public func overrideTokens(_ tokens: SideTabBarTokens?) -> Self {
+        overrideTokens = tokens
+        return self
+    }
+
+    var defaultTokens: SideTabBarTokens = .init()
+    var tokens: SideTabBarTokens = .init()
+    var overrideTokens: SideTabBarTokens? {
+        didSet {
+            updateSideTabBarTokens()        }
+    }
+
+    private class CustomSideTabBarItemTokens: TabBarItemTokens {
+        var sideTabBarTokens: SideTabBarTokens
+
+        @available(*, unavailable)
+        required init() {
+            preconditionFailure("init() has not been implemented")
+        }
+
+        init (sideTabBarTokens: SideTabBarTokens) {
+            self.sideTabBarTokens = sideTabBarTokens
+            super.init()
+        }
+
+        override var selectedColor: DynamicColor {
+            sideTabBarTokens.tabBarItemSelectedColor ?? super.selectedColor
+        }
+
+        override var unselectedColor: DynamicColor {
+            sideTabBarTokens.tabBarItemUnselectedColor ?? super.unselectedColor
+        }
+
+        override var titleLabelFontPortrait: FontInfo {
+            sideTabBarTokens.tabBarItemTitleLabelFontPortrait ?? super.titleLabelFontPortrait
+        }
+
+        override var titleLabelFontLandscape: FontInfo {
+            sideTabBarTokens.tabBarItemTitleLabelFontLandscape ?? super.titleLabelFontLandscape
+        }
+    }
+
+    private func updateSideTabBarTokens() {
+        tokens = resolvedTokens
+        updateSideTabBarTokensForSection(in: .top)
+        updateSideTabBarTokensForSection(in: .bottom)
+    }
+
+    private func updateSideTabBarTokensForSection(in section: Section) {
+        for subview in stackView(in: section).arrangedSubviews {
+            if let tabBarItemView = subview as? TabBarItemView {
+                tabBarItemView.overrideTokens = CustomSideTabBarItemTokens.init(sideTabBarTokens: tokens)
+            }
+        }
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateSideTabBarTokens()
     }
 }

--- a/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
@@ -10,37 +10,37 @@ open class SideTabBarTokens: ControlTokens {
     /// The width of the SideTabBar
     open var sideTabBarWidth: CGFloat { 62.0 }
 
-    ///
+    /// The safe spacing for the avatar
     open var avatarViewSafeTopSpacing: CGFloat { 18.0 }
 
-    ///
+    /// The minimum spacing for the avatar
     open var avatarViewMinTopSpacing: CGFloat { 36.0 }
 
-    ///
+    /// The
     open var avatarViewTopStackViewSpacing: CGFloat { 34.0 }
 
-    ///
+    /// The safe spacing for the bottom StackView
     open var bottomStackViewSafeSpacing: CGFloat { 14.0 }
 
-    ///
+    /// The min spacing for the bottom StackView
     open var bottomStackViewMinSpacing: CGFloat { 24.0 }
 
-    ///
+    /// The spacing between the top set of TabBarItems
     open var topTabBarItemSpacing: CGFloat { 32.0 }
 
-    ///
+    /// The spacing between the bottom set of TabBarItems
     open var bottomTabBarItemSpacing: CGFloat { 24.0 }
 
-    ///
+    /// The size of the top set of TabBarItems
     open var topTabBarItemSize: CGFloat { 28.0 }
 
-    ///
+    /// The size of the bottom set of TabBarItems
     open var bottomTabBarItemSize: CGFloat { 24.0 }
 
-    ///
+    /// The padding for the badges on the top set of TabBarItems
     open var badgeTopSectionPadding: CGFloat { 2.0 }
 
-    ///
+    /// The padding for the badges on the bottom set of TabBarItems
     open var badgeBottomSectionPadding: CGFloat { 4.0 }
 
     /// Defines the background color of the  of the `TabBarItem` when selected.

--- a/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
@@ -14,7 +14,7 @@ open class SideTabBarTokens: ControlTokens {
     open var avatarViewSafeTopSpacing: CGFloat { 18.0 }
 
     /// The minimum spacing for the avatar
-    open var avatarViewMinTopSpacing: CGFloat { 36.0 }
+    open var avatarViewMinTopSpacing: CGFloat { globalTokens.spacing[.xxLarge] }
 
     /// The
     open var avatarViewTopStackViewSpacing: CGFloat { 34.0 }
@@ -23,19 +23,19 @@ open class SideTabBarTokens: ControlTokens {
     open var bottomStackViewSafeSpacing: CGFloat { 14.0 }
 
     /// The min spacing for the bottom StackView
-    open var bottomStackViewMinSpacing: CGFloat { 24.0 }
+    open var bottomStackViewMinSpacing: CGFloat { globalTokens.spacing[.xLarge] }
 
     /// The spacing between the top set of TabBarItems
     open var topTabBarItemSpacing: CGFloat { 32.0 }
 
     /// The spacing between the bottom set of TabBarItems
-    open var bottomTabBarItemSpacing: CGFloat { 24.0 }
+    open var bottomTabBarItemSpacing: CGFloat { globalTokens.spacing[.xLarge] }
 
     /// The size of the top set of TabBarItems
-    open var topTabBarItemSize: CGFloat { 28.0 }
+    open var topTabBarItemSize: CGFloat { globalTokens.iconSize[.large] }
 
     /// The size of the bottom set of TabBarItems
-    open var bottomTabBarItemSize: CGFloat { 24.0 }
+    open var bottomTabBarItemSize: CGFloat { globalTokens.iconSize[.medium] }
 
     /// The padding for the badges on the top set of TabBarItems
     open var badgeTopSectionPadding: CGFloat { 2.0 }

--- a/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
@@ -16,7 +16,7 @@ open class SideTabBarTokens: ControlTokens {
     /// The minimum spacing for the avatar
     open var avatarViewMinTopSpacing: CGFloat { globalTokens.spacing[.xxLarge] }
 
-    /// The
+    /// The spacing for the avatar StackView
     open var avatarViewTopStackViewSpacing: CGFloat { 34.0 }
 
     /// The safe spacing for the bottom StackView

--- a/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Design token set for the `TabBar`.
+open class SideTabBarTokens: ControlTokens {
+    /// The width of the SideTabBar
+    open var sideTabBarWidth: CGFloat { 62.0 }
+
+    ///
+    open var avatarViewSafeTopSpacing: CGFloat { 18.0 }
+
+    ///
+    open var avatarViewMinTopSpacing: CGFloat { 36.0 }
+
+    ///
+    open var avatarViewTopStackViewSpacing: CGFloat { 34.0 }
+
+    ///
+    open var bottomStackViewSafeSpacing: CGFloat { 14.0 }
+
+    ///
+    open var bottomStackViewMinSpacing: CGFloat { 24.0 }
+
+    ///
+    open var topTabBarItemSpacing: CGFloat { 32.0 }
+
+    ///
+    open var bottomTabBarItemSpacing: CGFloat { 24.0 }
+
+    ///
+    open var topTabBarItemSize: CGFloat { 28.0 }
+
+    ///
+    open var bottomTabBarItemSize: CGFloat { 24.0 }
+
+    ///
+    open var badgeTopSectionPadding: CGFloat { 2.0 }
+
+    ///
+    open var badgeBottomSectionPadding: CGFloat { 4.0 }
+
+    /// Defines the background color of the  of the `TabBarItem` when selected.
+    open var tabBarItemSelectedColor: DynamicColor? { nil }
+
+    /// Defines the background color of the  of the `TabBarItem` when not selected.
+    open var tabBarItemUnselectedColor: DynamicColor? { nil }
+
+    /// Font info for the title label when in portrait view
+    open var tabBarItemTitleLabelFontPortrait: FontInfo? { nil }
+
+    /// Font info for the title label when in landscape view
+    open var tabBarItemTitleLabelFontLandscape: FontInfo? { nil }
+}

--- a/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
@@ -37,15 +37,15 @@ open class SideTabBarTokens: ControlTokens {
     /// The padding for the badges on the bottom set of TabBarItems
     open var badgeBottomSectionPadding: CGFloat { 4.0 }
 
-    /// Defines the background color of the  of the `TabBarItem` when selected.
+    /// Optionally overrides the default background color of the  of the `TabBarItem` when selected.
     open var tabBarItemSelectedColor: DynamicColor? { nil }
 
-    /// Defines the background color of the  of the `TabBarItem` when not selected.
+    /// Optionally overrides the default background color of the  of the `TabBarItem` when not selected.
     open var tabBarItemUnselectedColor: DynamicColor? { nil }
 
-    /// Font info for the title label when in portrait view
+    /// Optionally overrides the default font info for the title label of the `TabBarItem`when in portrait view
     open var tabBarItemTitleLabelFontPortrait: FontInfo? { nil }
 
-    /// Font info for the title label when in landscape view
+    /// Optionally overrides the default font info for the title label of the `TabBarItem`when in landscape view
     open var tabBarItemTitleLabelFontLandscape: FontInfo? { nil }
 }

--- a/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokens.swift
@@ -31,12 +31,6 @@ open class SideTabBarTokens: ControlTokens {
     /// The spacing between the bottom set of TabBarItems
     open var bottomTabBarItemSpacing: CGFloat { globalTokens.spacing[.xLarge] }
 
-    /// The size of the top set of TabBarItems
-    open var topTabBarItemSize: CGFloat { globalTokens.iconSize[.large] }
-
-    /// The size of the bottom set of TabBarItems
-    open var bottomTabBarItemSize: CGFloat { globalTokens.iconSize[.medium] }
-
     /// The padding for the badges on the top set of TabBarItems
     open var badgeTopSectionPadding: CGFloat { 2.0 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Tokenization of SideTabBar. As part of this change, we also needed to update the calling pattern of the theming popover. 

### Verification

Manually tested SideTabBar before and after, on multiple devices via simulator, as well as other demo apps to ensure no regression of theming popover behavior.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SideTabBarBeforeTokenization](https://user-images.githubusercontent.com/23249106/171312883-e595e5ed-5e28-4d4c-9d54-fc8ace714af3.gif) | ![SideTabBarAfterTokenization](https://user-images.githubusercontent.com/23249106/171311384-7dea6487-6da3-45c9-8838-f834cc54a139.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/996)