### PR TITLE
SearchBar Colors Update

### DIFF
--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -53,77 +53,77 @@ public protocol SearchBarDelegate: AnyObject {
 open class SearchBar: UIView {
     @objc(MSFSearchBarStyle)
     public enum Style: Int {
-        case lightContent, darkContent
+        case lightContent, darkContent, brandContent
 
         func backgroundColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
+            case .lightContent, .darkContent:
                 return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background5])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background5])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandBackground2])
             }
         }
 
         func cancelButtonColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
+            case .lightContent, .darkContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundOnColor])
             }
         }
 
         func clearIconColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
+            case .lightContent, .darkContent:
                 return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground2])
             }
         }
 
         func placeholderColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
+            case .lightContent, .darkContent:
                 return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground3])
             }
         }
 
-        func searchIconColor(view: UIView) -> UIColor {
+        func searchIconColor(view: UIView, isSearching: Bool = false) -> UIColor {
             switch self {
-            case .lightContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
+            case .lightContent, .darkContent:
+                return isSearching ? UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1]) : UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
+            case .brandContent:
+                return isSearching ? UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundOnColor]) : UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground3])
             }
         }
 
         func textColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
+            case .lightContent, .darkContent:
                 return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundOnColor])
             }
         }
 
         func tintColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
+            case .lightContent, .darkContent:
                 return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground2])
             }
         }
 
         func progressSpinnerColor(view: UIView) -> UIColor {
             switch self {
-            case .lightContent:
+            case .lightContent, .darkContent:
                 return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
-            case .darkContent:
-                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
+            case .brandContent:
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground3])
             }
         }
     }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -64,12 +64,12 @@ open class SearchBar: UIView {
             }
         }
 
-        var cancelButtonColor: UIColor {
+        func cancelButtonColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.cancelButton
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.cancelButton
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
             }
         }
 
@@ -474,7 +474,7 @@ open class SearchBar: UIView {
         searchTextField.tintColor = style.tintColor
         clearButton.tintColor = style.clearIconColor
         progressSpinner.state.color = style.progressSpinnerColor
-        cancelButton.setTitleColor(style.cancelButtonColor, for: .normal)
+        cancelButton.setTitleColor(style.cancelButtonColor(view: self), for: .normal)
         attributePlaceholderText()
     }
 

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -313,7 +313,7 @@ open class SearchBar: UIView {
         if isActive {
             return
         }
-
+        updateSearchingColors()
         attributePlaceholderText()
         showCancelButton()
 
@@ -335,6 +335,7 @@ open class SearchBar: UIView {
             return
         }
 
+        updateRestingColors()
         isActive = false
         searchTextField.resignFirstResponder()
         searchTextField.text = nil
@@ -476,6 +477,14 @@ open class SearchBar: UIView {
         progressSpinner.state.color = style.progressSpinnerColor(view: self)
         cancelButton.setTitleColor(style.cancelButtonColor(view: self), for: .normal)
         attributePlaceholderText()
+    }
+
+    private func updateSearchingColors(){
+        searchIconImageView.tintColor = style.searchIconColor(view: self, isSearching: true)
+    }
+
+    private func updateRestingColors(){
+        searchIconImageView.tintColor = style.searchIconColor(view: self)
     }
 
     // MARK: - UIActions

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -55,12 +55,12 @@ open class SearchBar: UIView {
     public enum Style: Int {
         case lightContent, darkContent
 
-        var backgroundColor: UIColor {
+        func backgroundColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.background
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background5])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.background
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background5])
             }
         }
 
