### PR TITLE
[Fluent 2 iOS] Added ColorAliasTokensDemoController to demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		532FE3DB26EA6D8D007539C0 /* ActivityIndicatorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3D926EA6D8D007539C0 /* ActivityIndicatorDemoController.swift */; };
 		532FE3DC26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3DA26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift */; };
 		5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */; };
+		6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */; };
 		7D0931C124AAA3D30072458A /* SideTabBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */; };
 		80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */; };
 		80B1F7012628D8BB004DFEE5 /* BottomSheetDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */; };
@@ -89,6 +90,7 @@
 		5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController.swift; sourceTree = "<group>"; };
 		5373F95426F28D3A007F1410 /* IndeterminateProgressBarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		5373F95626F28D9B007F1410 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
+		6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAliasTokensDemoController.swift; sourceTree = "<group>"; };
 		7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideTabBarDemoController.swift; sourceTree = "<group>"; };
 		7DC2FB2A24C0F4FD00367A55 /* TableViewCellFileAccessoryViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellFileAccessoryViewDemoController.swift; sourceTree = "<group>"; };
 		80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCommandingDemoController.swift; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */,
 				B4EF66532295F1A8007FEAB0 /* TableViewHeaderFooterViewDemoController.swift */,
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
+				6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -482,6 +485,7 @@
 				92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */,
 				5303259826B31A6300611D05 /* FluentUIDemoToggle.swift in Sources */,
 				9245E1F927BECDBB007616F3 /* ColorTokensDemoController.swift in Sources */,
+				6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */,
 				A5DCA760211E3B4C005F4CB7 /* DemoController.swift in Sources */,
 				5328D97B26FBA3EA00F3723B /* IndeterminateProgressBarDemoController.swift in Sources */,
 				5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		8F0B8116267021A700463726 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0B8115267021A700463726 /* AppCenterCrashes */; };
 		923DF2DB271158C900637646 /* libFluentUI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 923DF2DA271158C900637646 /* libFluentUI.a */; };
 		923DF2DF27115B4700637646 /* FluentUIResources-ios.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 923DF2DC271158CD00637646 /* FluentUIResources-ios.bundle */; };
-		9245E1F927BECDBB007616F3 /* ColorTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245E1F827BECDBB007616F3 /* ColorTokensDemoController.swift */; };
+		9245E1F927BECDBB007616F3 /* ColorGlobalTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245E1F827BECDBB007616F3 /* ColorGlobalTokensDemoController.swift */; };
 		92561E732718AD090072ED00 /* DemoTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92561E722718AD090072ED00 /* DemoTableViewController.swift */; };
 		92B45E4E279A1A0B00E72517 /* DemoAppearanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B45E4D279A1A0B00E72517 /* DemoAppearanceController.swift */; };
 		92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */; };
@@ -97,7 +97,7 @@
 		80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetDemoController.swift; sourceTree = "<group>"; };
 		923DF2DA271158C900637646 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		923DF2DC271158CD00637646 /* FluentUIResources-ios.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = "FluentUIResources-ios.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9245E1F827BECDBB007616F3 /* ColorTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTokensDemoController.swift; sourceTree = "<group>"; };
+		9245E1F827BECDBB007616F3 /* ColorGlobalTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorGlobalTokensDemoController.swift; sourceTree = "<group>"; };
 		92561E722718AD090072ED00 /* DemoTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTableViewController.swift; sourceTree = "<group>"; };
 		92B45E4D279A1A0B00E72517 /* DemoAppearanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppearanceController.swift; sourceTree = "<group>"; };
 		92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeDemoController.swift; sourceTree = "<group>"; };
@@ -313,7 +313,7 @@
 				92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */,
 				CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */,
 				114CF8B72423E10900D064AA /* ColorDemoController.swift */,
-				9245E1F827BECDBB007616F3 /* ColorTokensDemoController.swift */,
+				9245E1F827BECDBB007616F3 /* ColorGlobalTokensDemoController.swift */,
 				FC414E3625888BC300069E73 /* CommandBarDemoController.swift */,
 				FD7254EC21471A3F002F4069 /* DateTimePickerDemoController.swift */,
 				A5DCA75D211E3A92005F4CB7 /* DrawerDemoController.swift */,
