### PR TITLE
[Fluent2 Tokens] Fix AttributedText width in Notification when displaying from UIKit

### DIFF
--- a/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
@@ -36,11 +36,11 @@ struct UIViewAdapter: UIViewRepresentable {
 struct AttributedText: UIViewRepresentable {
 
     let attributedString: NSAttributedString
-    let width: CGFloat
+    let preferredMaxWidth: CGFloat
 
-    init(_ attributedString: NSAttributedString, _ width: CGFloat) {
+    init(_ attributedString: NSAttributedString, _ preferredMaxWidth: CGFloat) {
         self.attributedString = attributedString
-        self.width = width
+        self.preferredMaxWidth = preferredMaxWidth
     }
 
     func makeUIView(context: Context) -> UILabel {
@@ -57,7 +57,7 @@ struct AttributedText: UIViewRepresentable {
         // Update the UILabel's attributes if it changes.
         DispatchQueue.main.async {
             label.attributedText = attributedString
-            label.preferredMaxLayoutWidth = width
+            label.preferredMaxLayoutWidth = preferredMaxWidth
         }
     }
 }

--- a/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
@@ -36,9 +36,11 @@ struct UIViewAdapter: UIViewRepresentable {
 struct AttributedText: UIViewRepresentable {
 
     let attributedString: NSAttributedString
+    let width: CGFloat
 
-    init(_ attributedString: NSAttributedString) {
+    init(_ attributedString: NSAttributedString, _ width: CGFloat) {
         self.attributedString = attributedString
+        self.width = width
     }
 
     func makeUIView(context: Context) -> UILabel {
@@ -55,7 +57,7 @@ struct AttributedText: UIViewRepresentable {
         // Update the UILabel's attributes if it changes.
         DispatchQueue.main.async {
             label.attributedText = attributedString
-            label.preferredMaxLayoutWidth = label.bounds.width
+            label.preferredMaxLayoutWidth = width
         }
     }
 }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -118,6 +118,9 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 if let attributedTitle = state.attributedTitle {
                     AttributedText(attributedTitle, attributedTitleSize.width)
                         .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
+                        .onSizeChange { newSize in
+                            attributedTitleSize = newSize
+                        }
                 } else if let title = state.title {
                     Text(title)
                         .font(.fluent(tokens.boldTextFont))
@@ -131,6 +134,9 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             if let attributedMessage = state.attributedMessage {
                 AttributedText(attributedMessage, attributedMessageSize.width)
                     .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
+                    .onSizeChange { newSize in
+                        attributedMessageSize = newSize
+                    }
             } else if let message = state.message {
                 let messageFont = hasSecondTextRow ? tokens.footnoteTextFont : (state.style.isToast ? tokens.boldTextFont : tokens.regularTextFont)
                 Text(message)

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -116,7 +116,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         var titleLabel: some View {
             if state.style.isToast && hasSecondTextRow {
                 if let attributedTitle = state.attributedTitle {
-                    AttributedText(attributedTitle)
+                    AttributedText(attributedTitle, attributedTitleSize.width)
                         .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
                 } else if let title = state.title {
                     Text(title)
@@ -129,7 +129,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         @ViewBuilder
         var messageLabel: some View {
             if let attributedMessage = state.attributedMessage {
-                AttributedText(attributedMessage)
+                AttributedText(attributedMessage, attributedMessageSize.width)
                     .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
             } else if let message = state.message {
                 let messageFont = hasSecondTextRow ? tokens.footnoteTextFont : (state.style.isToast ? tokens.boldTextFont : tokens.regularTextFont)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

I added the .onSizeChange modifier to the AttributedText used in the Notification. In order to let the .onSizeChange modifier to have access to self, I moved all the `@ViewBuiler`s in to the body. Now if we're displaying a flexible width toast Notification from UIKit, with either an attributed title or message, the string won't go off screen.

The diff makes the change look more drastic than it was, but the commits break it down fairly well. 1. Move the views that used to be private variables into the body of the view (so they can access self). 2. Add the .onSizeChange modifier, and have it set the `@State` variable tracking the size of the `AttributedText` so that we'll try to redraw when the size changed. 3. Pass the new width in to the `AttributedText`.

### Verification

For testing purposes, I replaced the text of the flexible width toast demo with an NSAttributedString.
The other styles are unchanged.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Notification_attrStrWidth_before_ish](https://user-images.githubusercontent.com/67026548/178824239-796fa375-026f-4143-8658-4416c6c96006.png) | ![Notification_attrStrWidth_after](https://user-images.githubusercontent.com/67026548/178824254-7990f840-01db-4db0-9939-e170be896279.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1070)