### PR TITLE
[Fluent2 iOS] Moved new color tokens into a consolidated enum

### DIFF
--- a/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokens.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokens.swift
@@ -23,7 +23,7 @@ open class ActivityIndicatorTokens: ControlTokens {
     // MARK: - Design Tokens
 
     /// The default color of the Activity Indicator.
-    open var defaultColor: DynamicColor { aliasTokens.strokeColors[.stroke1] }
+    open var defaultColor: DynamicColor { aliasTokens.colors[.stroke1] }
 
     /// The value for the side of the square frame of an Activity Indicator.
     open var side: CGFloat {

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -7,278 +7,6 @@ import SwiftUI
 
 public final class AliasTokens {
 
-    // MARK: Colors
-
-    public enum ColorsTokens: CaseIterable {
-        // Foreground colors
-        case foreground1
-        case foreground2
-        case foreground3
-        case foregroundDisabled1
-        case foregroundDisabled2
-        case foregroundContrast
-        case foregroundOnColor
-        case foregroundInverted1
-        case foregroundInverted2
-        case brandForeground1
-        case brandForeground1Pressed
-        case brandForeground1Selected
-        case brandForeground2
-        case brandForeground3
-        case brandForeground4
-        case brandForeground5
-        case brandForegroundInverted
-        case brandForegroundDisabled
-        // Background colors
-        case background1
-        case background1Pressed
-        case background1Selected
-        case background2
-        case background2Pressed
-        case background2Selected
-        case background3
-        case background3Pressed
-        case background3Selected
-        case background4
-        case background4Pressed
-        case background4Selected
-        case background5
-        case background5Pressed
-        case background5Selected
-        case background5SelectedBrandFilled
-        case background5BrandTint
-        case background6
-        case background6Pressed
-        case background6Selected
-        case backgroundInverted
-        case backgroundDisabled
-        case brandBackground1
-        case brandBackground1Pressed
-        case brandBackground1Selected
-        case brandBackground2
-        case brandBackground2Pressed
-        case brandBackground2Selected
-        case brandBackground3
-        case brandBackground3Pressed
-        case brandBackground3Selected
-        case brandBackground4
-        case background5BrandFilledSelected
-        case background5BrandTintSelected
-        case brandBackgroundInverted
-        case brandBackgroundDisabled
-        case brandBackgroundInvertedDisabled
-        case stencil1
-        case stencil2
-        // Stroke colors
-        case stroke1
-        case stroke2
-        case strokeDisabled
-        case strokeAccessible
-        case strokeFocus1
-        case strokeFocus2
-        case brandStroke1
-        case brandStroke1Pressed
-        case brandStroke1Selected
-    }
-    public lazy var colors: TokenSet<ColorsTokens, DynamicColor> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
-        switch token {
-        // Foreground colors
-        case .foreground1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
-                                dark: strongSelf.globalTokens.neutralColors[.white])
-        case .foreground2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84])
-        case .foreground3:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey50],
-                                dark: strongSelf.globalTokens.neutralColors[.grey68])
-        case .foregroundDisabled1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36])
-        case .foregroundDisabled2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.grey24])
-        case .foregroundContrast:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
-                                dark: strongSelf.globalTokens.neutralColors[.black])
-        case .foregroundOnColor:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.black])
-        case .foregroundInverted1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
-        case .foregroundInverted2:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.neutralColors[.white])
-        case .brandForeground1:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
-        case .brandForeground1Pressed:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
-        case .brandForeground1Selected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
-        case .brandForeground2:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm20].light)
-        case .brandForeground3:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
-        case .brandForeground4:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
-        case .brandForeground5:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
-        case .brandForegroundInverted:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.neutralColors[.white])
-        case .brandForegroundDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm90].light)
-        // Background colors
-        case .background1:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                             dark: strongSelf.globalTokens.neutralColors[.black])
-        case .background1Pressed:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                             dark: strongSelf.globalTokens.neutralColors[.grey18])
-        case .background1Selected:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
-                             dark: strongSelf.globalTokens.neutralColors[.grey14])
-        case .background2:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                             dark: strongSelf.globalTokens.neutralColors[.grey12])
-        case .background2Pressed:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                             dark: strongSelf.globalTokens.neutralColors[.grey30])
-        case .background2Selected:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
-                             dark: strongSelf.globalTokens.neutralColors[.grey26])
-        case .background3:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                             dark: strongSelf.globalTokens.neutralColors[.grey16])
-        case .background3Pressed:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                             dark: strongSelf.globalTokens.neutralColors[.grey34])
-        case .background3Selected:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
-                             dark: strongSelf.globalTokens.neutralColors[.grey30])
-        case .background4:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
-                             dark: strongSelf.globalTokens.neutralColors[.grey20])
-        case .background4Pressed:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey86],
-                             dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background4Selected:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey90],
-                             dark: strongSelf.globalTokens.neutralColors[.grey34])
-        case .background5:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
-                             dark: strongSelf.globalTokens.neutralColors[.grey24])
-        case .background5Pressed:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
-                             dark: strongSelf.globalTokens.neutralColors[.grey42])
-        case .background5Selected:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey86],
-                             dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background5SelectedBrandFilled:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                             dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background5BrandTint:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
-                             dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background6:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
-                             dark: strongSelf.globalTokens.neutralColors[.grey36])
-        case .background6Pressed:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey70],
-                             dark: strongSelf.globalTokens.neutralColors[.grey54])
-        case .background6Selected:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
-                             dark: strongSelf.globalTokens.neutralColors[.grey50])
-        case .backgroundInverted:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
-                             dark: strongSelf.globalTokens.neutralColors[.grey34])
-        case .backgroundDisabled:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                             dark: strongSelf.globalTokens.neutralColors[.grey32])
-        case .brandBackground1:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
-        case .brandBackground1Pressed:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
-        case .brandBackground1Selected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
-        case .brandBackground2:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
-        case .brandBackground2Pressed:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm40].light)
-        case .brandBackground2Selected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light)
-        case .brandBackground3:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
-        case .brandBackground3Pressed:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm30].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm160].light)
-        case .brandBackground3Selected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
-        case .brandBackground4:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm20].light)
-        case .background5BrandFilledSelected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .background5BrandTintSelected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
-                                dark: strongSelf.globalTokens.neutralColors[.grey38])
-        case .brandBackgroundInverted:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.white])
-        case .brandBackgroundDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm140].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm40].light)
-        case .brandBackgroundInvertedDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.grey86])
-        case .stencil1:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey90],
-                             dark: strongSelf.globalTokens.neutralColors[.grey34])
-        case .stencil2:
-         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
-                             dark: strongSelf.globalTokens.neutralColors[.grey20])
-        // Stroke colors
-        case .stroke1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
-                                dark: strongSelf.globalTokens.neutralColors[.grey32])
-        case .stroke2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey24])
-        case .strokeDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey26])
-        case .strokeAccessible:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey62])
-        case .strokeFocus1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.black])
-        case .strokeFocus2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
-                                dark: strongSelf.globalTokens.neutralColors[.white])
-        case .brandStroke1:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
-        case .brandStroke1Pressed:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
-        case .brandStroke1Selected:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
-                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
-        }
-    }
-
     // MARK: ForegroundColors
 
     public enum ForegroundColorsTokens: CaseIterable {
@@ -620,6 +348,278 @@ public final class AliasTokens {
             return strongSelf.shadow[.shadow02]
         case .interactiveElevation1Disabled:
             return strongSelf.shadow[.shadow02]
+        }
+    }
+
+    // MARK: Colors
+
+    public enum ColorsTokens: CaseIterable {
+        // Foreground colors
+        case foreground1
+        case foreground2
+        case foreground3
+        case foregroundDisabled1
+        case foregroundDisabled2
+        case foregroundContrast
+        case foregroundOnColor
+        case foregroundInverted1
+        case foregroundInverted2
+        case brandForeground1
+        case brandForeground1Pressed
+        case brandForeground1Selected
+        case brandForeground2
+        case brandForeground3
+        case brandForeground4
+        case brandForeground5
+        case brandForegroundInverted
+        case brandForegroundDisabled
+        // Background colors
+        case background1
+        case background1Pressed
+        case background1Selected
+        case background2
+        case background2Pressed
+        case background2Selected
+        case background3
+        case background3Pressed
+        case background3Selected
+        case background4
+        case background4Pressed
+        case background4Selected
+        case background5
+        case background5Pressed
+        case background5Selected
+        case background5SelectedBrandFilled
+        case background5BrandTint
+        case background6
+        case background6Pressed
+        case background6Selected
+        case backgroundInverted
+        case backgroundDisabled
+        case brandBackground1
+        case brandBackground1Pressed
+        case brandBackground1Selected
+        case brandBackground2
+        case brandBackground2Pressed
+        case brandBackground2Selected
+        case brandBackground3
+        case brandBackground3Pressed
+        case brandBackground3Selected
+        case brandBackground4
+        case background5BrandFilledSelected
+        case background5BrandTintSelected
+        case brandBackgroundInverted
+        case brandBackgroundDisabled
+        case brandBackgroundInvertedDisabled
+        case stencil1
+        case stencil2
+        // Stroke colors
+        case stroke1
+        case stroke2
+        case strokeDisabled
+        case strokeAccessible
+        case strokeFocus1
+        case strokeFocus2
+        case brandStroke1
+        case brandStroke1Pressed
+        case brandStroke1Selected
+    }
+    public lazy var colors: TokenSet<ColorsTokens, DynamicColor> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        // Foreground colors
+        case .foreground1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .foreground2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84])
+        case .foreground3:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey50],
+                                dark: strongSelf.globalTokens.neutralColors[.grey68])
+        case .foregroundDisabled1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36])
+        case .foregroundDisabled2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.grey24])
+        case .foregroundContrast:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
+                                dark: strongSelf.globalTokens.neutralColors[.black])
+        case .foregroundOnColor:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.black])
+        case .foregroundInverted1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white])
+        case .foregroundInverted2:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandForeground1:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
+        case .brandForeground1Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
+        case .brandForeground1Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandForeground2:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm20].light)
+        case .brandForeground3:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
+        case .brandForeground4:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandForeground5:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
+        case .brandForegroundInverted:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandForegroundDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm90].light)
+        // Background colors
+        case .background1:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                             dark: strongSelf.globalTokens.neutralColors[.black])
+        case .background1Pressed:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                             dark: strongSelf.globalTokens.neutralColors[.grey18])
+        case .background1Selected:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
+                             dark: strongSelf.globalTokens.neutralColors[.grey14])
+        case .background2:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                             dark: strongSelf.globalTokens.neutralColors[.grey12])
+        case .background2Pressed:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                             dark: strongSelf.globalTokens.neutralColors[.grey30])
+        case .background2Selected:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
+                             dark: strongSelf.globalTokens.neutralColors[.grey26])
+        case .background3:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                             dark: strongSelf.globalTokens.neutralColors[.grey16])
+        case .background3Pressed:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                             dark: strongSelf.globalTokens.neutralColors[.grey34])
+        case .background3Selected:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
+                             dark: strongSelf.globalTokens.neutralColors[.grey30])
+        case .background4:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
+                             dark: strongSelf.globalTokens.neutralColors[.grey20])
+        case .background4Pressed:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey86],
+                             dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .background4Selected:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey90],
+                             dark: strongSelf.globalTokens.neutralColors[.grey34])
+        case .background5:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
+                             dark: strongSelf.globalTokens.neutralColors[.grey24])
+        case .background5Pressed:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
+                             dark: strongSelf.globalTokens.neutralColors[.grey42])
+        case .background5Selected:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey86],
+                             dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .background5SelectedBrandFilled:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                             dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .background5BrandTint:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                             dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .background6:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
+                             dark: strongSelf.globalTokens.neutralColors[.grey36])
+        case .background6Pressed:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey70],
+                             dark: strongSelf.globalTokens.neutralColors[.grey54])
+        case .background6Selected:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
+                             dark: strongSelf.globalTokens.neutralColors[.grey50])
+        case .backgroundInverted:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
+                             dark: strongSelf.globalTokens.neutralColors[.grey34])
+        case .backgroundDisabled:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                             dark: strongSelf.globalTokens.neutralColors[.grey32])
+        case .brandBackground1:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
+        case .brandBackground1Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
+        case .brandBackground1Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandBackground2:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm70].light)
+        case .brandBackground2Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm40].light)
+        case .brandBackground2Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light)
+        case .brandBackground3:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        case .brandBackground3Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm30].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm160].light)
+        case .brandBackground3Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm150].light)
+        case .brandBackground4:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm20].light)
+        case .background5BrandFilledSelected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .background5BrandTintSelected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm160].light,
+                                dark: strongSelf.globalTokens.neutralColors[.grey38])
+        case .brandBackgroundInverted:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandBackgroundDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm140].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm40].light)
+        case .brandBackgroundInvertedDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.grey86])
+        case .stencil1:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey90],
+                             dark: strongSelf.globalTokens.neutralColors[.grey34])
+        case .stencil2:
+         return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
+                             dark: strongSelf.globalTokens.neutralColors[.grey20])
+        // Stroke colors
+        case .stroke1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
+                                dark: strongSelf.globalTokens.neutralColors[.grey32])
+        case .stroke2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey24])
+        case .strokeDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey26])
+        case .strokeAccessible:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey62])
+        case .strokeFocus1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.black])
+        case .strokeFocus2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
+                                dark: strongSelf.globalTokens.neutralColors[.white])
+        case .brandStroke1:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm100].light)
+        case .brandStroke1Pressed:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm50].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm140].light)
+        case .brandStroke1Selected:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm120].light)
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -7,21 +7,10 @@ import SwiftUI
 
 public final class AliasTokens {
 
-    // MARK: ForegroundColors
+    // MARK: Colors
 
-    public enum ForegroundColorsTokens: CaseIterable {
-        case neutral1
-        case neutral2
-        case neutral3
-        case neutral4
-        case neutralDisabled
-        case neutralInverted
-        case brandRest
-        case brandHover
-        case brandPressed
-        case brandSelected
-        case brandDisabled
-        // New foreground colors
+    public enum ColorsTokens: CaseIterable {
+        // Foreground colors
         case foreground1
         case foreground2
         case foreground3
@@ -40,56 +29,61 @@ public final class AliasTokens {
         case brandForeground5
         case brandForegroundInverted
         case brandForegroundDisabled
-
+        // Background colors
+        case background1
+        case background1Pressed
+        case background1Selected
+        case background2
+        case background2Pressed
+        case background2Selected
+        case background3
+        case background3Pressed
+        case background3Selected
+        case background4
+        case background4Pressed
+        case background4Selected
+        case background5
+        case background5Pressed
+        case background5Selected
+        case background5SelectedBrandFilled
+        case background5BrandTint
+        case background6
+        case background6Pressed
+        case background6Selected
+        case backgroundInverted
+        case backgroundDisabled
+        case brandBackground1
+        case brandBackground1Pressed
+        case brandBackground1Selected
+        case brandBackground2
+        case brandBackground2Pressed
+        case brandBackground2Selected
+        case brandBackground3
+        case brandBackground3Pressed
+        case brandBackground3Selected
+        case brandBackground4
+        case background5BrandFilledSelected
+        case background5BrandTintSelected
+        case brandBackgroundInverted
+        case brandBackgroundDisabled
+        case brandBackgroundInvertedDisabled
+        case stencil1
+        case stencil2
+        // Stroke colors
+        case stroke1
+        case stroke2
+        case strokeDisabled
+        case strokeAccessible
+        case strokeFocus1
+        case strokeFocus2
+        case brandStroke1
+        case brandStroke1Pressed
+        case brandStroke1Selected
     }
-    public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, DynamicColor> = .init { [weak self] token in
+    public lazy var colors: TokenSet<ColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
-        case .neutral1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
-                                dark: strongSelf.globalTokens.neutralColors[.white],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
-        case .neutral2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey26],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
-        case .neutral3:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey14],
-                                dark: strongSelf.globalTokens.neutralColors[.grey68],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
-        case .neutral4:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey50],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey26],
-                                dark: strongSelf.globalTokens.neutralColors[.grey52],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
-        case .neutralDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey62])
-        case .neutralInverted:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.black],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.black])
-        case .brandRest:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.primary].light,
-                                lightHighContrast: strongSelf.globalTokens.brandColors[.shade20].light,
-                                dark: strongSelf.globalTokens.brandColors[.primary].dark,
-                                darkHighContrast: strongSelf.globalTokens.brandColors[.tint20].dark)
-        case .brandHover:
-            return strongSelf.globalTokens.brandColors[.shade10]
-        case .brandPressed:
-            return strongSelf.globalTokens.brandColors[.shade30]
-        case .brandSelected:
-            return strongSelf.globalTokens.brandColors[.shade20]
-        case .brandDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36])
-        // New foreground colors
+        // Foreground colors
         case .foreground1:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
                                 dark: strongSelf.globalTokens.neutralColors[.white])
