### PR TITLE
Adjusting separatorLeadingInset calculation in TableViewCell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1694,13 +1694,17 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     func separatorLeadingInset(for type: SeparatorType) -> CGFloat {
-        guard type == .inset else {
+        switch type {
+        case .none:
             return 0
+        case .inset:
+            let baseOffset = TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
+                                                              selectionImageMarginTrailing: tokenSet[.selectionImageMarginTrailing].float,
+                                                              selectionImageSize: tokenSet[.selectionImageSize].float)
+            return baseOffset + paddingLeading + tokenSet[.customViewDimensions].float + tokenSet[.customViewTrailingMargin].float
+        case .full:
+            return -safeAreaInsets.left
         }
-        let baseOffset = safeAreaInsets.left + TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
-                                                                                    selectionImageMarginTrailing: tokenSet[.selectionImageMarginTrailing].float,
-                                                                                    selectionImageSize: tokenSet[.selectionImageSize].float)
-        return baseOffset + paddingLeading + tokenSet[.customViewDimensions].float + tokenSet[.customViewTrailingMargin].float
     }
 
     open override func prepareForReuse() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

An update to #1093 

In the previous PR, it was discovered that since the Divider was added to the cell's contentView, we needed to accommodate for the additional safeAreaInset. This means that while it is no longer needed for the `.inset` Separator Type, we need to include it for the `.full` type instead.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/184984292-d89a7061-d052-42a1-973a-1ef23e04149f.png) | ![image](https://user-images.githubusercontent.com/22566866/184983562-d6369a30-e93c-4182-afe6-0a78bd678109.png) |
| ![image](https://user-images.githubusercontent.com/22566866/184984125-059dd446-3736-4ad5-a0a2-a2bb3326cd6b.png) | ![image](https://user-images.githubusercontent.com/22566866/184983746-d8811d0f-3ba1-4322-8251-bebf54b0b787.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)