### PR TITLE
CommandBar implementation improvements

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -161,6 +161,7 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(createLabelWithText("Default"))
 
         let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        commandBar.translatesAutoresizingMaskIntoConstraints = false
         commandBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(commandBar)
         defaultCommandBar = commandBar
@@ -215,6 +216,7 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(createLabelWithText("With Fixed Button"))
 
         let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+        fixedButtonCommandBar.translatesAutoresizingMaskIntoConstraints = false
         fixedButtonCommandBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(fixedButtonCommandBar)
 
@@ -233,6 +235,7 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(textFieldContainer)
 
         let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
+        accessoryCommandBar.translatesAutoresizingMaskIntoConstraints = false
         textField.inputAccessoryView = accessoryCommandBar
     }
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -33,15 +33,21 @@ open class CommandBar: UIView {
     @objc public convenience init(itemGroups: [CommandBarItemGroup],
                                   leadingItem: CommandBarItem? = nil,
                                   trailingItem: CommandBarItem? = nil) {
-        var leadingItems: [CommandBarItemGroup]?
-        var trailingItems: [CommandBarItemGroup]?
+        let leadingItems: [CommandBarItemGroup]? = {
+            guard let leadingItem = leadingItem else {
+                return nil
+            }
 
-        if let leadingItem = leadingItem {
-            leadingItems = [[leadingItem]]
-        }
-        if let trailingItem = trailingItem {
-            trailingItems = [[trailingItem]]
-        }
+            return [[leadingItem]]
+        }()
+
+        let trailingItems: [CommandBarItemGroup]? = {
+            guard let trailingItem = trailingItem else {
+                return nil
+            }
+
+            return [[trailingItem]]
+        }()
 
         self.init(itemGroups: itemGroups,
                   leadingItemGroups: leadingItems,
@@ -113,7 +119,7 @@ open class CommandBar: UIView {
             leadingCommandGroupsView.itemGroups
         }
         set {
-            set(leadingCommandGroupsView, with: newValue)
+            setupGroupsView(leadingCommandGroupsView, with: newValue)
         }
     }
 
@@ -123,7 +129,7 @@ open class CommandBar: UIView {
             trailingCommandGroupsView.itemGroups
         }
         set {
-            set(trailingCommandGroupsView, with: newValue)
+            setupGroupsView(trailingCommandGroupsView, with: newValue)
         }
     }
 
@@ -248,12 +254,8 @@ open class CommandBar: UIView {
     }
 
     /// Updates the provided `CommandBarCommandGroupsView` with the `items` array and marks the view as needing a layout
-    private func set(_ commandGroupsView: CommandBarCommandGroupsView, with items: [CommandBarItemGroup]?) {
-        if let items = items {
-            commandGroupsView.itemGroups = items
-        } else {
-            commandGroupsView.itemGroups = []
-        }
+    private func setupGroupsView(_ commandGroupsView: CommandBarCommandGroupsView, with items: [CommandBarItemGroup]?) {
+        commandGroupsView.itemGroups = items ?? []
 
         commandGroupsView.isHidden = commandGroupsView.itemGroups.isEmpty
         scrollView.contentInset = scrollViewContentInset()
@@ -263,7 +265,10 @@ open class CommandBar: UIView {
     private struct LayoutConstants {
         static let fadeViewWidth: CGFloat = 16.0
         static let fixedButtonSpacing: CGFloat = 2.0
-        static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+        static let insets = UIEdgeInsets(top: 8.0,
+                                         left: 8.0,
+                                         bottom: 8.0,
+                                         right: 8.0)
     }
 }
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -46,15 +46,11 @@ open class CommandBar: UIView {
     }
 
     @objc public init(itemGroups: [CommandBarItemGroup], leadingItemGroups: [CommandBarItemGroup]? = nil, trailingItemGroups: [CommandBarItemGroup]? = nil) {
-        self.itemGroups = itemGroups
-        self.leadingItemGroups = leadingItemGroups
-        self.trailingItemGroups = trailingItemGroups
-
-        leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.leadingItemGroups, buttonsPersistSelection: false)
+        leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: leadingItemGroups, buttonsPersistSelection: false)
         leadingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
-        mainCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.itemGroups)
+        mainCommandGroupsView = CommandBarCommandGroupsView(itemGroups: itemGroups)
         mainCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
-        trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.trailingItemGroups, buttonsPersistSelection: false)
+        trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: trailingItemGroups, buttonsPersistSelection: false)
         trailingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
 
         commandBarContainerStackView = UIStackView()
