### PR TITLE
Update ActivityIndicator demo to use UITableViewCell

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -65,16 +65,36 @@ class ActivityIndicatorDemoController: DemoTableViewController {
 
             return cell
         case.demoOfSize:
-            let cell = TableViewCell()
+            let cell = UITableViewCell()
 
             let activityIndicatorSize = MSFActivityIndicatorSize.allCases.reversed()[indexPath.row]
             let activityIndicatorDictionaries = [defaultColorIndicators, customColorIndicators]
             let activityIndicatorPath = indexPath.section - 2
-            let activityIndicator = activityIndicatorDictionaries[activityIndicatorPath][activityIndicatorSize]
+            guard let activityIndicator = activityIndicatorDictionaries[activityIndicatorPath][activityIndicatorSize] else {
+                return cell
+            }
 
-            cell.setup(title: activityIndicatorSize.description,
-                       customView: activityIndicator)
-            cell.titleNumberOfLines = 0
+            let titleLabel = Label(style: .body, colorStyle: .regular)
+            titleLabel.text = activityIndicatorSize.description
+            titleLabel.numberOfLines = 0
+
+            let contentStack = UIStackView(arrangedSubviews: [activityIndicator, titleLabel])
+            contentStack.isLayoutMarginsRelativeArrangement = true
+            contentStack.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 15, leading: 20, bottom: 15, trailing: 20)
+            contentStack.translatesAutoresizingMaskIntoConstraints = false
+            contentStack.alignment = .center
+            contentStack.distribution = .fill
+            contentStack.spacing = 10
+
+            cell.contentView.addSubview(contentStack)
+            NSLayoutConstraint.activate([
+                activityIndicator.widthAnchor.constraint(equalToConstant: xLargeSize),
+                cell.contentView.leadingAnchor.constraint(equalTo: contentStack.leadingAnchor),
+                cell.contentView.trailingAnchor.constraint(equalTo: contentStack.trailingAnchor),
+                cell.contentView.topAnchor.constraint(equalTo: contentStack.topAnchor),
+                cell.contentView.bottomAnchor.constraint(equalTo: contentStack.bottomAnchor)
+            ])
+
             return cell
         }
     }
@@ -208,6 +228,8 @@ class ActivityIndicatorDemoController: DemoTableViewController {
         }
 
     }
+
+    private let xLargeSize: CGFloat = 36
 
     @objc private func startStopActivity() {
         isAnimating.toggle()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The ActivityIndicator demo was using our TableViewCell, which was causing each cell to be read as a button through VoiceOver. Switching to UITableViewCell to match our other demos fixes this, and lets VoiceOver actually navigate to the ActivityIndicator.

### Verification
Before:

https://user-images.githubusercontent.com/67026548/185714074-253ad542-1f2e-42f1-a7d3-1e384adf5d6f.mov

After:

https://user-images.githubusercontent.com/67026548/185714085-25cb6134-71a2-4969-9bc7-904b3b15ca90.mov

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1177)