### PR TITLE
Fixing Avatar and AvatarGroup build warnings caused by the deprecated animation modifier.

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -267,10 +267,29 @@ public struct Avatar: View, ConfigurableTokenizedControl {
             }
         }
 
+        let standardAnimation = Animation.linear(duration: animationDuration)
+
         return avatarBody
             .pointerInteraction(state.hasPointerInteraction)
             .modifyIf(state.isAnimated, { thisView in
-                thisView.animation(.linear(duration: animationDuration))
+                thisView
+                    .animation(standardAnimation,
+                               value: [state.hasRingInnerGap,
+                                       state.isRingVisible,
+                                       state.isTransparent,
+                                       state.isOutOfOffice])
+                    .animation(standardAnimation,
+                               value: [state.backgroundColor,
+                                       state.foregroundColor,
+                                       state.ringColor])
+                    .animation(standardAnimation,
+                               value: state.size)
+                    .animation(standardAnimation,
+                               value: [state.primaryText, state.secondaryText])
+                    .animation(standardAnimation,
+                               value: [state.image, state.imageBasedRingColor])
+                    .animation(standardAnimation,
+                               value: state.overrideTokens)
             })
             .showsLargeContentViewer(text: accessibilityLabel, image: shouldUseDefaultImage ? avatarImageInfo.image : nil)
             .accessibilityElement(children: .ignore)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -182,7 +182,6 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                             })
                     }
                     .padding(.trailing, isStackStyle ? stackPadding : interspace)
-                    .animation(Animation.linear(duration: animationDuration))
                     .transition(AnyTransition.move(edge: .leading))
                 }
 
@@ -190,7 +189,6 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
                     VStack {
                         overflowAvatar
                     }
-                    .animation(Animation.linear(duration: animationDuration))
                     .transition(AnyTransition.move(edge: .leading))
                 }
             }
@@ -213,8 +211,6 @@ public struct AvatarGroup: View, ConfigurableTokenizedControl {
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.layoutDirection) var layoutDirection: LayoutDirection
     @ObservedObject var state: MSFAvatarGroupStateImpl
-
-    private let animationDuration: CGFloat = 0.1
 
     private func createOverflow(count: Int) -> Avatar {
         var avatar = Avatar(style: .overflow, size: state.size)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The [animation(_:) modifier](https://developer.apple.com/documentation/swiftui/view/animation(_:)-7mq1i) is now deprecated for iOS 15. This means that when the target deployment version is bumped to iOS 15, deprecation warnings will be issued by the compiler.

Because some of our client apps have the compiler configured to treat warnings as errors, we have to fix these warnings in advance so they won't get build breaks when the target deployment version is updated.

This PR addresses the use of the animation modifier in the Avatar and AvatarGroup SwiftUI controls.

The fix for the AvatarGroup is just a matter of removing the animation modifier as the transition modifier is doing the job of animating the position and visibility of avatars.

The fix for the Avatar control consists of calling individual animation modifier based on all the values of the state object that need to be monitored to trigger those animations.

### Verification

Basic sanity validation of Avatar scenarios.
Verified all animations remain working properly.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1161)