### PR TITLE
[Fluent2 iOS] Replace Colorful tokens with Brand tokens

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -23,22 +23,23 @@ public final class AliasTokens {
         case brandDisabled
         // New foreground colors
         case foreground1
-        case foreground1Colorful
         case foreground2
-        case foreground2Colorful
         case foreground3
-        case foreground3Colorful
         case foregroundDisabled1
-        case foregroundDisabled1Colorful
         case foregroundDisabled2
         case foregroundContrast
-        case foregroundContrastColorful
         case foregroundOnColor
-        case foregroundOnColorColorful
         case foregroundInverted1
-        case foregroundInverted1Colorful
         case foregroundInverted2
-        case foregroundInverted2Colorful
+        case brandForeground1
+        case brandForeground1Pressed
+        case brandForeground1Selected
+        case brandForeground2
+        case brandForeground3
+        case brandForeground4
+        case brandForeground5
+        case brandForegroundInverted
+        case brandForegroundDisabled
 
     }
     public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, DynamicColor> = .init { [weak self] token in
@@ -92,45 +93,53 @@ public final class AliasTokens {
         case .foreground1:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
                                 dark: strongSelf.globalTokens.neutralColors[.white])
-        case .foreground1Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
         case .foreground2:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
                                 dark: strongSelf.globalTokens.neutralColors[.grey84])
-        case .foreground2Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light)
         case .foreground3:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey50],
                                 dark: strongSelf.globalTokens.neutralColors[.grey68])
-        case .foreground3Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
         case .foregroundDisabled1:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
                                 dark: strongSelf.globalTokens.neutralColors[.grey36])
-        case .foregroundDisabled1Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm90].light)
         case .foregroundDisabled2:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
                                 dark: strongSelf.globalTokens.neutralColors[.grey24])
         case .foregroundContrast:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
                                 dark: strongSelf.globalTokens.neutralColors[.black])
-        case .foregroundContrastColorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
         case .foregroundOnColor:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
                                 dark: strongSelf.globalTokens.neutralColors[.black])
-        case .foregroundOnColorColorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light)
         case .foregroundInverted1:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
-        case .foregroundInverted1Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light)
         case .foregroundInverted2:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
                                 dark: strongSelf.globalTokens.neutralColors[.white])
-        case .foregroundInverted2Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
+        case .brandForeground1:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
+        case .brandForeground1Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
+        case .brandForeground1Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandForeground2:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm20].light)
+        case .brandForeground3:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
+        case .brandForeground4:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandForeground5:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
+        case .brandForegroundInverted:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandForegroundDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm90].light)
         }
     }
 
@@ -151,43 +160,42 @@ public final class AliasTokens {
         case surfaceQuaternary
         // New background colors
         case background1
-        case background1Colorful
         case background1Pressed
-        case background1PressedColorful
         case background1Selected
-        case background1SelectedColorful
         case background2
-        case background2Colorful
         case background2Pressed
-        case background2PressedColorful
         case background2Selected
-        case background2SelectedColorful
         case background3
-        case background3Colorful
         case background3Pressed
-        case background3PressedColorful
         case background3Selected
-        case background3SelectedColorful
         case background4
         case background4Pressed
         case background4Selected
         case background5
-        case background5Colorful
         case background5Pressed
-        case background5PressedColorful
         case background5Selected
-        case background5SelectedColorful
         case background5SelectedBrandFilled
-        case background5SelectedBrandFilledColorful
         case background5BrandTint
         case background6
-        case background6Colorful
         case background6Pressed
-        case background6PressedColorful
         case background6Selected
-        case background6SelectedColorful
         case backgroundInverted
         case backgroundDisabled
+        case brandBackground1
+        case brandBackground1Pressed
+        case brandBackground1Selected
+        case brandBackground2
+        case brandBackground2Pressed
+        case brandBackground2Selected
+        case brandBackground3
+        case brandBackground3Pressed
+        case brandBackground3Selected
+        case brandBackground4
+        case background5BrandFilledSelected
+        case background5BrandTintSelected
+        case brandBackgroundInverted
+        case brandBackgroundDisabled
+        case brandBackgroundInvertedDisabled
         case stencil1
         case stencil2
     }
