### PR TITLE
Enable Fluent Notification Customization

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -178,7 +178,8 @@ class NotificationViewDemoController: DemoController {
         case .primaryToastWithStrikethroughAttribute:
             let notification = MSFNotification(style: .primaryToast)
             notification.state.attributedMessage = NSAttributedString(string: "This is a toast with a blue strikethrough attribute.",
-                                                                      attributes: [.strikethroughStyle: 1,
+                                                                      attributes: [.font: UIFont.preferredFont(forTextStyle: .body),
+                                                                                   .strikethroughStyle: 1,
                                                                                    .strikethroughColor: UIColor.blue])
             notification.state.actionButtonAction = { [weak self] in
                 self?.showMessage("`Dismiss` tapped")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -20,6 +20,8 @@ class NotificationViewDemoController: DemoController {
         case persistentBarWithCancel
         case primaryToastWithStrikethroughAttribute
         case neutralBarWithFontAttribute
+        case neutralToastWithOverriddenTokens
+        case warningToastWithFlexibleWidth
 
         var displayText: String {
             switch self {
@@ -47,6 +49,10 @@ class NotificationViewDemoController: DemoController {
                 return "Primary Toast with Strikethrough Attribute"
             case .neutralBarWithFontAttribute:
                 return "Neutral Bar with Font Attribute"
+            case .neutralToastWithOverriddenTokens:
+                return "Neutral Toast With Overridden Tokens"
+            case .warningToastWithFlexibleWidth:
+                return "Warning Toast With Flexible Width"
             }
         }
     }
@@ -190,6 +196,36 @@ class NotificationViewDemoController: DemoController {
                 notification.hide()
             }
             return notification
+        case .neutralToastWithOverriddenTokens:
+            let notification = MSFNotification(style: .neutralToast)
+            notification.state.message = "The image color and spacing between the elements of this notification have been customized with override tokens."
+            notification.state.image = UIImage(named: "play-in-circle-24x24")
+            notification.state.overrideTokens = NotificationOverrideTokens()
+            notification.state.actionButtonAction = { [weak self] in
+                self?.showMessage("`Dismiss` tapped")
+                notification.hide()
+            }
+            return notification
+        case .warningToastWithFlexibleWidth:
+            let notification = MSFNotification(style: .warningToast,
+                                               isFlexibleWidthToast: true)
+            notification.state.message = "This toast has a flexible width which means the width is based on the content rather than the screen size."
+            notification.state.overrideTokens = NotificationOverrideTokens()
+            notification.state.actionButtonAction = { [weak self] in
+                self?.showMessage("`Dismiss` tapped")
+                notification.hide()
+            }
+            return notification
+        }
+    }
+
+    private class NotificationOverrideTokens: NotificationTokens {
+        override var imageColor: DynamicColor {
+            return DynamicColor(light: GlobalTokens().sharedColors[.orange][.primary])
+        }
+
+        override var horizontalSpacing: CGFloat {
+            return 5.0
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -33,6 +33,8 @@ struct NotificationDemoView: View {
     @State var showImage: Bool = false
     @State var showAlert: Bool = false
     @State var isPresented: Bool = false
+    @State var overrideTokens: Bool = false
+    @State var isFlexibleWidthToast: Bool = false
 
     public var body: some View {
         let hasAttribute = hasBlueStrikethroughAttribute || hasLargeRedPapyrusFontAttribute
@@ -48,6 +50,7 @@ struct NotificationDemoView: View {
         let hasMessage = !message.isEmpty
         let hasTitle = !title.isEmpty
         let notification = FluentNotification(style: style,
+                                              isFlexibleWidthToast: isFlexibleWidthToast,
                                               message: hasMessage ? message : nil,
                                               attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
                                               title: hasTitle ? title : nil,
@@ -55,7 +58,7 @@ struct NotificationDemoView: View {
                                               image: image,
                                               actionButtonTitle: actionButtonTitle,
                                               actionButtonAction: actionButtonAction,
-                                              messageButtonAction: messageButtonAction)
+                                              messageButtonAction: messageButtonAction).overrideTokens(overrideTokens ? NotificationOverrideTokens() : nil)
 
         VStack {
             notification
@@ -103,7 +106,7 @@ struct NotificationDemoView: View {
                             .textFieldStyle(RoundedBorderTextFieldStyle())
 
                         FluentUIDemoToggle(titleKey: "Has Attributed Text: Strikethrough", isOn: $hasBlueStrikethroughAttribute)
-                        FluentUIDemoToggle(titleKey: "Has Attributed Text: LargeRed Papyrus Font", isOn: $hasLargeRedPapyrusFontAttribute)
+                        FluentUIDemoToggle(titleKey: "Has Attributed Text: Large Red Papyrus Font", isOn: $hasLargeRedPapyrusFontAttribute)
                         FluentUIDemoToggle(titleKey: "Set image", isOn: $showImage)
                     }
 
@@ -137,12 +140,16 @@ struct NotificationDemoView: View {
                         }
                         .labelsHidden()
                         .frame(maxWidth: .infinity, alignment: .leading)
+
+                        FluentUIDemoToggle(titleKey: "Override Tokens (Image Color and Horizontal Spacing)", isOn: $overrideTokens)
+                        FluentUIDemoToggle(titleKey: "Flexible Width Toast", isOn: $isFlexibleWidthToast)
                     }
                 }
                 .padding()
             }
         }
         .presentNotification(style: style,
+                             isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
                              message: hasMessage ? message : nil,
                              attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
                              isBlocking: false,
@@ -152,6 +159,17 @@ struct NotificationDemoView: View {
                              image: image,
                              actionButtonTitle: actionButtonTitle,
                              actionButtonAction: actionButtonAction,
-                             messageButtonAction: messageButtonAction)
+                             messageButtonAction: messageButtonAction,
+                             overrideTokens: $overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+    }
+
+    private class NotificationOverrideTokens: NotificationTokens {
+        override var imageColor: DynamicColor {
+            return DynamicColor(light: GlobalTokens().sharedColors[.orange][.primary])
+        }
+
+        override var horizontalSpacing: CGFloat {
+            return 5.0
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -39,7 +39,7 @@ struct NotificationDemoView: View {
     public var body: some View {
         let hasAttribute = hasBlueStrikethroughAttribute || hasLargeRedPapyrusFontAttribute
         let bothAttributes = [NSAttributedString.Key.strikethroughStyle: 1, NSAttributedString.Key.strikethroughColor: UIColor.blue, .font: UIFont.init(name: "Papyrus", size: 30.0)!, .foregroundColor: UIColor.red] as [NSAttributedString.Key: Any]
-        let blueStrikethroughAttribute = [NSAttributedString.Key.strikethroughStyle: 1, NSAttributedString.Key.strikethroughColor: UIColor.blue] as [NSAttributedString.Key: Any]
+        let blueStrikethroughAttribute = [.font: UIFont.preferredFont(forTextStyle: .body), NSAttributedString.Key.strikethroughStyle: 1, NSAttributedString.Key.strikethroughColor: UIColor.blue] as [NSAttributedString.Key: Any]
         let redPapyrusFontAttribute = [.font: UIFont.init(name: "Papyrus", size: 30.0)!, .foregroundColor: UIColor.red] as [NSAttributedString.Key: Any]
         let attributedMessage = NSMutableAttributedString(string: message, attributes: (hasLargeRedPapyrusFontAttribute && hasBlueStrikethroughAttribute) ? bothAttributes : (hasLargeRedPapyrusFontAttribute ? redPapyrusFontAttribute : blueStrikethroughAttribute))
         let attributedTitle = NSMutableAttributedString(string: title, attributes: (hasLargeRedPapyrusFontAttribute && hasBlueStrikethroughAttribute) ? bothAttributes : (hasLargeRedPapyrusFontAttribute ? redPapyrusFontAttribute : blueStrikethroughAttribute))
@@ -58,7 +58,8 @@ struct NotificationDemoView: View {
                                               image: image,
                                               actionButtonTitle: actionButtonTitle,
                                               actionButtonAction: actionButtonAction,
-                                              messageButtonAction: messageButtonAction).overrideTokens(overrideTokens ? NotificationOverrideTokens() : nil)
+                                              messageButtonAction: messageButtonAction)
+                            .overrideTokens(overrideTokens ? NotificationOverrideTokens() : nil)
 
         VStack {
             notification
@@ -165,7 +166,7 @@ struct NotificationDemoView: View {
 
     private class NotificationOverrideTokens: NotificationTokens {
         override var imageColor: DynamicColor {
-            return DynamicColor(light: GlobalTokens().sharedColors[.orange][.primary])
+            return DynamicColor(light: globalTokens.sharedColors[.orange][.primary])
         }
 
         override var horizontalSpacing: CGFloat {

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -47,8 +47,8 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     /// Creates the FluentNotification
     /// - Parameters:
     ///   - style: `MSFNotificationStyle` enum value that defines the style of the Notification being presented.
-    ///   - shouldSelfPresent: Whether the notification should  present itself (SwiftUI environment) or externally (UIKit environment)
-    ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
+    ///   - shouldSelfPresent: Whether the notification should  present itself (SwiftUI environment) or externally (UIKit environment).
+    ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents.
     ///   - message: Optional text for the main title area of the control. If there is a title, the message becomes subtext.
     ///   - attributedMessage: Optional attributed text for the main title area of the control. If there is a title, the message becomes subtext. If set, it will override the message parameter.
     ///   - isPresented: Controls whether the Notification is being presented.

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -174,8 +174,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                            height: imageSize.height,
                            alignment: .center)
                     .foregroundColor(Color(dynamicColor: tokens.imageColor))
-                    .padding(.vertical, tokens.verticalPadding)
-                    .padding(.leading, tokens.horizontalPadding)
             }
         }
     }
@@ -215,7 +213,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             }
             messageLabel
         }
-        .padding(.horizontal, !hasImage ? tokens.horizontalPadding : 0)
         .padding(.vertical, hasSecondTextRow ? tokens.verticalPadding : tokens.verticalPaddingForOneLine)
     }
 
@@ -223,9 +220,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     private var button: some View {
         if let buttonAction = state.actionButtonAction {
             let foregroundColor = tokens.foregroundColor
-            let horizontalPadding = tokens.horizontalPadding
-            let verticalPadding = tokens.verticalPadding
-
             if let actionTitle = state.actionButtonTitle, !actionTitle.isEmpty {
                 SwiftUI.Button(actionTitle) {
                     isPresented = false
@@ -233,8 +227,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 }
                 .lineLimit(1)
                 .foregroundColor(Color(dynamicColor: foregroundColor))
-                .padding(.horizontal, horizontalPadding)
-                .padding(.vertical, verticalPadding)
                 .font(.fluent(tokens.boldTextFont))
             } else {
                 SwiftUI.Button(action: {
@@ -243,8 +235,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 }, label: {
                     Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
                 })
-                .padding(.horizontal, horizontalPadding)
-                .padding(.vertical, verticalPadding)
                 .accessibility(identifier: "Accessibility.Dismiss.Label")
                 .foregroundColor(Color(dynamicColor: foregroundColor))
             }
@@ -261,11 +251,13 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             }
             .frame(minHeight: tokens.minimumHeight)
         } else {
-            HStack(spacing: tokens.horizontalSpacing) {
+            let horizontalSpacing = tokens.horizontalSpacing
+            HStack(spacing: isFlexibleWidthToast ? horizontalSpacing : 0) {
                 image
+                    .padding(.trailing, isFlexibleWidthToast ? 0 : horizontalSpacing)
                 textContainer
                 if !isFlexibleWidthToast {
-                    Spacer()
+                    Spacer(minLength: horizontalSpacing)
                 }
                 button
                     .layoutPriority(1)
@@ -274,6 +266,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 innerContentsSize = newSize
             }
             .frame(minHeight: tokens.minimumHeight)
+            .padding(.horizontal, tokens.horizontalPadding)
             .clipped()
         }
     }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -48,6 +48,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     /// - Parameters:
     ///   - style: `MSFNotificationStyle` enum value that defines the style of the Notification being presented.
     ///   - shouldSelfPresent: Whether the notification should  present itself (SwiftUI environment) or externally (UIKit environment)
+    ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
     ///   - message: Optional text for the main title area of the control. If there is a title, the message becomes subtext.
     ///   - attributedMessage: Optional attributed text for the main title area of the control. If there is a title, the message becomes subtext. If set, it will override the message parameter.
     ///   - isPresented: Controls whether the Notification is being presented.
@@ -59,6 +60,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
     public init(style: MSFNotificationStyle,
                 shouldSelfPresent: Bool = true,
+                isFlexibleWidthToast: Bool = false,
                 message: String? = nil,
                 attributedMessage: NSAttributedString? = nil,
                 isPresented: Binding<Bool>? = nil,
@@ -79,6 +81,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         state.messageButtonAction = messageButtonAction
         self.state = state
         self.shouldSelfPresent = shouldSelfPresent
+        self.isFlexibleWidthToast = isFlexibleWidthToast && style.isToast
 
         if let isPresented = isPresented {
             _isPresented = isPresented
@@ -94,13 +97,15 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             GeometryReader { proxy in
                 let proposedSize = proxy.size
                 let proposedWidth = proposedSize.width
+                let horizontalPadding = 2 * tokens.presentationOffset
                 let calculatedNotificationWidth: CGFloat = {
                     let isHalfLength = state.style.isToast && horizontalSizeClass == .regular
-                    return isHalfLength ? proposedWidth / 2 : proposedWidth - (2 * tokens.presentationOffset)
+                    return isHalfLength ? proposedWidth / 2 : proposedWidth - horizontalPadding
                 }()
 
                 notification
-                    .frame(width: calculatedNotificationWidth, alignment: .center)
+                    .frame(idealWidth: isFlexibleWidthToast ? innerContentsSize.width - horizontalPadding : calculatedNotificationWidth,
+                           maxWidth: isFlexibleWidthToast ? proposedWidth : calculatedNotificationWidth, alignment: .center)
                     .onChange(of: isPresented, perform: { present in
                         if present {
                             presentAnimated()
@@ -168,7 +173,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     .frame(width: imageSize.width,
                            height: imageSize.height,
                            alignment: .center)
-                    .foregroundColor(Color(dynamicColor: tokens.foregroundColor))
+                    .foregroundColor(Color(dynamicColor: tokens.imageColor))
                     .padding(.vertical, tokens.verticalPadding)
                     .padding(.leading, tokens.horizontalPadding)
             }
@@ -180,7 +185,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         if state.style.isToast && hasSecondTextRow {
             if let attributedTitle = state.attributedTitle {
                 AttributedText(attributedTitle)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
             } else if let title = state.title {
                 Text(title)
                     .font(.fluent(tokens.boldTextFont))
@@ -193,7 +198,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     private var messageLabel: some View {
         if let attributedMessage = state.attributedMessage {
             AttributedText(attributedMessage)
-                .fixedSize(horizontal: false, vertical: true)
+                .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
         } else if let message = state.message {
             let messageFont = hasSecondTextRow ? tokens.footnoteTextFont : (state.style.isToast ? tokens.boldTextFont : tokens.regularTextFont)
             Text(message)
@@ -216,12 +221,22 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
 
     @ViewBuilder
     private var button: some View {
-        if let buttonAction = state.actionButtonAction, let actionTitle = state.actionButtonTitle {
+        if let buttonAction = state.actionButtonAction {
             let foregroundColor = tokens.foregroundColor
             let horizontalPadding = tokens.horizontalPadding
             let verticalPadding = tokens.verticalPadding
 
-            if actionTitle.isEmpty {
+            if let actionTitle = state.actionButtonTitle, !actionTitle.isEmpty {
+                SwiftUI.Button(actionTitle) {
+                    isPresented = false
+                    buttonAction()
+                }
+                .lineLimit(1)
+                .foregroundColor(Color(dynamicColor: foregroundColor))
+                .padding(.horizontal, horizontalPadding)
+                .padding(.vertical, verticalPadding)
+                .font(.fluent(tokens.boldTextFont))
+            } else {
                 SwiftUI.Button(action: {
                     isPresented = false
                     buttonAction()
@@ -232,16 +247,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 .padding(.vertical, verticalPadding)
                 .accessibility(identifier: "Accessibility.Dismiss.Label")
                 .foregroundColor(Color(dynamicColor: foregroundColor))
-            } else {
-                SwiftUI.Button(actionTitle) {
-                    isPresented = false
-                    buttonAction()
-                }
-                .lineLimit(1)
-                .foregroundColor(Color(dynamicColor: foregroundColor))
-                .padding(.horizontal, horizontalPadding)
-                .padding(.vertical, verticalPadding)
-                .font(.fluent(tokens.boldTextFont))
             }
         }
     }
@@ -259,9 +264,14 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             HStack(spacing: tokens.horizontalSpacing) {
                 image
                 textContainer
-                Spacer(minLength: tokens.horizontalPadding)
+                if !isFlexibleWidthToast {
+                    Spacer()
+                }
                 button
                     .layoutPriority(1)
+            }
+            .onSizeChange { newSize in
+                innerContentsSize = newSize
             }
             .frame(minHeight: tokens.minimumHeight)
             .clipped()
@@ -302,6 +312,9 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     @Binding private var isPresented: Bool
     @State private var bottomOffsetForDismissedState: CGFloat = 0
     @State private var bottomOffset: CGFloat = 0
+    @State private var innerContentsSize: CGSize = CGSize()
+    @State private var attributedMessageSize: CGSize = CGSize()
+    @State private var attributedTitleSize: CGSize = CGSize()
 
     // When true, the notification view will take up all proposed space
     // and automatically position itself within it.
@@ -310,6 +323,10 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     // When false, the view will have a fitting, flexible width and self-sized height.
     // In this mode the notification should be positioned and presented externally.
     private let shouldSelfPresent: Bool
+
+    // When true, the notification will fit the size of its contents.
+    // When false, the notification will be fixed based on the size of the screen.
+    private let isFlexibleWidthToast: Bool
 }
 
 class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationState {

--- a/ios/FluentUI/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Notification/MSFNotificationView.swift
@@ -15,7 +15,7 @@ import UIKit
     ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
     @objc public init(style: MSFNotificationStyle,
                       isFlexibleWidthToast: Bool = false) {
-        self.isFlexibleWidthToast = isFlexibleWidthToast
+        self.isFlexibleWidthToast = isFlexibleWidthToast && style.isToast
         notification = FluentNotification(style: style,
                                           shouldSelfPresent: false)
         super.init(AnyView(notification))

--- a/ios/FluentUI/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Notification/MSFNotificationView.swift
@@ -12,8 +12,10 @@ import UIKit
     /// Creates a new MSFNotification instance.
     /// - Parameters:
     ///   - style: The MSFNotification value used by the Notification.
-    ///   - shouldSelfPresent: Whether the notification should  present itself (SwiftUI environment) or externally (UIKit environment)
-    @objc public init(style: MSFNotificationStyle) {
+    ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
+    @objc public init(style: MSFNotificationStyle,
+                      isFlexibleWidthToast: Bool = false) {
+        self.isFlexibleWidthToast = isFlexibleWidthToast
         notification = FluentNotification(style: style,
                                           shouldSelfPresent: false)
         super.init(AnyView(notification))
@@ -57,12 +59,18 @@ import UIKit
         constraints.append(animated ? constraintWhenHidden : constraintWhenShown)
         constraints.append(self.centerXAnchor.constraint(equalTo: view.centerXAnchor))
 
-        let isHalfLength = state.style.isToast && traitCollection.horizontalSizeClass == .regular
-        if isHalfLength {
-            constraints.append(self.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.5))
+        let horizontalPadding = -2 * notification.tokens.presentationOffset
+        let widthAnchor = self.widthAnchor
+        let viewWidthAnchor = view.widthAnchor
+        if isFlexibleWidthToast {
+            constraints.append(widthAnchor.constraint(lessThanOrEqualTo: viewWidthAnchor, constant: horizontalPadding))
         } else {
-            let padding = notification.tokens.presentationOffset
-            constraints.append(self.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -2 * padding))
+            let isHalfLength = state.style.isToast && traitCollection.horizontalSizeClass == .regular
+            if isHalfLength {
+                constraints.append(widthAnchor.constraint(equalTo: viewWidthAnchor, multiplier: 0.5))
+            } else {
+                constraints.append(widthAnchor.constraint(equalTo: viewWidthAnchor, constant: horizontalPadding))
+            }
         }
         NSLayoutConstraint.activate(constraints)
 
@@ -128,6 +136,8 @@ import UIKit
             })
         }
     }
+
+    var isFlexibleWidthToast: Bool
 
     // MARK: - Private variables
     private static var allowsMultipleToasts: Bool = false

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -9,6 +9,7 @@ public extension View {
     /// Presents a Notification on top of the modified View.
     /// - Parameters:
     ///   - style: `MSFNotificationStyle` enum value that defines the style of the Notification being presented.
+    ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
     ///   - message: Optional text for the main title area of the control. If there is a title, the message becomes subtext.
     ///   - attributedMessage: Optional attributed text for the main title area of the control. If there is a title, the message becomes subtext.
     ///   - isBlocking: Whether the interaction with the view will be blocked while the Notification is being presented.
@@ -19,8 +20,10 @@ public extension View {
     ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
     ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
+    ///   - overrideTokens: Custom NotificationTokens class that will override the default tokens..
     /// - Returns: The modified view with the capability of presenting a Notification.
     func presentNotification(style: MSFNotificationStyle,
+                             isFlexibleWidthToast: Bool,
                              message: String? = nil,
                              attributedMessage: NSAttributedString? = nil,
                              isBlocking: Bool = true,
@@ -31,10 +34,11 @@ public extension View {
                              actionButtonTitle: String? = nil,
                              actionButtonAction: (() -> Void)? = nil,
                              messageButtonAction: (() -> Void)? = nil,
-                             dismissAction: (() -> Void)? = nil) -> some View {
+                             overrideTokens: NotificationTokens? = nil) -> some View {
         self.presentingView(isPresented: isPresented,
                             isBlocking: isBlocking) {
             FluentNotification(style: style,
+                               isFlexibleWidthToast: isFlexibleWidthToast,
                                message: message,
                                attributedMessage: attributedMessage,
                                isPresented: isPresented,
@@ -43,7 +47,7 @@ public extension View {
                                image: image,
                                actionButtonTitle: actionButtonTitle,
                                actionButtonAction: actionButtonAction,
-                               messageButtonAction: messageButtonAction)
+                               messageButtonAction: messageButtonAction).overrideTokens(overrideTokens)
         }
     }
 }

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -9,7 +9,7 @@ public extension View {
     /// Presents a Notification on top of the modified View.
     /// - Parameters:
     ///   - style: `MSFNotificationStyle` enum value that defines the style of the Notification being presented.
-    ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
+    ///   - isFlexibleWidthToast: Whether the width of the toast is set based on the width of the screen or on its contents/
     ///   - message: Optional text for the main title area of the control. If there is a title, the message becomes subtext.
     ///   - attributedMessage: Optional attributed text for the main title area of the control. If there is a title, the message becomes subtext.
     ///   - isBlocking: Whether the interaction with the view will be blocked while the Notification is being presented.
@@ -20,7 +20,7 @@ public extension View {
     ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
     ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
-    ///   - overrideTokens: Custom NotificationTokens class that will override the default tokens..
+    ///   - overrideTokens: Custom NotificationTokens class that will override the default tokens.
     /// - Returns: The modified view with the capability of presenting a Notification.
     func presentNotification(style: MSFNotificationStyle,
                              isFlexibleWidthToast: Bool,
@@ -47,7 +47,8 @@ public extension View {
                                image: image,
                                actionButtonTitle: actionButtonTitle,
                                actionButtonAction: actionButtonAction,
-                               messageButtonAction: messageButtonAction).overrideTokens(overrideTokens)
+                               messageButtonAction: messageButtonAction)
+            .overrideTokens(overrideTokens)
         }
     }
 }

--- a/ios/FluentUI/Notification/NotificationTokens.swift
+++ b/ios/FluentUI/Notification/NotificationTokens.swift
@@ -94,6 +94,26 @@ open class NotificationTokens: ControlTokens {
         }
     }
 
+    /// The color of the notification's icon image
+    open var imageColor: DynamicColor {
+        switch style {
+        case .primaryToast:
+            return DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.brandColors[.shade30].dark)
+        case .neutralToast:
+            return DynamicColor(light: ColorValue(0x393939), dark: ColorValue(0xF7F7F7))
+        case .primaryBar:
+            return DynamicColor(light: globalTokens.brandColors[.shade20].light, dark: ColorValue(0x000000))
+        case .primaryOutlineBar:
+            return DynamicColor(light: globalTokens.brandColors[.primary].light, dark: ColorValue(0xF7F7F7))
+        case .neutralBar:
+            return DynamicColor(light: ColorValue(0x090909), dark: ColorValue(0xF7F7F7))
+        case .dangerToast:
+            return DynamicColor(light: ColorValue(0xBC2F34), dark: ColorValue(0xDC5F63))
+        case .warningToast:
+            return DynamicColor(light: ColorValue(0x4C4400), dark: ColorValue(0xFDEA3D))
+        }
+    }
+
     /// The value for the corner radius of the frame of the notification
     open var cornerRadius: CGFloat {
         switch style.isToast {

--- a/ios/FluentUI/Notification/NotificationTokens.swift
+++ b/ios/FluentUI/Notification/NotificationTokens.swift
@@ -60,17 +60,23 @@ open class NotificationTokens: ControlTokens {
         case .primaryToast:
             return globalTokens.brandColors[.tint40]
         case .neutralToast:
-            return DynamicColor(light: ColorValue(0xF7F7F7), dark: ColorValue(0x393939))
+            return DynamicColor(light: ColorValue(0xF7F7F7),
+                                dark: ColorValue(0x393939))
         case .primaryBar:
-            return DynamicColor(light: globalTokens.brandColors[.tint40].light, dark: globalTokens.brandColors[.tint10].dark)
+            return DynamicColor(light: globalTokens.brandColors[.tint40].light,
+                                dark: globalTokens.brandColors[.tint10].dark)
         case .primaryOutlineBar:
-            return DynamicColor(light: ColorValue(0xFFFFFF), dark: ColorValue(0x393939))
+            return DynamicColor(light: ColorValue(0xFFFFFF),
+                                dark: ColorValue(0x393939))
         case .neutralBar:
-            return DynamicColor(light: ColorValue(0xDFDFDF), dark: ColorValue(0x393939))
+            return DynamicColor(light: ColorValue(0xDFDFDF),
+                                dark: ColorValue(0x393939))
         case .dangerToast:
-            return DynamicColor(light: ColorValue(0xFDF6F6), dark: ColorValue(0x3F1011))
+            return DynamicColor(light: ColorValue(0xFDF6F6),
+                                dark: ColorValue(0x3F1011))
         case .warningToast:
-            return DynamicColor(light: ColorValue(0xFFFBD6), dark: ColorValue(0x4C4400))
+            return DynamicColor(light: ColorValue(0xFFFBD6),
+                                dark: ColorValue(0x4C4400))
         }
     }
 
@@ -78,19 +84,26 @@ open class NotificationTokens: ControlTokens {
     open var foregroundColor: DynamicColor {
         switch style {
         case .primaryToast:
-            return DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.brandColors[.shade30].dark)
+            return DynamicColor(light: globalTokens.brandColors[.shade10].light,
+                                dark: globalTokens.brandColors[.shade30].dark)
         case .neutralToast:
-            return DynamicColor(light: ColorValue(0x393939), dark: ColorValue(0xF7F7F7))
+            return DynamicColor(light: ColorValue(0x393939),
+                                dark: ColorValue(0xF7F7F7))
         case .primaryBar:
-            return DynamicColor(light: globalTokens.brandColors[.shade20].light, dark: ColorValue(0x000000))
+            return DynamicColor(light: globalTokens.brandColors[.shade20].light,
+                                dark: ColorValue(0x000000))
         case .primaryOutlineBar:
-            return DynamicColor(light: globalTokens.brandColors[.primary].light, dark: ColorValue(0xF7F7F7))
+            return DynamicColor(light: globalTokens.brandColors[.primary].light,
+                                dark: ColorValue(0xF7F7F7))
         case .neutralBar:
-            return DynamicColor(light: ColorValue(0x090909), dark: ColorValue(0xF7F7F7))
+            return DynamicColor(light: ColorValue(0x090909),
+                                dark: ColorValue(0xF7F7F7))
         case .dangerToast:
-            return DynamicColor(light: ColorValue(0xBC2F34), dark: ColorValue(0xDC5F63))
+            return DynamicColor(light: ColorValue(0xBC2F34),
+                                dark: ColorValue(0xDC5F63))
         case .warningToast:
-            return DynamicColor(light: ColorValue(0x4C4400), dark: ColorValue(0xFDEA3D))
+            return DynamicColor(light: ColorValue(0x4C4400),
+                                dark: ColorValue(0xFDEA3D))
         }
     }
 
@@ -98,19 +111,26 @@ open class NotificationTokens: ControlTokens {
     open var imageColor: DynamicColor {
         switch style {
         case .primaryToast:
-            return DynamicColor(light: globalTokens.brandColors[.shade10].light, dark: globalTokens.brandColors[.shade30].dark)
+            return DynamicColor(light: globalTokens.brandColors[.shade10].light,
+                                dark: globalTokens.brandColors[.shade30].dark)
         case .neutralToast:
-            return DynamicColor(light: ColorValue(0x393939), dark: ColorValue(0xF7F7F7))
+            return DynamicColor(light: ColorValue(0x393939),
+                                dark: ColorValue(0xF7F7F7))
         case .primaryBar:
-            return DynamicColor(light: globalTokens.brandColors[.shade20].light, dark: ColorValue(0x000000))
+            return DynamicColor(light: globalTokens.brandColors[.shade20].light,
+                                dark: ColorValue(0x000000))
         case .primaryOutlineBar:
-            return DynamicColor(light: globalTokens.brandColors[.primary].light, dark: ColorValue(0xF7F7F7))
+            return DynamicColor(light: globalTokens.brandColors[.primary].light,
+                                dark: ColorValue(0xF7F7F7))
         case .neutralBar:
-            return DynamicColor(light: ColorValue(0x090909), dark: ColorValue(0xF7F7F7))
+            return DynamicColor(light: ColorValue(0x090909),
+                                dark: ColorValue(0xF7F7F7))
         case .dangerToast:
-            return DynamicColor(light: ColorValue(0xBC2F34), dark: ColorValue(0xDC5F63))
+            return DynamicColor(light: ColorValue(0xBC2F34),
+                                dark: ColorValue(0xDC5F63))
         case .warningToast:
-            return DynamicColor(light: ColorValue(0x4C4400), dark: ColorValue(0xFDEA3D))
+            return DynamicColor(light: ColorValue(0x4C4400),
+                                dark: ColorValue(0xFDEA3D))
         }
     }
 


### PR DESCRIPTION
Enable flexible width toasts and customizable image color/element spacing

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change separates the uses of some tokens so that they can be customized without impacting other elements. Image color and element spacing can now be customized. This change also implements isFlexibleWidthToast which allows the notification to be sized either based on the size of the screen (default) or the size of its content.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-06-23 at 02 28 14](https://user-images.githubusercontent.com/31874971/175266525-7f031167-e094-4497-97f9-5662993c2846.png) |  ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-06-23 at 02 27 00](https://user-images.githubusercontent.com/31874971/175266569-66108da8-5519-4ef0-adf7-bd1d1b5a665e.png) |
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-06-23 at 02 28 24](https://user-images.githubusercontent.com/31874971/175266643-66aa7ed5-a593-41b2-825c-07668238660a.png) |  ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-06-23 at 02 26 05](https://user-images.githubusercontent.com/31874971/175266709-15729ff9-ebae-4f71-bca3-f5aed82fe596.png) |
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-06-23 at 02 28 24](https://user-images.githubusercontent.com/31874971/175266678-5b2cbd48-c536-484b-9c26-793a6a80fc94.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-06-23 at 02 26 09](https://user-images.githubusercontent.com/31874971/175266760-b16bcfe4-c421-46a2-9ab8-217fff0b9930.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1029)