### PR TITLE
[Fluent 2 iOS] TableViewHeaderFooterView colors update

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -30,7 +30,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .regular:
-                return Colors.Table.HeaderFooter.accessoryButtonText
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.globalTokens.sharedColors[.red][.shade10], dark: fluentTheme.globalTokens.sharedColors[.red][.tint30]))
             case .primary:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
             }
@@ -52,9 +52,8 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
             case .divider:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
-            // This color might be changed
             case .dividerHighlighted:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground2])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground4])
             }
         }
 
@@ -64,12 +63,10 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .divider:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            // This color might be changed
             case .dividerHighlighted:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3])
-            // This color might be changed
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground4])
             case .headerPrimary:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             }
         }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -27,12 +27,12 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         case regular
         case primary
 
-        func textColor(for window: UIWindow) -> UIColor {
+        func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .regular:
                 return Colors.Table.HeaderFooter.accessoryButtonText
             case .primary:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.primary(for: window))
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
             }
         }
     }
@@ -46,27 +46,30 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         case footer
         case headerPrimary
 
-        func backgroundColor(for window: UIWindow) -> UIColor {
+        func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .header, .footer, .headerPrimary:
-                return Colors.Table.HeaderFooter.background
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
             case .divider:
-                return Colors.Table.HeaderFooter.backgroundDivider
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
+            // This color might be changed
             case .dividerHighlighted:
-                return UIColor(light: Colors.primaryTint40(for: window), dark: Colors.surfaceSecondary)
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground2])
             }
         }
 
-        func textColor(for window: UIWindow) -> UIColor {
+        func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .header, .footer:
-                return Colors.Table.HeaderFooter.text
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .divider:
-                return Colors.Table.HeaderFooter.textDivider
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            // This color might be changed
             case .dividerHighlighted:
-                return Colors.primary(for: window)
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3])
+            // This color might be changed
             case .headerPrimary:
-                return Colors.textPrimary
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3])
             }
         }
 
@@ -486,17 +489,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     }
 
     private func updateTitleAndBackgroundColors() {
-        if let window = window {
-            titleView.textColor = style.textColor(for: window)
-            backgroundView?.backgroundColor = style.backgroundColor(for: window)
-            titleView.font = style.textFont()
-        }
+        titleView.textColor = style.textColor(fluentTheme: fluentTheme)
+        backgroundView?.backgroundColor = style.backgroundColor(fluentTheme: fluentTheme)
+        titleView.font = style.textFont()
     }
 
     private func updateAccessoryButtonTitleColor() {
-        if let window = window {
-            accessoryButton?.setTitleColor(accessoryButtonStyle.textColor(for: window), for: .normal)
-        }
+        accessoryButton?.setTitleColor(accessoryButtonStyle.textColor(fluentTheme: fluentTheme), for: .normal)
     }
 
     private func updateAccessoryButtonTitleStyle() {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -280,6 +280,19 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         contentView.addGestureRecognizer(tapGesture)
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateTitleAndBackgroundColors()
+        updateAccessoryButtonTitleColor()
     }
 
     // MARK: Setup
@@ -468,12 +481,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 accessoryView: accessoryView
             )
         )
-    }
-
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateTitleAndBackgroundColors()
-        updateAccessoryButtonTitleColor()
     }
 
     private func updateTitleViewFont() {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -30,7 +30,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .regular:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.globalTokens.sharedColors[.red][.shade10], dark: fluentTheme.globalTokens.sharedColors[.red][.tint30]))
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .primary:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The colors were updated with fluent 2 tokens. 

### Verification

All the changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_default_light](https://user-images.githubusercontent.com/106181067/180874675-e0df1804-8669-4f04-ad36-e6285a821875.gif) | ![after_default_light](https://user-images.githubusercontent.com/106181067/180875380-984b4cb7-1f5d-4357-97b2-1ec701b4bcf3.gif) |
| ![before_default_dark](https://user-images.githubusercontent.com/106181067/180875439-76ddf06e-936b-45f2-81e5-7ecff55eb111.gif) | ![after_default_dark](https://user-images.githubusercontent.com/106181067/180875666-e68c72e2-8587-4540-b074-252b56f67c21.gif) |
| ![before_divider_light](https://user-images.githubusercontent.com/106181067/180875741-bcfe9760-db28-4121-8c16-c4fb2eecb10d.gif) | ![after_divider_light](https://user-images.githubusercontent.com/106181067/180875779-d8902401-19e8-490e-932c-6fcb7ccc0b66.gif) |
| ![before_divider_dark](https://user-images.githubusercontent.com/106181067/180875809-6c13552e-a612-4d07-afde-e25c427c12d4.gif) | ![after_divider_dark](https://user-images.githubusercontent.com/106181067/180875836-b9d22214-b1d1-484d-b470-9b2c54109611.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1094)