### PR TITLE
Indeterminate Progress Bar Colors Update

### DIFF
--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
@@ -10,7 +10,7 @@ import UIKit
 public class IndeterminateProgressBarTokens: ControlTokens {
 
     /// Progress bar's background color.
-    open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.surfaceQuaternary] }
+    open var backgroundColor: DynamicColor { aliasTokens.strokeColors[.stroke1] }
 
     /// Progress bar's gradient color.
     open var gradientColor: DynamicColor { globalTokens.brandColors[.primary] }

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
@@ -13,7 +13,7 @@ public class IndeterminateProgressBarTokens: ControlTokens {
     open var backgroundColor: DynamicColor { aliasTokens.strokeColors[.stroke1] }
 
     /// Progress bar's gradient color.
-    open var gradientColor: DynamicColor { globalTokens.brandColors[.primary] }
+    open var gradientColor: DynamicColor { globalTokens.brandColors[.comm100] }
 
     /// Progress bar's height.
     open var height: CGFloat { 2 }

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
@@ -13,7 +13,7 @@ public class IndeterminateProgressBarTokens: ControlTokens {
     open var backgroundColor: DynamicColor { aliasTokens.strokeColors[.stroke1] }
 
     /// Progress bar's gradient color.
-    open var gradientColor: DynamicColor { globalTokens.brandColors[.comm100] }
+    open var gradientColor: DynamicColor { aliasTokens.backgroundColors[.brandBackground1] }
 
     /// Progress bar's height.
     open var height: CGFloat { 2 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The Indeterminate Progress Bar color tokens were updated to match Fluent 2 specs.

### Verification

New colors were tested on the demo app

| Before (light)                                      | After (light)                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="312" alt="ipb_before_light" src="https://user-images.githubusercontent.com/106181067/175406646-07ea4b6c-618b-441d-a8d2-908aacc50c94.png"> | <img width="311" alt="ipb_after_light" src="https://user-images.githubusercontent.com/106181067/175406696-95178b02-79e0-42ab-b2c8-e27d946f7c25.png"> |

| Before (dark)                                      | After (dark)                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="319" alt="ipb_before_dark" src="https://user-images.githubusercontent.com/106181067/175406852-1428b158-1c19-4331-86b9-9885b7a5bf95.png"> | <img width="315" alt="ipb_after_dark" src="https://user-images.githubusercontent.com/106181067/175406878-7cf6fcf7-76ec-436a-a424-7933f7ec0bda.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)