### PR TITLE
improvements on objc api for tableviewcell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -218,9 +218,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - title: The title string
     ///   - subtitle: The subtitle string
     ///   - footer: The footer string
-    ///   - titleFont: The title font; If not set, it will default to the font definition in tokens
-    ///   - subtitleFont: The subtitle font; If not set, it will default to the font definition in tokens
-    ///   - footerFont: The footer font; If not set, it will default to the font definition in tokens
     ///   - titleLeadingAccessoryView: The accessory view on the leading edge of the title
     ///   - titleTrailingAccessoryView: The accessory view on the trailing edge of the title
     ///   - subtitleLeadingAccessoryView: The accessory view on the leading edge of the subtitle
@@ -240,9 +237,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public class func height(title: String,
                                    subtitle: String = "",
                                    footer: String = "",
-                                   titleFont: UIFont? = nil,
-                                   subtitleFont: UIFont? = nil,
-                                   footerFont: UIFont? = nil,
                                    titleLeadingAccessoryView: UIView? = nil,
                                    titleTrailingAccessoryView: UIView? = nil,
                                    subtitleLeadingAccessoryView: UIView? = nil,
@@ -262,9 +256,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                            title: title,
                            subtitle: subtitle,
                            footer: footer,
-                           titleFont: titleFont,
-                           subtitleFont: subtitleFont,
-                           footerFont: footerFont,
+                           titleFont: nil,
+                           subtitleFont: nil,
+                           footerFont: nil,
                            titleLeadingAccessoryView: titleLeadingAccessoryView,
                            titleTrailingAccessoryView: titleTrailingAccessoryView,
                            subtitleLeadingAccessoryView: subtitleLeadingAccessoryView,
@@ -431,9 +425,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - title: The title string
     ///   - subtitle: The subtitle string
     ///   - footer: The footer string
-    ///   - titleFont: The title font; If not set, it will default to the font definition in tokens
-    ///   - subtitleFont: The subtitle font; If not set, it will default to the font definition in tokens
-    ///   - footerFont: The footer font; If not set, it will default to the font definition in tokens
     ///   - titleLeadingAccessoryView: The accessory view on the leading edge of the title
     ///   - titleTrailingAccessoryView: The accessory view on the trailing edge of the title
     ///   - subtitleLeadingAccessoryView: The accessory view on the leading edge of the subtitle
@@ -449,9 +440,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public class func preferredWidth(title: String,
                                            subtitle: String = "",
                                            footer: String = "",
-                                           titleFont: UIFont? = nil,
-                                           subtitleFont: UIFont? = nil,
-                                           footerFont: UIFont? = nil,
                                            titleLeadingAccessoryView: UIView? = nil,
                                            titleTrailingAccessoryView: UIView? = nil,
                                            subtitleLeadingAccessoryView: UIView? = nil,
@@ -467,9 +455,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                    title: title,
                                    subtitle: subtitle,
                                    footer: footer,
-                                   titleFont: titleFont,
-                                   subtitleFont: subtitleFont,
-                                   footerFont: footerFont,
+                                   titleFont: nil,
+                                   subtitleFont: nil,
+                                   footerFont: nil,
                                    titleLeadingAccessoryView: titleLeadingAccessoryView,
                                    titleTrailingAccessoryView: titleTrailingAccessoryView,
                                    subtitleLeadingAccessoryView: subtitleLeadingAccessoryView,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Make objc clients transition little easier by making sure the api is closer to what it was before.

### Verification

no impact on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  + (CGFloat)heightWithTitle:(NSString * _Nonnull)title subtitle:(NSString * _Nonnull)subtitle footer:(NSString * _Nonnull)footer titleFont:(UIFont * _Nullable)titleFont subtitleFont:(UIFont * _Nullable)subtitleFont footerFont:(UIFont * _Nullable)footerFont titleLeadingAccessoryView:(UIView * _Nullable)titleLeadingAccessoryView titleTrailingAccessoryView:(UIView * _Nullable)titleTrailingAccessoryView subtitleLeadingAccessoryView:(UIView * _Nullable)subtitleLeadingAccessoryView subtitleTrailingAccessoryView:(UIView * _Nullable)subtitleTrailingAccessoryView footerLeadingAccessoryView:(UIView * _Nullable)footerLeadingAccessoryView footerTrailingAccessoryView:(UIView * _Nullable)footerTrailingAccessoryView customViewSize:(enum MSFTableViewCellCustomViewSize)customViewSize customAccessoryView:(UIView * _Nullable)customAccessoryView accessoryType:(enum MSFTableViewCellAccessoryType)accessoryType titleNumberOfLines:(NSInteger)titleNumberOfLines subtitleNumberOfLines:(NSInteger)subtitleNumberOfLines footerNumberOfLines:(NSInteger)footerNumberOfLines customAccessoryViewExtendsToEdge:(BOOL)customAccessoryViewExtendsToEdge containerWidth:(CGFloat)containerWidth isInSelectionMode:(BOOL)isInSelectionMode |  + (CGFloat)heightWithTitle:(NSString * _Nonnull)title subtitle:(NSString * _Nonnull)subtitle footer:(NSString * _Nonnull)footer titleLeadingAccessoryView:(UIView * _Nullable)titleLeadingAccessoryView titleTrailingAccessoryView:(UIView * _Nullable)titleTrailingAccessoryView subtitleLeadingAccessoryView:(UIView * _Nullable)subtitleLeadingAccessoryView subtitleTrailingAccessoryView:(UIView * _Nullable)subtitleTrailingAccessoryView footerLeadingAccessoryView:(UIView * _Nullable)footerLeadingAccessoryView footerTrailingAccessoryView:(UIView * _Nullable)footerTrailingAccessoryView customViewSize:(enum MSFTableViewCellCustomViewSize)customViewSize customAccessoryView:(UIView * _Nullable)customAccessoryView accessoryType:(enum MSFTableViewCellAccessoryType)accessoryType titleNumberOfLines:(NSInteger)titleNumberOfLines subtitleNumberOfLines:(NSInteger)subtitleNumberOfLines footerNumberOfLines:(NSInteger)footerNumberOfLines customAccessoryViewExtendsToEdge:(BOOL)customAccessoryViewExtendsToEdge containerWidth:(CGFloat)containerWidth isInSelectionMode:(BOOL)isInSelectionMode SWIFT_WARN_UNUSED_RESULT;
 |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)