### PR TITLE
popupmenuitemcell is default to .custom backgroundstyle

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -89,6 +89,9 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         contentView.addSubview(accessoryImageView)
 
         isAccessibilityElement = true
+
+        // until popupmenuitemcell actually supports token system, clients will override colors via cell's backgroundColor property
+        backgroundStyleType = .custom
     }
 
     func setup(item: PopupMenuTemplateItem) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
While PopupMenuItemCell is subclass of fluent TableViewCell, it doesn't have all the token system hooked up yet.
Make sure the default style is .custom so clients can continue to override it's color via `backgroundColor`

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Screen Shot 2022-07-28 at 3 39 27 PM](https://user-images.githubusercontent.com/20715435/181649561-c2cdbfd5-f979-4cb8-83fa-f0a64a28e242.png)|![Screen Shot 2022-07-28 at 3 39 27 PM](https://user-images.githubusercontent.com/20715435/181649284-1b36516d-4fac-4390-a38d-d4b9e367b6f2.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1112)