### PR TITLE
[main -> vnext_tokens] Update with latest main changes to unblock SegmentedControl work

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -141,6 +141,8 @@ class CommandBarDemoController: DemoController {
         }
     }
 
+    var defaultCommandBar: CommandBar?
+
     let textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
@@ -156,6 +158,110 @@ class CommandBarDemoController: DemoController {
         container.layoutMargins.left = 0
         view.backgroundColor = Colors.surfaceSecondary
 
+        container.addArrangedSubview(createLabelWithText("Default"))
+
+        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        commandBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(commandBar)
+        defaultCommandBar = commandBar
+
+        let itemCustomizationContainer = UIStackView()
+        itemCustomizationContainer.spacing = CommandBarDemoController.verticalStackViewSpacing
+        itemCustomizationContainer.axis = .vertical
+        itemCustomizationContainer.backgroundColor = Colors.navigationBarBackground
+
+        itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
+
+        let refreshButton = MSFButton(style: .secondary,
+                                      size: .small) { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.refreshDefaultBarItems()
+        }
+        refreshButton.state.text = "Refresh 'Default' Bar"
+        itemCustomizationContainer.addArrangedSubview(refreshButton)
+
+        let removeTrailingItemButton = MSFButton(style: .secondary,
+                                                 size: .small) { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.removeDefaultTrailingBarItems()
+        }
+        removeTrailingItemButton.state.text = "Remove Trailing Button"
+        itemCustomizationContainer.addArrangedSubview(removeTrailingItemButton)
+
+        let refreshTrailingItemButton = MSFButton(style: .secondary,
+                                                  size: .small) { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.refreshDefaultTrailingBarItems()
+        }
+        refreshTrailingItemButton.state.text = "Refresh Trailing Button"
+        itemCustomizationContainer.addArrangedSubview(refreshTrailingItemButton)
+
+        let removeLeadingItemButton = MSFButton(style: .secondary,
+                                                size: .small) { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.removeDefaultLeadingBarItems()
+        }
+        removeLeadingItemButton.state.text = "Remove Leading Button"
+        itemCustomizationContainer.addArrangedSubview(removeLeadingItemButton)
+
+        let refreshLeadingItemButton = MSFButton(style: .secondary,
+                                                 size: .small) { [weak self] _ in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.refreshDefaultLeadingBarItems()
+        }
+        refreshLeadingItemButton.state.text = "Refresh Leading Button"
+        itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
+
+        let customizationStackView = UIStackView()
+        customizationStackView.axis = .horizontal
+        customizationStackView.alignment = .fill
+        customizationStackView.distribution = .fillProportionally
+        customizationStackView.addArrangedSubview(createLabelWithText("'+' Item Enabled"))
+        let itemEnabledSwitch: UISwitch = UISwitch()
+        itemEnabledSwitch.isOn = true
+        itemEnabledSwitch.addTarget(self, action: #selector(itemEnabledValueChanged), for: .valueChanged)
+        customizationStackView.addArrangedSubview(itemEnabledSwitch)
+        itemCustomizationContainer.addArrangedSubview(customizationStackView)
+
+        itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
+
+        container.addArrangedSubview(itemCustomizationContainer)
+
+        container.addArrangedSubview(createLabelWithText("With Fixed Button"))
+
+        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+        fixedButtonCommandBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(fixedButtonCommandBar)
+
+        container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
+
+        let textFieldContainer = UIView()
+        textFieldContainer.backgroundColor = Colors.navigationBarBackground
+        textFieldContainer.addSubview(textField)
+        NSLayoutConstraint.activate([
+            textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
+            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 16.0),
+            textFieldContainer.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: 16.0),
+            textFieldContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 16.0)
+        ])
+
+        container.addArrangedSubview(textFieldContainer)
+
+        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
+        textField.inputAccessoryView = accessoryCommandBar
+    }
+
+    func createItemGroups() -> [CommandBarItemGroup] {
         let commandGroups: [[Command]] = [
             [
                 .add,
@@ -204,32 +310,7 @@ class CommandBarDemoController: DemoController {
                                           UIAction(title: "Copy Text", image: UIImage(named: "text24Regular"), handler: { _ in })])
         copyItem.showsMenuAsPrimaryAction = true
 
-        container.addArrangedSubview(createLabelWithText("Default"))
-
-        let defaultCommandBar = CommandBar(itemGroups: itemGroups)
-        container.addArrangedSubview(defaultCommandBar)
-
-        container.addArrangedSubview(createLabelWithText("With Fixed Button"))
-
-        let fixedButtonCommandBar = CommandBar(itemGroups: itemGroups, leadingItem: newItem(for: .copy), trailingItem: newItem(for: .keyboard))
-        container.addArrangedSubview(fixedButtonCommandBar)
-
-        container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
-
-        let textFieldContainer = UIView()
-        textFieldContainer.backgroundColor = Colors.navigationBarBackground
-        textFieldContainer.addSubview(textField)
-        NSLayoutConstraint.activate([
-            textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
-            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 16.0),
-            textFieldContainer.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: 16.0),
-            textFieldContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 16.0)
-        ])
-
-        container.addArrangedSubview(textFieldContainer)
-
-        let accessoryCommandBar = CommandBar(itemGroups: itemGroups, trailingItem: newItem(for: .keyboard))
-        textField.inputAccessoryView = accessoryCommandBar
+        return itemGroups
     }
 
     func createLabelWithText(_ text: String = "") -> Label {
@@ -274,4 +355,34 @@ class CommandBarDemoController: DemoController {
             present(alert, animated: true)
         }
     }
