### PR TITLE
Revert CommandBar revert commit

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -141,6 +141,8 @@ class CommandBarDemoController: DemoController {
         }
     }
 
+    var defaultCommandBar: CommandBar?
+
     let textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
@@ -156,6 +158,85 @@ class CommandBarDemoController: DemoController {
         container.layoutMargins.left = 0
         view.backgroundColor = Colors.surfaceSecondary
 
+        container.addArrangedSubview(createLabelWithText("Default"))
+
+        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        commandBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(commandBar)
+        defaultCommandBar = commandBar
+
+        let itemCustomizationContainer = UIStackView()
+        itemCustomizationContainer.spacing = CommandBarDemoController.verticalStackViewSpacing
+        itemCustomizationContainer.axis = .vertical
+        itemCustomizationContainer.backgroundColor = Colors.navigationBarBackground
+
+        itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
+
+        let refreshButton = Button(style: .tertiaryOutline)
+        refreshButton.setTitle("Refresh 'Default' Bar", for: .normal)
+        refreshButton.addTarget(self, action: #selector(refreshDefaultBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(refreshButton)
+
+        let removeTrailingItemButton = Button(style: .tertiaryOutline)
+        removeTrailingItemButton.setTitle("Remove Trailing Button", for: .normal)
+        removeTrailingItemButton.addTarget(self, action: #selector(removeDefaultTrailingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(removeTrailingItemButton)
+
+        let refreshTrailingItemButton = Button(style: .tertiaryOutline)
+        refreshTrailingItemButton.setTitle("Refresh Trailing Button", for: .normal)
+        refreshTrailingItemButton.addTarget(self, action: #selector(refreshDefaultTrailingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(refreshTrailingItemButton)
+
+        let removeLeadingItemButton = Button(style: .tertiaryOutline)
+        removeLeadingItemButton.setTitle("Remove Leading Button", for: .normal)
+        removeLeadingItemButton.addTarget(self, action: #selector(removeDefaultLeadingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(removeLeadingItemButton)
+
+        let refreshLeadingItemButton = Button(style: .tertiaryOutline)
+        refreshLeadingItemButton.setTitle("Refresh Leading Button", for: .normal)
+        refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
+
+        let customizationStackView = UIStackView()
+        customizationStackView.axis = .horizontal
+        customizationStackView.alignment = .fill
+        customizationStackView.distribution = .fillProportionally
+        customizationStackView.addArrangedSubview(createLabelWithText("'+' Item Enabled"))
+        let itemEnabledSwitch: UISwitch = UISwitch()
+        itemEnabledSwitch.isOn = true
+        itemEnabledSwitch.addTarget(self, action: #selector(itemEnabledValueChanged), for: .valueChanged)
+        customizationStackView.addArrangedSubview(itemEnabledSwitch)
+        itemCustomizationContainer.addArrangedSubview(customizationStackView)
+
+        itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
+
+        container.addArrangedSubview(itemCustomizationContainer)
+
+        container.addArrangedSubview(createLabelWithText("With Fixed Button"))
+
+        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+        fixedButtonCommandBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(fixedButtonCommandBar)
+
+        container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
+
+        let textFieldContainer = UIView()
+        textFieldContainer.backgroundColor = Colors.navigationBarBackground
+        textFieldContainer.addSubview(textField)
+        NSLayoutConstraint.activate([
+            textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
+            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 16.0),
+            textFieldContainer.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: 16.0),
+            textFieldContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 16.0)
+        ])
+
+        container.addArrangedSubview(textFieldContainer)
+
+        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
+        textField.inputAccessoryView = accessoryCommandBar
+    }
+
+    func createItemGroups() -> [CommandBarItemGroup] {
         let commandGroups: [[Command]] = [
             [
                 .add,
@@ -204,32 +285,7 @@ class CommandBarDemoController: DemoController {
                                           UIAction(title: "Copy Text", image: UIImage(named: "text24Regular"), handler: { _ in })])
         copyItem.showsMenuAsPrimaryAction = true
 
-        container.addArrangedSubview(createLabelWithText("Default"))
-
-        let defaultCommandBar = CommandBar(itemGroups: itemGroups)
-        container.addArrangedSubview(defaultCommandBar)
-
-        container.addArrangedSubview(createLabelWithText("With Fixed Button"))
-
-        let fixedButtonCommandBar = CommandBar(itemGroups: itemGroups, leadingItem: newItem(for: .copy), trailingItem: newItem(for: .keyboard))
-        container.addArrangedSubview(fixedButtonCommandBar)
-
-        container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
-
-        let textFieldContainer = UIView()
-        textFieldContainer.backgroundColor = Colors.navigationBarBackground
-        textFieldContainer.addSubview(textField)
-        NSLayoutConstraint.activate([
-            textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
-            textField.leadingAnchor.constraint(equalTo: textFieldContainer.leadingAnchor, constant: 16.0),
-            textFieldContainer.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: 16.0),
-            textFieldContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: 16.0)
-        ])
-
-        container.addArrangedSubview(textFieldContainer)
-
-        let accessoryCommandBar = CommandBar(itemGroups: itemGroups, trailingItem: newItem(for: .keyboard))
-        textField.inputAccessoryView = accessoryCommandBar
+        return itemGroups
     }
 
     func createLabelWithText(_ text: String = "") -> Label {
@@ -274,4 +330,34 @@ class CommandBarDemoController: DemoController {
             present(alert, animated: true)
         }
     }
+
+    @objc func itemEnabledValueChanged(sender: UISwitch!) {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
+            return
+        }
+
+        item.isEnabled = sender.isOn
+    }
+
+    @objc func refreshDefaultBarItems(sender: UIButton!) {
+        defaultCommandBar?.itemGroups = createItemGroups()
+    }
+
+    @objc func removeDefaultTrailingBarItems(sender: UIButton!) {
+        defaultCommandBar?.trailingItemGroups = []
+    }
+
+    @objc func refreshDefaultTrailingBarItems(sender: UIButton!) {
+        defaultCommandBar?.trailingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    @objc func removeDefaultLeadingBarItems(sender: UIButton!) {
+        defaultCommandBar?.leadingItemGroups = []
+    }
+
+    @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
+        defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    private static let verticalStackViewSpacing: CGFloat = 8.0
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
+		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
@@ -268,6 +269,7 @@
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
+		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -1014,6 +1016,7 @@
 				FC414E4E2588B65C00069E73 /* CommandBarItem.swift */,
 				FC414E2A25887A4B00069E73 /* CommandBarButton.swift */,
 				FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */,
+				94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */,
 			);
 			path = "Command Bar";
 			sourceTree = "<group>";
