### PR TITLE
Cleaning up redundant @available attributes for iOS 14.

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -34,7 +34,6 @@ open class CommandBarItem: NSObject {
         self.accessibilityHint = accessibilityHint
     }
 
-    @available(iOS 14.0, *)
     @objc public init(
         iconImage: UIImage?,
         title: String? = nil,
@@ -101,10 +100,8 @@ open class CommandBarItem: NSObject {
     /// Set `isSelected` to desired value in this handler. Default implementation is toggling `isSelected` property.
     @objc public var itemTappedHandler: ItemTappedHandler
 
-    @available(iOS 14.0, *)
     @objc public lazy var menu: UIMenu? = nil // Only lazy property can be used with @available
 
-    @available(iOS 14.0, *)
     @objc public lazy var showsMenuAsPrimaryAction: Bool = false
 
     public static let defaultItemTappedHandler: ItemTappedHandler = { _, item in


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#1058 reports a break with Xcode 14 beta 2 related to @available annotations in stored properties.
Turns out that those annotations are now redundant as our minimum target deployment version is already iOS 14.

This change removes the annotations which will consequentially resolve the issue mentioned above.

### Verification

- Sanity build and run of demo app.
- pod lib lint

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1079)