### PR TITLE
[Fluent 2 iOS] Add ShadowTokensDemoController to demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		5336B17D27F7817300B01E0D /* HUDDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17B27F7817300B01E0D /* HUDDemoController_SwiftUI.swift */; };
 		5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */; };
 		6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */; };
-		6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */; };
+		6FEED93B28A6E5520099D178 /* AliasColorTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */; };
 		7D0931C124AAA3D30072458A /* SideTabBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */; };
 		80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */; };
 		80B1F7012628D8BB004DFEE5 /* BottomSheetDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */; };
@@ -40,7 +40,7 @@
 		8F0B8116267021A700463726 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0B8115267021A700463726 /* AppCenterCrashes */; };
 		923DF2DB271158C900637646 /* libFluentUI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 923DF2DA271158C900637646 /* libFluentUI.a */; };
 		923DF2DF27115B4700637646 /* FluentUIResources-ios.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 923DF2DC271158CD00637646 /* FluentUIResources-ios.bundle */; };
-		9245E1F927BECDBB007616F3 /* ColorGlobalTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245E1F827BECDBB007616F3 /* ColorGlobalTokensDemoController.swift */; };
+		9245E1F927BECDBB007616F3 /* GlobalColorTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */; };
 		92561E732718AD090072ED00 /* DemoTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92561E722718AD090072ED00 /* DemoTableViewController.swift */; };
 		92B45E4E279A1A0B00E72517 /* DemoAppearanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B45E4D279A1A0B00E72517 /* DemoAppearanceController.swift */; };
 		92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */; };
@@ -94,14 +94,14 @@
 		5373F95426F28D3A007F1410 /* IndeterminateProgressBarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		5373F95626F28D9B007F1410 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
 		6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowTokensDemoController.swift; sourceTree = "<group>"; };
-		6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAliasTokensDemoController.swift; sourceTree = "<group>"; };
+		6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasColorTokensDemoController.swift; sourceTree = "<group>"; };
 		7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideTabBarDemoController.swift; sourceTree = "<group>"; };
 		7DC2FB2A24C0F4FD00367A55 /* TableViewCellFileAccessoryViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellFileAccessoryViewDemoController.swift; sourceTree = "<group>"; };
 		80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCommandingDemoController.swift; sourceTree = "<group>"; };
 		80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetDemoController.swift; sourceTree = "<group>"; };
 		923DF2DA271158C900637646 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		923DF2DC271158CD00637646 /* FluentUIResources-ios.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = "FluentUIResources-ios.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9245E1F827BECDBB007616F3 /* ColorGlobalTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorGlobalTokensDemoController.swift; sourceTree = "<group>"; };
+		9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalColorTokensDemoController.swift; sourceTree = "<group>"; };
 		92561E722718AD090072ED00 /* DemoTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTableViewController.swift; sourceTree = "<group>"; };
 		92B45E4D279A1A0B00E72517 /* DemoAppearanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppearanceController.swift; sourceTree = "<group>"; };
 		92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeDemoController.swift; sourceTree = "<group>"; };
@@ -317,7 +317,7 @@
 				92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */,
 				CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */,
 				114CF8B72423E10900D064AA /* ColorDemoController.swift */,
-				9245E1F827BECDBB007616F3 /* ColorGlobalTokensDemoController.swift */,
+				9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */,
 				FC414E3625888BC300069E73 /* CommandBarDemoController.swift */,
 				FD7254EC21471A3F002F4069 /* DateTimePickerDemoController.swift */,
 				A5DCA75D211E3A92005F4CB7 /* DrawerDemoController.swift */,
@@ -346,7 +346,7 @@
 				C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */,
 				B4EF66532295F1A8007FEAB0 /* TableViewHeaderFooterViewDemoController.swift */,
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
-				6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */,
+				6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */,
 				6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */,
 			);
 			path = Demos;
@@ -490,9 +490,9 @@
 				5303259326B3198A00611D05 /* AvatarDemoController_SwiftUI.swift in Sources */,
 				92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */,
 				5303259826B31A6300611D05 /* FluentUIDemoToggle.swift in Sources */,
-				9245E1F927BECDBB007616F3 /* ColorGlobalTokensDemoController.swift in Sources */,
+				9245E1F927BECDBB007616F3 /* GlobalColorTokensDemoController.swift in Sources */,
 				6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */,
-				6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */,
+				6FEED93B28A6E5520099D178 /* AliasColorTokensDemoController.swift in Sources */,
 				A5DCA760211E3B4C005F4CB7 /* DemoController.swift in Sources */,
 				5328D97B26FBA3EA00F3723B /* IndeterminateProgressBarDemoController.swift in Sources */,
 				5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		532FE3DC26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3DA26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift */; };
 		5336B17D27F7817300B01E0D /* HUDDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17B27F7817300B01E0D /* HUDDemoController_SwiftUI.swift */; };
 		5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */; };
