### PR TITLE
Replace usages of fatalError(...) with preconditionFailure(...)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -50,7 +50,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
     }
 
     required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -12,7 +12,7 @@ class ActivityIndicatorDemoController: DemoTableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
@@ -12,7 +12,7 @@ class IndeterminateProgressBarDemoController: DemoTableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -12,7 +12,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -55,7 +55,7 @@ open class ControlHostingView: UIView {
     }
 
     required public init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
     }
 
     /// Adds `hostingController.view` to ourselves as a subview, and enables necessary constraints.

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -164,7 +164,7 @@ class MSFPersonaButtonCarouselStateImpl: NSObject, ObservableObject, Identifiabl
 
     func remove(at index: Int) {
         guard index < self.count else {
-            fatalError("Attempting to remove item outside bounds of carousel")
+            preconditionFailure("Attempting to remove item outside bounds of carousel")
         }
         self.buttons.remove(at: index)
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
When `fatalError(...)` is called in both Debug and Release builds, it will print the full system path of a source file. This behavior can be considered undesirable for Release builds running in production environments.

https://lapcatsoftware.com/articles/fatalError.html

Usages of `fatalError(...)` are replaced with `preconditionFailure(...)`. `preconditionFailure(...)` was used in all cases so that apps will continue to terminate if the function is called in a Release build. `assertionFailure(...)`
will not terminate the app if called in a Release build.

### Verification
- Built FluentUI static library
- Verified functionality in respective Demo controllers
- Verified objects initialize as expected changes do not cause unwanted behavior

**NO VISUAL CHANGES**

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1008)