### PR TITLE
PillButtonBar: Fixing warnings for iOS 15 target deployment version.

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -126,7 +126,6 @@ open class PillButton: UIButton {
                                              left: Constants.horizontalInset,
                                              bottom: Constants.bottomInset,
                                              right: Constants.horizontalInset)
-
         }
 
         layer.cornerRadius = PillButton.cornerRadius
@@ -204,7 +203,6 @@ open class PillButton: UIButton {
                 resolvedBackgroundColor = customSelectedBackgroundColor ?? (isHighlighted
                                                                             ? PillButton.selectedHighlightedBackgroundColor(for: window, for: style)
                                                                             : PillButton.selectedBackgroundColor(for: window, for: style))
-
                 if #available(iOS 15.0, *) {
                     resolvedTitleColor = customSelectedTextColor ?? (isHighlighted ? PillButton.selectedHighlightedTitleColor(for: window,
                                                                                                                               for: style)
@@ -221,7 +219,6 @@ open class PillButton: UIButton {
             } else {
                 resolvedBackgroundColor = PillButton.selectedDisabledBackgroundColor(for: window,
                                                                                      for: style)
-
                 if #available(iOS 15.0, *) {
                     resolvedTitleColor = PillButton.selectedDisabledTitleColor(for: window,
                                                                        for: style)
@@ -240,7 +237,6 @@ open class PillButton: UIButton {
                                                                                                             for: style)
                                                                     : PillButton.normalBackgroundColor(for: window,
                                                                                                        for: style))
-
                 if #available(iOS 15.0, *) {
                     resolvedTitleColor = {
                         guard let customTextColor = customTextColor else {
@@ -266,7 +262,6 @@ open class PillButton: UIButton {
                                                                                            for: style)
                 resolvedBackgroundColor = customBackgroundColor ?? PillButton.disabledBackgroundColor(for: window,
                                                                                                       for: style)
-
                 if #available(iOS 15.0, *) {
                     resolvedTitleColor = PillButton.disabledTitleColor(for: window,
                                                                for: style)

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -125,6 +125,7 @@ open class PillButtonBar: UIScrollView {
 
     private var stackView: UIStackView = {
         let view = UIStackView()
+        view.distribution = .fillProportionally
         view.alignment = .center
         view.spacing = Constants.minButtonsSpacing
         return view
@@ -411,8 +412,8 @@ open class PillButtonBar: UIScrollView {
         buttonExtraSidePadding = ceil(totalPadding / CGFloat(buttonEdges))
         for button in buttons {
             button.layoutIfNeeded()
-            button.contentEdgeInsets.right += buttonExtraSidePadding
-            button.contentEdgeInsets.left += buttonExtraSidePadding
+            button.configuration?.contentInsets.leading += buttonExtraSidePadding
+            button.configuration?.contentInsets.trailing += buttonExtraSidePadding
             button.layoutIfNeeded()
         }
     }
@@ -453,8 +454,8 @@ open class PillButtonBar: UIScrollView {
             let buttonWidth = button.frame.width
             if buttonWidth > 0, buttonWidth < Constants.minButtonWidth {
                 let extraInset = floor((Constants.minButtonWidth - button.frame.width) / 2)
-                button.contentEdgeInsets.left += extraInset
-                button.contentEdgeInsets.right = button.contentEdgeInsets.left
+                button.configuration?.contentInsets.leading += extraInset
+                button.configuration?.contentInsets.trailing = button.configuration?.contentInsets.leading ?? extraInset
                 button.layoutIfNeeded()
             }
         }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -412,8 +412,15 @@ open class PillButtonBar: UIScrollView {
         buttonExtraSidePadding = ceil(totalPadding / CGFloat(buttonEdges))
         for button in buttons {
             button.layoutIfNeeded()
-            button.configuration?.contentInsets.leading += buttonExtraSidePadding
-            button.configuration?.contentInsets.trailing += buttonExtraSidePadding
+
+            if #available(iOS 15.0, *) {
+                button.configuration?.contentInsets.leading += buttonExtraSidePadding
+                button.configuration?.contentInsets.trailing += buttonExtraSidePadding
+            } else {
+                button.contentEdgeInsets.right += buttonExtraSidePadding
+                button.contentEdgeInsets.left += buttonExtraSidePadding
+            }
+
             button.layoutIfNeeded()
         }
     }
@@ -454,8 +461,15 @@ open class PillButtonBar: UIScrollView {
             let buttonWidth = button.frame.width
             if buttonWidth > 0, buttonWidth < Constants.minButtonWidth {
                 let extraInset = floor((Constants.minButtonWidth - button.frame.width) / 2)
-                button.configuration?.contentInsets.leading += extraInset
-                button.configuration?.contentInsets.trailing = button.configuration?.contentInsets.leading ?? extraInset
+
+                if #available(iOS 15.0, *) {
+                    button.configuration?.contentInsets.leading += extraInset
+                    button.configuration?.contentInsets.trailing = button.configuration?.contentInsets.leading ?? extraInset
+                } else {
+                    button.contentEdgeInsets.left += extraInset
+                    button.contentEdgeInsets.right = button.contentEdgeInsets.left
+                }
+
                 button.layoutIfNeeded()
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We're soon going to be bumping our target deployment version to iOS 15.
This will trigger compile time warnings regarding deprecated APIs in iOS 15.

Because some of our client apps have the compiler configured to treat warnings as errors, we have to fix these warnings in advance so they won't get build breaks when the target deployment version is updated.

This PR addresses the PillButtonBar that now needs to use the UIButton Configuration to set title, background color and content insets.

### Verification

Exercised scenarios in the demo app to ensure no regressions were caused:

https://user-images.githubusercontent.com/68076145/184774897-021dea42-b3ef-410c-8f3e-5d38e069d7ff.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1165)