+
+    @objc func itemEnabledValueChanged(sender: UISwitch!) {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
+            return
+        }
+
+        item.isEnabled = sender.isOn
+    }
+
+    @objc func refreshDefaultBarItems() {
+        defaultCommandBar?.itemGroups = createItemGroups()
+    }
+
+    @objc func removeDefaultTrailingBarItems() {
+        defaultCommandBar?.trailingItemGroups = []
+    }
+
+    @objc func refreshDefaultTrailingBarItems() {
+        defaultCommandBar?.trailingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    @objc func removeDefaultLeadingBarItems() {
+        defaultCommandBar?.leadingItemGroups = []
+    }
+
+    @objc func refreshDefaultLeadingBarItems() {
+        defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    private static let verticalStackViewSpacing: CGFloat = 8.0
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -9,7 +9,7 @@ import UIKit
 class SegmentedControlDemoController: DemoController {
     let segmentItems: [SegmentItem] = [
         SegmentItem(title: "First"),
-        SegmentItem(title: "Second"),
+        SegmentItem(title: "Second", image: UIImage(named: "Placeholder_20")),
         SegmentItem(title: "Third", isUnread: true),
         SegmentItem(title: "Fourth")
     ]

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
+		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
@@ -334,6 +335,7 @@
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
+		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -1166,6 +1168,7 @@
 				FC414E4E2588B65C00069E73 /* CommandBarItem.swift */,
 				FC414E2A25887A4B00069E73 /* CommandBarButton.swift */,
 				FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */,
+				94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */,
 				0AD70F5926E80A5D008774EC /* CommandBarTokens.swift */,
 			);
 			path = "Command Bar";
@@ -1701,6 +1704,7 @@
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,
 				5314E08925F00F2D0099271A /* CommandBarButtonGroupView.swift in Sources */,
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,
+				94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */,
 				EC6A71EA273DBA520076A586 /* Divider.swift in Sources */,
 				5314E21E25F022120099271A /* UIView+Extensions.swift in Sources */,
 				5314E06A25F00F100099271A /* GenericDateTimePicker.swift in Sources */,

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -823,15 +823,25 @@ open class BadgeField: UIView {
     }
 
     open override func index(ofAccessibilityElement element: Any) -> Int {
-        if element as? UILabel == labelView {
+        guard element as? UILabel != labelView else {
+            // The label is always the first accessible element of the BadgeField.
             return 0
         }
 
-        let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
-        if let badge = element as? BadgeView, let index = activeBadges.firstIndex(of: badge) {
-            return isIntroductionLabelAccessible() ? index + 1 : index
+        guard element as? BadgeTextField != textField else {
+            // The text field is always the last accessible element of the BadgeField.
+            return accessibilityElementCount() - 1
         }
-        return accessibilityElementCount() - 1
+
+        let activeBadges = shouldUseConstrainedBadges ? constrainedBadges : badges
+        guard let badge = element as? BadgeView,
+              let index = activeBadges.firstIndex(of: badge) else {
+            // If it's an unknown element to the BadgeField, return NSNotFound
+            // which means the element does not exist in the control.
+            return NSNotFound
+        }
+
+        return isIntroductionLabelAccessible() ? index + 1 : index
     }
 
     private func isIntroductionLabelAccessible() -> Bool {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -445,6 +445,11 @@ public class BottomSheetController: UIViewController {
         collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
     }
 
+    public override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        completeAnimationsIfNeeded(skipToEnd: true)
+    }
+
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -7,38 +7,65 @@ import UIKit
 
 /**
  `CommandBar` is a horizontal scrollable list of icon buttons divided by groups.
- Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItem` and `trailingItem` add fixed buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
+ Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItemGroups` and `trailingItemGroups` add buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  */
 @objc(MSFCommandBar)
 public class CommandBar: UIView, TokenizedControlInternal {
     // Hierarchy:
     //
-    // leadingButton
-    // containerView
-    // |--layer.mask -> containerMaskLayer (fill containerView)
-    // |--subviews
-    // |  |--scrollView (fill containerView)
-    // |  |  |--subviews
-    // |  |  |  |--stackView
-    // |  |  |  |  |--buttons (fill scrollView content)
-    // trailingButton
+    // commandBarContainerStackView
+    // |--leadingCommandGroupsView
+    // |--|--buttons
+    // |--containerView
+    // |--|--layer.mask -> containerMaskLayer (fill containerView)
+    // |--|--subviews
+    // |--|  |--scrollView (fill containerView)
+    // |--|  |  |--subviews
+    // |--|  |  |  |--stackView
+    // |--|  |  |  |  |--buttons (fill scrollView content)
+    // |--trailingCommandGroupsView
+    // |--|--buttons
 
     // MARK: - Public methods
 
-    @objc public init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
-        self.itemGroups = itemGroups
-
-        super.init(frame: .zero)
+    @available(*, renamed: "init(itemGroups:leadingItemGroups:trailingItemGroups:)")
+    @objc public convenience init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
+        var leadingItems: [CommandBarItemGroup]?
+        var trailingItems: [CommandBarItemGroup]?
 
         if let leadingItem = leadingItem {
-            self.leadingButton = button(forItem: leadingItem, isPersistSelection: false)
-        }
-        if let trailingItem = trailingItem {
-            self.trailingButton = button(forItem: trailingItem, isPersistSelection: false)
+            leadingItems = [[leadingItem]]
         }
 
-        backgroundColor = UIColor(dynamicColor: tokens.backgroundColor)
-        translatesAutoresizingMaskIntoConstraints = false
+        if let trailingItem = trailingItem {
+            trailingItems = [[trailingItem]]
+        }
+
+        self.init(itemGroups: itemGroups, leadingItemGroups: leadingItems, trailingItemGroups: trailingItems)
+    }
+
+    @objc public init(itemGroups: [CommandBarItemGroup], leadingItemGroups: [CommandBarItemGroup]? = nil, trailingItemGroups: [CommandBarItemGroup]? = nil) {
+        self.itemGroups = itemGroups
+        self.leadingItemGroups = leadingItemGroups
+        self.trailingItemGroups = trailingItemGroups
+
+        leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.leadingItemGroups,
+                                                               buttonsPersistSelection: false,
+                                                               tokens: tokens)
+        leadingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
+        mainCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.itemGroups,
+                                                            tokens: tokens)
+        mainCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
+        trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.trailingItemGroups,
+                                                                buttonsPersistSelection: false,
+                                                                tokens: tokens)
+        trailingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
+
+        commandBarContainerStackView = UIStackView()
+        commandBarContainerStackView.axis = .horizontal
+        commandBarContainerStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        super.init(frame: .zero)
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(themeDidChange),
@@ -46,7 +73,6 @@ public class CommandBar: UIView, TokenizedControlInternal {
                                                object: nil)
 
         configureHierarchy()
-        updateButtonsState()
     }
 
     public override func didMoveToWindow() {
@@ -60,10 +86,11 @@ public class CommandBar: UIView, TokenizedControlInternal {
     }
 
     /// Apply `isEnabled` and `isSelected` state from `CommandBarItem` to the buttons
+    @available(*, message: "Changes on CommandBarItem objects will automatically trigger updates to their corresponding CommandBarButtons. Calls to this method are no longer necessary.")
     @objc public func updateButtonsState() {
-        for button in itemsToButtonsMap.values {
-            button.updateState()
-        }
+        leadingCommandGroupsView.updateButtonsState()
+        mainCommandGroupsView.updateButtonsState()
+        trailingCommandGroupsView.updateButtonsState()
     }
 
     public func overrideTokens(_ tokens: CommandBarTokens?) -> Self {
@@ -79,6 +106,8 @@ public class CommandBar: UIView, TokenizedControlInternal {
 
     public override func layoutSubviews() {
         super.layoutSubviews()
+
+        commandBarContainerStackView.layoutIfNeeded()
 
         containerMaskLayer.frame = containerView.bounds
         updateShadow()
@@ -103,16 +132,52 @@ public class CommandBar: UIView, TokenizedControlInternal {
         }
     }
 
+    /// Scrollable items shown in the center of the CommandBar
+    public var itemGroups: [CommandBarItemGroup] {
+        didSet {
+            mainCommandGroupsView.itemGroups = itemGroups
+        }
+    }
+
+    /// Items pinned to the leading end of the CommandBar
+    public var leadingItemGroups: [CommandBarItemGroup]? {
+        didSet {
+            guard let leadingItemGroups = leadingItemGroups else {
+                return
+            }
+
+            leadingCommandGroupsView.itemGroups = leadingItemGroups
+            leadingCommandGroupsView.isHidden = leadingItemGroups.isEmpty
+            scrollView.contentInset = scrollViewContentInset()
+        }
+    }
+
+    /// Items pinned to the trailing end of the CommandBar
+    public var trailingItemGroups: [CommandBarItemGroup]? {
+        didSet {
+            guard let trailingItemGroups = trailingItemGroups else {
+                return
+            }
+
+            trailingCommandGroupsView.itemGroups = trailingItemGroups
+            trailingCommandGroupsView.isHidden = trailingItemGroups.isEmpty
+            scrollView.contentInset = scrollViewContentInset()
+        }
+    }
+
     // MARK: - Private properties
 
-    private let itemGroups: [CommandBarItemGroup]
+    /// Container UIStackView that holds the leading, main and trailing views
+    private var commandBarContainerStackView: UIStackView
 
-    private lazy var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = {
-        let allButtons = itemGroups.flatMap({ $0 }).map({ button(forItem: $0) }) +
-            [leadingButton, trailingButton].compactMap({ $0 })
+    /// View holding the items pinned to the leading end of the CommandBar
+    private var leadingCommandGroupsView: CommandBarCommandGroupsView
 
-        return Dictionary(uniqueKeysWithValues: allButtons.map { ($0.item, $0) })
-    }()
+    /// View holding the items in the middle of the CommandBar
+    private var mainCommandGroupsView: CommandBarCommandGroupsView
+
+    /// View holding the items pinned to the trailing end of the CommandBar
+    private var trailingCommandGroupsView: CommandBarCommandGroupsView
 
     // MARK: Views and Layers
 
@@ -136,54 +201,24 @@ public class CommandBar: UIView, TokenizedControlInternal {
         let scrollView = UIScrollView()
         let itemInterspace: CGFloat = tokens.itemInterspace
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.contentInset = UIEdgeInsets(
-            top: 0,
-            left: leadingButton == nil ? CommandBar.insets.left : itemInterspace,
-            bottom: 0,
-            right: trailingButton == nil ? CommandBar.insets.right : itemInterspace
-        )
+        scrollView.contentInset = scrollViewContentInset()
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
         scrollView.delegate = self
 
-        scrollView.addSubview(stackView)
+        scrollView.addSubview(mainCommandGroupsView)
         NSLayoutConstraint.activate([
             scrollView.contentLayoutGuide.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
 
-            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+            mainCommandGroupsView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            mainCommandGroupsView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: mainCommandGroupsView.bottomAnchor),
+            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: mainCommandGroupsView.trailingAnchor)
         ])
 
         return scrollView
     }()
-
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: buttonGroupViews)
-
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = tokens.groupInterspace
-
-        return stackView
-    }()
-
-    private lazy var buttonGroupViews: [CommandBarButtonGroupView] = {
-        itemGroups.map { items in
-            CommandBarButtonGroupView(buttons: items.compactMap { item in
-                guard let button = itemsToButtonsMap[item] else {
-                    preconditionFailure("Button is not initialized in commandsToButtons")
-                }
-
-                return button
-            }, commandBarTokens: tokens)
-        }
-    }()
-
-    private var leadingButton: CommandBarButton?
-    private var trailingButton: CommandBarButton?
 
     private let containerMaskLayer: CAGradientLayer = {
         // A mask layer using alpha color channel.
@@ -197,72 +232,55 @@ public class CommandBar: UIView, TokenizedControlInternal {
     }()
 
     private func configureHierarchy() {
-        let itemInterspace: CGFloat = tokens.itemInterspace
-        addSubview(containerView)
+        leadingCommandGroupsView.isHidden = leadingCommandGroupsView.itemGroups.isEmpty
+        trailingCommandGroupsView.isHidden = trailingCommandGroupsView.itemGroups.isEmpty
 
-        // Left and right button layout constraints
-        if let leadingButton = leadingButton {
-            addSubview(leadingButton)
-            NSLayoutConstraint.activate([
-                leadingButton.topAnchor.constraint(equalTo: containerView.topAnchor),
-                leadingButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: itemInterspace),
-                containerView.bottomAnchor.constraint(equalTo: leadingButton.bottomAnchor),
-                containerView.leadingAnchor.constraint(equalTo: leadingButton.trailingAnchor, constant: itemInterspace)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                containerView.leadingAnchor.constraint(equalTo: leadingAnchor)
-            ])
-        }
+        addSubview(commandBarContainerStackView)
 
-        if let trailingButton = trailingButton {
-            addSubview(trailingButton)
-            NSLayoutConstraint.activate([
-                trailingButton.topAnchor.constraint(equalTo: containerView.topAnchor),
-                trailingButton.leadingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: itemInterspace),
-                containerView.bottomAnchor.constraint(equalTo: trailingButton.bottomAnchor),
-                trailingAnchor.constraint(equalTo: trailingButton.trailingAnchor, constant: itemInterspace)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
-            ])
-        }
+        commandBarContainerStackView.addArrangedSubview(leadingCommandGroupsView)
+        commandBarContainerStackView.addArrangedSubview(containerView)
+        commandBarContainerStackView.addArrangedSubview(trailingCommandGroupsView)
 
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBar.insets.top),
-            bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: CommandBar.insets.bottom)
+            commandBarContainerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            commandBarContainerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            commandBarContainerStackView.topAnchor.constraint(equalTo: topAnchor),
+            commandBarContainerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-
-        stackView.layoutIfNeeded()
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
             let flipTransform = CGAffineTransform(scaleX: -1, y: 1)
             scrollView.transform = flipTransform
