### PR TITLE
[Fluent2 TokenSet] Final cleanup merge from the WIP branch

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -29,7 +29,7 @@ protocol DemoAppearanceDelegate: NSObjectProtocol {
     /// Returns whether "theme-wide override" tokens are currently registered for the given control.
     ///
     /// This method, when implemented, should query the current `FluentTheme` using its
-    /// `tokenOverride(for:)` API, and return whether a token creation function is returned.
+    /// `tokens(for:)` API, and return whether a token creation function is returned.
     func isThemeWideOverrideApplied() -> Bool
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -242,13 +242,7 @@ extension ActivityIndicatorDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         defaultColorIndicators.values.forEach { activityIndicator in
-            perControlOverrideActivityIndicatorTokens.forEach { (key, value) in
-                if isOverrideEnabled {
-                    activityIndicator.tokenSet[key] = value
-                } else {
-                    activityIndicator.tokenSet.removeOverride(key)
-                }
-            }
+            activityIndicator.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideActivityIndicatorTokens : nil)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -316,13 +316,7 @@ extension ButtonDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         self.buttons.forEach({ (_: String, button: MSFButton) in
-            perControlOverrideButtonTokens.forEach { (key: ButtonTokenSet.Tokens, value: ControlTokenValue) in
-                if isOverrideEnabled {
-                    button.tokenSet[key] = value
-                } else {
-                    button.tokenSet.removeOverride(key)
-                }
-            }
+            button.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideButtonTokens : nil)
         })
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -241,13 +241,7 @@ extension CardNudgeDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         self.cardNudges.forEach { cardNudge in
-            perControlOverrideCardNudgeTokens.forEach { (key: CardNudgeTokenSet.Tokens, value: ControlTokenValue) in
-                if isOverrideEnabled {
-                    cardNudge.tokenSet[key] = value
-                } else {
-                    cardNudge.tokenSet.removeOverride(key)
-                }
-            }
+            cardNudge.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideCardNudgeTokens : nil)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -200,18 +200,12 @@ extension DividerDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         dividers.forEach { divider in
-            perControlOverrideDividerTokens.forEach { (key: DividerTokenSet.Tokens, value: ControlTokenValue) in
-                if isOverrideEnabled {
-                    divider.tokenSet[key] = value
-                } else {
-                    divider.tokenSet.removeOverride(key)
-                }
-            }
+            divider.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideDividerTokens : nil)
         }
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: FluentDivider.self) != nil
+        return self.view.window?.fluentTheme.tokens(for: DividerTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -280,7 +280,7 @@ extension HUDDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return view.window?.fluentTheme.tokenOverride(for: HeadsUpDisplay.self) != nil
+        return view.window?.fluentTheme.tokens(for: HeadsUpDisplayTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -50,7 +50,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: ActivityIndicatorCell.self) != nil
+        return self.view.window?.fluentTheme.tokens(for: TableViewCellTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens
@@ -107,13 +107,13 @@ extension OtherCellsDemoController: UITableViewDataSource {
             cell.setup(action1Title: item.text1, action2Title: item.text2, action2Type: .destructive)
             let isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
             cell.bottomSeparatorType = isLastInSection ? .full : .inset
-            applyOverrideTokens(to: cell.tokenSet)
+            cell.tokenSet.replaceAllOverrides(with: overrideTokens)
             return cell
         }
 
         if let cell = tableView.dequeueReusableCell(withIdentifier: ActivityIndicatorCell.identifier) as? ActivityIndicatorCell,
            section.title == "ActivityIndicatorCell" {
-            applyOverrideTokens(to: cell.tokenSet)
+            cell.tokenSet.replaceAllOverrides(with: overrideTokens)
             return cell
         }
 
@@ -125,7 +125,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
             cell.onValueChanged = { [unowned self, unowned cell] in
                 self.showAlertForSwitchTapped(isOn: cell.isOn)
             }
-            applyOverrideTokens(to: cell.tokenSet)
+            cell.tokenSet.replaceAllOverrides(with: overrideTokens)
             return cell
         }
 
@@ -134,7 +134,7 @@ extension OtherCellsDemoController: UITableViewDataSource {
                 return UITableViewCell()
             }
             cell.setup(text: item.text1)
-            applyOverrideTokens(to: cell.tokenSet)
+            cell.tokenSet.replaceAllOverrides(with: overrideTokens)
             return cell
         }
 
