### PR TITLE
Adding CustomView values to TableViewCell tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -156,6 +156,10 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
             return DynamicColor(light: GlobalTokens().sharedColors[.forest][.tint10],
                                 dark: GlobalTokens().sharedColors[.forest][.shade40])
         }
+
+        override var customViewTrailingMargin: CGFloat {
+            return 0
+        }
     }
 }
 

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -13,7 +13,7 @@ open class PersonaCell: TableViewCell {
         static let avatarSize: MSFAvatarSize = .large
     }
 
-    open override var customViewSize: TableViewCell.CustomViewSize { get { return .medium } set { } }
+    open override var customViewSize: MSFTableViewCellCustomViewSize { get { return .medium } set { } }
 
     /// Sets up the cell with an Persona and an accessory
     ///

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -13,7 +13,7 @@ open class PersonaCell: TableViewCell {
         static let avatarSize: MSFAvatarSize = .large
     }
 
-    open override var customViewSize: MSFTableViewCellCustomViewSize { get { return .medium } set { } }
+    open override var customViewSizeType: MSFTableViewCellCustomViewSize { get { return .medium } set { } }
 
     /// Sets up the cell with an Persona and an accessory
     ///

--- a/ios/FluentUI/People Picker/PersonaCell.swift
+++ b/ios/FluentUI/People Picker/PersonaCell.swift
@@ -13,7 +13,7 @@ open class PersonaCell: TableViewCell {
         static let avatarSize: MSFAvatarSize = .large
     }
 
-    open override var customViewSizeType: MSFTableViewCellCustomViewSize { get { return .medium } set { } }
+    open override var customViewSize: MSFTableViewCellCustomViewSize { get { return .medium } set { } }
 
     /// Sets up the cell with an Persona and an accessory
     ///

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -67,7 +67,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
     var preservesSpaceForImage: Bool = false
 
-    override var customViewSizeType: MSFTableViewCellCustomViewSize {
+    override var customViewSize: MSFTableViewCellCustomViewSize {
         get { return customView != nil || preservesSpaceForImage ? Constants.imageViewSize : .zero }
         set { }
     }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -29,7 +29,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         static let labelVerticalMarginForOneLine: CGFloat = 15
         static let accessoryImageViewOffset: CGFloat = 5
 
-        static let imageViewSize: CustomViewSize = .small
+        static let imageViewSize: MSFTableViewCellCustomViewSize = .small
         static let accessoryImageViewSize: CGFloat = 8
 
         static let defaultAlpha: CGFloat = 1.0
@@ -46,7 +46,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             return 0
         }
 
-        let imageViewSize: CustomViewSize = item.image != nil || preserveSpaceForImage ? Constants.imageViewSize : .zero
+        let imageViewSize: MSFTableViewCellCustomViewSize = item.image != nil || preserveSpaceForImage ? Constants.imageViewSize : .zero
         return preferredWidth(title: item.title, subtitle: item.subtitle ?? "", customViewSize: imageViewSize, customAccessoryView: item.accessoryView, accessoryType: .checkmark)
     }
 
@@ -67,7 +67,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
     var preservesSpaceForImage: Bool = false
 
