### PR TITLE
update readme documentation on manual library installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,13 @@ pod 'MicrosoftFluentUI', '~> X.X.X'
 
 - Download the latest changes from the [FluentUI for Apple](https://github.com/microsoft/fluentui-apple) repository.
 - Move the `fluentui-apple` folder into your project folder.
-- Move the relevant `FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
-- In Xcode select your project -> your target -> General -> Embedded Binaries -> add `libFluentUI.a`.
+- For iOS platform
+    - Move the relevant `ios\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
+    - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `libFluentUI.a`.
+    - In Xcode select your project -> your target -> "Build Phases" -> "Copy Bundle Resources" -> add `FluentUIResources-ios.bundle`.
+- For macOS platform
+    - Move the relevant `macos\xcode\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
+    - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `FluentUI.framework`.
 
 ### Import and use FluentUI
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ pod 'MicrosoftFluentUI', '~> X.X.X'
 - Download the latest changes from the [FluentUI for Apple](https://github.com/microsoft/fluentui-apple) repository.
 - Move the `fluentui-apple` folder into your project folder.
 - For iOS platform
-    - Move `ios\FluentUI.xcodeproj` into your Xcode project.
+    - Move `ios/FluentUI.xcodeproj` into your Xcode project.
     - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `libFluentUI.a`.
     - In Xcode select your project -> your target -> "Build Phases" -> "Copy Bundle Resources" -> add `FluentUIResources-ios.bundle`.
 - For macOS platform
-    - Move `macos\xcode\FluentUI.xcodeproj` into your Xcode project.
+    - Move `macos/xcode/FluentUI.xcodeproj` into your Xcode project.
     - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `FluentUI.framework`.
 
 ### Import and use FluentUI

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ pod 'MicrosoftFluentUI', '~> X.X.X'
 - Download the latest changes from the [FluentUI for Apple](https://github.com/microsoft/fluentui-apple) repository.
 - Move the `fluentui-apple` folder into your project folder.
 - For iOS platform
-    - Move the relevant `ios\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
+    - Move `ios\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
     - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `libFluentUI.a`.
     - In Xcode select your project -> your target -> "Build Phases" -> "Copy Bundle Resources" -> add `FluentUIResources-ios.bundle`.
 - For macOS platform
-    - Move the relevant `macos\xcode\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
+    - Move `macos\xcode\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
     - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `FluentUI.framework`.
 
 ### Import and use FluentUI

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ pod 'MicrosoftFluentUI', '~> X.X.X'
 - Download the latest changes from the [FluentUI for Apple](https://github.com/microsoft/fluentui-apple) repository.
 - Move the `fluentui-apple` folder into your project folder.
 - For iOS platform
-    - Move `ios\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
+    - Move `ios\FluentUI.xcodeproj` into your Xcode project.
     - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `libFluentUI.a`.
     - In Xcode select your project -> your target -> "Build Phases" -> "Copy Bundle Resources" -> add `FluentUIResources-ios.bundle`.
 - For macOS platform
-    - Move `macos\xcode\FluentUI.xcodeproj` into your Xcode project depending on which platform you want to support.
+    - Move `macos\xcode\FluentUI.xcodeproj` into your Xcode project.
     - In Xcode select your project -> your target -> "General" -> "Frameworks, Libraries, and Embedded Content" -> add `FluentUI.framework`.
 
 ### Import and use FluentUI


### PR DESCRIPTION


### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

- iOS should have instructions that client needs to specify copying resource bundle.
- add separate instructions on macos.

### Verification

n/a

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1075)