### PR TITLE
[Fluent 2 iOS] Card Colors Update

### DIFF
--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -329,7 +329,7 @@ open class CardView: UIView {
         iconView = UIImageView(image: icon)
 
         super.init(frame: .zero)
-
+        setupColors()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(themeDidChange),
                                                name: .didChangeTheme,
@@ -380,11 +380,6 @@ open class CardView: UIView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-        setupColors()
-    }
-
     @objc private func themeDidChange(_ notification: Notification) {
         setupColors()
     }
@@ -402,9 +397,7 @@ open class CardView: UIView {
                 // Update border color
                 switch colorStyle {
                 case .appColor:
-                    if let window = window {
-                        layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
-                    }
+                    layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
                 case .neutral:
                     layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
                 case .custom:
@@ -421,10 +414,8 @@ open class CardView: UIView {
             primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             iconView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
-            if let window = window {
-                backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
-                layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
-            }
+            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+            layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
         case .neutral:
             backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
             primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -226,7 +226,7 @@ open class CardView: UIView {
     }
 
     /// Set `customBackgroundColor` in order to set the background color when using the custom color style
-    @objc open var customBackgroundColor: UIColor = Constants.defaultBackgroundColor {
+    @objc open lazy var customBackgroundColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2]) {
         didSet {
             if customBackgroundColor != oldValue {
                 setupColors()
@@ -417,7 +417,7 @@ open class CardView: UIView {
                 layer.borderColor = UIColor(light: Colors.primaryTint30(for: window), dark: .clear).cgColor
             }
         case .neutral:
-            backgroundColor = Constants.defaultBackgroundColor
+            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
             primaryLabel.textColor = Colors.textPrimary
             secondaryLabel.textColor = Colors.textSecondary
             iconView.tintColor = Colors.iconSecondary

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -235,7 +235,7 @@ open class CardView: UIView {
     }
 
     /// Set `customTitleColor` in order to set the title's text color when using the custom color style
-    @objc open var customTitleColor: UIColor = Colors.textPrimary {
+    @objc open lazy var customTitleColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]) {
         didSet {
             if customTitleColor != oldValue {
                 setupColors()
@@ -418,7 +418,7 @@ open class CardView: UIView {
             }
         case .neutral:
             backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
-            primaryLabel.textColor = Colors.textPrimary
+            primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             secondaryLabel.textColor = Colors.textSecondary
             iconView.tintColor = Colors.iconSecondary
             layer.borderColor = Constants.defaultBorderColor.cgColor

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -330,6 +330,11 @@ open class CardView: UIView {
 
         super.init(frame: .zero)
 
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
         translatesAutoresizingMaskIntoConstraints = false
 
         // View border and background
@@ -377,6 +382,10 @@ open class CardView: UIView {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
+        setupColors()
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
         setupColors()
     }
 

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -262,7 +262,7 @@ open class CardView: UIView {
     }
 
     /// Set `customBorderColor` in order to set the border's color when using the custom color style
-    @objc open var customBorderColor: UIColor = Constants.defaultBorderColor {
+    @objc open lazy var customBorderColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]) {
         didSet {
             if customBorderColor != oldValue {
                 setupColors()
@@ -421,7 +421,7 @@ open class CardView: UIView {
             primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             iconView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            layer.borderColor = Constants.defaultBorderColor.cgColor
+            layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
         case .custom:
             backgroundColor = customBackgroundColor
             primaryLabel.textColor = customTitleColor

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -397,7 +397,7 @@ open class CardView: UIView {
                         layer.borderColor = UIColor(light: Colors.primaryTint30(for: window), dark: .clear).cgColor
                     }
                 case .neutral:
-                    layer.borderColor = Constants.defaultBorderColor.cgColor
+                    layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
                 case .custom:
                     layer.borderColor = customBorderColor.cgColor
                 }
@@ -432,8 +432,6 @@ open class CardView: UIView {
     }
 
     private struct Constants {
-        static let defaultBackgroundColor = UIColor(light: .white, dark: Colors.gray900)
-        static let defaultBorderColor = UIColor(light: Colors.dividerOnPrimary, dark: .clear)
         static let iconWidth: CGFloat = 24
         static let iconHeight: CGFloat = 24
         static let borderRadius: CGFloat = 8.0

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -253,7 +253,7 @@ open class CardView: UIView {
     }
 
     /// Set `customIconTintColor` in order to set the icon's tint color when using the custom color style
-    @objc open var customIconTintColor: UIColor = Colors.iconSecondary {
+    @objc open lazy var customIconTintColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]) {
         didSet {
             if customIconTintColor != oldValue {
                 setupColors()
@@ -420,7 +420,7 @@ open class CardView: UIView {
             backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
             primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            iconView.tintColor = Colors.iconSecondary
+            iconView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             layer.borderColor = Constants.defaultBorderColor.cgColor
         case .custom:
             backgroundColor = customBackgroundColor

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -403,7 +403,7 @@ open class CardView: UIView {
                 switch colorStyle {
                 case .appColor:
                     if let window = window {
-                        layer.borderColor = UIColor(light: Colors.primaryTint30(for: window), dark: .clear).cgColor
+                        layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
                     }
                 case .neutral:
                     layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
@@ -418,12 +418,12 @@ open class CardView: UIView {
     private func setupColors() {
         switch colorStyle {
         case .appColor:
-            primaryLabel.textColor = UIColor(light: .black, dark: Colors.gray100)
-            secondaryLabel.textColor = UIColor(light: Colors.gray600, dark: Colors.gray400)
-            iconView.tintColor = UIColor(light: Colors.gray600, dark: Colors.gray500)
+            primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            iconView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
             if let window = window {
-                backgroundColor = UIColor(light: Colors.primaryTint40(for: window), dark: Colors.primaryTint30(for: window))
-                layer.borderColor = UIColor(light: Colors.primaryTint30(for: window), dark: .clear).cgColor
+                backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+                layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
             }
         case .neutral:
             backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -244,7 +244,7 @@ open class CardView: UIView {
     }
 
     /// Set `customSubtitleColor` in order to set the subtitle's text color when using the custom color style
-    @objc open var customSubtitleColor: UIColor = Colors.textSecondary {
+    @objc open lazy var customSubtitleColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]) {
         didSet {
             if customSubtitleColor != oldValue {
                 setupColors()
@@ -419,7 +419,7 @@ open class CardView: UIView {
         case .neutral:
             backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
             primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-            secondaryLabel.textColor = Colors.textSecondary
+            secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             iconView.tintColor = Colors.iconSecondary
             layer.borderColor = Constants.defaultBorderColor.cgColor
         case .custom:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The Card colors were updated to match fluent 2 specs.

### Verification

The cards were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="301" alt="before_light" src="https://user-images.githubusercontent.com/106181067/178339630-714d4467-5f25-4e43-9776-0e207462c0f5.png"> | <img width="299" alt="after_light" src="https://user-images.githubusercontent.com/106181067/178339650-768688d4-cada-478b-80ca-8e76f70ad4d7.png"> |
| <img width="304" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/178339676-f7dc6a72-dac5-4536-8207-2126af03eab5.png"> | <img width="303" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/178339699-8adbff5e-7ae4-4faf-b57a-a39ba5f11d35.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1065)