### PR TITLE
Saving theming work for UIViewController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -132,6 +132,11 @@ class BottomSheetDemoController: UIViewController {
         secondarySheetController.isHidden = false
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.configureAppearancePopover()
+    }
+
     private lazy var personaListView: UIScrollView = {
         let personaListView = PersonaListView()
         personaListView.personaList = samplePersonas
@@ -233,6 +238,31 @@ class BottomSheetDemoController: UIViewController {
         let type: DemoItemType
         let action: Selector?
         var isOn: Bool = false
+    }
+
+    // MARK: - Demo Appearance Popover
+
+    func configureAppearancePopover() {
+        // Display the DemoAppearancePopover button
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "ic_fluent_settings_24_regular"),
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(showAppearancePopover))
+    }
+
+    @objc func showAppearancePopover(_ sender: UIBarButtonItem) {
+        appearanceController.popoverPresentationController?.barButtonItem = sender
+        appearanceController.popoverPresentationController?.delegate = self
+        self.present(appearanceController, animated: true, completion: nil)
+    }
+
+    private lazy var appearanceController: DemoAppearanceController = .init(delegate: self as? DemoAppearanceDelegate)
+}
+
+extension BottomSheetDemoController: UIPopoverPresentationControllerDelegate {
+    /// Overridden to allow for popover-style modal presentation on compact (e.g. iPhone) devices.
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        return .none
     }
 }
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -409,10 +409,10 @@ public class BottomSheetController: UIViewController {
 
         // We need to have the shadow on a parent of the view that does the corner masking.
         // Otherwise the view will mask its own shadow.
-        bottomSheetView.layer.shadowColor = shadowColor
-        bottomSheetView.layer.shadowOffset = Constants.Shadow.offset
-        bottomSheetView.layer.shadowOpacity = Constants.Shadow.opacity
-        bottomSheetView.layer.shadowRadius = Constants.Shadow.radius
+        let shadow28 = view.fluentTheme.aliasTokens.shadow[.shadow28]
+        bottomSheetView.layer.shadowColor = UIColor(dynamicColor: shadow28.colorTwo).cgColor
+        bottomSheetView.layer.shadowOffset = CGSize(width: shadow28.xTwo, height: shadow28.yTwo)
+        bottomSheetView.layer.shadowRadius = shadow28.blurTwo
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.backgroundColor = backgroundColor
@@ -873,7 +873,6 @@ public class BottomSheetController: UIViewController {
 
     private let shouldShowDimmingView: Bool
 
-    private lazy var shadowColor = UIColor(colorValue: self.view.fluentTheme.globalTokens.neutralColors[.black]).cgColor
     private lazy var backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.background2])
 
     private struct Constants {
@@ -915,12 +914,6 @@ public class BottomSheetController: UIViewController {
 
             // Off-screen overflow that can be partially revealed during spring oscillation or rubber banding (dragging the sheet beyond limits)
             static let overflowHeight: CGFloat = 50.0
-        }
-
-        struct Shadow {
-            static let opacity: Float = 0.14
-            static let radius: CGFloat = 8
-            static let offset: CGSize = CGSize(width: 0, height: 4)
         }
     }
 }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -873,7 +873,7 @@ public class BottomSheetController: UIViewController {
 
     private let shouldShowDimmingView: Bool
 
-    private lazy var backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.background2])
+    private lazy var backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
 
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -335,7 +335,7 @@ public class BottomSheetController: UIViewController {
 
         let overflowView = UIView()
         overflowView.translatesAutoresizingMaskIntoConstraints = false
-        overflowView.backgroundColor = Colors.NavigationBar.background
+        overflowView.backgroundColor = backgroundColor
         view.addSubview(overflowView)
 
         if let headerContentView = headerContentView {
@@ -409,13 +409,13 @@ public class BottomSheetController: UIViewController {
 
         // We need to have the shadow on a parent of the view that does the corner masking.
         // Otherwise the view will mask its own shadow.
-        bottomSheetView.layer.shadowColor = Constants.Shadow.color
+        bottomSheetView.layer.shadowColor = shadowColor
         bottomSheetView.layer.shadowOffset = Constants.Shadow.offset
         bottomSheetView.layer.shadowOpacity = Constants.Shadow.opacity
         bottomSheetView.layer.shadowRadius = Constants.Shadow.radius
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.backgroundColor = Colors.NavigationBar.background
+        contentView.backgroundColor = backgroundColor
         contentView.layer.cornerRadius = Constants.cornerRadius
         contentView.layer.cornerCurve = .continuous
         contentView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
@@ -873,6 +873,9 @@ public class BottomSheetController: UIViewController {
 
     private let shouldShowDimmingView: Bool
 
+    private lazy var shadowColor = UIColor(colorValue: self.view.fluentTheme.globalTokens.neutralColors[.black]).cgColor
+    private lazy var backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.background2])
+
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance
         static let maxRubberBandOffset: CGFloat = 20.0
@@ -915,7 +918,6 @@ public class BottomSheetController: UIViewController {
         }
 
         struct Shadow {
-            static let color: CGColor = UIColor.black.cgColor
             static let opacity: Float = 0.14
             static let radius: CGFloat = 8
             static let offset: CGSize = CGSize(width: 0, height: 4)

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -97,6 +97,23 @@ extension UIWindow: FluentThemeable {
     }
 }
 
+@objc extension UIViewController: FluentThemeable {
+    private struct Keys {
+        static var fluentTheme: String = "fluentTheme_key"
+    }
+
+    /// The custom `FluentTheme` to apply to this UIViewController.
+    public var fluentTheme: FluentTheme {
+        get {
+            return objc_getAssociatedObject(self, &Keys.fluentTheme) as? FluentTheme ?? FluentThemeKey.defaultValue
+        }
+        set {
+            objc_setAssociatedObject(self, &Keys.fluentTheme, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            NotificationCenter.default.post(name: .didChangeTheme, object: self)
+        }
+    }
+}
+
 // MARK: - Environment
 
 public extension View {

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -7,7 +7,7 @@ import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
-    /// The color of the shador for shadow 1
+    /// The color of the shadow for shadow 1
     let colorOne: DynamicColor
 
     /// The radius of the shadow for shadow 1
@@ -19,7 +19,7 @@ public struct ShadowInfo {
     /// The size of the shadow on the y-axis (also, height) for shadow 1
     let yOne: CGFloat
 
-    /// The color of the shador for shadow 2
+    /// The color of the shadow for shadow 2
     let colorTwo: DynamicColor
 
     /// The radius of the shadow for shadow 2

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -13,10 +13,10 @@ public struct ShadowInfo {
     /// The radius of the shadow for shadow 1
     let blurOne: CGFloat
 
-    /// The size of the shadow on the x-axis (also, width) for shadow 1
+    /// The offset of the shadow on the x-axis for shadow 1, from the center of the control
     let xOne: CGFloat
 
-    /// The size of the shadow on the y-axis (also, height) for shadow 1
+    /// The offset of the shadow on the y-axis for shadow 1, from the center of the control
     let yOne: CGFloat
 
     /// The color of the shadow for shadow 2

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -6,6 +6,7 @@
 import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
+/// Blur refers to the radius of the shadow's blur.
 public struct ShadowInfo {
     let colorOne: DynamicColor
     let blurOne: CGFloat

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -6,14 +6,28 @@
 import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
-/// Blur refers to the radius of the shadow's blur.
 public struct ShadowInfo {
+    /// The color of the shador for shadow 1
     let colorOne: DynamicColor
+
+    /// The radius of the shadow for shadow 1
     let blurOne: CGFloat
+
+    /// The size of the shadow on the x-axis (also, width) for shadow 1
     let xOne: CGFloat
+
+    /// The size of the shadow on the y-axis (also, height) for shadow 1
     let yOne: CGFloat
+
+    /// The color of the shador for shadow 2
     let colorTwo: DynamicColor
+
+    /// The radius of the shadow for shadow 2
     let blurTwo: CGFloat
+
+    /// The size of the shadow on the x-axis (also, width) for shadow 2
     let xTwo: CGFloat
+
+    /// The size of the shadow on the y-axis (also, height) for shadow 2
     let yTwo: CGFloat
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

This is a draft PR just to save some in-progress work trying to get brand color overrides/theming to work for a UIViewController (specifically the BottomSheet, in this circumstance). Note, this does not fully work, nor does it really make sense, because the control doesn't have any brand colors, but may serve as a starting point for future changes for UIViewController based controls.

Key change is the extension on UIViewController in FluentTheme.swift, as well as adding the appearance popover to the demo controller.

### Verification

Validated it in simulator.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1125)