### PR TITLE
[Fluent 2 iOS] Tooltip shadow update

### DIFF
--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -11,10 +11,6 @@ class TooltipView: UIView {
     private struct Constants {
         static let messageLabelTextStyle: TextStyle = .subhead
 
-        static let shadowRadius: CGFloat = 4
-        static let shadowOffset: CGFloat = 2
-        static let shadowOpacity: Float = 0.24
-
         static let maximumWidth: CGFloat = 500
 
         static let paddingHorizontal: CGFloat = 13
@@ -99,9 +95,10 @@ class TooltipView: UIView {
         addSubview(messageLabel)
 
         // Shadow
-        layer.shadowOpacity = Constants.shadowOpacity
-        layer.shadowRadius = Constants.shadowRadius
-        layer.shadowOffset = CGSize(width: 0.0, height: Constants.shadowOffset)
+        let shadow = fluentTheme.aliasTokens.shadow[.shadow16]
+        layer.shadowColor = UIColor(dynamicColor: shadow.colorOne).cgColor
+        layer.shadowRadius = shadow.blurOne
+        layer.shadowOffset = CGSize(width: shadow.xOne, height: shadow.yOne)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -94,11 +94,7 @@ class TooltipView: UIView {
         messageLabel.isAccessibilityElement = false
         addSubview(messageLabel)
 
-        // Shadow
-        let shadow = fluentTheme.aliasTokens.shadow[.shadow16]
-        layer.shadowColor = UIColor(dynamicColor: shadow.colorOne).cgColor
-        layer.shadowRadius = shadow.blurOne
-        layer.shadowOffset = CGSize(width: shadow.xOne, height: shadow.yOne)
+        updateShadow()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -136,6 +132,7 @@ class TooltipView: UIView {
 
     @objc private func themeDidChange(_ notification: Notification) {
         updateColors()
+        updateShadow()
     }
 
     private func transformForArrowImageView() -> CGAffineTransform {
@@ -149,6 +146,16 @@ class TooltipView: UIView {
         case .right:
             return CGAffineTransform(rotationAngle: .pi * 0.5)
         }
+    }
+
+    private func updateShadow() {
+        let shadow = fluentTheme.aliasTokens.shadow[.shadow16]
+        let color = UIColor(dynamicColor: shadow.colorOne).cgColor
+
+        layer.shadowColor = color
+        layer.shadowOpacity = Float(color.alpha)
+        layer.shadowRadius = shadow.blurOne
+        layer.shadowOffset = CGSize(width: shadow.xOne, height: shadow.yOne)
     }
 
     private func updateColors() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Tooltip's shadow was updated to match fluent 2 specs.

### Verification

The change was tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="before_top_light" src="https://user-images.githubusercontent.com/106181067/183212224-1fe84d1b-d26e-429b-8897-db2e6eaec237.png"> | <img width="482" alt="after_top_light" src="https://user-images.githubusercontent.com/106181067/183212303-b683e7b0-eea2-4d7f-b412-92dc4b72f020.png"> |
| <img width="482" alt="before_bot_dark" src="https://user-images.githubusercontent.com/106181067/183212388-7129f9fd-086f-46e9-8a7e-8384f12abe0a.png"> | <img width="482" alt="after_bot_dark" src="https://user-images.githubusercontent.com/106181067/183212459-ddb9094e-f726-4bb2-8520-954fa9e368f6.png"> |
| <img width="482" alt="before_bot_light" src="https://user-images.githubusercontent.com/106181067/183212632-0244a890-dce2-4386-a088-ed40ca8b4342.png"> | <img width="482" alt="after_bot_light" src="https://user-images.githubusercontent.com/106181067/183212716-a371a8ef-c12b-4ee9-b23c-9967f8507687.png"> |
| <img width="482" alt="before_top_dark" src="https://user-images.githubusercontent.com/106181067/183212850-84380406-2ca4-4b83-9d26-be2ad51a76d5.png"> | <img width="482" alt="after_top_dark" src="https://user-images.githubusercontent.com/106181067/183212946-05bd7202-bd18-45d8-88ba-04bba7852201.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1137)