### PR TITLE
remove BUILD_LIBRARY_FOR_DISTRIBUTION flag

### DIFF
--- a/.ado/xcconfig/publish_overrides.xcconfig
+++ b/.ado/xcconfig/publish_overrides.xcconfig
@@ -9,8 +9,5 @@ SWIFT_OPTIMIZATION_LEVEL=-Osize
 // Build for all architectures, not just the active one
 ONLY_ACTIVE_ARCH=NO
 
-// Build for distribution so that this is consumable from other versions of Xcode
-BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-
 // Turn off ASAN for Nuget package consumption.
 ENABLE_ADDRESS_SANITIZER = NO


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

No clear benefit with this " BUILD_LIBRARY_FOR_DISTRIBUTION" right now. might as well remove it.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1133)