### PR TITLE
Introduce isHidden property to CommandBarItem

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -198,16 +198,21 @@ class CommandBarDemoController: DemoController {
         refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
-        let customizationStackView = UIStackView()
-        customizationStackView.axis = .horizontal
-        customizationStackView.alignment = .fill
-        customizationStackView.distribution = .fillProportionally
-        customizationStackView.addArrangedSubview(createLabelWithText("'+' Item Enabled"))
+        let itemEnabledStackView = createHorizontalStackView()
+        itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Item Enabled"))
         let itemEnabledSwitch: UISwitch = UISwitch()
         itemEnabledSwitch.isOn = true
         itemEnabledSwitch.addTarget(self, action: #selector(itemEnabledValueChanged), for: .valueChanged)
-        customizationStackView.addArrangedSubview(itemEnabledSwitch)
-        itemCustomizationContainer.addArrangedSubview(customizationStackView)
+        itemEnabledStackView.addArrangedSubview(itemEnabledSwitch)
+        itemCustomizationContainer.addArrangedSubview(itemEnabledStackView)
+
+        let itemHiddenStackView = createHorizontalStackView()
+        itemHiddenStackView.addArrangedSubview(createLabelWithText("'+' Item Hidden"))
+        let itemHiddenSwitch: UISwitch = UISwitch()
+        itemHiddenSwitch.isOn = false
+        itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
+        itemHiddenStackView.addArrangedSubview(itemHiddenSwitch)
+        itemCustomizationContainer.addArrangedSubview(itemHiddenStackView)
 
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
@@ -334,12 +339,28 @@ class CommandBarDemoController: DemoController {
         }
     }
 
+    func createHorizontalStackView() -> UIStackView {
+        let switchView = UIStackView()
+        switchView.axis = .horizontal
+        switchView.alignment = .fill
+        switchView.distribution = .fillProportionally
+        return switchView
+    }
+
     @objc func itemEnabledValueChanged(sender: UISwitch!) {
         guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
             return
         }
 
         item.isEnabled = sender.isOn
+    }
+
+    @objc func itemHiddenValueChanged(sender: UISwitch!) {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
+            return
+        }
+
+        item.isHidden = sender.isOn
     }
 
     @objc func refreshDefaultBarItems(sender: UIButton!) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -199,7 +199,7 @@ class CommandBarDemoController: DemoController {
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
         let itemEnabledStackView = createHorizontalStackView()
-        itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Item Enabled"))
+        itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Enabled"))
         let itemEnabledSwitch: UISwitch = UISwitch()
         itemEnabledSwitch.isOn = true
         itemEnabledSwitch.addTarget(self, action: #selector(itemEnabledValueChanged), for: .valueChanged)
@@ -207,7 +207,7 @@ class CommandBarDemoController: DemoController {
         itemCustomizationContainer.addArrangedSubview(itemEnabledStackView)
 
         let itemHiddenStackView = createHorizontalStackView()
-        itemHiddenStackView.addArrangedSubview(createLabelWithText("'+' Item Hidden"))
+        itemHiddenStackView.addArrangedSubview(createLabelWithText("'+' Hidden"))
         let itemHiddenSwitch: UISwitch = UISwitch()
         itemHiddenSwitch.isOn = false
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
@@ -340,11 +340,12 @@ class CommandBarDemoController: DemoController {
     }
 
     func createHorizontalStackView() -> UIStackView {
-        let switchView = UIStackView()
-        switchView.axis = .horizontal
-        switchView.alignment = .fill
-        switchView.distribution = .fillProportionally
-        return switchView
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fillProportionally
+        stackView.spacing = CommandBarDemoController.horizontalStackViewSpacing
+        return stackView
     }
 
     @objc func itemEnabledValueChanged(sender: UISwitch!) {
@@ -383,5 +384,6 @@ class CommandBarDemoController: DemoController {
         defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
     }
 
+    private static let horizontalStackViewSpacing: CGFloat = 16.0
     private static let verticalStackViewSpacing: CGFloat = 8.0
 }

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -276,7 +276,7 @@ extension CommandBar: UIScrollViewDelegate {
     }
 }
 
-/// A UIView subclass that udpates its mask frame during layoutSubviews. By default, the layer mask
+/// A UIView subclass that updates its mask frame during layoutSubviews. By default, the layer mask
 /// is not hooked into auto-layout and will not update its frame if its parent frame changes size. This implementation
 /// fixes that.
 private class MaskedView: UIView {

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -280,15 +280,6 @@ extension CommandBar: UIScrollViewDelegate {
 /// is not hooked into auto-layout and will not update its frame if its parent frame changes size. This implementation
 /// fixes that.
 private class MaskedView: UIView {
-    init() {
-        super.init(frame: .zero)
-    }
-
-    @available(*, unavailable)
-    required init(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
-
     override func layoutSubviews() {
         super.layoutSubviews()
         layer.mask?.frame = bounds

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -97,9 +97,6 @@ open class CommandBar: UIView {
     public override func layoutSubviews() {
         super.layoutSubviews()
 
-        commandBarContainerStackView.layoutIfNeeded()
-
-        containerMaskLayer.frame = containerView.bounds
         updateShadow()
     }
 
@@ -149,8 +146,8 @@ open class CommandBar: UIView {
 
     // MARK: Views and Layers
 
-    private lazy var containerView: UIView = {
-        let containerView = UIView()
+    private lazy var containerView: MaskedView = {
+        let containerView = MaskedView()
         containerView.translatesAutoresizingMaskIntoConstraints = false
         containerView.layer.mask = containerMaskLayer
 
@@ -259,7 +256,6 @@ open class CommandBar: UIView {
 
         commandGroupsView.isHidden = commandGroupsView.itemGroups.isEmpty
         scrollView.contentInset = scrollViewContentInset()
-        setNeedsLayout()
     }
 
     private struct LayoutConstants {
@@ -277,5 +273,24 @@ open class CommandBar: UIView {
 extension CommandBar: UIScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateShadow()
+    }
+}
+
+/// A UIView subclass that udpates its mask frame during layoutSubviews. By default, the layer mask
+/// is not hooked into auto-layout and will not update its frame if its parent frame changes size. This implementation
+/// fixes that.
+private class MaskedView: UIView {
+    init() {
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.mask?.frame = bounds
     }
 }

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -146,8 +146,8 @@ open class CommandBar: UIView {
 
     // MARK: Views and Layers
 
-    private lazy var containerView: MaskedView = {
-        let containerView = MaskedView()
+    private lazy var containerView: CommandBarContainerView = {
+        let containerView = CommandBarContainerView()
         containerView.translatesAutoresizingMaskIntoConstraints = false
         containerView.layer.mask = containerMaskLayer
 
@@ -279,7 +279,7 @@ extension CommandBar: UIScrollViewDelegate {
 /// A UIView subclass that updates its mask frame during layoutSubviews. By default, the layer mask
 /// is not hooked into auto-layout and will not update its frame if its parent frame changes size. This implementation
 /// fixes that.
-private class MaskedView: UIView {
+private class CommandBarContainerView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         layer.mask?.frame = bounds

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -59,6 +59,7 @@ class CommandBarButton: UIButton {
     func updateState() {
         isEnabled = item.isEnabled
         isSelected = isPersistSelection && item.isSelected
+        isHidden = item.isHidden
 
         // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
         let iconImage = item.iconImage

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -27,7 +27,6 @@ open class CommandBarItem: NSObject {
         self.isEnabled = isEnabled
         self.isSelected = isSelected
         self.itemTappedHandler = itemTappedHandler
-        self.isHidden = false
 
         super.init()
 
@@ -53,7 +52,6 @@ open class CommandBarItem: NSObject {
         self.isEnabled = isEnabled
         self.isSelected = isSelected
         self.itemTappedHandler = itemTappedHandler
-        self.isHidden = false
 
         super.init()
 
@@ -90,7 +88,7 @@ open class CommandBarItem: NSObject {
         }
     }
 
-    @objc public var isHidden: Bool {
+    @objc public var isHidden: Bool = false {
         didSet {
             if isHidden != oldValue {
                 propertyChangedUpdateBlock?(self)

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -27,6 +27,7 @@ open class CommandBarItem: NSObject {
         self.isEnabled = isEnabled
         self.isSelected = isSelected
         self.itemTappedHandler = itemTappedHandler
+        self.isHidden = false
 
         super.init()
 
@@ -52,6 +53,7 @@ open class CommandBarItem: NSObject {
         self.isEnabled = isEnabled
         self.isSelected = isSelected
         self.itemTappedHandler = itemTappedHandler
+        self.isHidden = false
 
         super.init()
 
@@ -83,6 +85,14 @@ open class CommandBarItem: NSObject {
     @objc public var isEnabled: Bool {
         didSet {
             if isEnabled != oldValue {
+                propertyChangedUpdateBlock?(self)
+            }
+        }
+    }
+
+    @objc public var isHidden: Bool {
+        didSet {
+            if isHidden != oldValue {
                 propertyChangedUpdateBlock?(self)
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The existing CommandBarItem does not allow items to change their hidden state. This change aims to enable that capability and fix a related layout issue.

- Add a public `isHidden` `bool` property to `CommandBarItem` that defaults to `false`. This value is used in the `CommandBarButton updateButtonState` method to update the button's `isHidden` property.
    - A new argument in the `CommandBarItem` initializer was _not added_ so that this will not be a breaking API change for Obj-C consumers. I don't think it's 100% necessary to add it as an argument at this time anyways.
- Add the `MaskedView` private UIView subclass to resolve a layout issue where the mask's frame does update when the size of the `CommandBarView`'s subviews change.
    - A layer mask is applied to the `containerView` inside `CommandBarView` to create a visual texture between the leading and trailing pinned items and the center scrolling items. The mask is set on the `layer` of the `containerView`. Currently, the `CommandBarView.layoutSubview()` attempts to update the mask's frame when the subviews change, but the `layoutSubviews` method isn't always called since the size of the CommandBarView's view generally doesn't change when its subviews change. To fix this, `layoutSubviews` is implemented on actual parent view of the layer mask and the mask frame is updated there.

### Verification

- Verified the behavior using the demo controller
- Verified the behavior with devmain builds


https://user-images.githubusercontent.com/10938746/183263977-e82e90de-2e5d-4cf7-92a3-e5510939b2df.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1139)