### PR TITLE
[Fluent2 iOS] TabBar and SideTabBar Color Update

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -207,7 +207,7 @@ class TabBarItemView: UIControl {
         let titleLabel = Label()
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.textAlignment = .center
-        titleLabel.textColor = unselectedColor
+        titleLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
 
         return titleLabel
     }()

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -146,7 +146,8 @@ class TabBarItemView: UIControl {
     }
 
     private struct Constants {
-        static let unselectedColor: UIColor = Colors.textSecondary
+        // TODO: to be updated
+        // static let unselectedColor: UIColor =
         static let spacingVertical: CGFloat = 3
         static let spacingHorizontal: CGFloat = 8
         static let portraitImageSize: CGFloat = 28
@@ -163,6 +164,8 @@ class TabBarItemView: UIControl {
         static let badgeHorizontalPadding: CGFloat = 10
         static let badgeCorderRadii: CGFloat = 10
     }
+
+    lazy var unselectedColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
 
     private var badgeValue: String? {
         didSet {
@@ -184,7 +187,7 @@ class TabBarItemView: UIControl {
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = Constants.unselectedColor
+        imageView.tintColor = unselectedColor
 
         if canResizeImage {
             let sizeConstraints = (
@@ -200,11 +203,11 @@ class TabBarItemView: UIControl {
 
     private var imageViewSizeConstraints: (width: NSLayoutConstraint, height: NSLayoutConstraint)?
 
-    private let titleLabel: Label = {
+    private lazy var titleLabel: Label = {
         let titleLabel = Label()
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.textAlignment = .center
-        titleLabel.textColor = Constants.unselectedColor
+        titleLabel.textColor = unselectedColor
 
         return titleLabel
     }()
@@ -235,11 +238,9 @@ class TabBarItemView: UIControl {
     }
 
     private func updateColors() {
-        if let window = window {
-            let primaryColor = Colors.primary(for: window)
-            titleLabel.highlightedTextColor = primaryColor
-            imageView.tintColor = isSelected ? primaryColor : Constants.unselectedColor
-        }
+        let primaryColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+        titleLabel.highlightedTextColor = primaryColor
+        imageView.tintColor = isSelected ? primaryColor : unselectedColor
     }
 
     private func updateLayout() {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -165,7 +165,7 @@ class TabBarItemView: UIControl {
         static let badgeCorderRadii: CGFloat = 10
     }
 
-    lazy var unselectedColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+    private lazy var unselectedColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
 
     private var badgeValue: String? {
         didSet {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated the selected, unselected and highlight colors for TabBar and SideTabBar to match the new Fluent 2 iOS colors defined by design.

### Verification

Checked in Simulator in light and dark mode, verified colors are correct by design.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-12 at 16 22 51](https://user-images.githubusercontent.com/23249106/178615049-3b47c5b6-c883-4cb1-aa38-afa3215cf77b.png)
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-12 at 16 23 02](https://user-images.githubusercontent.com/23249106/178615071-1de392ad-0eab-4d72-b690-090499156e07.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-12 at 16 22 07](https://user-images.githubuserconten
![Simulator Screen Shot - iPhone 13 Pro - 2022-07-12 at 16 21 52](https://user-images.githubusercontent.com/23249106/178615102-3194a31e-d273-4d76-af24-8924b54e2748.png)
t.com/23249106/178615095-74e9d245-e5ee-4e91-a894-0898fdb0593e.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)