### PR TITLE
[Fluent2 Tokens] Fix usages of arguments in showNotification and hide in MSFNotification

### DIFF
--- a/ios/FluentUI/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Notification/MSFNotificationView.swift
@@ -59,7 +59,7 @@ import UIKit
         let presentationOffset: CGFloat! = notification.tokens.presentationOffset
         if style.isToast, let currentToast = MSFNotification.currentToast, currentToast.window != nil {
             currentToast.hide {
-                self.showNotification(in: view, completion: completion)
+                self.showNotification(in: view, from: anchorView, animated: animated, completion: completion)
             }
             return
         }

--- a/ios/FluentUI/Notification/MSFNotificationView.swift
+++ b/ios/FluentUI/Notification/MSFNotificationView.swift
@@ -152,16 +152,20 @@ import UIKit
             self.completionsForHide.forEach { $0() }
             self.completionsForHide.removeAll()
         }
-        if animated && !isHiding {
-            isHiding = true
-            UIView.animate(withDuration: notification.tokens.style.animationDurationForHide, animations: {
-                self.constraintWhenShown.isActive = false
-                self.constraintWhenHidden.isActive = true
-                self.superview?.layoutIfNeeded()
-            }, completion: { _ in
-                self.isHiding = false
-                completionForHide()
-            })
+        if animated {
+            if !isHiding {
+                isHiding = true
+                UIView.animate(withDuration: notification.tokens.style.animationDurationForHide, animations: {
+                    self.constraintWhenShown.isActive = false
+                    self.constraintWhenHidden.isActive = true
+                    self.superview?.layoutIfNeeded()
+                }, completion: { _ in
+                    self.isHiding = false
+                    completionForHide()
+                })
+            }
+        } else {
+            completionForHide()
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When we updated the hide method, we simplified the logic for when we do `completionForHide()`, but we unfortunately simplified it too much and removed the case where we need to actually dismiss the notification without animations. We also stopped passing the anchorView and animated down to the call to show the new toast after dismissing the current toast.

### Verification

For testing purposes, I set the dismiss button action to not be animated, and removed the auto dismiss we have in the demo controller.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Notification_Dismiss_Before](https://user-images.githubusercontent.com/67026548/180107890-2d5a609b-b5a7-441a-bfd9-0713b8971e43.gif) | ![Notification_Dismiss_After](https://user-images.githubusercontent.com/67026548/180107902-f23e3c6c-fc9d-48ac-82a9-3fd24c76321a.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1087)