### PR TITLE
Improve font scaling for Fluent text

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		92561E732718AD090072ED00 /* DemoTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92561E722718AD090072ED00 /* DemoTableViewController.swift */; };
 		92B45E4E279A1A0B00E72517 /* DemoAppearanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B45E4D279A1A0B00E72517 /* DemoAppearanceController.swift */; };
 		92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */; };
+		92D5FDFD28AC57650087894B /* TypographyTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */; };
 		92DD1E8D279F496300FDEE0F /* DemoAppearanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DD1E8C279F496300FDEE0F /* DemoAppearanceView.swift */; };
 		92E977B726C7144F008E10A8 /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E977B526C713F3008E10A8 /* UIResponder+Extensions.swift */; };
 		92E977B826C7144F008E10A8 /* DemoControllerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E977B426C713F3008E10A8 /* DemoControllerScrollView.swift */; };
@@ -101,6 +102,7 @@
 		92561E722718AD090072ED00 /* DemoTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoTableViewController.swift; sourceTree = "<group>"; };
 		92B45E4D279A1A0B00E72517 /* DemoAppearanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppearanceController.swift; sourceTree = "<group>"; };
 		92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeDemoController.swift; sourceTree = "<group>"; };
+		92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyTokensDemoController.swift; sourceTree = "<group>"; };
 		92DD1E8C279F496300FDEE0F /* DemoAppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppearanceView.swift; sourceTree = "<group>"; };
 		92E4784B2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselDemoController.swift; sourceTree = "<group>"; };
 		92E977B426C713F3008E10A8 /* DemoControllerScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoControllerScrollView.swift; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */,
 				B4EF66532295F1A8007FEAB0 /* TableViewHeaderFooterViewDemoController.swift */,
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
+				92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 				2F0A96FC25CA047100EF9736 /* SearchBarDemoController.swift in Sources */,
 				CCC18C2F2501C75F00BE830E /* CardViewDemoController.swift in Sources */,
 				B4575C5122FB8B6900EBD0EB /* PeoplePickerDemoController.swift in Sources */,
