### PR TITLE
Updated activity indicator color tokens

### DIFF
--- a/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokens.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokens.swift
@@ -23,7 +23,7 @@ open class ActivityIndicatorTokens: ControlTokens {
     // MARK: - Design Tokens
 
     /// The default color of the Activity Indicator.
-    open var defaultColor: DynamicColor { aliasTokens.foregroundColors[.neutral4] }
+    open var defaultColor: DynamicColor { aliasTokens.strokeColors[.stroke1] }
 
     /// The value for the side of the square frame of an Activity Indicator.
     open var side: CGFloat {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The Activity Indicator's default color was updated to its new Fluent 2 color per the  Figma specs.

### Verification

I made sure the Activity Indicator's colors in the Demo app matched the colors on the Figma.

| Before (light)                                     | After (light)                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="170" alt="ai_before_light" src="https://user-images.githubusercontent.com/106181067/175168464-99ad8198-f468-41e2-ac52-3766c9661e2e.png"> | <img width="164" alt="ai_after_light" src="https://user-images.githubusercontent.com/106181067/175168517-792ad36a-6571-4715-b371-59918d98d9ae.png"> |

| Before (dark)                                     | After (dark)                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="138" alt="ai_before_dark" src="https://user-images.githubusercontent.com/106181067/175168582-3fbdfd9e-afd9-4661-80c2-84977155562d.png"> | <img width="165" alt="ai_after_dark" src="https://user-images.githubusercontent.com/106181067/175168625-1e58c42b-556d-4d37-b3ea-b410fdcffce8.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1027)