### PR TITLE
Expose CommandBarDelegate to notify implementer of CommandBar events

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -142,6 +142,7 @@ class CommandBarDemoController: DemoController {
     }
 
     var defaultCommandBar: CommandBar?
+    var animateCommandBarDelegateEvents: Bool = false
 
     let textField: UITextField = {
         let textField = UITextField()
@@ -161,6 +162,7 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(createLabelWithText("Default"))
 
         let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
         commandBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(commandBar)
@@ -213,6 +215,14 @@ class CommandBarDemoController: DemoController {
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
         itemHiddenStackView.addArrangedSubview(itemHiddenSwitch)
         itemCustomizationContainer.addArrangedSubview(itemHiddenStackView)
+
+        let commandBarDelegateEventAnimationView = createHorizontalStackView()
+        commandBarDelegateEventAnimationView.addArrangedSubview(createLabelWithText("Animate CommandBarDelegate Events"))
+        let commandBarDelegateEventAnimationSwitch: UISwitch = UISwitch()
+        commandBarDelegateEventAnimationSwitch.isOn = animateCommandBarDelegateEvents
+        commandBarDelegateEventAnimationSwitch.addTarget(self, action: #selector(animateCommandBarDelegateEventsValueChanged), for: .valueChanged)
+        commandBarDelegateEventAnimationView.addArrangedSubview(commandBarDelegateEventAnimationSwitch)
+        itemCustomizationContainer.addArrangedSubview(commandBarDelegateEventAnimationView)
 
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
@@ -364,6 +374,10 @@ class CommandBarDemoController: DemoController {
         item.isHidden = sender.isOn
     }
 
+    @objc func animateCommandBarDelegateEventsValueChanged(sender: UISwitch!) {
+        animateCommandBarDelegateEvents = sender.isOn
+    }
+
     @objc func refreshDefaultBarItems(sender: UIButton!) {
         defaultCommandBar?.itemGroups = createItemGroups()
     }
@@ -386,4 +400,18 @@ class CommandBarDemoController: DemoController {
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0
     private static let verticalStackViewSpacing: CGFloat = 8.0
+}
+
+extension CommandBarDemoController: CommandBarDelegate {
+    func commandBarDidScroll(_ commandBar: CommandBar) {
+        if animateCommandBarDelegateEvents {
+            let originalBackgroundColor = commandBar.backgroundColor
+
+            UIView.animate(withDuration: 1.0, delay: 0.0, options: [.allowUserInteraction]) {
+                commandBar.backgroundColor = Colors.communicationBlue
+            } completion: { _ in
+                commandBar.backgroundColor = originalBackgroundColor
+            }
+        }
+    }
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
+		94A40ADD28AE9CD1001BB081 /* CommandBarDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A40ADC28AE9CD1001BB081 /* CommandBarDelegate.swift */; };
 		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
 		A257F82A251D98DD002CAA6E /* FluentUI-apple.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
@@ -299,6 +300,7 @@
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
+		94A40ADC28AE9CD1001BB081 /* CommandBarDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarDelegate.swift; sourceTree = "<group>"; };
 		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
 		A257F829251D98DD002CAA6E /* FluentUI-apple.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-apple.xcassets"; path = "../apple/Resources/FluentUI-apple.xcassets"; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
@@ -1056,6 +1058,7 @@
 				FC414E2A25887A4B00069E73 /* CommandBarButton.swift */,
 				FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */,
 				94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */,
+				94A40ADC28AE9CD1001BB081 /* CommandBarDelegate.swift */,
 			);
 			path = "Command Bar";
 			sourceTree = "<group>";
@@ -1551,6 +1554,7 @@
 				92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */,
 				5314E13425F016370099271A /* PopupMenuItem.swift in Sources */,
 				ECA9218A27A33A2D00B66117 /* AvatarGroupModifiers.swift in Sources */,
+				94A40ADD28AE9CD1001BB081 /* CommandBarDelegate.swift in Sources */,
 				5314E13825F016370099271A /* PopupMenuSection.swift in Sources */,
 				5314E07C25F00F1A0099271A /* DateTimePickerViewLayout.swift in Sources */,
 				5314E11625F015EA0099271A /* PersonaBadgeViewDataSource.swift in Sources */,

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -130,6 +130,9 @@ open class CommandBar: UIView {
         }
     }
 
+    /// Delegate object that notifies consumers of events occuring inside the `CommandBar`
+    public weak var delegate: CommandBarDelegate?
+
     // MARK: - Private properties
 
     /// Container UIStackView that holds the leading, main and trailing views
@@ -273,6 +276,8 @@ open class CommandBar: UIView {
 extension CommandBar: UIScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateShadow()
+
+        delegate?.commandBarDidScroll(self)
     }
 }
 

--- a/ios/FluentUI/Command Bar/CommandBarDelegate.swift
+++ b/ios/FluentUI/Command Bar/CommandBarDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+/// `CommandBarDelegate` is used to notify consumers of the `CommandBar` of certain events occurring within the `CommandBar`
+public protocol CommandBarDelegate: AnyObject {
+    /// Called when a scroll occurs in the `CommandBar`
+    /// - Parameter commandBar: the instance of `CommandBar` that received the scroll
+    func commandBarDidScroll(_ commandBar: CommandBar)
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a need for consumers of the `CommandBar` to be notified when scroll events occur.

Created the `CommandBarDelegate` that exposes a method, `commandBarDidScroll(_ commandBar: CommandBar)` that notifies the implementer when a scroll event occurs.

Some alternative approaches were explored including:
1. Utilizing `NSNotification` to publish event globally
2. Have the consumer use KVM to monitor for scroll events. 

Both of these seemed less than ideal so I went with the `CommandBarDelegate` approach.

### Verification

- Verified static library compiles
- Updated the `CommandBarDemoController` with a switch to turn on animations when the `CommandBarDelegate` events occur. The animation simply changes the `CommandBar` background color to blue and then back to the original background color. See video below.

https://user-images.githubusercontent.com/10938746/185459748-9aff1bca-4fc3-440b-af7d-e8a10e8b8f8c.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)