@@ -484,7 +484,7 @@
 				5303259326B3198A00611D05 /* AvatarDemoController_SwiftUI.swift in Sources */,
 				92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */,
 				5303259826B31A6300611D05 /* FluentUIDemoToggle.swift in Sources */,
-				9245E1F927BECDBB007616F3 /* ColorTokensDemoController.swift in Sources */,
+				9245E1F927BECDBB007616F3 /* ColorGlobalTokensDemoController.swift in Sources */,
 				6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */,
 				A5DCA760211E3B4C005F4CB7 /* DemoController.swift in Sources */,
 				5328D97B26FBA3EA00F3723B /* IndeterminateProgressBarDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -120,6 +120,7 @@ class DemoListViewController: DemoTableViewController {
 
     private enum DemoControllerSection: CaseIterable {
         case fluent2Controls
+        case fluent2DesignTokens
         case controls
 #if DEBUG
         case debug
@@ -129,6 +130,8 @@ class DemoListViewController: DemoTableViewController {
             switch self {
             case .fluent2Controls:
                 return "Fluent 2 Controls"
+            case .fluent2DesignTokens:
+                return "Fluent 2 Design Tokens"
             case .controls:
                 return "Controls"
 #if DEBUG
@@ -142,6 +145,8 @@ class DemoListViewController: DemoTableViewController {
             switch self {
             case .fluent2Controls:
                 return Demos.fluent2
+            case .fluent2DesignTokens:
+                return Demos.fluent2DesignTokens
             case .controls:
                 return Demos.controls
 #if DEBUG

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -23,12 +23,12 @@ struct Demos {
         DemoDescriptor("Avatar", AvatarDemoController.self),
         DemoDescriptor("AvatarGroup", AvatarGroupDemoController.self),
         DemoDescriptor("CardNudge", CardNudgeDemoController.self),
-        DemoDescriptor("ColorTokens", ColorTokensDemoController.self),
         DemoDescriptor("IndeterminateProgressBar", IndeterminateProgressBarDemoController.self),
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
+        DemoDescriptor("Color Global Tokens", ColorGlobalTokensDemoController.self),
         DemoDescriptor("Color Alias Tokens", ColorAliasTokensDemoController.self)
     ]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -27,7 +27,10 @@ struct Demos {
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
-        DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
+        DemoDescriptor("TableViewCell", TableViewCellDemoController.self)
+    ]
+
+    static let fluent2DesignTokens: [DemoDescriptor] = [
         DemoDescriptor("Color Global Tokens", ColorGlobalTokensDemoController.self),
         DemoDescriptor("Color Alias Tokens", ColorAliasTokensDemoController.self)
     ]

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -28,7 +28,8 @@ struct Demos {
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
-        DemoDescriptor("TableViewCell", TableViewCellDemoController.self)
+        DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
+        DemoDescriptor("Color Alias Tokens", ColorAliasTokensDemoController.self)
     ]
 
     static let controls: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
@@ -11,13 +11,6 @@ class ColorAliasTokensDemoController: DemoTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
-        tableView.backgroundColor = .lightGray
-    }
-
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        if let headerView = view as? UITableViewHeaderFooterView {
-            headerView.textLabel?.textColor = .black
-        }
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -57,13 +50,76 @@ class ColorAliasTokensDemoController: DemoTableViewController {
         let white = ColorValue(0xFFFFFF)
 
         switch token {
-        case .background1, .background1Pressed, .background1Selected, .background2, .background2Pressed, .background2Selected, .background3, .background3Pressed, .background3Selected, .background4, .background4Pressed, .background4Selected, .background5, .background5Pressed, .background5Selected, .background5BrandTint, .background6, .background6Pressed, .background6Selected, .backgroundDisabled, .brandBackground4, .background5BrandTintSelected, .brandBackgroundDisabled, .canvasBackground, .stencil1, .stencil2, .foregroundDisabled2, .foregroundOnColor, .brandForeground2, .stroke1, .stroke2, .strokeDisabled, .strokeFocus1, .foregroundDisabled1:
+        case .background1,
+             .background1Pressed,
+             .background1Selected,
+             .background2,
+             .background2Pressed,
+             .background2Selected,
+             .background3,
+             .background3Pressed,
+             .background3Selected,
+             .background4,
+             .background4Pressed,
+             .background4Selected,
+             .background5,
+             .background5Pressed,
+             .background5Selected,
+             .background5BrandTint,
+             .background6,
+             .background6Pressed,
+             .background6Selected,
+             .backgroundDisabled,
+             .brandBackground4,
+             .background5BrandTintSelected,
+             .brandBackgroundDisabled,
+             .canvasBackground,
+             .stencil1,
+             .stencil2,
+             .foregroundDisabled2,
+             .foregroundOnColor,
+             .brandForeground2,
+             .stroke1,
+             .stroke2,
+             .strokeDisabled,
+             .strokeFocus1,
+             .foregroundDisabled1:
             return UIColor(dynamicColor: DynamicColor(light: black, dark: white))
-        case .brandBackground3Pressed, .foreground1, .foreground2, .foreground3, .foregroundInverted2, .brandForegroundInverted, .strokeFocus2, .brandBackground1Pressed, .brandForeground1Pressed, .brandStroke1Pressed, .brandStroke1, .brandStroke1Selected:
+        case .brandBackground3Pressed,
+             .foreground1,
+             .foreground2,
+             .foreground3,
+             .foregroundInverted2,
+             .brandForegroundInverted,
+             .strokeFocus2,
+             .brandBackground1Pressed,
+             .brandForeground1Pressed,
+             .brandStroke1Pressed,
+             .brandStroke1,
+             .brandStroke1Selected:
             return UIColor(dynamicColor: DynamicColor(light: white, dark: black))
-        case .brandBackground3Selected, .brandBackgroundInverted, .brandBackgroundInvertedDisabled, .foregroundInverted1, .brandForeground3:
+        case .brandBackground3Selected,
+             .brandBackgroundInverted,
+             .brandBackgroundInvertedDisabled,
+             .foregroundInverted1,
+             .brandForeground3:
             return .black
-        case .foregroundContrast, .brandForeground1, .brandForeground1Selected, .brandForeground4, .brandForeground5, .brandForegroundDisabled, .background5SelectedBrandFilled, .backgroundInverted, .brandBackground1, .brandBackground1Selected, .brandBackground2, .brandBackground2Pressed, .brandBackground2Selected, .brandBackground3, .strokeAccessible, .background5BrandFilledSelected:
+        case .foregroundContrast,
+             .brandForeground1,
+             .brandForeground1Selected,
+             .brandForeground4,
+             .brandForeground5,
+             .brandForegroundDisabled,
+             .background5SelectedBrandFilled,
+             .backgroundInverted,
+             .brandBackground1,
+             .brandBackground1Selected,
+             .brandBackground2,
+             .brandBackground2Pressed,
+             .brandBackground2Selected,
+             .brandBackground3,
+             .strokeAccessible,
+             .background5BrandFilledSelected:
             return .white
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
@@ -1,0 +1,323 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+class ColorAliasTokensDemoController: DemoTableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
+        tableView.backgroundColor = .lightGray
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        if let headerView = view as? UITableViewHeaderFooterView {
+            headerView.textLabel?.textColor = .black
+        }
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return ColorAliasTokensDemoSection.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return ColorAliasTokensDemoSection.allCases[section].title
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return ColorAliasTokensDemoSection.allCases[section].rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath)
+        let section = ColorAliasTokensDemoSection.allCases[indexPath.section]
+        let row = section.rows[indexPath.row]
+
+        cell.backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: aliasTokens.colors[row])
+        cell.selectionStyle = .none
+
+        var contentConfiguration = cell.defaultContentConfiguration()
+        let text = "\(row.text)"
+        contentConfiguration.attributedText = NSAttributedString(string: text,
+                                                                 attributes: [
+                                                                    .foregroundColor: textColor(for: row)
+                                                                 ])
+        contentConfiguration.textProperties.alignment = .center
+        cell.contentConfiguration = contentConfiguration
+
+        return cell
+    }
+
+    private func textColor(for token: AliasTokens.ColorsTokens) -> UIColor {
+        let black = ColorValue(0x000000)
+        let white = ColorValue(0xFFFFFF)
+
+        switch token {
+        case .background1, .background1Pressed, .background1Selected, .background2, .background2Pressed, .background2Selected, .background3, .background3Pressed, .background3Selected, .background4, .background4Pressed, .background4Selected, .background5, .background5Pressed, .background5Selected, .background5BrandTint, .background6, .background6Pressed, .background6Selected, .backgroundDisabled, .brandBackground4, .background5BrandTintSelected, .background5BrandFilledSelected, .brandBackgroundDisabled, .canvasBackground, .stencil1, .stencil2, .foregroundDisabled2, .foregroundOnColor, .brandForeground2, .stroke1, .stroke2, .strokeDisabled, .strokeFocus1:
+            return UIColor(dynamicColor: DynamicColor(light: black, dark: white))
+        case .brandBackground3Pressed, .foreground1, .foreground2, .foreground3, .foregroundInverted2, .brandForegroundInverted, .strokeFocus2, .brandBackground1Pressed, .brandForeground1Pressed, .brandStroke1Pressed, .brandStroke1, .brandStroke1Selected:
+            return UIColor(dynamicColor: DynamicColor(light: white, dark: black))
+        case .brandBackground3Selected, .brandBackgroundInverted, .brandBackgroundInvertedDisabled, .foregroundInverted1, .brandForeground3:
+            return .black
+        case .foregroundDisabled1, .foregroundContrast, .brandForeground1, .brandForeground1Selected, .brandForeground4, .brandForeground5, .brandForegroundDisabled, .background5SelectedBrandFilled, .backgroundInverted, .brandBackground1, .brandBackground1Selected, .brandBackground2, .brandBackground2Pressed, .brandBackground2Selected, .brandBackground3, .strokeAccessible:
+            return .white
+        }
+    }
+
+    private var aliasTokens: AliasTokens {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return AliasTokens()
+        }
+        return fluentTheme.aliasTokens
+    }
+
+}
+
+private enum ColorAliasTokensDemoSection: CaseIterable {
+    case neutralBackgrounds
+    case brandBackgrounds
+    case neutralForegrounds
+    case brandForegrounds
+    case neutralStrokes
+    case brandStrokes
+
+    var title: String {
+        switch self {
+        case .neutralBackgrounds:
+            return "Neutral Backgrounds"
+        case .brandBackgrounds:
+            return "Brand Backgrounds"
+        case .neutralForegrounds:
+            return "Neutral Foregrounds"
+        case .brandForegrounds:
+            return "Brand Foregrounds"
+        case .neutralStrokes:
+            return "Neutral Strokes"
+        case .brandStrokes:
+            return "Brand Strokes"
+        }
+    }
+
+    var rows: [AliasTokens.ColorsTokens] {
+        switch self {
+        case .neutralBackgrounds:
+            return [.background1,
+                    .background1Pressed,
+                    .background1Selected,
+                    .background2,
+                    .background2Pressed,
+                    .background2Selected,
+                    .background3,
+                    .background3Pressed,
+                    .background3Selected,
+                    .background4,
+                    .background4Pressed,
+                    .background4Selected,
+                    .background5,
+                    .background5Pressed,
+                    .background5Selected,
+                    .background6,
+                    .background6Pressed,
+                    .background6Selected,
+                    .backgroundInverted,
+                    .backgroundDisabled,
+                    .canvasBackground,
+                    .stencil1,
+                    .stencil2]
+        case .brandBackgrounds:
+            return [.brandBackground1,
+                    .brandBackground1Pressed,
+                    .brandBackground1Selected,
+                    .brandBackground2,
+                    .brandBackground2Pressed,
+                    .brandBackground2Selected,
+                    .brandBackground3,
+                    .brandBackground3Pressed,
+                    .brandBackground3Selected,
+                    .brandBackground4,
+                    .background5BrandTint,
+                    .background5SelectedBrandFilled,
+                    .background5BrandFilledSelected,
+                    .background5BrandTintSelected,
+                    .brandBackgroundInverted,
+                    .brandBackgroundDisabled,
+                    .brandBackgroundInvertedDisabled]
+        case .neutralForegrounds:
+            return [.foreground1,
+                    .foreground2,
+                    .foreground3,
+                    .foregroundDisabled1,
+                    .foregroundDisabled2,
+                    .foregroundContrast,
+                    .foregroundOnColor,
+                    .foregroundInverted1,
+                    .foregroundInverted2]
+        case .brandForegrounds:
+            return [.brandForeground1,
+                    .brandForeground1Pressed,
+                    .brandForeground1Selected,
+                    .brandForeground2,
+                    .brandForeground3,
+                    .brandForeground4,
+                    .brandForeground5,
+                    .brandForegroundInverted,
+                    .brandForegroundDisabled]
+        case .neutralStrokes:
+            return [.stroke1,
+                    .stroke2,
+                    .strokeDisabled,
+                    .strokeAccessible,
+                    .strokeFocus1,
+                    .strokeFocus2]
+        case .brandStrokes:
+            return [.brandStroke1,
+                    .brandStroke1Pressed,
+                    .brandStroke1Selected]
+        }
+    }
+}
+
+private extension AliasTokens.ColorsTokens {
+    var text: String {
+        switch self {
+        case .foreground1:
+            return "Foreground 1"
+        case .foreground2:
+            return "Foreground 2"
+        case .foreground3:
+            return "Foreground 3"
+        case .foregroundDisabled1:
+            return "Foreground Disabled 1"
+        case .foregroundDisabled2:
+            return "Foreground Disabled 2"
+        case .foregroundContrast:
+            return "Foreground Contrast"
+        case .foregroundOnColor:
+            return "Foreground On Color"
+        case .foregroundInverted1:
+            return "Foreground Inverted 1"
+        case .foregroundInverted2:
+            return "Foreground Inverted 2"
+        case .brandForeground1:
+            return "Brand Foreground 1"
+        case .brandForeground1Pressed:
+            return "Brand Foreground 1 Pressed"
+        case .brandForeground1Selected:
+            return "Brand Foreground 1 Selected"
+        case .brandForeground2:
+            return "Brand Foreground 2"
+        case .brandForeground3:
+            return "Brand Foreground 3"
+        case .brandForeground4:
+            return "Brand Foreground 4"
+        case .brandForeground5:
+            return "Brand Foreground 5"
+        case .brandForegroundInverted:
+            return "Brand Foreground Inverted"
+        case .brandForegroundDisabled:
+            return "Brand Foreground Disabled"
+        case .background1:
+            return "Background 1"
+        case .background1Pressed:
+            return "Background 1 Pressed"
+        case .background1Selected:
+            return "Background 1 Selected"
+        case .background2:
+            return "Background 2"
+        case .background2Pressed:
+            return "Background 2 Pressed"
+        case .background2Selected:
+            return "Background 2 Selected"
+        case .background3:
+            return "Background 3"
+        case .background3Pressed:
+            return "Background 3 Pressed"
+        case .background3Selected:
+            return "Background 3 Selected"
+        case .background4:
+            return "Background 4"
+        case .background4Pressed:
+            return "Background 4 Pressed"
+        case .background4Selected:
+            return "Background 4 Selected"
+        case .background5:
+            return "Background 5"
+        case .background5Pressed:
+            return "Background 5 Pressed"
+        case .background5Selected:
+            return "Background 5 Selected"
+        case .background5SelectedBrandFilled:
+            return "Background 5 Selected Brand Filled"
+        case .background5BrandTint:
+            return "Background 5 Brand Tint"
+        case .background6:
+            return "Background 6"
+        case .background6Pressed:
+            return "Background 6 Pressed"
+        case .background6Selected:
+            return "Background 6 Selected"
+        case .backgroundInverted:
+            return "Background Inverted"
+        case .backgroundDisabled:
+            return "Background Disabled"
+        case .brandBackground1:
+            return "Brand Background 1"
+        case .brandBackground1Pressed:
+            return "Brand Background 1 Pressed"
+        case .brandBackground1Selected:
+            return "Brand Background 1 Selected"
+        case .brandBackground2:
+            return "Brand Background 2"
+        case .brandBackground2Pressed:
+            return "Brand Background 2 Pressed"
+        case .brandBackground2Selected:
+            return "Brand Background 2 Selected"
+        case .brandBackground3:
+            return "Brand Background 3"
+        case .brandBackground3Pressed:
+            return "Brand Background 3 Pressed"
+        case .brandBackground3Selected:
+            return "Brand Background 3 Selected"
+        case .brandBackground4:
+            return "Brand Background 4"
+        case .background5BrandFilledSelected:
+            return "Background 5 Brand Filled Selected"
+        case .background5BrandTintSelected:
+            return "Background 5 Brand Tint Selected"
+        case .brandBackgroundInverted:
+            return "Brand Background Inverted"
+        case .brandBackgroundDisabled:
+            return "Brand Background Disabled"
+        case .brandBackgroundInvertedDisabled:
+            return "Brand Background Inverted Disabled"
+        case .stencil1:
+            return "Stencil 1"
+        case .stencil2:
+            return "Stencil 2"
+        case .canvasBackground:
+            return "Canvas Background"
+        case .stroke1:
+            return "Stroke 1"
+        case .stroke2:
+            return "Stroke 2"
+        case .strokeDisabled:
+            return "Stroke Disabled"
+        case .strokeAccessible:
+            return "Stroke Accessible"
+        case .strokeFocus1:
+            return "Stroke Focus 1"
+        case .strokeFocus2:
+            return "Stroke Focus 2"
+        case .brandStroke1:
+            return "Brand Stroke 1"
+        case .brandStroke1Pressed:
+            return "Brand Stroke 1 Pressed"
+        case .brandStroke1Selected:
+            return "Brand Stroke 1 Selected"
+        }
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
@@ -46,9 +46,6 @@ class ColorAliasTokensDemoController: DemoTableViewController {
     }
 
     private func textColor(for token: AliasTokens.ColorsTokens) -> UIColor {
-        let black = ColorValue(0x000000)
-        let white = ColorValue(0xFFFFFF)
-
         switch token {
         case .background1,
              .background1Pressed,
@@ -84,7 +81,7 @@ class ColorAliasTokensDemoController: DemoTableViewController {
              .strokeDisabled,
              .strokeFocus1,
              .foregroundDisabled1:
-            return UIColor(dynamicColor: DynamicColor(light: black, dark: white))
+            return UIColor(dynamicColor: aliasTokens.colors[.foreground1])
         case .brandBackground3Pressed,
              .foreground1,
              .foreground2,
@@ -97,13 +94,13 @@ class ColorAliasTokensDemoController: DemoTableViewController {
              .brandStroke1Pressed,
              .brandStroke1,
              .brandStroke1Selected:
-            return UIColor(dynamicColor: DynamicColor(light: white, dark: black))
+            return UIColor(dynamicColor: aliasTokens.colors[.foregroundOnColor])
         case .brandBackground3Selected,
              .brandBackgroundInverted,
              .brandBackgroundInvertedDisabled,
              .foregroundInverted1,
              .brandForeground3:
-            return .black
+            return UIColor(dynamicColor: aliasTokens.colors[.foregroundContrast])
         case .foregroundContrast,
              .brandForeground1,
              .brandForeground1Selected,
@@ -120,7 +117,7 @@ class ColorAliasTokensDemoController: DemoTableViewController {
              .brandBackground3,
              .strokeAccessible,
              .background5BrandFilledSelected:
-            return .white
+            return UIColor(dynamicColor: aliasTokens.colors[.foregroundInverted1])
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorAliasTokensDemoController.swift
@@ -57,13 +57,13 @@ class ColorAliasTokensDemoController: DemoTableViewController {
         let white = ColorValue(0xFFFFFF)
 
         switch token {
-        case .background1, .background1Pressed, .background1Selected, .background2, .background2Pressed, .background2Selected, .background3, .background3Pressed, .background3Selected, .background4, .background4Pressed, .background4Selected, .background5, .background5Pressed, .background5Selected, .background5BrandTint, .background6, .background6Pressed, .background6Selected, .backgroundDisabled, .brandBackground4, .background5BrandTintSelected, .background5BrandFilledSelected, .brandBackgroundDisabled, .canvasBackground, .stencil1, .stencil2, .foregroundDisabled2, .foregroundOnColor, .brandForeground2, .stroke1, .stroke2, .strokeDisabled, .strokeFocus1:
+        case .background1, .background1Pressed, .background1Selected, .background2, .background2Pressed, .background2Selected, .background3, .background3Pressed, .background3Selected, .background4, .background4Pressed, .background4Selected, .background5, .background5Pressed, .background5Selected, .background5BrandTint, .background6, .background6Pressed, .background6Selected, .backgroundDisabled, .brandBackground4, .background5BrandTintSelected, .brandBackgroundDisabled, .canvasBackground, .stencil1, .stencil2, .foregroundDisabled2, .foregroundOnColor, .brandForeground2, .stroke1, .stroke2, .strokeDisabled, .strokeFocus1, .foregroundDisabled1:
             return UIColor(dynamicColor: DynamicColor(light: black, dark: white))
         case .brandBackground3Pressed, .foreground1, .foreground2, .foreground3, .foregroundInverted2, .brandForegroundInverted, .strokeFocus2, .brandBackground1Pressed, .brandForeground1Pressed, .brandStroke1Pressed, .brandStroke1, .brandStroke1Selected:
             return UIColor(dynamicColor: DynamicColor(light: white, dark: black))
         case .brandBackground3Selected, .brandBackgroundInverted, .brandBackgroundInvertedDisabled, .foregroundInverted1, .brandForeground3:
             return .black
-        case .foregroundDisabled1, .foregroundContrast, .brandForeground1, .brandForeground1Selected, .brandForeground4, .brandForeground5, .brandForegroundDisabled, .background5SelectedBrandFilled, .backgroundInverted, .brandBackground1, .brandBackground1Selected, .brandBackground2, .brandBackground2Pressed, .brandBackground2Selected, .brandBackground3, .strokeAccessible:
+        case .foregroundContrast, .brandForeground1, .brandForeground1Selected, .brandForeground4, .brandForeground5, .brandForegroundDisabled, .background5SelectedBrandFilled, .backgroundInverted, .brandBackground1, .brandBackground1Selected, .brandBackground2, .brandBackground2Pressed, .brandBackground2Selected, .brandBackground3, .strokeAccessible, .background5BrandFilledSelected:
             return .white
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorGlobalTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorGlobalTokensDemoController.swift
@@ -6,7 +6,7 @@
 import FluentUI
 import UIKit
 
-class ColorTokensDemoController: DemoTableViewController {
+class ColorGlobalTokensDemoController: DemoTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellID)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

I have added `ColorAliasTokensDemoController` to display color alias tokens in a table view for light and dark mode. Considering all the alias colors that are used in fluent 2 update are from a single `ColorTokens` enum, the different sections (i.e. neutral backgrounds, brand foregrounds etc.) had to be setup manually in the DemoController. 

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="before_main" src="https://user-images.githubusercontent.com/106181067/184681255-449b4721-6c7e-4b26-8c15-5861e031950b.png"> | <img width="482" alt="Screen Shot 2022-08-15 at 11 43 27 AM" src="https://user-images.githubusercontent.com/106181067/184696643-a00fc29f-ca6d-4e21-b5ff-65b76ccc87b7.png"> |

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="background_light" src="https://user-images.githubusercontent.com/106181067/184726805-cb35307b-8e36-4579-adb3-c4f1441fd7eb.png"> | <img width="482" alt="background_dark" src="https://user-images.githubusercontent.com/106181067/184726829-674cfd29-7d1e-41f9-a731-f7232042e695.png"> |
| <img width="482" alt="brand_background_light" src="https://user-images.githubusercontent.com/106181067/184726851-6ee1422c-81fa-453d-b55c-4d678256cd16.png"> | <img width="482" alt="brand_background_dark" src="https://user-images.githubusercontent.com/106181067/184726879-6113ed68-f202-4be7-b3c8-6abc166bef19.png"> |
| <img width="482" alt="foreground_light" src="https://user-images.githubusercontent.com/106181067/184726906-47d063fe-9e79-4291-bc64-872c8a265163.png"> | <img width="482" alt="foreground_dark" src="https://user-images.githubusercontent.com/106181067/184726930-359c27d4-45f6-4472-a927-247d47bf79fa.png"> |
| <img width="482" alt="stroke_light" src="https://user-images.githubusercontent.com/106181067/184726948-5a99efab-f058-4740-abe7-c9c2a03939ab.png"> | <img width="482" alt="stroke_dark" src="https://user-images.githubusercontent.com/106181067/184726970-7daf1334-a12b-4986-9cf6-49ce6b148a8b.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1163)