### PR TITLE
[Fluent2 Tokens] Moving `Avatar` calculated colors out of `AvatarTokens`

### DIFF
--- a/ios/FluentUI.Tests/ColorTests.swift
+++ b/ios/FluentUI.Tests/ColorTests.swift
@@ -14,39 +14,6 @@ class ColorTests: XCTestCase {
         }
     }
 
-    /// Validates that the background and foreground colors for a given index of the Colors.avatarColors property match comparing:
-    ///  1. A color light mode background color with its counterpart dark mode foreground color. The color should be the same (tint40)
-    ///  2. A color light mode foreground color with its counterpart dark mode background color. The color should be the same (shade30)
-    ///
-    /// Text calculated colors are defined as the following for a given color:
-    ///  - Light mode:
-    ///    - Background: tint40
-    ///    - Foreground: shade30
-    ///  - Dark mode:
-    ///    - Background: shade30
-    ///    - Foreground: tint40
-    func testAvatarColorsMatch() {
-        let avatarTokens = AvatarTokens()
-        let backgroundColors = avatarTokens.backgroundCalculatedColorOptions
-        let foregroundColors = avatarTokens.foregroundCalculatedColorOptions
-
-        for (index, bgColor) in backgroundColors.enumerated() {
-            let fgColor = foregroundColors[index]
-            let bgLightColor = UIColor(colorValue: bgColor.light)
-            let bgDarkColor = UIColor(colorValue: bgColor.dark!)
-            let fgLightColor = UIColor(colorValue: fgColor.light)
-            let fgDarkColor = UIColor(colorValue: fgColor.dark!)
-
-            XCTAssertEqual(bgLightColor,
-                           fgDarkColor,
-                           "Index \(index): Background color in light mode does not match Foreground color in dark mode.")
-
-            XCTAssertEqual(bgDarkColor,
-                           fgLightColor,
-                           "Index \(index): Background color in dark mode does not match Foreground color in light mode.")
-        }
-    }
-
     func testColorValue() {
         let hexColorValue = ColorValue(0xC7E0F4)
         XCTAssertEqual(hexColorValue.a, 1.0)

--- a/ios/FluentUI/Avatar/AvatarTokens.swift
+++ b/ios/FluentUI/Avatar/AvatarTokens.swift
@@ -141,40 +141,6 @@ open class AvatarTokens: ControlTokens {
     /// The color of the outline around the presence.
     open var presenceOutlineColor: DynamicColor { aliasTokens.backgroundColors[.neutral1] }
 
-    /// The color for the background calculated using a hash of the strings.
-    open var backgroundCalculatedColorOptions: [DynamicColor] {
-        return [.init(light: globalTokens.sharedColors[.darkRed][.tint40], dark: globalTokens.sharedColors[.darkRed][.shade30]),
-                .init(light: globalTokens.sharedColors[.cranberry][.tint40], dark: globalTokens.sharedColors[.cranberry][.shade30]),
-                .init(light: globalTokens.sharedColors[.red][.tint40], dark: globalTokens.sharedColors[.red][.shade30]),
-                .init(light: globalTokens.sharedColors[.pumpkin][.tint40], dark: globalTokens.sharedColors[.pumpkin][.shade30]),
-                .init(light: globalTokens.sharedColors[.peach][.tint40], dark: globalTokens.sharedColors[.peach][.shade30]),
-                .init(light: globalTokens.sharedColors[.marigold][.tint40], dark: globalTokens.sharedColors[.marigold][.shade30]),
-                .init(light: globalTokens.sharedColors[.gold][.tint40], dark: globalTokens.sharedColors[.gold][.shade30]),
-                .init(light: globalTokens.sharedColors[.brass][.tint40], dark: globalTokens.sharedColors[.brass][.shade30]),
-                .init(light: globalTokens.sharedColors[.brown][.tint40], dark: globalTokens.sharedColors[.brown][.shade30]),
-                .init(light: globalTokens.sharedColors[.forest][.tint40], dark: globalTokens.sharedColors[.forest][.shade30]),
-                .init(light: globalTokens.sharedColors[.seafoam][.tint40], dark: globalTokens.sharedColors[.seafoam][.shade30]),
-                .init(light: globalTokens.sharedColors[.darkGreen][.tint40], dark: globalTokens.sharedColors[.darkGreen][.shade30]),
-                .init(light: globalTokens.sharedColors[.lightTeal][.tint40], dark: globalTokens.sharedColors[.lightTeal][.shade30]),
-                .init(light: globalTokens.sharedColors[.teal][.tint40], dark: globalTokens.sharedColors[.teal][.shade30]),
-                .init(light: globalTokens.sharedColors[.steel][.tint40], dark: globalTokens.sharedColors[.steel][.shade30]),
-                .init(light: globalTokens.sharedColors[.blue][.tint40], dark: globalTokens.sharedColors[.blue][.shade30]),
-                .init(light: globalTokens.sharedColors[.royalBlue][.tint40], dark: globalTokens.sharedColors[.royalBlue][.shade30]),
-                .init(light: globalTokens.sharedColors[.cornflower][.tint40], dark: globalTokens.sharedColors[.cornflower][.shade30]),
-                .init(light: globalTokens.sharedColors[.navy][.tint40], dark: globalTokens.sharedColors[.navy][.shade30]),
-                .init(light: globalTokens.sharedColors[.lavender][.tint40], dark: globalTokens.sharedColors[.lavender][.shade30]),
-                .init(light: globalTokens.sharedColors[.purple][.tint40], dark: globalTokens.sharedColors[.purple][.shade30]),
-                .init(light: globalTokens.sharedColors[.grape][.tint40], dark: globalTokens.sharedColors[.grape][.shade30]),
-                .init(light: globalTokens.sharedColors[.lilac][.tint40], dark: globalTokens.sharedColors[.lilac][.shade30]),
-                .init(light: globalTokens.sharedColors[.pink][.tint40], dark: globalTokens.sharedColors[.pink][.shade30]),
-                .init(light: globalTokens.sharedColors[.magenta][.tint40], dark: globalTokens.sharedColors[.magenta][.shade30]),
-                .init(light: globalTokens.sharedColors[.plum][.tint40], dark: globalTokens.sharedColors[.plum][.shade30]),
-                .init(light: globalTokens.sharedColors[.beige][.tint40], dark: globalTokens.sharedColors[.beige][.shade30]),
-                .init(light: globalTokens.sharedColors[.mink][.tint40], dark: globalTokens.sharedColors[.mink][.shade30]),
-                .init(light: globalTokens.sharedColors[.platinum][.tint40], dark: globalTokens.sharedColors[.platinum][.shade30]),
-                .init(light: globalTokens.sharedColors[.anchor][.tint40], dark: globalTokens.sharedColors[.anchor][.shade30])]
-    }
-
     /// The default color of the background of the `Avatar`.
     open var backgroundDefaultColor: DynamicColor {
         switch style {
@@ -189,40 +155,6 @@ open class AvatarTokens: ControlTokens {
         case .overflow:
             return aliasTokens.backgroundColors[.neutral4]
         }
-    }
-
-    /// The color of the foreground calculated using a hash of the strings.
-    open var foregroundCalculatedColorOptions: [DynamicColor] {
-        return [.init(light: globalTokens.sharedColors[.darkRed][.shade30], dark: globalTokens.sharedColors[.darkRed][.tint40]),
-                .init(light: globalTokens.sharedColors[.cranberry][.shade30], dark: globalTokens.sharedColors[.cranberry][.tint40]),
-                .init(light: globalTokens.sharedColors[.red][.shade30], dark: globalTokens.sharedColors[.red][.tint40]),
-                .init(light: globalTokens.sharedColors[.pumpkin][.shade30], dark: globalTokens.sharedColors[.pumpkin][.tint40]),
-                .init(light: globalTokens.sharedColors[.peach][.shade30], dark: globalTokens.sharedColors[.peach][.tint40]),
-                .init(light: globalTokens.sharedColors[.marigold][.shade30], dark: globalTokens.sharedColors[.marigold][.tint40]),
-                .init(light: globalTokens.sharedColors[.gold][.shade30], dark: globalTokens.sharedColors[.gold][.tint40]),
-                .init(light: globalTokens.sharedColors[.brass][.shade30], dark: globalTokens.sharedColors[.brass][.tint40]),
-                .init(light: globalTokens.sharedColors[.brown][.shade30], dark: globalTokens.sharedColors[.brown][.tint40]),
-                .init(light: globalTokens.sharedColors[.forest][.shade30], dark: globalTokens.sharedColors[.forest][.tint40]),
-                .init(light: globalTokens.sharedColors[.seafoam][.shade30], dark: globalTokens.sharedColors[.seafoam][.tint40]),
-                .init(light: globalTokens.sharedColors[.darkGreen][.shade30], dark: globalTokens.sharedColors[.darkGreen][.tint40]),
-                .init(light: globalTokens.sharedColors[.lightTeal][.shade30], dark: globalTokens.sharedColors[.lightTeal][.tint40]),
-                .init(light: globalTokens.sharedColors[.teal][.shade30], dark: globalTokens.sharedColors[.teal][.tint40]),
-                .init(light: globalTokens.sharedColors[.steel][.shade30], dark: globalTokens.sharedColors[.steel][.tint40]),
-                .init(light: globalTokens.sharedColors[.blue][.shade30], dark: globalTokens.sharedColors[.blue][.tint40]),
-                .init(light: globalTokens.sharedColors[.royalBlue][.shade30], dark: globalTokens.sharedColors[.royalBlue][.tint40]),
-                .init(light: globalTokens.sharedColors[.cornflower][.shade30], dark: globalTokens.sharedColors[.cornflower][.tint40]),
-                .init(light: globalTokens.sharedColors[.navy][.shade30], dark: globalTokens.sharedColors[.navy][.tint40]),
-                .init(light: globalTokens.sharedColors[.lavender][.shade30], dark: globalTokens.sharedColors[.lavender][.tint40]),
-                .init(light: globalTokens.sharedColors[.purple][.shade30], dark: globalTokens.sharedColors[.purple][.tint40]),
-                .init(light: globalTokens.sharedColors[.grape][.shade30], dark: globalTokens.sharedColors[.grape][.tint40]),
-                .init(light: globalTokens.sharedColors[.lilac][.shade30], dark: globalTokens.sharedColors[.lilac][.tint40]),
-                .init(light: globalTokens.sharedColors[.pink][.shade30], dark: globalTokens.sharedColors[.pink][.tint40]),
-                .init(light: globalTokens.sharedColors[.magenta][.shade30], dark: globalTokens.sharedColors[.magenta][.tint40]),
-                .init(light: globalTokens.sharedColors[.plum][.shade30], dark: globalTokens.sharedColors[.plum][.tint40]),
-                .init(light: globalTokens.sharedColors[.beige][.shade30], dark: globalTokens.sharedColors[.beige][.tint40]),
-                .init(light: globalTokens.sharedColors[.mink][.shade30], dark: globalTokens.sharedColors[.mink][.tint40]),
-                .init(light: globalTokens.sharedColors[.platinum][.shade30], dark: globalTokens.sharedColors[.platinum][.tint40]),
-                .init(light: globalTokens.sharedColors[.anchor][.shade30], dark: globalTokens.sharedColors[.anchor][.tint40])]
     }
 
     /// The default color of the foreground of the `Avatar`


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The calculated colors used by `Avatar` are not really design tokens per se, so this PR moves them out of the `AvatarTokens` class entirely.

This change creates a new struct, `Avatar.CalculatedColors`, that is responsible for all the work of calculating the colors based on a set of our "standard" global colors.

### Verification

Verified that there are no behavioral changes after this change.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/180870343-62fa400e-2562-4847-9894-bf437a9ec02d.gif) | ![after](https://user-images.githubusercontent.com/4934719/180870411-3cfc0c38-f2bd-4dc4-90b3-97b2df189c2a.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1095)