-            stackView.transform = flipTransform
+            leadingCommandGroupsView.transform = flipTransform
+            mainCommandGroupsView.transform = flipTransform
+            trailingCommandGroupsView.transform = flipTransform
             containerMaskLayer.setAffineTransform(flipTransform)
         }
+
+        scrollView.contentInset = scrollViewContentInset()
     }
 
-    private func button(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
-        let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection, commandBarTokens: tokens)
-        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
-
-        return button
+    private func scrollViewContentInset() -> UIEdgeInsets {
+        let fixedButtonSpacing = tokens.itemInterspace
+        return UIEdgeInsets(top: 0,
+                            left: leadingCommandGroupsView.isHidden ? CommandBar.insets.left : fixedButtonSpacing,
+                            bottom: 0,
+                            right: trailingCommandGroupsView.isHidden ? CommandBar.insets.right : fixedButtonSpacing
+        )
     }
 
     private func updateShadow() {
         var locations: [CGFloat] = [0, 0, 1]
 
-        if leadingButton != nil {
+        if !leadingCommandGroupsView.isHidden {
             let leadingOffset = max(0, scrollView.contentOffset.x)
             let percentage = min(1, leadingOffset / scrollView.contentInset.left)
             locations[1] = CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }
 
-        if trailingButton != nil {
-            let trailingOffset = max(0, stackView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
+        if !trailingCommandGroupsView.isHidden {
+            let trailingOffset = max(0, mainCommandGroupsView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
             let percentage = min(1, trailingOffset / scrollView.contentInset.right)
             locations[2] = 1 - CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }
@@ -272,9 +290,9 @@ public class CommandBar: UIView, TokenizedControlInternal {
 
     private func updateButtonTokens() {
         self.tokens = resolvedTokens
-        for button in itemsToButtonsMap.values {
-            button.commandBarTokens = tokens
-        }
+        leadingCommandGroupsView.tokens = tokens
+        mainCommandGroupsView.tokens = tokens
+        trailingCommandGroupsView.tokens = tokens
     }
 
     @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
@@ -285,7 +303,6 @@ public class CommandBar: UIView, TokenizedControlInternal {
     private var themeObserver: NSObjectProtocol?
 
     private static let fadeViewWidth: CGFloat = 16.0
-
     private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
 }
 

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -1,0 +1,119 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+class CommandBarCommandGroupsView: UIView {
+    init(itemGroups: [CommandBarItemGroup]? = nil, buttonsPersistSelection: Bool = true, tokens: CommandBarTokens) {
+        self.itemGroups = itemGroups ?? []
+        self.buttonsPersistSelection = buttonsPersistSelection
+        self.tokens = tokens
+
+        buttonGroupsStackView = UIStackView()
+
+        super.init(frame: .zero)
+
+        buttonGroupsStackView.translatesAutoresizingMaskIntoConstraints = false
+        buttonGroupsStackView.axis = .horizontal
+        buttonGroupsStackView.spacing = CommandBarCommandGroupsView.buttonGroupSpacing
+
+        configureHierarchy()
+        updateButtonsShown()
+    }
+
+    required init(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    public var itemGroups: [CommandBarItemGroup] {
+        didSet {
+            if itemGroups != oldValue {
+                updateButtonsShown()
+            }
+        }
+    }
+
+    /// Updates the state of all buttons in the group
+    public func updateButtonsState() {
+        for button in itemsToButtonsMap.values {
+            button.updateState()
+        }
+    }
+
+    var tokens: CommandBarTokens {
+        didSet {
+            updateButtonGroupViews()
+        }
+    }
+
+    // MARK: - Private properties
+
+    private var buttonGroupsStackView: UIStackView
+    private var buttonGroupViews: [CommandBarButtonGroupView] = []
+    private var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = [:]
+    private var buttonsPersistSelection: Bool
+
+    // MARK: View Updates
+
+    private func configureHierarchy() {
+        addSubview(buttonGroupsStackView)
+
+        NSLayoutConstraint.activate([
+            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    /// Refreshes the buttons shown in the `arrangedSubviews`
+    private func updateButtonsShown() {
+        for view in buttonGroupsStackView.arrangedSubviews {
+            view.removeFromSuperview()
+        }
+
+        updateButtonGroupViews()
+        for view in buttonGroupViews {
+            buttonGroupsStackView.addArrangedSubview(view)
+        }
+    }
+
+    /// Refreshes the `buttonGroupViews` array of `CommandBarButtonGroupView`s that are displayed in the view
+    private func updateButtonGroupViews() {
+        updateItemsToButtonsMap()
+        buttonGroupViews = itemGroups.map { items in
+                CommandBarButtonGroupView(buttons: items.compactMap { item in
+                    guard let button = itemsToButtonsMap[item] else {
+                        preconditionFailure("Button is not initialized in map")
+                    }
+                    item.propertyChangedUpdateBlock = { _ in
+                        button.updateState()
+                    }
+                    return button
+                }, commandBarTokens: tokens)
+        }
+    }
+
+    /// Refreshes the `itemsToButtonsMap` of `CommandBarItem`s to their corresponding `CommandBarButton`
+    private func updateItemsToButtonsMap() {
+        let allButtons = itemGroups.flatMap({ $0 }).map({ createButton(forItem: $0, isPersistSelection: buttonsPersistSelection) })
+        itemsToButtonsMap = Dictionary(uniqueKeysWithValues: allButtons.map { ($0.item, $0) })
+    }
+
+    private func createButton(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
+        let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection, commandBarTokens: tokens)
+        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
+
+        return button
+    }
+
+    @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
+        sender.item.handleTapped(sender)
+        sender.updateState()
+    }
+
+    private static let buttonGroupSpacing: CGFloat = 16
+    private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+}

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -62,17 +62,41 @@ open class CommandBarItem: NSObject {
         self.accessibilityHint = accessibilityHint
     }
 
-    @objc public var iconImage: UIImage?
+    @objc public var iconImage: UIImage? {
+        didSet {
+            if iconImage != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     /// Title for the item. Only valid when `iconImage` is `nil`.
-    @objc public var title: String?
+    @objc public var title: String? {
+        didSet {
+            if title != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     @objc public var titleFont: UIFont?
 
-    @objc public var isEnabled: Bool
+    @objc public var isEnabled: Bool {
+        didSet {
+            if isEnabled != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     /// If `isPersistSelection` is `true`, this value would be changed to reflect the selection state of the button. Setting this value before providing to `CommandBar` would set the initial selection state.
-    @objc public var isSelected: Bool
+    @objc public var isSelected: Bool {
+        didSet {
+            if isSelected != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     /// Set `isSelected` to desired value in this handler. Default implementation is toggling `isSelected` property.
     @objc public var itemTappedHandler: ItemTappedHandler
@@ -90,4 +114,7 @@ open class CommandBarItem: NSObject {
     func handleTapped(_ sender: CommandBarButton) {
         itemTappedHandler(sender, self)
     }
+
+    /// Called after a property is changed to trigger the update of a corresponding button
+    var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
 }

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -14,7 +14,19 @@ open class ControlHostingView: UIView {
         guard let hostedView = hostingController.view else {
             return super.intrinsicContentSize
         }
+
+        // Our desired size should always be the same as our hosted view.
         return hostedView.intrinsicContentSize
+    }
+
+    /// Asks the view to calculate and return the size that best fits the specified size.
+    @objc public override func sizeThatFits(_ size: CGSize) -> CGSize {
+        guard let hostedView = hostingController.view else {
+            return super.sizeThatFits(size)
+        }
+
+        // Our desired size should always be the same as our hosted view.
+        return hostedView.sizeThatFits(size)
     }
 
     /// Initializes and returns an instance of `ControlHostingContainer` that wraps `controlView`.
@@ -55,11 +67,6 @@ open class ControlHostingView: UIView {
 
         addSubview(hostedView)
         hostedView.translatesAutoresizingMaskIntoConstraints = false
-
-        // Initialize our frame with the hosted view's initial bounds so we don't start as a (0,0,0,0) view.
-        // Future updates will be handled by the autolayout constraints below.
-        hostedView.sizeToFit()
-        self.frame = hostedView.bounds
 
         let requiredConstraints = [
             hostedView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -574,6 +574,57 @@ open class SearchBar: UIView {
     private func dismissKeyboard() {
         searchTextField.resignFirstResponder()
     }
+
+    // MARK: - Cancel Button Accessibility Properties
+
+    public var cancelButtonAccessibilityHint: String? {
+        get { return cancelButton.accessibilityHint }
+        set { cancelButton.accessibilityHint = newValue }
+    }
+
+    public var cancelButtonAccessibilityLabel: String? {
+        get { return cancelButton.accessibilityLabel }
+        set { cancelButton.accessibilityLabel = newValue }
+    }
+
+    public var cancelButtonAccessibilityIdentifier: String? {
+        get { return cancelButton.accessibilityIdentifier }
+        set { cancelButton.accessibilityIdentifier = newValue }
+    }
+
+    // MARK: - Clear Button Accessibility Properties
+
+    public var clearButtonAccessibilityHint: String? {
+        get { return clearButton.accessibilityHint }
+        set { clearButton.accessibilityHint = newValue }
+    }
+
+    public var clearButtonAccessibilityLabel: String? {
+        get { return clearButton.accessibilityLabel }
+        set { clearButton.accessibilityLabel = newValue }
+    }
+
+    public var clearButtonAccessibilityIdentifier: String? {
+        get { return clearButton.accessibilityIdentifier }
+        set { clearButton.accessibilityIdentifier = newValue }
+    }
+
+    // MARK: - Search Text Field Accessibility Properties
+
+    public var searchTextFieldAccessibilityHint: String? {
+        get { return searchTextField.accessibilityHint }
+        set { searchTextField.accessibilityHint = newValue }
+    }
+
+    public var searchTextFieldAccessibilityLabel: String? {
+        get { return searchTextField.accessibilityLabel }
+        set { searchTextField.accessibilityLabel = newValue }
+    }
+
+    public var searchTextFieldAccessibilityIdentifier: String? {
+        get { return searchTextField.accessibilityIdentifier }
+        set { searchTextField.accessibilityIdentifier = newValue }
+    }
 }
 
 // MARK: - SearchBar: UITextFieldDelegate

--- a/ios/FluentUI/SegmentedControl/SegmentItem.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentItem.swift
@@ -3,11 +3,13 @@
 //  Licensed under the MIT License.
 //
 import Foundation
+import UIKit
 
 /// Used for SegmentedControl array of views
 @objc(MSFSegmentItem)
 public class SegmentItem: NSObject {
     public let title: String
+    public let image: UIImage?
 
     /// This value will determine whether or not to show dot next to the pill button label
     public var isUnread: Bool {
@@ -18,8 +20,26 @@ public class SegmentItem: NSObject {
        }
    }
 
-    @objc public init(title: String, isUnread: Bool = false) {
+    /// Creates a new instance of a `SegmentItem` that holds data used to create a segment in the `SegmentedControl`.
+    /// - Parameters
+    ///   - title: Title that will be displayed by the segment and used as the accessibility label and large content viewer title.
+    ///   - isUnread:  Whether the segment shows the mark that represents the "unread" state.
+    @objc public convenience init(title: String, isUnread: Bool = false) {
+        self.init(title: title,
+                  image: nil,
+                  isUnread: isUnread)
+    }
+
+    /// Creates a new instance of a `SegmentItem` that holds data used to create a segment in the `SegmentedControl`.
+    /// - Parameters
+    ///   - title: Title that will be displayed by the segment if the image is nil, and used as the accessibility label and large content viewer title.
+    ///   - image: Image that will display instead of the title if not nil.
+    ///   - isUnread:  Whether the segment shows the mark that represents the "unread" state.
+    @objc public init(title: String,
+                      image: UIImage? = nil,
+                      isUnread: Bool = false) {
         self.title = title
+        self.image = image
         self.isUnread = isUnread
         super.init()
     }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -49,9 +49,13 @@ class SegmentPillButton: UIButton {
         super.init(frame: .zero)
 
         let title = item.title
-        self.setTitle(title, for: .normal)
-        self.accessibilityLabel = title
-        self.largeContentTitle = title
+        if let image = item.image {
+            self.setImage(image, for: .normal)
+            self.accessibilityLabel = title
+            self.largeContentTitle = title
+        } else {
+            self.setTitle(title, for: .normal)
+        }
         self.showsLargeContentViewer = true
 
         NotificationCenter.default.addObserver(self,

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -396,7 +396,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         switch style {
         case .header, .footer, .headerPrimary:
             titleYOffset = style == .footer ? Constants.titleDefaultBottomMargin : Constants.titleDefaultTopMargin
-            titleHeight = contentView.frame.height - Constants.titleDefaultTopMargin - Constants.titleDefaultBottomMargin
+            titleHeight = contentView.frame.height - titleYOffset - Constants.titleDefaultBottomMargin
         case .divider, .dividerHighlighted:
             titleYOffset = Constants.titleDividerVerticalMargin
             titleHeight = contentView.frame.height - (Constants.titleDividerVerticalMargin * 2)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update vnext_tokens to have the latest changes from main, so that I can continue working on the SegmentedControl in the vnext_tokens branch. I had to make some changes to the CommandBar and SegmentedControl to make the merge happen. Generally, though, includes changes from:
#1001 
#997 
#987 
#995 
#993 
#992 
#989 
#982 
I had to update the CommandBar demo to use the MSFButton. I also had to add tokens to the CommandBarGroupsView to pass it down to the CommandBarButtons, and I had to update the SegmentedControl's icons to use the token colors.
### Verification

Built locally and verified that the changed controls are behaving as expected between main and vnext_tokens.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="534" alt="CommandBar_before" src="https://user-images.githubusercontent.com/67026548/173158785-45a51006-5466-4cc9-9bac-02a6c6953c8e.png"> | <img width="534" alt="CommandBar_after" src="https://user-images.githubusercontent.com/67026548/173158781-c84936c8-beb5-4dff-8789-3858e238f770.png"> |
| <img width="534" alt="SegmentedControl_before" src="https://user-images.githubusercontent.com/67026548/173158788-931689e4-1f67-46b9-98c5-3711b64f7b08.png"> | <img width="534" alt="SegmentedControl_after" src="https://user-images.githubusercontent.com/67026548/173158775-84adc3ff-c4e5-4e2b-8dd0-bdce2627aa74.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1003)