### PR TITLE
Tokenizing other cells and TableViewCell subclasses

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -33,6 +33,7 @@ struct Demos {
         DemoDescriptor("LeftNav", LeftNavDemoController.self),
         DemoDescriptor("List", ListDemoController.self),
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
+        DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
         DemoDescriptor("PillButtonBar", PillButtonBarDemoController.self),
         DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
@@ -61,8 +62,7 @@ struct Demos {
         DemoDescriptor("TableViewCellFileAccessoryView", TableViewCellFileAccessoryViewDemoController.self),
         DemoDescriptor("TableViewCellShimmer", TableViewCellShimmerDemoController.self),
         DemoDescriptor("TableViewHeaderFooterView", TableViewHeaderFooterViewDemoController.self),
-        DemoDescriptor("Tooltip", TooltipDemoController.self),
-        DemoDescriptor("Other cells", OtherCellsDemoController.self)
+        DemoDescriptor("Tooltip", TooltipDemoController.self)
     ]
 
     static let debug: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -13,7 +13,7 @@ class OtherCellsDemoController: DemoController {
 
     private var tableView: UITableView!
 
-    private var overrideTokens: TableViewCellTokens?
+    private var overrideTokens: ActionsCellTokens?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,14 +40,30 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((ActionsCell) -> ActionsCellTokens)?
+        var actionsTokensClosure: (() -> ActionsCellTokens)?
+        var activityTokensClosure: (() -> TableViewCellTokens)?
+        var booleanTokensClosure: (() -> TableViewCellTokens)?
+        var centeredTokensClosure: (() -> TableViewCellTokens)?
+
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            actionsTokensClosure = {
                 return ThemeWideOverrideActionsCellTokens()
+            }
+            activityTokensClosure = {
+                return ThemeWideOverrideOtherCellTokens()
+            }
+            booleanTokensClosure = {
+                return ThemeWideOverrideOtherCellTokens()
+            }
+            centeredTokensClosure = {
+                return ThemeWideOverrideOtherCellTokens()
             }
         }
 
-        fluentTheme.register(controlType: ActionsCell.self, tokens: tokensClosure)
+        fluentTheme.register(controlType: ActionsCell.self, tokens: actionsTokensClosure)
+        fluentTheme.register(controlType: ActivityIndicatorCell.self, tokens: activityTokensClosure)
+        fluentTheme.register(controlType: BooleanCell.self, tokens: booleanTokensClosure)
+        fluentTheme.register(controlType: CenteredLabelCell.self, tokens: centeredTokensClosure)
     }
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
@@ -68,7 +84,15 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
         }
     }
 
-    private class PerControlOverrideTableViewCellTokens: TableViewCellTokens {
+    private class ThemeWideOverrideOtherCellTokens: TableViewCellTokens {
+        override var cellBackgroundColor: DynamicColor {
+            // "Charcoal"
+            return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
+                                dark: GlobalTokens().sharedColors[.charcoal][.shade40])
+        }
+    }
+
+    private class PerControlOverrideTableViewCellTokens: ActionsCellTokens {
         override var cellBackgroundColor: DynamicColor {
             // "Burgundy"
             return DynamicColor(light: GlobalTokens().sharedColors[.burgundy][.tint50],
@@ -99,6 +123,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
             cell.setup(action1Title: item.text1, action2Title: item.text2, action2Type: .destructive)
             let isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
             cell.bottomSeparatorType = isLastInSection ? .full : .inset
+            cell.actionsCellOverrideTokens = overrideTokens
             return cell
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -13,6 +13,8 @@ class OtherCellsDemoController: DemoController {
 
     private var tableView: UITableView!
 
+    private var overrideTokens: TableViewCellTokens?
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -29,6 +31,49 @@ class OtherCellsDemoController: DemoController {
         tableView.separatorColor = Colors.Separator.default
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)
+    }
+}
+
+extension OtherCellsDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        var tokensClosure: ((ActionsCell) -> ActionsCellTokens)?
+        if isOverrideEnabled {
+            tokensClosure = { _ in
+                return ThemeWideOverrideActionsCellTokens()
+            }
+        }
+
+        fluentTheme.register(controlType: ActionsCell.self, tokens: tokensClosure)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        overrideTokens = isOverrideEnabled ? PerControlOverrideTableViewCellTokens() : nil
+        self.tableView.reloadData()
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokenOverride(for: ActivityIndicatorCell.self) != nil
+    }
+
+    // MARK: - Custom tokens
+    private class ThemeWideOverrideActionsCellTokens: ActionsCellTokens {
+        override var regularTextColor: DynamicColor {
+            // "Charcoal"
+            return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
+                                dark: GlobalTokens().sharedColors[.charcoal][.shade40])
+        }
+    }
+
+    private class PerControlOverrideTableViewCellTokens: TableViewCellTokens {
+        override var cellBackgroundColor: DynamicColor {
+            // "Burgundy"
+            return DynamicColor(light: GlobalTokens().sharedColors[.burgundy][.tint50],
+                                dark: GlobalTokens().sharedColors[.burgundy][.shade40])
+        }
     }
 }
 