@@ -236,48 +244,30 @@ public final class AliasTokens {
         case .background1:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
                              dark: strongSelf.globalTokens.neutralColors[.black])
-        case .background1Colorful:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
         case .background1Pressed:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
                              dark: strongSelf.globalTokens.neutralColors[.grey18])
-        case .background1PressedColorful:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88])
         case .background1Selected:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
                              dark: strongSelf.globalTokens.neutralColors[.grey14])
-        case .background1SelectedColorful:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92])
         case .background2:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
                              dark: strongSelf.globalTokens.neutralColors[.grey12])
-        case .background2Colorful:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
         case .background2Pressed:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
                              dark: strongSelf.globalTokens.neutralColors[.grey30])
-        case .background2PressedColorful:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88])
         case .background2Selected:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
                              dark: strongSelf.globalTokens.neutralColors[.grey26])
-        case .background2SelectedColorful:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92])
         case .background3:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
                              dark: strongSelf.globalTokens.neutralColors[.grey16])
-        case .background3Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light)
         case .background3Pressed:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
                              dark: strongSelf.globalTokens.neutralColors[.grey34])
-        case .background3PressedColorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light)
         case .background3Selected:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
                              dark: strongSelf.globalTokens.neutralColors[.grey30])
-        case .background3SelectedColorful:
-         return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light)
         case .background4:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
                              dark: strongSelf.globalTokens.neutralColors[.grey20])
@@ -290,47 +280,74 @@ public final class AliasTokens {
         case .background5:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
                              dark: strongSelf.globalTokens.neutralColors[.grey24])
-        case .background5Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
         case .background5Pressed:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
                              dark: strongSelf.globalTokens.neutralColors[.grey42])
-        case .background5PressedColorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm40].light)
         case .background5Selected:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey86],
                              dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background5SelectedColorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light)
         case .background5SelectedBrandFilled:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
                              dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background5SelectedBrandFilledColorful:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
         case .background5BrandTint:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
                              dark: strongSelf.globalTokens.neutralColors[.grey38])
         case .background6:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
                              dark: strongSelf.globalTokens.neutralColors[.grey36])
-        case .background6Colorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light)
         case .background6Pressed:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey70],
                              dark: strongSelf.globalTokens.neutralColors[.grey54])
-        case .background6PressedColorful:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm30].light)
         case .background6Selected:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
                              dark: strongSelf.globalTokens.neutralColors[.grey50])
-        case .background6SelectedColorful:
-        return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
         case .backgroundInverted:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
                              dark: strongSelf.globalTokens.neutralColors[.grey34])
         case .backgroundDisabled:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
                              dark: strongSelf.globalTokens.neutralColors[.grey32])
+        case .brandBackground1:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
+        case .brandBackground1Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
+        case .brandBackground1Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandBackground2:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
+        case .brandBackground2Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm40].light)
+        case .brandBackground2Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light)
+        case .brandBackground3:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandBackground3Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm30].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm160].light)
+        case .brandBackground3Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
+        case .brandBackground4:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm20].light)
+        case .background5BrandFilledSelected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .background5BrandTintSelected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                                dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .brandBackgroundInverted:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandBackgroundDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm140].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm40].light)
+        case .brandBackgroundInvertedDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.grey86])
         case .stencil1:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey90],
                              dark: strongSelf.globalTokens.neutralColors[.grey34])
@@ -352,6 +369,9 @@ public final class AliasTokens {
         case strokeAccessible
         case strokeFocus1
         case strokeFocus2
+        case brandStroke1
+        case brandStroke1Pressed
+        case brandStroke1Selected
     }
     public lazy var strokeColors: TokenSet<StrokeColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
@@ -386,6 +406,15 @@ public final class AliasTokens {
         case .strokeFocus2:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
                                 dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandStroke1:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
+        case .brandStroke1Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
+        case .brandStroke1Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

After a change in direction from the designers, we are locking on a new organization for colorful/branded tokens. Remove the old "colorful" tokens and add the new "brand" tokens.

### Verification

Built and ran the demo app. No colors are yet consumed, so no further verification is necessary.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1030)