### PR TITLE
Fix for progress bar accessibility trait bug

### DIFF
--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -42,6 +42,7 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
                    maxHeight: height,
                    alignment: .center)
             .background(backgroundColor)
+            .accessibilityAddTraits(.isImage)
             .modifyIf(state.isAnimating, { view in
                 view
                     .onAppear {

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -31,6 +31,16 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
         let height = tokens.height
         let gradientColor = Color(dynamicColor: tokens.gradientColor)
         let backgroundColor = Color(dynamicColor: tokens.backgroundColor)
+        let accessibilityLabel: String = {
+            if let overriddenAccessibilityLabel = state.accessibilityLabel {
+                return overriddenAccessibilityLabel
+            }
+
+            return state.isAnimating ?
+                "Accessibility.ActivityIndicator.Animating.label".localized
+                :
+                "Accessibility.ActivityIndicator.Stopped.label".localized
+        }()
 
         Rectangle()
             .fill(LinearGradient(gradient: Gradient(colors: [backgroundColor, gradientColor, backgroundColor]),
@@ -42,6 +52,7 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
                    maxHeight: height,
                    alignment: .center)
             .background(backgroundColor)
+            .accessibilityLabel(Text(accessibilityLabel))
             .accessibilityAddTraits(.updatesFrequently)
             .modifyIf(state.isAnimating, { view in
                 view

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -42,7 +42,7 @@ public struct IndeterminateProgressBar: View, ConfigurableTokenizedControl {
                    maxHeight: height,
                    alignment: .center)
             .background(backgroundColor)
-            .accessibilityAddTraits(.isImage)
+            .accessibilityAddTraits(.updatesFrequently)
             .modifyIf(state.isAnimating, { view in
                 view
                     .onAppear {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When selecting the progress bar in the UIKit demo, VoiceOver would say "button", but nothing would happen in the SwiftUI demo. It appears this had nothing to do with the progress bar, but it was the `TableViewCell` in the UIKit demo that has accessibility traits set to button by default which is what VoiceOver was reading out. The `updatesFrequently` trait was added to the progress bar as well as the activity indicator accessibility label.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/106181067/180839351-93739efb-d23d-4f5a-ad8e-31d583a62af6.mov | https://user-images.githubusercontent.com/106181067/181353958-79c1a0ed-a72a-4848-806e-9152c37fe795.mov |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1091)