### PR TITLE
[Fluent 2 iOS] Updating BottomSheetController colors to Fluent 2 colors

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -409,10 +409,10 @@ public class BottomSheetController: UIViewController {
 
         // We need to have the shadow on a parent of the view that does the corner masking.
         // Otherwise the view will mask its own shadow.
-        bottomSheetView.layer.shadowColor = shadowColor
-        bottomSheetView.layer.shadowOffset = Constants.Shadow.offset
-        bottomSheetView.layer.shadowOpacity = Constants.Shadow.opacity
-        bottomSheetView.layer.shadowRadius = Constants.Shadow.radius
+        let shadow28 = view.fluentTheme.aliasTokens.shadow[.shadow28]
+        bottomSheetView.layer.shadowColor = UIColor(dynamicColor: shadow28.colorTwo).cgColor
+        bottomSheetView.layer.shadowOffset = CGSize(width: shadow28.xTwo, height: shadow28.yTwo)
+        bottomSheetView.layer.shadowRadius = shadow28.blurTwo
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.backgroundColor = backgroundColor
@@ -873,7 +873,6 @@ public class BottomSheetController: UIViewController {
 
     private let shouldShowDimmingView: Bool
 
-    private lazy var shadowColor = UIColor(colorValue: self.view.fluentTheme.globalTokens.neutralColors[.black]).cgColor
     private lazy var backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.background2])
 
     private struct Constants {
@@ -915,12 +914,6 @@ public class BottomSheetController: UIViewController {
 
             // Off-screen overflow that can be partially revealed during spring oscillation or rubber banding (dragging the sheet beyond limits)
             static let overflowHeight: CGFloat = 50.0
-        }
-
-        struct Shadow {
-            static let opacity: Float = 0.14
-            static let radius: CGFloat = 8
-            static let offset: CGSize = CGSize(width: 0, height: 4)
         }
     }
 }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -873,7 +873,7 @@ public class BottomSheetController: UIViewController {
 
     private let shouldShowDimmingView: Bool
 
-    private lazy var backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.background2])
+    private lazy var backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
 
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -335,7 +335,7 @@ public class BottomSheetController: UIViewController {
 
         let overflowView = UIView()
         overflowView.translatesAutoresizingMaskIntoConstraints = false
-        overflowView.backgroundColor = Colors.NavigationBar.background
+        overflowView.backgroundColor = backgroundColor
         view.addSubview(overflowView)
 
         if let headerContentView = headerContentView {
@@ -409,13 +409,13 @@ public class BottomSheetController: UIViewController {
 
         // We need to have the shadow on a parent of the view that does the corner masking.
         // Otherwise the view will mask its own shadow.
-        bottomSheetView.layer.shadowColor = Constants.Shadow.color
+        bottomSheetView.layer.shadowColor = shadowColor
         bottomSheetView.layer.shadowOffset = Constants.Shadow.offset
         bottomSheetView.layer.shadowOpacity = Constants.Shadow.opacity
         bottomSheetView.layer.shadowRadius = Constants.Shadow.radius
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.backgroundColor = Colors.NavigationBar.background
+        contentView.backgroundColor = backgroundColor
         contentView.layer.cornerRadius = Constants.cornerRadius
         contentView.layer.cornerCurve = .continuous
         contentView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
@@ -873,6 +873,9 @@ public class BottomSheetController: UIViewController {
 
     private let shouldShowDimmingView: Bool
 
+    private lazy var shadowColor = UIColor(colorValue: self.view.fluentTheme.globalTokens.neutralColors[.black]).cgColor
+    private lazy var backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.background2])
+
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance
         static let maxRubberBandOffset: CGFloat = 20.0
@@ -915,7 +918,6 @@ public class BottomSheetController: UIViewController {
         }
 
         struct Shadow {
-            static let color: CGColor = UIColor.black.cgColor
             static let opacity: Float = 0.14
             static let radius: CGFloat = 8
             static let offset: CGSize = CGSize(width: 0, height: 4)

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -7,7 +7,7 @@ import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
-    /// The color of the shador for shadow 1
+    /// The color of the shadow for shadow 1
     let colorOne: DynamicColor
 
     /// The radius of the shadow for shadow 1
@@ -19,7 +19,7 @@ public struct ShadowInfo {
     /// The size of the shadow on the y-axis (also, height) for shadow 1
     let yOne: CGFloat
 
-    /// The color of the shador for shadow 2
+    /// The color of the shadow for shadow 2
     let colorTwo: DynamicColor
 
     /// The radius of the shadow for shadow 2

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -13,10 +13,10 @@ public struct ShadowInfo {
     /// The radius of the shadow for shadow 1
     let blurOne: CGFloat
 
-    /// The size of the shadow on the x-axis (also, width) for shadow 1
+    /// The offset of the shadow on the x-axis for shadow 1, from the center of the control
     let xOne: CGFloat
 
-    /// The size of the shadow on the y-axis (also, height) for shadow 1
+    /// The offset of the shadow on the y-axis for shadow 1, from the center of the control
     let yOne: CGFloat
 
     /// The color of the shadow for shadow 2

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -6,6 +6,7 @@
 import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
+/// Blur refers to the radius of the shadow's blur.
 public struct ShadowInfo {
     let colorOne: DynamicColor
     let blurOne: CGFloat

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -6,14 +6,28 @@
 import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
-/// Blur refers to the radius of the shadow's blur.
 public struct ShadowInfo {
+    /// The color of the shador for shadow 1
     let colorOne: DynamicColor
+
+    /// The radius of the shadow for shadow 1
     let blurOne: CGFloat
+
+    /// The size of the shadow on the x-axis (also, width) for shadow 1
     let xOne: CGFloat
+
+    /// The size of the shadow on the y-axis (also, height) for shadow 1
     let yOne: CGFloat
+
+    /// The color of the shador for shadow 2
     let colorTwo: DynamicColor
+
+    /// The radius of the shadow for shadow 2
     let blurTwo: CGFloat
+
+    /// The size of the shadow on the x-axis (also, width) for shadow 2
     let xTwo: CGFloat
+
+    /// The size of the shadow on the y-axis (also, height) for shadow 2
     let yTwo: CGFloat
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated BottomSheetController to use the new Fluent 2 colors.

### Verification

Verified using Simulator and compared against design spec.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-15 at 13 57 07](https://user-images.githubusercontent.com/23249106/179310599-f0600c24-85a6-4661-b0bd-80647344b529.png) ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-15 at 13 56 57](https://user-images.githubusercontent.com/23249106/179310613-f9eb4209-0c7f-475f-9bed-ed4c6b0f9802.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-27 at 14 50 44](https://user-images.githubusercontent.com/23249106/181378900-78aa4979-6095-4058-a166-d615b3e8da69.png) ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-15 at 13 56 15](https://user-images.githubusercontent.com/23249106/179310581-390e7c7c-33de-4521-8231-f824f120cf77.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1072)