-    override var customViewSize: CustomViewSize {
+    override var customViewSize: MSFTableViewCellCustomViewSize {
         get { return customView != nil || preservesSpaceForImage ? Constants.imageViewSize : .zero }
         set { }
     }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -67,7 +67,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
     var preservesSpaceForImage: Bool = false
 
-    override var customViewSize: MSFTableViewCellCustomViewSize {
+    override var customViewSizeType: MSFTableViewCellCustomViewSize {
         get { return customView != nil || preservesSpaceForImage ? Constants.imageViewSize : .zero }
         set { }
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -134,7 +134,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         case twoLines
         case threeLines
 
-        var customViewSize: MSFTableViewCellCustomViewSize { return self == .oneLine ? .small : .medium }
+        var customViewSizeType: MSFTableViewCellCustomViewSize { return self == .oneLine ? .small : .medium }
     }
 
     struct TextStyles {
@@ -246,6 +246,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                          subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                                          footerLeadingAccessoryView: footerLeadingAccessoryView,
                                          footerTrailingAccessoryView: footerTrailingAccessoryView)
+        // Layout type should accommodate for the customViewSize, even if it is only one line.
         if customViewSize == .medium && layoutType == .oneLine {
             layoutType = .twoLines
         }
@@ -443,7 +444,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private static func customViewSize(from size: MSFTableViewCellCustomViewSize, layoutType: LayoutType) -> MSFTableViewCellCustomViewSize {
-        return size == .default ? layoutType.customViewSize : size
+        return size == .default ? layoutType.customViewSizeType : size
     }
 
     private static func customViewLeadingOffset(isInSelectionMode: Bool,
@@ -458,7 +459,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                               tokens: TableViewCellTokens) -> CGFloat {
         var textAreaLeadingOffset = customViewLeadingOffset(isInSelectionMode: isInSelectionMode, tokens: tokens)
         if customViewSize != .zero {
-            textAreaLeadingOffset += tokens.customViewDimensions.width + tokens.customViewTrailingMargin
+            textAreaLeadingOffset += tokens.customViewSize.width + tokens.customViewTrailingMargin
         }
 
         return textAreaLeadingOffset
@@ -694,25 +695,25 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     /// Override to set a specific `MSFTableViewCellCustomViewSize` on the `customView`
-    @objc open var customViewSize: MSFTableViewCellCustomViewSize {
+    @objc open var customViewSizeType: MSFTableViewCellCustomViewSize {
         get {
             if customView == nil {
                 return .zero
             }
-            tokens.customViewSize = _customViewSize == .default ? layoutType.customViewSize : _customViewSize
-            return tokens.customViewSize
+            tokens.customViewSizeType = _customViewSizeType == .default ? layoutType.customViewSizeType : _customViewSizeType
+            return tokens.customViewSizeType
         }
         set {
-            if _customViewSize == newValue {
+            if _customViewSizeType == newValue {
                 return
             }
-            tokens.customViewSize = newValue
-            _customViewSize = newValue
+            tokens.customViewSizeType = newValue
+            _customViewSizeType = newValue
             setNeedsLayout()
             invalidateIntrinsicContentSize()
         }
     }
-    private var _customViewSize: MSFTableViewCellCustomViewSize = .default
+    private var _customViewSizeType: MSFTableViewCellCustomViewSize = .default
 
     /// The custom accessory view of the TableViewCell.
     @objc open private(set) var customAccessoryView: UIView? {
@@ -789,7 +790,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                 footerLeadingAccessoryView: footerLeadingAccessoryView,
                 footerTrailingAccessoryView: footerTrailingAccessoryView,
-                customViewSize: customViewSize,
+                customViewSize: customViewSizeType,
                 customAccessoryView: customAccessoryView,
                 accessoryType: _accessoryType,
                 customAccessoryViewExtendsToEdge: customAccessoryViewExtendsToEdge,
@@ -806,7 +807,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                 footerLeadingAccessoryView: footerLeadingAccessoryView,
                 footerTrailingAccessoryView: footerTrailingAccessoryView,
-                customViewSize: customViewSize,
+                customViewSize: customViewSizeType,
                 customAccessoryView: customAccessoryView,
                 accessoryType: _accessoryType,
                 titleNumberOfLines: titleNumberOfLines,
@@ -907,7 +908,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private var textAreaWidth: CGFloat {
-        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSize,
+        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSizeType,
                                                                         isInSelectionMode: isInSelectionMode,
                                                                         tokens: tokens)
         let textAreaTrailingOffset = TableViewCell.textAreaTrailingOffset(customAccessoryView: customAccessoryView,
@@ -1165,11 +1166,11 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
 
         if let customView = customView {
-            let customViewYOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - tokens.customViewDimensions.height) / 2)
+            let customViewYOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - tokens.customViewSize.height) / 2)
             let customViewXOffset = TableViewCell.customViewLeadingOffset(isInSelectionMode: isInSelectionMode, tokens: tokens)
             customView.frame = CGRect(
                 origin: CGPoint(x: customViewXOffset, y: customViewYOffset),
-                size: tokens.customViewDimensions
+                size: tokens.customViewSize
             )
         }
 
@@ -1250,7 +1251,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                   leadingAccessoryViewSize: CGSize,
                                   trailingAccessoryView: UIView?,
                                   trailingAccessoryViewSize: CGSize) {
-        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSize,
+        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSizeType,
                                                                         isInSelectionMode: isInSelectionMode,
                                                                         tokens: tokens)
         let text = label.text ?? ""
@@ -1319,7 +1320,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         let baseOffset = safeAreaInsets.left + TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
                                                                                     selectionImageMarginTrailing: tokens.selectionImageMarginTrailing,
                                                                                     selectionImageSize: tokens.selectionImageSize.width)
-        return baseOffset + paddingLeading + tokens.customViewDimensions.width + tokens.customViewTrailingMargin
+        return baseOffset + paddingLeading + tokens.customViewSize.width + tokens.customViewTrailingMargin
     }
 
     open override func prepareForReuse() {
@@ -1344,7 +1345,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         footerLeadingAccessoryView = nil
         footerTrailingAccessoryView = nil
 
-        customViewSize = .default
+        customViewSizeType = .default
         customAccessoryViewExtendsToEdge = false
 
         topSeparatorType = .none
@@ -1373,7 +1374,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                     subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                     footerLeadingAccessoryView: footerLeadingAccessoryView,
                     footerTrailingAccessoryView: footerTrailingAccessoryView,
-                    customViewSize: customViewSize,
+                    customViewSize: customViewSizeType,
                     customAccessoryView: customAccessoryView,
                     accessoryType: _accessoryType,
                     customAccessoryViewExtendsToEdge: customAccessoryViewExtendsToEdge,
@@ -1392,7 +1393,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                 footerLeadingAccessoryView: footerLeadingAccessoryView,
                 footerTrailingAccessoryView: footerTrailingAccessoryView,
-                customViewSize: customViewSize,
+                customViewSize: customViewSizeType,
                 customAccessoryView: customAccessoryView,
                 accessoryType: _accessoryType,
                 titleNumberOfLines: titleNumberOfLines,

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -122,41 +122,6 @@ NOTE: This cell implements its own custom separator. Make sure to remove the UIT
 */
 @objc(MSFTableViewCell)
 open class TableViewCell: UITableViewCell, TokenizedControlInternal {
-    @objc(MSFTableViewCellCustomViewSize)
-    public enum CustomViewSize: Int {
-        case `default`
-        case zero
-        case small
-        case medium
-
-        var size: CGSize {
-            switch self {
-            case .zero:
-                return .zero
-            case .small:
-                return CGSize(width: 24, height: 24)
-            case .medium, .default:
-                return CGSize(width: 40, height: 40)
-            }
-        }
-        var trailingMargin: CGFloat {
-            switch self {
-            case .zero:
-                return 0
-            case .small:
-                return 16
-            case .medium, .default:
-                return 12
-            }
-        }
-
-        fileprivate func validateLayoutTypeForHeightCalculation(_ layoutType: inout LayoutType) {
-            if self == .medium && layoutType == .oneLine {
-                layoutType = .twoLines
-            }
-        }
-    }
-
     @objc(MSFTableViewCellSeparatorType)
     public enum SeparatorType: Int {
         case none
@@ -169,7 +134,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         case twoLines
         case threeLines
 
-        var customViewSize: CustomViewSize { return self == .oneLine ? .small : .medium }
+        var customViewSize: MSFTableViewCellCustomViewSize { return self == .oneLine ? .small : .medium }
     }
 
     struct TextStyles {
@@ -204,16 +169,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     /// The vertical margins for cells with one or three lines of text
     class var labelVerticalMarginForOneAndThreeLines: CGFloat { return Constants.labelVerticalMarginForOneAndThreeLines }
-
-    private var separatorLeadingInsetForSmallCustomView: CGFloat {
-        return paddingLeading + CustomViewSize.small.size.width + CustomViewSize.small.trailingMargin
-    }
-    private var separatorLeadingInsetForMediumCustomView: CGFloat {
-        return paddingLeading + CustomViewSize.medium.size.width + CustomViewSize.medium.trailingMargin
-    }
-    private var separatorLeadingInsetForNoCustomView: CGFloat {
-        return paddingLeading
-    }
 
     // MARK: - TableViewCell TokenizedControl
     @objc public var tableViewCellOverrideTokens: TableViewCellTokens? {
@@ -276,7 +231,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                    subtitleTrailingAccessoryView: UIView? = nil,
                                    footerLeadingAccessoryView: UIView? = nil,
                                    footerTrailingAccessoryView: UIView? = nil,
-                                   customViewSize: CustomViewSize = .default,
+                                   customViewSize: MSFTableViewCellCustomViewSize = .default,
                                    customAccessoryView: UIView? = nil,
                                    accessoryType: TableViewCellAccessoryType = .none,
                                    titleNumberOfLines: Int = 1,
@@ -291,7 +246,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                          subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                                          footerLeadingAccessoryView: footerLeadingAccessoryView,
                                          footerTrailingAccessoryView: footerTrailingAccessoryView)
-        customViewSize.validateLayoutTypeForHeightCalculation(&layoutType)
+        if customViewSize == .medium && layoutType == .oneLine {
+            layoutType = .twoLines
+        }
         let customViewSize = Self.customViewSize(from: customViewSize, layoutType: layoutType)
 
         let textAreaLeadingOffset = Self.textAreaLeadingOffset(customViewSize: customViewSize,
@@ -380,7 +337,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                            subtitleTrailingAccessoryView: UIView? = nil,
                                            footerLeadingAccessoryView: UIView? = nil,
                                            footerTrailingAccessoryView: UIView? = nil,
-                                           customViewSize: CustomViewSize = .default,
+                                           customViewSize: MSFTableViewCellCustomViewSize = .default,
                                            customAccessoryView: UIView? = nil,
                                            accessoryType: TableViewCellAccessoryType = .none,
                                            customAccessoryViewExtendsToEdge: Bool = false,
@@ -485,7 +442,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         return isInSelectionMode ? selectionImageSize + selectionImageMarginTrailing : 0
     }
 
-    private static func customViewSize(from size: CustomViewSize, layoutType: LayoutType) -> CustomViewSize {
+    private static func customViewSize(from size: MSFTableViewCellCustomViewSize, layoutType: LayoutType) -> MSFTableViewCellCustomViewSize {
         return size == .default ? layoutType.customViewSize : size
     }
 
@@ -496,12 +453,12 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                                               selectionImageSize: tokens.selectionImageSize.width)
     }
 
-    private static func textAreaLeadingOffset(customViewSize: CustomViewSize,
+    private static func textAreaLeadingOffset(customViewSize: MSFTableViewCellCustomViewSize,
                                               isInSelectionMode: Bool,
                                               tokens: TableViewCellTokens) -> CGFloat {
         var textAreaLeadingOffset = customViewLeadingOffset(isInSelectionMode: isInSelectionMode, tokens: tokens)
         if customViewSize != .zero {
-            textAreaLeadingOffset += customViewSize.size.width + customViewSize.trailingMargin
+            textAreaLeadingOffset += tokens.customViewDimensions.width + tokens.customViewTrailingMargin
         }
 
         return textAreaLeadingOffset
@@ -736,24 +693,26 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
-    /// Override to set a specific `CustomViewSize` on the `customView`
-    @objc open var customViewSize: CustomViewSize {
+    /// Override to set a specific `MSFTableViewCellCustomViewSize` on the `customView`
+    @objc open var customViewSize: MSFTableViewCellCustomViewSize {
         get {
             if customView == nil {
                 return .zero
             }
-            return _customViewSize == .default ? layoutType.customViewSize : _customViewSize
+            tokens.customViewSize = _customViewSize == .default ? layoutType.customViewSize : _customViewSize
+            return tokens.customViewSize
         }
         set {
             if _customViewSize == newValue {
                 return
             }
+            tokens.customViewSize = newValue
             _customViewSize = newValue
             setNeedsLayout()
             invalidateIntrinsicContentSize()
         }
     }
-    private var _customViewSize: CustomViewSize = .default
+    private var _customViewSize: MSFTableViewCellCustomViewSize = .default
 
     /// The custom accessory view of the TableViewCell.
     @objc open private(set) var customAccessoryView: UIView? {
@@ -1206,11 +1165,11 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
 
         if let customView = customView {
-            let customViewYOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - customViewSize.size.height) / 2)
+            let customViewYOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - tokens.customViewDimensions.height) / 2)
             let customViewXOffset = TableViewCell.customViewLeadingOffset(isInSelectionMode: isInSelectionMode, tokens: tokens)
             customView.frame = CGRect(
                 origin: CGPoint(x: customViewXOffset, y: customViewYOffset),
-                size: customViewSize.size
+                size: tokens.customViewDimensions
             )
         }
 
@@ -1360,14 +1319,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         let baseOffset = safeAreaInsets.left + TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
                                                                                     selectionImageMarginTrailing: tokens.selectionImageMarginTrailing,
                                                                                     selectionImageSize: tokens.selectionImageSize.width)
-        switch customViewSize {
-        case .zero:
-            return baseOffset + separatorLeadingInsetForNoCustomView
-        case .small:
-            return baseOffset + separatorLeadingInsetForSmallCustomView
-        case .medium, .default:
-            return baseOffset + separatorLeadingInsetForMediumCustomView
-        }
+        return baseOffset + paddingLeading + tokens.customViewDimensions.width + tokens.customViewTrailingMargin
     }
 
     open override func prepareForReuse() {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -134,7 +134,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         case twoLines
         case threeLines
 
-        var customViewSizeType: MSFTableViewCellCustomViewSize { return self == .oneLine ? .small : .medium }
+        var customViewSize: MSFTableViewCellCustomViewSize { return self == .oneLine ? .small : .medium }
     }
 
     struct TextStyles {
@@ -444,7 +444,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private static func customViewSize(from size: MSFTableViewCellCustomViewSize, layoutType: LayoutType) -> MSFTableViewCellCustomViewSize {
-        return size == .default ? layoutType.customViewSizeType : size
+        return size == .default ? layoutType.customViewSize : size
     }
 
     private static func customViewLeadingOffset(isInSelectionMode: Bool,
@@ -459,7 +459,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                               tokens: TableViewCellTokens) -> CGFloat {
         var textAreaLeadingOffset = customViewLeadingOffset(isInSelectionMode: isInSelectionMode, tokens: tokens)
         if customViewSize != .zero {
-            textAreaLeadingOffset += tokens.customViewSize.width + tokens.customViewTrailingMargin
+            textAreaLeadingOffset += tokens.customViewDimensions.width + tokens.customViewTrailingMargin
         }
 
         return textAreaLeadingOffset
@@ -695,25 +695,25 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     /// Override to set a specific `MSFTableViewCellCustomViewSize` on the `customView`
-    @objc open var customViewSizeType: MSFTableViewCellCustomViewSize {
+    @objc open var customViewSize: MSFTableViewCellCustomViewSize {
         get {
             if customView == nil {
                 return .zero
             }
-            tokens.customViewSizeType = _customViewSizeType == .default ? layoutType.customViewSizeType : _customViewSizeType
-            return tokens.customViewSizeType
+            tokens.customViewSize = _customViewSize == .default ? layoutType.customViewSize : _customViewSize
+            return tokens.customViewSize
         }
         set {
-            if _customViewSizeType == newValue {
+            if _customViewSize == newValue {
                 return
             }
-            tokens.customViewSizeType = newValue
-            _customViewSizeType = newValue
+            tokens.customViewSize = newValue
+            _customViewSize = newValue
             setNeedsLayout()
             invalidateIntrinsicContentSize()
         }
     }
-    private var _customViewSizeType: MSFTableViewCellCustomViewSize = .default
+    private var _customViewSize: MSFTableViewCellCustomViewSize = .default
 
     /// The custom accessory view of the TableViewCell.
     @objc open private(set) var customAccessoryView: UIView? {
@@ -790,7 +790,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                 footerLeadingAccessoryView: footerLeadingAccessoryView,
                 footerTrailingAccessoryView: footerTrailingAccessoryView,
-                customViewSize: customViewSizeType,
+                customViewSize: customViewSize,
                 customAccessoryView: customAccessoryView,
                 accessoryType: _accessoryType,
                 customAccessoryViewExtendsToEdge: customAccessoryViewExtendsToEdge,
@@ -807,7 +807,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                 footerLeadingAccessoryView: footerLeadingAccessoryView,
                 footerTrailingAccessoryView: footerTrailingAccessoryView,
-                customViewSize: customViewSizeType,
+                customViewSize: customViewSize,
                 customAccessoryView: customAccessoryView,
                 accessoryType: _accessoryType,
                 titleNumberOfLines: titleNumberOfLines,
@@ -908,7 +908,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private var textAreaWidth: CGFloat {
-        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSizeType,
+        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSize,
                                                                         isInSelectionMode: isInSelectionMode,
                                                                         tokens: tokens)
         let textAreaTrailingOffset = TableViewCell.textAreaTrailingOffset(customAccessoryView: customAccessoryView,
@@ -1166,11 +1166,11 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
 
         if let customView = customView {
-            let customViewYOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - tokens.customViewSize.height) / 2)
+            let customViewYOffset = UIScreen.main.roundToDevicePixels((contentView.frame.height - tokens.customViewDimensions.height) / 2)
             let customViewXOffset = TableViewCell.customViewLeadingOffset(isInSelectionMode: isInSelectionMode, tokens: tokens)
             customView.frame = CGRect(
                 origin: CGPoint(x: customViewXOffset, y: customViewYOffset),
-                size: tokens.customViewSize
+                size: tokens.customViewDimensions
             )
         }
 
@@ -1251,7 +1251,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                   leadingAccessoryViewSize: CGSize,
                                   trailingAccessoryView: UIView?,
                                   trailingAccessoryViewSize: CGSize) {
-        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSizeType,
+        let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSize,
                                                                         isInSelectionMode: isInSelectionMode,
                                                                         tokens: tokens)
         let text = label.text ?? ""
@@ -1320,7 +1320,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         let baseOffset = safeAreaInsets.left + TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
                                                                                     selectionImageMarginTrailing: tokens.selectionImageMarginTrailing,
                                                                                     selectionImageSize: tokens.selectionImageSize.width)
-        return baseOffset + paddingLeading + tokens.customViewSize.width + tokens.customViewTrailingMargin
+        return baseOffset + paddingLeading + tokens.customViewDimensions.width + tokens.customViewTrailingMargin
     }
 
     open override func prepareForReuse() {
@@ -1345,7 +1345,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         footerLeadingAccessoryView = nil
         footerTrailingAccessoryView = nil
 
-        customViewSizeType = .default
+        customViewSize = .default
         customAccessoryViewExtendsToEdge = false
 
         topSeparatorType = .none
@@ -1374,7 +1374,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                     subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                     footerLeadingAccessoryView: footerLeadingAccessoryView,
                     footerTrailingAccessoryView: footerTrailingAccessoryView,
-                    customViewSize: customViewSizeType,
+                    customViewSize: customViewSize,
                     customAccessoryView: customAccessoryView,
                     accessoryType: _accessoryType,
                     customAccessoryViewExtendsToEdge: customAccessoryViewExtendsToEdge,
@@ -1393,7 +1393,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 subtitleTrailingAccessoryView: subtitleTrailingAccessoryView,
                 footerLeadingAccessoryView: footerLeadingAccessoryView,
                 footerTrailingAccessoryView: footerTrailingAccessoryView,
-                customViewSize: customViewSizeType,
+                customViewSize: customViewSize,
                 customAccessoryView: customAccessoryView,
                 accessoryType: _accessoryType,
                 titleNumberOfLines: titleNumberOfLines,

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -32,8 +32,8 @@ open class TableViewCellTokens: ControlTokens {
     open var imageColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
     /// The size dimensions of the customView.
-    open var customViewSize: CGSize {
-        switch customViewSizeType {
+    open var customViewDimensions: CGSize {
+        switch customViewSize {
         case .zero:
             return .zero
         case .small:
@@ -47,7 +47,7 @@ open class TableViewCellTokens: ControlTokens {
 
     /// The trailing margin of the customView.
     open var customViewTrailingMargin: CGFloat {
-        switch customViewSizeType {
+        switch customViewSize {
         case .zero:
             return globalTokens.spacing[.none]
         case .small:
@@ -139,7 +139,7 @@ open class TableViewCellTokens: ControlTokens {
     open var accessoryDetailButtonColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
     /// Defines the size of the customView size.
-    public internal(set) var customViewSizeType: MSFTableViewCellCustomViewSize = .default
+    public internal(set) var customViewSize: MSFTableViewCellCustomViewSize = .default
 }
 
 /// Pre-defined sizes of the customView size.

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -31,6 +31,32 @@ open class TableViewCellTokens: ControlTokens {
     /// The leading image color.
     open var imageColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
+    /// The size dimensions of the customView
+    open var customViewDimensions: CGSize {
+        switch customViewSize {
+        case .zero:
+            return .zero
+        case .small:
+            return CGSize(width: globalTokens.iconSize[.medium],
+                          height: globalTokens.iconSize[.medium])
+        case .medium, .default:
+            return CGSize(width: globalTokens.iconSize[.xxLarge],
+                          height: globalTokens.iconSize[.xxLarge])
+        }
+    }
+
+    /// The trailing margin of the customView
+    open var customViewTrailingMargin: CGFloat {
+        switch customViewSize {
+        case .zero:
+            return globalTokens.spacing[.none]
+        case .small:
+            return globalTokens.spacing[.medium]
+        case .medium, .default:
+            return globalTokens.spacing[.small]
+        }
+    }
+
     /// The title label color.
     open var titleColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
@@ -111,4 +137,15 @@ open class TableViewCellTokens: ControlTokens {
 
     /// The color for the accessoryDetailButtonColor.
     open var accessoryDetailButtonColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
+
+    /// Defines the size of the customView size.
+    public internal(set) var customViewSize: MSFTableViewCellCustomViewSize = .default
+}
+
+/// Pre-defined sizes of the customView size
+@objc public enum MSFTableViewCellCustomViewSize: Int, CaseIterable {
+    case `default`
+    case zero
+    case small
+    case medium
 }

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -32,8 +32,8 @@ open class TableViewCellTokens: ControlTokens {
     open var imageColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
     /// The size dimensions of the customView.
-    open var customViewDimensions: CGSize {
-        switch customViewSize {
+    open var customViewSize: CGSize {
+        switch customViewSizeType {
         case .zero:
             return .zero
         case .small:
@@ -47,7 +47,7 @@ open class TableViewCellTokens: ControlTokens {
 
     /// The trailing margin of the customView.
     open var customViewTrailingMargin: CGFloat {
-        switch customViewSize {
+        switch customViewSizeType {
         case .zero:
             return globalTokens.spacing[.none]
         case .small:
@@ -139,7 +139,7 @@ open class TableViewCellTokens: ControlTokens {
     open var accessoryDetailButtonColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
     /// Defines the size of the customView size.
-    public internal(set) var customViewSize: MSFTableViewCellCustomViewSize = .default
+    public internal(set) var customViewSizeType: MSFTableViewCellCustomViewSize = .default
 }
 
 /// Pre-defined sizes of the customView size.

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -31,7 +31,7 @@ open class TableViewCellTokens: ControlTokens {
     /// The leading image color.
     open var imageColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
 
-    /// The size dimensions of the customView
+    /// The size dimensions of the customView.
     open var customViewDimensions: CGSize {
         switch customViewSize {
         case .zero:
@@ -45,7 +45,7 @@ open class TableViewCellTokens: ControlTokens {
         }
     }
 
-    /// The trailing margin of the customView
+    /// The trailing margin of the customView.
     open var customViewTrailingMargin: CGFloat {
         switch customViewSize {
         case .zero:
@@ -142,7 +142,7 @@ open class TableViewCellTokens: ControlTokens {
     public internal(set) var customViewSize: MSFTableViewCellCustomViewSize = .default
 }
 
-/// Pre-defined sizes of the customView size
+/// Pre-defined sizes of the customView size.
 @objc public enum MSFTableViewCellCustomViewSize: Int, CaseIterable {
     case `default`
     case zero


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Tokenizing CustomViewSize enum in TableViewCell. This includes the dimensions and trailing margin of the customView.

**Note: This PR brings breaking changes to the TableViewCell API: the CustomViewSize enum is being moved over to tokens and renamed as MSFTableViewCellCustomViewSize.

### Verification

Tested on iOS 15.5 iPhone 12 Pro. There should be no visible difference in the before/after.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro - 2022-06-02 at 17 24 16](https://user-images.githubusercontent.com/22566866/171761311-a72aa100-8ad1-4f28-a14f-9a27160a00e9.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-06-02 at 17 25 00](https://user-images.githubusercontent.com/22566866/171761402-0785a3b8-be44-43a6-93a7-f5b2c5b0bcb6.png) |
| ![Simulator Screen Shot - iPhone 12 - 2022-06-08 at 13 38 37](https://user-images.githubusercontent.com/22566866/172712762-d50b4884-de70-4b85-af90-a0939a89edea.png) | ![Simulator Screen Shot - iPhone 12 - 2022-06-08 at 13 45 28](https://user-images.githubusercontent.com/22566866/172713792-b2efa203-4dfb-439f-8edf-0900069eaa18.png) |
| ![Simulator Screen Shot - iPhone 12 - 2022-06-08 at 13 39 15](https://user-images.githubusercontent.com/22566866/172712879-6c4db5f7-6f84-4856-8e9d-2d40dadb78f1.png) | ![Simulator Screen Shot - iPhone 12 - 2022-06-08 at 13 45 09](https://user-images.githubusercontent.com/22566866/172713740-f1fd00d3-1f79-4f9b-9528-e157f4de53f1.png) |


Per-control theme validation:

https://user-images.githubusercontent.com/22566866/171761485-01ad55a8-4aac-4a98-9ed9-791402355e06.mov



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/998)