### PR TITLE
Fixing separator leading insets.

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1430,9 +1430,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         guard type == .inset else {
             return 0
         }
-        let baseOffset = safeAreaInsets.left + TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
-                                                                                    selectionImageMarginTrailing: tokens.selectionImageMarginTrailing,
-                                                                                    selectionImageSize: tokens.selectionImageSize.width)
+        let baseOffset = TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
+                                                              selectionImageMarginTrailing: tokens.selectionImageMarginTrailing,
+                                                              selectionImageSize: tokens.selectionImageSize.width)
         return baseOffset + paddingLeading + tokens.customViewDimensions.width + tokens.customViewTrailingMargin
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The calculation for the leading insets of the separator (now replaced with the new MSFDivider control) is incorrect as it takes the safe area left inset into consideration while it's being added to the cell's content view, which already respects the safe area insets.

The previous version of the TableViewCell that used the Separator control added it to the cell view directly instead of the contentView. That was the reason the safeAreaInsets.left need to be considered in the calculation of the separator insets.

### Verification

Ran in both iPhone and iPad running iOS 14 and 15.
Verified that the Separator inset was always rendered correctly as the screenshots below show:

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![separatorLeadingInsets_bug_dark](https://user-images.githubusercontent.com/68076145/180584684-67cdf603-fe40-411b-9b64-d54387b02304.png) | ![separatorLeadingInsets_fixed_dark](https://user-images.githubusercontent.com/68076145/180584689-0248c14b-39a7-4e27-9cf1-28696a2d0fb4.png) |
| ![separatorLeadingInsets_bug](https://user-images.githubusercontent.com/68076145/180584688-412679ad-fc8e-4ea6-ba1e-97bf9deaccc5.png) | ![separatorLeadingInsets_fixed](https://user-images.githubusercontent.com/68076145/180584690-adce6ae9-b2e1-4f9c-9f6a-69609e396388.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1093)