### PR TITLE
Fluent 2 Brand Colors Update

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -19,6 +19,22 @@ public final class GlobalTokens {
         case tint20
         case tint30
         case tint40
+        case communicationBlue10
+        case communicationBlue20
+        case communicationBlue30
+        case communicationBlue40
+        case communicationBlue50
+        case communicationBlue60
+        case communicationBlue70
+        case communicationBlue80
+        case communicationBlue90
+        case communicationBlue100
+        case communicationBlue110
+        case communicationBlue120
+        case communicationBlue130
+        case communicationBlue140
+        case communicationBlue150
+        case communicationBlue160
     }
     /*
     public enum BrandColorsTokens: CaseIterable {
@@ -69,6 +85,38 @@ public final class GlobalTokens {
         case .tint40:
             // Communication Blue 140 and Communication Blue 20
             return DynamicColor(light: ColorValue(0xB4D6FA), dark: ColorValue(0x082338))
+        case .communicationBlue10:
+            <#code#>
+        case .communicationBlue20:
+            <#code#>
+        case .communicationBlue30:
+            <#code#>
+        case .communicationBlue40:
+            <#code#>
+        case .communicationBlue50:
+            <#code#>
+        case .communicationBlue60:
+            <#code#>
+        case .communicationBlue70:
+            <#code#>
+        case .communicationBlue80:
+            <#code#>
+        case .communicationBlue90:
+            <#code#>
+        case .communicationBlue100:
+            <#code#>
+        case .communicationBlue110:
+            <#code#>
+        case .communicationBlue120:
+            <#code#>
+        case .communicationBlue130:
+            <#code#>
+        case .communicationBlue140:
+            <#code#>
+        case .communicationBlue150:
+            <#code#>
+        case .communicationBlue160:
+            <#code#>
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -36,29 +36,7 @@ public final class GlobalTokens {
         case communicationBlue150
         case communicationBlue160
     }
-    /*
-    public enum BrandColorsTokens: CaseIterable {
-        case communicationBlue10
-        case communicationBlue20
-        case communicationBlue30
-        case communicationBlue40
-        case communicationBlue50
-        case communicationBlue60
-        case communicationBlue70
-        case communicationBlue80
-        case communicationBlue90
-        case communicationBlue100
-        case communicationBlue110
-        case communicationBlue120
-        case communicationBlue130
-        case communicationBlue140
-        case communicationBlue150
-        case communicationBlue160
-     }
-     lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
-         switch token {
 
-     */
     lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
         switch token {
         case .primary:
@@ -86,37 +64,37 @@ public final class GlobalTokens {
             // Communication Blue 140 and Communication Blue 20
             return DynamicColor(light: ColorValue(0xB4D6FA), dark: ColorValue(0x082338))
         case .communicationBlue10:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x061724))
         case .communicationBlue20:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x082338))
         case .communicationBlue30:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x0A2E4A))
         case .communicationBlue40:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x0C3B5E))
         case .communicationBlue50:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x0E4775))
         case .communicationBlue60:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x0F548C))
         case .communicationBlue70:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x115EA3))
         case .communicationBlue80:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x0F6CBD))
         case .communicationBlue90:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x2886DE))
         case .communicationBlue100:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x479EF5))
         case .communicationBlue110:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x62ABF5))
         case .communicationBlue120:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x77B7F7))
         case .communicationBlue130:
-            <#code#>
+            return DynamicColor(light: ColorValue(0x96C6FA))
         case .communicationBlue140:
-            <#code#>
+            return DynamicColor(light: ColorValue(0xB4D6FA))
         case .communicationBlue150:
-            <#code#>
+            return DynamicColor(light: ColorValue(0xCFE4FA))
         case .communicationBlue160:
-            <#code#>
+            return DynamicColor(light: ColorValue(0xEBF3FC))
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -40,29 +40,21 @@ public final class GlobalTokens {
     lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
         switch token {
         case .primary:
-            // Communication Blue 80 and Communication Blue 90
-            return DynamicColor(light: ColorValue(0x0F6CBD), dark: ColorValue(0x2886DE))
+            return DynamicColor(light: ColorValue(0x0F6CBD) /*comm80*/, dark: ColorValue(0x2886DE) /*comm90*/)
         case .shade10:
-            // Communication Blue 70 and Communication Blue 100
-            return DynamicColor(light: ColorValue(0x115EA3), dark: ColorValue(0x292929))
+            return DynamicColor(light: ColorValue(0x115EA3) /*comm70*/, dark: ColorValue(0x292929) /*comm100*/)
         case .shade20:
-            // Communication Blue 60 and Communication Blue 110
-            return DynamicColor(light: ColorValue(0x0F548C), dark: ColorValue(0x479EF5))
+            return DynamicColor(light: ColorValue(0x0F548C) /*comm60*/, dark: ColorValue(0x479EF5) /*comm110*/)
         case .shade30:
-            // Communication Blue 50 and Communication Blue 120
-            return DynamicColor(light: ColorValue(0x0E4775), dark: ColorValue(0x77B7F7))
+            return DynamicColor(light: ColorValue(0x0E4775) /*comm50*/, dark: ColorValue(0x77B7F7) /*comm120*/)
         case .tint10:
-            // Communication Blue 90 and Communication Blue 80
-            return DynamicColor(light: ColorValue(0x2886DE), dark: ColorValue(0x0F6CBD))
+            return DynamicColor(light: ColorValue(0x2886DE) /*comm90*/, dark: ColorValue(0x0F6CBD) /*comm80*/)
         case .tint20:
-            // Communication Blue 100 and Communication Blue 70
-            return DynamicColor(light: ColorValue(0x292929), dark: ColorValue(0x115EA3))
+            return DynamicColor(light: ColorValue(0x292929) /*comm100*/, dark: ColorValue(0x115EA3) /*comm70*/)
         case .tint30:
-            // Communication Blue 110 and Communication Blue 94
-            return DynamicColor(light: ColorValue(0x479EF5), dark: ColorValue(0x0C3B5E))
+            return DynamicColor(light: ColorValue(0x479EF5) /*comm110*/, dark: ColorValue(0x0C3B5E) /*comm90*/)
         case .tint40:
-            // Communication Blue 140 and Communication Blue 20
-            return DynamicColor(light: ColorValue(0xB4D6FA), dark: ColorValue(0x082338))
+            return DynamicColor(light: ColorValue(0xB4D6FA) /*comm140*/, dark: ColorValue(0x082338) /*comm20*/)
         case .comm10:
             return DynamicColor(light: ColorValue(0x061724))
         case .comm20:

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -19,22 +19,22 @@ public final class GlobalTokens {
         case tint20
         case tint30
         case tint40
-        case communicationBlue10
-        case communicationBlue20
-        case communicationBlue30
-        case communicationBlue40
-        case communicationBlue50
-        case communicationBlue60
-        case communicationBlue70
-        case communicationBlue80
-        case communicationBlue90
-        case communicationBlue100
-        case communicationBlue110
-        case communicationBlue120
-        case communicationBlue130
-        case communicationBlue140
-        case communicationBlue150
-        case communicationBlue160
+        case comm10
+        case comm20
+        case comm30
+        case comm40
+        case comm50
+        case comm60
+        case comm70
+        case comm80
+        case comm90
+        case comm100
+        case comm110
+        case comm120
+        case comm130
+        case comm140
+        case comm150
+        case comm160
     }
 
     lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
@@ -63,37 +63,37 @@ public final class GlobalTokens {
         case .tint40:
             // Communication Blue 140 and Communication Blue 20
             return DynamicColor(light: ColorValue(0xB4D6FA), dark: ColorValue(0x082338))
-        case .communicationBlue10:
+        case .comm10:
             return DynamicColor(light: ColorValue(0x061724))
-        case .communicationBlue20:
+        case .comm20:
             return DynamicColor(light: ColorValue(0x082338))
-        case .communicationBlue30:
+        case .comm30:
             return DynamicColor(light: ColorValue(0x0A2E4A))
-        case .communicationBlue40:
+        case .comm40:
             return DynamicColor(light: ColorValue(0x0C3B5E))
-        case .communicationBlue50:
+        case .comm50:
             return DynamicColor(light: ColorValue(0x0E4775))
-        case .communicationBlue60:
+        case .comm60:
             return DynamicColor(light: ColorValue(0x0F548C))
-        case .communicationBlue70:
+        case .comm70:
             return DynamicColor(light: ColorValue(0x115EA3))
-        case .communicationBlue80:
+        case .comm80:
             return DynamicColor(light: ColorValue(0x0F6CBD))
-        case .communicationBlue90:
+        case .comm90:
             return DynamicColor(light: ColorValue(0x2886DE))
-        case .communicationBlue100:
+        case .comm100:
             return DynamicColor(light: ColorValue(0x479EF5))
-        case .communicationBlue110:
+        case .comm110:
             return DynamicColor(light: ColorValue(0x62ABF5))
-        case .communicationBlue120:
+        case .comm120:
             return DynamicColor(light: ColorValue(0x77B7F7))
-        case .communicationBlue130:
+        case .comm130:
             return DynamicColor(light: ColorValue(0x96C6FA))
-        case .communicationBlue140:
+        case .comm140:
             return DynamicColor(light: ColorValue(0xB4D6FA))
-        case .communicationBlue150:
+        case .comm150:
             return DynamicColor(light: ColorValue(0xCFE4FA))
-        case .communicationBlue160:
+        case .comm160:
             return DynamicColor(light: ColorValue(0xEBF3FC))
         }
     }

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -20,24 +20,55 @@ public final class GlobalTokens {
         case tint30
         case tint40
     }
+    /*
+    public enum BrandColorsTokens: CaseIterable {
+        case communicationBlue10
+        case communicationBlue20
+        case communicationBlue30
+        case communicationBlue40
+        case communicationBlue50
+        case communicationBlue60
+        case communicationBlue70
+        case communicationBlue80
+        case communicationBlue90
+        case communicationBlue100
+        case communicationBlue110
+        case communicationBlue120
+        case communicationBlue130
+        case communicationBlue140
+        case communicationBlue150
+        case communicationBlue160
+     }
+     lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
+         switch token {
+
+     */
     lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
         switch token {
         case .primary:
-            return DynamicColor(light: ColorValue(0x0078D4), dark: ColorValue(0x0086F0))
+            // Communication Blue 80 and Communication Blue 90
+            return DynamicColor(light: ColorValue(0x0F6CBD), dark: ColorValue(0x2886DE))
         case .shade10:
-            return DynamicColor(light: ColorValue(0x106EBE), dark: ColorValue(0x1890F1))
+            // Communication Blue 70 and Communication Blue 100
+            return DynamicColor(light: ColorValue(0x115EA3), dark: ColorValue(0x292929))
         case .shade20:
-            return DynamicColor(light: ColorValue(0x005A9E), dark: ColorValue(0x3AA0F3))
+            // Communication Blue 60 and Communication Blue 110
+            return DynamicColor(light: ColorValue(0x0F548C), dark: ColorValue(0x479EF5))
         case .shade30:
-            return DynamicColor(light: ColorValue(0x004578), dark: ColorValue(0x6CB8F6))
+            // Communication Blue 50 and Communication Blue 120
+            return DynamicColor(light: ColorValue(0x0E4775), dark: ColorValue(0x77B7F7))
         case .tint10:
-            return DynamicColor(light: ColorValue(0x2B88D8), dark: ColorValue(0x0074D3))
+            // Communication Blue 90 and Communication Blue 80
+            return DynamicColor(light: ColorValue(0x2886DE), dark: ColorValue(0x0F6CBD))
         case .tint20:
-            return DynamicColor(light: ColorValue(0xC7E0F4), dark: ColorValue(0x004F90))
+            // Communication Blue 100 and Communication Blue 70
+            return DynamicColor(light: ColorValue(0x292929), dark: ColorValue(0x115EA3))
         case .tint30:
-            return DynamicColor(light: ColorValue(0xDEECF9), dark: ColorValue(0x002848))
+            // Communication Blue 110 and Communication Blue 94
+            return DynamicColor(light: ColorValue(0x479EF5), dark: ColorValue(0x0C3B5E))
         case .tint40:
-            return DynamicColor(light: ColorValue(0xEFF6FC), dark: ColorValue(0x001526))
+            // Communication Blue 140 and Communication Blue 20
+            return DynamicColor(light: ColorValue(0xB4D6FA), dark: ColorValue(0x082338))
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

New brand colors and their respective hex values were added to BrandColorsTokens enum in GlobalTokens. 

### Verification

All the colors were tested on the TableViewCell to make sure they match the colors specified on the [Figma](https://www.figma.com/file/OLIFtMJnKfD4FGcnNq9TVo/Fluent-2-iOS?node-id=744%3A0)
A few examples below.

| comm40 on TVC                                       | comm40 on Figma                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="321" alt="comm40" src="https://user-images.githubusercontent.com/106181067/174412999-b8193869-ba78-473c-b10a-f46b76b0fb8e.png"> | <img width="230" alt="Screen Shot 2022-06-17 at 4 41 48 PM" src="https://user-images.githubusercontent.com/106181067/174413033-96b93e9b-f83b-4f1a-9fc9-6cfc6bd4cf36.png"> |

| comm100 on TVC                                       | comm100 on Figma                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="321" alt="comm100" src="https://user-images.githubusercontent.com/106181067/174413173-7d6a113f-6f3b-4fa5-9bb1-f743aaf47c85.png"> | <img width="265" alt="Screen Shot 2022-06-17 at 4 44 10 PM" src="https://user-images.githubusercontent.com/106181067/174413204-6b98d3b0-99c1-4e1d-a2a1-3c773ad4e122.png"> |

| comm160 on TVC                                       | comm160 on Figma                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="319" alt="comm160" src="https://user-images.githubusercontent.com/106181067/174413229-9ccc3ea2-c55f-4b62-8cff-4198202e7c28.png"> | <img width="260" alt="Screen Shot 2022-06-17 at 4 44 21 PM" src="https://user-images.githubusercontent.com/106181067/174413240-cb5ae324-3f16-4546-b802-f93685601142.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1017)