### PR TITLE
[main -> fluent2-tokens] Merging version 0.5.1 from the main branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,20 @@ on:
     branches:
       - main
       - main_0.1
-      - vnext-prototype
-      - vnext-tokens
+      - main_0.2
+      - main_0.3
+      - main_0.4
+      - fluent2-tokens
+      - fluent2-colors
   pull_request:
     branches:
       - main
       - main_0.1
-      - vnext-prototype
-      - vnext-tokens
+      - main_0.2
+      - main_0.3
+      - main_0.4
+      - fluent2-tokens
+      - fluent2-colors
 
 jobs:
   validation:

--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUI'
-  s.version          = '0.5.0'
+  s.version          = '0.5.1'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -700,7 +700,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.OfficeUIFabricDemo-df";
 				PRODUCT_NAME = FluentUI.Demo;
 				PROVISIONING_PROFILE = "4596e7d8-5232-4b9f-82bf-63883e38cd5c";
-				PROVISIONING_PROFILE_SPECIFIER = "Microsoft Dogfood Provisioning Profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Office Fabric Demo Dogfood Distribution";
 				SWIFT_OBJC_BRIDGING_HEADER = "FluentUI.Demo/FluentUI.Demo-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -837,7 +837,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = UBF8T346G9;
+				DEVELOPMENT_TEAM = 9KBH5RKYEW;
 				INFOPLIST_FILE = FluentUI.Demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -847,10 +847,10 @@
 					"$(OTHER_LDFLAGS)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.OfficeUIFabricDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.OfficeUIFabricDemo-df";
 				PRODUCT_NAME = FluentUI.Demo;
 				PROVISIONING_PROFILE = "63d62159-2691-4b44-9553-b668cc1746c1";
-				PROVISIONING_PROFILE_SPECIFIER = "iOS Team Provisioning Profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Office Fabric Demo Dogfood development";
 				SWIFT_OBJC_BRIDGING_HEADER = "FluentUI.Demo/FluentUI.Demo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -866,7 +866,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = UBF8T346G9;
+				DEVELOPMENT_TEAM = 9KBH5RKYEW;
 				INFOPLIST_FILE = FluentUI.Demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -876,10 +876,10 @@
 					"$(OTHER_LDFLAGS)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.OfficeUIFabricDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.OfficeUIFabricDemo-df";
 				PRODUCT_NAME = FluentUI.Demo;
 				PROVISIONING_PROFILE = "63d62159-2691-4b44-9553-b668cc1746c1";
-				PROVISIONING_PROFILE_SPECIFIER = "iOS Team Provisioning Profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Office Fabric Demo Dogfood development";
 				SWIFT_OBJC_BRIDGING_HEADER = "FluentUI.Demo/FluentUI.Demo-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -50,7 +50,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
     }
 
     required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -12,7 +12,7 @@ class ActivityIndicatorDemoController: DemoTableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
@@ -12,7 +12,7 @@ class IndeterminateProgressBarDemoController: DemoTableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -12,7 +12,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -180,14 +180,29 @@ extension TableViewCellDemoController {
         }
         let section = sections[indexPath.section]
         let item = section.item
-        cell.setup(
-            title: item.text1,
-            subtitle: item.text2,
-            footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
-            customView: TableViewSampleData.createCustomView(imageName: item.image),
-            customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
-            accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
-        )
+        if section.title == "Inverted double line cell" {
+            cell.setup(
+                attributedTitle: NSAttributedString(string: item.text1,
+                                                    attributes: [.font: TextStyle.footnote.font,
+                                                                 .foregroundColor: UIColor.purple]),
+                attributedSubtitle: NSAttributedString(string: item.text2,
+                                                       attributes: [.font: TextStyle.body.font,
+                                                                    .foregroundColor: UIColor.red]),
+                footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
+                customView: TableViewSampleData.createCustomView(imageName: item.image),
+                customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
+                accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
+            )
+        } else {
+            cell.setup(
+                title: item.text1,
+                subtitle: item.text2,
+                footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
+                customView: TableViewSampleData.createCustomView(imageName: item.image),
+                customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
+                accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
+            )
+        }
 
         let showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
         cell.titleLeadingAccessoryView = showsLabelAccessoryView ? item.text1LeadingAccessoryView() : nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -22,6 +22,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
 
             strongSelf.updateActiveTabContent()
         }
