### PR TITLE
add backgroundstyletype in othercell types

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -85,7 +85,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
     }
 
     private class ThemeWideOverrideOtherCellTokens: TableViewCellTokens {
-        override var cellBackgroundColor: DynamicColor {
+        override var cellBackgroundGrouped: DynamicColor {
             // "Charcoal"
             return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
                                 dark: GlobalTokens().sharedColors[.charcoal][.shade40])
@@ -93,7 +93,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
     }
 
     private class PerControlOverrideTableViewCellTokens: ActionsCellTokens {
-        override var cellBackgroundColor: DynamicColor {
+        override var cellBackgroundGrouped: DynamicColor {
             // "Burgundy"
             return DynamicColor(light: GlobalTokens().sharedColors[.burgundy][.tint50],
                                 dark: GlobalTokens().sharedColors[.burgundy][.shade40])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -124,12 +124,14 @@ extension OtherCellsDemoController: UITableViewDataSource {
             let isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
             cell.bottomSeparatorType = isLastInSection ? .full : .inset
             cell.actionsCellOverrideTokens = overrideTokens
+            cell.backgroundStyleType = .grouped
             return cell
         }
 
         if let cell = tableView.dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier) as? ActivityIndicatorCell,
            section.title == "ActivityIndicatorCell" {
             cell.activityIndicatorCellOverrideTokens = overrideTokens
+            cell.backgroundStyleType = .grouped
             return cell
         }
 
@@ -142,6 +144,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
                 self.showAlertForSwitchTapped(isOn: cell.isOn)
             }
             cell.tableViewCellOverrideTokens = overrideTokens
+            cell.backgroundStyleType = .grouped
             return cell
         }
 
@@ -151,6 +154,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
             }
             cell.setup(text: item.text1)
             cell.centeredLabelCellOverrideTokens = overrideTokens
+            cell.backgroundStyleType = .grouped
             return cell
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -85,7 +85,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
     }
 
     private class ThemeWideOverrideOtherCellTokens: TableViewCellTokens {
-        override var cellBackgroundGrouped: DynamicColor {
+        override var cellBackgroundGroupedColor: DynamicColor {
             // "Charcoal"
             return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
                                 dark: GlobalTokens().sharedColors[.charcoal][.shade40])
@@ -93,7 +93,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
     }
 
     private class PerControlOverrideTableViewCellTokens: ActionsCellTokens {
-        override var cellBackgroundGrouped: DynamicColor {
+        override var cellBackgroundGroupedColor: DynamicColor {
             // "Burgundy"
             return DynamicColor(light: GlobalTokens().sharedColors[.burgundy][.tint50],
                                 dark: GlobalTokens().sharedColors[.burgundy][.shade40])

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -77,8 +77,8 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
     private func updateTokens() {
         tokens = resolvedTokens
+        setupBackgroundColors()
         updateActionTitleColors()
-        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
     }
 
     @objc public class func height(action1Title: String, action2Title: String = "", containerWidth: CGFloat, tokens: ActionsCellTokens) -> CGFloat {
@@ -122,6 +122,14 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         return sizeThatFits(CGSize(width: CGFloat.infinity, height: .infinity))
     }
 
+    @objc public var backgroundStyleType: TableViewCellBackgroundStyleType = .plain {
+        didSet {
+            if backgroundStyleType != oldValue {
+                setupBackgroundColors()
+            }
+        }
+    }
+
     // By design, an actions cell has 2 actions at most
     @objc public let action1Button = UIButton()
     @objc public let action2Button = UIButton()
@@ -145,7 +153,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         hideSystemSeparator()
         updateHorizontalSeparator(topSeparator, with: topSeparatorType)
         updateHorizontalSeparator(bottomSeparator, with: bottomSeparatorType)
-        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        setupBackgroundColors()
 
         setupAction(action1Button)
         setupAction(action2Button)
@@ -273,5 +281,13 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
             action2Button.setTitleColor(action2Type.highlightedTextColor(tokens: tokens), for: .highlighted)
         }
 
+    }
+
+    private func setupBackgroundColors() {
+        if backgroundStyleType != .custom {
+            var customBackgroundConfig = UIBackgroundConfiguration.clear()
+            customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+            backgroundConfiguration = customBackgroundConfig
+        }
     }
 }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -11,6 +11,15 @@ import UIKit
 open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
     public static let identifier: String = "ActivityIndicatorCell"
 
+    @objc public var backgroundStyleType: TableViewCellBackgroundStyleType = .plain {
+        didSet {
+            if backgroundStyleType != oldValue {
+                setupBackgroundColors()
+                setNeedsUpdateConfiguration()
+            }
+        }
+    }
+
     // MARK: - ActivityIndicatorCell TokenizedControl
     @objc public var activityIndicatorCellOverrideTokens: TableViewCellTokens? {
         didSet {
@@ -41,7 +50,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
     private func updateTokens() {
         tokens = resolvedTokens
-        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        setupBackgroundColors()
     }
 
     private let activityIndicator: MSFActivityIndicator = {
@@ -59,7 +68,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
                                                name: .didChangeTheme,
                                                object: nil)
 
-        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        setupBackgroundColors()
     }
 
     @objc public required init(coder aDecoder: NSCoder) {
@@ -96,4 +105,12 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
 
     open override func setSelected(_ selected: Bool, animated: Bool) { }
+
+    private func setupBackgroundColors() {
+        if backgroundStyleType != .custom {
+            var customBackgroundConfig = UIBackgroundConfiguration.clear()
+            customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+            backgroundConfiguration = customBackgroundConfig
+        }
+    }
 }

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -41,7 +41,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
 
     private func updateTokens() {
         tokens = resolvedTokens
-        backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundColor)
+        setupBackgroundColors()
         label.font = UIFont.fluent(tokens.titleFont)
         label.textColor = UIColor(dynamicColor: tokens.mainBrandColor)
     }
@@ -55,6 +55,14 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         return label
     }()
 
