### PR TITLE
Made ShadowInfo properties and UIView's FluentTheme public

### DIFF
--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -90,7 +90,7 @@ extension UIWindow: FluentThemeable {
     }
 }
 
-@objc extension UIView {
+@objc public extension UIView {
     /// Returns the current view's window's `FluentTheme`, or the default `FluentTheme` if no window yet exists.
     var fluentTheme: FluentTheme {
         return self.window?.fluentTheme ?? FluentThemeKey.defaultValue

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -7,12 +7,56 @@ import CoreGraphics
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
-    let colorOne: DynamicColor
-    let blurOne: CGFloat
-    let xOne: CGFloat
-    let yOne: CGFloat
-    let colorTwo: DynamicColor
-    let blurTwo: CGFloat
-    let xTwo: CGFloat
-    let yTwo: CGFloat
+    /// Initializes a shadow struct to be used in Fluent.
+    ///
+    /// - Parameters:
+    ///   - colorOne: The color of the shadow for shadow 1.
+    ///   - blurOne: The blur of the shadow for shadow 1.
+    ///   - xOne: The horizontal offset of the shadow for shadow 1.
+    ///   - yOne: The vertical offset of the shadow for shadow 1.
+    ///   - colorTwo: The color of the shadow for shadow 2.
+    ///   - blurTwo: The blur of the shadow for shadow 2.
+    ///   - xTwo: The horizontal offset of the shadow for shadow 2.
+    ///   - yTwo: The vertical offset of the shadow for shadow 2.
+    public init(colorOne: DynamicColor,
+                blurOne: CGFloat,
+                xOne: CGFloat,
+                yOne: CGFloat,
+                colorTwo: DynamicColor,
+                blurTwo: CGFloat,
+                xTwo: CGFloat,
+                yTwo: CGFloat) {
+        self.colorOne = colorOne
+        self.blurOne = blurOne
+        self.xOne = xOne
+        self.yOne = yOne
+        self.colorTwo = colorTwo
+        self.blurTwo = blurTwo
+        self.xTwo = xTwo
+        self.yTwo = yTwo
+    }
+
+    /// The color of the shadow for shadow 1.
+    public let colorOne: DynamicColor
+
+    /// The blur of the shadow for shadow 1.
+    public let blurOne: CGFloat
+
+    /// The horizontal offset of the shadow for shadow 1.
+    public let xOne: CGFloat
+
+    /// The vertical offset of the shadow for shadow 1.
+    public let yOne: CGFloat
+
+    /// The color of the shadow for shadow 2.
+    public let colorTwo: DynamicColor
+
+    /// The blur of the shadow for shadow 2.
+    public let blurTwo: CGFloat
+
+    /// The horizontal offset of the shadow for shadow 2.
+    public let xTwo: CGFloat
+
+    /// The vertical offset of the shadow for shadow 2.
+    public let yTwo: CGFloat
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`ShadowInfo`'s properties and `UIView`'s `FluentTheme` were inaccessible outside of FluentUI. This change makes them public.

### Verification

App built and ran fine.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1171)