### PR TITLE
Fixing warning in TableViewHeaderFooterViewDemoController.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -12,9 +12,13 @@ class TableViewHeaderFooterViewDemoController: DemoController {
     private let groupedSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.groupedSections
     private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
 
-    private let segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
-        segmentedControl.addTarget(self, action: #selector(updateActiveTabContent), for: .valueChanged)
+    private lazy var segmentedControl: SegmentedControl = {
+        let tabTitles = TableViewHeaderFooterSampleData.tabTitles
+        let segmentedControl = SegmentedControl(items: tabTitles.map({ return SegmentItem(title: $0) }),
+                                                style: .primaryPill)
+        segmentedControl.addTarget(self,
+                                   action: #selector(updateActiveTabContent),
+                                   for: .valueChanged)
         return segmentedControl
     }()
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The following warning is currently being issued by Xcode in the TableViewHeaderFooterViewDemoController:

<img width="622" alt="warning_self_initialisation" src="https://user-images.githubusercontent.com/68076145/174685563-c913093b-40df-49fb-9728-15782b5ee990.png">

I found out that Xcode's suggestion (and fix) is not correct and ends up crashing the app when the segmented control is used to switch tabs.

**Cause:**
The use of `self` should be available once the class is fully initialized.
The warning is being issued because there is a reference to `self` in the initialisation closure of the property of the class which is not yet ready at the time it's executed.

**Fix:**
The fix for the warning is to make the property a lazy var so that it's only initialized when it's called for use, which will be after the class initialisation. At this point `self` will be available.

### Verification

1. No warnings are issued anymore.
2. The demo controller works as expected when switching tabs.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1019)