@@ -59,6 +104,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
 
         if let cell = tableView.dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier) as? ActivityIndicatorCell,
            section.title == "ActivityIndicatorCell" {
+            cell.activityIndicatorCellOverrideTokens = overrideTokens
             return cell
         }
 
@@ -70,6 +116,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
             cell.onValueChanged = { [unowned self, unowned cell] in
                 self.showAlertForSwitchTapped(isOn: cell.isOn)
             }
+            cell.tableViewCellOverrideTokens = overrideTokens
             return cell
         }
 
@@ -78,6 +125,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
                 return UITableViewCell()
             }
             cell.setup(text: item.text1)
+            cell.centeredLabelCellOverrideTokens = overrideTokens
             return cell
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -77,7 +77,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
 
     // MARK: - Custom tokens
     private class ThemeWideOverrideActionsCellTokens: ActionsCellTokens {
-        override var regularTextColor: DynamicColor {
+        override var mainBrandColor: DynamicColor {
             // "Charcoal"
             return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
                                 dark: GlobalTokens().sharedColors[.charcoal][.shade40])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -103,10 +103,6 @@ extension OtherCellsDemoController: UITableViewDelegate {
         return header
     }
 
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        cell.backgroundColor = Colors.tableCellBackgroundGrouped
-    }
-
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -15,51 +15,85 @@ import UIKit
  `topSeparatorType` and `bottomSeparatorType` can be used to show custom horizontal separators. Make sure to remove the `UITableViewCell` built-in separator by setting `separatorStyle = .none` on your table view.
  */
 @objc(MSFActionsCell)
-open class ActionsCell: UITableViewCell {
+open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     @objc(MSFActionsCellActionType)
     public enum ActionType: Int {
         case regular
         case destructive
         case communication
 
-        func highlightedTextColor(for window: UIWindow) -> UIColor {
+        func highlightedTextColor(tokens: ActionsCellTokens) -> UIColor {
             switch self {
             case .regular:
-                return Colors.primary(for: window).withAlphaComponent(0.4)
+                return UIColor(dynamicColor: tokens.regularTextColor).withAlphaComponent(0.4)
             case .destructive:
-                return Colors.Table.ActionCell.textDestructiveHighlighted
+                return UIColor(dynamicColor: tokens.destructiveTextColor).withAlphaComponent(0.4)
             case .communication:
-                return Colors.Table.ActionCell.textCommunicationHighlighted
+                return UIColor(dynamicColor: tokens.communicationTextColor).withAlphaComponent(0.4)
             }
         }
 
-        func textColor(for window: UIWindow) -> UIColor {
+        func textColor(tokens: ActionsCellTokens) -> UIColor {
             switch self {
             case .regular:
-                return Colors.primary(for: window)
+                return UIColor(dynamicColor: tokens.regularTextColor)
             case .destructive:
-                return Colors.Table.ActionCell.textDestructive
+                return UIColor(dynamicColor: tokens.destructiveTextColor)
             case .communication:
-                return Colors.Table.ActionCell.textCommunication
+                return UIColor(dynamicColor: tokens.communicationTextColor)
             }
         }
     }
 
     public static let identifier: String = "ActionsCell"
 
-    @objc public class func height(action1Title: String, action2Title: String = "", containerWidth: CGFloat) -> CGFloat {
+    // MARK: - ActionsCell TokenizedControl
+    @objc public var actionsCellOverrideTokens: ActionsCellTokens? {
+        didSet {
+            self.overrideTokens = actionsCellOverrideTokens
+        }
+    }
+
+    let defaultTokens: ActionsCellTokens = .init()
+    var tokens: ActionsCellTokens = .init()
+    /// Design token set for this control, to use in place of the control's default Fluent tokens.
+    var overrideTokens: ActionsCellTokens? {
+        didSet {
+            updateTokens()
+        }
+    }
+
+    public func overrideTokens(_ tokens: ActionsCellTokens?) -> Self {
+        overrideTokens = tokens
+        return self
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateTokens()
+    }
+
+    private func updateTokens() {
+        tokens = resolvedTokens
+        updateActionTitleColors()
+        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+    }
+
+    @objc public class func height(action1Title: String, action2Title: String = "", containerWidth: CGFloat, tokens: ActionsCellTokens) -> CGFloat {
         let actionCount: CGFloat = action2Title == "" ? 1 : 2
         let width = UIScreen.main.roundToDevicePixels(containerWidth / actionCount)
 
-        let actionTitleFont = TableViewCell.TextStyles.title.font
+        let actionTitleFont = UIFont.fluent(tokens.titleFont)
         let action1TitleHeight = action1Title.preferredSize(for: actionTitleFont, width: width).height
         let action2TitleHeight = action2Title.preferredSize(for: actionTitleFont, width: width).height
 
-        return max(Constants.verticalMargin * 2 + max(action1TitleHeight, action2TitleHeight), Constants.defaultHeight)
+        return max(tokens.paddingVertical * 2 + max(action1TitleHeight, action2TitleHeight), tokens.minHeight)
     }
 
-    @objc public class func preferredWidth(action1Title: String, action2Title: String = "") -> CGFloat {
-        let actionTitleFont = TableViewCell.TextStyles.title.font
+    @objc public class func preferredWidth(action1Title: String, action2Title: String = "", tokens: ActionsCellTokens) -> CGFloat {
+        let actionTitleFont = UIFont.fluent(tokens.titleFont)
         let action1TitleWidth = action1Title.preferredSize(for: actionTitleFont).width
         let action2TitleWidth = action2Title.preferredSize(for: actionTitleFont).width
 
@@ -112,10 +146,15 @@ open class ActionsCell: UITableViewCell {
         updateHorizontalSeparator(topSeparator, with: topSeparatorType)
         updateHorizontalSeparator(bottomSeparator, with: bottomSeparatorType)
 
-        backgroundColor = Colors.Table.Cell.background
+        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
 
         setupAction(action1Button)
         setupAction(action2Button)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     public required init(coder aDecoder: NSCoder) {
@@ -174,21 +213,23 @@ open class ActionsCell: UITableViewCell {
             width: max(
                 type(of: self).preferredWidth(
                     action1Title: action1Button.currentTitle ?? "",
-                    action2Title: action2Button.currentTitle ?? ""
+                    action2Title: action2Button.currentTitle ?? "",
+                    tokens: tokens
                 ),
                 maxWidth
             ),
             height: type(of: self).height(
                 action1Title: action1Button.currentTitle ?? "",
                 action2Title: action2Button.currentTitle ?? "",
-                containerWidth: maxWidth
+                containerWidth: maxWidth,
+                tokens: tokens
             )
         )
     }
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateActionTitleColors()
+        updateTokens()
     }
 
     open override func prepareForReuse() {
@@ -202,13 +243,13 @@ open class ActionsCell: UITableViewCell {
     open override func setSelected(_ selected: Bool, animated: Bool) { }
 
     private func setupAction(_ button: UIButton) {
-        button.titleLabel?.font = TableViewCell.TextStyles.title.font
+        button.titleLabel?.font = UIFont.fluent(tokens.titleFont)
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.textAlignment = .center
     }
 
     private func layoutHorizontalSeparator(_ separator: MSFDivider, with type: TableViewCell.SeparatorType, at verticalOffset: CGFloat) {
-        let horizontalOffset = type == .inset ? safeAreaInsets.left + Constants.horizontalSpacing : 0
+        let horizontalOffset = type == .inset ? safeAreaInsets.left + tokens.horizontalSpacing : 0
 
         separator.frame = CGRect(
             x: horizontalOffset,
@@ -225,20 +266,12 @@ open class ActionsCell: UITableViewCell {
     }
 
     private func updateActionTitleColors() {
-        if let window = window {
-            action1Button.setTitleColor(action1Type.textColor(for: window), for: .normal)
-            action1Button.setTitleColor(action1Type.highlightedTextColor(for: window), for: .highlighted)
-            if !action2Button.isHidden {
-                action2Button.setTitleColor(action2Type.textColor(for: window), for: .normal)
-                action2Button.setTitleColor(action2Type.highlightedTextColor(for: window), for: .highlighted)
-            }
+        action1Button.setTitleColor(action1Type.textColor(tokens: tokens), for: .normal)
+        action1Button.setTitleColor(action1Type.highlightedTextColor(tokens: tokens), for: .highlighted)
+        if !action2Button.isHidden {
+            action2Button.setTitleColor(action2Type.textColor(tokens: tokens), for: .normal)
+            action2Button.setTitleColor(action2Type.highlightedTextColor(tokens: tokens), for: .highlighted)
         }
 
-    }
-
-    private struct Constants {
-        static let horizontalSpacing: CGFloat = 16
-        static let verticalMargin: CGFloat = 11
-        static let defaultHeight: CGFloat = 48
     }
 }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -25,7 +25,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         func highlightedTextColor(tokens: ActionsCellTokens) -> UIColor {
             switch self {
             case .regular:
-                return UIColor(dynamicColor: tokens.regularTextColor).withAlphaComponent(0.4)
+                return UIColor(dynamicColor: tokens.mainBrandColor).withAlphaComponent(0.4)
             case .destructive:
                 return UIColor(dynamicColor: tokens.destructiveTextColor).withAlphaComponent(0.4)
             case .communication:
@@ -36,7 +36,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         func textColor(tokens: ActionsCellTokens) -> UIColor {
             switch self {
             case .regular:
-                return UIColor(dynamicColor: tokens.regularTextColor)
+                return UIColor(dynamicColor: tokens.mainBrandColor)
             case .destructive:
                 return UIColor(dynamicColor: tokens.destructiveTextColor)
             case .communication:

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -234,6 +234,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
     open override func prepareForReuse() {
         super.prepareForReuse()
+        updateTokens()
         action1Button.removeTarget(nil, action: nil, for: .allEvents)
         action2Button.removeTarget(nil, action: nil, for: .allEvents)
     }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -75,6 +75,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
     open override func prepareForReuse() {
         super.prepareForReuse()
+        updateTokens()
         activityIndicator.state.isAnimating = true
     }
 

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -8,8 +8,41 @@ import UIKit
 // MARK: ActivityIndicatorCell
 
 @objc(MSFActivityIndicatorCell)
-open class ActivityIndicatorCell: UITableViewCell {
+open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
     public static let identifier: String = "ActivityIndicatorCell"
+
+    // MARK: - ActivityIndicatorCell TokenizedControl
+    @objc public var activityIndicatorCellOverrideTokens: TableViewCellTokens? {
+        didSet {
+            self.overrideTokens = activityIndicatorCellOverrideTokens
+        }
+    }
+
+    let defaultTokens: TableViewCellTokens = .init()
+    var tokens: TableViewCellTokens = .init()
+    /// Design token set for this control, to use in place of the control's default Fluent tokens.
+    var overrideTokens: TableViewCellTokens? {
+        didSet {
+            updateTokens()
+        }
+    }
+
+    public func overrideTokens(_ tokens: TableViewCellTokens?) -> Self {
+        overrideTokens = tokens
+        return self
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateTokens()
+    }
+
+    private func updateTokens() {
+        tokens = resolvedTokens
+        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+    }
 
     private let activityIndicator: MSFActivityIndicator = {
         let activityIndicator = MSFActivityIndicator(size: .small)
@@ -20,7 +53,13 @@ open class ActivityIndicatorCell: UITableViewCell {
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.addSubview(activityIndicator)
-        backgroundColor = Colors.Table.Cell.background
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
+        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
     }
 
     @objc public required init(coder aDecoder: NSCoder) {
@@ -45,12 +84,10 @@ open class ActivityIndicatorCell: UITableViewCell {
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
         let maxWidth = size.width != 0 ? size.width : .infinity
-        return CGSize(width: maxWidth, height: ActivityIndicatorCell.defaultHeight)
+        return CGSize(width: maxWidth, height: tokens.minHeight)
     }
 
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
 
     open override func setSelected(_ selected: Bool, animated: Bool) { }
-
-    private static let defaultHeight: CGFloat = 48
 }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -73,6 +73,11 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         activityIndicatorView.center = CGPoint(x: UIScreen.main.roundToDevicePixels(contentView.frame.width / 2), y: UIScreen.main.roundToDevicePixels(contentView.frame.height / 2))
     }
 
+    open override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateTokens()
+    }
+
     open override func prepareForReuse() {
         super.prepareForReuse()
         updateTokens()

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -89,7 +89,7 @@ open class BooleanCell: TableViewCell {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        `switch`.onTintColor = UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
+        `switch`.onTintColor = UIColor(dynamicColor: tokens.mainBrandColor)
     }
 
     private func updateAccessibility() {

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -89,9 +89,7 @@ open class BooleanCell: TableViewCell {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        if let window = window {
-            `switch`.onTintColor = Colors.primary(for: window)
-        }
+        `switch`.onTintColor = UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
     }
 
     private func updateAccessibility() {

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -76,6 +76,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     @objc open func setup(text: String) {
         label.text = text
         label.font = UIFont.fluent(tokens.titleFont)
+        label.textColor = UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
         setNeedsLayout()
     }
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -108,8 +108,4 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
 
     open override func setSelected(_ selected: Bool, animated: Bool) { }
-
-    private struct Constants {
-        static let paddingVertical: CGFloat = 11
-    }
 }

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -43,7 +43,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         tokens = resolvedTokens
         backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
         label.font = UIFont.fluent(tokens.titleFont)
-        label.textColor = UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
+        label.textColor = UIColor(dynamicColor: tokens.mainBrandColor)
     }
 
     // Public to be able to change style without wrapping every property
@@ -76,7 +76,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     @objc open func setup(text: String) {
         label.text = text
         label.font = UIFont.fluent(tokens.titleFont)
-        label.textColor = UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
+        label.textColor = UIColor(dynamicColor: tokens.mainBrandColor)
         setNeedsLayout()
     }
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -8,14 +8,48 @@ import UIKit
 // MARK: CenteredLabelCell
 
 @objc(MSFCenteredLabelCell)
-open class CenteredLabelCell: UITableViewCell {
+open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     public static let identifier: String = "CenteredLabelCell"
+
+    // MARK: - CenteredLabelCell TokenizedControl
+    @objc public var centeredLabelCellOverrideTokens: TableViewCellTokens? {
+        didSet {
+            self.overrideTokens = centeredLabelCellOverrideTokens
+        }
+    }
+
+    let defaultTokens: TableViewCellTokens = .init()
+    var tokens: TableViewCellTokens = .init()
+    /// Design token set for this control, to use in place of the control's default Fluent tokens.
+    var overrideTokens: TableViewCellTokens? {
+        didSet {
+            updateTokens()
+        }
+    }
+
+    public func overrideTokens(_ tokens: TableViewCellTokens?) -> Self {
+        overrideTokens = tokens
+        return self
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateTokens()
+    }
+
+    private func updateTokens() {
+        tokens = resolvedTokens
+        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        label.font = UIFont.fluent(tokens.titleFont)
+        label.textColor = UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
+    }
 
     // Public to be able to change style without wrapping every property
     public let label: UILabel = {
         let label = UILabel()
         label.backgroundColor = .clear
-        label.font = Constants.labelFont
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
@@ -23,8 +57,13 @@ open class CenteredLabelCell: UITableViewCell {
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
         contentView.addSubview(label)
-        backgroundColor = Colors.Table.Cell.background
     }
 
     @objc public required init(coder aDecoder: NSCoder) {
@@ -36,6 +75,7 @@ open class CenteredLabelCell: UITableViewCell {
     /// - Parameter text: The text to be displayed
     @objc open func setup(text: String) {
         label.text = text
+        label.font = UIFont.fluent(tokens.titleFont)
         setNeedsLayout()
     }
 
@@ -48,7 +88,7 @@ open class CenteredLabelCell: UITableViewCell {
 
         let labelWidthArea = maxWidth - layoutMargins.left - layoutMargins.right
         let labelFittingSize = label.sizeThatFits(CGSize(width: labelWidthArea, height: CGFloat.greatestFiniteMagnitude))
-        let height = max(Constants.paddingVertical * 2 + ceil(labelFittingSize.height), Constants.defaultHeight)
+        let height = max(tokens.paddingVertical * 2 + ceil(labelFittingSize.height), tokens.minHeight)
         return CGSize(width: maxWidth, height: height)
     }
 
@@ -61,9 +101,7 @@ open class CenteredLabelCell: UITableViewCell {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        if let window = window {
-            label.textColor = Colors.primary(for: window)
-        }
+        updateTokens()
     }
 
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
@@ -71,8 +109,6 @@ open class CenteredLabelCell: UITableViewCell {
     open override func setSelected(_ selected: Bool, animated: Bool) { }
 
     private struct Constants {
-        static let labelFont: UIFont = Fonts.body
         static let paddingVertical: CGFloat = 11
-        static let defaultHeight: CGFloat = 48
     }
 }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -698,9 +698,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc open var customViewSize: MSFTableViewCellCustomViewSize {
         get {
             if customView == nil {
-                return .zero
+                tokens.customViewSize = .zero
+            } else {
+                tokens.customViewSize = _customViewSize == .default ? layoutType.customViewSize : _customViewSize
             }
-            tokens.customViewSize = _customViewSize == .default ? layoutType.customViewSize : _customViewSize
             return tokens.customViewSize
         }
         set {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -63,20 +63,9 @@ public enum TableViewCellAccessoryType: Int {
 public extension Colors {
     internal struct Table {
         struct Cell {
-            static var background: UIColor = surfacePrimary
             static var image: UIColor = iconSecondary
             static var title: UIColor = textPrimary
             static var subtitle: UIColor = textSecondary
-            static var accessoryDisclosureIndicator: UIColor = iconSecondary
-            static var accessoryDetailButton: UIColor = iconSecondary
-            static var selectionIndicatorOff: UIColor = iconSecondary
-        }
-
-        struct ActionCell {
-            static var textDestructive: UIColor = error
-            static var textDestructiveHighlighted: UIColor = error.withAlphaComponent(0.4)
-            static var textCommunication: UIColor = communicationBlue
-            static var textCommunicationHighlighted: UIColor = communicationBlue.withAlphaComponent(0.4)
         }
 
         struct HeaderFooter {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -43,7 +43,7 @@ public enum TableViewCellAccessoryType: Int {
         case .detailButton:
             return UIColor(dynamicColor: tokens.accessoryDetailButtonColor)
         case .checkmark:
-            return UIColor(dynamicColor: tokens.globalTokens.brandColors[.primary])
+            return UIColor(dynamicColor: tokens.mainBrandColor)
         }
     }
 
@@ -1537,7 +1537,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private func updateSelectionImageColor() {
-        selectionImageView.tintColor = UIColor(dynamicColor: isSelected ? tokens.globalTokens.brandColors[.primary] : tokens.selectionIndicatorOffColor)
+        selectionImageView.tintColor = UIColor(dynamicColor: isSelected ? tokens.mainBrandColor : tokens.selectionIndicatorOffColor)
     }
 
     private func updateSeparator(_ separator: MSFDivider, with type: SeparatorType) {

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -141,6 +141,9 @@ open class TableViewCellTokens: ControlTokens {
     /// The color for the accessoryDetailButtonColor.
     open var accessoryDetailButtonColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
+    /// The main primary brand color of the theme.
+    open var mainBrandColor: DynamicColor { globalTokens.brandColors[.primary] }
+
     /// Defines the size of the customView size.
     public internal(set) var customViewSize: MSFTableViewCellCustomViewSize = .default
 }

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -129,6 +129,9 @@ open class TableViewCellTokens: ControlTokens {
     /// The leading padding in the cell.
     open var paddingLeading: CGFloat { globalTokens.spacing[.medium] }
 
+    /// The vertical padding in the cell.
+    open var paddingVertical: CGFloat = 11
+
     /// The trailing padding in the cell.
     open var paddingTrailing: CGFloat { globalTokens.spacing[.medium] }
 
@@ -148,4 +151,15 @@ open class TableViewCellTokens: ControlTokens {
     case zero
     case small
     case medium
+}
+
+open class ActionsCellTokens: TableViewCellTokens {
+    /// The trailing margin of the customView.
+    open var regularTextColor: DynamicColor { globalTokens.brandColors[.primary] }
+
+    open var destructiveTextColor: DynamicColor { DynamicColor(light: ColorValue(0xD92C2C),
+                                                    dark: ColorValue(0xE83A3A)) }
+
+    open var communicationTextColor: DynamicColor { DynamicColor(light: ColorValue(0x0078D4),
+                                                    dark: ColorValue(0x0086F0)) }
 }

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -154,12 +154,14 @@ open class TableViewCellTokens: ControlTokens {
 }
 
 open class ActionsCellTokens: TableViewCellTokens {
-    /// The trailing margin of the customView.
+    /// The regular text color in an ActionsCell
     open var regularTextColor: DynamicColor { globalTokens.brandColors[.primary] }
 
+    /// The destructive text color in an ActionsCell.
     open var destructiveTextColor: DynamicColor { DynamicColor(light: ColorValue(0xD92C2C),
                                                     dark: ColorValue(0xE83A3A)) }
 
+    /// The communication text color in an ActionsCell.
     open var communicationTextColor: DynamicColor { DynamicColor(light: ColorValue(0x0078D4),
                                                     dark: ColorValue(0x0086F0)) }
 }

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -157,9 +157,6 @@ open class TableViewCellTokens: ControlTokens {
 }
 
 open class ActionsCellTokens: TableViewCellTokens {
-    /// The regular text color in an ActionsCell
-    open var regularTextColor: DynamicColor { globalTokens.brandColors[.primary] }
-
     /// The destructive text color in an ActionsCell.
     open var destructiveTextColor: DynamicColor { DynamicColor(light: ColorValue(0xD92C2C),
                                                     dark: ColorValue(0xE83A3A)) }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This pt. 2 change following #998 brings tokenization to the following:

- ActionsCell
- ActivityIndicatorCell
- BooleanCell
- CenteredLabelCell

PopupMenuItemCell has been excluded in this PR as it will be tokenized at a later time.

### Verification

Tested on iPhone 12 iOS 14.5

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 - 2022-06-09 at 14 08 09](https://user-images.githubusercontent.com/22566866/172944733-79d0ce91-4fb9-4fe4-9794-5565ebd29b61.png) | ![Simulator Screen Shot - iPhone 12 - 2022-06-09 at 14 05 59](https://user-images.githubusercontent.com/22566866/172944423-8904bdc4-7397-4ca8-9f3f-9a67e0ab66d4.png) |


Tokenization validation:

https://user-images.githubusercontent.com/22566866/173450148-5c450f91-ab0f-4c65-9caa-41639c6e1443.mov



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1002)