@@ -146,16 +146,6 @@ extension OtherCellsDemoController: UITableViewDataSource {
         present(alert, animated: true)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             alert.dismiss(animated: true)
-        }
-    }
-
-    private func applyOverrideTokens(to tokenSet: TableViewCellTokenSet) {
-        TableViewCellTokenSet.Tokens.allCases.forEach { token in
-            if let override = overrideTokens?[token] {
-                tokenSet[token] = override
-            } else {
-                tokenSet.removeOverride(token)
-            }
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -230,7 +230,7 @@ extension PillButtonBarDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: PillButton.self) != nil
+        return self.view.window?.fluentTheme.tokens(for: PillButtonTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -134,7 +134,7 @@ extension SegmentedControlDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: SegmentedControl.self) != nil
+        return self.view.window?.fluentTheme.tokens(for: SegmentedControlTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -341,7 +341,7 @@ extension SideTabBarDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return contentViewController?.view.window?.fluentTheme.tokenOverride(for: SideTabBar.self) != nil
+        return contentViewController?.view.window?.fluentTheme.tokens(for: SideTabBarTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -224,7 +224,7 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: TabBarView.self) != nil
+        return self.view.window?.fluentTheme.tokens(for: TabBarTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -126,7 +126,7 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
     }
 
     func isThemeWideOverrideApplied() -> Bool {
-        return self.view.window?.fluentTheme.tokenOverride(for: TableViewCell.self) != nil
+        return self.view.window?.fluentTheme.tokens(for: TableViewCellTokenSet.self) != nil
     }
 
     // MARK: - Custom tokens
@@ -225,13 +225,7 @@ extension TableViewCellDemoController {
 
         cell.isInSelectionMode = section.allowsMultipleSelection ? isInSelectionMode : false
 
-        TableViewCellTokenSet.Tokens.allCases.forEach { token in
-            if let override = overrideTokens?[token] {
-                cell.tokenSet[token] = override
-            } else {
-                cell.tokenSet.removeOverride(token)
-            }
-        }
+        cell.tokenSet.replaceAllOverrides(with: overrideTokens)
 
         return cell
     }

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -132,7 +132,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
     @objc private func themeDidChange(_ notification: Notification) {
         if let window = self.window,
            window.isEqual(notification.object) {
-            tokenSet.update(fluentTheme)
+            tokenSet.update(window.fluentTheme)
         }
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
+++ b/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
@@ -30,18 +30,20 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarTokenSet.Tokens> {
 
         case .itemBackgroundColor:
             return .buttonDynamicColors {
-                ButtonDynamicColors(rest:self.aliasTokens.backgroundColors[.neutral4],
+                ButtonDynamicColors(rest: self.aliasTokens.backgroundColors[.neutral4],
                                     hover: DynamicColor(light: self.aliasTokens.backgroundColors[.neutral5].light,
                                                         dark: self.aliasTokens.strokeColors[.neutral2].dark),
                                     pressed: DynamicColor(light: self.aliasTokens.backgroundColors[.neutralDisabled].light,
                                                           dark: self.aliasTokens.backgroundColors[.neutral5].dark),
                                     selected: self.aliasTokens.backgroundColors[.brandRest],
-                                    disabled: self.aliasTokens.strokeColors[.neutral1]) }
+                                    disabled: self.aliasTokens.strokeColors[.neutral1])
+            }
 
         case .itemFixedIconColor:
             return .dynamicColor {
                 DynamicColor(light: self.aliasTokens.foregroundColors[.neutral1].light,
-                             dark: self.aliasTokens.foregroundColors[.neutral3].dark) }
+                             dark: self.aliasTokens.foregroundColors[.neutral3].dark)
+            }
 
         case .itemIconColor:
             return .buttonDynamicColors {
@@ -49,7 +51,8 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarTokenSet.Tokens> {
                                     hover: self.aliasTokens.foregroundColors[.neutral1],
                                     pressed: self.aliasTokens.foregroundColors[.neutral1],
                                     selected: self.aliasTokens.foregroundColors[.neutralInverted],
-                                    disabled: self.aliasTokens.foregroundColors[.neutralDisabled]) }
+                                    disabled: self.aliasTokens.foregroundColors[.neutralDisabled])
+            }
 
         case .itemInterspace:
             return .float { self.globalTokens.spacing[.xxxSmall] }

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -20,18 +20,14 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
     /// ```
     public subscript(token: T) -> ControlTokenValue {
         get {
-            if let value = valueOverrides?[token] {
+            if let value = overrideValue(forToken: token) {
                 return value
-            } else if let value = fluentTheme.tokens(for: type(of: self))?[token] {
-                return value
+            } else {
+                return defaultValue(token)
             }
-            return defaultValue(token)
         }
         set(value) {
-            if valueOverrides == nil {
-                valueOverrides = [:]
-            }
-            valueOverrides?[token] = value
+            setOverrideValue(value, forToken: token)
         }
     }
 
@@ -42,8 +38,21 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
         valueOverrides?[token] = nil
     }
 
