### PR TITLE
Tooltip Colors Update

### DIFF
--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -88,6 +88,11 @@ class TooltipView: UIView {
 
         super.init(frame: .zero)
 
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
         isAccessibilityElement = true
 
         addSubview(backgroundView)
@@ -144,6 +149,11 @@ class TooltipView: UIView {
         updateWindowSpecificColors()
     }
 
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateMessageLabelColor()
+        updateWindowSpecificColors()
+    }
+
     private func transformForArrowImageView() -> CGAffineTransform {
         switch positionController.arrowDirection {
         case .up:
@@ -163,6 +173,10 @@ class TooltipView: UIView {
             backgroundView.backgroundColor = backgroundColor
             arrowImageView.image = arrowImageViewBaseImage?.withTintColor(backgroundColor, renderingMode: .alwaysOriginal)
         }
+    }
+
+    private func updateMessageLabelColor() {
+        messageLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundInverted1])
     }
 
     // MARK: - Accessibility

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -5,14 +5,6 @@
 
 import UIKit
 
-// MARK: Tooltip Colors
-
-private extension Colors {
-    struct Tooltip {
-        static var text: UIColor = textOnAccent
-    }
-}
-
 // MARK: TooltipView
 
 class TooltipView: UIView {

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -74,7 +74,7 @@ class TooltipView: UIView {
 
     private let messageLabel: UILabel = {
         let label = Label(style: Constants.messageLabelTextStyle)
-        label.textColor = Colors.Tooltip.text
+        label.textColor = UIColor(dynamicColor: label.fluentTheme.aliasTokens.colors[.foregroundInverted1])
         label.numberOfLines = 0
         return label
     }()
@@ -159,7 +159,7 @@ class TooltipView: UIView {
 
     private func updateWindowSpecificColors() {
         if let window = window {
-            let backgroundColor = UIColor(light: Colors.gray900.withAlphaComponent(0.95), dark: Colors.primary(for: window))
+            let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundInverted])
             backgroundView.backgroundColor = backgroundColor
             arrowImageView.image = arrowImageViewBaseImage?.withTintColor(backgroundColor, renderingMode: .alwaysOriginal)
         }

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -66,7 +66,6 @@ class TooltipView: UIView {
 
     private let messageLabel: UILabel = {
         let label = Label(style: Constants.messageLabelTextStyle)
-        label.textColor = UIColor(dynamicColor: label.fluentTheme.aliasTokens.colors[.foregroundInverted1])
         label.numberOfLines = 0
         return label
     }()
@@ -79,6 +78,8 @@ class TooltipView: UIView {
         arrowImageView = UIImageView(image: arrowImageViewBaseImage)
 
         super.init(frame: .zero)
+
+        updateColors()
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(themeDidChange),
@@ -136,14 +137,8 @@ class TooltipView: UIView {
         messageLabel.frame = backgroundView.frame.insetBy(dx: Constants.paddingHorizontal, dy: 0)
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateWindowSpecificColors()
-    }
-
     @objc private func themeDidChange(_ notification: Notification) {
-        updateMessageLabelColor()
-        updateWindowSpecificColors()
+        updateColors()
     }
 
     private func transformForArrowImageView() -> CGAffineTransform {
@@ -159,15 +154,10 @@ class TooltipView: UIView {
         }
     }
 
-    private func updateWindowSpecificColors() {
-        if let window = window {
-            let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundInverted])
-            backgroundView.backgroundColor = backgroundColor
-            arrowImageView.image = arrowImageViewBaseImage?.withTintColor(backgroundColor, renderingMode: .alwaysOriginal)
-        }
-    }
-
-    private func updateMessageLabelColor() {
+    private func updateColors() {
+        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundInverted])
+        backgroundView.backgroundColor = backgroundColor
+        arrowImageView.image = arrowImageViewBaseImage?.withTintColor(backgroundColor, renderingMode: .alwaysOriginal)
         messageLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundInverted1])
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The tooltip's colors were updated to match Fluent 2 colors.

### Verification

The color changes were tested on the Demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="272" alt="before_light" src="https://user-images.githubusercontent.com/106181067/176970018-a7ac779c-438c-4f70-95c7-c468861c3c3c.png"> | <img width="273" alt="after_light" src="https://user-images.githubusercontent.com/106181067/176970050-43f6fec8-6684-41c7-bc1b-4bf77757fc5a.png"> |
| <img width="272" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/176970068-04a4e91f-f67c-4f2a-9950-35b09af76530.png"> | <img width="273" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/176970083-e50a0449-9541-48b2-ae1c-786cc46fb862.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1051)