### PR TITLE
Persona Button Carousel Color Tokens Update

### DIFF
--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselTokens.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselTokens.swift
@@ -12,5 +12,5 @@ public class PersonaButtonCarouselTokens: ControlTokens {
     // MARK: - Design Tokens
 
     /// The background color for the `PersonaButtonCarousel`.
-    open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.neutral1] }
+    open var backgroundColor: DynamicColor { aliasTokens.backgroundColors[.background1] }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The background color token of the PersonaButtonCarousel was updated with its fluent 2 color token.

### Verification

The change was tested on the persona carousel in the demo app. You might notice the before and after references are the same, this is because both the old and new tokens use black and white for the background colors.

| Before (light)                                       | After (light)                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="299" alt="before_light" src="https://user-images.githubusercontent.com/106181067/175751706-65446456-3bb1-43b6-b348-1952cfbdae3e.png"> | <img width="298" alt="after_light" src="https://user-images.githubusercontent.com/106181067/175751718-5455bc2c-0894-48ad-b311-3117db070e25.png"> |

| Before (dark)                                       | After (dark)                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="297" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/175751726-ea325264-ebbc-423a-bb09-d0da9df3328b.png"> | <img width="303" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/175751729-59f39073-945e-4648-a5e0-b5f2f6ea9b91.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1037)