### PR TITLE
[Fluent2 Tokens] Add MSFNotification convenience init with just MSFNotificationStyle

### DIFF
--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -108,7 +108,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                                height: imageSize.height,
                                alignment: .center)
                         .foregroundColor(Color(dynamicColor: tokens.imageColor))
-                        .accessibilityHidden(true)
                 }
             }
         }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -108,6 +108,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                                height: imageSize.height,
                                alignment: .center)
                         .foregroundColor(Color(dynamicColor: tokens.imageColor))
+                        .accessibilityHidden(true)
                 }
             }
         }

--- a/ios/FluentUI/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Notification/MSFNotificationView.swift
@@ -12,6 +12,13 @@ import UIKit
     /// Creates a new MSFNotification instance.
     /// - Parameters:
     ///   - style: The MSFNotification value used by the Notification.
+    @objc public convenience init(style: MSFNotificationStyle) {
+        self.init(style: style, isFlexibleWidthToast: false)
+    }
+
+    /// Creates a new MSFNotification instance.
+    /// - Parameters:
+    ///   - style: The MSFNotification value used by the Notification.
     ///   - isFlexibleWidthToast: Whether the width of the toast is set based  on the width of the screen or on its contents
     @objc public init(style: MSFNotificationStyle,
                       isFlexibleWidthToast: Bool = false) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added a new convenience init so that all the Objective C clients wouldn't have to specify if they wanted a flexible width toast or not on every notification.

### Verification

Objective C can access an init with just the MSFNotificationStyle.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1076)