### PR TITLE
UIBackgroundConfiguration to change the cell color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -110,6 +110,10 @@ class DemoListViewController: DemoTableViewController {
         UserDefaults.standard.set(demo.title, forKey: DemoListViewController.lastDemoControllerKey)
     }
 
+    override func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+
     let cellReuseIdentifier: String = "TableViewCell"
     private static var isFirstLaunch: Bool = true
     private static let lastDemoControllerKey: String = "LastDemoController"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -108,7 +108,7 @@ class AvatarDemoController: DemoTableViewController {
                 cell.contentView.bottomAnchor.constraint(equalTo: avatarContentView.bottomAnchor)
             ])
 
-            cell.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -142,7 +142,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
-            cell.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -58,7 +58,7 @@ class CardNudgeDemoController: DemoTableViewController {
             let contentView = cell.contentView
             contentView.addSubview(view)
             cell.selectionStyle = .none
-            cell.backgroundColor = .systemBackground
+            cell.backgroundConfiguration?.backgroundColor = .systemBackground
             view.translatesAutoresizingMaskIntoConstraints = false
 
             let constraints = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -45,7 +45,6 @@ class DividerDemoController: DemoTableViewController {
             return cell
         case .dividerDemo:
             let cell = TableViewCell()
-            cell.backgroundColor = Colors.surfacePrimary
             let contentView = cell.contentView
 
             let spacing: MSFDividerSpacing = section == .defaultMedium ? .medium : .none

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -520,6 +520,10 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         }
     }
 
+    func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+
     private func updateNavigationTitle() {
         if isInSelectionMode {
             let selectedCount = tableView.indexPathsForSelectedRows?.count ?? 0
@@ -709,6 +713,10 @@ class ChildViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }
+
+    override func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
 }
 
 // MARK: - ModalViewController
@@ -761,7 +769,7 @@ class ModalViewController: UITableViewController {
             return UITableViewCell()
         }
         cell.setup(title: "Child Cell #\(1 + indexPath.row)")
-        cell.backgroundColor = isGrouped ? Colors.tableCellBackgroundGrouped : Colors.tableCellBackground
+        cell.backgroundStyleType = isGrouped ? .grouped : .plain
         cell.topSeparatorType = isGrouped && indexPath.row == 0 ? .full : .none
         return cell
     }
