### PR TITLE
Notification animation improvements

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -36,6 +36,7 @@ struct NotificationDemoView: View {
     @State var isPresented: Bool = false
     @State var overrideTokens: Bool = false
     @State var isFlexibleWidthToast: Bool = false
+    @State var showFromBottom: Bool = true
 
     public var body: some View {
         let hasAttribute = hasBlueStrikethroughAttribute || hasLargeRedPapyrusFontAttribute
@@ -51,22 +52,23 @@ struct NotificationDemoView: View {
         let messageButtonAction = hasMessageAction ? { showAlert = true } : nil
         let hasMessage = !message.isEmpty
         let hasTitle = !title.isEmpty
-        let notification = FluentNotification(style: style,
-                                              isFlexibleWidthToast: isFlexibleWidthToast,
-                                              message: hasMessage ? message : nil,
-                                              attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
-                                              title: hasTitle ? title : nil,
-                                              attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
-                                              image: image,
-                                              trailingImage: trailingImage,
-                                              trailingImageAccessibilityLabel: showTrailingImage ? "Circle" : nil,
-                                              actionButtonTitle: actionButtonTitle,
-                                              actionButtonAction: actionButtonAction,
-                                              messageButtonAction: messageButtonAction)
-                            .overrideTokens(overrideTokens ? NotificationOverrideTokens() : nil)
 
         VStack {
-            notification
+            Rectangle()
+                .foregroundColor(.clear)
+                .presentNotification(style: style,
+                                     isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
+                                     message: hasMessage ? message : nil,
+                                     attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
+                                     isBlocking: false,
+                                     isPresented: .constant(true),
+                                     title: hasTitle ? title : nil,
+                                     attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
+                                     image: image,
+                                     actionButtonTitle: actionButtonTitle,
+                                     actionButtonAction: actionButtonAction,
+                                     messageButtonAction: messageButtonAction,
+                                     overrideTokens: $overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
                 .frame(maxWidth: .infinity, maxHeight: 150, alignment: .center)
                 .alert(isPresented: $showAlert, content: {
                     Alert(title: Text("Button tapped"))
@@ -147,6 +149,7 @@ struct NotificationDemoView: View {
 
                         FluentUIDemoToggle(titleKey: "Override Tokens (Image Color and Horizontal Spacing)", isOn: $overrideTokens)
                         FluentUIDemoToggle(titleKey: "Flexible Width Toast", isOn: $isFlexibleWidthToast)
+                        FluentUIDemoToggle(titleKey: "Present From Bottom", isOn: $showFromBottom)
                     }
                 }
                 .padding()
@@ -164,6 +167,7 @@ struct NotificationDemoView: View {
                              actionButtonTitle: actionButtonTitle,
                              actionButtonAction: actionButtonAction,
                              messageButtonAction: messageButtonAction,
+                             showFromBottom: showFromBottom,
                              overrideTokens: $overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -48,6 +48,7 @@ struct NotificationDemoView: View {
 
         let image = showImage ? UIImage(named: "play-in-circle-24x24") : nil
         let trailingImage = showTrailingImage ? UIImage(named: "Placeholder_24") : nil
+        let trailingImageLabel = showTrailingImage ? "Circle" : nil
         let actionButtonAction = hasActionButtonAction ? { showAlert = true } : nil
         let messageButtonAction = hasMessageAction ? { showAlert = true } : nil
         let hasMessage = !message.isEmpty
@@ -65,6 +66,8 @@ struct NotificationDemoView: View {
                                      title: hasTitle ? title : nil,
                                      attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
                                      image: image,
+                                     trailingImage: trailingImage,
+                                     trailingImageAccessibilityLabel: trailingImageLabel,
                                      actionButtonTitle: actionButtonTitle,
                                      actionButtonAction: actionButtonAction,
                                      messageButtonAction: messageButtonAction,
@@ -164,6 +167,8 @@ struct NotificationDemoView: View {
                              title: hasTitle ? title : nil,
                              attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
                              image: image,
+                             trailingImage: trailingImage,
+                             trailingImageAccessibilityLabel: trailingImageLabel,
                              actionButtonTitle: actionButtonTitle,
                              actionButtonAction: actionButtonAction,
                              messageButtonAction: messageButtonAction,

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -277,6 +277,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 GeometryReader { proxy in
                     let proposedSize = proxy.size
                     let proposedWidth = proposedSize.width
+                    // Get total horizontal padding by doubling the offset
                     let horizontalPadding = 2 * tokens.presentationOffset
                     let calculatedNotificationWidth: CGFloat = {
                         let isHalfLength = state.style.isToast && horizontalSizeClass == .regular
@@ -296,8 +297,11 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                         })
                         .padding(showFromBottom ? .bottom : .top, tokens.bottomPresentationPadding)
                         .onSizeChange { newSize in
-                            // Bottom offset is only updated when the notification isn't presented to account for the new notification height (if presented, offset doesn't need to be updated since it grows upward vertically)
                             bottomOffsetForDismissedState = newSize.height
+                            // Bottom offset is only updated when the notification
+                            // isn't presented to account for the new notification
+                            // height (if presented, offset doesn't need to be
+                            // updated since it grows upward vertically)
                             if !isPresented {
                                 bottomOffset = bottomOffsetForDismissedState
                             }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -106,6 +106,10 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         } else {
             _isPresented = .constant(true)
         }
+
+        if _isPresented.wrappedValue == true {
+            _opacity = .init(initialValue: 1)
+        }
     }
 
     public var body: some View {
@@ -300,6 +304,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                         }
                         .offset(y: showFromBottom ? bottomOffset : -bottomOffset)
                         .frame(width: proposedWidth, height: proposedSize.height, alignment: showFromBottom ? .bottom : .top)
+                        .opacity(opacity)
                 }
             }
         }
@@ -337,12 +342,14 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                               dampingFraction: tokens.style.animationDampingRatio,
                               blendDuration: 0)) {
             bottomOffset = 0
+            opacity = 1
         }
     }
 
     private func dismissAnimated() {
         withAnimation(.linear(duration: tokens.style.animationDurationForHide)) {
             bottomOffset = bottomOffsetForDismissedState
+            opacity = 0
         }
     }
 
@@ -353,6 +360,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     @State private var innerContentsSize: CGSize = CGSize()
     @State private var attributedMessageSize: CGSize = CGSize()
     @State private var attributedTitleSize: CGSize = CGSize()
+    @State private var opacity: CGFloat = 0
 
     // When true, the notification view will take up all proposed space
     // and automatically position itself within it.

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -69,6 +69,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
     ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
     ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
+    ///   - showFromBottom: Defines whether the notification shows from the bottom of the presenting view or the top.
     public init(style: MSFNotificationStyle,
                 shouldSelfPresent: Bool = true,
                 isFlexibleWidthToast: Bool = false,
@@ -82,7 +83,8 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                 trailingImageAccessibilityLabel: String? = nil,
                 actionButtonTitle: String? = nil,
                 actionButtonAction: (() -> Void)? = nil,
-                messageButtonAction: (() -> Void)? = nil) {
+                messageButtonAction: (() -> Void)? = nil,
+                showFromBottom: Bool = true) {
         let state = MSFNotificationStateImpl(style: style)
         state.message = message
         state.attributedMessage = attributedMessage
@@ -94,6 +96,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         state.actionButtonTitle = actionButtonTitle
         state.actionButtonAction = actionButtonAction
         state.messageButtonAction = messageButtonAction
+        state.showFromBottom = showFromBottom
         self.state = state
         self.shouldSelfPresent = shouldSelfPresent
         self.isFlexibleWidthToast = isFlexibleWidthToast && style.isToast

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -278,6 +278,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                         let isHalfLength = state.style.isToast && horizontalSizeClass == .regular
                         return isHalfLength ? proposedWidth / 2 : proposedWidth - horizontalPadding
                     }()
+                    let showFromBottom = state.showFromBottom
 
                     notification
                         .frame(idealWidth: isFlexibleWidthToast ? innerContentsSize.width - horizontalPadding : calculatedNotificationWidth,
@@ -289,7 +290,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                                 dismissAnimated()
                             }
                         })
-                        .padding(.bottom, tokens.bottomPresentationPadding)
+                        .padding(showFromBottom ? .bottom : .top, tokens.bottomPresentationPadding)
                         .onSizeChange { newSize in
                             bottomOffsetForDismissedState = newSize.height + (tokens.ambientShadowOffsetY / 2)
                             // Bottom offset is only updated when the notification isn't presented to account for the new notification height (if presented, offset doesn't need to be updated since it grows upward vertically)
@@ -297,8 +298,8 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                                 bottomOffset = bottomOffsetForDismissedState
                             }
                         }
