### PR TITLE
[Tokens] Simplify theme token lookup and generation

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -237,7 +237,7 @@ extension ActivityIndicatorDemoController: DemoAppearanceDelegate {
             return
         }
         if isOverrideEnabled {
-            fluentTheme.register(controlType: ActivityIndicator.self, tokens: { _ in
+            fluentTheme.register(controlType: ActivityIndicator.self, tokens: {
                 ThemeWideOverrideActivityIndicatorTokens()
             })
         } else {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -311,9 +311,9 @@ extension ButtonDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((FluentButton) -> ButtonTokens)?
+        var tokensClosure: (() -> ButtonTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverrideButtonTokens()
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -236,9 +236,9 @@ extension CardNudgeDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((CardNudge) -> CardNudgeTokens)?
+        var tokensClosure: (() -> CardNudgeTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverrideCardNudgeTokens()
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -214,7 +214,7 @@ extension DividerDemoController: DemoAppearanceDelegate {
             return
         }
         if isOverrideEnabled {
-            fluentTheme.register(controlType: FluentDivider.self, tokens: { _ in
+            fluentTheme.register(controlType: FluentDivider.self, tokens: {
                 ThemeWideOverrideDividerTokens()
             })
         } else {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -272,7 +272,7 @@ extension HUDDemoController: DemoAppearanceDelegate {
             return
         }
         if isOverrideEnabled {
-            fluentTheme.register(controlType: HeadsUpDisplay.self, tokens: { _ in
+            fluentTheme.register(controlType: HeadsUpDisplay.self, tokens: {
                 ThemeWideOverrideActivityHeadsUpDisplayTokens()
             })
         } else {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -216,9 +216,9 @@ extension PillButtonBarDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((PillButton) -> PillButtonTokens)?
+        var tokensClosure: (() -> PillButtonTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverridePillButtonTokens()
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -119,9 +119,9 @@ extension SegmentedControlDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((SegmentedControl) -> SegmentedControlTokens)?
+        var tokensClosure: (() -> SegmentedControlTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverrideSegmentedControlTokens()
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -331,9 +331,9 @@ extension SideTabBarDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((SideTabBar) -> SideTabBarTokens)?
+        var tokensClosure: (() -> SideTabBarTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverrideSideTabBarTokens()
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -201,9 +201,9 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((TabBarView) -> TabBarTokens)?
+        var tokensClosure: (() -> TabBarTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverrideTabBarTokens()
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -116,9 +116,9 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
             return
         }
 
-        var tokensClosure: ((TableViewCell) -> TableViewCellTokens)?
+        var tokensClosure: (() -> TableViewCellTokens)?
         if isOverrideEnabled {
-            tokensClosure = { _ in
+            tokensClosure = {
                 return ThemeWideOverrideTableViewCellTokens()
             }
         }

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -22,29 +22,29 @@ import SwiftUI
     /// Registers a custom set of `ControlTokens` for a given `TokenizedControl`.
     ///
     /// - Parameters:
-    ///   - control: The control to use custom tokens on.
+    ///   - controlType: The control type to use custom tokens on.
     ///   - tokens: A closure that returns a custom set of tokens.
-    public func register<T: TokenizedControl>(controlType: T.Type, tokens: ((T) -> T.TokenType)?) {
+    public func register<T: TokenizedControl>(controlType: T.Type, tokens: (() -> T.TokenType)?) {
         controlTokens[tokenKey(controlType)] = tokens
     }
 
     /// Returns the specified `ControlTokens` generator for a given `TokenizedControl`, if a lookup function has been registered.
     ///
-    /// - Parameter control: The control to fetch the token generator for.
+    /// - Parameter controlType: The control type to fetch the token generator for.
     ///
     /// - Returns: A `ControlTokens` generator for the given control, or `nil` if no lookup function has been registered.
-    public func tokenOverride<T: TokenizedControl>(for controlType: T.Type) -> ((T) -> T.TokenType)? {
-        return controlTokens[tokenKey(controlType)] as? ((T) -> T.TokenType)
+    public func tokenOverride<T: TokenizedControl>(for controlType: T.Type) -> (() -> T.TokenType)? {
+        return controlTokens[tokenKey(controlType)] as? (() -> T.TokenType)
     }
 
     /// Returns a custom `ControlTokens` instance for a given `TokenizedControl`, if a lookup function has been registered.
     ///
-    /// - Parameter control: The control to fetch tokens for.
+    /// - Parameter controlType: The control type to fetch tokens for.
     ///
     /// - Returns: A `ControlTokens` instance for the given control, or `nil` if no lookup function has been registered.
-    func tokens<T: TokenizedControl>(for control: T) -> T.TokenType? {
-        if let lookup = controlTokens[tokenKey(type(of: control))] as? ((T) -> T.TokenType) {
-            return lookup(control)
+    func tokens<T: TokenizedControl>(for controlType: T.Type) -> T.TokenType? {
+        if let lookup = controlTokens[tokenKey(controlType)] as? (() -> T.TokenType) {
+            return lookup()
         } else {
             return nil
         }

--- a/ios/FluentUI/Core/Theme/Tokens/TokenizedControl.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenizedControl.swift
@@ -34,7 +34,7 @@ protocol TokenizedControlInternal: TokenizedControl {
 extension TokenizedControlInternal {
     /// Returns the correct token set for a given tokenizable control.
     var resolvedTokens: TokenType {
-        let tokens = overrideTokens ?? fluentTheme.tokens(for: self) ?? defaultTokens
+        let tokens = overrideTokens ?? fluentTheme.tokens(for: type(of: self)) ?? defaultTokens
         tokens.fluentTheme = fluentTheme
         return tokens
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In anticipation of a fix for #985, this change slightly modifies how theme-wide token overrides are generated and retrieved.

Briefly:
* The existing code requires passing the control whose tokens are being looked up as an argument to the generator.
* This is actually bad:
  * In SwiftUI, the view is being passed by value rather than by reference, which means it's being copied!
  * The new approach for `overrideTokens` I'm finalizing will not have access to the control instance at theme lookup time anyway.

NOTE: This will be an API-breaking change when merged to `main`. In particular, the following public API changes:

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| `FluentTheme.register<T: TokenizedControl>(controlType: T.Type, tokens: ((T) -> T.TokenType)?)` | `FluentTheme.register<T: TokenizedControl>(controlType: T.Type, tokens: (() -> T.TokenType)?)` |
| `FluentTheme.tokenOverride<T: TokenizedControl>(for controlType: T.Type) -> ((T) -> T.TokenType)?` | `FluentTheme.tokenOverride<T: TokenizedControl>(for controlType: T.Type) -> (() -> T.TokenType)?` |

### Verification

Tested theme-wide overrides for a few controls and saw no difference in behavior:

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/173161885-cf36b28e-97c6-465d-8e89-0900b765c463.png) | ![after](https://user-images.githubusercontent.com/4934719/173161915-926efcd6-eb8f-486f-b920-69a47b8c6b34.png) |
| ![before2](https://user-images.githubusercontent.com/4934719/173161888-534155dd-63f0-4b14-978b-7673394790d3.png) | ![after2](https://user-images.githubusercontent.com/4934719/173161916-78247ec6-b7cf-461c-9290-654b33771af2.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)