### PR TITLE
Expanding label width in TableViewCell to prevent attributedText from getting cut off

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -405,7 +405,11 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                                                               text: text, labelAccessoryViewMarginLeading: labelAccessoryViewMarginLeading)
 
         let availableWidth = textAreaWidth - (leadingAccessoryAreaWidth + trailingAccessoryAreaWidth)
-        return text.preferredSize(for: font, width: availableWidth, numberOfLines: numberOfLines)
+
+        // The width from preferredSize() will hug the label, which results in cut-off text if the label has additional attributes.
+        // We want to have the available width to prevent any cut-off.
+        return CGSize(width: text.isEmpty ? 0 : availableWidth,
+                      height: text.preferredSize(for: font, width: availableWidth, numberOfLines: numberOfLines).height)
     }
 
     private static func labelPreferredWidth(text: String,

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -443,16 +443,21 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     private static func preferredLabelSize(with attributedText: NSAttributedString,
                                            availableTextWidth: CGFloat = .greatestFiniteMagnitude) -> CGSize {
-        let estimatedBoundsWidth = attributedText.boundingRect(
+        // We need to have .usesDeviceMetrics to ensure that there is no trailing clipping in our label.
+        // However, it causes the bottom portion of the label to be clipped instead. Creating a caluclated CGRect
+        // for width and height accommodates for both scenarios so that there is no clipping.
+        let estimatedBoundsRectForWidth = attributedText.boundingRect(
             with: CGSize(width: availableTextWidth, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading, .usesDeviceMetrics],
             context: nil)
-        let estimatedBoundsHeight = attributedText.boundingRect(
+        let estimatedBoundsRectForHeight = attributedText.boundingRect(
             with: CGSize(width: availableTextWidth, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading],
             context: nil)
 
-        return CGSize(width: ceil(max(estimatedBoundsWidth.width, estimatedBoundsHeight.width)), height: ceil(estimatedBoundsHeight.height))
+        // We want the larger width value so that the label does not undergo any trucation.
+        return CGSize(width: ceil(max(estimatedBoundsRectForWidth.width, estimatedBoundsRectForHeight.width)),
+                      height: ceil(estimatedBoundsRectForHeight.height))
 
     }
 
@@ -1444,7 +1449,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         if isAttributedTextSet, let attributedText = label.attributedText {
             visibleText = attributedText.string
-            size = Self.preferredLabelSize(with: attributedText)
+            size = Self.preferredLabelSize(with: attributedText, availableTextWidth: textAreaWidth)
         } else {
             visibleText = text
             size = text.preferredSize(for: label.font, width: textAreaWidth, numberOfLines: numberOfLines)

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -446,18 +446,13 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         // We need to have .usesDeviceMetrics to ensure that there is no trailing clipping in our label.
         // However, it causes the bottom portion of the label to be clipped instead. Creating a calculated CGRect
         // for width and height accommodates for both scenarios so that there is no clipping.
-        let estimatedBoundsRectForWidth = attributedText.boundingRect(
-            with: CGSize(width: availableTextWidth, height: .greatestFiniteMagnitude),
-            options: [.usesLineFragmentOrigin, .usesFontLeading, .usesDeviceMetrics],
-            context: nil)
-        let estimatedBoundsRectForHeight = attributedText.boundingRect(
+        let estimatedBoundsHeight = attributedText.boundingRect(
             with: CGSize(width: availableTextWidth, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading],
             context: nil)
 
         // We want the larger width value so that the label does not undergo any trucation.
-        return CGSize(width: ceil(max(estimatedBoundsRectForWidth.width, estimatedBoundsRectForHeight.width)),
-                      height: ceil(estimatedBoundsRectForHeight.height))
+        return CGSize(width: ceil(availableTextWidth), height: ceil(estimatedBoundsHeight.height))
 
     }
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -406,10 +406,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         let availableWidth = textAreaWidth - (leadingAccessoryAreaWidth + trailingAccessoryAreaWidth)
 
-        // The width from preferredSize() will hug the label, which results in cut-off text if the label has additional attributes.
-        // We want to have the available width to prevent any cut-off.
-        return CGSize(width: text.isEmpty ? 0 : availableWidth,
-                      height: text.preferredSize(for: font, width: availableWidth, numberOfLines: numberOfLines).height)
+        return text.preferredSize(for: font, width: availableWidth, numberOfLines: numberOfLines)
     }
 
     private static func labelPreferredWidth(text: String,

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -444,7 +444,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     private static func preferredLabelSize(with attributedText: NSAttributedString,
                                            availableTextWidth: CGFloat = .greatestFiniteMagnitude) -> CGSize {
         // We need to have .usesDeviceMetrics to ensure that there is no trailing clipping in our label.
-        // However, it causes the bottom portion of the label to be clipped instead. Creating a caluclated CGRect
+        // However, it causes the bottom portion of the label to be clipped instead. Creating a calculated CGRect
         // for width and height accommodates for both scenarios so that there is no clipping.
         let estimatedBoundsRectForWidth = attributedText.boundingRect(
             with: CGSize(width: availableTextWidth, height: .greatestFiniteMagnitude),

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -285,6 +285,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                    labelAccessoryViewMarginTrailing: labelAccessoryViewMarginTrailing).height,
             subtitleHeight: labelSize(text: subtitle,
                                       attributedText: attributedSubtitle,
+                                      isAttributedTextSet: isAttributedSubtitleSet,
                                       font: subtitleFont ?? UIFont.fluent(layoutType == .twoLines ? tokens.subtitleTwoLinesFont : tokens.subtitleThreeLinesFont),
                                       numberOfLines: subtitleNumberOfLines,
                                       textAreaWidth: textAreaWidth,
@@ -294,6 +295,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                       labelAccessoryViewMarginTrailing: labelAccessoryViewMarginTrailing).height,
             footerHeight: labelSize(text: footer,
                                     attributedText: attributedFooter,
+                                    isAttributedTextSet: isAttributedFooterSet,
                                     font: footerFont ?? UIFont.fluent(tokens.subtitleThreeLinesFont),
                                     numberOfLines: footerNumberOfLines,
                                     textAreaWidth: textAreaWidth,
@@ -384,6 +386,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         let labelAccessoryViewMarginTrailing = tokens.labelAccessoryViewMarginTrailing
 
         var textAreaWidth = Self.labelPreferredWidth(text: title,
+                                                     attributedText: attributedTitle,
+                                                     isAttributedTextSet: isAttributedTitleSet,
                                                      font: titleFont ?? UIFont.fluent(tokens.titleFont),
                                                      leadingAccessoryView: titleLeadingAccessoryView,
                                                      trailingAccessoryView: titleTrailingAccessoryView,
@@ -391,6 +395,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                                      labelAccessoryViewMarginLeading: labelAccessoryViewMarginLeading)
         if layoutType == .twoLines || layoutType == .threeLines {
             let subtitleWidth = Self.labelPreferredWidth(text: subtitle,
+                                                         attributedText: attributedSubtitle,
+                                                         isAttributedTextSet: isAttributedSubtitleSet,
                                                          font: subtitleFont ?? UIFont.fluent(layoutType == .twoLines ? tokens.subtitleTwoLinesFont : tokens.subtitleThreeLinesFont),
                                                          leadingAccessoryView: subtitleLeadingAccessoryView,
                                                          trailingAccessoryView: subtitleTrailingAccessoryView,
@@ -399,6 +405,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             textAreaWidth = max(textAreaWidth, subtitleWidth)
             if layoutType == .threeLines {
                 let footerWidth = Self.labelPreferredWidth(text: footer,
+                                                           attributedText: attributedFooter,
+                                                           isAttributedTextSet: isAttributedFooterSet,
                                                            font: footerFont ?? UIFont.fluent(tokens.footerFont),
                                                            leadingAccessoryView: footerLeadingAccessoryView,
                                                            trailingAccessoryView: footerTrailingAccessoryView,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Addressing #1057. 

The width of the label frame in TableViewCell is determined by our String extension `preferredSize()`, which chooses the minimum value between a given available text width and the width of the text's font. However, with the addition of the `.attributedText` support, we need to make sure we are accommodating for any other label attributes to prevent the label from being cut off.

### Verification

Made sure that this changed fixed any cut-off scenarios and prevented any visual regressions.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-21 at 12 21 11](https://user-images.githubusercontent.com/22566866/180298510-1b64bac4-8c3a-4572-bff2-007e92b7c9fa.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-21 at 12 22 09](https://user-images.githubusercontent.com/22566866/180298675-d59833ad-9384-4c96-9841-0f991a150088.png) |
| ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-25 at 18 01 31](https://user-images.githubusercontent.com/22566866/180900110-a72bdba9-41b7-46ff-997a-2b70f11f01a4.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-07-25 at 17 58 59](https://user-images.githubusercontent.com/22566866/180899873-d739eb3b-ba2a-42ed-a124-9b2817ffe184.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1088)