### PR TITLE
Update NotificationView toast fonts

### DIFF
--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -164,9 +164,8 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     }
                     .accessibilityLabel(attributedMessage.string)
             } else if let message = state.message {
-                let messageFont = tokens.regularTextFont
                 Text(message)
-                    .font(.fluent(messageFont))
+                    .font(.fluent(tokens.regularTextFont))
                     .foregroundColor(Color(dynamicColor: tokens.foregroundColor))
             }
         }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -164,7 +164,7 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
                     }
                     .accessibilityLabel(attributedMessage.string)
             } else if let message = state.message {
-                let messageFont = hasSecondTextRow ? tokens.footnoteTextFont : (state.style.isToast ? tokens.boldTextFont : tokens.regularTextFont)
+                let messageFont = tokens.regularTextFont
                 Text(message)
                     .font(.fluent(messageFont))
                     .foregroundColor(Color(dynamicColor: tokens.foregroundColor))

--- a/ios/FluentUI/Notification/NotificationTokens.swift
+++ b/ios/FluentUI/Notification/NotificationTokens.swift
@@ -222,6 +222,4 @@ open class NotificationTokens: ControlTokens {
     open var boldTextFont: FontInfo { aliasTokens.typography[.body2Strong] }
     /// The font for regular text within a notification
     open var regularTextFont: FontInfo { aliasTokens.typography[.body2] }
-    /// The font for footnote text within a notification
-    open var footnoteTextFont: FontInfo { aliasTokens.typography[.caption1] }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Notification was updated to use body 2 font for subtext and single text toast.
Footnote font is now unused so it was removed as well.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="before-light" src="https://user-images.githubusercontent.com/106181067/185712583-73ffe3d2-aad8-4d32-89d0-14d472a17658.png"> | <img width="482" alt="after-light" src="https://user-images.githubusercontent.com/106181067/185712599-53b10159-5108-4c94-8b01-61ff571edae8.png"> |
| <img width="482" alt="before-dark" src="https://user-images.githubusercontent.com/106181067/185712619-f3a50061-7521-4b3c-848b-4022f265f62f.png"> | <img width="482" alt="after-dark" src="https://user-images.githubusercontent.com/106181067/185712637-7c6f0fbf-d11e-45bf-b2f4-a2ee37a95128.png"> |
| <img width="482" alt="before_light" src="https://user-images.githubusercontent.com/106181067/185711579-0762ae67-8100-43e8-9e83-b616f4038a9b.png"> | <img width="482" alt="Screen Shot 2022-08-19 at 2 46 25 PM" src="https://user-images.githubusercontent.com/106181067/185711619-bae25ef8-8816-4ec1-a901-e19d123e81d3.png"> |
| <img width="482" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/185711642-1ef48f35-8dca-4f43-8de9-d43901c4f283.png"> | <img width="482" alt="Screen Shot 2022-08-19 at 2 46 31 PM" src="https://user-images.githubusercontent.com/106181067/185711659-53bf0818-5efc-4c2e-9050-e3063ee3aede.png"> |
| <img width="482" alt="Screen Shot 2022-08-19 at 2 35 19 PM" src="https://user-images.githubusercontent.com/106181067/185710416-358a3ca3-a3d1-4c73-96ce-b5ab497ec708.png"> | <img width="482" alt="after_swiftui_light" src="https://user-images.githubusercontent.com/106181067/185709206-08a5433a-1007-442e-9490-de6a2c20a194.png"> |
| <img width="482" alt="before_swiftui_dark" src="https://user-images.githubusercontent.com/106181067/185709240-276bdda2-4dc2-4c4d-a67d-ebf0f329059a.png"> | <img width="482" alt="after_swiftui_dark" src="https://user-images.githubusercontent.com/106181067/185709269-275e2e56-b12b-49d6-b542-0536b051adb7.png"> |
| <img width="482" alt="before_primary_light" src="https://user-images.githubusercontent.com/106181067/185709310-00c98544-8969-4024-a5ca-7b55b7a14fc5.png"> | <img width="482" alt="after_primary_light" src="https://user-images.githubusercontent.com/106181067/185709341-0266665a-bcba-4c9c-b87a-e2b612831231.png"> |
| <img width="482" alt="before_primary_dark" src="https://user-images.githubusercontent.com/106181067/185709391-10df3a22-695a-4543-b11d-b7bf5d8edf3d.png"> | <img width="482" alt="after_primary_dark" src="https://user-images.githubusercontent.com/106181067/185709416-176b531d-753d-42f2-a761-3b197b6c86d8.png"> |
| <img width="482" alt="before_neutral_light" src="https://user-images.githubusercontent.com/106181067/185709467-b99e63db-25d0-461b-8f63-425337e089b4.png"> | <img width="482" alt="after_neutral_light" src="https://user-images.githubusercontent.com/106181067/185709492-fdcc01eb-7e0d-4a8a-97e3-89c62bf0ac16.png"> |
| <img width="482" alt="before_neutral_dark" src="https://user-images.githubusercontent.com/106181067/185709526-76f8c443-f3b9-4a73-92e4-852e84db84dd.png"> | <img width="482" alt="after_neutral_dark" src="https://user-images.githubusercontent.com/106181067/185709553-2baf190e-a0d8-4071-bc38-55681ac1f7df.png"> |
| <img width="482" alt="before_danger_light" src="https://user-images.githubusercontent.com/106181067/185709633-9c41de17-ae5f-4559-a227-84d7776ce809.png"> | <img width="482" alt="after_danger_light" src="https://user-images.githubusercontent.com/106181067/185709669-d8ec5611-0802-4b7c-8573-de67307dab17.png"> |
| <img width="482" alt="before_danger_dark" src="https://user-images.githubusercontent.com/106181067/185709700-b1d6f99e-a406-442d-b3c5-06d36ee1db2a.png"> | <img width="482" alt="after_danger_dark" src="https://user-images.githubusercontent.com/106181067/185709725-1fb3c355-4f03-4d6d-8e08-3e8e804f0828.png"> |
| <img width="482" alt="before_warning_light" src="https://user-images.githubusercontent.com/106181067/185709764-d0eaea04-cb75-4c2e-94c1-2b14898996e1.png"> | <img width="482" alt="after_warning_light" src="https://user-images.githubusercontent.com/106181067/185709793-6a0ca688-8f43-49b4-b1f7-c8be80263398.png"> |
| <img width="482" alt="before_warning_dark" src="https://user-images.githubusercontent.com/106181067/185709822-e86716d1-d4e0-4cde-9788-b0b17867869a.png"> | <img width="482" alt="after_warning_dark" src="https://user-images.githubusercontent.com/106181067/185709847-5ad8f86a-6180-4a9a-8f20-c7c1c0eed906.png"> |
| <img width="482" alt="Screen Shot 2022-08-19 at 7 49 37 PM" src="https://user-images.githubusercontent.com/106181067/185726258-7446f387-fa84-4954-9891-34c6ca9745e3.png"> | <img width="482" alt="after_light" src="https://user-images.githubusercontent.com/106181067/185726264-d5987e46-c440-4421-8f40-079ed290163b.png"> |
| <img width="482" alt="Screen Shot 2022-08-19 at 7 49 43 PM" src="https://user-images.githubusercontent.com/106181067/185726268-770667eb-b817-418d-95c5-ad2564f129fa.png"> | <img width="482" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/185726270-1379e0c4-6bb0-4c3d-8471-a5f1469bb302.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1176)