### PR TITLE
Fix CardNudge truncation in large text sizes

### DIFF
--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -84,6 +84,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                 .fontWeight(.medium)
                 .lineLimit(1)
                 .foregroundColor(Color(dynamicColor: tokens.textColor))
+                .showsLargeContentViewer(text: state.title)
 
             if hasSecondTextRow {
                 HStack(spacing: tokens.accentPadding) {
@@ -99,12 +100,14 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                             .layoutPriority(1)
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.accentColor))
+                            .showsLargeContentViewer(text: accent, image: state.accentIcon)
                     }
                     if let subtitle = state.subtitle {
                         Text(subtitle)
                             .font(.subheadline)
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.subtitleTextColor))
+                            .showsLargeContentViewer(text: subtitle)
                     }
                 }
             }
@@ -127,17 +130,23 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                     RoundedRectangle(cornerRadius: tokens.circleRadius)
                         .foregroundColor(Color(dynamicColor: tokens.buttonBackgroundColor))
                 )
+                .showsLargeContentViewer(text: actionTitle)
             }
             if let dismissAction = state.dismissButtonAction {
+                let dismissImage = UIImage.staticImageNamed("dismiss-20x20")
+                let dismissLabel = "Accessibility.Dismiss.Label".localized
                 SwiftUI.Button(action: {
                     dismissAction(state)
                 }, label: {
-                    Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
+                    if let image = dismissImage {
+                        Image(uiImage: image)
+                    }
                 })
                 .padding(.horizontal, tokens.buttonInnerPaddingHorizontal)
                 .padding(.vertical, tokens.verticalPadding)
-                .accessibility(identifier: "Accessibility.Dismiss.Label")
+                .accessibilityLabel(dismissLabel)
                 .foregroundColor(Color(dynamicColor: tokens.textColor))
+                .showsLargeContentViewer(text: dismissLabel, image: dismissImage)
             }
         }
     }

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -69,6 +69,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                     .foregroundColor(Color(dynamicColor: tokens.accentColor))
             }
             .padding(.trailing, tokens.horizontalPadding)
+            .showsLargeContentViewer(text: state.title, image: state.mainIcon)
         }
     }
 
@@ -80,11 +81,10 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
     var textContainer: some View {
         VStack(alignment: .leading, spacing: tokens.interTextVerticalPadding) {
             Text(state.title)
-                .font(.subheadline)
-                .fontWeight(.medium)
+                .font(.fluent(tokens.aliasTokens.typography[.body2Strong], shouldScale: false))
                 .lineLimit(1)
                 .foregroundColor(Color(dynamicColor: tokens.textColor))
-                .showsLargeContentViewer(text: state.title)
+                .showsLargeContentViewer(text: state.title, image: state.mainIcon)
 
             if hasSecondTextRow {
                 HStack(spacing: tokens.accentPadding) {
@@ -96,7 +96,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                     }
                     if let accent = state.accentText {
                         Text(accent)
-                            .font(.subheadline)
+                            .font(.fluent(tokens.aliasTokens.typography[.caption1], shouldScale: false))
                             .layoutPriority(1)
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.accentColor))
@@ -104,7 +104,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                     }
                     if let subtitle = state.subtitle {
                         Text(subtitle)
-                            .font(.subheadline)
+                            .font(.fluent(tokens.aliasTokens.typography[.caption1], shouldScale: false))
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.subtitleTextColor))
                             .showsLargeContentViewer(text: subtitle)
@@ -122,6 +122,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                 SwiftUI.Button(actionTitle) {
                     action(state)
                 }