-                        .offset(y: bottomOffset)
-                        .frame(width: proposedWidth, height: proposedSize.height, alignment: .bottom)
+                        .offset(y: showFromBottom ? bottomOffset : -bottomOffset)
+                        .frame(width: proposedWidth, height: proposedSize.height, alignment: showFromBottom ? .bottom : .top)
                 }
             }
         }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -296,8 +296,8 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                         })
                         .padding(showFromBottom ? .bottom : .top, tokens.bottomPresentationPadding)
                         .onSizeChange { newSize in
-                            bottomOffsetForDismissedState = newSize.height + (tokens.ambientShadowOffsetY / 2)
                             // Bottom offset is only updated when the notification isn't presented to account for the new notification height (if presented, offset doesn't need to be updated since it grows upward vertically)
+                            bottomOffsetForDismissedState = newSize.height
                             if !isPresented {
                                 bottomOffset = bottomOffsetForDismissedState
                             }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -47,6 +47,9 @@ import SwiftUI
 
     /// Design token set for this control, to use in place of the control's default Fluent tokens.
     var overrideTokens: NotificationTokens? { get set }
+
+    /// Defines whether the notification shows from the bottom of the presenting view or the top.
+    var showFromBottom: Bool { get set }
 }
 
 /// View that represents the Notification.
