### PR TITLE
Changed "vNext" to "Fluent 2" in the demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -124,7 +124,7 @@ class DemoListViewController: DemoTableViewController {
         var title: String {
             switch self {
             case .vNextControls:
-                return "vNext Controls"
+                return "Fluent 2 Controls"
             case .controls:
                 return "Controls"
 #if DEBUG


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Changed the title string from "vNext Controls" to "Fluent 2 Controls" in the demo app.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="307" alt="before_light" src="https://user-images.githubusercontent.com/106181067/178049362-892c0284-7344-4093-909a-961d486288ff.png"> | <img width="310" alt="after_light" src="https://user-images.githubusercontent.com/106181067/178049382-26225ff8-5b62-4c72-a175-ef50c20b401e.png"> |
| <img width="310" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/178049400-22c44415-5eac-4c57-8b45-87a30d998df3.png"> | <img width="307" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/178049439-7b7ba395-8122-4660-bacd-4235bee8dae6.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)