### PR TITLE
Fixing Label support for custom fonts, text color and max font size.

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -72,6 +72,8 @@ open class Label: UILabel {
     }
     private var _textColor: UIColor?
 
+    private var isUsingCustomAttributedText: Bool = false
+
     @objc public init(style: TextStyle = .body, colorStyle: TextColorStyle = .regular) {
         self.style = style
         self.colorStyle = colorStyle
@@ -89,6 +91,12 @@ open class Label: UILabel {
         updateTextColor()
     }
 
+    open override var attributedText: NSAttributedString? {
+      didSet {
+          isUsingCustomAttributedText = attributedText != nil
+        }
+    }
+
     private func initialize() {
         // textColor is assigned in super.init to a default value and so we need to reset our cache afterwards
         _textColor = nil
@@ -102,9 +110,10 @@ open class Label: UILabel {
 
     private func updateFont() {
         // If attributedText is set, it will be prioritized over any other label property changes
-        guard self.attributedText == nil else {
+        guard !isUsingCustomAttributedText else {
             return
         }
+
         let defaultFont = style.font
         if maxFontSize > 0 && defaultFont.pointSize > maxFontSize {
             font = defaultFont.withSize(maxFontSize)
@@ -115,9 +124,10 @@ open class Label: UILabel {
 
     private func updateTextColor() {
         // If attributedText is set, it will be prioritized over any other label property changes
-        guard self.attributedText == nil else {
+        guard !isUsingCustomAttributedText else {
             return
         }
+
         if let window = window {
             super.textColor = _textColor ?? colorStyle.color(for: window)
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Changes in PR #1067 introduced an issue where the updateFont and updateTextColor funcs stopped working.
The root cause of the problem is that the attributedText property is internally set when a new color was set in the Label.
Since the check added was only verifying a non nil attributedText property, it escaped the funcs every time after a color was set.

The solution is to override the attributedText property to differentiate when the client code explicitly sets a new NSAttributedString in the attributedText property. In that case, the update funcs should indeed be ignored.

### Verification

1. Exercised the large text support scenario in the TabBarView that was used to report the issue:

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Label_attributedText_bug](https://user-images.githubusercontent.com/68076145/184007104-e414d901-eabb-47e6-a041-21d2ea2fa632.png) | ![Label_attributedText_bug_fixed](https://user-images.githubusercontent.com/68076145/184006918-3e4e2365-5f5f-4ac2-a6c2-2c1b60e455cc.png) |

2. Ensured the attributed string support in the TableViewCell remains working correctly on the scrolling scenario that #1067 intended to fix:

![TableViewCell_AttributedString](https://user-images.githubusercontent.com/68076145/184007499-7cc9a9d9-3484-4308-bfdb-108525083aaf.png)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1150)