### PR TITLE
Fixing BadgeView logic for returning index of its inner accessible elements.

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -823,15 +823,25 @@ open class BadgeField: UIView {
     }
 
     open override func index(ofAccessibilityElement element: Any) -> Int {
-        if element as? UILabel == labelView {
+        guard element as? UILabel != labelView else {
+            // The label is always the first accessible element of the BadgeField.
             return 0
         }
 
-        let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
-        if let badge = element as? BadgeView, let index = activeBadges.firstIndex(of: badge) {
-            return isIntroductionLabelAccessible() ? index + 1 : index
+        guard element as? BadgeTextField != textField else {
+            // The text field is always the last accessible element of the BadgeField.
+            return accessibilityElementCount() - 1
         }
-        return accessibilityElementCount() - 1
+
+        let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
+        guard let badge = element as? BadgeView,
+              let index = activeBadges.firstIndex(of: badge) else {
+            // If it's an unknown element to the BadgeField, return NSNotFound
+            // which means the element does not exist in the control.
+            return NSNotFound
+        }
+
+        return isIntroductionLabelAccessible() ? index + 1 : index
     }
 
     private func isIntroductionLabelAccessible() -> Bool {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A partner app team reported an issue that VoiceOver is blocked in a scenario where the BadgeField is used inside a UITableViewCell that has an accessory view. (before video reproduces the problem)

This happens because VoiceOver queries the BadgeField with the accessoryView element when VoiceOver focuses on it.

Because the logic of the BadgeField always assumed that it'd be queried only for the elements that it contains, it incorrectly returns the last index of its elements when the accessoryView of the cell was queried by VoiceOver, therefore confusing VoiceOver and causing the issue.

The fix is on the overridden implementation of [index(ofAccessibilityElement:)](https://developer.apple.com/documentation/objectivec/nsobject/1615078-index) which now checks only for the elements that the BadgeField contains and returns NSNotFound otherwise. This way VoiceOver works correctly as it understands that the accessoryView button is not part of the BadgeField. 

### Verification

- Modified the demo app to reproduce the scenario reported by the client app. The issue has be reproduced.
**Before:**

https://user-images.githubusercontent.com/68076145/172913738-435e1a2d-cafe-4c08-8594-da11718ec6d9.MP4


- Validated the changes made to the BadgeField fix the issue.
**After:**

https://user-images.githubusercontent.com/68076145/172913785-2b85ddc3-cf16-4423-9f9e-6406ff2a7f93.MP4


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1001)