### PR TITLE
[Fluent 2 iOS] BadgeField colors update

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -206,7 +206,7 @@ open class BadgeField: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let window = window, window.isEqual(notification.object) else {
+        guard window?.isEqual(notification.object) == true else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -162,7 +162,12 @@ open class BadgeField: UIView {
 
     @objc public init() {
         super.init(frame: .zero)
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
+        updateBackgroundColor()
 
         labelView.style = Constants.textStyle
         labelView.colorStyle = Constants.labelColorStyle
@@ -200,12 +205,22 @@ open class BadgeField: UIView {
         isAccessibilityElement = false
     }
 
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateBackgroundColor()
+    }
+
+    private func updateBackgroundColor() {
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+    }
+
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
     deinit {
-
         UIDevice.current.endGeneratingDeviceOrientationNotifications()
     }
 

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -45,14 +45,6 @@ public protocol BadgeFieldDelegate: AnyObject {
     @objc optional func badgeFieldShouldKeepBadgesActiveOnEndEditing(_ badgeField: BadgeField) -> Bool
 }
 
-// MARK: - BadgeField Colors
-
-private extension Colors {
-    struct BadgeField {
-        static var background: UIColor = surfacePrimary
-    }
-}
-
 // MARK: - BadgeField
 /**
  BadgeField is a UIView that acts as a UITextField that can contains badges with enclosed text.
@@ -170,7 +162,7 @@ open class BadgeField: UIView {
 
     @objc public init() {
         super.init(frame: .zero)
-        backgroundColor = Colors.BadgeField.background
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
 
         labelView.style = Constants.textStyle
         labelView.colorStyle = Constants.labelColorStyle


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The background color of the BadgeField was updated to match fluent 2 specs. 

### Verification

The change was tested on iPhone and iPad on the demo app. The background color looks off on the iPad screenshots since dark elevated colors aren't yet defined for this control. This will be updated in another pass later on once dark elevated color tokens are defined. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="311" alt="before_light" src="https://user-images.githubusercontent.com/106181067/179822377-7dfaa85e-e0b5-4917-8a4d-e10c4773a706.png"> | <img width="315" alt="after_light" src="https://user-images.githubusercontent.com/106181067/179822428-e5414351-21bb-49b8-8ece-bca04ad20a99.png"> |
| <img width="317" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/179822485-1590b8a9-24ba-45e3-b507-5cc88c806257.png"> | <img width="315" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/179822539-7be4660f-106f-4ae5-953e-127b043cc11b.png"> |
| <img width="858" alt="ipad_before" src="https://user-images.githubusercontent.com/106181067/179822599-9d009515-796a-4025-b451-3bcfc4089f23.png"> | <img width="858" alt="ipad_after" src="https://user-images.githubusercontent.com/106181067/179822659-14746739-4235-4971-ae28-0357a0c080cf.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1080)