### PR TITLE
Shimmer Colors Update

### DIFF
--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -153,10 +153,16 @@ open class ShimmerView: UIView {
         self.shimmerStyle = shimmerStyle
         self.shimmerAlpha = shimmerStyle.defaultAlphaValue
         super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
-        self.viewTintColor = shimmerStyle.defaultTintColor(view: self)
+
+        updateViewTintColor()
+
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(syncAnimation),
                                                name: UIAccessibility.reduceMotionStatusDidChangeNotification,
+                                               object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
                                                object: nil)
     }
 
@@ -183,6 +189,14 @@ open class ShimmerView: UIView {
     /// Manaully sync with the synchronizer
     @objc open func syncAnimation() {
         updateShimmeringAnimation()
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateViewTintColor()
+    }
+    
+    private func updateViewTintColor(){
+        self.viewTintColor = shimmerStyle.defaultTintColor(view: self)
     }
 
     /// Update the frame of each layer covering views in the containerView

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -24,12 +24,12 @@ public enum ShimmerStyle: Int, CaseIterable {
         }
     }
 
-    var defaultTintColor: UIColor {
+    func defaultTintColor(view: UIView) -> UIColor {
         switch self {
         case .concealing:
-            return Colors.Shimmer.gradientCenter
+            return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stencil2])
         case .revealing:
-            return Colors.Shimmer.tint
+            return UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stencil1])
         }
     }
 }
@@ -151,10 +151,9 @@ open class ShimmerView: UIView {
         self.excludedViews = excludedViews
         self.animationSynchronizer = animationSynchronizer
         self.shimmerStyle = shimmerStyle
-        self.viewTintColor = shimmerStyle.defaultTintColor
         self.shimmerAlpha = shimmerStyle.defaultAlphaValue
         super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
-
+        self.viewTintColor = shimmerStyle.defaultTintColor(view: self)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(syncAnimation),
                                                name: UIAccessibility.reduceMotionStatusDidChangeNotification,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The colors for Shimmer were updated to match Fluent 2 tokens.

### Verification

The changes were tested on the Demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="272" alt="before_light" src="https://user-images.githubusercontent.com/106181067/177430122-f8b26fb9-8dd2-4278-8441-5fadfd23b92a.png"> | <img width="273" alt="after_light" src="https://user-images.githubusercontent.com/106181067/177430136-065c8f5b-4cc6-4a78-bf1c-b070f4e9e0df.png"> |
| <img width="272" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/177430157-a26caf37-b2a6-4386-9c60-76c52b68f6d5.png"> | <img width="273" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/177430176-e692361b-dbe5-4b5e-b238-7b9a31705b35.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)