-    public var globalTokens: GlobalTokens { fluentTheme.globalTokens }
-    public var aliasTokens: AliasTokens { fluentTheme.aliasTokens }
+    /// Convenience method to replace all overrides with a new set of values.
+    ///
+    /// Any value present in `overrideTokens` will be set onto this control. All other values will be
+    /// removed from this control. If overrideTokens is `nil`, then all current overrides will be removed.
+    ///
+    /// - Parameter overrideTokens: The set of tokens to set as custom, or `nil` to remove all overrides.
+    public func replaceAllOverrides(with overrideTokens: [T: ControlTokenValue]?) {
+        T.allCases.forEach { token in
+            if let value = overrideTokens?[token] {
+                self[token] = value
+            } else {
+                self.removeOverride(token)
+            }
+        }
+    }
 
     /// Returns the default values for a given `ControlTokenSet`.
     ///
@@ -79,10 +88,31 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
         }
     }
 
+    // Internal accessor and setter functions for the override dictionary
+
+    func overrideValue(forToken token: T) -> ControlTokenValue? {
+        if let value = valueOverrides?[token] {
+            return value
+        } else if let value = fluentTheme.tokens(for: type(of: self))?[token] {
+            return value
+        }
+        return nil
+    }
+
+    func setOverrideValue(_ value: ControlTokenValue?, forToken token: T) {
+        if valueOverrides == nil {
+            valueOverrides = [:]
+        }
+        valueOverrides?[token] = value
+    }
+
+    var globalTokens: GlobalTokens { fluentTheme.globalTokens }
+    var aliasTokens: AliasTokens { fluentTheme.aliasTokens }
+
     @Published var fluentTheme: FluentTheme = FluentTheme.shared
 
     /// Access to raw overrides for the `ControlTokenSet`.
-    @Published var valueOverrides: [T: ControlTokenValue]?
+    @Published private var valueOverrides: [T: ControlTokenValue]?
 }
 
 /// Union-type enumeration of all possible token values to be stored by a `ControlTokenSet`.

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -199,7 +199,7 @@ public enum ControlTokenValue {
         // Use our global "Hot Pink" in debug builds, to help identify unintentional conversions.
         return DynamicColor(light: ColorValue(0xE3008C))
 #else
-        return DynamicColor(light: 0x000000)
+        return DynamicColor(light: ColorValue(0xE3008C))
 #endif
     }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
