### PR TITLE
Searchbar accessibility fields

### DIFF
--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -574,6 +574,12 @@ open class SearchBar: UIView {
     private func dismissKeyboard() {
         searchTextField.resignFirstResponder()
     }
+
+    private func setAccessibilityFields(_ element: UIView, accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
+        element.accessibilityHint = accessibilityHint
+        element.accessibilityLabel = accessibilityLabel
+        element.accessibilityIdentifier = accessibilityIdentifier
+    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -577,71 +577,53 @@ open class SearchBar: UIView {
 
     // MARK: - Cancel Button Accessibility Properties
 
-    public func setAllCancelButtonAccessibilityProperties(accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
-        cancelButtonAccessibilityHint = accessibilityHint
-        cancelButtonAccessibilityLabel = accessibilityLabel
-        cancelButtonAccessibilityIdentifier = accessibilityIdentifier
-    }
-
     public var cancelButtonAccessibilityHint: String? {
-        get {return cancelButton.accessibilityHint}
-        set {cancelButton.accessibilityHint = newValue}
+        get { return cancelButton.accessibilityHint }
+        set { cancelButton.accessibilityHint = newValue }
     }
 
     public var cancelButtonAccessibilityLabel: String? {
-        get {return cancelButton.accessibilityLabel}
-        set {cancelButton.accessibilityLabel = newValue}
+        get { return cancelButton.accessibilityLabel }
+        set { cancelButton.accessibilityLabel = newValue }
     }
 
     public var cancelButtonAccessibilityIdentifier: String? {
-        get {return cancelButton.accessibilityIdentifier}
-        set {cancelButton.accessibilityIdentifier = newValue}
+        get { return cancelButton.accessibilityIdentifier }
+        set { cancelButton.accessibilityIdentifier = newValue }
     }
 
     // MARK: - Clear Button Accessibility Properties
 
-    public func setAllClearButtonAccessibilityProperties(accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
-        clearButtonAccessibilityHint = accessibilityHint
-        clearButtonAccessibilityLabel = accessibilityLabel
-        clearButtonAccessibilityIdentifier = accessibilityIdentifier
-    }
-
     public var clearButtonAccessibilityHint: String? {
-        get {return clearButton.accessibilityHint}
-        set {clearButton.accessibilityHint = newValue}
+        get { return clearButton.accessibilityHint }
+        set { clearButton.accessibilityHint = newValue }
     }
 
     public var clearButtonAccessibilityLabel: String? {
-        get {return clearButton.accessibilityLabel}
-        set {clearButton.accessibilityLabel = newValue}
+        get { return clearButton.accessibilityLabel }
+        set { clearButton.accessibilityLabel = newValue }
     }
 
     public var clearButtonAccessibilityIdentifier: String? {
-        get {return clearButton.accessibilityIdentifier}
-        set {clearButton.accessibilityIdentifier = newValue}
+        get { return clearButton.accessibilityIdentifier }
+        set { clearButton.accessibilityIdentifier = newValue }
     }
 
     // MARK: - Search Text Field Accessibility Properties
 
-    public func setAllSearchTextFieldAccessibilityProperties(accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
-        searchTextFieldAccessibilityHint = accessibilityHint
-        searchTextFieldAccessibilityLabel = accessibilityLabel
-        searchTextFieldAccessibilityIdentifier = accessibilityIdentifier
-    }
-
     public var searchTextFieldAccessibilityHint: String? {
-        get {return searchTextField.accessibilityHint}
-        set {searchTextField.accessibilityHint = newValue}
+        get { return searchTextField.accessibilityHint }
+        set { searchTextField.accessibilityHint = newValue }
     }
 
     public var searchTextFieldAccessibilityLabel: String? {
-        get {return searchTextField.accessibilityLabel}
-        set {searchTextField.accessibilityLabel = newValue}
+        get { return searchTextField.accessibilityLabel }
+        set { searchTextField.accessibilityLabel = newValue }
     }
 
     public var searchTextFieldAccessibilityIdentifier: String? {
-        get {return searchTextField.accessibilityIdentifier}
-        set {searchTextField.accessibilityIdentifier = newValue}
+        get { return searchTextField.accessibilityIdentifier }
+        set { searchTextField.accessibilityIdentifier = newValue }
     }
 }
 

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -583,17 +583,17 @@ open class SearchBar: UIView {
         cancelButtonAccessibilityIdentifier = accessibilityIdentifier
     }
 
-    var cancelButtonAccessibilityHint: String? {
+    public var cancelButtonAccessibilityHint: String? {
         get {return cancelButton.accessibilityHint}
         set {cancelButton.accessibilityHint = newValue}
     }
 
-    var cancelButtonAccessibilityLabel: String? {
+    public var cancelButtonAccessibilityLabel: String? {
         get {return cancelButton.accessibilityLabel}
         set {cancelButton.accessibilityLabel = newValue}
     }
 
-    var cancelButtonAccessibilityIdentifier: String? {
+    public var cancelButtonAccessibilityIdentifier: String? {
         get {return cancelButton.accessibilityIdentifier}
         set {cancelButton.accessibilityIdentifier = newValue}
     }
@@ -606,17 +606,17 @@ open class SearchBar: UIView {
         clearButtonAccessibilityIdentifier = accessibilityIdentifier
     }
 
-    var clearButtonAccessibilityHint: String? {
+    public var clearButtonAccessibilityHint: String? {
         get {return clearButton.accessibilityHint}
         set {clearButton.accessibilityHint = newValue}
     }
 
-    var clearButtonAccessibilityLabel: String? {
+    public var clearButtonAccessibilityLabel: String? {
         get {return clearButton.accessibilityLabel}
         set {clearButton.accessibilityLabel = newValue}
     }
 
-    var clearButtonAccessibilityIdentifier: String? {
+    public var clearButtonAccessibilityIdentifier: String? {
         get {return clearButton.accessibilityIdentifier}
         set {clearButton.accessibilityIdentifier = newValue}
     }
@@ -629,17 +629,17 @@ open class SearchBar: UIView {
         searchTextFieldAccessibilityIdentifier = accessibilityIdentifier
     }
 
-    var searchTextFieldAccessibilityHint: String? {
+    public var searchTextFieldAccessibilityHint: String? {
         get {return searchTextField.accessibilityHint}
         set {searchTextField.accessibilityHint = newValue}
     }
 
-    var searchTextFieldAccessibilityLabel: String? {
+    public var searchTextFieldAccessibilityLabel: String? {
         get {return searchTextField.accessibilityLabel}
         set {searchTextField.accessibilityLabel = newValue}
     }
 
-    var searchTextFieldAccessibilityIdentifier: String? {
+    public var searchTextFieldAccessibilityIdentifier: String? {
         get {return searchTextField.accessibilityIdentifier}
         set {searchTextField.accessibilityIdentifier = newValue}
     }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -580,6 +580,18 @@ open class SearchBar: UIView {
         element.accessibilityLabel = accessibilityLabel
         element.accessibilityIdentifier = accessibilityIdentifier
     }
+
+    public func setCancelButtonAccessibilityFields(hint: String?, label: String?, identifier: String?){
+        setAccessibilityFields(cancelButton, accessibilityHint: hint, accessibilityLabel: label, accessibilityIdentifier: identifier)
+    }
+
+    public func setClearButtonAccessibilityFields(hint: String?, label: String?, identifier: String?){
+        setAccessibilityFields(clearButton, accessibilityHint: hint, accessibilityLabel: label, accessibilityIdentifier: identifier)
+    }
+
+    public func setTextFieldAccessibilityFields(hint: String?, label: String?, identifier: String?){
+        setAccessibilityFields(searchTextField, accessibilityHint: hint, accessibilityLabel: label, accessibilityIdentifier: identifier)
+    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -589,6 +589,21 @@ open class SearchBar: UIView {
         get {return cancelButton.accessibilityIdentifier}
         set {cancelButton.accessibilityIdentifier = newValue}
     }
+
+    var clearButtonAccessibilityHint: String? {
+        get {return clearButton.accessibilityHint}
+        set {clearButton.accessibilityHint = newValue}
+    }
+
+    var clearButtonAccessibilityLabel: String? {
+        get {return clearButton.accessibilityLabel}
+        set {clearButton.accessibilityLabel = newValue}
+    }
+
+    var clearButtonAccessibilityIdentifier: String? {
+        get {return clearButton.accessibilityIdentifier}
+        set {clearButton.accessibilityIdentifier = newValue}
+    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -577,6 +577,12 @@ open class SearchBar: UIView {
 
     // MARK: - Cancel Button Accessibility Properties
 
+    public func setAllCancelButtonAccessibilityProperties(accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
+        cancelButtonAccessibilityHint = accessibilityHint
+        cancelButtonAccessibilityLabel = accessibilityLabel
+        cancelButtonAccessibilityIdentifier = accessibilityIdentifier
+    }
+
     var cancelButtonAccessibilityHint: String? {
         get {return cancelButton.accessibilityHint}
         set {cancelButton.accessibilityHint = newValue}
@@ -594,6 +600,12 @@ open class SearchBar: UIView {
 
     // MARK: - Clear Button Accessibility Properties
 
+    public func setAllClearButtonAccessibilityProperties(accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
+        clearButtonAccessibilityHint = accessibilityHint
+        clearButtonAccessibilityLabel = accessibilityLabel
+        clearButtonAccessibilityIdentifier = accessibilityIdentifier
+    }
+
     var clearButtonAccessibilityHint: String? {
         get {return clearButton.accessibilityHint}
         set {clearButton.accessibilityHint = newValue}
@@ -610,6 +622,12 @@ open class SearchBar: UIView {
     }
 
     // MARK: - Search Text Field Accessibility Properties
+
+    public func setAllSearchTextFieldAccessibilityProperties(accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
+        searchTextFieldAccessibilityHint = accessibilityHint
+        searchTextFieldAccessibilityLabel = accessibilityLabel
+        searchTextFieldAccessibilityIdentifier = accessibilityIdentifier
+    }
 
     var searchTextFieldAccessibilityHint: String? {
         get {return searchTextField.accessibilityHint}

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -575,6 +575,8 @@ open class SearchBar: UIView {
         searchTextField.resignFirstResponder()
     }
 
+    // MARK: - Cancel Button Accessibility Properties
+
     var cancelButtonAccessibilityHint: String? {
         get {return cancelButton.accessibilityHint}
         set {cancelButton.accessibilityHint = newValue}
@@ -590,6 +592,8 @@ open class SearchBar: UIView {
         set {cancelButton.accessibilityIdentifier = newValue}
     }
 
+    // MARK: - Clear Button Accessibility Properties
+
     var clearButtonAccessibilityHint: String? {
         get {return clearButton.accessibilityHint}
         set {clearButton.accessibilityHint = newValue}
@@ -604,6 +608,8 @@ open class SearchBar: UIView {
         get {return clearButton.accessibilityIdentifier}
         set {clearButton.accessibilityIdentifier = newValue}
     }
+
+    // MARK: - Search Text Field Accessibility Properties
 
     var searchTextFieldAccessibilityHint: String? {
         get {return searchTextField.accessibilityHint}

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -604,6 +604,21 @@ open class SearchBar: UIView {
         get {return clearButton.accessibilityIdentifier}
         set {clearButton.accessibilityIdentifier = newValue}
     }
+
+    var searchTextFieldAccessibilityHint: String? {
+        get {return searchTextField.accessibilityHint}
+        set {searchTextField.accessibilityHint = newValue}
+    }
+
+    var searchTextFieldAccessibilityLabel: String? {
+        get {return searchTextField.accessibilityLabel}
+        set {searchTextField.accessibilityLabel = newValue}
+    }
+
+    var searchTextFieldAccessibilityIdentifier: String? {
+        get {return searchTextField.accessibilityIdentifier}
+        set {searchTextField.accessibilityIdentifier = newValue}
+    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -574,24 +574,6 @@ open class SearchBar: UIView {
     private func dismissKeyboard() {
         searchTextField.resignFirstResponder()
     }
-
-    private func setAccessibilityFields(_ element: UIView, accessibilityHint: String?, accessibilityLabel: String?, accessibilityIdentifier: String?){
-        element.accessibilityHint = accessibilityHint
-        element.accessibilityLabel = accessibilityLabel
-        element.accessibilityIdentifier = accessibilityIdentifier
-    }
-
-    public func setCancelButtonAccessibilityFields(hint: String?, label: String?, identifier: String?){
-        setAccessibilityFields(cancelButton, accessibilityHint: hint, accessibilityLabel: label, accessibilityIdentifier: identifier)
-    }
-
-    public func setClearButtonAccessibilityFields(hint: String?, label: String?, identifier: String?){
-        setAccessibilityFields(clearButton, accessibilityHint: hint, accessibilityLabel: label, accessibilityIdentifier: identifier)
-    }
-
-    public func setTextFieldAccessibilityFields(hint: String?, label: String?, identifier: String?){
-        setAccessibilityFields(searchTextField, accessibilityHint: hint, accessibilityLabel: label, accessibilityIdentifier: identifier)
-    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -574,6 +574,21 @@ open class SearchBar: UIView {
     private func dismissKeyboard() {
         searchTextField.resignFirstResponder()
     }
+
+    var cancelButtonAccessibilityHint: String? {
+        get {return cancelButton.accessibilityHint}
+        set {cancelButton.accessibilityHint = newValue}
+    }
+
+    var cancelButtonAccessibilityLabel: String? {
+        get {return cancelButton.accessibilityLabel}
+        set {cancelButton.accessibilityLabel = newValue}
+    }
+
+    var cancelButtonAccessibilityIdentifier: String? {
+        get {return cancelButton.accessibilityIdentifier}
+        set {cancelButton.accessibilityIdentifier = newValue}
+    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Created computed properties for accessibility hints/labels/identifiers for `cancelButton`, `clearButton` and `searchTextField`. 
In order to facilitate changing the three parameters with a one line change, I also created functions that set all these parameters for each of the controls. However, each parameter can still be called and changed individually if preferred.

### Verification

- The identifiers were tested by running unit tests in `FluentUITests`
- The hints and labels of each control were tested with VoiceOver. For example, when changing the cancel button's hint to "go back" and its label to "cancel item" we get the VoiceOver results shown below


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| VO: cancel, button | VO: cancel item, button, go back |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/997)