### PR TITLE
(macOS) Make Link open URLs asynchronously

### DIFF
--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -57,7 +57,7 @@ open class Link: NSButton {
 	/// - Parameters:
 	///   - title: The visible text of the link that the user sees.
 	///   - url: The URL that is opened when the link is clicked.
-	@objc public convenience init(title: String, url: NSURL) {
+	@objc public convenience init(title: String, url: URL) {
 		self.init(frame: .zero, title: title, url: url)
 	}
 
@@ -82,7 +82,7 @@ open class Link: NSButton {
 	///   - frame: The position and size of this view in the superview's coordinate system.
 	///   - title: The visible text of the link that the user sees.
 	///   - url: The URL that is opened when the link is clicked.
-	public init(frame: NSRect = .zero, title: String = "", url: NSURL? = nil) {
+	public init(frame: NSRect = .zero, title: String = "", url: URL? = nil) {
 		super.init(frame: frame)
 		self.title = title
 		self.url = url
@@ -98,7 +98,7 @@ open class Link: NSButton {
 	}
 
 	/// The URL that is opened when the link is clicked
-	@objc public var url: NSURL?
+	@objc public var url: URL?
 
 	@objc public var showsUnderlineWhileMouseInside: Bool = false {
 		didSet {
@@ -145,9 +145,9 @@ open class Link: NSButton {
 	@objc private func linkClicked() {
 		if let url = url {
 			if #available(macOS 10.15, *) {
-				NSWorkspace.shared.open(url as URL, configuration: NSWorkspace.OpenConfiguration(), completionHandler: nil)
+				NSWorkspace.shared.open(url, configuration: NSWorkspace.OpenConfiguration(), completionHandler: nil)
 			} else {
-				NSWorkspace.shared.open(url as URL)
+				NSWorkspace.shared.open(url)
 			}
 		}
 	}

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -144,7 +144,11 @@ open class Link: NSButton {
 
 	@objc private func linkClicked() {
 		if let url = url {
-			NSWorkspace.shared.open(url as URL)
+			if #available(macOS 10.15, *) {
+				NSWorkspace.shared.open(url as URL, configuration: NSWorkspace.OpenConfiguration(), completionHandler: nil)
+			} else {
+				NSWorkspace.shared.open(url as URL)
+			}
 		}
 	}
 }

--- a/macos/FluentUITestViewControllers/TestLinkViewController.swift
+++ b/macos/FluentUITestViewControllers/TestLinkViewController.swift
@@ -16,7 +16,7 @@ class TestLinkViewController: NSViewController {
 	}()
 
 	override func loadView() {
-		let url = NSURL(string: "https://github.com/microsoft/fluentui-apple")
+		let url = URL(string: "https://github.com/microsoft/fluentui-apple")
 
 		let linkWithNoUnderlineTitle = "FluentUI on GitHub"
 		let linkWithNoUnderline = Link(title: linkWithNoUnderlineTitle, url: url)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

In an internal UI Framework (who's name begins with Cocoa...) I saw @ntre make this change on a similar link control. Might as well make it here too

### Verification

Links in the test app still open...

Simple
### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1061)