@@ -48,7 +48,6 @@ extension View {
     ///
     /// - Parameter tokenSet: The control's `ControlTokenSet` that should be updated.
     /// - Parameter fluentTheme: The current `FluentTheme` for the given rendering context.
-    /// - Parameter configuration: An optional callback to perform additional configuration, such as setting `style` or `size`.
     ///
     /// - Returns: The rendered view after applying updates.
     func fluentTokens<TokenSetType: Hashable>(_ tokenSet: ControlTokenSet<TokenSetType>,

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -64,10 +64,6 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
             .fluentTokens(tokenSet, fluentTheme)
     }
 
-    let defaultTokens: IndeterminateProgressBarTokens = .init()
-    var tokens: IndeterminateProgressBarTokens {
-        return resolvedTokens
-    }
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.layoutDirection) var layoutDirection: LayoutDirection
     @ObservedObject var state: MSFIndeterminateProgressBarStateImpl
@@ -112,13 +108,8 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
 }
 
 /// Properties available to customize the state of the Indeterminate Progress Bar
-class MSFIndeterminateProgressBarStateImpl: NSObject,
-                                            ObservableObject,
-                                            ControlConfiguration,
+class MSFIndeterminateProgressBarStateImpl: ControlState,
                                             MSFIndeterminateProgressBarState {
     @Published var isAnimating: Bool = false
     @Published var hidesWhenStopped: Bool = true
-
-    /// Design token set for this control, to use in place of the control's default Fluent tokens.
-    @Published @objc public var overrideTokens: IndeterminateProgressBarTokens?
 }

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarModifiers.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarModifiers.swift
@@ -23,10 +23,4 @@ public extension IndeterminateProgressBar {
         state.hidesWhenStopped = hidesWhenStopped
         return self
     }
-
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: IndeterminateProgressBarTokens?) -> IndeterminateProgressBar {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -54,9 +54,4 @@ public extension View {
 }
 
 public extension FluentNotification {
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: NotificationTokens?) -> FluentNotification {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -56,10 +56,11 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 
-    private func updateTokens() {
+    private func updateAppearance() {
         updateActionTitleColors()
         backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokenSet[.cellBackgroundColor].dynamicColor)
     }
@@ -141,7 +142,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
         // Update appearance whenever `tokenSet` changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateTokens()
+            self?.updateAppearance()
         }
     }
 
@@ -217,12 +218,14 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateTokens()
+
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     open override func prepareForReuse() {
         super.prepareForReuse()
-        updateTokens()
+        updateAppearance()
         action1Button.removeTarget(nil, action: nil, for: .allEvents)
         action2Button.removeTarget(nil, action: nil, for: .allEvents)
     }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -20,10 +20,11 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 
-    private func updateTokens() {
+    private func updateAppearance() {
         backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokenSet[.cellBackgroundColor].dynamicColor)
     }
 
@@ -47,7 +48,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
         // Update appearance whenever `tokenSet` changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateTokens()
+            self?.updateAppearance()
         }
     }
 
@@ -64,12 +65,13 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateTokens()
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     open override func prepareForReuse() {
         super.prepareForReuse()
-        updateTokens()
+        updateAppearance()
         activityIndicator.state.isAnimating = true
     }
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -20,10 +20,11 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 
-    private func updateTokens() {
+    private func updateAppearance() {
         backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: tokenSet[.cellBackgroundColor].dynamicColor)
         label.font = UIFont.fluent(tokenSet[.titleFont].fontInfo)
         label.textColor = UIColor(dynamicColor: tokenSet[.mainBrandColor].dynamicColor)
@@ -51,7 +52,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
 
         // Update appearance whenever `tokenSet` changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateTokens()
+            self?.updateAppearance()
         }
     }
 
