### PR TITLE
[Fluent2 Tokens] Fix Notification VoiceOver grouping

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -59,6 +59,7 @@ struct NotificationDemoView: View {
                                               attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
                                               image: image,
                                               trailingImage: trailingImage,
+                                              trailingImageAccessibilityLabel: showTrailingImage ? "Circle" : nil,
                                               actionButtonTitle: actionButtonTitle,
                                               actionButtonAction: actionButtonAction,
                                               messageButtonAction: messageButtonAction)

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -185,6 +185,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             }
         }
 
+        let messageButtonAction = state.messageButtonAction
         @ViewBuilder
         var innerContents: some View {
             if hasCenteredText {
@@ -205,7 +206,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                         }
                     }
                     .accessibilityElement(children: .combine)
-                    .modifyIf(state.messageButtonAction != nil, { messageButton in
+                    .modifyIf(messageButtonAction != nil, { messageButton in
                         messageButton.accessibilityAddTraits(.isButton)
                     })
                     button
@@ -240,7 +241,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                                 y: tokens.perimeterShadowOffsetY)
                 )
                 .onTapGesture {
-                    if let messageAction = state.messageButtonAction {
+                    if let messageAction = messageButtonAction {
                         isPresented = false
                         messageAction()
                     }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -320,6 +320,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                               blendDuration: 0)) {
             bottomOffset = 0
         }
+        UIAccessibility.post(notification: .layoutChanged, argument: self)
     }
 
     private func dismissAnimated() {

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -204,6 +204,10 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                             Spacer(minLength: horizontalSpacing)
                         }
                     }
+                    .accessibilityElement(children: .combine)
+                    .modifyIf(state.messageButtonAction != nil, { messageButton in
+                        messageButton.accessibilityAddTraits(.isButton)
+                    })
                     button
                         .layoutPriority(1)
                 }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -177,9 +177,9 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                             Image(uiImage: trailingImage)
                         } else {
                             Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
+                                .accessibilityLabel("Accessibility.Dismiss.Label".localized)
                         }
                     })
-                    .accessibility(identifier: "Accessibility.Dismiss.Label")
                     .foregroundColor(Color(dynamicColor: foregroundColor))
                 }
             }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -26,7 +26,11 @@ import SwiftUI
     var image: UIImage? { get set }
 
     /// Optional icon to display in the action button if no button title is provided.
+    /// If the trailingImage is set, the trailingImageAccessibilityLabel should also be set.
     var trailingImage: UIImage? { get set }
+
+    /// Optional localized accessibility label for the trailing image.
+    var trailingImageAccessibilityLabel: String? { get set }
 
     /// Title to display in the action button on the trailing edge of the control.
     ///
@@ -72,6 +76,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 attributedTitle: NSAttributedString? = nil,
                 image: UIImage? = nil,
                 trailingImage: UIImage? = nil,
+                trailingImageAccessibilityLabel: String? = nil,
                 actionButtonTitle: String? = nil,
                 actionButtonAction: (() -> Void)? = nil,
                 messageButtonAction: (() -> Void)? = nil) {
@@ -82,6 +87,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         state.attributedTitle = attributedTitle
         state.image = image
         state.trailingImage = trailingImage
+        state.trailingImageAccessibilityLabel = trailingImageAccessibilityLabel
         state.actionButtonTitle = actionButtonTitle
         state.actionButtonAction = actionButtonAction
         state.messageButtonAction = messageButtonAction
@@ -176,6 +182,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     }, label: {
                         if let trailingImage = state.trailingImage {
                             Image(uiImage: trailingImage)
+                                .accessibilityLabel(state.trailingImageAccessibilityLabel ?? "")
                         } else {
                             Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
                                 .accessibilityLabel("Accessibility.Dismiss.Label".localized)
@@ -359,6 +366,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
     @Published public var attributedTitle: NSAttributedString?
     @Published public var image: UIImage?
     @Published public var trailingImage: UIImage?
+    @Published public var trailingImageAccessibilityLabel: String?
 
     /// Title to display in the action button on the trailing edge of the control.
     ///
@@ -392,6 +400,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
                      attributedTitle: NSAttributedString? = nil,
                      image: UIImage? = nil,
                      trailingImage: UIImage? = nil,
+                     trailingImageAccessibilityLabel: String? = nil,
                      actionButtonTitle: String? = nil,
                      actionButtonAction: (() -> Void)? = nil,
                      messageButtonAction: (() -> Void)? = nil) {
@@ -403,6 +412,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
         self.attributedTitle = attributedTitle
         self.image = image
         self.trailingImage = trailingImage
+        self.trailingImageAccessibilityLabel = trailingImageAccessibilityLabel
         self.actionButtonTitle = actionButtonTitle
         self.actionButtonAction = actionButtonAction
         self.messageButtonAction = messageButtonAction

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -286,17 +286,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             }
         }
 
