### PR TITLE
Fix adding datetime picker components as a child

### DIFF
--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -104,8 +104,6 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
 
         dateTimePickerView.addTarget(self, action: #selector(handleDidSelectDate(_:)), for: .valueChanged)
 
-        updateNavigationBar()
-
         if self.mode != .single {
             initSegmentedControl(includesTime: mode.includesTime)
         }
@@ -125,7 +123,10 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             view.backgroundColor = Colors.Toolbar.background
         }
         view.addSubview(dateTimePickerView)
+        dateTimePickerView.setupComponents(for: self)
         initNavigationBar()
+
+        updateNavigationBar()
     }
 
     override func viewWillLayoutSubviews() {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -66,11 +66,6 @@ class DateTimePickerView: UIControl {
 
         super.init(frame: .zero)
 
-        for component in componentsByType.values {
-            component.delegate = self
-            addSubview(component.view)
-        }
-
         layer.addSublayer(gradientLayer)
         addSubview(selectionTopSeparator)
         addSubview(selectionBottomSeparator)
@@ -84,6 +79,15 @@ class DateTimePickerView: UIControl {
 
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    func setupComponents(for viewController: UIViewController) {
+        for component in componentsByType.values {
+            component.delegate = self
+            viewController.addChild(component)
+            addSubview(component.view)
+            component.didMove(toParent: viewController)
+        }
     }
 
     /// Set the date displayed on the picker. This does not trigger UIControlEventValueChanged


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add calling child VC methods in DateTimePickerView.
And transferred navBar methods to viewDidLoad in DateTimePickerController.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Simulator Screen Shot - iPhone 8 - 2022-07-04 at 16 01 51](https://user-images.githubusercontent.com/17963739/177171309-d7072a40-0b1a-42d4-950e-6bd8f13c638d.png) |  ![Simulator Screen Shot - iPhone 8 - 2022-07-04 at 16 07 13](https://user-images.githubusercontent.com/17963739/177171340-91c23fb5-7181-4670-b370-9661a6793dcf.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1049)