### PR TITLE
address all the swiftlint errors (#1129)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-whitelist_rules:
+only_rules:
   # Delegate protocols should be class-only so they can be weakly referenced.
   - class_delegate_protocol
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -334,7 +334,7 @@ class AvatarDemoController: DemoTableViewController {
             presence = presenceIterator.next()
         }
 
-        if presence! ==  .none {
+        if presence! == .none {
             presence = presenceIterator.next()
         }
 

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -65,7 +65,7 @@ class BadgeLabelButton: UIButton {
 
     private var badgeFrameOriginX: CGFloat {
         let xOrigin: CGFloat = isLeftToRightUserInterfaceLayoutDirection ?
-            frame.size.width - contentEdgeInsets.left  :
+            frame.size.width - contentEdgeInsets.left :
             contentEdgeInsets.left
 
         return (xOrigin - badgeWidth / 2)

--- a/macos/FluentUI/Link/Link.swift
+++ b/macos/FluentUI/Link/Link.swift
@@ -137,7 +137,7 @@ open class Link: NSButton {
 	private let cornerRadius: CGFloat = 2
 
 	private func updateTitle() {
-		let titleAttributes = (isEnabled && showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes: linkAttributes
+		let titleAttributes = (isEnabled && showsUnderlineWhileMouseInside && mouseInside) ? underlinedLinkAttributes : linkAttributes
 		attributedTitle = NSAttributedString(string: title, attributes: titleAttributes)
 		setAccessibilityTitle(title)
 	}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Merge for linting issues into `fluent2-colors`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1134)