-        @ViewBuilder
-        var accessibleNotification: some View {
-            if #available(iOS 15.0, *) {
-                presentableNotification
-                    .accessibilityFocused($isNotificationFocused)
-            } else {
-                presentableNotification
-            }
-        }
-
-        return accessibleNotification
+        return presentableNotification
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
@@ -330,17 +320,11 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                               blendDuration: 0)) {
             bottomOffset = 0
         }
-        if #available(iOS 15.0, *) {
-            isNotificationFocused = true
-        }
     }
 
     private func dismissAnimated() {
         withAnimation(.linear(duration: tokens.style.animationDurationForHide)) {
             bottomOffset = bottomOffsetForDismissedState
-        }
-        if #available(iOS 15.0, *) {
-            isNotificationFocused = false
         }
     }
 
@@ -351,8 +335,6 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     @State private var innerContentsSize: CGSize = CGSize()
     @State private var attributedMessageSize: CGSize = CGSize()
     @State private var attributedTitleSize: CGSize = CGSize()
-    @available(iOS 15.0, *)
-    @AccessibilityFocusState var isNotificationFocused: Bool
 
     // When true, the notification view will take up all proposed space
     // and automatically position itself within it.

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -286,7 +286,17 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             }
         }
 
-        return presentableNotification
+        @ViewBuilder
+        var accessibleNotification: some View {
+            if #available(iOS 15.0, *) {
+                presentableNotification
+                    .accessibilityFocused($isNotificationFocused)
+            } else {
+                presentableNotification
+            }
+        }
+
+        return accessibleNotification
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
@@ -320,12 +330,17 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                               blendDuration: 0)) {
             bottomOffset = 0
         }
-        UIAccessibility.post(notification: .layoutChanged, argument: self)
+        if #available(iOS 15.0, *) {
+            isNotificationFocused = true
+        }
     }
 
     private func dismissAnimated() {
         withAnimation(.linear(duration: tokens.style.animationDurationForHide)) {
             bottomOffset = bottomOffsetForDismissedState
+        }
+        if #available(iOS 15.0, *) {
+            isNotificationFocused = false
         }
     }
 
@@ -336,6 +351,8 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     @State private var innerContentsSize: CGSize = CGSize()
     @State private var attributedMessageSize: CGSize = CGSize()
     @State private var attributedTitleSize: CGSize = CGSize()
+    @available(iOS 15.0, *)
+    @AccessibilityFocusState var isNotificationFocused: Bool
 
     // When true, the notification view will take up all proposed space
     // and automatically position itself within it.

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -197,11 +197,12 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
             } else {
                 let horizontalSpacing = tokens.horizontalSpacing
                 HStack(spacing: isFlexibleWidthToast ? horizontalSpacing : 0) {
-                    image
-                        .padding(.trailing, isFlexibleWidthToast ? 0 : horizontalSpacing)
-                    textContainer
-                    if !isFlexibleWidthToast {
-                        Spacer(minLength: horizontalSpacing)
+                    HStack(spacing: horizontalSpacing) {
+                        image
+                        textContainer
+                        if !isFlexibleWidthToast {
+                            Spacer(minLength: horizontalSpacing)
+                        }
                     }
                     button
                         .layoutPriority(1)

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -168,6 +168,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     .lineLimit(1)
                     .foregroundColor(Color(dynamicColor: foregroundColor))
                     .font(.fluent(tokens.boldTextFont))
+                    .hoverEffect()
                 } else {
                     SwiftUI.Button(action: {
                         isPresented = false
@@ -181,6 +182,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                         }
                     })
                     .foregroundColor(Color(dynamicColor: foregroundColor))
+                    .hoverEffect()
                 }
             }
         }
@@ -208,6 +210,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     .accessibilityElement(children: .combine)
                     .modifyIf(messageButtonAction != nil, { messageButton in
                         messageButton.accessibilityAddTraits(.isButton)
+                            .hoverEffect()
                     })
                     button
                         .layoutPriority(1)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- Image and Text
  - Put the image and text container in their own stack so they could be read as a single accessible element
  - Added the button trait if there is a message button action, to indicate that selection will do something
  - Added pointer interaction if there is a message button action
- Button 
  - Fixed the default X icon dismiss button reading out "dismiss-20x20" instead of just "Dismiss"
  - Added pointer interaction
  - Added way to set accessibility label for custom trailing image

### Verification

Before:

https://user-images.githubusercontent.com/67026548/179638030-47bf951f-0e36-4585-aa5a-76c970fefe8a.mov


After:

https://user-images.githubusercontent.com/67026548/179870616-e12d9625-a99a-4f96-b6b4-32bccce5d4f7.mov

| Before | After |
|---|---|
| ![Notification_Pointer_Before](https://user-images.githubusercontent.com/67026548/179871266-cda00adc-b615-42ee-9b36-c75f7508159e.gif) | ![Notification_Pointer_After](https://user-images.githubusercontent.com/67026548/179871282-d25064c7-e739-48fa-bb0c-2ef9db14715d.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1078)