### PR TITLE
Fixing slow NSAttributedString update in TableViewCell

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -122,18 +122,20 @@ extension TableViewCellDemoController {
         let section = sections[indexPath.section]
         let item = section.item
         if section.title == "Inverted double line cell" {
-            cell.setup(
-                attributedTitle: NSAttributedString(string: item.text1,
-                                                    attributes: [.font: TextStyle.footnote.font,
-                                                                 .foregroundColor: Colors.Table.Cell.footer]),
-                attributedSubtitle: NSAttributedString(string: item.text2,
-                                                       attributes: [.font: TextStyle.body.font,
-                                                                    .foregroundColor: Colors.Table.Cell.title]),
-                footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
-                customView: TableViewSampleData.createCustomView(imageName: item.image),
-                customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
-                accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
-            )
+            DispatchQueue.main.async {
+                cell.setup(
+                    attributedTitle: NSAttributedString(string: item.text1,
+                                                        attributes: [.font: TextStyle.footnote.font,
+                                                                     .foregroundColor: Colors.Table.Cell.footer]),
+                    attributedSubtitle: NSAttributedString(string: item.text2,
+                                                           attributes: [.font: TextStyle.body.font,
+                                                                        .foregroundColor: Colors.Table.Cell.title]),
+                    footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
+                    customView: TableViewSampleData.createCustomView(imageName: item.image),
+                    customAccessoryView: section.hasAccessory ? TableViewCellSampleData.customAccessoryView : nil,
+                    accessoryType: TableViewCellSampleData.accessoryType(for: indexPath)
+                )
+            }
         } else {
             cell.setup(
                 title: item.text1,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When setting an attributed string to the cell, the cells would not automatically update, even with calling `setNeedsLayout()` being called in the cell setup. What was more interesting was that the fonts would all be updated, but not the color, although debugging showed that all attributes were set correctly. This change makes sure that the attributed strings are fully and accurately updating.

### Verification

Colors are changed to better demonstrate the bug.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ezgif com-gif-maker](https://user-images.githubusercontent.com/22566866/178064171-634db4e3-59ad-4308-af2b-239ef5320209.gif) | ![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/22566866/178064294-8d94f77b-b88d-4251-954c-d750bc2f4191.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1064)