### PR TITLE
Fixing NSAttributedString not reflecting changes in Label

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -101,6 +101,9 @@ open class Label: UILabel {
     }
 
     private func updateFont() {
+        guard self.attributedText == nil else {
+            return
+        }
         let defaultFont = style.font
         if maxFontSize > 0 && defaultFont.pointSize > maxFontSize {
             font = defaultFont.withSize(maxFontSize)
@@ -111,6 +114,9 @@ open class Label: UILabel {
 
     private func updateTextColor() {
         if let window = window {
+            guard self.attributedText == nil else {
+                return
+            }
             super.textColor = _textColor ?? colorStyle.color(for: window)
         }
     }

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -101,6 +101,7 @@ open class Label: UILabel {
     }
 
     private func updateFont() {
+        // If attributedText is set, it will be prioritized over any other label property changes
         guard self.attributedText == nil else {
             return
         }
@@ -113,10 +114,11 @@ open class Label: UILabel {
     }
 
     private func updateTextColor() {
+        // If attributedText is set, it will be prioritized over any other label property changes
+        guard self.attributedText == nil else {
+            return
+        }
         if let window = window {
-            guard self.attributedText == nil else {
-                return
-            }
             super.textColor = _textColor ?? colorStyle.color(for: window)
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes
Updated version of #1064

Labels in the TableViewCell did not seem to update unless scrolled, and sometimes the visuals would change as well. This was revealed to be a bug in the Label, where the `updateFont()` and `updateTextColor()` methods were not considering attributedText to be set.

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/22566866/178359982-6fbaebfc-ebf0-4cb0-b149-4889b6522c14.gif) | ![ezgif com-gif-maker](https://user-images.githubusercontent.com/22566866/178359695-cdaa15ad-ea6c-408f-bf04-8ad43ab9ffe9.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1067)