@@ -221,7 +221,7 @@ open class SearchBar: UIView {
     // backgroundview is used to achive an inset textfield
     private lazy var searchTextFieldBackgroundView: UIView = {
         let backgroundView = UIView()
-        backgroundView.backgroundColor = style.backgroundColor
+        backgroundView.backgroundColor = style.backgroundColor(view: self)
         backgroundView.layer.cornerRadius = Constants.searchTextFieldCornerRadius
         return backgroundView
     }()
@@ -467,7 +467,7 @@ open class SearchBar: UIView {
     }
 
     private func updateColorsForStyle() {
-        searchTextFieldBackgroundView.backgroundColor = style.backgroundColor
+        searchTextFieldBackgroundView.backgroundColor = style.backgroundColor(view: self)
         searchIconImageView.tintColor = style.searchIconColor
         searchTextField.textColor = style.textColor
         // used for cursor or selection handle

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -284,7 +284,16 @@ open class SearchBar: UIView {
 
     @objc public override init(frame: CGRect) {
         super.init(frame: frame)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
         initialize()
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateColorsForStyle()
     }
 
     @objc public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -100,30 +100,30 @@ open class SearchBar: UIView {
             }
         }
 
-        var textColor: UIColor {
+        func textColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.text
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.text
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])
             }
         }
 
-        var tintColor: UIColor {
+        func tintColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.tint
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.tint
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             }
         }
 
-        var progressSpinnerColor: UIColor {
+        func progressSpinnerColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.progressSpinner
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.progressSpinner
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             }
         }
     }
@@ -469,11 +469,11 @@ open class SearchBar: UIView {
     private func updateColorsForStyle() {
         searchTextFieldBackgroundView.backgroundColor = style.backgroundColor(view: self)
         searchIconImageView.tintColor = style.searchIconColor(view: self)
-        searchTextField.textColor = style.textColor
+        searchTextField.textColor = style.textColor(view: self)
         // used for cursor or selection handle
-        searchTextField.tintColor = style.tintColor
+        searchTextField.tintColor = style.tintColor(view: self)
         clearButton.tintColor = style.clearIconColor(view: self)
-        progressSpinner.state.color = style.progressSpinnerColor
+        progressSpinner.state.color = style.progressSpinnerColor(view: self)
         cancelButton.setTitleColor(style.cancelButtonColor(view: self), for: .normal)
         attributePlaceholderText()
     }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -82,21 +82,21 @@ open class SearchBar: UIView {
             }
         }
 
-        var placeholderColor: UIColor {
+        func placeholderColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.placeholderText
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.placeholderText
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             }
         }
 
-        var searchIconColor: UIColor {
+        func searchIconColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.searchIcon
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.searchIcon
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground3])
             }
         }
 
@@ -361,7 +361,7 @@ open class SearchBar: UIView {
             searchTextField.attributedPlaceholder = nil
             return
         }
-        let newAttributes = [NSAttributedString.Key.foregroundColor: style.placeholderColor]
+        let newAttributes = [NSAttributedString.Key.foregroundColor: style.placeholderColor(view: self)]
         let attributedPlaceholderText = NSAttributedString(string: newPlaceholder, attributes: newAttributes)
         searchTextField.attributedPlaceholder = attributedPlaceholderText
     }
