### PR TITLE
Fixing text color update in TableViewCell for rich text support

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1075,25 +1075,22 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                           customAccessoryView: UIView? = nil,
                           accessoryType: TableViewCellAccessoryType = .none) {
         if let attributedTitle = attributedTitle {
-            titleLabel.attributedText = attributedTitle
-            isUsingAttributedTitle = true
+            self.attributedTitle = attributedTitle
         } else {
+            self.attributedTitle = nil
             titleLabel.text = title
-            isUsingAttributedTitle = false
         }
         if let attributedSubtitle = attributedSubtitle {
-            subtitleLabel.attributedText = attributedSubtitle
-            isUsingAttributedSubtitle = true
+            self.attributedSubtitle = attributedSubtitle
         } else {
+            self.attributedSubtitle = nil
             subtitleLabel.text = subtitle
-            isUsingAttributedSubtitle = false
         }
         if let attributedFooter = attributedFooter {
-            footerLabel.attributedText = attributedFooter
-            isUsingAttributedFooter = true
+            self.attributedFooter = attributedFooter
         } else {
+            self.attributedFooter = nil
             footerLabel.text = footer
-            isUsingAttributedFooter = false
         }
 
         self.customView = customView
@@ -1154,20 +1151,43 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     private var isUsingCustomTextColors: Bool = false
 
-    private var isUsingAttributedTitle: Bool = false
-    private var isUsingAttributedSubtitle: Bool = false
-    private var isUsingAttributedFooter: Bool = false
+    private var attributedTitle: NSAttributedString? {
+        get {
+            return titleLabel.attributedText
+        }
+        set {
+            titleLabel.attributedText = newValue
+        }
+    }
+
+    private var attributedSubtitle: NSAttributedString? {
+        get {
+            return subtitleLabel.attributedText
+        }
+        set {
+            subtitleLabel.attributedText = newValue
+        }
+    }
+
+    private var attributedFooter: NSAttributedString? {
+        get {
+            return footerLabel.attributedText
+        }
+        set {
+            footerLabel.attributedText = newValue
+        }
+    }
 
     /// Updates label text colors.
     public func updateTextColors() {
         if !isUsingCustomTextColors {
-            if !isUsingAttributedTitle {
+            if attributedTitle == nil {
                 titleLabel.textColor = UIColor(dynamicColor: tokens.titleColor)
             }
-            if !isUsingAttributedSubtitle {
+            if attributedSubtitle == nil {
                 subtitleLabel.textColor = UIColor(dynamicColor: tokens.subtitleColor)
             }
-            if !isUsingAttributedFooter {
+            if attributedFooter == nil {
                 footerLabel.textColor = UIColor(dynamicColor: tokens.footerColor)
             }
         }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1076,18 +1076,24 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                           accessoryType: TableViewCellAccessoryType = .none) {
         if let attributedTitle = attributedTitle {
             titleLabel.attributedText = attributedTitle
+            isUsingAttributedTitle = true
         } else {
             titleLabel.text = title
+            isUsingAttributedTitle = false
         }
         if let attributedSubtitle = attributedSubtitle {
             subtitleLabel.attributedText = attributedSubtitle
+            isUsingAttributedSubtitle = true
         } else {
             subtitleLabel.text = subtitle
+            isUsingAttributedSubtitle = false
         }
         if let attributedFooter = attributedFooter {
             footerLabel.attributedText = attributedFooter
+            isUsingAttributedFooter = true
         } else {
             footerLabel.text = footer
+            isUsingAttributedFooter = false
         }
 
         self.customView = customView
@@ -1148,12 +1154,22 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     private var isUsingCustomTextColors: Bool = false
 
+    private var isUsingAttributedTitle: Bool = false
+    private var isUsingAttributedSubtitle: Bool = false
+    private var isUsingAttributedFooter: Bool = false
+
     /// Updates label text colors.
     public func updateTextColors() {
         if !isUsingCustomTextColors {
-            titleLabel.textColor = UIColor(dynamicColor: tokens.titleColor)
-            subtitleLabel.textColor = UIColor(dynamicColor: tokens.subtitleColor)
-            footerLabel.textColor = UIColor(dynamicColor: tokens.footerColor)
+            if !isUsingAttributedTitle {
+                titleLabel.textColor = UIColor(dynamicColor: tokens.titleColor)
+            }
+            if !isUsingAttributedSubtitle {
+                subtitleLabel.textColor = UIColor(dynamicColor: tokens.subtitleColor)
+            }
+            if !isUsingAttributedFooter {
+                footerLabel.textColor = UIColor(dynamicColor: tokens.footerColor)
+            }
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Rich text support does not update the labels in TableViewCell due to the `updateTextColors()` method. This fix takes the rich text into consideration when updating text colors.

Note: This fix does not include the fonts update with rich text support, which will come in a later PR.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-06 at 14 54 24](https://user-images.githubusercontent.com/22566866/177650062-aefcd7aa-5ccc-4297-98f5-3b208aa7c158.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-06 at 14 53 41](https://user-images.githubusercontent.com/22566866/177649978-edac00c0-8811-4369-88bd-77ae936d73ba.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1056)