@@ -368,6 +371,7 @@ class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationS
     @Published public var image: UIImage?
     @Published public var trailingImage: UIImage?
     @Published public var trailingImageAccessibilityLabel: String?
+    @Published public var showFromBottom: Bool = true
 
     /// Title to display in the action button on the trailing edge of the control.
     ///

--- a/ios/FluentUI/Notification/MSFNotification.swift
+++ b/ios/FluentUI/Notification/MSFNotification.swift
@@ -81,9 +81,16 @@ import UIKit
             view.addSubview(self)
         }
 
-        let anchor = anchorView?.topAnchor ?? view.safeAreaLayoutGuide.bottomAnchor
-        constraintWhenHidden = self.topAnchor.constraint(equalTo: anchor)
-        constraintWhenShown = self.bottomAnchor.constraint(equalTo: anchor, constant: -presentationOffset)
+        let anchor: NSLayoutYAxisAnchor
+        if state.showFromBottom {
+            anchor = anchorView?.topAnchor ?? view.safeAreaLayoutGuide.bottomAnchor
+            constraintWhenHidden = self.topAnchor.constraint(equalTo: anchor)
+            constraintWhenShown = self.bottomAnchor.constraint(equalTo: anchor, constant: -presentationOffset)
+        } else {
+            anchor = anchorView?.bottomAnchor ?? view.safeAreaLayoutGuide.topAnchor
+            constraintWhenHidden = self.bottomAnchor.constraint(equalTo: anchor)
+            constraintWhenShown = self.topAnchor.constraint(equalTo: anchor, constant: presentationOffset)
+        }
 
         var constraints = [NSLayoutConstraint]()
         constraints.append(animated ? constraintWhenHidden : constraintWhenShown)

--- a/ios/FluentUI/Notification/MSFNotification.swift
+++ b/ios/FluentUI/Notification/MSFNotification.swift
@@ -120,6 +120,7 @@ import UIKit
             completion?(self)
         }
 
