### PR TITLE
Adding rich text support for fonts in TableViewCell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -940,9 +940,15 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }()
 
     private func updateFonts() {
-        titleLabel.font = TextStyles.title.font
-        subtitleLabel.font = layoutType == .twoLines ? TextStyles.subtitleTwoLines.font : TextStyles.subtitleThreeLines.font
-        footerLabel.font = TextStyles.footer.font
+        if attributedTitle == nil {
+            titleLabel.font = UIFont.fluent(tokens.titleFont)
+        }
+        if attributedSubtitle == nil {
+            subtitleLabel.font = UIFont.fluent(layoutType == .twoLines ? tokens.subtitleTwoLinesFont : tokens.subtitleThreeLinesFont)
+        }
+        if attributedFooter == nil {
+            footerLabel.font = UIFont.fluent(tokens.footerFont)
+        }
     }
 
     private func updateLabelAccessoryView(oldValue: UIView?, newValue: UIView?, size: inout CGSize) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Applying NSAttributedString check to `updateFonts()` method to ignore tokenized fonts in the case of using rich text.

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-07 at 13 44 04](https://user-images.githubusercontent.com/22566866/177867948-0a1c116a-f619-43c8-a20e-c1383c8a2830.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-07 at 13 43 50](https://user-images.githubusercontent.com/22566866/177867909-606fc4d8-216e-454d-a900-680c3505b0dd.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1062)