### PR TITLE
Adding NSAttributedString support to TableViewCell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1036,20 +1036,38 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///
     /// - Parameters:
     ///   - title: Text that appears as the first line of text
+    ///   - attributedTitle: Optional attributed text for the first line of text. If this is not set, the title will be used
     ///   - subtitle: Text that appears as the second line of text
+    ///   - attributedSubtitle: Optional attributed text for the second line of text. If this is not set, the subtitle will be used
     ///   - footer: Text that appears as the third line of text
+    ///   - attributedFooter: Optional attributed text for the third line of text. If this is not set, the footer will be used
     ///   - customView: The custom view that appears near the leading edge next to the text
     ///   - customAccessoryView: The view acting as an accessory view that appears on the trailing edge, next to the accessory type if provided
     ///   - accessoryType: The type of accessory that appears on the trailing edge: a disclosure indicator or a details button with an ellipsis icon
-    @objc open func setup(title: String,
+    @objc open func setup(title: String = "",
+                          attributedTitle: NSAttributedString? = nil,
                           subtitle: String = "",
+                          attributedSubtitle: NSAttributedString? = nil,
                           footer: String = "",
+                          attributedFooter: NSAttributedString? = nil,
                           customView: UIView? = nil,
                           customAccessoryView: UIView? = nil,
                           accessoryType: TableViewCellAccessoryType = .none) {
-        titleLabel.text = title
-        subtitleLabel.text = subtitle
-        footerLabel.text = footer
+        if let attributedTitle = attributedTitle {
+            titleLabel.attributedText = attributedTitle
+        } else {
+            titleLabel.text = title
+        }
+        if let attributedSubtitle = attributedSubtitle {
+            subtitleLabel.attributedText = attributedSubtitle
+        } else {
+            subtitleLabel.text = subtitle
+        }
+        if let attributedFooter = attributedFooter {
+            footerLabel.attributedText = attributedFooter
+        } else {
+            footerLabel.text = footer
+        }
         self.customView = customView
         self.customAccessoryView = customAccessoryView
         _accessoryType = accessoryType


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added support to use `NSAttributedString` for labels in TableViewCell. The attributed text is optional, so if it is not set, the cell will default to the original `String` text.

### Verification

Example NSAttributedString usage for title (NSAttributedString takes precedence over String):

![Simulator Screen Shot - iPhone 12 - 2022-06-15 at 16 07 51](https://user-images.githubusercontent.com/22566866/173957001-c625792f-c041-49fd-8bb2-b0d598817009.png)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1013)