### PR TITLE
[Fluent2 Tokens] Add an optional trailing image to the Notification

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -31,6 +31,7 @@ struct NotificationDemoView: View {
     @State var hasLargeRedPapyrusFontAttribute: Bool = false
     @State var hasMessageAction: Bool = false
     @State var showImage: Bool = false
+    @State var showTrailingImage: Bool = false
     @State var showAlert: Bool = false
     @State var isPresented: Bool = false
     @State var overrideTokens: Bool = false
@@ -45,6 +46,7 @@ struct NotificationDemoView: View {
         let attributedTitle = NSMutableAttributedString(string: title, attributes: (hasLargeRedPapyrusFontAttribute && hasBlueStrikethroughAttribute) ? bothAttributes : (hasLargeRedPapyrusFontAttribute ? redPapyrusFontAttribute : blueStrikethroughAttribute))
 
         let image = showImage ? UIImage(named: "play-in-circle-24x24") : nil
+        let trailingImage = showTrailingImage ? UIImage(named: "Placeholder_24") : nil
         let actionButtonAction = hasActionButtonAction ? { showAlert = true } : nil
         let messageButtonAction = hasMessageAction ? { showAlert = true } : nil
         let hasMessage = !message.isEmpty
@@ -56,6 +58,7 @@ struct NotificationDemoView: View {
                                               title: hasTitle ? title : nil,
                                               attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
                                               image: image,
+                                              trailingImage: trailingImage,
                                               actionButtonTitle: actionButtonTitle,
                                               actionButtonAction: actionButtonAction,
                                               messageButtonAction: messageButtonAction)
@@ -109,6 +112,7 @@ struct NotificationDemoView: View {
                         FluentUIDemoToggle(titleKey: "Has Attributed Text: Strikethrough", isOn: $hasBlueStrikethroughAttribute)
                         FluentUIDemoToggle(titleKey: "Has Attributed Text: Large Red Papyrus Font", isOn: $hasLargeRedPapyrusFontAttribute)
                         FluentUIDemoToggle(titleKey: "Set image", isOn: $showImage)
+                        FluentUIDemoToggle(titleKey: "Set trailing image", isOn: $showTrailingImage)
                     }
 
                     Group {

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -58,6 +58,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     ///   - title: Optional text to draw above the message area.
     ///   - attributedTitle: Optional attributed text to draw above the message area. If set, it will override the title parameter.
     ///   - image: Optional icon to draw at the leading edge of the control.
+    ///   - trailingImage: Optional icon to show in the action button if no button title is provided.
     ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
     ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
@@ -70,6 +71,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 title: String? = nil,
                 attributedTitle: NSAttributedString? = nil,
                 image: UIImage? = nil,
+                trailingImage: UIImage? = nil,
                 actionButtonTitle: String? = nil,
                 actionButtonAction: (() -> Void)? = nil,
                 messageButtonAction: (() -> Void)? = nil) {
@@ -79,6 +81,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         state.title = title
         state.attributedTitle = attributedTitle
         state.image = image
+        state.trailingImage = trailingImage
         state.actionButtonTitle = actionButtonTitle
         state.actionButtonAction = actionButtonAction
         state.messageButtonAction = messageButtonAction

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -236,7 +236,11 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     isPresented = false
                     buttonAction()
                 }, label: {
-                    Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
+                    if let trailingImage = state.trailingImage {
+                        Image(uiImage: trailingImage)
+                    } else {
+                        Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
+                    }
                 })
                 .accessibility(identifier: "Accessibility.Dismiss.Label")
                 .foregroundColor(Color(dynamicColor: foregroundColor))

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -25,6 +25,9 @@ import SwiftUI
     /// Optional icon to draw at the leading edge of the control.
     var image: UIImage? { get set }
 
+    /// Optional icon to display in the action button if no button title is provided.
+    var trailingImage: UIImage? { get set }
+
     /// Title to display in the action button on the trailing edge of the control.
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
@@ -328,6 +331,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
     @Published public var title: String?
     @Published public var attributedTitle: NSAttributedString?
     @Published public var image: UIImage?
+    @Published public var trailingImage: UIImage?
 
     /// Title to display in the action button on the trailing edge of the control.
     ///
@@ -360,6 +364,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
                      title: String? = nil,
                      attributedTitle: NSAttributedString? = nil,
                      image: UIImage? = nil,
+                     trailingImage: UIImage? = nil,
                      actionButtonTitle: String? = nil,
                      actionButtonAction: (() -> Void)? = nil,
                      messageButtonAction: (() -> Void)? = nil) {
@@ -370,6 +375,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
         self.title = title
         self.attributedTitle = attributedTitle
         self.image = image
+        self.trailingImage = trailingImage
         self.actionButtonTitle = actionButtonTitle
         self.actionButtonAction = actionButtonAction
         self.messageButtonAction = messageButtonAction


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds the option to set the image the notification shows for the action button if no button title is set. Currently, if there's a button action set but no button title set, we'll show the X icon shown in the before image. With this change, the user can change the icon that's shown in the button when there is a button action set but no button title.

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Notification_trailingImage_before](https://user-images.githubusercontent.com/67026548/177439772-9a55a242-5513-4e3a-b7a3-aac4d0fcc872.png) | ![Notification_trailingImage_after](https://user-images.githubusercontent.com/67026548/177439779-7836e634-81ae-4014-9340-2ccbb7c6ea95.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1055)