### PR TITLE
Adding NSAttributedString support to TableViewCell

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -121,14 +121,29 @@ extension TableViewCellDemoController {
         }
         let section = sections[indexPath.section]
         let item = section.item
-        cell.setup(
-            title: item.text1,
-            subtitle: item.text2,
-            footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
-            customView: TableViewSampleData.createCustomView(imageName: item.image),
-            customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
-            accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
-        )
+        if section.title == "Inverted double line cell" {
+            cell.setup(
+                attributedTitle: NSAttributedString(string: item.text1,
+                                                    attributes: [.font: TextStyle.footnote.font,
+                                                                 .foregroundColor: Colors.Table.Cell.footer]),
+                attributedSubtitle: NSAttributedString(string: item.text2,
+                                                       attributes: [.font: TextStyle.body.font,
+                                                                    .foregroundColor: Colors.Table.Cell.title]),
+                footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
+                customView: TableViewSampleData.createCustomView(imageName: item.image),
+                customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
+                accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
+            )
+        } else {
+            cell.setup(
+                title: item.text1,
+                subtitle: item.text2,
+                footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
+                customView: TableViewSampleData.createCustomView(imageName: item.image),
+                customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
+                accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
+            )
+        }
 
         let showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
         cell.titleLeadingAccessoryView = showsLabelAccessoryView ? item.text1LeadingAccessoryView() : nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
@@ -31,6 +31,14 @@ class TableViewCellSampleData: TableViewSampleData {
             ]
         ),
         Section(
+            title: "Inverted double line cell",
+            items: [
+                Item(text1: "Contoso Survey",
+                     text2: "Research Notes",
+                     text2LeadingAccessoryView: { createIconsAccessoryView(images: ["shared-12x12", "success-12x12"]) })
+            ]
+        ),
+        Section(
             title: "Triple line cell",
             items: [
                 Item(text1: "Contoso Survey",

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -970,9 +970,54 @@ open class TableViewCell: UITableViewCell {
     ///   - customAccessoryView: The view acting as an accessory view that appears on the trailing edge, next to the accessory type if provided
     ///   - accessoryType: The type of accessory that appears on the trailing edge: a disclosure indicator or a details button with an ellipsis icon
     @objc open func setup(title: String, subtitle: String = "", footer: String = "", customView: UIView? = nil, customAccessoryView: UIView? = nil, accessoryType: TableViewCellAccessoryType = .none) {
-        titleLabel.text = title
-        subtitleLabel.text = subtitle
-        footerLabel.text = footer
+        setup(title: title,
+              attributedTitle: nil,
+              subtitle: subtitle,
+              attributedSubtitle: nil,
+              footer: footer,
+              attributedFooter: nil,
+              customView: customView,
+              customAccessoryView: customAccessoryView,
+              accessoryType: accessoryType)
+    }
+
+    /// Sets up the cell with text, a custom view, a custom accessory view, and an accessory type
+    ///
+    /// - Parameters:
+    ///   - title: Text that appears as the first line of text
+    ///   - attributedTitle: Optional attributed text for the first line of text. If this is not set, the title will be used
+    ///   - subtitle: Text that appears as the second line of text
+    ///   - attributedSubtitle: Optional attributed text for the second line of text. If this is not set, the subtitle will be used
+    ///   - footer: Text that appears as the third line of text
+    ///   - attributedFooter: Optional attributed text for the third line of text. If this is not set, the footer will be used
+    ///   - customView: The custom view that appears near the leading edge next to the text
+    ///   - customAccessoryView: The view acting as an accessory view that appears on the trailing edge, next to the accessory type if provided
+    ///   - accessoryType: The type of accessory that appears on the trailing edge: a disclosure indicator or a details button with an ellipsis icon
+    @objc open func setup(title: String = "",
+                          attributedTitle: NSAttributedString? = nil,
+                          subtitle: String = "",
+                          attributedSubtitle: NSAttributedString? = nil,
+                          footer: String = "",
+                          attributedFooter: NSAttributedString? = nil,
+                          customView: UIView? = nil,
+                          customAccessoryView: UIView? = nil,
+                          accessoryType: TableViewCellAccessoryType = .none) {
+        if let attributedTitle = attributedTitle {
+            titleLabel.attributedText = attributedTitle
+        } else {
+            titleLabel.text = title
+        }
+        if let attributedSubtitle = attributedSubtitle {
+            subtitleLabel.attributedText = attributedSubtitle
+        } else {
+            subtitleLabel.text = subtitle
+        }
+        if let attributedFooter = attributedFooter {
+            footerLabel.attributedText = attributedFooter
+        } else {
+            footerLabel.text = footer
+        }
+
         self.customView = customView
         self.customAccessoryView = customAccessoryView
         _accessoryType = accessoryType
@@ -982,7 +1027,6 @@ open class TableViewCell: UITableViewCell {
         setNeedsLayout()
         invalidateIntrinsicContentSize()
     }
-
     /// Allows to change the accessory type without doing a full `setup`.
     @objc open func changeAccessoryType(to accessoryType: TableViewCellAccessoryType) {
         _accessoryType = accessoryType

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -832,8 +832,9 @@ open class TableViewCell: UITableViewCell {
         didSet {
             subtitleLabel.isHidden = layoutType == .oneLine
             footerLabel.isHidden = layoutType != .threeLines
-
-            subtitleLabel.style = layoutType.subtitleTextStyle
+            if subtitleLabel.attributedText == nil {
+                subtitleLabel.style = layoutType.subtitleTextStyle
+            }
 
             setNeedsLayout()
             invalidateIntrinsicContentSize()
@@ -1080,6 +1081,7 @@ open class TableViewCell: UITableViewCell {
         }
     }
 
+    @available(*, deprecated, message: "Any color or stylistic changes on TableViewCell labels should be done through NSAttributedString.")
     /// To set color for title label
     /// - Parameter color: UIColor to set
     @objc public func setTitleLabelTextColor(color: UIColor) {
@@ -1087,6 +1089,7 @@ open class TableViewCell: UITableViewCell {
         isUsingCustomTextColors = true
     }
 
+    @available(*, deprecated, message: "Any color or stylistic changes on TableViewCell labels should be done through NSAttributedString.")
     /// To set color for subTitle label
     /// - Parameter color: UIColor to set
     @objc public func setSubTitleLabelTextColor(color: UIColor) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added new API support to use `NSAttributedString` for labels in TableViewCell. The attributed text is optional, so if it is not set, the cell will default to the original `String` text.

Referencing #1013.

### Verification

Example NSAttributedString usage for title (NSAttributedString takes precedence over String):

![Simulator Screen Shot - iPhone 12 Pro - 2022-06-21 at 03 10 12](https://user-images.githubusercontent.com/22566866/174775284-c627612c-5722-497f-b4da-a5f6b64a8191.png)

![Simulator Screen Shot - iPhone 12 - 2022-06-15 at 16 07 51](https://user-images.githubusercontent.com/22566866/173957001-c625792f-c041-49fd-8bb2-b0d598817009.png)



### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1015)