### PR TITLE
Adding custom ring color for AvatarGroup in demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -75,6 +75,19 @@ class AvatarGroupDemoController: DemoTableViewController {
 
             return cell
 
+        case .customRingColor:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
+                return UITableViewCell()
+            }
+
+            cell.setup(title: row.title, isOn: self.isUsingImageBasedCustomColor)
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.isUsingImageBasedCustomColor = cell?.isOn ?? true
+            }
+
+            return cell
+
         case .maxDisplayedAvatars,
              .overflow:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
@@ -234,6 +247,7 @@ class AvatarGroupDemoController: DemoTableViewController {
             case .settings:
                 return [.avatarCount,
                         .alternateBackground,
+                        .customRingColor,
                         .maxDisplayedAvatars,
                         .overflow]
             case .avatarStackNoBorder,
@@ -261,6 +275,7 @@ class AvatarGroupDemoController: DemoTableViewController {
     private enum AvatarGroupDemoRow: CaseIterable {
         case avatarCount
         case alternateBackground
+        case customRingColor
         case maxDisplayedAvatars
         case overflow
         case xxlargeTitle
@@ -293,6 +308,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .xsmallTitle,
                  .avatarCount,
                  .alternateBackground,
+                 .customRingColor,
                  .maxDisplayedAvatars,
                  .overflow:
                 return false
@@ -321,6 +337,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .xsmallTitle,
                  .avatarCount,
                  .alternateBackground,
+                 .customRingColor,
                  .maxDisplayedAvatars,
                  .overflow:
                 preconditionFailure("Row should not display an Avatar Group")
@@ -333,6 +350,8 @@ class AvatarGroupDemoController: DemoTableViewController {
                 return "Avatar count"
             case .alternateBackground:
                 return "Use alternate background color"
+            case .customRingColor:
+                return "Use image based custom ring color"
             case.maxDisplayedAvatars:
                 return "Max displayed avatars"
             case .overflow:
@@ -493,6 +512,19 @@ class AvatarGroupDemoController: DemoTableViewController {
     private var isUsingAlternateBackgroundColor: Bool = false {
         didSet {
             updateBackgroundColor()
+        }
+    }
+
+    private var isUsingImageBasedCustomColor: Bool = false {
+        didSet {
+            if oldValue != isUsingImageBasedCustomColor {
+                allDemoAvatarGroupsCombined.forEach { group in
+                    for i in 0...maxDisplayedAvatars - 1 {
+                        let avatar = group.state.getAvatarState(at: i)
+                        avatar.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
+                    }
+                }
+            }
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -403,7 +403,11 @@ class AvatarGroupDemoController: DemoTableViewController {
 
     @objc private func setMaxAvatarCount() {
         if let text = maxAvatarsTextField.text, let count = Int(text) {
-            maxDisplayedAvatars = count
+            if count <= avatarCount {
+                maxDisplayedAvatars = count
+            } else {
+                maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
+            }
             maxAvatarButton.isEnabled = false
         }
 
@@ -464,6 +468,7 @@ class AvatarGroupDemoController: DemoTableViewController {
             guard oldValue != avatarCount && avatarCount >= 0 else {
                 return
             }
+            adjustMaxDisplayedAvatarsCount()
             AvatarGroupDemoSection.allCases.filter({ section in
                 return section.isDemoSection
             }).forEach { section in
@@ -491,6 +496,10 @@ class AvatarGroupDemoController: DemoTableViewController {
                 demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
             }
         }
+    }
+
+    private func adjustMaxDisplayedAvatarsCount() {
+        maxDisplayedAvatars = min(avatarCount, maxDisplayedAvatars)
     }
 
     @objc private func addAvatarCount(_ cell: ActionsCell) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -407,7 +407,9 @@ class AvatarGroupDemoController: DemoTableViewController {
         if let text = maxAvatarsTextField.text, let newMax = Int(text) {
             if newMax <= avatarCount {
                 maxDisplayedAvatars = newMax
-                updateAvatarsCustomColorRing(index1: oldMax, index2: newMax - 1)
+                if oldMax < newMax {
+                    updateAvatarsCustomRingColor(for: oldMax..<newMax)
+                }
             } else {
                 maxAvatarsTextField.text = "\(oldMax)"
             }
@@ -529,17 +531,13 @@ class AvatarGroupDemoController: DemoTableViewController {
 
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
-            updateAvatarsCustomColorRing(index1: 0, index2: avatarCount - 1)
+            updateAvatarsCustomRingColor(for: 0..<avatarCount)
         }
     }
 
-    private func updateAvatarsCustomColorRing(index1: Int, index2: Int) {
-        if index1 > index2 {
-            return
-        }
-
+    private func updateAvatarsCustomRingColor(for range: Range<Int>) {
         for group in allDemoAvatarGroupsCombined {
-            for index in index1...index2 {
+            for index in range {
                 let avatar = group.state.getAvatarState(at: index)
                 avatar.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -402,11 +402,14 @@ class AvatarGroupDemoController: DemoTableViewController {
     }()
 
     @objc private func setMaxAvatarCount() {
-        if let text = maxAvatarsTextField.text, let count = Int(text) {
-            if count <= avatarCount {
-                maxDisplayedAvatars = count
+        let oldMax = maxDisplayedAvatars
+
+        if let text = maxAvatarsTextField.text, let newMax = Int(text) {
+            if newMax <= avatarCount {
+                maxDisplayedAvatars = newMax
+                updateAvatarsCustomColorRing(index1: oldMax, index2: newMax - 1)
             } else {
-                maxAvatarsTextField.text = "\(maxDisplayedAvatars)"
+                maxAvatarsTextField.text = "\(oldMax)"
             }
             maxAvatarButton.isEnabled = false
         }
@@ -526,13 +529,19 @@ class AvatarGroupDemoController: DemoTableViewController {
 
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
-            if oldValue != isUsingImageBasedCustomColor {
-                for group in allDemoAvatarGroupsCombined {
-                    for index in 0...avatarCount - 1 {
-                        let avatar = group.state.getAvatarState(at: index)
-                        avatar.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
-                    }
-                }
+            updateAvatarsCustomColorRing(index1: 0, index2: avatarCount - 1)
+        }
+    }
+
+    private func updateAvatarsCustomColorRing(index1: Int, index2: Int) {
+        if index1 > index2 {
+            return
+        }
+
+        for group in allDemoAvatarGroupsCombined {
+            for index in index1...index2 {
+                let avatar = group.state.getAvatarState(at: index)
+                avatar.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
             }
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -468,7 +468,7 @@ class AvatarGroupDemoController: DemoTableViewController {
             guard oldValue != avatarCount && avatarCount >= 0 else {
                 return
             }
-            adjustMaxDisplayedAvatarsCount()
+            adjustMaxDisplayedAvatars()
             AvatarGroupDemoSection.allCases.filter({ section in
                 return section.isDemoSection
             }).forEach { section in
@@ -498,7 +498,7 @@ class AvatarGroupDemoController: DemoTableViewController {
         }
     }
 
-    private func adjustMaxDisplayedAvatarsCount() {
+    private func adjustMaxDisplayedAvatars() {
         maxDisplayedAvatars = min(avatarCount, maxDisplayedAvatars)
     }
 
@@ -527,9 +527,9 @@ class AvatarGroupDemoController: DemoTableViewController {
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
             if oldValue != isUsingImageBasedCustomColor {
-                allDemoAvatarGroupsCombined.forEach { group in
-                    for i in 0...maxDisplayedAvatars - 1 {
-                        let avatar = group.state.getAvatarState(at: i)
+                for group in allDemoAvatarGroupsCombined {
+                    for index in 0...avatarCount - 1 {
+                        let avatar = group.state.getAvatarState(at: index)
                         avatar.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
                     }
                 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- Custom ring color was added as a toggle for AvatarGroup demo
- Made sure `maxDisplayedAvatars` cannot exceed `avatarCount`
- Made sure newly displayed avatars update to their custom ring color if the toggle is on 

### Verification

The tests were run on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="311" alt="options_before" src="https://user-images.githubusercontent.com/106181067/178344818-cb95e024-eba3-4090-a579-93e097074f2f.png"> | <img width="309" alt="option_after" src="https://user-images.githubusercontent.com/106181067/178344857-7e98dab2-9b56-4315-91af-403d1740a955.png"> |
| <img width="251" alt="before_light" src="https://user-images.githubusercontent.com/106181067/178344898-56d3346a-1396-4162-9b43-c62499e8caf7.png"> | <img width="249" alt="after_light" src="https://user-images.githubusercontent.com/106181067/178344934-de8ed4df-7dc9-415c-bce4-6dfbf4fb633d.png"> |
| <img width="266" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/178344966-37171445-b0fb-41ee-bee2-cc2ab6c4ed07.png"> | <img width="268" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/178345038-dfc7f12a-50b6-43fc-a76d-a12397dc64a2.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1066)