### PR TITLE
Avatar Color Tokens Update

### DIFF
--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -75,7 +75,7 @@ open class AvatarTokens: ControlTokens {
         case .outlined, .overflow:
             return aliasTokens.strokeColors[.stroke1]
         case .outlinedPrimary:
-            return .init(light: globalTokens.brandColors[.tint10].light, dark: globalTokens.neutralColors[.grey78])
+            return aliasTokens.strokeColors[.brandStroke1]
         }
     }
 
@@ -179,15 +179,15 @@ open class AvatarTokens: ControlTokens {
     open var backgroundDefaultColor: DynamicColor {
         switch style {
         case .default, .group:
-            return .init(light: globalTokens.neutralColors[.white], dark: globalTokens.brandColors[.primary].dark)
+            return aliasTokens.backgroundColors[.background1]
         case .accent:
-            return globalTokens.brandColors[.primary]
+            return aliasTokens.foregroundColors[.brandForeground1]
         case .outlined:
-            return .init(light: globalTokens.neutralColors[.grey94], dark: globalTokens.neutralColors[.grey26])
+            return aliasTokens.backgroundColors[.background5]
         case .outlinedPrimary:
-            return .init(light: globalTokens.brandColors[.tint40].light, dark: globalTokens.neutralColors[.grey26])
+            return aliasTokens.backgroundColors[.brandBackground4]
         case .overflow:
-            return aliasTokens.backgroundColors[.neutral4]
+            return aliasTokens.backgroundColors[.background5]
         }
     }
 
@@ -229,15 +229,15 @@ open class AvatarTokens: ControlTokens {
     open var foregroundDefaultColor: DynamicColor {
         switch style {
         case .default, .group:
-            return .init(light: globalTokens.brandColors[.primary].light, dark: globalTokens.neutralColors[.black])
+            return aliasTokens.foregroundColors[.brandForeground1]
         case .accent:
-            return aliasTokens.foregroundColors[.neutralInverted]
+            return aliasTokens.foregroundColors[.foregroundOnColor]
         case .outlined:
-            return .init(light: globalTokens.neutralColors[.grey42], dark: globalTokens.neutralColors[.grey78])
+            return aliasTokens.foregroundColors[.foreground2]
         case .outlinedPrimary:
-            return .init(light: globalTokens.brandColors[.primary].light, dark: globalTokens.neutralColors[.grey78])
+            return aliasTokens.foregroundColors[.brandForeground4]
         case .overflow:
-            return aliasTokens.foregroundColors[.neutral3]
+            return aliasTokens.foregroundColors[.foreground2]
         }
     }
 

--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -68,14 +68,10 @@ open class AvatarTokens: ControlTokens {
     /// The default color of the ring around the `Avatar`.
     open var ringDefaultColor: DynamicColor {
         switch style {
-        case .default, .group:
-            return aliasTokens.colors[.brandStroke1]
-        case .accent:
+        case .default, .group, .accent, .outlinedPrimary:
             return aliasTokens.colors[.brandStroke1]
         case .outlined, .overflow:
             return aliasTokens.colors[.stroke1]
-        case .outlinedPrimary:
-            return aliasTokens.colors[.brandStroke1]
         }
     }
 
@@ -182,12 +178,10 @@ open class AvatarTokens: ControlTokens {
             return aliasTokens.colors[.background1]
         case .accent:
             return aliasTokens.colors[.brandBackground1]
-        case .outlined:
+        case .outlined, .overflow:
             return aliasTokens.colors[.background5]
         case .outlinedPrimary:
             return aliasTokens.colors[.brandBackground4]
-        case .overflow:
-            return aliasTokens.colors[.background5]
         }
     }
 
@@ -232,12 +226,10 @@ open class AvatarTokens: ControlTokens {
             return aliasTokens.colors[.brandForeground1]
         case .accent:
             return aliasTokens.colors[.foregroundOnColor]
-        case .outlined:
+        case .outlined, .overflow:
             return aliasTokens.colors[.foreground2]
         case .outlinedPrimary:
             return aliasTokens.colors[.brandForeground4]
-        case .overflow:
-            return aliasTokens.colors[.foreground2]
         }
     }
 

--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -181,7 +181,7 @@ open class AvatarTokens: ControlTokens {
         case .default, .group:
             return aliasTokens.backgroundColors[.background1]
         case .accent:
-            return aliasTokens.foregroundColors[.brandForeground1]
+            return aliasTokens.backgroundColors[.brandBackground1]
         case .outlined:
             return aliasTokens.backgroundColors[.background5]
         case .outlinedPrimary:

--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -69,11 +69,11 @@ open class AvatarTokens: ControlTokens {
     open var ringDefaultColor: DynamicColor {
         switch style {
         case .default, .group:
-            return globalTokens.brandColors[.tint10]
+            return aliasTokens.strokeColors[.brandStroke1]
         case .accent:
-            return globalTokens.brandColors[.shade10]
+            return aliasTokens.strokeColors[.brandStroke1]
         case .outlined, .overflow:
-            return aliasTokens.backgroundColors[.neutralDisabled]
+            return aliasTokens.strokeColors[.stroke1]
         case .outlinedPrimary:
             return .init(light: globalTokens.brandColors[.tint10].light, dark: globalTokens.neutralColors[.grey78])
         }

--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -69,13 +69,13 @@ open class AvatarTokens: ControlTokens {
     open var ringDefaultColor: DynamicColor {
         switch style {
         case .default, .group:
-            return aliasTokens.strokeColors[.brandStroke1]
+            return aliasTokens.colors[.brandStroke1]
         case .accent:
-            return aliasTokens.strokeColors[.brandStroke1]
+            return aliasTokens.colors[.brandStroke1]
         case .outlined, .overflow:
-            return aliasTokens.strokeColors[.stroke1]
+            return aliasTokens.colors[.stroke1]
         case .outlinedPrimary:
-            return aliasTokens.strokeColors[.brandStroke1]
+            return aliasTokens.colors[.brandStroke1]
         }
     }
 
@@ -179,15 +179,15 @@ open class AvatarTokens: ControlTokens {
     open var backgroundDefaultColor: DynamicColor {
         switch style {
         case .default, .group:
-            return aliasTokens.backgroundColors[.background1]
+            return aliasTokens.colors[.background1]
         case .accent:
-            return aliasTokens.backgroundColors[.brandBackground1]
+            return aliasTokens.colors[.brandBackground1]
         case .outlined:
-            return aliasTokens.backgroundColors[.background5]
+            return aliasTokens.colors[.background5]
         case .outlinedPrimary:
-            return aliasTokens.backgroundColors[.brandBackground4]
+            return aliasTokens.colors[.brandBackground4]
         case .overflow:
-            return aliasTokens.backgroundColors[.background5]
+            return aliasTokens.colors[.background5]
         }
     }
 
@@ -229,15 +229,15 @@ open class AvatarTokens: ControlTokens {
     open var foregroundDefaultColor: DynamicColor {
         switch style {
         case .default, .group:
-            return aliasTokens.foregroundColors[.brandForeground1]
+            return aliasTokens.colors[.brandForeground1]
         case .accent:
-            return aliasTokens.foregroundColors[.foregroundOnColor]
+            return aliasTokens.colors[.foregroundOnColor]
         case .outlined:
-            return aliasTokens.foregroundColors[.foreground2]
+            return aliasTokens.colors[.foreground2]
         case .outlinedPrimary:
-            return aliasTokens.foregroundColors[.brandForeground4]
+            return aliasTokens.colors[.brandForeground4]
         case .overflow:
-            return aliasTokens.foregroundColors[.foreground2]
+            return aliasTokens.colors[.foreground2]
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated the Avatar's color tokens to Fluent 2 tokens. These changes were on the background, the foreground and the ring colors.

### Verification

The changes were tested on the avatars in the demo app.

`No Ring/No Presence`

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="285" alt="before_light" src="https://user-images.githubusercontent.com/106181067/176322902-6b5dc8d0-dc7d-48c9-ad0b-d3f3c3898891.png"> | <img width="260" alt="after_light" src="https://user-images.githubusercontent.com/106181067/176322949-90975283-2db3-47cb-b077-a11043800733.png"> |
| <img width="282" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/176323042-24c74bf3-4369-4d89-a4bb-17a26b7eded3.png"> | <img width="278" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/176323065-ade21cc6-0b20-4ab8-a66d-2a47e772e6da.png"> |

`With Presence`

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="261" alt="before_light" src="https://user-images.githubusercontent.com/106181067/176323102-c156c22c-79a5-4e74-912a-081189792d81.png"> | <img width="268" alt="after_light" src="https://user-images.githubusercontent.com/106181067/176323132-d943b621-57c2-418f-90a3-289cc35f6999.png"> |
| <img width="269" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/176323157-e6e69773-79f1-489f-9ade-b0a774522c48.png"> | <img width="270" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/176323190-0b242e02-1fc9-4358-8c06-9c2252b7d1eb.png"> |

`With Ring`

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="249" alt="before_light" src="https://user-images.githubusercontent.com/106181067/176323231-b1ce8527-f3e5-417c-9b58-02c65c51b6a6.png"> | <img width="253" alt="after_light" src="https://user-images.githubusercontent.com/106181067/176323248-bac1e6cc-4c3a-4454-8b98-7d497a9ea8f1.png"> |
| <img width="275" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/176323268-fb52e972-0bf5-4069-82b4-51e8075d5ebc.png"> | <img width="263" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/176323286-fe067383-9aa8-43bd-b48b-0b55774d9049.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1045)