### PR TITLE
[Fluent Tokens] Fix Theming Bug with SideTabBar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -327,7 +327,7 @@ extension SideTabBarDemoController: UITableViewDataSource {
 // MARK: - SideTabBarDemoController: DemoAppearanceDelegate
 extension SideTabBarDemoController: DemoAppearanceDelegate {
     func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
-        guard let fluentTheme = self.view.window?.fluentTheme else {
+        guard let fluentTheme = contentViewController?.view.window?.fluentTheme else {
             return
         }
 
@@ -347,7 +347,7 @@ extension SideTabBarDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: SideTabBar.self) != nil
+        return contentViewController?.view.window?.fluentTheme.tokenOverride(for: SideTabBar.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -215,6 +215,11 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         NSLayoutConstraint.activate(layoutConstraints)
     }
 
+    override public func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateSideTabBarTokens()
+    }
+
     private func didUpdateItems(in section: Section) {
         for subview in stackView(in: section).arrangedSubviews {
             subview.removeFromSuperview()

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -215,7 +215,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         NSLayoutConstraint.activate(layoutConstraints)
     }
 
-    override public func didMoveToWindow() {
+    open override func didMoveToWindow() {
         super.didMoveToWindow()
         updateSideTabBarTokens()
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Prior to this fix, the SideTabBar demo was not behaving as expected when changing themes. You could force some level of theme changes locally, but as soon as you exited and returned, they would be lost. This change fixes that issue.

### Verification

Built and ran the demo app, verifying that the theme overrides and branding theme changes worked as expected.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SideTabBarThemeBefore](https://user-images.githubusercontent.com/23249106/176976753-4c587a44-6279-4ee0-b361-044237445152.gif) |  ![SideTabBarThemeAfter](https://user-images.githubusercontent.com/23249106/176976684-5240df23-e81a-407b-b365-0c3cf491c285.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1052)