### PR TITLE
AvatarGroup VoiceOver order bug fix

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -106,6 +106,8 @@ class AvatarGroupDemoController: DemoTableViewController {
             }()
 
             let stackView = UIStackView(arrangedSubviews: buttonView)
+            stackView.shouldGroupAccessibilityChildren = true
+            stackView.accessibilityElements = buttonView
             stackView.frame = CGRect(x: 0,
                                      y: 0,
                                      width: 120,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

VoiceOver would use a wrong order for "Max displayed avatars" and "Overflow count" cells with swipe gesture. 
The order is fixed by explicitly setting `accessibilityElements`' order.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/106181067/182730361-14bff824-b386-44dd-a275-2a9ede3392e5.mov | https://user-images.githubusercontent.com/106181067/182730412-62989627-2290-41df-959c-dbacd86a359e.mov |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1132)