@@ -784,6 +792,10 @@ class ModalViewController: UITableViewController {
     private func updateTableView() {
         tableView.backgroundColor = isGrouped ? Colors.tableBackgroundGrouped : Colors.tableBackground
         tableView.reloadData()
+    }
+
+    override func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
+        return true
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -177,7 +177,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
 
         cell.contentView.addSubview(carousel)
         cell.selectionStyle = .none
-        cell.backgroundColor = .tertiarySystemFill
+        cell.backgroundConfiguration?.backgroundColor = .tertiarySystemFill
         var constraints: [NSLayoutConstraint] = []
         carousel.translatesAutoresizingMaskIntoConstraints = false
 
@@ -218,7 +218,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
 
         cell.contentView.addSubview(personaButton)
         cell.selectionStyle = .none
-        cell.backgroundColor = .tertiarySystemFill
+        cell.backgroundConfiguration?.backgroundColor = .tertiarySystemFill
         var constraints: [NSLayoutConstraint] = []
         personaButton.translatesAutoresizingMaskIntoConstraints = false
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -222,7 +222,7 @@ extension TableViewCellDemoController {
         cell.subtitleNumberOfLinesForLargerDynamicType = section.numberOfLines == 1 ? 2 : TableViewCell.defaultNumberOfLinesForLargerDynamicType
         cell.footerNumberOfLinesForLargerDynamicType = section.numberOfLines == 1 ? 2 : TableViewCell.defaultNumberOfLinesForLargerDynamicType
 
-        cell.backgroundColor = isGrouped ? Colors.tableCellBackgroundGrouped : Colors.tableCellBackground
+        cell.backgroundStyleType = isGrouped ? .grouped : .plain
         cell.topSeparatorType = isGrouped && indexPath.row == 0 ? .full : .none
         let isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
         cell.bottomSeparatorType = isLastInSection ? .full : .inset
@@ -269,5 +269,9 @@ extension TableViewCellDemoController {
         let action = UIAlertAction(title: "OK", style: .default)
         alert.addAction(action)
         present(alert, animated: true)
+    }
+
+    override func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
+        return true
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -684,7 +684,7 @@ class TableViewCellFileAccessoryViewDemoController: DemoTableViewController {
         cell.titleNumberOfLinesForLargerDynamicType = 3
         cell.subtitleNumberOfLinesForLargerDynamicType = 2
 
-        cell.backgroundColor = Colors.tableCellBackgroundGrouped
+        cell.backgroundStyleType = .grouped
         cell.topSeparatorType = .none
         cell.bottomSeparatorType = (top ? .inset : .none)
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -649,7 +649,7 @@ open class BottomCommandingController: UIViewController {
             cell.setup(title: item.title ?? "", customView: iconView)
         }
         cell.isEnabled = item.isEnabled
-        cell.backgroundColor = Constants.tableViewBackgroundColor
+        cell.backgroundStyleType = .clear
 
         let shouldShowSeparator = expandedListSections
             .prefix(expandedListSections.count - 1)

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -78,7 +78,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     private func updateTokens() {
         tokens = resolvedTokens
         updateActionTitleColors()
-        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
     }
 
     @objc public class func height(action1Title: String, action2Title: String = "", containerWidth: CGFloat, tokens: ActionsCellTokens) -> CGFloat {
@@ -145,8 +145,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         hideSystemSeparator()
         updateHorizontalSeparator(topSeparator, with: topSeparatorType)
         updateHorizontalSeparator(bottomSeparator, with: bottomSeparatorType)
-
-        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
 
         setupAction(action1Button)
         setupAction(action2Button)

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -41,7 +41,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
     private func updateTokens() {
         tokens = resolvedTokens
-        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
     }
 
     private let activityIndicator: MSFActivityIndicator = {
@@ -59,7 +59,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
                                                name: .didChangeTheme,
                                                object: nil)
 
-        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
     }
 
     @objc public required init(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -41,7 +41,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
 
     private func updateTokens() {
         tokens = resolvedTokens
-        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
         label.font = UIFont.fluent(tokens.titleFont)
         label.textColor = UIColor(dynamicColor: tokens.mainBrandColor)
     }

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -185,7 +185,7 @@ extension PersonaListView: UITableViewDataSource {
             }
             let persona = personaList[indexPath.row]
             cell.setup(persona: persona, accessoryType: accessoryType)
-            cell.backgroundColor = .clear
+            cell.backgroundStyleType = .clear
             cell.accessibilityTraits = .button
             return cell
         case .searchDirectory:

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -58,6 +58,25 @@ public enum TableViewCellAccessoryType: Int {
     }
 }
 
+// Different background color is shown based on if `TableViewCell` is shown in `TableView` as grouped or plain style
+@objc(MSFTableViewCellBackgroundStyleType)
+public enum TableViewCellBackgroundStyleType: Int {
+    case plain
+    case grouped
+    case clear
+
+    func defaultColor(tokens: TableViewCellTokens) -> UIColor? {
+        switch self {
+        case .plain:
+            return UIColor(dynamicColor: tokens.cellBackgroundColor)
+        case .grouped:
+            return UIColor(dynamicColor: tokens.cellBackgroundGrouped)
+        case .clear:
+            return .clear
+        }
+    }
+}
+
 // MARK: - Table Colors
 
 public extension Colors {
@@ -756,6 +775,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         didSet {
             if bottomSeparatorType != oldValue {
                 updateSeparator(bottomSeparator, with: bottomSeparatorType)
+            }
+        }
+    }
+
+    @objc public var backgroundStyleType: TableViewCellBackgroundStyleType = .plain {
+        didSet {
+            if backgroundStyleType != oldValue {
+                setupBackgroundColors()
             }
         }
     }
@@ -1587,6 +1614,15 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         updateSelectionImageView()
     }
 
+    open override func updateConfiguration(using state: UICellConfigurationState) {
+        // Customize the background color to use the tint color when the cell is highlighted or selected.
+        if state.isHighlighted || state.isSelected || state.isFocused {
+            backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundSelectedColor)
+        } else {
+            backgroundConfiguration?.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+        }
+    }
+
     private func updateLayoutType() {
         layoutType = TableViewCell.layoutType(
             subtitle: subtitleLabel.text ?? "",
@@ -1635,11 +1671,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private func setupBackgroundColors() {
-        backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
-
-        let selectedStateBackgroundView = UIView()
-        selectedStateBackgroundView.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundSelectedColor)
-        selectedBackgroundView = selectedStateBackgroundView
+        automaticallyUpdatesBackgroundConfiguration = false
+        var customBackgroundConfig = UIBackgroundConfiguration.clear()
+        customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+        backgroundConfiguration = customBackgroundConfig
     }
 
     private func initAccessibilityForAccessoryType() {

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -18,12 +18,18 @@ open class TableViewCellTokens: ControlTokens {
     }
 
     /// The background color of the TableViewCell.
-    open var cellBackgroundColor: DynamicColor { aliasTokens.backgroundColors[.neutral1] }
+    open var cellBackgroundColor: DynamicColor {
+        .init(light: aliasTokens.backgroundColors[.neutral1].light,
+              dark: aliasTokens.backgroundColors[.neutral1].dark,
+              darkElevated: aliasTokens.backgroundColors[.neutral2].darkElevated)
+    }
 
     /// The grouped background color of the TableViewCell.
     open var cellBackgroundGrouped: DynamicColor {
         .init(light: aliasTokens.backgroundColors[.neutral1].light,
-              dark: aliasTokens.backgroundColors[.neutral2].dark)}
+              dark: aliasTokens.backgroundColors[.neutral3].dark,
+              darkElevated: ColorValue(0x212121))
+    }
 
     /// The selected background color of the TableViewCell.
     open var cellBackgroundSelectedColor: DynamicColor { aliasTokens.backgroundColors[.neutral5] }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Follow the best practice https://developer.apple.com/videos/play/wwdc2020/10027/ to use the UIBackgroundConfiguration which is mutually exclusive to UITableViewCell's backgroundColor property.

- Use the token system to be hooked with UIBackgroundConfiguration
- Dark Elevated colors are not correctly defined for fluent2-token branch (Unknown: why MSFDivider color is different from Fluent1?)
- New api: clients can set cellstyletype to determine whether or not it should be grouped or plain style cell. If clients wants to override the color of the cell they should use the token system
- DemoController: add support for keyboard navigation on
- Cell background color when there is a keyboard focus on the cell is currently the same color as when user taps on the cell.

### Verification

(how the change was tested, including both manual and automated tests)

|style| Before                                       | After                                      |
|----|----------------------------------------------|--------------------------------------------|
| dark elevated group style|![dark_elevated_grouped](https://user-images.githubusercontent.com/20715435/180901763-42e737db-3efa-4046-8731-2a5fae1b5a2d.png) | ![dark_elevated_groupstyle](https://user-images.githubusercontent.com/20715435/180900494-7255e85b-617a-4872-b4ee-3f375d8be7e3.png)|
| dark elevated plain style| ![dark_elevated_plain](https://user-images.githubusercontent.com/20715435/180901795-8971629d-788c-4ed2-85ee-8310d6939005.png)|   ![dark_elevated_plainstyle](https://user-images.githubusercontent.com/20715435/180900531-0d0fa999-7c63-4de1-b27c-b3a38f86a98d.png)|
| dark group style| ![dark_group](https://user-images.githubusercontent.com/20715435/180901825-7593d4f5-8796-4012-a70c-b5503d4f9cf4.png) | ![dark_groupstyle](https://user-images.githubusercontent.com/20715435/180900585-4e4e293c-2343-4929-95ee-3120496e4c8d.png)|
| dark plain style| ![dark_plain](https://user-images.githubusercontent.com/20715435/180901852-ba81fcf6-9f1b-48ab-9bb9-2f8c3099a9f2.png) | ![dark_plainstyle](https://user-images.githubusercontent.com/20715435/180900630-15f4e6e1-ce6d-46b2-a98d-d50e518ad808.png) |
| light group style| ![light_groupstyle](https://user-images.githubusercontent.com/20715435/180901884-2bfb4e13-d07d-4467-8ad6-37367dc5ed27.png) | ![light_groupstyle](https://user-images.githubusercontent.com/20715435/180900673-7786b7ed-917a-4e95-a306-6b6f7d55be40.png)
| light plain style|![light_plainstyle](https://user-images.githubusercontent.com/20715435/180901916-4aac9d3b-7f07-47c3-b087-13cb5fe6f19d.png) |![light_plainstyle](https://user-images.githubusercontent.com/20715435/180900692-fb8a9ff3-bd38-449d-a362-bf23a66c87b0.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1097)