@@ -96,34 +92,47 @@ open class CommandBar: UIView {
 
     /// Scrollable items shown in the center of the CommandBar
     public var itemGroups: [CommandBarItemGroup] {
-        didSet {
-            mainCommandGroupsView.itemGroups = itemGroups
+        get {
+            mainCommandGroupsView.itemGroups
+        }
+        set {
+            mainCommandGroupsView.itemGroups = newValue
         }
     }
 
     /// Items pinned to the leading end of the CommandBar
     public var leadingItemGroups: [CommandBarItemGroup]? {
-        didSet {
-            guard let leadingItemGroups = leadingItemGroups else {
-                return
+        get {
+            leadingCommandGroupsView.itemGroups
+        }
+        set {
+            if let newValue = newValue {
+                leadingCommandGroupsView.itemGroups = newValue
+            } else {
+                leadingCommandGroupsView.itemGroups = []
             }
 
-            leadingCommandGroupsView.itemGroups = leadingItemGroups
-            leadingCommandGroupsView.isHidden = leadingItemGroups.isEmpty
+            leadingCommandGroupsView.isHidden = leadingCommandGroupsView.itemGroups.isEmpty
             scrollView.contentInset = scrollViewContentInset()
+            setNeedsLayout()
         }
     }
 
     /// Items pinned to the trailing end of the CommandBar
     public var trailingItemGroups: [CommandBarItemGroup]? {
-        didSet {
-            guard let trailingItemGroups = trailingItemGroups else {
-                return
+        get {
+            trailingCommandGroupsView.itemGroups
+        }
+        set {
+            if let newValue = newValue {
+                trailingCommandGroupsView.itemGroups = newValue
+            } else {
+                trailingCommandGroupsView.itemGroups = []
             }
 
-            trailingCommandGroupsView.itemGroups = trailingItemGroups
-            trailingCommandGroupsView.isHidden = trailingItemGroups.isEmpty
+            trailingCommandGroupsView.isHidden = trailingCommandGroupsView.itemGroups.isEmpty
             scrollView.contentInset = scrollViewContentInset()
+            setNeedsLayout()
         }
     }
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -33,15 +33,14 @@ open class CommandBar: UIView {
     @objc public convenience init(itemGroups: [CommandBarItemGroup],
                                   leadingItem: CommandBarItem? = nil,
                                   trailingItem: CommandBarItem? = nil) {
-        var leadingItems: [CommandBarItemGroup] = []
-        var trailingItems: [CommandBarItemGroup] = []
+        var leadingItems: [CommandBarItemGroup]?
+        var trailingItems: [CommandBarItemGroup]?
 
         if let leadingItem = leadingItem {
-            leadingItems.append([leadingItem])
+            leadingItems = [[leadingItem]]
         }
-
         if let trailingItem = trailingItem {
-            trailingItems.append([trailingItem])
+            trailingItems = [[trailingItem]]
         }
 
         self.init(itemGroups: itemGroups,
@@ -109,28 +108,22 @@ open class CommandBar: UIView {
     }
 
     /// Items pinned to the leading end of the CommandBar
-    public var leadingItemGroups: [CommandBarItemGroup] {
+    public var leadingItemGroups: [CommandBarItemGroup]? {
         get {
             leadingCommandGroupsView.itemGroups
         }
         set {
-            leadingCommandGroupsView.itemGroups = newValue
-            leadingCommandGroupsView.isHidden = leadingCommandGroupsView.itemGroups.isEmpty
-            scrollView.contentInset = scrollViewContentInset()
-            setNeedsLayout()
+            set(leadingCommandGroupsView, with: newValue)
         }
     }
 
     /// Items pinned to the trailing end of the CommandBar
-    public var trailingItemGroups: [CommandBarItemGroup] {
+    public var trailingItemGroups: [CommandBarItemGroup]? {
         get {
             trailingCommandGroupsView.itemGroups
         }
         set {
-            trailingCommandGroupsView.itemGroups = newValue
-            trailingCommandGroupsView.isHidden = trailingCommandGroupsView.itemGroups.isEmpty
-            scrollView.contentInset = scrollViewContentInset()
-            setNeedsLayout()
+            set(trailingCommandGroupsView, with: newValue)
         }
     }
 
@@ -231,9 +224,9 @@ open class CommandBar: UIView {
 
     private func scrollViewContentInset() -> UIEdgeInsets {
         UIEdgeInsets( top: 0,
-                      left: leadingCommandGroupsView.isHidden ? Constants.insets.left : Constants.fixedButtonSpacing,
+                      left: leadingCommandGroupsView.isHidden ? LayoutConstants.insets.left : LayoutConstants.fixedButtonSpacing,
                       bottom: 0,
-                      right: trailingCommandGroupsView.isHidden ? Constants.insets.right : Constants.fixedButtonSpacing )
+                      right: trailingCommandGroupsView.isHidden ? LayoutConstants.insets.right : LayoutConstants.fixedButtonSpacing )
     }
 
     private func updateShadow() {
@@ -242,19 +235,32 @@ open class CommandBar: UIView {
         if !leadingCommandGroupsView.isHidden {
             let leadingOffset = max(0, scrollView.contentOffset.x)
             let percentage = min(1, leadingOffset / scrollView.contentInset.left)
-            locations[1] = Constants.fadeViewWidth / containerView.frame.width * percentage
+            locations[1] = LayoutConstants.fadeViewWidth / containerView.frame.width * percentage
         }
 
         if !trailingCommandGroupsView.isHidden {
             let trailingOffset = max(0, mainCommandGroupsView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
             let percentage = min(1, trailingOffset / scrollView.contentInset.right)
-            locations[2] = 1 - Constants.fadeViewWidth / containerView.frame.width * percentage
+            locations[2] = 1 - LayoutConstants.fadeViewWidth / containerView.frame.width * percentage
         }
 
         containerMaskLayer.locations = locations.map { NSNumber(value: Float($0)) }
     }
 
-    private struct Constants {
+    /// Updates the provided `CommandBarCommandGroupsView` with the `items` array and marks the view as needing a layout
+    private func set(_ commandGroupsView: CommandBarCommandGroupsView, with items: [CommandBarItemGroup]?) {
+        if let items = items {
+            commandGroupsView.itemGroups = items
+        } else {
+            commandGroupsView.itemGroups = []
+        }
+
+        commandGroupsView.isHidden = commandGroupsView.itemGroups.isEmpty
+        scrollView.contentInset = scrollViewContentInset()
+        setNeedsLayout()
+    }
+
+    private struct LayoutConstants {
         static let fadeViewWidth: CGFloat = 16.0
         static let fixedButtonSpacing: CGFloat = 2.0
         static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -30,27 +30,35 @@ open class CommandBar: UIView {
     // MARK: - Public methods
 
     @available(*, renamed: "init(itemGroups:leadingItemGroups:trailingItemGroups:)")
-    @objc public convenience init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
-        var leadingItems: [CommandBarItemGroup]?
-        var trailingItems: [CommandBarItemGroup]?
+    @objc public convenience init(itemGroups: [CommandBarItemGroup],
+                                  leadingItem: CommandBarItem? = nil,
+                                  trailingItem: CommandBarItem? = nil) {
+        var leadingItems: [CommandBarItemGroup] = []
+        var trailingItems: [CommandBarItemGroup] = []
 
         if let leadingItem = leadingItem {
-            leadingItems = [[leadingItem]]
+            leadingItems.append([leadingItem])
         }
 
         if let trailingItem = trailingItem {
-            trailingItems = [[trailingItem]]
+            trailingItems.append([trailingItem])
         }
 
-        self.init(itemGroups: itemGroups, leadingItemGroups: leadingItems, trailingItemGroups: trailingItems)
+        self.init(itemGroups: itemGroups,
+                  leadingItemGroups: leadingItems,
+                  trailingItemGroups: trailingItems)
     }
 
-    @objc public init(itemGroups: [CommandBarItemGroup], leadingItemGroups: [CommandBarItemGroup]? = nil, trailingItemGroups: [CommandBarItemGroup]? = nil) {
-        leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: leadingItemGroups, buttonsPersistSelection: false)
+    @objc public init(itemGroups: [CommandBarItemGroup],
+                      leadingItemGroups: [CommandBarItemGroup]? = nil,
+                      trailingItemGroups: [CommandBarItemGroup]? = nil) {
+        leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: leadingItemGroups,
+                                                               buttonsPersistSelection: false)
         leadingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
         mainCommandGroupsView = CommandBarCommandGroupsView(itemGroups: itemGroups)
         mainCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
-        trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: trailingItemGroups, buttonsPersistSelection: false)
+        trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: trailingItemGroups,
+                                                                buttonsPersistSelection: false)
         trailingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
 
         commandBarContainerStackView = UIStackView()
@@ -101,17 +109,12 @@ open class CommandBar: UIView {
     }
 
     /// Items pinned to the leading end of the CommandBar
-    public var leadingItemGroups: [CommandBarItemGroup]? {
+    public var leadingItemGroups: [CommandBarItemGroup] {
         get {
             leadingCommandGroupsView.itemGroups
         }
         set {
-            if let newValue = newValue {
-                leadingCommandGroupsView.itemGroups = newValue
-            } else {
-                leadingCommandGroupsView.itemGroups = []
-            }
-
+            leadingCommandGroupsView.itemGroups = newValue
             leadingCommandGroupsView.isHidden = leadingCommandGroupsView.itemGroups.isEmpty
             scrollView.contentInset = scrollViewContentInset()
             setNeedsLayout()
@@ -119,17 +122,12 @@ open class CommandBar: UIView {
     }
 
     /// Items pinned to the trailing end of the CommandBar
-    public var trailingItemGroups: [CommandBarItemGroup]? {
+    public var trailingItemGroups: [CommandBarItemGroup] {
         get {
             trailingCommandGroupsView.itemGroups
         }
         set {
-            if let newValue = newValue {
-                trailingCommandGroupsView.itemGroups = newValue
-            } else {
-                trailingCommandGroupsView.itemGroups = []
-            }
-
+            trailingCommandGroupsView.itemGroups = newValue
             trailingCommandGroupsView.isHidden = trailingCommandGroupsView.itemGroups.isEmpty
             scrollView.contentInset = scrollViewContentInset()
             setNeedsLayout()
@@ -232,12 +230,10 @@ open class CommandBar: UIView {
     }
 
     private func scrollViewContentInset() -> UIEdgeInsets {
-        UIEdgeInsets(
-            top: 0,
-            left: leadingCommandGroupsView.isHidden ? CommandBar.insets.left : CommandBar.fixedButtonSpacing,
-            bottom: 0,
-            right: trailingCommandGroupsView.isHidden ? CommandBar.insets.right : CommandBar.fixedButtonSpacing
-        )
+        UIEdgeInsets( top: 0,
+                      left: leadingCommandGroupsView.isHidden ? Constants.insets.left : Constants.fixedButtonSpacing,
+                      bottom: 0,
+                      right: trailingCommandGroupsView.isHidden ? Constants.insets.right : Constants.fixedButtonSpacing )
     }
 
     private func updateShadow() {
@@ -246,21 +242,23 @@ open class CommandBar: UIView {
         if !leadingCommandGroupsView.isHidden {
             let leadingOffset = max(0, scrollView.contentOffset.x)
             let percentage = min(1, leadingOffset / scrollView.contentInset.left)
-            locations[1] = CommandBar.fadeViewWidth / containerView.frame.width * percentage
+            locations[1] = Constants.fadeViewWidth / containerView.frame.width * percentage
         }
 
         if !trailingCommandGroupsView.isHidden {
             let trailingOffset = max(0, mainCommandGroupsView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
             let percentage = min(1, trailingOffset / scrollView.contentInset.right)
-            locations[2] = 1 - CommandBar.fadeViewWidth / containerView.frame.width * percentage
+            locations[2] = 1 - Constants.fadeViewWidth / containerView.frame.width * percentage
         }
 
         containerMaskLayer.locations = locations.map { NSNumber(value: Float($0)) }
     }
 
-    private static let fadeViewWidth: CGFloat = 16.0
-    private static let fixedButtonSpacing: CGFloat = 2.0
-    private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+    private struct Constants {
+        static let fadeViewWidth: CGFloat = 16.0
+        static let fixedButtonSpacing: CGFloat = 2.0
+        static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+    }
 }
 
 // MARK: - Scroll view delegate

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -76,18 +76,22 @@ class CommandBarButton: UIButton {
 
     private var selectedTintColor: UIColor {
         guard let window = window else {
-            return UIColor(light: Colors.communicationBlue, dark: .black)
+            return UIColor(light: Colors.communicationBlue,
+                           dark: .black)
         }
 
-        return UIColor(light: Colors.primary(for: window), dark: .black)
+        return UIColor(light: Colors.primary(for: window),
+                       dark: .black)
     }
 
     private var selectedBackgroundColor: UIColor {
         guard let window = window else {
-            return UIColor(light: Colors.Palette.communicationBlueTint30.color, dark: Colors.Palette.communicationBlue.color)
+            return UIColor(light: Colors.Palette.communicationBlueTint30.color,
+                           dark: Colors.Palette.communicationBlue.color)
         }
 
-        return  UIColor(light: Colors.primaryTint30(for: window), dark: Colors.primary(for: window))
+        return  UIColor(light: Colors.primaryTint30(for: window),
+                        dark: Colors.primary(for: window))
     }
 
     private func updateStyle() {
@@ -113,7 +117,9 @@ class CommandBarButton: UIButton {
 
     private struct ColorConstants {
         static let normalTintColor: UIColor = Colors.textPrimary
-        static let normalBackgroundColor = UIColor(light: Colors.gray50, dark: Colors.gray600)
-        static let highlightedBackgroundColor = UIColor(light: Colors.gray100, dark: Colors.gray900)
+        static let normalBackgroundColor = UIColor(light: Colors.gray50,
+                                                   dark: Colors.gray600)
+        static let highlightedBackgroundColor = UIColor(light: Colors.gray100,
+                                                        dark: Colors.gray900)
     }
 }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -43,7 +43,7 @@ class CommandBarButton: UIButton {
         let accessibilityDescription = item.accessibilityLabel
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
         accessibilityHint = item.accessibilityHint
-        contentEdgeInsets = CommandBarButton.contentEdgeInsets
+        contentEdgeInsets = Constants.contentEdgeInsets
 
         menu = item.menu
         showsMenuAsPrimaryAction = item.showsMenuAsPrimaryAction
@@ -91,7 +91,7 @@ class CommandBarButton: UIButton {
     }
 
     private func updateStyle() {
-        tintColor = isSelected ? selectedTintColor : CommandBarButton.normalTintColor
+        tintColor = isSelected ? selectedTintColor : Constants.normalTintColor
         setTitleColor(tintColor, for: .normal)
 
         if !isPersistSelection {
@@ -100,15 +100,17 @@ class CommandBarButton: UIButton {
             if isSelected {
                 backgroundColor = selectedBackgroundColor
             } else if isHighlighted {
-                backgroundColor = CommandBarButton.highlightedBackgroundColor
+                backgroundColor = Constants.highlightedBackgroundColor
             } else {
-                backgroundColor = CommandBarButton.normalBackgroundColor
+                backgroundColor = Constants.normalBackgroundColor
             }
         }
     }
 
-    private static let contentEdgeInsets = UIEdgeInsets(top: 8.0, left: 10.0, bottom: 8.0, right: 10.0)
-    private static let normalTintColor: UIColor = Colors.textPrimary
-    private static let normalBackgroundColor = UIColor(light: Colors.gray50, dark: Colors.gray600)
-    private static let highlightedBackgroundColor = UIColor(light: Colors.gray100, dark: Colors.gray900)
+    private struct Constants {
+        static let contentEdgeInsets = UIEdgeInsets(top: 8.0, left: 10.0, bottom: 8.0, right: 10.0)
+        static let normalTintColor: UIColor = Colors.textPrimary
+        static let normalBackgroundColor = UIColor(light: Colors.gray50, dark: Colors.gray600)
+        static let highlightedBackgroundColor = UIColor(light: Colors.gray100, dark: Colors.gray900)
+    }
 }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -43,7 +43,7 @@ class CommandBarButton: UIButton {
         let accessibilityDescription = item.accessibilityLabel
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
         accessibilityHint = item.accessibilityHint
-        contentEdgeInsets = Constants.contentEdgeInsets
+        contentEdgeInsets = LayoutConstants.contentEdgeInsets
 
         menu = item.menu
         showsMenuAsPrimaryAction = item.showsMenuAsPrimaryAction
@@ -91,7 +91,7 @@ class CommandBarButton: UIButton {
     }
 
     private func updateStyle() {
-        tintColor = isSelected ? selectedTintColor : Constants.normalTintColor
+        tintColor = isSelected ? selectedTintColor : ColorConstants.normalTintColor
         setTitleColor(tintColor, for: .normal)
 
         if !isPersistSelection {
@@ -100,15 +100,18 @@ class CommandBarButton: UIButton {
             if isSelected {
                 backgroundColor = selectedBackgroundColor
             } else if isHighlighted {
-                backgroundColor = Constants.highlightedBackgroundColor
+                backgroundColor = ColorConstants.highlightedBackgroundColor
             } else {
-                backgroundColor = Constants.normalBackgroundColor
+                backgroundColor = ColorConstants.normalBackgroundColor
             }
         }
     }
 
-    private struct Constants {
+    private struct LayoutConstants {
         static let contentEdgeInsets = UIEdgeInsets(top: 8.0, left: 10.0, bottom: 8.0, right: 10.0)
+    }
+
+    private struct ColorConstants {
         static let normalTintColor: UIColor = Colors.textPrimary
         static let normalBackgroundColor = UIColor(light: Colors.gray50, dark: Colors.gray600)
         static let highlightedBackgroundColor = UIColor(light: Colors.gray100, dark: Colors.gray900)

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -15,7 +15,7 @@ class CommandBarButtonGroupView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
 
         clipsToBounds = true
-        layer.cornerRadius = Constants.cornerRadius
+        layer.cornerRadius = LayoutConstants.cornerRadius
         layer.cornerCurve = .continuous
 
         configureHierarchy()
@@ -31,7 +31,7 @@ class CommandBarButtonGroupView: UIView {
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
-        stackView.spacing = Constants.buttonPadding
+        stackView.spacing = LayoutConstants.buttonPadding
 
         return stackView
     }()
@@ -47,11 +47,11 @@ class CommandBarButtonGroupView: UIView {
     }
 
     private func applyInsets() {
-        buttons.first?.contentEdgeInsets.left += Constants.leftRightBuffer
-        buttons.last?.contentEdgeInsets.right += Constants.leftRightBuffer
+        buttons.first?.contentEdgeInsets.left += LayoutConstants.leftRightBuffer
+        buttons.last?.contentEdgeInsets.right += LayoutConstants.leftRightBuffer
     }
 
-    private struct Constants {
+    private struct LayoutConstants {
         static let cornerRadius: CGFloat = 8.0
         static let buttonPadding: CGFloat = 2.0
         static let leftRightBuffer: CGFloat = 2.0

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -15,7 +15,7 @@ class CommandBarButtonGroupView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
 
         clipsToBounds = true
-        layer.cornerRadius = CommandBarButtonGroupView.cornerRadius
+        layer.cornerRadius = Constants.cornerRadius
         layer.cornerCurve = .continuous
 
         configureHierarchy()
@@ -31,7 +31,7 @@ class CommandBarButtonGroupView: UIView {
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
-        stackView.spacing = CommandBarButtonGroupView.buttonPadding
+        stackView.spacing = Constants.buttonPadding
 
         return stackView
     }()
@@ -47,11 +47,13 @@ class CommandBarButtonGroupView: UIView {
     }
 
     private func applyInsets() {
-        buttons.first?.contentEdgeInsets.left += CommandBarButtonGroupView.leftRightBuffer
-        buttons.last?.contentEdgeInsets.right += CommandBarButtonGroupView.leftRightBuffer
+        buttons.first?.contentEdgeInsets.left += Constants.leftRightBuffer
+        buttons.last?.contentEdgeInsets.right += Constants.leftRightBuffer
     }
 
-    private static let cornerRadius: CGFloat = 8.0
-    private static let buttonPadding: CGFloat = 2.0
-    private static let leftRightBuffer: CGFloat = 2.0
+    private struct Constants {
+        static let cornerRadius: CGFloat = 8.0
+        static let buttonPadding: CGFloat = 2.0
+        static let leftRightBuffer: CGFloat = 2.0
+    }
 }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -18,15 +18,15 @@ class CommandBarCommandGroupsView: UIView {
 
         buttonGroupsStackView.translatesAutoresizingMaskIntoConstraints = false
         buttonGroupsStackView.axis = .horizontal
-        buttonGroupsStackView.spacing = Constants.buttonGroupSpacing
+        buttonGroupsStackView.spacing = LayoutConstants.buttonGroupSpacing
 
         addSubview(buttonGroupsStackView)
 
         NSLayoutConstraint.activate([
             buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor,
-                                                       constant: Constants.insets.top),
+                                                       constant: LayoutConstants.insets.top),
             bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor,
-                                    constant: Constants.insets.top),
+                                    constant: LayoutConstants.insets.top),
             buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
@@ -107,7 +107,7 @@ class CommandBarCommandGroupsView: UIView {
         sender.updateState()
     }
 
-    private struct Constants {
+    private struct LayoutConstants {
         static let buttonGroupSpacing: CGFloat = 16
         static let insets = UIEdgeInsets(top: 8.0,
                                          left: 8.0,

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -19,10 +19,19 @@ class CommandBarCommandGroupsView: UIView {
         buttonGroupsStackView.axis = .horizontal
         buttonGroupsStackView.spacing = CommandBarCommandGroupsView.buttonGroupSpacing
 
-        configureHierarchy()
+        addSubview(buttonGroupsStackView)
+
+        NSLayoutConstraint.activate([
+            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+
         updateButtonsShown()
     }
 
+    @available(*, unavailable)
     required init(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
@@ -48,19 +57,6 @@ class CommandBarCommandGroupsView: UIView {
     private var buttonGroupViews: [CommandBarButtonGroupView] = []
     private var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = [:]
     private var buttonsPersistSelection: Bool
-
-    // MARK: View Updates
-
-    private func configureHierarchy() {
-        addSubview(buttonGroupsStackView)
-
-        NSLayoutConstraint.activate([
-            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBarCommandGroupsView.insets.top),
-            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor, constant: CommandBarCommandGroupsView.insets.top),
-            buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
-    }
 
     /// Refreshes the buttons shown in the `arrangedSubviews`
     private func updateButtonsShown() {

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -6,7 +6,8 @@
 import UIKit
 
 class CommandBarCommandGroupsView: UIView {
-    init(itemGroups: [CommandBarItemGroup]? = nil, buttonsPersistSelection: Bool = true) {
+    init(itemGroups: [CommandBarItemGroup]? = nil,
+         buttonsPersistSelection: Bool = true) {
         self.itemGroups = itemGroups ?? []
 
         self.buttonsPersistSelection = buttonsPersistSelection
@@ -17,13 +18,15 @@ class CommandBarCommandGroupsView: UIView {
 
         buttonGroupsStackView.translatesAutoresizingMaskIntoConstraints = false
         buttonGroupsStackView.axis = .horizontal
-        buttonGroupsStackView.spacing = CommandBarCommandGroupsView.buttonGroupSpacing
+        buttonGroupsStackView.spacing = Constants.buttonGroupSpacing
 
         addSubview(buttonGroupsStackView)
 
         NSLayoutConstraint.activate([
-            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBarCommandGroupsView.insets.top),
-            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor,
+                                                       constant: Constants.insets.top),
+            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor,
+                                    constant: Constants.insets.top),
             buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
@@ -104,6 +107,11 @@ class CommandBarCommandGroupsView: UIView {
         sender.updateState()
     }
 
-    private static let buttonGroupSpacing: CGFloat = 16
-    private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+    private struct Constants {
+        static let buttonGroupSpacing: CGFloat = 16
+        static let insets = UIEdgeInsets(top: 8.0,
+                                         left: 8.0,
+                                         bottom: 8.0,
+                                         right: 8.0)
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Make some additional improvements to the CommandBar implementation
--> The usages of `CommandBar` in `CommandBarDemoController` were not setting `translatesAutoResizingMaskIntoConstraints` to `false`
--> Move implementation from `configureHierarchy()` in `CommandBarCommandGroupsView` to be inline to reduce future confusion around use. The method should only be called once on init.
--> Update the `CommandBar` `*ItemGroups` properties to get and set the `itemGroups` property on the corresponding `CommandBarCommandGroupsView`. This will make it so that there is only 1 source of truth for each of the views.
--> Call `setNeedsLayout` after updating the value of `leadingItemGroups` and `trailingItemGroups`. In some cases, I found that the size of the `containerMaskLayer` was not updating as the leading and trailing views hide. Calling `setNeedsLayout` on the `CommandBar` marks the view as needing a layout and causes the `containerMaskLayer` frame to be updated.

### Verification

- Verified in devmain necessary devmain apps.
- Verified in the CommandBarDemoController.
- Some screenshots can be found in the original PR [here](https://github.com/microsoft/fluentui-apple/pull/987).

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)