@@ -1513,6 +1516,7 @@
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,
 				5314E08925F00F2D0099271A /* CommandBarButtonGroupView.swift in Sources */,
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,
+				94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */,
 				5314E21E25F022120099271A /* UIView+Extensions.swift in Sources */,
 				5314E0BD25F0106F0099271A /* HUD.swift in Sources */,
 				5314E06A25F00F100099271A /* GenericDateTimePicker.swift in Sources */,

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -7,41 +7,63 @@ import UIKit
 
 /**
  `CommandBar` is a horizontal scrollable list of icon buttons divided by groups.
- Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItem` and `trailingItem` add fixed buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  Set the `delegate` property to determine whether a button can be selected and deselected, and listen to selection changes.
+ Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItemGroups` and `trailingItemGroups` add buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  */
 @objc(MSFCommandBar)
 open class CommandBar: UIView {
     // Hierarchy:
     //
-    // leadingButton
-    // containerView
-    // |--layer.mask -> containerMaskLayer (fill containerView)
-    // |--subviews
-    // |  |--scrollView (fill containerView)
-    // |  |  |--subviews
-    // |  |  |  |--stackView
-    // |  |  |  |  |--buttons (fill scrollView content)
-    // trailingButton
+    // commandBarContainerStackView
+    // |--leadingCommandGroupsView
+    // |--|--buttons
+    // |--containerView
+    // |--|--layer.mask -> containerMaskLayer (fill containerView)
+    // |--|--subviews
+    // |--|  |--scrollView (fill containerView)
+    // |--|  |  |--subviews
+    // |--|  |  |  |--stackView
+    // |--|  |  |  |  |--buttons (fill scrollView content)
+    // |--trailingCommandGroupsView
+    // |--|--buttons
 
     // MARK: - Public methods
 
-    @objc public init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
+    @available(*, renamed: "init(itemGroups:leadingItemGroups:trailingItemGroups:)")
+    @objc public convenience init(itemGroups: [CommandBarItemGroup], leadingItem: CommandBarItem? = nil, trailingItem: CommandBarItem? = nil) {
+        var leadingItems: [CommandBarItemGroup]?
+        var trailingItems: [CommandBarItemGroup]?
+
+        if let leadingItem = leadingItem {
+            leadingItems = [[leadingItem]]
+        }
+
+        if let trailingItem = trailingItem {
+            trailingItems = [[trailingItem]]
+        }
+
+        self.init(itemGroups: itemGroups, leadingItemGroups: leadingItems, trailingItemGroups: trailingItems)
+    }
+
+    @objc public init(itemGroups: [CommandBarItemGroup], leadingItemGroups: [CommandBarItemGroup]? = nil, trailingItemGroups: [CommandBarItemGroup]? = nil) {
         self.itemGroups = itemGroups
+        self.leadingItemGroups = leadingItemGroups
+        self.trailingItemGroups = trailingItemGroups
+
+        leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.leadingItemGroups, buttonsPersistSelection: false)
+        leadingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
+        mainCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.itemGroups)
+        mainCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
+        trailingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: self.trailingItemGroups, buttonsPersistSelection: false)
+        trailingCommandGroupsView.translatesAutoresizingMaskIntoConstraints = false
+
+        commandBarContainerStackView = UIStackView()
+        commandBarContainerStackView.axis = .horizontal
+        commandBarContainerStackView.translatesAutoresizingMaskIntoConstraints = false
 
         super.init(frame: .zero)
 
