### PR TITLE
Avatar custom ring bug fix

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -48,12 +48,10 @@ class AvatarDemoController: DemoTableViewController {
 
         case .alternateBackground,
              .animating,
-             .imageBasedRingColor,
              .outOfOffice,
              .pointerInteraction,
              .presence,
              .ringInnerGap,
-             .ring,
              .transparency:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
@@ -64,6 +62,36 @@ class AvatarDemoController: DemoTableViewController {
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.updateSetting(for: row, isOn: cell?.isOn ?? true)
             }
+
+            return cell
+
+        case .imageBasedRingColor:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
+                return UITableViewCell()
+            }
+
+            cell.setup(title: row.title, isOn: self.isSettingOn(row: row))
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.updateSetting(for: row, isOn: cell?.isOn ?? true)
+            }
+
+            customRingIndexPath = indexPath
+
+            return cell
+
+        case .ring:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
+                return UITableViewCell()
+            }
+
+            cell.setup(title: row.title, isOn: self.isSettingOn(row: row))
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.updateSetting(for: row, isOn: cell?.isOn ?? true)
+            }
+
+            ringIndexPath = indexPath
 
             return cell
 
@@ -138,6 +166,9 @@ class AvatarDemoController: DemoTableViewController {
         }
     }
 
+    private var ringIndexPath: IndexPath?
+    private var customRingIndexPath: IndexPath?
+
     private var isAnimated: Bool = true {
         didSet {
             if oldValue != isAnimated {
@@ -187,6 +218,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isShowingRings: Bool = false {
         didSet {
             if oldValue != isShowingRings {
+                updateCustomRingCell()
                 allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.isRingVisible = isShowingRings
                 }
@@ -194,9 +226,30 @@ class AvatarDemoController: DemoTableViewController {
         }
     }
 
+    private func updateCustomRingCell() {
+        guard let customRingIndexPath = customRingIndexPath, !isShowingRings else {
+            return
+        }
+
+        let cell = tableView.cellForRow(at: customRingIndexPath) as! BooleanCell
+        cell.isOn = false
+        updateSetting(for: .imageBasedRingColor, isOn: false)
+    }
+
+    private func updateRingCell() {
+        guard let ringIndexPath = ringIndexPath, isUsingImageBasedCustomColor else {
+            return
+        }
+
+        let cell = tableView.cellForRow(at: ringIndexPath) as! BooleanCell
+        cell.isOn = true
+        updateSetting(for: .ring, isOn: true)
+    }
+
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
             if oldValue != isUsingImageBasedCustomColor {
+                updateRingCell()
                 allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
                 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -65,7 +65,8 @@ class AvatarDemoController: DemoTableViewController {
 
             return cell
 
-        case .imageBasedRingColor:
+        case .imageBasedRingColor,
+             .ring:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
             }
@@ -76,22 +77,11 @@ class AvatarDemoController: DemoTableViewController {
                 self?.updateSetting(for: row, isOn: cell?.isOn ?? true)
             }
 
-            customRingIndexPath = indexPath
-
-            return cell
-
-        case .ring:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
-                return UITableViewCell()
+            if row == .imageBasedRingColor {
+                customRingIndexPath = indexPath
+            } else {
+                ringIndexPath = indexPath
             }
-
-            cell.setup(title: row.title, isOn: self.isSettingOn(row: row))
-            cell.titleNumberOfLines = 0
-            cell.onValueChanged = { [weak self, weak cell] in
-                self?.updateSetting(for: row, isOn: cell?.isOn ?? true)
-            }
-
-            ringIndexPath = indexPath
 
             return cell
 
@@ -218,7 +208,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isShowingRings: Bool = false {
         didSet {
             if oldValue != isShowingRings {
-                updateCustomRingCell()
+                switchOffCustomRingCell()
                 allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.isRingVisible = isShowingRings
                 }
@@ -226,7 +216,7 @@ class AvatarDemoController: DemoTableViewController {
         }
     }
 
-    private func updateCustomRingCell() {
+    private func switchOffCustomRingCell() {
         guard let customRingIndexPath = customRingIndexPath, !isShowingRings else {
             return
         }
@@ -236,7 +226,7 @@ class AvatarDemoController: DemoTableViewController {
         updateSetting(for: .imageBasedRingColor, isOn: false)
     }
 
-    private func updateRingCell() {
+    private func switchOnRingCell() {
         guard let ringIndexPath = ringIndexPath, isUsingImageBasedCustomColor else {
             return
         }
@@ -249,7 +239,7 @@ class AvatarDemoController: DemoTableViewController {
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
             if oldValue != isUsingImageBasedCustomColor {
-                updateRingCell()
+                switchOnRingCell()
                 allDemoAvatarsCombined.forEach { avatar in
                     avatar.state.imageBasedRingColor = isUsingImageBasedCustomColor ? AvatarDemoController.colorfulCustomImage : nil
                 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -45,7 +45,7 @@ struct AvatarDemoView: View {
                    image: showImage ? UIImage(named: "avatar_kat_larsson") : nil,
                    primaryText: primaryText,
                    secondaryText: secondaryText)
-                .isRingVisible(isRingVisible)
+                .isRingVisible(showImageBasedRingColor ? true : isRingVisible)
                 .hasRingInnerGap(hasRingInnerGap)
                 .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
                 .isTransparent(isTransparent)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -45,7 +45,7 @@ struct AvatarDemoView: View {
                    image: showImage ? UIImage(named: "avatar_kat_larsson") : nil,
                    primaryText: primaryText,
                    secondaryText: secondaryText)
-                .isRingVisible(showImageBasedRingColor ? true : isRingVisible)
+                .isRingVisible(showImageBasedRingColor || isRingVisible)
                 .hasRingInnerGap(hasRingInnerGap)
                 .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
                 .isTransparent(isTransparent)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The show custom ring toggle has been changed to show even when show ring toggle is off.

### Verification

**UIKit**
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_uikit](https://user-images.githubusercontent.com/106181067/180065154-6c4e0ca3-0326-4032-bb00-98ffe2bdbb8e.gif) | ![after_uikit](https://user-images.githubusercontent.com/106181067/180065202-93aea398-3b2a-48db-af0a-549c40685ccb.gif) |

**SwiftUI**
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_swiftui](https://user-images.githubusercontent.com/106181067/180065260-e29c93e8-9dde-425b-93c3-e9ac9d952333.gif) | ![after_swiftui](https://user-images.githubusercontent.com/106181067/180065294-8cdbf0e1-2bd3-4ff4-bfac-ffc3c05b97bd.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1085)