### PR TITLE
Extend CI to cover all `main_*` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,13 @@ on:
   push:
     branches:
       - main
-      - main_0.1
-      - main_0.2
-      - main_0.3
-      - main_0.4
-      - main_0.6
+      - main_*
       - fluent2-tokens
       - fluent2-colors
   pull_request:
     branches:
       - main
-      - main_0.1
-      - main_0.2
-      - main_0.3
-      - main_0.4
-      - main_0.6
+      - main_*
       - fluent2-tokens
       - fluent2-colors
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Run CI on all `main_*` branches instead of just an explicit list.

### Verification

CI should still run in main branches.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1107)