-        if let leadingItem = leadingItem {
-            self.leadingButton = button(forItem: leadingItem, isPersistSelection: false)
-        }
-        if let trailingItem = trailingItem {
-            self.trailingButton = button(forItem: trailingItem, isPersistSelection: false)
-        }
-
-        translatesAutoresizingMaskIntoConstraints = false
-
         configureHierarchy()
-        updateButtonsState()
     }
 
     @available(*, unavailable)
@@ -50,10 +72,11 @@ open class CommandBar: UIView {
     }
 
     /// Apply `isEnabled` and `isSelected` state from `CommandBarItem` to the buttons
+    @available(*, message: "Changes on CommandBarItem objects will automatically trigger updates to their corresponding CommandBarButtons. Calls to this method are no longer necessary.")
     @objc public func updateButtonsState() {
-        for button in itemsToButtonsMap.values {
-            button.updateState()
-        }
+        leadingCommandGroupsView.updateButtonsState()
+        mainCommandGroupsView.updateButtonsState()
+        trailingCommandGroupsView.updateButtonsState()
     }
 
     // MARK: Overrides
@@ -65,20 +88,58 @@ open class CommandBar: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
 
+        commandBarContainerStackView.layoutIfNeeded()
+
         containerMaskLayer.frame = containerView.bounds
         updateShadow()
     }
 
+    /// Scrollable items shown in the center of the CommandBar
+    public var itemGroups: [CommandBarItemGroup] {
+        didSet {
+            mainCommandGroupsView.itemGroups = itemGroups
+        }
+    }
+
+    /// Items pinned to the leading end of the CommandBar
+    public var leadingItemGroups: [CommandBarItemGroup]? {
+        didSet {
+            guard let leadingItemGroups = leadingItemGroups else {
+                return
+            }
+
+            leadingCommandGroupsView.itemGroups = leadingItemGroups
+            leadingCommandGroupsView.isHidden = leadingItemGroups.isEmpty
+            scrollView.contentInset = scrollViewContentInset()
+        }
+    }
+
+    /// Items pinned to the trailing end of the CommandBar
+    public var trailingItemGroups: [CommandBarItemGroup]? {
+        didSet {
+            guard let trailingItemGroups = trailingItemGroups else {
+                return
+            }
+
+            trailingCommandGroupsView.itemGroups = trailingItemGroups
+            trailingCommandGroupsView.isHidden = trailingItemGroups.isEmpty
+            scrollView.contentInset = scrollViewContentInset()
+        }
+    }
+
     // MARK: - Private properties
 
