### PR TITLE
[Fluent 2 iOS] Fixing SearchBar's brand colors for dark mode

### DIFF
--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -32,7 +32,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground2])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2].light, dark: fluentTheme.aliasTokens.colors[.background5].dark))
             }
         }
 
@@ -41,7 +41,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
             }
         }
 
@@ -50,7 +50,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground2])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground2].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             }
         }
 
@@ -59,16 +59,19 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground3])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
 
         func searchIconColor(fluentTheme: FluentTheme, isSearching: Bool = false) -> UIColor {
+            let searchBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+            let idleBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+
             switch self {
             case .lightContent, .darkContent:
                 return isSearching ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .brandContent:
-                return isSearching ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground3])
+                return isSearching ? searchBrandColor : idleBrandColor
             }
         }
 
@@ -77,7 +80,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
             }
         }
 
@@ -86,7 +89,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground2])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground2].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
 
@@ -95,7 +98,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .brandContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground3])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`brandContent` style now defaults to neutral colors for dark mode.

### Verification

The changes were tested on the iPad split mode dark.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="814" alt="before_brand" src="https://user-images.githubusercontent.com/106181067/178828239-fd8ee3f8-5994-4e2f-9e89-184be9526d84.png"> | <img width="814" alt="after_brand" src="https://user-images.githubusercontent.com/106181067/178828275-72a7c2ec-d4c1-4bb4-9daf-a5b1592f6e3b.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1071)