### PR TITLE
Changing the BadgeLabelButton to use UIButton Configuration.

### DIFF
--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -25,7 +25,9 @@ class BadgeLabelButton: UIButton {
 
         super.init(frame: frame)
 
-        configuration = UIButton.Configuration.plain()
+        if #available(iOS 15.0, *) {
+            configuration = UIButton.Configuration.plain()
+        }
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(badgeValueDidChange),
@@ -67,11 +69,15 @@ class BadgeLabelButton: UIButton {
 
     private var badgeFrameOriginX: CGFloat {
         let xOrigin: CGFloat = {
-            if isLeftToRightUserInterfaceLayoutDirection {
-                return frame.size.width - (configuration?.contentInsets.leading ?? 0)
+            if #available(iOS 15.0, *) {
+                return isLeftToRightUserInterfaceLayoutDirection ?
+                frame.size.width - (configuration?.contentInsets.leading ?? 0) :
+                configuration?.contentInsets.trailing ?? 0
+            } else {
+                return isLeftToRightUserInterfaceLayoutDirection ?
+                frame.size.width - contentEdgeInsets.left :
+                contentEdgeInsets.left
             }
-
-            return configuration?.contentInsets.trailing ?? 0
         }()
 
         return (xOrigin - badgeWidth / 2)
@@ -122,8 +128,14 @@ class BadgeLabelButton: UIButton {
             landscapeImage = landscapeImage?.withRenderingMode(.alwaysTemplate)
         }
 
-        configuration?.image = traitCollection.verticalSizeClass == .regular ? portraitImage : landscapeImage
-        configuration?.title = item.title
+        if #available(iOS 15.0, *) {
+            configuration?.image = traitCollection.verticalSizeClass == .regular ? portraitImage : landscapeImage
+            configuration?.title = item.title
+        } else {
+            setImage(traitCollection.verticalSizeClass == .regular ? portraitImage : landscapeImage, for: .normal)
+            setTitle(item.title, for: .normal)
+        }
+
 
         if let action = item.action {
             addTarget(item.target, action: action, for: .touchUpInside)

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -136,7 +136,6 @@ class BadgeLabelButton: UIButton {
             setTitle(item.title, for: .normal)
         }
 
-
         if let action = item.action {
             addTarget(item.target, action: action, for: .touchUpInside)
         }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -25,6 +25,8 @@ class BadgeLabelButton: UIButton {
 
         super.init(frame: frame)
 
+        configuration = UIButton.Configuration.plain()
+
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(badgeValueDidChange),
                                                name: UIBarButtonItem.badgeValueDidChangeNotification,
@@ -64,9 +66,13 @@ class BadgeLabelButton: UIButton {
     }
 
     private var badgeFrameOriginX: CGFloat {
-        let xOrigin: CGFloat = isLeftToRightUserInterfaceLayoutDirection ?
-            frame.size.width - contentEdgeInsets.left :
-            contentEdgeInsets.left
+        let xOrigin: CGFloat = {
+            if isLeftToRightUserInterfaceLayoutDirection {
+                return frame.size.width - (configuration?.contentInsets.leading ?? 0)
+            }
+
+            return configuration?.contentInsets.trailing ?? 0
+        }()
 
         return (xOrigin - badgeWidth / 2)
     }
@@ -116,8 +122,8 @@ class BadgeLabelButton: UIButton {
             landscapeImage = landscapeImage?.withRenderingMode(.alwaysTemplate)
         }
 
-        setImage(traitCollection.verticalSizeClass == .regular ? portraitImage : landscapeImage, for: .normal)
-        setTitle(item.title, for: .normal)
+        configuration?.image = traitCollection.verticalSizeClass == .regular ? portraitImage : landscapeImage
+        configuration?.title = item.title
 
         if let action = item.action {
             addTarget(item.target, action: action, for: .touchUpInside)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -585,12 +585,21 @@ open class NavigationBar: UINavigationBar {
         let button = BadgeLabelButton(type: .system)
         button.item = item
         button.shouldUseWindowColorInBadge = style != .system
+
+        let insets: NSDirectionalEdgeInsets
         if isLeftItem {
-            let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
-            button.contentEdgeInsets = UIEdgeInsets(top: 0, left: isRTL ? 0 : Constants.leftBarButtonItemLeadingMargin, bottom: 0, right: isRTL ? Constants.leftBarButtonItemLeadingMargin : 0)
+            insets = NSDirectionalEdgeInsets(top: 0,
+                                             leading: Constants.leftBarButtonItemLeadingMargin,
+                                             bottom: 0,
+                                             trailing: 0)
         } else {
-            button.contentEdgeInsets = UIEdgeInsets(top: 0, left: Constants.rightBarButtonItemHorizontalPadding, bottom: 0, right: Constants.rightBarButtonItemHorizontalPadding)
+            insets = NSDirectionalEdgeInsets(top: 0,
+                                             leading: Constants.rightBarButtonItemHorizontalPadding,
+                                             bottom: 0,
+                                             trailing: Constants.rightBarButtonItemHorizontalPadding)
         }
+
+        button.configuration?.contentInsets = insets
         return button
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -586,20 +586,36 @@ open class NavigationBar: UINavigationBar {
         button.item = item
         button.shouldUseWindowColorInBadge = style != .system
 
-        let insets: NSDirectionalEdgeInsets
-        if isLeftItem {
-            insets = NSDirectionalEdgeInsets(top: 0,
-                                             leading: Constants.leftBarButtonItemLeadingMargin,
-                                             bottom: 0,
-                                             trailing: 0)
+        if #available(iOS 15.0, *) {
+            let insets: NSDirectionalEdgeInsets
+            if isLeftItem {
+                insets = NSDirectionalEdgeInsets(top: 0,
+                                                 leading: Constants.leftBarButtonItemLeadingMargin,
+                                                 bottom: 0,
+                                                 trailing: 0)
+            } else {
+                insets = NSDirectionalEdgeInsets(top: 0,
+                                                 leading: Constants.rightBarButtonItemHorizontalPadding,
+                                                 bottom: 0,
+                                                 trailing: Constants.rightBarButtonItemHorizontalPadding)
+            }
+
+            button.configuration?.contentInsets = insets
         } else {
-            insets = NSDirectionalEdgeInsets(top: 0,
-                                             leading: Constants.rightBarButtonItemHorizontalPadding,
-                                             bottom: 0,
-                                             trailing: Constants.rightBarButtonItemHorizontalPadding)
+            if isLeftItem {
+                let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
+                button.contentEdgeInsets = UIEdgeInsets(top: 0,
+                                                        left: isRTL ? 0 : Constants.leftBarButtonItemLeadingMargin,
+                                                        bottom: 0,
+                                                        right: isRTL ? Constants.leftBarButtonItemLeadingMargin : 0)
+            } else {
+                button.contentEdgeInsets = UIEdgeInsets(top: 0,
+                                                        left: Constants.rightBarButtonItemHorizontalPadding,
+                                                        bottom: 0,
+                                                        right: Constants.rightBarButtonItemHorizontalPadding)
+            }
         }
 
-        button.configuration?.contentInsets = insets
         return button
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We're soon going to be bumping our target deployment version to iOS 15.
This will trigger compile time warnings regarding deprecated APIs in iOS 15.

Because some of our client apps have the compiler configured to treat warnings as errors, we have to fix these warnings in advance so they won't get build breaks when the target deployment version is updated.

This PR addresses the BadgeLabelButton that now needs to use the UIButton Configuration to set title, image and content insets.

### Verification

Tested the BadgeLabelButton scenarios with a badge and ensured its functionality is intact:

| LTR                                       | RTL                                      |
|----------------------------------------------|--------------------------------------------|
| ![NavigationBar_LTR](https://user-images.githubusercontent.com/68076145/184407282-910a1f5e-1035-40d9-b77c-afcc5b733291.png) | ![NavigationBar_RTL](https://user-images.githubusercontent.com/68076145/184407296-cd8bc561-6d01-4c63-a84b-4e9448bde727.png) |
| ![Selection_LTR](https://user-images.githubusercontent.com/68076145/184418505-5b44ca21-abad-401e-8108-e825b430e618.png) | ![Selection_RTL](https://user-images.githubusercontent.com/68076145/184418437-d6da7862-0aa0-4831-aa2a-9b6875b22e6d.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1158)