-    private let itemGroups: [CommandBarItemGroup]
+    /// Container UIStackView that holds the leading, main and trailing views
+    private var commandBarContainerStackView: UIStackView
 
-    private lazy var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = {
-        let allButtons = itemGroups.flatMap({ $0 }).map({ button(forItem: $0) }) +
-            [leadingButton, trailingButton].compactMap({ $0 })
+    /// View holding the items pinned to the leading end of the CommandBar
+    private var leadingCommandGroupsView: CommandBarCommandGroupsView
 
-        return Dictionary(uniqueKeysWithValues: allButtons.map { ($0.item, $0) })
-    }()
+    /// View holding the items in the middle of the CommandBar
+    private var mainCommandGroupsView: CommandBarCommandGroupsView
+
+    /// View holding the items pinned to the trailing end of the CommandBar
+    private var trailingCommandGroupsView: CommandBarCommandGroupsView
 
     // MARK: Views and Layers
 
@@ -101,54 +162,24 @@ open class CommandBar: UIView {
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.contentInset = UIEdgeInsets(
-            top: 0,
-            left: leadingButton == nil ? CommandBar.insets.left : CommandBar.fixedButtonSpacing,
-            bottom: 0,
-            right: trailingButton == nil ? CommandBar.insets.right : CommandBar.fixedButtonSpacing
-        )
+        scrollView.contentInset = scrollViewContentInset()
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = true
         scrollView.delegate = self
 
-        scrollView.addSubview(stackView)
+        scrollView.addSubview(mainCommandGroupsView)
         NSLayoutConstraint.activate([
             scrollView.contentLayoutGuide.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
 
-            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+            mainCommandGroupsView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            mainCommandGroupsView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: mainCommandGroupsView.bottomAnchor),
+            scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: mainCommandGroupsView.trailingAnchor)
         ])
 
         return scrollView
     }()
-
-    private lazy var stackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: buttonGroupViews)
-
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = CommandBar.buttonGroupSpacing
-
-        return stackView
-    }()
-
-    private lazy var buttonGroupViews: [CommandBarButtonGroupView] = {
-        itemGroups.map { items in
-            CommandBarButtonGroupView(buttons: items.compactMap { item in
-                guard let button = itemsToButtonsMap[item] else {
-                    preconditionFailure("Button is not initialized in commandsToButtons")
-                }
-
-                return button
-            })
-        }
-    }()
-
-    private var leadingButton: CommandBarButton?
-    private var trailingButton: CommandBarButton?
 
     private let containerMaskLayer: CAGradientLayer = {
         // A mask layer using alpha color channel.
@@ -162,71 +193,55 @@ open class CommandBar: UIView {
     }()
 
     private func configureHierarchy() {
-        addSubview(containerView)
+        leadingCommandGroupsView.isHidden = leadingCommandGroupsView.itemGroups.isEmpty
+        trailingCommandGroupsView.isHidden = trailingCommandGroupsView.itemGroups.isEmpty
 
-        // Left and right button layout constraints
-        if let leadingButton = leadingButton {
-            addSubview(leadingButton)
-            NSLayoutConstraint.activate([
-                leadingButton.topAnchor.constraint(equalTo: containerView.topAnchor),
-                leadingButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: CommandBar.fixedButtonSpacing),
-                containerView.bottomAnchor.constraint(equalTo: leadingButton.bottomAnchor),
-                containerView.leadingAnchor.constraint(equalTo: leadingButton.trailingAnchor, constant: CommandBar.fixedButtonSpacing)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                containerView.leadingAnchor.constraint(equalTo: leadingAnchor)
-            ])
-        }
+        addSubview(commandBarContainerStackView)
 
-        if let trailingButton = trailingButton {
-            addSubview(trailingButton)
-            NSLayoutConstraint.activate([
-                trailingButton.topAnchor.constraint(equalTo: containerView.topAnchor),
-                trailingButton.leadingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: CommandBar.fixedButtonSpacing),
-                containerView.bottomAnchor.constraint(equalTo: trailingButton.bottomAnchor),
-                trailingAnchor.constraint(equalTo: trailingButton.trailingAnchor, constant: CommandBar.fixedButtonSpacing)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
-            ])
-        }
+        commandBarContainerStackView.addArrangedSubview(leadingCommandGroupsView)
+        commandBarContainerStackView.addArrangedSubview(containerView)
+        commandBarContainerStackView.addArrangedSubview(trailingCommandGroupsView)
 
         NSLayoutConstraint.activate([
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBar.insets.top),
-            bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: CommandBar.insets.bottom)
+            commandBarContainerStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            commandBarContainerStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            commandBarContainerStackView.topAnchor.constraint(equalTo: topAnchor),
+            commandBarContainerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-
-        stackView.layoutIfNeeded()
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
             let flipTransform = CGAffineTransform(scaleX: -1, y: 1)
             scrollView.transform = flipTransform