+
         return segmentedControl
     }()
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>123</string>
+	<string>124</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
@@ -31,6 +31,14 @@ class TableViewCellSampleData: TableViewSampleData {
             ]
         ),
         Section(
+            title: "Inverted double line cell",
+            items: [
+                Item(text1: "Contoso Survey",
+                     text2: "Research Notes",
+                     text2LeadingAccessoryView: { createIconsAccessoryView(images: ["shared-12x12", "success-12x12"]) })
+            ]
+        ),
+        Section(
             title: "Triple line cell",
             items: [
                 Item(text1: "Contoso Survey",

--- a/ios/FluentUI.Resources/Info.plist
+++ b/ios/FluentUI.Resources/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 </dict>
 </plist>

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -272,6 +272,7 @@ public struct Avatar: View, ConfigurableTokenizedControl {
             .modifyIf(state.isAnimated, { thisView in
                 thisView.animation(.linear(duration: animationDuration))
             })
+            .showsLargeContentViewer(text: accessibilityLabel, image: shouldUseDefaultImage ? avatarImageInfo.image : nil)
             .accessibilityElement(children: .ignore)
             .accessibility(addTraits: state.hasButtonAccessibilityTrait ? .isButton : .isImage)
             .accessibility(label: Text(accessibilityLabel))

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -7,6 +7,7 @@ import UIKit
 
 /**
  `CommandBar` is a horizontal scrollable list of icon buttons divided by groups.
+ Set the `delegate` property to determine whether a button can be selected and deselected, and listen to selection changes.
  Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItemGroups` and `trailingItemGroups` add buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  */
 @objc(MSFCommandBar)
@@ -59,6 +60,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
         trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.trailingItemGroups,
                                                                 buttonsPersistSelection: false,
                                                                 tokens: tokens)
+
         trailingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
 
         commandBarContainerStackView = UIStackView()
@@ -303,6 +305,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
     private var themeObserver: NSObjectProtocol?
 
     private static let fadeViewWidth: CGFloat = 16.0
+
     private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
 }
 

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -55,7 +55,7 @@ open class ControlHostingView: UIView {
     }
 
     required public init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
     }
 
     /// Adds `hostingController.view` to ourselves as a subview, and enables necessary constraints.

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -164,7 +164,7 @@ class MSFPersonaButtonCarouselStateImpl: NSObject, ObservableObject, Identifiabl
 
     func remove(at index: Int) {
         guard index < self.count else {
-            fatalError("Attempting to remove item outside bounds of carousel")
+            preconditionFailure("Attempting to remove item outside bounds of carousel")
         }
         self.buttons.remove(at: index)
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1041,15 +1041,55 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - customView: The custom view that appears near the leading edge next to the text
     ///   - customAccessoryView: The view acting as an accessory view that appears on the trailing edge, next to the accessory type if provided
     ///   - accessoryType: The type of accessory that appears on the trailing edge: a disclosure indicator or a details button with an ellipsis icon
-    @objc open func setup(title: String,
+    @objc open func setup(title: String, subtitle: String = "", footer: String = "", customView: UIView? = nil, customAccessoryView: UIView? = nil, accessoryType: TableViewCellAccessoryType = .none) {
+        setup(title: title,
+              attributedTitle: nil,
+              subtitle: subtitle,
+              attributedSubtitle: nil,
+              footer: footer,
+              attributedFooter: nil,
+              customView: customView,
+              customAccessoryView: customAccessoryView,
+              accessoryType: accessoryType)
+    }
+
+    /// Sets up the cell with text, a custom view, a custom accessory view, and an accessory type
+    ///
+    /// - Parameters:
+    ///   - title: Text that appears as the first line of text
+    ///   - attributedTitle: Optional attributed text for the first line of text. If this is not set, the title will be used
+    ///   - subtitle: Text that appears as the second line of text
+    ///   - attributedSubtitle: Optional attributed text for the second line of text. If this is not set, the subtitle will be used
+    ///   - footer: Text that appears as the third line of text
+    ///   - attributedFooter: Optional attributed text for the third line of text. If this is not set, the footer will be used
+    ///   - customView: The custom view that appears near the leading edge next to the text
+    ///   - customAccessoryView: The view acting as an accessory view that appears on the trailing edge, next to the accessory type if provided
+    ///   - accessoryType: The type of accessory that appears on the trailing edge: a disclosure indicator or a details button with an ellipsis icon
+    @objc open func setup(title: String = "",
+                          attributedTitle: NSAttributedString? = nil,
                           subtitle: String = "",
+                          attributedSubtitle: NSAttributedString? = nil,
                           footer: String = "",
+                          attributedFooter: NSAttributedString? = nil,
                           customView: UIView? = nil,
                           customAccessoryView: UIView? = nil,
                           accessoryType: TableViewCellAccessoryType = .none) {
-        titleLabel.text = title
-        subtitleLabel.text = subtitle
-        footerLabel.text = footer
+        if let attributedTitle = attributedTitle {
+            titleLabel.attributedText = attributedTitle
+        } else {
+            titleLabel.text = title
+        }
+        if let attributedSubtitle = attributedSubtitle {
+            subtitleLabel.attributedText = attributedSubtitle
+        } else {
+            subtitleLabel.text = subtitle
+        }
+        if let attributedFooter = attributedFooter {
+            footerLabel.attributedText = attributedFooter
+        } else {
+            footerLabel.text = footer
+        }
+
         self.customView = customView
         self.customAccessoryView = customAccessoryView
         _accessoryType = accessoryType
@@ -1059,7 +1099,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         setNeedsLayout()
         invalidateIntrinsicContentSize()
     }
-
     /// Allows to change the accessory type without doing a full `setup`.
     @objc open func changeAccessoryType(to accessoryType: TableViewCellAccessoryType) {
         _accessoryType = accessoryType
@@ -1118,6 +1157,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
+    @available(*, deprecated, message: "Any color or stylistic changes on TableViewCell labels should be done through NSAttributedString.")
     /// To set color for title label
     /// - Parameter color: UIColor to set
     @objc public func setTitleLabelTextColor(color: UIColor) {
@@ -1125,6 +1165,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         isUsingCustomTextColors = true
     }
 
+    @available(*, deprecated, message: "Any color or stylistic changes on TableViewCell labels should be done through NSAttributedString.")
     /// To set color for subTitle label
     /// - Parameter color: UIColor to set
     @objc public func setSubTitleLabelTextColor(color: UIColor) {

--- a/macos/FluentUI/FluentUI-Info.plist
+++ b/macos/FluentUI/FluentUI-Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 </dict>
 </plist>

--- a/macos/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/macos/FluentUITestApp/FluentUITestApp-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>48</string>
+	<string>49</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Merging version 0.5.1 released last week into fluent2-tokens branch.

### Verification

Sanity validation by running the Demo App.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1022)