@@ -91,7 +92,9 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateTokens()
+
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     open override func setHighlighted(_ highlighted: Bool, animated: Bool) { }

--- a/ios/FluentUI/PersonaButton/PersonaButtonModifiers.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonModifiers.swift
@@ -6,9 +6,4 @@
 import SwiftUI
 
 public extension PersonaButton {
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: PersonaButtonTokens?) -> PersonaButton {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselModifiers.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselModifiers.swift
@@ -6,9 +6,4 @@
 import SwiftUI
 
 public extension PersonaButtonCarousel {
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: PersonaButtonCarouselTokens?) -> PersonaButtonCarousel {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -125,7 +125,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        tokenSet.update(fluentTheme)
+        tokenSet.update(window.fluentTheme)
     }
 
     private func initUnreadDotLayer() -> CALayer {

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -56,7 +56,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         super.didMoveToWindow()
 
         tokenSet.update(fluentTheme)
-        updateAppearance()
+        updatePillButtonAppearance()
     }
 
     open override func layoutSubviews() {
@@ -115,7 +115,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         tokenSetSink = tokenSet.objectWillChange.sink { [weak self] _ in
             // Values will be updated on the next run loop iteration.
             DispatchQueue.main.async {
-                self?.updateAppearance()
+                self?.updatePillButtonAppearance()
             }
         }
     }
@@ -198,7 +198,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
 
     public var pillButtonOverrideTokens: [PillButtonTokenSet.Tokens: ControlTokenValue]? {
         didSet {
-            updateAppearance()
+            updatePillButtonAppearance()
         }
     }
 
@@ -266,7 +266,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
             }
 
             if pillButtonOverrideTokens != nil {
-                updateAppearance()
+                updatePillButtonAppearance()
             }
         }
     }
@@ -485,7 +485,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         }
     }
 
-    private func updateAppearance() {
+    private func updatePillButtonAppearance() {
         for button in buttons {
             button.tokenSet.replaceAllOverrides(with: pillButtonOverrideTokens)
         }
@@ -496,7 +496,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
             return
         }
         tokenSet.update(window.fluentTheme)
-        updateAppearance()
+        updatePillButtonAppearance()
     }
 
     private var leadingConstraint: NSLayoutConstraint?

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -56,7 +56,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         super.didMoveToWindow()
 
         tokenSet.update(fluentTheme)
-        updatePillButtonTokens()
+        updateAppearance()
     }
 
     open override func layoutSubviews() {
@@ -115,7 +115,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         tokenSetSink = tokenSet.objectWillChange.sink { [weak self] _ in
             // Values will be updated on the next run loop iteration.
             DispatchQueue.main.async {
-                self?.updatePillButtonTokens()
+                self?.updateAppearance()
             }
         }
     }
@@ -198,7 +198,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
 
     public var pillButtonOverrideTokens: [PillButtonTokenSet.Tokens: ControlTokenValue]? {
         didSet {
-            updatePillButtonTokens()
+            updateAppearance()
         }
     }
 
@@ -266,7 +266,7 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
             }
 
             if pillButtonOverrideTokens != nil {
-                updatePillButtonTokens()
+                updateAppearance()
             }
         }
     }
@@ -485,15 +485,9 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         }
     }
 