+				92D5FDFD28AC57650087894B /* TypographyTokensDemoController.swift in Sources */,
 				A5CEC21220E436F10016922A /* DemoListViewController.swift in Sources */,
 				53097D3E27028ADC00A6E4DC /* NotificationViewDemoController.swift in Sources */,
 				5328D97A26FBA3EA00F3723B /* IndeterminateProgressBarDemoController_SwiftUI.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -29,7 +29,8 @@ struct Demos {
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
-        DemoDescriptor("TableViewCell", TableViewCellDemoController.self)
+        DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
+        DemoDescriptor("TypographyTokens", TypographyTokensDemoController.self)
     ]
 
     static let controls: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TypographyTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TypographyTokensDemoController.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+class TypographyTokensDemoController: DemoTableViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellID)
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return AliasTokens.TypographyTokens.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellID, for: indexPath)
+        let typographyToken = AliasTokens.TypographyTokens.allCases[indexPath.row]
+
+        cell.selectionStyle = .none
+
+        var contentConfiguration = cell.defaultContentConfiguration()
+        let text = "\(typographyToken.text)"
+        contentConfiguration.attributedText = NSAttributedString(string: text,
+                                                                 attributes: [
+                                                                    .font: UIFont.fluent(aliasTokens.typography[typographyToken])
+                                                                 ])
+        contentConfiguration.textProperties.alignment = .center
+        cell.contentConfiguration = contentConfiguration
+
+        return cell
+    }
+
+    private var aliasTokens: AliasTokens {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return AliasTokens()
+        }
+        return fluentTheme.aliasTokens
+    }
+
+    private struct Constants {
+        static let cellID: String = "cellID"
+    }
+}
+
+// MARK: - Private extensions
+
+private extension AliasTokens.TypographyTokens {
+    var text: String {
+        switch self {
+        case .display:
+            return "Display"
+        case .largeTitle:
+            return "Large Title"
+        case .title1:
+            return "Title 1"
+        case .title2:
+            return "Title 2"
+        case .title3:
+            return "Title 3"
+        case .body1Strong:
+            return "Body 1 Strong"
+        case .body1:
+            return "Body 1"
+        case .body2Strong:
+            return "Body 2 Strong"
+        case .body2:
+            return "Body 2"
+        case .caption1Strong:
+            return "Caption 1 Strong"
+        case .caption1:
+            return "Caption 1"
+        case .caption2:
+            return "Caption 2"
+        }
+    }
+}

--- a/ios/FluentUI.Tests/FontTests.swift
+++ b/ios/FluentUI.Tests/FontTests.swift
@@ -12,48 +12,14 @@ class FontTests: XCTestCase {
     func testBasicFont() throws {
         // Basic system font
         let size = 24.0
-        let weight = Font.Weight.regular
-
-        let fontInfo = FontInfo(size: size)
-        let font = Font.fluent(fontInfo)
-        let otherFont = Font.system(size: size).weight(weight)
-        XCTAssertEqual(font, otherFont)
-    }
-
-    func testAdvancedFont() throws {
-        // More advanced font info
-        let name = "Papyrus"
-        let size = 16.0
-        let weight = Font.Weight.semibold
-
-        let fontInfo = FontInfo(name: name, size: size, weight: weight)
-        let font = Font.fluent(fontInfo, shouldScale: false)
-        let otherFont = Font.custom(name, fixedSize: size).weight(weight)
-        XCTAssertEqual(font, otherFont)
-    }
-
-    func testScalingFont() throws {
-        // Scaling
-        let size = 24.0
-        let weight = Font.Weight.regular
-
-        let fontInfo = FontInfo(size: size)
-        let font = Font.fluent(fontInfo, shouldScale: true)
-        let otherFont = Font.system(size: UIFontMetrics.default.scaledValue(for: fontInfo.size)).weight(weight)
-        XCTAssertEqual(font, otherFont)
-    }
-
-    func testBasicUIFont() throws {
-        // Basic system font
-        let size = 24.0
 
         let fontInfo = FontInfo(size: size)
         let font = UIFont.fluent(fontInfo)
         let otherFont = UIFont.systemFont(ofSize: size, weight: UIFont.Weight.regular)
-        XCTAssertEqual(font, otherFont)
+        XCTAssertEqual(font.fontDescriptor, otherFont.fontDescriptor)
     }
 
-    func testAdvancedUIFont() throws {
+    func testAdvancedFont() throws {
         // More advanced font info
         let name = "Baskerville"
         let size = 16.0
@@ -63,16 +29,16 @@ class FontTests: XCTestCase {
         let font = UIFont.fluent(fontInfo)
         let otherFontDescriptor = UIFontDescriptor(name: name.appending("-Semibold"), size: size)
         let otherFont = UIFont(descriptor: otherFontDescriptor, size: size)
-        XCTAssertEqual(font, otherFont)
+        XCTAssertEqual(font.fontDescriptor, otherFont.fontDescriptor)
     }
 
-    func testScalingUIFont() throws {
+    func testScalingFont() throws {
         // Scaling
         let size = 24.0
 
         let fontInfo = FontInfo(size: size)
         let font = UIFont.fluent(fontInfo, shouldScale: true)
         let otherFont = UIFont.systemFont(ofSize: UIFontMetrics.default.scaledValue(for: fontInfo.size))
-        XCTAssertEqual(font, otherFont)
+        XCTAssertEqual(font.fontDescriptor, otherFont.fontDescriptor)
     }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -17,10 +17,39 @@ public struct FontInfo {
     /// - Parameter weight: The weight to use for the font. Defaults to `.regular`.
     ///
     /// - Returns: A struct containing the information needed to create a font object.
-    public init(name: String? = nil, size: CGFloat, weight: Font.Weight = .regular) {
+    public init(name: String? = nil,
+                size: CGFloat,
+                weight: Font.Weight = .regular) {
         self.name = name
         self.size = size
         self.weight = weight
+    }
+
+    static var sizeTuples: [(size: CGFloat, textStyle: Font.TextStyle)] = [
+        (34.0, .largeTitle),
+        (28.0, .title),
+        (22.0, .title2),
+        (20.0, .title3),
+        // Note: `17.0: .headline` is removed to avoid needing duplicate size key values.
+        // But it's okay because Apple's scaling curve is identical between it and `.body`.
+        (17.0, .body),
+        (16.0, .callout),
+        (15.0, .subheadline),
+        (13.0, .footnote),
+        (12.0, .caption),
+        (11.0, .caption2)
+    ]
+
+    public var textStyle: Font.TextStyle {
+        // Defaults to smallest supported text style for mapping, before checking if we're bigger.
+        var textStyle = Font.TextStyle.caption2
+        for tuple in Self.sizeTuples {
+            if self.size >= tuple.size {
+                textStyle = tuple.textStyle
+                break
+            }
+        }
+        return textStyle
     }
 
     let name: String?
@@ -30,34 +59,33 @@ public struct FontInfo {
 
 // MARK: - ViewModifier
 
-extension Font {
+public extension Font {
     static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> Font {
-        let size = shouldScale ?
-            UIFontMetrics.default.scaledValue(for: fontInfo.size) :
-            fontInfo.size
-
-        let font: Font
-        if let name = fontInfo.name {
-            // We use fixedSize because scaling is already managed above.
-            font = .custom(name, fixedSize: size)
-        } else {
-            font = .system(size: size)
-        }
-        return font.weight(fontInfo.weight)
+        // SwiftUI Font is missing some of the ease of construction available in UIFont.
+        // So just leverage the logic there to create the equivalent SwiftUI font.
+        let uiFont = UIFont.fluent(fontInfo, shouldScale: shouldScale)
+        return Font(uiFont)
     }
 }
 
 extension UIFont {
-    static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
-        let size = shouldScale ?
-            UIFontMetrics.default.scaledValue(for: fontInfo.size) :
-            fontInfo.size
+    public static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
+        let unscaledFont: UIFont
 
         if let name = fontInfo.name,
-           let font = UIFont(name: name, size: size) {
-            return font.withWeight(uiWeight(fontInfo.weight))
+           let font = UIFont(name: name, size: fontInfo.size) {
+            // Named font
+            unscaledFont = font.withWeight(uiWeight(fontInfo.weight))
         } else {
-            return .systemFont(ofSize: size, weight: uiWeight(fontInfo.weight))
+            // System font
+            unscaledFont = .systemFont(ofSize: fontInfo.size, weight: uiWeight(fontInfo.weight))
+        }
+
+        if shouldScale {
+            let fontMetrics = UIFontMetrics(forTextStyle: uiTextStyle(fontInfo.textStyle))
+            return fontMetrics.scaledFont(for: unscaledFont)
+        } else {
+            return unscaledFont
         }
     }
 
@@ -76,6 +104,37 @@ extension UIFont {
         let descriptor = UIFontDescriptor(fontAttributes: attributes)
 
         return UIFont(descriptor: descriptor, size: pointSize)
+    }
+
+    public static func uiTextStyle(_ textStyle: Font.TextStyle) -> UIFont.TextStyle {
+        switch textStyle {
+        case .largeTitle:
+            return .largeTitle
+        case .title:
+            return .title1
+        case .title2:
+            return .title2
+        case .title3:
+            return .title3
+        case .headline:
+            return .headline
+        case .body:
+            return .body
+        case .callout:
+            return .callout
+        case .subheadline:
+            return .subheadline
+        case .footnote:
+            return .footnote
+        case .caption:
+            return .caption1
+        case .caption2:
+            return .caption2
+        default:
+            // Font.TextStyle has `@unknown default` attribute, so we need a default.
+            assertionFailure("Unknown Font.TextStyle found! Reverting to .body style.")
+            return .body
+        }
     }
 
     private static func uiWeight(_ weight: Font.Weight) -> UIFont.Weight {
@@ -99,6 +158,8 @@ extension UIFont {
         case .black:
             return .black
         default:
+            // Font.Weight has `@unknown default` attribute, so we need a default.
+            assertionFailure("Unknown Font.Weight found! Reverting to .regular weight.")
             return .regular
         }
     }

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -25,20 +25,14 @@ public struct FontInfo {
         self.weight = weight
     }
 
-    static var sizeTuples: [(size: CGFloat, textStyle: Font.TextStyle)] = [
-        (34.0, .largeTitle),
-        (28.0, .title),
-        (22.0, .title2),
-        (20.0, .title3),
-        // Note: `17.0: .headline` is removed to avoid needing duplicate size key values.
-        // But it's okay because Apple's scaling curve is identical between it and `.body`.
-        (17.0, .body),
-        (16.0, .callout),
-        (15.0, .subheadline),
-        (13.0, .footnote),
-        (12.0, .caption),
-        (11.0, .caption2)
-    ]
+    /// An optional name for the font. If none is provided, defaults to the standard system font.
+    public let name: String?
+
+    /// The point size to use for the font.
+    public let size: CGFloat
+
+    /// The weight to use for the font.
+    public let weight: Font.Weight
 
     var textStyle: Font.TextStyle {
         // Defaults to smallest supported text style for mapping, before checking if we're bigger.
@@ -52,9 +46,20 @@ public struct FontInfo {
         return textStyle
     }
 
-    let name: String?
-    let size: CGFloat
-    let weight: Font.Weight
+    private static var sizeTuples: [(size: CGFloat, textStyle: Font.TextStyle)] = [
+        (34.0, .largeTitle),
+        (28.0, .title),
+        (22.0, .title2),
+        (20.0, .title3),
+        // Note: `17.0: .headline` is removed to avoid needing duplicate size key values.
+        // But it's okay because Apple's scaling curve is identical between it and `.body`.
+        (17.0, .body),
+        (16.0, .callout),
+        (15.0, .subheadline),
+        (13.0, .footnote),
+        (12.0, .caption),
+        (11.0, .caption2)
+    ]
 }
 
 // MARK: - ViewModifier

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -40,7 +40,7 @@ public struct FontInfo {
         (11.0, .caption2)
     ]
 
-    public var textStyle: Font.TextStyle {
+    var textStyle: Font.TextStyle {
         // Defaults to smallest supported text style for mapping, before checking if we're bigger.
         var textStyle = Font.TextStyle.caption2
         for tuple in Self.sizeTuples {
@@ -106,7 +106,7 @@ extension UIFont {
         return UIFont(descriptor: descriptor, size: pointSize)
     }
 
-    public static func uiTextStyle(_ textStyle: Font.TextStyle) -> UIFont.TextStyle {
+    private static func uiTextStyle(_ textStyle: Font.TextStyle) -> UIFont.TextStyle {
         switch textStyle {
         case .largeTitle:
             return .largeTitle


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Previously, we've been scaling all text using the ramp for Apple's `body` text style. This works pretty well for _most_ text sizes, but results in too much growth for large text and too little for smaller text. This is because each text style has a fully custom, hand-built scaling ramp, which we were not respecting.

A complication: our Fluent typography system technically supports any arbitrary text size for a component, which won't neatly map to Apple's system.

Solution: let's inspect font sizes and intelligently map them to specific text styles for the purposes of size scaling.

### Verification

I added a new Typography demo controller and used it to compare before/after shots of the different typefaces:

| Size     | Before            | After               | Apple (as FYI) |
|----------|-------------------|---------------------|----------------|
| Standard ("Large") size | ![before-l](https://user-images.githubusercontent.com/4934719/185241838-2524c35d-f0d8-4d94-bc35-44141e7843a4.png) |  ![after-l](https://user-images.githubusercontent.com/4934719/185241841-d6a4ebe7-1523-4422-9264-00d39b291936.png) | ![apple-l](https://user-images.githubusercontent.com/4934719/185487956-2b62fc20-39f5-41f6-b100-3969e3ed2d1b.png) |
| Largest accessibility size | ![before-a11y](https://user-images.githubusercontent.com/4934719/185241844-b6456ad9-7d1b-48e4-be2d-425f70db2cde.png) | ![after-a11y](https://user-images.githubusercontent.com/4934719/185241848-a880faa2-4848-4574-bedb-45771696a7a1.png) | ![apple-a11y](https://user-images.githubusercontent.com/4934719/185487949-a08ad11d-92c4-4cc0-b1d2-6491141ac5a4.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1169)