+        self.alpha = 0
         if animated {
             view.layoutIfNeeded()
             UIView.animate(withDuration: style.animationDurationForShow,
@@ -129,10 +130,12 @@ import UIKit
                            animations: {
                 self.constraintWhenHidden.isActive = false
                 self.constraintWhenShown.isActive = true
+                self.alpha = 1
                 view.layoutIfNeeded()
             }, completion: completionForShow)
         } else {
             completionForShow(true)
+            self.alpha = 1
         }
     }
 
@@ -175,6 +178,7 @@ import UIKit
                 UIView.animate(withDuration: notification.tokens.style.animationDurationForHide, animations: {
                     self.constraintWhenShown.isActive = false
                     self.constraintWhenHidden.isActive = true
+                    self.alpha = 0
                     self.superview?.layoutIfNeeded()
                 }, completion: { _ in
                     self.isHiding = false
@@ -182,6 +186,7 @@ import UIKit
                 })
             }
         } else {
+            self.alpha = 0
             completionForHide()
         }
     }

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -17,9 +17,12 @@ public extension View {
     ///   - title: Optional text to draw above the message area.
     ///   - attributedTitle: Optional attributed text to draw above the message area.
     ///   - image: Optional icon to draw at the leading edge of the control.
+    ///   - trailingImage: Optional icon to show in the action button if no button title is provided.
+    ///   - trailingImageAccessibilityLabel: Optional localized accessibility label for the trailing image.
     ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
     ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
+    ///   - showFromBottom: Defines whether the notification shows from the bottom of the presenting view or the top.
     ///   - overrideTokens: Custom NotificationTokens class that will override the default tokens.
     /// - Returns: The modified view with the capability of presenting a Notification.
     func presentNotification(style: MSFNotificationStyle,
@@ -31,6 +34,8 @@ public extension View {
                              title: String? = nil,
                              attributedTitle: NSAttributedString? = nil,
                              image: UIImage? = nil,
+                             trailingImage: UIImage? = nil,
+                             trailingImageAccessibilityLabel: String? = nil,
                              actionButtonTitle: String? = nil,
                              actionButtonAction: (() -> Void)? = nil,
                              messageButtonAction: (() -> Void)? = nil,
@@ -46,6 +51,8 @@ public extension View {
                                title: title,
                                attributedTitle: attributedTitle,
                                image: image,
+                               trailingImage: trailingImage,
+                               trailingImageAccessibilityLabel: trailingImageAccessibilityLabel,
                                actionButtonTitle: actionButtonTitle,
                                actionButtonAction: actionButtonAction,
                                messageButtonAction: messageButtonAction,

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -34,6 +34,7 @@ public extension View {
                              actionButtonTitle: String? = nil,
                              actionButtonAction: (() -> Void)? = nil,
                              messageButtonAction: (() -> Void)? = nil,
+                             showFromBottom: Bool = true,
                              overrideTokens: NotificationTokens? = nil) -> some View {
         self.presentingView(isPresented: isPresented,
                             isBlocking: isBlocking) {
@@ -47,7 +48,8 @@ public extension View {
                                image: image,
                                actionButtonTitle: actionButtonTitle,
                                actionButtonAction: actionButtonAction,
-                               messageButtonAction: messageButtonAction)
+                               messageButtonAction: messageButtonAction,
+                               showFromBottom: showFromBottom)
             .overrideTokens(overrideTokens)
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated the Notification to be able to show from the top.
Added an animation for the alpha changing from 0 to 1 when presenting, and back.
Updated the height logic in `.onSizeChange`, it was adding 1/2 the y offset for the shadow before, but the shadow should already be taken into account with `newSize`.

### Verification

| MSFNotification (UIKit) | FluentNotification (SwiftUI) |
|----------------------------------------------|--------------------------------------------|
| ![Notification_Top_UIKit](https://user-images.githubusercontent.com/67026548/184250248-dcd8a0ee-512a-4564-b541-8574f267d69a.gif) | ![Notification_Top_SwiftUI](https://user-images.githubusercontent.com/67026548/184250261-5dbcb84b-6bbf-4a15-8e09-cdb2a5490fc4.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1155)