-    private func updatePillButtonTokens() {
+    private func updateAppearance() {
         for button in buttons {
-            PillButtonTokenSet.Tokens.allCases.forEach { token in
-                if let tokenValue = pillButtonOverrideTokens?[token] {
-                    button.tokenSet[token] = tokenValue
-                } else {
-                    button.tokenSet.removeOverride(token)
-                }
-            }
+            button.tokenSet.replaceAllOverrides(with: pillButtonOverrideTokens)
         }
     }
 
@@ -501,7 +495,8 @@ open class PillButtonBar: UIScrollView, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updatePillButtonTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 
     private var leadingConstraint: NSLayoutConstraint?

--- a/ios/FluentUI/Pill Button Bar/PillButtonBarTokenSet.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBarTokenSet.swift
@@ -12,7 +12,7 @@ public class PillButtonBarTokenSet: ControlTokenSet<PillButtonBarTokenSet.Tokens
         case maxButtonsSpacing
 
         /// Minimum spacing between `PillButton` controls
-        case  minButtonsSpacing
+        case minButtonsSpacing
 
         /// Minimum width of the last button that must be showing on screen when the `PillButtonBar` loads or redraws
         case minButtonVisibleWidth

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleTokenSet.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleTokenSet.swift
@@ -7,7 +7,7 @@ import UIKit
 import SwiftUI
 
 /// Design token set for the `ResizingHandleView` control.
-open class ResizingHandleTokenSet: ControlTokenSet<ResizingHandleTokenSet.Tokens> {
+public class ResizingHandleTokenSet: ControlTokenSet<ResizingHandleTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
         /// Defines the color of the mark of the `ResizingHandle`.
         case markColor

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -88,6 +88,7 @@ open class ResizingHandleView: UIView, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
+        tokenSet.update(window.fluentTheme)
         updateColors()
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -363,6 +363,8 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
+
+        tokenSet.update(fluentTheme)
         updateColors()
         updateButtons()
     }
@@ -515,6 +517,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
+        tokenSet.update(window.fluentTheme)
         updateColors()
         updateButtons()
     }

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -141,7 +141,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
 
         // Update appearance whenever overrideTokens changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateSideTabBarTokens()
+            self?.updateAppearance()
         }
     }
 
@@ -224,7 +224,9 @@ open class SideTabBar: UIView, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateSideTabBarTokens()
+
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     private func didUpdateItems(in section: Section) {
@@ -375,20 +377,25 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     public var tokenSet: SideTabBarTokenSet = .init()
     var tokenSetSink: AnyCancellable?
 
-    private func updateSideTabBarTokens() {
+    private func updateAppearance() {
         updateSideTabBarTokensForSection(in: .top)
         updateSideTabBarTokensForSection(in: .bottom)
     }
 
     private func updateSideTabBarTokensForSection(in section: Section) {
         for subview in stackView(in: section).arrangedSubviews {
-            if let tabBarItemView = subview as? TabBarItemView,
-               var tabBarItemOverrides = tabBarItemView.tokenSet.valueOverrides {
+            if let tabBarItemView = subview as? TabBarItemView {
+                let tabBarItemTokenSet = tabBarItemView.tokenSet
+
                 /// Directly map our custom values to theirs.
-                tabBarItemOverrides[.selectedColor] = tokenSet.valueOverrides?[.tabBarItemSelectedColor]
-                tabBarItemOverrides[.unselectedColor] = tokenSet.valueOverrides?[.tabBarItemUnselectedColor]
-                tabBarItemOverrides[.titleLabelFontPortrait] = tokenSet.valueOverrides?[.tabBarItemTitleLabelFontPortrait]
-                tabBarItemOverrides[.titleLabelFontLandscape] = tokenSet.valueOverrides?[.tabBarItemTitleLabelFontLandscape]
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),
+                                                    forToken: .selectedColor)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemUnselectedColor),
+                                                    forToken: .unselectedColor)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontPortrait),
+                                                    forToken: .titleLabelFontPortrait)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontLandscape),
+                                                    forToken: .titleLabelFontLandscape)
             }
         }
     }
@@ -397,6 +404,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateSideTabBarTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -13,11 +13,18 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
     var tokenSet: TabBarItemTokenSet = .init()
     var tokenSetSink: AnyCancellable?
 
