### PR TITLE
Adding large content viewer to Avatar-related controls

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -272,6 +272,7 @@ public struct Avatar: View, ConfigurableTokenizedControl {
             .modifyIf(state.isAnimated, { thisView in
                 thisView.animation(.linear(duration: animationDuration))
             })
+            .showsLargeContentViewer(text: accessibilityLabel, image: shouldUseDefaultImage ? avatarImageInfo.image : nil)
             .accessibilityElement(children: .ignore)
             .accessibility(addTraits: state.hasButtonAccessibilityTrait ? .isButton : .isImage)
             .accessibility(label: Text(accessibilityLabel))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding large content viewer support to Avatar. The Avatar image does not seem to render or resize despite adding the appropriate SwiftUI modifiers (`.renderingMode` and `.resizable`), so they are not shown if the default style is not used.

### Verification

iPhone 12, iOS 15.5


https://user-images.githubusercontent.com/22566866/173942121-514848bc-e78f-4dbf-bc97-eb02fa08b395.mov



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1011)