+		6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */; };
 		6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */; };
 		7D0931C124AAA3D30072458A /* SideTabBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */; };
 		80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */; };
@@ -92,6 +93,7 @@
 		5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController.swift; sourceTree = "<group>"; };
 		5373F95426F28D3A007F1410 /* IndeterminateProgressBarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		5373F95626F28D9B007F1410 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
+		6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowTokensDemoController.swift; sourceTree = "<group>"; };
 		6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAliasTokensDemoController.swift; sourceTree = "<group>"; };
 		7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideTabBarDemoController.swift; sourceTree = "<group>"; };
 		7DC2FB2A24C0F4FD00367A55 /* TableViewCellFileAccessoryViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellFileAccessoryViewDemoController.swift; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 				B4EF66532295F1A8007FEAB0 /* TableViewHeaderFooterViewDemoController.swift */,
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
 				6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */,
+				6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -488,6 +491,7 @@
 				92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */,
 				5303259826B31A6300611D05 /* FluentUIDemoToggle.swift in Sources */,
 				9245E1F927BECDBB007616F3 /* ColorGlobalTokensDemoController.swift in Sources */,
+				6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */,
 				6FEED93B28A6E5520099D178 /* ColorAliasTokensDemoController.swift in Sources */,
 				A5DCA760211E3B4C005F4CB7 /* DemoController.swift in Sources */,
 				5328D97B26FBA3EA00F3723B /* IndeterminateProgressBarDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -31,8 +31,8 @@ struct Demos {
     ]
 
     static let fluent2DesignTokens: [DemoDescriptor] = [
-        DemoDescriptor("Color Global Tokens", ColorGlobalTokensDemoController.self),
-        DemoDescriptor("Color Alias Tokens", ColorAliasTokensDemoController.self),
+        DemoDescriptor("Global Color Tokens", GlobalColorTokensDemoController.self),
+        DemoDescriptor("Alias Color Tokens", AliasColorTokensDemoController.self),
         DemoDescriptor("Shadow Tokens", ShadowTokensDemoController.self)
     ]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -32,7 +32,8 @@ struct Demos {
 
     static let fluent2DesignTokens: [DemoDescriptor] = [
         DemoDescriptor("Color Global Tokens", ColorGlobalTokensDemoController.self),
-        DemoDescriptor("Color Alias Tokens", ColorAliasTokensDemoController.self)
+        DemoDescriptor("Color Alias Tokens", ColorAliasTokensDemoController.self),
+        DemoDescriptor("Shadow Tokens", ShadowTokensDemoController.self)
     ]
 
     static let controls: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -6,7 +6,7 @@
 import FluentUI
 import UIKit
 
-class ColorAliasTokensDemoController: DemoTableViewController {
+class AliasColorTokensDemoController: DemoTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -14,20 +14,20 @@ class ColorAliasTokensDemoController: DemoTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return ColorAliasTokensDemoSection.allCases.count
+        return AliasColorTokensDemoSection.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return ColorAliasTokensDemoSection.allCases[section].title
+        return AliasColorTokensDemoSection.allCases[section].title
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return ColorAliasTokensDemoSection.allCases[section].rows.count
+        return AliasColorTokensDemoSection.allCases[section].rows.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier, for: indexPath)
-        let section = ColorAliasTokensDemoSection.allCases[indexPath.section]
+        let section = AliasColorTokensDemoSection.allCases[indexPath.section]
         let row = section.rows[indexPath.row]
 
         cell.backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: aliasTokens.colors[row])
@@ -130,7 +130,7 @@ class ColorAliasTokensDemoController: DemoTableViewController {
 
 }
 
-private enum ColorAliasTokensDemoSection: CaseIterable {
+private enum AliasColorTokensDemoSection: CaseIterable {
     case neutralBackgrounds
     case brandBackgrounds
     case neutralForegrounds

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/GlobalColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/GlobalColorTokensDemoController.swift
@@ -6,7 +6,7 @@
 import FluentUI
 import UIKit
 
-class ColorGlobalTokensDemoController: DemoTableViewController {
+class GlobalColorTokensDemoController: DemoTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellID)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -22,6 +22,8 @@ class ShadowTokensDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        container.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stencil2])
+
         navigationItem.titleView = segmentedControl
         container.alignment = .center
         container.spacing = Constants.spacing

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+class ShadowTokensDemoController: DemoController {
+    var cards: [CardView] = []
+
+    private lazy var segmentedControl: SegmentedControl = {
+        let tabTitles = Constants.titles
+        let segmentedControl = SegmentedControl(items: tabTitles.map({ return SegmentItem(title: $0) }),
+                                                style: .primaryPill)
+        segmentedControl.addTarget(self,
+                                   action: #selector(updateShadows),
+                                   for: .valueChanged)
+        return segmentedControl
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.titleView = segmentedControl
+        container.alignment = .center
+        container.spacing = Constants.spacing
+
+        initCards()
+        updateShadows()
+
+        container.addArrangedSubview(UIView())
+    }
+
+    private func initCards() {
+        let demoIcon = UIImage(named: "flag-24x24")
+
+        for shadow in AliasTokens.ShadowTokens.allCases {
+            let card = CardView(size: .large, title: shadow.title, icon: demoIcon!, colorStyle: .neutral)
+            cards.append(card)
+            container.addArrangedSubview(card)
+        }
+    }
+
+    @objc private func updateShadows() {
+        for index in 0..<AliasTokens.ShadowTokens.allCases.count {
+            let shadowInfo = view.fluentTheme.aliasTokens.shadow[AliasTokens.ShadowTokens.allCases[index]]
+            applyShadow(shadowInfo, for: cards[index], isShadowOne: segmentedControl.selectedSegmentIndex == 0)
+        }
+    }
+
+    private func applyShadow(_ shadow: ShadowInfo, for view: UIView, isShadowOne: Bool = false) {
+        view.layer.shadowColor = UIColor(dynamicColor: isShadowOne ? shadow.colorOne : shadow.colorTwo).cgColor
+        view.layer.shadowOpacity = 1
+        view.layer.shadowRadius = isShadowOne ? shadow.blurOne : shadow.blurTwo
+        view.layer.shadowOffset = CGSize(width: isShadowOne ? shadow.xOne : shadow.xTwo,
+                                         height: isShadowOne ? shadow.yOne : shadow.yTwo)
+    }
+
+    private struct Constants {
+        static let titles: [String] = ["Shadow 1", "Shadow 2"]
+        static let spacing: CGFloat = 120
+    }
+}
+
+private extension AliasTokens.ShadowTokens {
+    var title: String {
+        switch self {
+        case .shadow02:
+            return "Shadow02"
+        case .shadow04:
+            return "Shadow04"
+        case .shadow08:
+            return "Shadow08"
+        case .shadow16:
+            return "Shadow16"
+        case .shadow28:
+            return "Shadow28"
+        case .shadow64:
+            return "Shadow64"
+        }
+    }
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`ShadowTokensDemoController` was added to the demo app to display shadow tokens. Each shadow is displayed on a CardView. The users can toggle between elevation shadow (Shadow 1) and border shadow (Shadow 2).

### Verification

| Before                                  | After                                   |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="before_main" src="https://user-images.githubusercontent.com/106181067/184998286-d186476c-c566-47b5-b931-d880aa9015a0.png"> | <img width="488" alt="Screen Shot 2022-08-18 at 11 23 15 AM" src="https://user-images.githubusercontent.com/106181067/185466984-5ce593c7-90cb-4273-8397-5d6b660e5991.png"> |

| Shadow 1                                 |  Shadow 2                                   |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="shadow1_1" src="https://user-images.githubusercontent.com/106181067/184998350-60895074-7e7b-4d2d-8108-3b6acc197872.png"> | <img width="482" alt="shadow2_1" src="https://user-images.githubusercontent.com/106181067/184998377-eef0e285-f8e0-4065-b706-d24835fdb4ce.png"> |
| <img width="482" alt="shadow1_2" src="https://user-images.githubusercontent.com/106181067/184998397-a8e47ef3-14bb-4b4b-9bac-bc69610c0292.png"> | <img width="482" alt="shadow2_2" src="https://user-images.githubusercontent.com/106181067/184998413-87a429b2-3ca1-4dd7-9b20-91b00b3456a0.png"> |
| <img width="488" alt="shadow1_1" src="https://user-images.githubusercontent.com/106181067/185281882-9794090c-6d16-4066-8d67-382d43f7106f.png"> | <img width="488" alt="shadow2_1" src="https://user-images.githubusercontent.com/106181067/185281910-1199751e-bc5f-4ced-a5a5-7284d2d5772e.png"> |
| <img width="488" alt="shadow1_2" src="https://user-images.githubusercontent.com/106181067/185281937-84da7f2a-4289-434c-91eb-3714ed9ea973.png"> | <img width="488" alt="shadow2_2" src="https://user-images.githubusercontent.com/106181067/185281953-7c75fe74-60e3-4f0b-ba4d-08b5a4248ffc.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1168)