+    func updateAppearance() {
+        updateColors()
+        updateBadgeView()
+        updateLayout()
+    }
+
     @objc private func themeDidChange(_ notification: Notification) {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateColors()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 
     override var isEnabled: Bool {
@@ -32,7 +39,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         didSet {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected
-            updateColors()
+            updateAppearance()
             if isSelected {
                 accessibilityTraits.insert(.selected)
             } else {
@@ -122,11 +129,14 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         badgeValue = item.badgeValue
         updateLayout()
 
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
         // Update appearance whenever `tokenSet` changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateColors()
-            self?.updateBadgeView()
-            self?.updateLayout()
+            self?.updateAppearance()
         }
     }
 
@@ -160,9 +170,9 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateColors()
-        updateBadgeView()
-        updateLayout()
+
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     private var badgeValue: String? {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -68,7 +68,9 @@ open class TabBarView: UIView, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateTabBarTokens()
+
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     /// Set the custom spacing after the specified item.
@@ -115,7 +117,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
 
         // Update appearance whenever `tokenSet` changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateTabBarTokens()
+            self?.updateAppearance()
             self?.updateHeight()
         }
     }
@@ -188,16 +190,21 @@ open class TabBarView: UIView, TokenizedControlInternal {
     public var tokenSet: TabBarTokenSet = .init()
     private var tokenSetSink: AnyCancellable?
 
-    private func updateTabBarTokens() {
+    private func updateAppearance() {
         let arrangedSubviews = stackView.arrangedSubviews
         for subview in arrangedSubviews {
-            if let tabBarItemView = subview as? TabBarItemView,
-               var tabBarItemOverrides = tabBarItemView.tokenSet.valueOverrides {
+            if let tabBarItemView = subview as? TabBarItemView {
+                let tabBarItemTokenSet = tabBarItemView.tokenSet
+
                 /// Directly map our custom values to theirs.
-                tabBarItemOverrides[.selectedColor] = tokenSet.valueOverrides?[.tabBarItemSelectedColor]
-                tabBarItemOverrides[.unselectedColor] = tokenSet.valueOverrides?[.tabBarItemUnselectedColor]
-                tabBarItemOverrides[.titleLabelFontPortrait] = tokenSet.valueOverrides?[.tabBarItemTitleLabelFontPortrait]
-                tabBarItemOverrides[.titleLabelFontLandscape] = tokenSet.valueOverrides?[.tabBarItemTitleLabelFontLandscape]
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),
+                                                    forToken: .selectedColor)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemUnselectedColor),
+                                                    forToken: .unselectedColor)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontPortrait),
+                                                    forToken: .titleLabelFontPortrait)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontLandscape),
+                                                    forToken: .titleLabelFontLandscape)
             }
         }
     }
@@ -206,6 +213,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateTabBarTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -181,7 +181,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         guard let window = window, window.isEqual(notification.object) else {
             return
         }
-        updateTokens()
+        tokenSet.update(window.fluentTheme)
+        updateAppearance()
     }
 
     /// The height of the cell based on the height of its content.
@@ -1143,7 +1144,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         // Update appearance whenever `tokenSet` changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            self?.updateTokens()
+            self?.updateAppearance()
         }
     }
 
@@ -1576,7 +1577,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         onAccessoryTapped = nil
 
-        updateTokens()
+        updateAppearance()
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
@@ -1683,10 +1684,12 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateTokens()
+
+        tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
-    private func updateTokens() {
+    private func updateAppearance() {
         updateFonts()
         updateTextColors()
         updateSelectionImageColor()

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -316,12 +316,16 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
             return .dynamicColor { self.globalTokens.brandColors[.primary] }
 
         case .destructiveTextColor:
-            return .dynamicColor { DynamicColor(light: ColorValue(0xD92C2C),
-                                                dark: ColorValue(0xE83A3A)) }
+            return .dynamicColor {
+                DynamicColor(light: ColorValue(0xD92C2C),
+                             dark: ColorValue(0xE83A3A))
+            }
 
         case .communicationTextColor:
-            return .dynamicColor { DynamicColor(light: ColorValue(0x0078D4),
-                                                dark: ColorValue(0x0086F0)) }
+            return .dynamicColor {
+                DynamicColor(light: ColorValue(0x0078D4),
+                             dark: ColorValue(0x0086F0))
+            }
         }
     }
 

