### PR TITLE
make sure bottomcommanding supports larger text

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -653,6 +653,7 @@ open class BottomCommandingController: UIViewController {
             .prefix(expandedListSections.count - 1)
             .contains(where: { $0.items.last == item })
         cell.bottomSeparatorType = shouldShowSeparator ? .full : .none
+        cell.titleNumberOfLines = 0
     }
 
     // Reloads view in place from the given item object


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Make sure the TableViewCell's in the bottomcommandingcontroller supports multiline if the text sizes gets bigger
note: the TabbarItemView is broken caused by a different regression. tracking that bug separately.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 12 Pro Max - 2022-08-02 at 12 53 58](https://user-images.githubusercontent.com/20715435/182461807-eea1ca87-98cd-4522-92f9-f7f74d9fb43d.png) | ![Simulator Screen Shot - iPhone 12 Pro Max - 2022-08-02 at 12 51 24](https://user-images.githubusercontent.com/20715435/182461866-942f6d41-deda-4961-a1c5-c80dbcdb3457.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1123)