### PR TITLE
[Fluent 2 iOS] Navigation bar colors update

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -62,37 +62,34 @@ open class NavigationBar: UINavigationBar {
         case system
         case custom
 
-        var tintColor: UIColor {
+        func tintColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primary, .default, .custom:
-                return Colors.Navigation.Primary.tint
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground2].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             case .system:
-                return Colors.Navigation.System.tint
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             }
         }
 
-        var titleColor: UIColor {
+        func titleColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primary, .default, .custom:
-                return Colors.Navigation.Primary.title
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
             case .system:
-                return Colors.Navigation.System.title
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             }
         }
 
-        func backgroundColor(for window: UIWindow, customColor: UIColor?) -> UIColor {
+        func backgroundColor(fluentTheme: FluentTheme, customColor: UIColor?) -> UIColor {
+            let defaultColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground1].light, dark: fluentTheme.aliasTokens.colors[.background3].dark))
             switch self {
             case .primary, .default:
-                return defaultBackgroundColor(for: window)
+                return defaultColor
             case .system:
-                return Colors.Navigation.System.background
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
             case .custom:
-                return customColor ?? defaultBackgroundColor(for: window)
+                return customColor ?? defaultColor
             }
-        }
-
-        func defaultBackgroundColor(for window: UIWindow) -> UIColor {
-            return UIColor(light: Colors.primary(for: window), dark: Colors.Navigation.System.background)
         }
     }
 
@@ -432,11 +429,6 @@ open class NavigationBar: UINavigationBar {
         updateAccessibilityElements()
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateColors(for: topItem)
-    }
-
     open override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         // contentStackView's content extends its bounds outside of navigation bar bounds
         return super.point(inside: point, with: event) ||
@@ -499,29 +491,27 @@ open class NavigationBar: UINavigationBar {
     // MARK: UINavigationItem & UIBarButtonItem handling
 
     func updateColors(for navigationItem: UINavigationItem?) {
-        if let window = window {
-            let color = navigationItem?.navigationBarColor(for: window)
+        let color = navigationItem?.navigationBarColor(fluentTheme: fluentTheme)
 
-            switch style {
-            case .primary, .default, .custom:
-                titleView.style = .light
-            case .system:
-                titleView.style = .dark
-            }
+        switch style {
+        case .primary, .default, .custom:
+            titleView.style = .light
+        case .system:
+            titleView.style = .dark
+        }
 
-            standardAppearance.backgroundColor = color
-            backgroundView.backgroundColor = color
-            tintColor = style.tintColor
-            standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor
-            standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor
+        standardAppearance.backgroundColor = color
+        backgroundView.backgroundColor = color
+        tintColor = style.tintColor(fluentTheme: fluentTheme)
+        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: fluentTheme)
+        standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: fluentTheme)
 
-            // Update the scroll edge appearance to match the new standard appearance
-            scrollEdgeAppearance = standardAppearance
+        // Update the scroll edge appearance to match the new standard appearance
+        scrollEdgeAppearance = standardAppearance
 
-            navigationBarColorObserver = navigationItem?.observe(\.customNavigationBarColor) { [unowned self] navigationItem, _ in
-                // Unlike title or barButtonItems that depends on the topItem, navigation bar color can be set from the parentViewController's navigationItem
-                self.updateColors(for: navigationItem)
-            }
+        navigationBarColorObserver = navigationItem?.observe(\.customNavigationBarColor) { [unowned self] navigationItem, _ in
+            // Unlike title or barButtonItems that depends on the topItem, navigation bar color can be set from the parentViewController's navigationItem
+            self.updateColors(for: navigationItem)
         }
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -292,11 +292,20 @@ open class NavigationBar: UINavigationBar {
     @objc public override init(frame: CGRect) {
         super.init(frame: frame)
         initBase()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
 
     @objc public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         initBase()
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateColors(for: topItem)
     }
 
     /// Custom base initializer, used regardless of entry point

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -258,14 +258,14 @@ class ShyHeaderController: UIViewController {
         return true
     }
 
-    private func updateBackgroundColor(with item: UINavigationItem, window: UIWindow) {
-        let color = item.navigationBarColor(for: window)
+    private func updateBackgroundColor(with item: UINavigationItem) {
+        let color = item.navigationBarColor(fluentTheme: view.fluentTheme)
         shyHeaderView.backgroundColor = color
         view.backgroundColor = color
         paddingView.backgroundColor = color
 
         navigationBarColorObservation = item.observe(\.customNavigationBarColor) { [weak self] item, _ in
-            self?.updateBackgroundColor(with: item, window: window)
+            self?.updateBackgroundColor(with: item)
         }
     }
 
@@ -523,10 +523,9 @@ class ShyHeaderController: UIViewController {
 
     /// Updates based on the current navigation bar style.
     private func updateNavigationBarStyle() {
-        if let window = view.window,
-            let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
+        if let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
             shyHeaderView.navigationBarStyle = actualStyle
-            updateBackgroundColor(with: actualItem, window: window)
+            updateBackgroundColor(with: actualItem)
         }
     }
 

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -80,8 +80,8 @@ import UIKit
         }
     }
 
-    func navigationBarColor(for window: UIWindow) -> UIColor {
-        return navigationBarStyle.backgroundColor(for: window, customColor: customNavigationBarColor)
+    func navigationBarColor(fluentTheme: FluentTheme) -> UIColor {
+        return navigationBarStyle.backgroundColor(fluentTheme: fluentTheme, customColor: customNavigationBarColor)
     }
 
     var customNavigationBarColor: UIColor? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The NavigationBar's colors were updated to match fluent 2 tokens. 

### Verification

Changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="314" alt="before_brand" src="https://user-images.githubusercontent.com/106181067/178610430-1024944f-2bc1-4547-8c1d-8ad4bd2d9310.png"> | <img width="315" alt="after_brand" src="https://user-images.githubusercontent.com/106181067/178610465-18b19680-8483-4bb9-8239-48ff9df435c9.png"> |
| <img width="310" alt="before_light" src="https://user-images.githubusercontent.com/106181067/178610502-ed93d258-eb7f-4ae3-bb28-b86c2296300e.png"> | <img width="308" alt="after_light" src="https://user-images.githubusercontent.com/106181067/178610527-8a0bd822-f71c-4ea4-bff9-3f3d9afc3208.png"> |
| <img width="309" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/178610560-509effdf-de4b-4c6e-ad67-b837e6c75108.png"> | <img width="313" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/178610575-b2958b5d-3e50-454c-893d-9feca01e3848.png"> |
| <img width="858" alt="before" src="https://user-images.githubusercontent.com/106181067/178800773-23f63c83-e2e3-49c8-807f-c1b783e1c63e.png"> | <img width="858" alt="after" src="https://user-images.githubusercontent.com/106181067/178800819-08adf298-aab6-45c2-9a6c-c1e6bcc3b8c8.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1068)