--- a/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonModifiers.swift
@@ -15,9 +15,4 @@ public extension FluentButton {
         state.accessibilityLabel = accessibilityLabel
         return self
     }
-
-    func overrideTokens(_ tokens: ButtonTokens?) -> FluentButton {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/Vnext/Divider/DividerModifiers.swift
+++ b/ios/FluentUI/Vnext/Divider/DividerModifiers.swift
@@ -7,10 +7,4 @@ import SwiftUI
 import UIKit
 
 public extension FluentDivider {
-
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: DividerTokens?) -> FluentDivider {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/Vnext/HUD/HUDModifiers.swift
+++ b/ios/FluentUI/Vnext/HUD/HUDModifiers.swift
@@ -41,12 +41,6 @@ public extension HeadsUpDisplay {
         state.label = label
         return self
     }
-
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: HeadsUpDisplayTokens?) -> HeadsUpDisplay {
-        state.overrideTokens = tokens
-        return self
-    }
 }
 
 struct SquareShapedViewModifier: ViewModifier {

--- a/ios/FluentUI/Vnext/List/HeaderModifiers.swift
+++ b/ios/FluentUI/Vnext/List/HeaderModifiers.swift
@@ -7,9 +7,4 @@ import SwiftUI
 import UIKit
 
 extension Header {
-    /// Provides a custom design token set to be used when drawing this control.
-    func overrideTokens(_ tokens: HeaderTokens?) -> Header {
-        state.overrideTokens = tokens
-        return self
-    }
 }

--- a/ios/FluentUI/Vnext/List/List.swift
+++ b/ios/FluentUI/Vnext/List/List.swift
@@ -126,13 +126,12 @@ public struct FluentList: View {
 }
 
 /// Properties that make up section content
-class MSFListSectionStateImpl: NSObject, ObservableObject, Identifiable, ControlConfiguration, MSFListSectionState {
+class MSFListSectionStateImpl: ControlState, MSFListSectionState {
     init(style: MSFHeaderStyle = .standard) {
         self.style = style
         super.init()
     }
 
-    @Published var overrideTokens: HeaderTokens?
     @Published private(set) var cells: [MSFListCellStateImpl] = []
     @Published var title: String?
     @Published var backgroundColor: UIColor?


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This is the last of the Fluent2 TokenSet PRs into the `fluent2-tokenset` branch! It brings a bunch of miscellaneous cleanup from my "WIP" branch that didn't quite fit into any previous PR.

Probably the most exciting change: this branch finally builds AND runs AND passes unit tests! 🥳

Some other changes include:
* The new `ControlTokenSet.replaceAllOverrides(with:)` API! This simplifies the work of saying "please remove any custom overrides and only set those I have provided in this array", which up until now has been duplicated code in each demo controller.
* Calling the correct `FluentTheme.tokens(for:)` API to check if theme override is set. The previous `FluentTheme.tokenOverride(for:)` isn't even in this branch anymore!
* Minor tweaks to how UIKit controls redraw themselves when observing a `FluentTheme` change, or when override tokens are set. They should all now be consistently redrawing as needed.
* Removing some random dead code here and there (like the old `overrideTokens(_:)` modifiers.
* Miscellaneous whitespace cleanup to make the linter happy. Can't have an unhappy linter!

### Verification

Here's some demos that work better now!

#### Pill Button Bar

https://user-images.githubusercontent.com/4934719/183201108-63a14a86-5aaa-413b-94bd-56bf483fce13.mp4

#### Side Tab Bar

https://user-images.githubusercontent.com/4934719/183201722-8ce2bcd4-2c08-4e5a-989c-93a94c9aa966.mp4

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1136)