@@ -468,7 +468,7 @@ open class SearchBar: UIView {
 
     private func updateColorsForStyle() {
         searchTextFieldBackgroundView.backgroundColor = style.backgroundColor(view: self)
-        searchIconImageView.tintColor = style.searchIconColor
+        searchIconImageView.tintColor = style.searchIconColor(view: self)
         searchTextField.textColor = style.textColor
         // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -5,34 +5,6 @@
 
 import UIKit
 
-// MARK: Search Colors
-
-private extension Colors {
-    struct SearchBar {
-        struct DarkContent {
-            static var background = UIColor(light: surfaceTertiary, dark: LightContent.background)
-            static var cancelButton = UIColor(light: textSecondary, dark: LightContent.cancelButton)
-            static var clearIcon = UIColor(light: iconPrimary, dark: LightContent.clearIcon)
-            static var placeholderText = UIColor(light: textSecondary, dark: LightContent.placeholderText)
-            static var progressSpinner = UIColor(light: iconDisabled, dark: textPrimary)
-            static var searchIcon = UIColor(light: iconPrimary, dark: LightContent.searchIcon)
-            static var text = UIColor(light: textDominant, dark: LightContent.text)
-            static var tint = UIColor(light: iconSecondary, dark: LightContent.tint)
-        }
-
-        public struct LightContent {
-            public static var background = UIColor(light: UIColor.black.withAlphaComponent(0.2), dark: gray700, darkElevated: gray600)
-            public static var cancelButton: UIColor = LightContent.text
-            public static var clearIcon = UIColor(light: iconOnAccent, dark: textSecondary)
-            public static var placeholderText = UIColor(light: textOnAccent, dark: textSecondary)
-            public static var progressSpinner = UIColor(light: textOnAccent, dark: textSecondary)
-            public static var searchIcon: UIColor = placeholderText
-            public static var text = UIColor(light: textOnAccent, dark: textDominant)
-            public static var tint: UIColor = LightContent.text
-        }
-    }
-}
-
 // MARK: SearchBarDelegate
 
 /// Various state update methods coming from the SearchBar

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -460,11 +460,11 @@ open class SearchBar: UIView {
         attributePlaceholderText()
     }
 
-    private func updateSearchingColors(){
+    private func updateSearchingColors() {
         searchIconImageView.tintColor = style.searchIconColor(view: self, isSearching: true)
     }
 
-    private func updateRestingColors(){
+    private func updateRestingColors() {
         searchIconImageView.tintColor = style.searchIconColor(view: self)
     }
 

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -73,12 +73,12 @@ open class SearchBar: UIView {
             }
         }
 
-        var clearIconColor: UIColor {
+        func clearIconColor(view: UIView) -> UIColor {
             switch self {
             case .lightContent:
-                return Colors.SearchBar.LightContent.clearIcon
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
             case .darkContent:
-                return Colors.SearchBar.DarkContent.clearIcon
+                return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
             }
         }
 
@@ -472,7 +472,7 @@ open class SearchBar: UIView {
         searchTextField.textColor = style.textColor
         // used for cursor or selection handle
         searchTextField.tintColor = style.tintColor
-        clearButton.tintColor = style.clearIconColor
+        clearButton.tintColor = style.clearIconColor(view: self)
         progressSpinner.state.color = style.progressSpinnerColor
         cancelButton.setTitleColor(style.cancelButtonColor(view: self), for: .normal)
         attributePlaceholderText()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The SearchBar's colors were changed to match Fluent 2 colors. A new `brandContent` style was added.

### Verification

The changes were tested on the Demo app. The brand colors were tested by changing the SearchBar's style to `brandContent` in the `SearchBarDemoController`. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="305" alt="before_rest_light" src="https://user-images.githubusercontent.com/106181067/176934653-67ebbe20-05c1-4bf2-a796-4f1ed73fb2e4.png"> | <img width="307" alt="after_rest_light" src="https://user-images.githubusercontent.com/106181067/176934703-f7d081a3-ef8d-458b-8c01-1832452487cf.png"> |
| <img width="308" alt="before_typing_light" src="https://user-images.githubusercontent.com/106181067/176934751-52572cd6-29d7-4d6c-bf25-b9cd239cc017.png"> | <img width="307" alt="after_typing_light" src="https://user-images.githubusercontent.com/106181067/176934781-45a35189-3d21-44ec-82c5-d7dcf3c83c25.png"> |
| <img width="313" alt="before_rest_dark" src="https://user-images.githubusercontent.com/106181067/176934825-4f20599a-c62c-4852-a2da-71e1799f2137.png"> | <img width="308" alt="after_rest_dark" src="https://user-images.githubusercontent.com/106181067/176934877-d161755d-0b85-4cc2-b110-8e934a593bc8.png"> |
| <img width="317" alt="before_typing_dark" src="https://user-images.githubusercontent.com/106181067/176934912-01a6a6d1-75b8-4c8a-bc4b-2f16dacf961b.png"> | <img width="319" alt="after_typing_dark" src="https://user-images.githubusercontent.com/106181067/176934959-d76e8060-fb5a-4ecd-9267-2282582e90b3.png"> |

**Brand**

| Rest                                       | Typing                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="318" alt="brand_resting" src="https://user-images.githubusercontent.com/106181067/176935090-fc228f90-ac00-46bf-84af-bfd13d5a6fb5.png"> | <img width="314" alt="brand_typing" src="https://user-images.githubusercontent.com/106181067/176935116-6387b9b3-d654-4410-81d4-cc2c2f37acf9.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1050)