### PR TITLE
[vNext Tokens] Convert SegmentedControl from UIControl to UIView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -147,7 +147,7 @@ class ColorDemoController: UIViewController {
 
     private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: DemoColorTheme.allCases.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
-        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
+//        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
         return segmentedControl
     }()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -159,14 +159,6 @@ class ColorDemoController: UIViewController {
         return segmentedControl
     }()
 
-    @objc private func segmentedControlValueChanged(sender: Any) {
-        if let segmentedControl = sender as? SegmentedControl, let window = self.view.window {
-            if let currentDemoListViewController = currentDemoListViewController {
-                currentDemoListViewController.updateColorProviderFor(window: window, theme: DemoColorTheme.allCases[segmentedControl.selectedSegmentIndex])
-            }
-        }
-    }
-
     @objc private func didChangeTheme() {
         // The controls in this controller are not fully theme-aware yet, so
         // we need to manually poke them and have them refresh their colors.

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -147,7 +147,7 @@ class ColorDemoController: UIViewController {
 
     private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: DemoColorTheme.allCases.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
-        segmentedControl.onSelectAction = { [weak self] (_, _, index) in
+        segmentedControl.onSelectAction = { [weak self] (_, index) in
             guard let strongSelf = self,
                   let window = strongSelf.view.window,
                   let currentDemoListViewController = strongSelf.currentDemoListViewController else {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -147,7 +147,15 @@ class ColorDemoController: UIViewController {
 
     private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: DemoColorTheme.allCases.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
-//        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
+        segmentedControl.onSelectAction = { [weak self] (_, _, index) in
+            guard let strongSelf = self,
+                  let window = strongSelf.view.window,
+                  let currentDemoListViewController = strongSelf.currentDemoListViewController else {
+                return
+            }
+
+            currentDemoListViewController.updateColorProviderFor(window: window, theme: DemoColorTheme.allCases[index])
+        }
         return segmentedControl
     }()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -75,9 +75,9 @@ class SegmentedControlDemoController: DemoController {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled
-        pillControl.addTarget(self,
-                              action: #selector(updateLabel(forControl:)),
-                              for: .valueChanged)
+//        pillControl.addTarget(self,
+//                              action: #selector(updateLabel(forControl:)),
+//                              for: .valueChanged)
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
             switch style {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -75,12 +75,12 @@ class SegmentedControlDemoController: DemoController {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled
-        pillControl.onSelectAction = { [weak self] (segmentedControl, _, _) in
+        pillControl.onSelectAction = { [weak self] (_, _) in
             guard let strongSelf = self else {
                 return
             }
 
-            strongSelf.updateLabel(forControl: segmentedControl)
+            strongSelf.updateLabel(forControl: pillControl)
         }
 
         let backgroundStyle: ColoredPillBackgroundStyle = {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -75,7 +75,13 @@ class SegmentedControlDemoController: DemoController {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled
-        pillControl.segmentDelegate = self
+        pillControl.onSelectAction = { [weak self] (segmentedControl, _, _) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.updateLabel(forControl: segmentedControl)
+        }
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
             switch style {
@@ -109,12 +115,6 @@ class SegmentedControlDemoController: DemoController {
     }
 
     private var segmentedControls: [SegmentedControl] = []
-}
-
-extension SegmentedControlDemoController: SegmentedControlDelegate {
-    func segmentedControl(_ segmentedControl: SegmentedControl, didSelectItem item: SegmentItem, atIndex index: Int) {
-        updateLabel(forControl: segmentedControl)
-    }
 }
 
 extension SegmentedControlDemoController: DemoAppearanceDelegate {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -75,9 +75,7 @@ class SegmentedControlDemoController: DemoController {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isEnabled = enabled
-//        pillControl.addTarget(self,
-//                              action: #selector(updateLabel(forControl:)),
-//                              for: .valueChanged)
+        pillControl.segmentDelegate = self
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
             switch style {
@@ -111,6 +109,12 @@ class SegmentedControlDemoController: DemoController {
     }
 
     private var segmentedControls: [SegmentedControl] = []
+}
+
+extension SegmentedControlDemoController: SegmentedControlDelegate {
+    func segmentedControl(_ segmentedControl: SegmentedControl, didSelectItem item: SegmentItem, atIndex index: Int) {
+        updateLabel(forControl: segmentedControl)
+    }
 }
 
 extension SegmentedControlDemoController: DemoAppearanceDelegate {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -13,9 +13,15 @@ class TableViewHeaderFooterViewDemoController: DemoController {
     private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
     private let divider = MSFDivider()
 
-    private let segmentedControl: SegmentedControl = {
+    private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
-//        segmentedControl.addTarget(TableViewHeaderFooterViewDemoController.self, action: #selector(updateActiveTabContent), for: .valueChanged)
+        segmentedControl.onSelectAction = { [weak self] (_, _, _) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.updateActiveTabContent()
+        }
         return segmentedControl
     }()
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -15,7 +15,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
 
     private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
-        segmentedControl.onSelectAction = { [weak self] (_, _, _) in
+        segmentedControl.onSelectAction = { [weak self] (_, _) in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -15,7 +15,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
 
     private let segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
-        segmentedControl.addTarget(TableViewHeaderFooterViewDemoController.self, action: #selector(updateActiveTabContent), for: .valueChanged)
+//        segmentedControl.addTarget(TableViewHeaderFooterViewDemoController.self, action: #selector(updateActiveTabContent), for: .valueChanged)
         return segmentedControl
     }()
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -230,9 +230,16 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     private func initSegmentedControl() {
         let items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
-        segmentedControl = SegmentedControl(items: items,
+        let segmentedControl = SegmentedControl(items: items,
                                             style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-//        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
+        segmentedControl.onSelectAction = { [weak self] (_, _, index) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.handleDidSelectStartEnd(index)
+        }
+        self.segmentedControl = segmentedControl
     }
 
     private func updateNavigationBar() {
@@ -322,8 +329,8 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         dismiss()
     }
 
-    @objc private func handleDidSelectStartEnd(_ segmentedControl: SegmentedControl) {
-        selectionManager.selectionMode = segmentedControl.selectedSegmentIndex == 0 ? .start : .end
+    @objc private func handleDidSelectStartEnd(_ selectedIndex: Int) {
+        selectionManager.selectionMode = selectedIndex == 0 ? .start : .end
         updateNavigationBar()
         if let visibleDates = visibleDates, focusDate > visibleDates.endDate || focusDate < visibleDates.startDate {
             scrollToFocusDate(animated: false)

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -232,7 +232,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         segmentedControl = SegmentedControl(items: items,
                                             style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
+//        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 
     private func updateNavigationBar() {

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -232,7 +232,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         let segmentedControl = SegmentedControl(items: items,
                                             style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-        segmentedControl.onSelectAction = { [weak self] (_, _, index) in
+        segmentedControl.onSelectAction = { [weak self] (_, index) in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -161,7 +161,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         }
         segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
+//        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
     }
 
     private func initNavigationBar() {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -161,7 +161,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         }
         let segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-        segmentedControl.onSelectAction = { [weak self] (_, _, index) in
+        segmentedControl.onSelectAction = { [weak self] (_, index) in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -160,8 +160,15 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         }
-        segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-//        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
+        let segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
+        segmentedControl.onSelectAction = { [weak self] (_, _, index) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.handleDidSelectStartEnd(index)
+        }
+        self.segmentedControl = segmentedControl
     }
 
     private func initNavigationBar() {
@@ -211,8 +218,8 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
         delegate?.dateTimePicker(self, didSelectStartDate: startDate, endDate: endDate)
     }
 
-    @objc private func handleDidSelectStartEnd(_ segmentedControl: SegmentedControl) {
-        mode = segmentedControl.selectedSegmentIndex == 0 ? .start : .end
+    @objc private func handleDidSelectStartEnd(_ selectedIndex: Int) {
+        mode = selectedIndex == 0 ? .start : .end
     }
 
     @objc private func handleDidTapDone(_ item: UIBarButtonItem) {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -541,3 +541,11 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         }
     }
 }
+
+// MARK: SegmentedControlDelegate
+
+@objc(MSFSegmentedControlDelegate)
+public protocol SegmentedControlDelegate {
+    /// Called after the button representing the item is tapped in the UI.
+    @objc optional func segmentedControl(_ segmentedControl: SegmentedControl, didSelectItem item: SegmentItem, atIndex index: Int)
+}

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -20,7 +20,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         static let iPadMinimumWidth: CGFloat = 375
     }
 
-    open override var isEnabled: Bool {
+    open var isEnabled: Bool = true {
         didSet {
             for button in buttons {
                 button.isEnabled = isEnabled
@@ -465,7 +465,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     @objc private func handleButtonTap(_ sender: SegmentPillButton) {
         if let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index {
             selectSegment(at: index, animated: isAnimated)
-            sendActions(for: .valueChanged)
+//            sendActions(for: .valueChanged)
         }
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -48,7 +48,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         }
     }
     /// Action called when a segment is selected.
-    @objc public var onSelectAction: ((SegmentedControl, SegmentItem, Int) -> Void)?
+    @objc public var onSelectAction: ((SegmentItem, Int) -> Void)?
     @objc public var selectedSegmentIndex: Int {
         get { return _selectedSegmentIndex }
         set { selectSegment(at: newValue, animated: false) }
@@ -471,7 +471,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
 
         selectSegment(at: index, animated: isAnimated)
         if let onSelectAction = onSelectAction {
-            onSelectAction(self, items[index], index)
+            onSelectAction(items[index], index)
         }
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -47,7 +47,8 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
             invalidateIntrinsicContentSize()
         }
     }
-    /// Action called when a segment is selected.
+    /// The closure for the action to be called when a segment is selected.
+    /// When called, the selected item and its index will be passed in to the closure.
     @objc public var onSelectAction: ((SegmentItem, Int) -> Void)?
     @objc public var selectedSegmentIndex: Int {
         get { return _selectedSegmentIndex }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -47,8 +47,8 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
             invalidateIntrinsicContentSize()
         }
     }
-    /// Delegate used to listen to selection changes
-    @objc public weak var segmentDelegate: SegmentedControlDelegate?
+    /// Action called when a segment is selected.
+    @objc public var onSelectAction: ((SegmentedControl, SegmentItem, Int) -> Void)?
     @objc public var selectedSegmentIndex: Int {
         get { return _selectedSegmentIndex }
         set { selectSegment(at: newValue, animated: false) }
@@ -465,11 +465,13 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     }
 
     @objc private func handleButtonTap(_ sender: SegmentPillButton) {
-        if let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index {
-            selectSegment(at: index, animated: isAnimated)
-            segmentDelegate?.segmentedControl?(self,
-                                               didSelectItem: items[index],
-                                               atIndex: index)
+        guard let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index  else {
+            return
+        }
+
+        selectSegment(at: index, animated: isAnimated)
+        if let onSelectAction = onSelectAction {
+            onSelectAction(self, items[index], index)
         }
     }
 
@@ -544,12 +546,4 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                                                                         index + 1, items.count)
         }
     }
-}
-
-// MARK: SegmentedControlDelegate
-
-@objc(MSFSegmentedControlDelegate)
-public protocol SegmentedControlDelegate {
-    /// Called after the button representing the item is tapped in the UI.
-    @objc optional func segmentedControl(_ segmentedControl: SegmentedControl, didSelectItem item: SegmentItem, atIndex index: Int)
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -47,6 +47,8 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
             invalidateIntrinsicContentSize()
         }
     }
+    /// Delegate used to listen to selection changes
+    @objc public weak var segmentDelegate: SegmentedControlDelegate?
     @objc public var selectedSegmentIndex: Int {
         get { return _selectedSegmentIndex }
         set { selectSegment(at: newValue, animated: false) }
@@ -465,7 +467,9 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     @objc private func handleButtonTap(_ sender: SegmentPillButton) {
         if let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index {
             selectSegment(at: index, animated: isAnimated)
-//            sendActions(for: .valueChanged)
+            segmentDelegate?.segmentedControl?(self,
+                                               didSelectItem: items[index],
+                                               atIndex: index)
         }
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -7,7 +7,7 @@ import UIKit
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.
 @objc(MSFSegmentedControl)
-open class SegmentedControl: UIControl, TokenizedControlInternal {
+open class SegmentedControl: UIView, TokenizedControlInternal {
     public func overrideTokens(_ tokens: SegmentedControlTokens?) -> Self {
         overrideTokens = tokens
         return self


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The change from UIControl to UIView will be breaking, as clients will now need to set the onSelectAction rather than adding a target.

The current SegmentedControl is a UIControl, and that means that keyboard navigation will only select the entire control. By changing it to a UIView, we can now select each individual button. I recorded the keyboard navigation videos with increased contrast to show where the focus was. We don't have focus colors from design right now, so I'll come back and update the colors to change once we have those. With this change, though, the control is at least usable with keyboard navigation.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_UIView_before](https://user-images.githubusercontent.com/67026548/173468085-eae71531-1fce-435b-9e05-0623110f7e75.gif) | ![SegmentedControl_UIView_after](https://user-images.githubusercontent.com/67026548/173468092-52c2478c-1c8c-437e-8bba-04e4f473ba25.gif) |
| ![SegmentedControl_Color_before](https://user-images.githubusercontent.com/67026548/173468109-4cbcb915-824a-4065-92c6-a87ac5a68895.gif) | ![SegmentedControl_Color_after](https://user-images.githubusercontent.com/67026548/173468119-cabec842-1482-45af-be50-7937bb01eaba.gif) |
| Crash? | ![SegmentedControl_Table_after](https://user-images.githubusercontent.com/67026548/173468128-2c71774e-91c7-482f-b4c9-f35c9d39e383.gif) |
| ![SegmentedControl_Date_before](https://user-images.githubusercontent.com/67026548/173468134-2db02b12-481d-44e4-bd35-17e3e5205faa.gif) | ![SegmentedControl_Date_after](https://user-images.githubusercontent.com/67026548/173468155-470134fe-00cc-424d-8c98-f1cc3fee1b70.gif) |
| ![SegmentedControl_Time_before](https://user-images.githubusercontent.com/67026548/173468161-b3e3ff9a-b39c-4ea6-bad7-09d1e898e7e7.gif) | ![SegmentedControl_Time_after](https://user-images.githubusercontent.com/67026548/173468196-8cb3ddfa-41e6-4c89-87e2-0948fd5c4f73.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1006)