@@ -140,107 +134,7 @@ public final class AliasTokens {
                                 dark: strongSelf.globalTokens.neutralColors[.white])
         case .brandForegroundDisabled:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm90].light)
-        }
-    }
-
-    // MARK: BackgroundColors
-
-    public enum BackgroundColorsTokens: CaseIterable {
-        case neutral1
-        case neutral2
-        case neutral3
-        case neutral4
-        case neutral5
-        case neutralDisabled
-        case brandRest
-        case brandHover
-        case brandPressed
-        case brandSelected
-        case brandDisabled
-        case surfaceQuaternary
-        // New background colors
-        case background1
-        case background1Pressed
-        case background1Selected
-        case background2
-        case background2Pressed
-        case background2Selected
-        case background3
-        case background3Pressed
-        case background3Selected
-        case background4
-        case background4Pressed
-        case background4Selected
-        case background5
-        case background5Pressed
-        case background5Selected
-        case background5SelectedBrandFilled
-        case background5BrandTint
-        case background6
-        case background6Pressed
-        case background6Selected
-        case backgroundInverted
-        case backgroundDisabled
-        case brandBackground1
-        case brandBackground1Pressed
-        case brandBackground1Selected
-        case brandBackground2
-        case brandBackground2Pressed
-        case brandBackground2Selected
-        case brandBackground3
-        case brandBackground3Pressed
-        case brandBackground3Selected
-        case brandBackground4
-        case background5BrandFilledSelected
-        case background5BrandTintSelected
-        case brandBackgroundInverted
-        case brandBackgroundDisabled
-        case brandBackgroundInvertedDisabled
-        case stencil1
-        case stencil2
-    }
-    public lazy var backgroundColors: TokenSet<BackgroundColorsTokens, DynamicColor> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
-        switch token {
-        case .neutral1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.black],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey4])
-        case .neutral2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
-                                dark: strongSelf.globalTokens.neutralColors[.grey4],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey8])
-        case .neutral3:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey96],
-                                dark: strongSelf.globalTokens.neutralColors[.grey8],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey12])
-        case .neutral4:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
-                                dark: strongSelf.globalTokens.neutralColors[.grey12],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey16])
-        case .neutral5:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
-        case .neutralDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey84])
-        case .brandRest:
-            return strongSelf.globalTokens.brandColors[.primary]
-        case .brandHover:
-            return strongSelf.globalTokens.brandColors[.shade10]
-        case .brandPressed:
-            return strongSelf.globalTokens.brandColors[.shade30]
-        case .brandSelected:
-            return strongSelf.globalTokens.brandColors[.shade20]
-        case .brandDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84])
-        case .surfaceQuaternary:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey26])
-        // New background colors
+        // Background colors
         case .background1:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
                              dark: strongSelf.globalTokens.neutralColors[.black])
