### PR TITLE
[Fluent 2 iOS] TableViewCell colors update (1/2)

### DIFF
--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -6,36 +6,22 @@ import UIKit
 
 open class TableViewCellTokens: ControlTokens {
     /// The background color of the TableView.
-    open var backgroundColor: DynamicColor {
-        .init(light: globalTokens.neutralColors[.white],
-              dark: globalTokens.neutralColors[.black])
-    }
+    open var backgroundColor: DynamicColor { aliasTokens.colors[.background1] }
 
     /// The grouped background color of the TableView.
-    open var backgroundGroupedColor: DynamicColor {
-        .init(light: aliasTokens.backgroundColors[.neutral2].light,
-              dark: aliasTokens.backgroundColors[.neutral1].dark)
-    }
+    open var backgroundGrouped: DynamicColor {  aliasTokens.colors[.background5]}
 
     /// The background color of the TableViewCell.
-    open var cellBackgroundColor: DynamicColor {
-        .init(light: aliasTokens.backgroundColors[.neutral1].light,
-              dark: aliasTokens.backgroundColors[.neutral1].dark,
-              darkElevated: aliasTokens.backgroundColors[.neutral2].darkElevated)
-    }
+    open var cellBackgroundColor: DynamicColor { aliasTokens.colors[.background1] }
 
     /// The grouped background color of the TableViewCell.
-    open var cellBackgroundGroupedColor: DynamicColor {
-        .init(light: aliasTokens.backgroundColors[.neutral1].light,
-              dark: aliasTokens.backgroundColors[.neutral3].dark,
-              darkElevated: ColorValue(0x212121))
-    }
+    open var cellBackgroundGrouped: DynamicColor { aliasTokens.colors[.background3] }
 
     /// The selected background color of the TableViewCell.
-    open var cellBackgroundSelectedColor: DynamicColor { aliasTokens.backgroundColors[.neutral5] }
+    open var cellBackgroundSelectedColor: DynamicColor { aliasTokens.colors[.background1Pressed] }
 
     /// The leading image color.
-    open var imageColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
+    open var imageColor: DynamicColor { aliasTokens.colors[.foreground3] }
 
     /// The size dimensions of the customView.
     open var customViewDimensions: CGSize {
@@ -64,16 +50,16 @@ open class TableViewCellTokens: ControlTokens {
     }
 
     /// The title label color.
-    open var titleColor: DynamicColor { aliasTokens.foregroundColors[.neutral1] }
+    open var titleColor: DynamicColor { aliasTokens.colors[.foreground1] }
 
     /// The subtitle label color.
-    open var subtitleColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
+    open var subtitleColor: DynamicColor { aliasTokens.colors[.foreground2] }
 
     /// The footer label color.
-    open var footerColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
+    open var footerColor: DynamicColor { aliasTokens.colors[.foreground2] }
 
     /// The color of the selectionImageView when it is not selected.
-    open var selectionIndicatorOffColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
+    open var selectionIndicatorOffColor: DynamicColor { aliasTokens.colors[.foreground3] }
 
     /// The font for the title.
     open var titleFont: FontInfo { aliasTokens.typography[.body1] }
@@ -160,13 +146,13 @@ open class TableViewCellTokens: ControlTokens {
     open var paddingTrailing: CGFloat { globalTokens.spacing[.medium] }
 
     /// The color for the accessoryDisclosureIndicator.
-    open var accessoryDisclosureIndicatorColor: DynamicColor { aliasTokens.foregroundColors[.neutral4] }
+    open var accessoryDisclosureIndicatorColor: DynamicColor { aliasTokens.colors[.foreground3] }
 
     /// The color for the accessoryDetailButtonColor.
-    open var accessoryDetailButtonColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
+    open var accessoryDetailButtonColor: DynamicColor { aliasTokens.colors[.foreground3] }
 
     /// The main primary brand color of the theme.
-    open var mainBrandColor: DynamicColor { globalTokens.brandColors[.primary] }
+    open var mainBrandColor: DynamicColor { aliasTokens.colors[.brandForeground1] }
 
     /// Defines the size of the customView size.
     public internal(set) var customViewSize: MSFTableViewCellCustomViewSize = .default

--- a/ios/FluentUI/Table View/TableViewTokens.swift
+++ b/ios/FluentUI/Table View/TableViewTokens.swift
@@ -9,13 +9,13 @@ open class TableViewCellTokens: ControlTokens {
     open var backgroundColor: DynamicColor { aliasTokens.colors[.background1] }
 
     /// The grouped background color of the TableView.
-    open var backgroundGrouped: DynamicColor {  aliasTokens.colors[.background5]}
+    open var backgroundGroupedColor: DynamicColor {  aliasTokens.colors[.canvasBackground]}
 
     /// The background color of the TableViewCell.
     open var cellBackgroundColor: DynamicColor { aliasTokens.colors[.background1] }
 
     /// The grouped background color of the TableViewCell.
-    open var cellBackgroundGrouped: DynamicColor { aliasTokens.colors[.background3] }
+    open var cellBackgroundGroupedColor: DynamicColor { aliasTokens.colors[.background3] }
 
     /// The selected background color of the TableViewCell.
     open var cellBackgroundSelectedColor: DynamicColor { aliasTokens.colors[.background1Pressed] }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`TableViewCell` colors were updated to match fluent 2 specs. 

**NOTE**: These changes do not include:
- Color changes to `ActionsCell` -> This will be updated in a separate PR when the work on shared colors alias tokens is done.
- Removal of `Colors` extension -> A new PR will be up shortly dealing with this and addressing the dependencies.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="before_1_light" src="https://user-images.githubusercontent.com/106181067/183730187-89e7b69a-dea9-4d91-a0be-bb9ea1af2409.png"> | <img width="438" alt="after_1_light" src="https://user-images.githubusercontent.com/106181067/183730479-22b3ada7-4adf-488f-b8d5-f2f3f94882ae.png"> |
| <img width="482" alt="before_1_dark" src="https://user-images.githubusercontent.com/106181067/183731151-9dc3483a-449c-4187-9539-325d8edf2f48.png"> | <img width="482" alt="after_1_dark" src="https://user-images.githubusercontent.com/106181067/183731269-e852e95b-b4c0-4b93-9e18-dd0fd976d48d.png"> |
| <img width="482" alt="before_2_light" src="https://user-images.githubusercontent.com/106181067/183731401-90c30ef6-fc27-4808-93a7-eecb875de3b3.png"> | <img width="482" alt="after_2_light" src="https://user-images.githubusercontent.com/106181067/183731560-0d222e09-c5d9-4159-83e2-e6b8414127a4.png"> |
| <img width="482" alt="before_2_dark" src="https://user-images.githubusercontent.com/106181067/183731715-e54818aa-1f14-4104-a685-db905b219c91.png"> | <img width="482" alt="after_2_dark" src="https://user-images.githubusercontent.com/106181067/183731873-32215438-5cfb-46ef-89f4-45e98ed54bb3.png"> |
| <img width="482" alt="before_3_light" src="https://user-images.githubusercontent.com/106181067/183732172-99f83afd-418b-4a2b-8c88-81a00a9d336e.png"> | <img width="482" alt="after_3_light" src="https://user-images.githubusercontent.com/106181067/183732316-ee02deb3-4c36-4b71-b661-4fc574953fc6.png"> |
| <img width="482" alt="before_3_dark" src="https://user-images.githubusercontent.com/106181067/183732453-72de78bc-a1f1-4ead-af8c-b272c5ae2b67.png"> | <img width="482" alt="after_3_dark" src="https://user-images.githubusercontent.com/106181067/183732569-08258080-72bf-4124-8162-83424c633ada.png"> |
| <img width="482" alt="before_4_light" src="https://user-images.githubusercontent.com/106181067/183732693-017cea30-11fc-42d5-b0a9-8e541f996c2c.png"> | <img width="482" alt="after_4_light" src="https://user-images.githubusercontent.com/106181067/183732816-857a1dc1-83b3-4772-9118-2ae9045110e8.png"> |
| <img width="482" alt="before_4_dark" src="https://user-images.githubusercontent.com/106181067/183732918-29968e1e-dbf6-4296-b26e-f5f3a5f05c08.png"> | <img width="482" alt="after_4_dark" src="https://user-images.githubusercontent.com/106181067/183732995-c8f11643-e1ac-4fd7-a464-1cef5f9cfbff.png"> |
| <img width="482" alt="before_grouped_light" src="https://user-images.githubusercontent.com/106181067/183733169-a938fe1b-e1c8-4231-8106-bc1669cb7eb2.png"> | <img width="482" alt="after_grouped_light" src="https://user-images.githubusercontent.com/106181067/183733222-299d13a7-ca94-4917-ac8d-606d818d685b.png"> |
| <img width="482" alt="before_grouped_dark" src="https://user-images.githubusercontent.com/106181067/183733296-9ca33893-4d4e-4d56-8711-641d863385b3.png"> | <img width="482" alt="after_grouped_dark" src="https://user-images.githubusercontent.com/106181067/183733384-9b63b6ff-aa5c-474e-951a-127c5c2aece7.png"> |
| <img width="482" alt="before_selected_light" src="https://user-images.githubusercontent.com/106181067/183733576-5c1ea9a4-3444-4e85-974e-496852ba0b0b.png"> | <img width="482" alt="after_selected_light" src="https://user-images.githubusercontent.com/106181067/183733642-2632dec4-e5a1-4ca5-a492-63869bd2ee4b.png"> |
| <img width="482" alt="before_selected_dark" src="https://user-images.githubusercontent.com/106181067/183733697-c7b5c095-70f2-4322-9b93-c97f2965aa11.png"> | <img width="482" alt="after_selected_dark" src="https://user-images.githubusercontent.com/106181067/183733791-ff20d126-3831-4859-b4a0-e5e840e7ce75.png"> |
| <img width="482" alt="before_selected_grouped_light" src="https://user-images.githubusercontent.com/106181067/183733874-4c2d8ae4-21c7-42e7-a3be-71921e30da29.png"> | <img width="482" alt="after_selected_grouped_light" src="https://user-images.githubusercontent.com/106181067/183733968-74d2d863-a62d-442d-bf96-50ddb08eb459.png"> |
| <img width="482" alt="before_selected_grouped_dark" src="https://user-images.githubusercontent.com/106181067/183734037-5ca2ace1-9825-475e-9157-1828fd193222.png"> | <img width="482" alt="after_selected_grouped_dark" src="https://user-images.githubusercontent.com/106181067/183734108-6c548aac-7188-4db7-9bc2-2922f3fe8e0b.png"> |
| <img width="858" alt="before_dark_elevated" src="https://user-images.githubusercontent.com/106181067/183734209-b4b2650e-9fe6-4d61-9751-d66bf5645335.png"> | <img width="858" alt="after_dark_elevated" src="https://user-images.githubusercontent.com/106181067/183734260-2369496b-24f6-401d-8e6a-bd09d4861c55.png"> |
| <img width="858" alt="before_dark_elevated_grouped" src="https://user-images.githubusercontent.com/106181067/183734311-15f81f90-847a-473e-beff-6fe56cca6756.png"> | <img width="858" alt="after_dark_elevated_grouped" src="https://user-images.githubusercontent.com/106181067/183734359-27a85ddd-7553-49ef-9f01-880c43bc5702.png"> |
| ![before_light](https://user-images.githubusercontent.com/106181067/184428451-b7030b44-0a8d-4678-a62e-35d9c1634ce6.jpeg) | ![after_light](https://user-images.githubusercontent.com/106181067/184428649-8aefeca5-f371-4cf8-900d-2fc4528ce386.jpeg) |
| ![before_grouped_light](https://user-images.githubusercontent.com/106181067/184428515-d3d560c9-faab-4daa-b251-589ea63f54c3.jpeg) | ![after_grouped_light](https://user-images.githubusercontent.com/106181067/184428682-209c2dad-e585-432e-b810-47d19367e76b.jpeg) |
| ![before_dark](https://user-images.githubusercontent.com/106181067/184428748-6b1d45d5-bc62-408f-81c6-2b3466f493b1.jpeg) | ![after_dark](https://user-images.githubusercontent.com/106181067/184428785-9cb727a8-03d0-4073-9843-9b4efe35def1.jpeg) |
| ![before_grouped_dark](https://user-images.githubusercontent.com/106181067/184428822-6ce4eff5-3fdc-4581-9a50-35777216f6e6.PNG) | ![after_grouped_dark](https://user-images.githubusercontent.com/106181067/184428857-9d91cf41-a43f-41af-b8dd-26f1c7c82e67.jpeg) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1147)