-            stackView.transform = flipTransform
+            leadingCommandGroupsView.transform = flipTransform
+            mainCommandGroupsView.transform = flipTransform
+            trailingCommandGroupsView.transform = flipTransform
             containerMaskLayer.setAffineTransform(flipTransform)
         }
+
+        scrollView.contentInset = scrollViewContentInset()
     }
 
-    private func button(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
-        let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection)
-        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
-
-        return button
+    private func scrollViewContentInset() -> UIEdgeInsets {
+        UIEdgeInsets(
+            top: 0,
+            left: leadingCommandGroupsView.isHidden ? CommandBar.insets.left : CommandBar.fixedButtonSpacing,
+            bottom: 0,
+            right: trailingCommandGroupsView.isHidden ? CommandBar.insets.right : CommandBar.fixedButtonSpacing
+        )
     }
 
     private func updateShadow() {
         var locations: [CGFloat] = [0, 0, 1]
 
-        if leadingButton != nil {
+        if !leadingCommandGroupsView.isHidden {
             let leadingOffset = max(0, scrollView.contentOffset.x)
             let percentage = min(1, leadingOffset / scrollView.contentInset.left)
             locations[1] = CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }
 
-        if trailingButton != nil {
-            let trailingOffset = max(0, stackView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
+        if !trailingCommandGroupsView.isHidden {
+            let trailingOffset = max(0, mainCommandGroupsView.frame.width - scrollView.frame.width - scrollView.contentOffset.x)
             let percentage = min(1, trailingOffset / scrollView.contentInset.right)
             locations[2] = 1 - CommandBar.fadeViewWidth / containerView.frame.width * percentage
         }
@@ -234,13 +249,7 @@ open class CommandBar: UIView {
         containerMaskLayer.locations = locations.map { NSNumber(value: Float($0)) }
     }
 
-    @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
-        sender.item.handleTapped(sender)
-        sender.updateState()
-    }
-
     private static let fadeViewWidth: CGFloat = 16.0
-    private static let buttonGroupSpacing: CGFloat = 16.0
     private static let fixedButtonSpacing: CGFloat = 2.0
     private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
 }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -1,0 +1,113 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+class CommandBarCommandGroupsView: UIView {
+    init(itemGroups: [CommandBarItemGroup]? = nil, buttonsPersistSelection: Bool = true) {
+        self.itemGroups = itemGroups ?? []
+
+        self.buttonsPersistSelection = buttonsPersistSelection
+
+        buttonGroupsStackView = UIStackView()
+
+        super.init(frame: .zero)
+
+        buttonGroupsStackView.translatesAutoresizingMaskIntoConstraints = false
+        buttonGroupsStackView.axis = .horizontal
+        buttonGroupsStackView.spacing = CommandBarCommandGroupsView.buttonGroupSpacing
+
+        configureHierarchy()
+        updateButtonsShown()
+    }
+
+    required init(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    public var itemGroups: [CommandBarItemGroup] {
+        didSet {
+            if itemGroups != oldValue {
+                updateButtonsShown()
+            }
+        }
+    }
+
+    /// Updates the state of all buttons in the group
+    public func updateButtonsState() {
+        for button in itemsToButtonsMap.values {
+            button.updateState()
+        }
+    }
+
+    // MARK: - Private properties
+
+    private var buttonGroupsStackView: UIStackView
+    private var buttonGroupViews: [CommandBarButtonGroupView] = []
+    private var itemsToButtonsMap: [CommandBarItem: CommandBarButton] = [:]
+    private var buttonsPersistSelection: Bool
+
+    // MARK: View Updates
+
+    private func configureHierarchy() {
+        addSubview(buttonGroupsStackView)
+
+        NSLayoutConstraint.activate([
+            buttonGroupsStackView.topAnchor.constraint(equalTo: topAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            bottomAnchor.constraint(equalTo: buttonGroupsStackView.bottomAnchor, constant: CommandBarCommandGroupsView.insets.top),
+            buttonGroupsStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            buttonGroupsStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    /// Refreshes the buttons shown in the `arrangedSubviews`
+    private func updateButtonsShown() {
+        for view in buttonGroupsStackView.arrangedSubviews {
+            view.removeFromSuperview()
+        }
+
+        updateButtonGroupViews()
+        for view in buttonGroupViews {
+            buttonGroupsStackView.addArrangedSubview(view)
+        }
+    }
+
+    /// Refreshes the `buttonGroupViews` array of `CommandBarButtonGroupView`s that are displayed in the view
+    private func updateButtonGroupViews() {
+        updateItemsToButtonsMap()
+        buttonGroupViews = itemGroups.map { items in
+                CommandBarButtonGroupView(buttons: items.compactMap { item in
+                    guard let button = itemsToButtonsMap[item] else {
+                        preconditionFailure("Button is not initialized in map")
+                    }
+                    item.propertyChangedUpdateBlock = { _ in
+                        button.updateState()
+                    }
+                    return button
+                })
+        }
+    }
+
+    /// Refreshes the `itemsToButtonsMap` of `CommandBarItem`s to their corresponding `CommandBarButton`
+    private func updateItemsToButtonsMap() {
+        let allButtons = itemGroups.flatMap({ $0 }).map({ createButton(forItem: $0, isPersistSelection: buttonsPersistSelection) })
+        itemsToButtonsMap = Dictionary(uniqueKeysWithValues: allButtons.map { ($0.item, $0) })
+    }
+
+    private func createButton(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
+        let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection)
+        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
+
+        return button
+    }
+
+    @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
+        sender.item.handleTapped(sender)
+        sender.updateState()
+    }
+
+    private static let buttonGroupSpacing: CGFloat = 16
+    private static let insets = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+}

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -62,17 +62,41 @@ open class CommandBarItem: NSObject {
         self.accessibilityHint = accessibilityHint
     }
 
-    @objc public var iconImage: UIImage?
+    @objc public var iconImage: UIImage? {
+        didSet {
+            if iconImage != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     /// Title for the item. Only valid when `iconImage` is `nil`.
-    @objc public var title: String?
+    @objc public var title: String? {
+        didSet {
+            if title != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     @objc public var titleFont: UIFont?
 
-    @objc public var isEnabled: Bool
+    @objc public var isEnabled: Bool {
+        didSet {
+            if isEnabled != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     /// If `isPersistSelection` is `true`, this value would be changed to reflect the selection state of the button. Setting this value before providing to `CommandBar` would set the initial selection state.
-    @objc public var isSelected: Bool
+    @objc public var isSelected: Bool {
+        didSet {
+            if isSelected != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
 
     /// Set `isSelected` to desired value in this handler. Default implementation is toggling `isSelected` property.
     @objc public var itemTappedHandler: ItemTappedHandler
@@ -90,4 +114,7 @@ open class CommandBarItem: NSObject {
     func handleTapped(_ sender: CommandBarButton) {
         itemTappedHandler(sender, self)
     }
+
+    /// Called after a property is changed to trigger the update of a corresponding button
+    var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
 }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Revert the [revert commit](https://github.com/microsoft/fluentui-apple/commit/ccb226309e2c356db6ad7a1689f4b1e78de5c537) for the CommandBar changes. The commit was reverted for a bug. An investigation found that the root cause was that the consumer of the view was not properly setting `translatesAutoResizingMaskIntoConstraints` causing the bug.

### Verification

- Verified in devmain necessary devmain apps.
- Verified in the CommandBarDemoController.
- Some screenshots can be found in the original PR [here](https://github.com/microsoft/fluentui-apple/pull/987).

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1048)