@@ -354,40 +248,7 @@ public final class AliasTokens {
         case .stencil2:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
                              dark: strongSelf.globalTokens.neutralColors[.grey20])
-        }
-    }
-
-    // MARK: StrokeColors
-
-    public enum StrokeColorsTokens: CaseIterable {
-        case neutral1
-        case neutral2
-        // New stroke colors
-        case stroke1
-        case stroke2
-        case strokeDisabled
-        case strokeAccessible
-        case strokeFocus1
-        case strokeFocus2
-        case brandStroke1
-        case brandStroke1Pressed
-        case brandStroke1Selected
-    }
-    public lazy var strokeColors: TokenSet<StrokeColorsTokens, DynamicColor> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
-        switch token {
-        case .neutral1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey24],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey32])
-        case .neutral2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey32],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+        // Stroke colors
         case .stroke1:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey82],
                                 dark: strongSelf.globalTokens.neutralColors[.grey32])
@@ -415,6 +276,155 @@ public final class AliasTokens {
         case .brandStroke1Selected:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm60].light,
                                 dark: strongSelf.globalTokens.brandColors[.comm120].light)
+        }
+    }
+
+    // MARK: ForegroundColors
+
+    public enum ForegroundColorsTokens: CaseIterable {
+        case neutral1
+        case neutral2
+        case neutral3
+        case neutral4
+        case neutralDisabled
+        case neutralInverted
+        case brandRest
+        case brandHover
+        case brandPressed
+        case brandSelected
+        case brandDisabled
+    }
+    public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, DynamicColor> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .neutral1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
+                                dark: strongSelf.globalTokens.neutralColors[.white],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
+        case .neutral2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey26],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
+        case .neutral3:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey14],
+                                dark: strongSelf.globalTokens.neutralColors[.grey68],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
+        case .neutral4:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey50],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey26],
+                                dark: strongSelf.globalTokens.neutralColors[.grey52],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
+        case .neutralDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey62])
+        case .neutralInverted:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.black],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.black])
+        case .brandRest:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.primary].light,
+                                lightHighContrast: strongSelf.globalTokens.brandColors[.shade20].light,
+                                dark: strongSelf.globalTokens.brandColors[.primary].dark,
+                                darkHighContrast: strongSelf.globalTokens.brandColors[.tint20].dark)
+        case .brandHover:
+            return strongSelf.globalTokens.brandColors[.shade10]
+        case .brandPressed:
+            return strongSelf.globalTokens.brandColors[.shade30]
+        case .brandSelected:
+            return strongSelf.globalTokens.brandColors[.shade20]
+        case .brandDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36])
+        }
+    }
+
+    // MARK: BackgroundColors
+
+    public enum BackgroundColorsTokens: CaseIterable {
+        case neutral1
+        case neutral2
+        case neutral3
+        case neutral4
+        case neutral5
+        case neutralDisabled
+        case brandRest
+        case brandHover
+        case brandPressed
+        case brandSelected
+        case brandDisabled
+        case surfaceQuaternary
+    }
+    public lazy var backgroundColors: TokenSet<BackgroundColorsTokens, DynamicColor> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .neutral1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
+                                dark: strongSelf.globalTokens.neutralColors[.black],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey4])
+        case .neutral2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
+                                dark: strongSelf.globalTokens.neutralColors[.grey4],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey8])
+        case .neutral3:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey96],
+                                dark: strongSelf.globalTokens.neutralColors[.grey8],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey12])
+        case .neutral4:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
+                                dark: strongSelf.globalTokens.neutralColors[.grey12],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey16])
+        case .neutral5:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
+                                dark: strongSelf.globalTokens.neutralColors[.grey36],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+        case .neutralDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey84])
+        case .brandRest:
+            return strongSelf.globalTokens.brandColors[.primary]
+        case .brandHover:
+            return strongSelf.globalTokens.brandColors[.shade10]
+        case .brandPressed:
+            return strongSelf.globalTokens.brandColors[.shade30]
+        case .brandSelected:
+            return strongSelf.globalTokens.brandColors[.shade20]
+        case .brandDisabled:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey84])
+        case .surfaceQuaternary:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                dark: strongSelf.globalTokens.neutralColors[.grey26])
+        }
+    }
+
+    // MARK: StrokeColors
+
+    public enum StrokeColorsTokens: CaseIterable {
+        case neutral1
+        case neutral2
+    }
+    public lazy var strokeColors: TokenSet<StrokeColorsTokens, DynamicColor> = .init { [weak self] token in
+        guard let strongSelf = self else { preconditionFailure() }
+        switch token {
+        case .neutral1:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey24],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey32])
+        case .neutral2:
+            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
+                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
+                                dark: strongSelf.globalTokens.neutralColors[.grey32],
+                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
+                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
         }
     }
 

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokens.swift
@@ -10,10 +10,10 @@ import UIKit
 public class IndeterminateProgressBarTokens: ControlTokens {
 
     /// Progress bar's background color.
-    open var backgroundColor: DynamicColor { aliasTokens.strokeColors[.stroke1] }
+    open var backgroundColor: DynamicColor { aliasTokens.colors[.stroke1] }
 
     /// Progress bar's gradient color.
-    open var gradientColor: DynamicColor { aliasTokens.backgroundColors[.brandBackground1] }
+    open var gradientColor: DynamicColor { aliasTokens.colors[.brandBackground1] }
 
     /// Progress bar's height.
     open var height: CGFloat { 2 }

--- a/ios/FluentUI/PersonaButton/PersonaButtonTokens.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonTokens.swift
@@ -49,7 +49,7 @@ public class PersonaButtonTokens: ControlTokens {
     }
 
     /// The background color for the `PersonaButton`.
-    open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.background2] }
+    open var backgroundColor: DynamicColor { aliasTokens.colors[.background2] }
 
     /// How much space should be reserved to the left and right of the control's `Avatar`.
     open var horizontalAvatarPadding: CGFloat {
@@ -65,7 +65,7 @@ public class PersonaButtonTokens: ControlTokens {
     open var horizontalTextPadding: CGFloat { globalTokens.spacing[.xxxSmall] }
 
     /// The `DynamicColor` to use for the control's primary label.
-    open var labelColor: DynamicColor { aliasTokens.foregroundColors[.foreground1] }
+    open var labelColor: DynamicColor { aliasTokens.colors[.foreground1] }
 
     /// The `FontInfo` to use for the control's primary label.
     open var labelFont: FontInfo {
@@ -78,7 +78,7 @@ public class PersonaButtonTokens: ControlTokens {
     }
 
     /// The `DynamicColor` to use for the control's secondary label.
-    open var sublabelColor: DynamicColor { aliasTokens.foregroundColors[.foreground2] }
+    open var sublabelColor: DynamicColor { aliasTokens.colors[.foreground2] }
 
     /// The `FontInfo` to use for the control's secondary label.
     open var sublabelFont: FontInfo { aliasTokens.typography[.caption1] }

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselTokens.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselTokens.swift
@@ -12,5 +12,5 @@ public class PersonaButtonCarouselTokens: ControlTokens {
     // MARK: - Design Tokens
 
     /// The background color for the `PersonaButtonCarousel`.
-    open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.background1] }
+    open var backgroundColor: DynamicColor { aliasTokens.colors[.background1] }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

After offline discussions, we have decided to consolidate the new tokens under a single "color" enum/structure. Only one reference to the new tokens has been checked in (ActivityIndicator).

### Verification

Built and ran the demo app, verifying that the ActivityIndicator demo is behaving and looks as expected.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 16 12 23](https://user-images.githubusercontent.com/23249106/175430101-78e72075-def5-44b4-9ff4-c9fcbc4da39e.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 16 15 47](https://user-images.githubusercontent.com/23249106/175430181-679025a5-eed3-45c3-b823-d607fb04b32d.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1032)