+    @objc public var backgroundStyleType: TableViewCellBackgroundStyleType = .plain {
+        didSet {
+            if backgroundStyleType != oldValue {
+                setupBackgroundColors()
+            }
+        }
+    }
+
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -64,6 +72,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
                                                object: nil)
 
         contentView.addSubview(label)
+        setupBackgroundColors()
     }
 
     @objc public required init(coder aDecoder: NSCoder) {
@@ -108,4 +117,12 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }
 
     open override func setSelected(_ selected: Bool, animated: Bool) { }
+
+    private func setupBackgroundColors() {
+        if backgroundStyleType != .custom {
+            var customBackgroundConfig = UIBackgroundConfiguration.clear()
+            customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+            backgroundConfiguration = customBackgroundConfig
+        }
+    }
 }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1797,9 +1797,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     private func setupBackgroundColors() {
         if backgroundStyleType != .custom {
             automaticallyUpdatesBackgroundConfiguration = false
-            var customBackgroundConfig = UIBackgroundConfiguration.clear()
-            customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
-            backgroundConfiguration = customBackgroundConfig
+            var backgroundConfiguration = UIBackgroundConfiguration.clear()
+            backgroundConfiguration.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+            self.backgroundConfiguration = backgroundConfiguration
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -75,7 +75,7 @@ public enum TableViewCellBackgroundStyleType: Int {
         case .plain:
             return UIColor(dynamicColor: tokens.cellBackgroundColor)
         case .grouped:
-            return UIColor(dynamicColor: tokens.cellBackgroundGrouped)
+            return UIColor(dynamicColor: tokens.cellBackgroundGroupedColor)
         case .clear:
             return .clear
         case .custom:

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -58,12 +58,17 @@ public enum TableViewCellAccessoryType: Int {
     }
 }
 
-// Different background color is shown based on if `TableViewCell` is shown in `TableView` as grouped or plain style
+// Different background color is used for `TableViewCell` by getting the appropriate tokens and integrate with the cell's `UIBackgroundConfiguration`
 @objc(MSFTableViewCellBackgroundStyleType)
 public enum TableViewCellBackgroundStyleType: Int {
+    // use for flat list of cells
     case plain
+    // use for grouped list of cells
     case grouped
+    // clear background so that TableView's background can be shown
     case clear
+    // in case clients want to override the background on their own without using token system
+    case custom
 
     func defaultColor(tokens: TableViewCellTokens) -> UIColor? {
         switch self {
@@ -73,6 +78,8 @@ public enum TableViewCellBackgroundStyleType: Int {
             return UIColor(dynamicColor: tokens.cellBackgroundGrouped)
         case .clear:
             return .clear
+        case .custom:
+            return nil
         }
     }
 }
@@ -1730,11 +1737,13 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     open override func updateConfiguration(using state: UICellConfigurationState) {
-        // Customize the background color to use the tint color when the cell is highlighted or selected.
-        if state.isHighlighted || state.isSelected || state.isFocused {
-            backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundSelectedColor)
-        } else {
-            backgroundConfiguration?.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+        if backgroundStyleType != .custom {
+            // Customize the background color to use the tint color when the cell is highlighted or selected.
+            if state.isHighlighted || state.isSelected || state.isFocused {
+                backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokens.cellBackgroundSelectedColor)
+            } else {
+                backgroundConfiguration?.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+            }
         }
     }
 
@@ -1786,10 +1795,12 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private func setupBackgroundColors() {
-        automaticallyUpdatesBackgroundConfiguration = false
-        var customBackgroundConfig = UIBackgroundConfiguration.clear()
-        customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
-        backgroundConfiguration = customBackgroundConfig
+        if backgroundStyleType != .custom {
+            automaticallyUpdatesBackgroundConfiguration = false
+            var customBackgroundConfig = UIBackgroundConfiguration.clear()
+            customBackgroundConfig.backgroundColor = backgroundStyleType.defaultColor(tokens: tokens)
+            backgroundConfiguration = customBackgroundConfig
+        }
     }
 
     private func initAccessibilityForAccessoryType() {

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -12,7 +12,7 @@ open class TableViewCellTokens: ControlTokens {
     }
 
     /// The grouped background color of the TableView.
-    open var backgroundGrouped: DynamicColor {
+    open var backgroundGroupedColor: DynamicColor {
         .init(light: aliasTokens.backgroundColors[.neutral2].light,
               dark: aliasTokens.backgroundColors[.neutral1].dark)
     }
@@ -25,7 +25,7 @@ open class TableViewCellTokens: ControlTokens {
     }
 
     /// The grouped background color of the TableViewCell.
-    open var cellBackgroundGrouped: DynamicColor {
+    open var cellBackgroundGroupedColor: DynamicColor {
         .init(light: aliasTokens.backgroundColors[.neutral1].light,
               dark: aliasTokens.backgroundColors[.neutral3].dark,
               darkElevated: ColorValue(0x212121))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- Add TableViewCellBackgroundStyleType support for actioncell, centeredlabelcell, and activityindicatorcells.
- Fix the othercelldemocontroller dark mode regression from https://github.com/microsoft/fluentui-apple/pull/1059/files#diff-5b8d8c56faa1843adafa88a7459c06cbd06ae19df5cf81c86868269e2c103b31
- add .custom in TableViewCellBackgroundStyleType so that objc clients can still manually override the cellbackground color by directly calling cell's backgroundColor property.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-07-28 at 12 03 13](https://user-images.githubusercontent.com/20715435/181617675-713d67ce-e70c-455f-b44b-ded5f11b1fac.png)  |![Simulator Screen Shot - iPad Pro (12 9-inch) (5th generation) - 2022-07-28 at 11 55 08](https://user-images.githubusercontent.com/20715435/181617730-f6c3000a-c646-4e8a-b35a-5f5ce545d6d8.png)|



### Pull request checklist


This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1110)