### PR TITLE
[Fluent 2 iOS] TableViewCell colors update (2/2)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoTableViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoTableViewController.swift
@@ -22,7 +22,7 @@ class DemoTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.backgroundColor = TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme)
         tableView.separatorStyle = .none
 
         configureAppearancePopover()

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoTableViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoTableViewController.swift
@@ -22,7 +22,7 @@ class DemoTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
         tableView.separatorStyle = .none
 
         configureAppearancePopover()

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoTableViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoTableViewController.swift
@@ -22,7 +22,7 @@ class DemoTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.backgroundColor = Colors.tableBackgroundGrouped
+        tableView.backgroundColor = TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme)
         tableView.separatorStyle = .none
 
         configureAppearancePopover()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -126,7 +126,7 @@ class AvatarDemoController: DemoTableViewController {
                 cell.contentView.bottomAnchor.constraint(equalTo: avatarContentView.bottomAnchor)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackgroundColor(fluentTheme: cell.fluentTheme)
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor : TableViewCell.tableCellBackgroundColor
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -126,7 +126,7 @@ class AvatarDemoController: DemoTableViewController {
                 cell.contentView.bottomAnchor.constraint(equalTo: avatarContentView.bottomAnchor)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelected(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackground(fluentTheme: cell.fluentTheme)
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackgroundColor(fluentTheme: cell.fluentTheme)
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -126,7 +126,7 @@ class AvatarDemoController: DemoTableViewController {
                 cell.contentView.bottomAnchor.constraint(equalTo: avatarContentView.bottomAnchor)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelected(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackground(fluentTheme: cell.fluentTheme)
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -157,7 +157,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelected(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackground(fluentTheme: cell.fluentTheme)
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackgroundColor(fluentTheme: cell.fluentTheme)
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -157,7 +157,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackgroundColor(fluentTheme: cell.fluentTheme)
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor : TableViewCell.tableCellBackgroundColor
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -157,7 +157,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? Colors.tableCellBackgroundSelected : Colors.tableCellBackground
+            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelected(fluentTheme: cell.fluentTheme) : TableViewCell.tableCellBackground(fluentTheme: cell.fluentTheme)
 
             return cell
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -105,7 +105,7 @@ class ColorDemoController: UIViewController {
         tableView.delegate = self
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
-        tableView.backgroundColor = TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -105,7 +105,7 @@ class ColorDemoController: UIViewController {
         tableView.delegate = self
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
-        tableView.backgroundColor = TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundColor
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -105,7 +105,7 @@ class ColorDemoController: UIViewController {
         tableView.delegate = self
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
-        tableView.backgroundColor = Colors.tableBackground
+        tableView.backgroundColor = TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -719,7 +719,7 @@ class ModalViewController: UITableViewController {
     }
 
     private func updateTableView() {
-        tableView.backgroundColor = isGrouped ? Colors.tableBackgroundGrouped : Colors.tableBackground
+        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
         tableView.reloadData()
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -719,7 +719,7 @@ class ModalViewController: UITableViewController {
     }
 
     private func updateTableView() {
-        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGroupedColor : TableViewCell.tableBackgroundColor
         tableView.reloadData()
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -719,7 +719,7 @@ class ModalViewController: UITableViewController {
     }
 
     private func updateTableView() {
-        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
         tableView.reloadData()
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -27,7 +27,7 @@ class OtherCellsDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.backgroundColor = TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme)
         tableView.separatorColor = Colors.Separator.default
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -27,7 +27,7 @@ class OtherCellsDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
         tableView.separatorColor = Colors.Separator.default
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -27,7 +27,7 @@ class OtherCellsDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.backgroundColor = Colors.tableBackgroundGrouped
+        tableView.backgroundColor = TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme)
         tableView.separatorColor = Colors.Separator.default
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -105,7 +105,7 @@ class TableViewCellDemoController: DemoTableViewController {
     }
 
     private func updateTableView() {
-        tableView.backgroundColor = isGrouped ? Colors.tableBackgroundGrouped : Colors.tableBackground
+        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
         tableView.reloadData()
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -105,7 +105,7 @@ class TableViewCellDemoController: DemoTableViewController {
     }
 
     private func updateTableView() {
-        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGroupedColor : TableViewCell.tableBackgroundColor
         tableView.reloadData()
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -105,7 +105,7 @@ class TableViewCellDemoController: DemoTableViewController {
     }
 
     private func updateTableView() {
-        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGrouped(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = isGrouped ? TableViewCell.tableBackgroundGroupedColor(fluentTheme: tableView.fluentTheme) : TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
         tableView.reloadData()
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -57,7 +57,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.backgroundColor = TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundColor
         tableView.separatorStyle = .none
         return tableView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -57,7 +57,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.backgroundColor = TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
+        tableView.backgroundColor = TableViewCell.tableBackgroundColor(fluentTheme: tableView.fluentTheme)
         tableView.separatorStyle = .none
         return tableView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -57,7 +57,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.backgroundColor = Colors.tableBackground
+        tableView.backgroundColor = TableViewCell.tableBackground(fluentTheme: tableView.fluentTheme)
         tableView.separatorStyle = .none
         return tableView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
@@ -93,7 +93,7 @@ class TableViewSampleData {
         }
         let customView = UIImageView(image: image)
         customView.contentMode = .scaleAspectFit
-        customView.tintColor = TableViewCell.tableCellImage(fluentTheme: customView.fluentTheme)
+        customView.tintColor = TableViewCell.tableCellImageColor(fluentTheme: customView.fluentTheme)
         return customView
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
@@ -93,7 +93,7 @@ class TableViewSampleData {
         }
         let customView = UIImageView(image: image)
         customView.contentMode = .scaleAspectFit
-        customView.tintColor = Colors.tableCellImage
+        customView.tintColor = TableViewCell.tableCellImage(fluentTheme: customView.fluentTheme)
         return customView
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
@@ -93,7 +93,7 @@ class TableViewSampleData {
         }
         let customView = UIImageView(image: image)
         customView.contentMode = .scaleAspectFit
-        customView.tintColor = TableViewCell.tableCellImageColor(fluentTheme: customView.fluentTheme)
+        customView.tintColor = TableViewCell.tableCellImageColor
         return customView
     }
 }

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -78,7 +78,7 @@ open class PersonaListView: UITableView {
     @objc override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
 
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+        updateBackgroundColor()
         separatorStyle = .none
         tableFooterView = UIView(frame: .zero)
 
@@ -92,6 +92,22 @@ open class PersonaListView: UITableView {
 
         dataSource = self
         delegate = self
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateBackgroundColor()
+    }
+
+    private func updateBackgroundColor() {
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
     }
 
     @objc public required init(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -78,7 +78,7 @@ open class PersonaListView: UITableView {
     @objc override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
 
-        backgroundColor = Colors.Table.background
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
         separatorStyle = .none
         tableFooterView = UIView(frame: .zero)
 

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -77,7 +77,6 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     private let accessoryImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = Colors.Table.Cell.image
         return imageView
     }()
 
@@ -207,6 +206,8 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
 
     private func updateColors() {
+        accessoryImageView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+
         if let item = item {
             _imageView.tintColor = isSelected
                 ? item.imageSelectedColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -84,18 +84,6 @@ public enum TableViewCellBackgroundStyleType: Int {
     }
 }
 
-// MARK: - Table Colors
-
-public extension Colors {
-    // Objective-C support
-    @objc static var tableBackground: UIColor { return surfacePrimary }
-    @objc static var tableBackgroundGrouped: UIColor { return UIColor(light: surfaceSecondary, dark: surfacePrimary) }
-    @objc static var tableCellBackground: UIColor { return surfacePrimary }
-    @objc static var tableCellBackgroundGrouped: UIColor { return UIColor(light: surfacePrimary, dark: surfaceSecondary) }
-    @objc static var tableCellBackgroundSelected: UIColor { return surfaceTertiary }
-    @objc static var tableCellImage: UIColor { return iconSecondary }
-}
-
 // MARK: - TableViewCell
 
 /**
@@ -148,6 +136,26 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public static var smallHeight: CGFloat { return height(title: "", customViewSize: .small) }
     @objc public static var mediumHeight: CGFloat { return height(title: "", subtitle: " ") }
     @objc public static var largeHeight: CGFloat { return height(title: "", subtitle: " ", footer: " ") }
+
+    /// TableViewCell colors with obj-c support
+    @objc public static func tableBackground(fluentTheme: FluentTheme) -> UIColor {
+        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+    }
+    @objc public static func tableBackgroundGrouped(fluentTheme: FluentTheme) -> UIColor {
+        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.canvasBackground])
+    }
+    @objc public static func tableCellBackground(fluentTheme: FluentTheme) -> UIColor {
+        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+    }
+    @objc public static func tableCellBackgroundGrouped(fluentTheme: FluentTheme) -> UIColor {
+        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
+    }
+    @objc public static func tableCellBackgroundSelected(fluentTheme: FluentTheme) -> UIColor {
+        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1Pressed])
+    }
+    @objc public static func tableCellImage(fluentTheme: FluentTheme) -> UIColor {
+        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+    }
 
     /// Identifier string for TableViewCell
     @objc public static var identifier: String { return String(describing: self) }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -87,26 +87,6 @@ public enum TableViewCellBackgroundStyleType: Int {
 // MARK: - Table Colors
 
 public extension Colors {
-    internal struct Table {
-        struct Cell {
-            static var image: UIColor = iconSecondary
-            static var title: UIColor = textPrimary
-            static var subtitle: UIColor = textSecondary
-        }
-
-        struct HeaderFooter {
-            static var accessoryButtonText: UIColor = textSecondary
-            static var background: UIColor = .clear
-            static var backgroundDivider: UIColor = surfaceSecondary
-            static var text: UIColor = textSecondary
-            static var textDivider: UIColor = textSecondary
-            static var textLink = UIColor(light: Palette.communicationBlueShade10.color, dark: communicationBlue)
-        }
-
-        static var background: UIColor = surfacePrimary
-        static var backgroundGrouped = UIColor(light: surfaceSecondary, dark: surfacePrimary)
-    }
-
     // Objective-C support
     @objc static var tableBackground: UIColor { return surfacePrimary }
     @objc static var tableBackgroundGrouped: UIColor { return UIColor(light: surfaceSecondary, dark: surfacePrimary) }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -138,22 +138,22 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public static var largeHeight: CGFloat { return height(title: "", subtitle: " ", footer: " ") }
 
     /// TableViewCell colors with obj-c support
-    @objc public static func tableBackground(fluentTheme: FluentTheme) -> UIColor {
+    @objc public static func tableBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
         UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
     }
-    @objc public static func tableBackgroundGrouped(fluentTheme: FluentTheme) -> UIColor {
+    @objc public static func tableBackgroundGroupedColor(fluentTheme: FluentTheme) -> UIColor {
         UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.canvasBackground])
     }
-    @objc public static func tableCellBackground(fluentTheme: FluentTheme) -> UIColor {
+    @objc public static func tableCellBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
         UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
     }
-    @objc public static func tableCellBackgroundGrouped(fluentTheme: FluentTheme) -> UIColor {
+    @objc public static func tableCellBackgroundGroupedColor(fluentTheme: FluentTheme) -> UIColor {
         UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
     }
-    @objc public static func tableCellBackgroundSelected(fluentTheme: FluentTheme) -> UIColor {
+    @objc public static func tableCellBackgroundSelectedColor(fluentTheme: FluentTheme) -> UIColor {
         UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1Pressed])
     }
-    @objc public static func tableCellImage(fluentTheme: FluentTheme) -> UIColor {
+    @objc public static func tableCellImageColor(fluentTheme: FluentTheme) -> UIColor {
         UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
     }
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -138,23 +138,23 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public static var largeHeight: CGFloat { return height(title: "", subtitle: " ", footer: " ") }
 
     /// TableViewCell colors with obj-c support
-    @objc public static func tableBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
-        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+    @objc public static var tableBackgroundColor: UIColor {
+        UIColor(dynamicColor: TableViewCellTokens().backgroundColor)
     }
-    @objc public static func tableBackgroundGroupedColor(fluentTheme: FluentTheme) -> UIColor {
-        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.canvasBackground])
+    @objc public static var tableBackgroundGroupedColor: UIColor {
+        UIColor(dynamicColor: TableViewCellTokens().backgroundGroupedColor)
     }
-    @objc public static func tableCellBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
-        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+    @objc public static var tableCellBackgroundColor: UIColor {
+        UIColor(dynamicColor: TableViewCellTokens().cellBackgroundColor)
     }
-    @objc public static func tableCellBackgroundGroupedColor(fluentTheme: FluentTheme) -> UIColor {
-        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
+    @objc public static var tableCellBackgroundGroupedColor: UIColor {
+        UIColor(dynamicColor: TableViewCellTokens().cellBackgroundGroupedColor)
     }
-    @objc public static func tableCellBackgroundSelectedColor(fluentTheme: FluentTheme) -> UIColor {
-        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1Pressed])
+    @objc public static var tableCellBackgroundSelectedColor: UIColor {
+        UIColor(dynamicColor: TableViewCellTokens().cellBackgroundSelectedColor)
     }
-    @objc public static func tableCellImageColor(fluentTheme: FluentTheme) -> UIColor {
-        UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+    @objc public static var tableCellImageColor: UIColor {
+        UIColor(dynamicColor: TableViewCellTokens().imageColor)
     }
 
     /// Identifier string for TableViewCell

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -551,6 +551,22 @@ private class TableViewHeaderFooterTitleView: UITextView {
         self.textContainer.lineFragmentPadding = 0
         textContainerInset = .zero
         layoutManager.usesFontLeading = false
+        updateLinkTextColor()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateLinkTextColor()
+    }
+
+    private func updateLinkTextColor() {
         linkTextAttributes = [.foregroundColor: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])]
     }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -551,7 +551,7 @@ private class TableViewHeaderFooterTitleView: UITextView {
         self.textContainer.lineFragmentPadding = 0
         textContainerInset = .zero
         layoutManager.usesFontLeading = false
-        linkTextAttributes = [.foregroundColor: Colors.Table.HeaderFooter.textLink]
+        linkTextAttributes = [.foregroundColor: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])]
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

As we are trying to move away from `Colors.swift`, the `Colors` extension was removed from `TableViewCell`.
Some of the colors in the `Table` struct were used by other controls in fluent. In fact, `PersonaListView`, `TableViewHeaderFooterTitleView` & `PopupMenuItemCell` had dependencies to some of these colors and they were all updated to use their appropriate color tokens instead.
The Objective-C colors were changed into functions that take in a `FluentTheme` and output the right token. 

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="before_persona_light" src="https://user-images.githubusercontent.com/106181067/183772451-6aba394b-4149-476b-9e8f-08895ab05c77.png"> | <img width="482" alt="after_persona_light" src="https://user-images.githubusercontent.com/106181067/183772487-eabceb81-9a3a-4e2c-8517-cfecfd979199.png"> |
| <img width="482" alt="before_persona_dark" src="https://user-images.githubusercontent.com/106181067/183772510-51512c06-a66e-4858-ab6a-f21f4535893c.png"> | <img width="482" alt="after_persona_dark" src="https://user-images.githubusercontent.com/106181067/183772534-4b148e38-5b7b-4854-8658-802450a3ce8c.png"> |
| <img width="482" alt="before_title_light" src="https://user-images.githubusercontent.com/106181067/183772562-4b859ef9-4af7-42f9-8605-e670a1b95353.png"> | <img width="482" alt="after_title_light" src="https://user-images.githubusercontent.com/106181067/183772582-49e8bbcd-8510-49eb-adb3-fbec60220362.png"> |
| <img width="482" alt="before_title_dark" src="https://user-images.githubusercontent.com/106181067/183772609-970f8ea9-f0ae-48df-94c2-0536eeee06e8.png"> | <img width="482" alt="after_title_dark" src="https://user-images.githubusercontent.com/106181067/183772640-c4aa2689-3017-4b5c-b5f8-b733dbf2f380.png"> |
| <img width="820" alt="before" src="https://user-images.githubusercontent.com/106181067/183780112-3b0ed445-e22c-45a2-9af4-ce1babcac8ca.png"> | <img width="864" alt="after" src="https://user-images.githubusercontent.com/106181067/183780149-e90842bd-995c-4c40-ad96-fddabcbd35f4.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1148)