+                .font(.fluent(tokens.aliasTokens.typography[.body2Strong], shouldScale: false))
                 .lineLimit(1)
                 .padding(.horizontal, tokens.buttonInnerPaddingHorizontal)
                 .padding(.vertical, tokens.verticalPadding)

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -81,7 +81,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
     var textContainer: some View {
         VStack(alignment: .leading, spacing: tokens.interTextVerticalPadding) {
             Text(state.title)
-                .font(.fluent(tokens.aliasTokens.typography[.body2Strong], shouldScale: false))
+                .font(.fluent(tokens.titleFont, shouldScale: false))
                 .lineLimit(1)
                 .foregroundColor(Color(dynamicColor: tokens.textColor))
                 .showsLargeContentViewer(text: state.title, image: state.mainIcon)
@@ -96,7 +96,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                     }
                     if let accent = state.accentText {
                         Text(accent)
-                            .font(.fluent(tokens.aliasTokens.typography[.caption1], shouldScale: false))
+                            .font(.fluent(tokens.accentFont, shouldScale: false))
                             .layoutPriority(1)
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.accentColor))
@@ -104,7 +104,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                     }
                     if let subtitle = state.subtitle {
                         Text(subtitle)
-                            .font(.fluent(tokens.aliasTokens.typography[.caption1], shouldScale: false))
+                            .font(.fluent(tokens.subtitleFont, shouldScale: false))
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokens.subtitleTextColor))
                             .showsLargeContentViewer(text: subtitle)
@@ -122,7 +122,7 @@ public struct CardNudge: View, ConfigurableTokenizedControl {
                 SwiftUI.Button(actionTitle) {
                     action(state)
                 }
-                .font(.fluent(tokens.aliasTokens.typography[.body2Strong], shouldScale: false))
+                .font(.fluent(tokens.actionTitleFont, shouldScale: false))
                 .lineLimit(1)
                 .padding(.horizontal, tokens.buttonInnerPaddingHorizontal)
                 .padding(.vertical, tokens.verticalPadding)

--- a/ios/FluentUI/Card Nudge/CardNudgeTokens.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokens.swift
@@ -23,9 +23,13 @@ open class CardNudgeTokens: ControlTokens {
 
     open var accentColor: DynamicColor { globalTokens.brandColors[.shade20] }
 
+    open var accentFont: FontInfo { aliasTokens.typography[.caption1] }
+
     open var accentIconSize: CGFloat { globalTokens.iconSize[.xxSmall] }
 
     open var accentPadding: CGFloat { globalTokens.spacing[.xxSmall] }
+
+    open var actionTitleFont: FontInfo { aliasTokens.typography[.body2Strong] }
 
     open var backgroundColor: DynamicColor {
         switch style {
@@ -67,6 +71,8 @@ open class CardNudgeTokens: ControlTokens {
 
     open var outlineWidth: CGFloat { globalTokens.borderSize[.thin] }
 
+    open var subtitleFont: FontInfo { aliasTokens.typography[.caption1] }
+
     open var subtitleTextColor: DynamicColor { aliasTokens.foregroundColors[.neutral3] }
 
     open var textColor: DynamicColor {
@@ -77,6 +83,8 @@ open class CardNudgeTokens: ControlTokens {
             return globalTokens.brandColors[.shade20]
         }
     }
+
+    open var titleFont: FontInfo { aliasTokens.typography[.body2Strong] }
 
     open var verticalPadding: CGFloat { globalTokens.spacing[.xSmall] }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

CardNudge was truncating text in large font scenarios for accessibility. This change adds Large Content Viewer support and prevents scaling of font to ensure all text is visible and accessible from LCV.

### Verification

Built and ran simulator, setting font size to large accessibility size to test LCV.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-19 at 15 55 13](https://user-images.githubusercontent.com/23249106/185717268-29274925-b604-408e-8546-4604f6c24da5.png) | ![Simulator Screen Recording - iPhone 13 Pro Max - 2022-08-19 at 15 54 15](https://user-images.githubusercontent.com/23249106/185717766-7ad3be80-e819-4c85-9b59-51b684942af9.gif) |
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-19 at 15 55 19](https://user-images.githubusercontent.com/23249106/185717283-921f4657-17d4-477b-853c-55426da7f907.png) | ![Simulator Screen Recording - iPhone 13 Pro Max - 2022-08-19 at 15 54 48](https://user-images.githubusercontent.com/23249106/185717776-8abd710d-27f4-4add-b3f4-d1f0e2995df9.gif) |





### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1179)