### PR TITLE
[Fluent 2 iOS] Update and Add Alias Tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -76,6 +76,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .foregroundDisabled2,
              .foregroundOnColor,
              .brandForeground2,
+             .brandForegroundDisabled2,
              .stroke1,
              .stroke2,
              .strokeDisabled,
@@ -106,7 +107,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandForeground1Selected,
              .brandForeground4,
              .brandForeground5,
-             .brandForegroundDisabled,
+             .brandForegroundDisabled1,
              .background5SelectedBrandFilled,
              .backgroundInverted,
              .brandBackground1,
@@ -218,7 +219,8 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .brandForeground4,
                     .brandForeground5,
                     .brandForegroundInverted,
-                    .brandForegroundDisabled]
+                    .brandForegroundDisabled1,
+                    .brandForegroundDisabled2]
         case .neutralStrokes:
             return [.stroke1,
                     .stroke2,
@@ -271,8 +273,10 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Foreground 5"
         case .brandForegroundInverted:
             return "Brand Foreground Inverted"
-        case .brandForegroundDisabled:
-            return "Brand Foreground Disabled"
+        case .brandForegroundDisabled1:
+            return "Brand Foreground Disabled 1"
+        case .brandForegroundDisabled2:
+            return "Brand Foreground Disabled 2"
         case .background1:
             return "Background 1"
         case .background1Pressed:

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -372,7 +372,8 @@ public final class AliasTokens {
         case brandForeground4
         case brandForeground5
         case brandForegroundInverted
-        case brandForegroundDisabled
+        case brandForegroundDisabled1
+        case brandForegroundDisabled2
         // Background colors
         case background1
         case background1Pressed
@@ -443,7 +444,7 @@ public final class AliasTokens {
                                 dark: strongSelf.globalTokens.neutralColors[.grey36])
         case .foregroundDisabled2:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.grey24])
+                                dark: strongSelf.globalTokens.neutralColors[.grey18])
         case .foregroundContrast:
             return DynamicColor(light: strongSelf.globalTokens.neutralColors[.black],
                                 dark: strongSelf.globalTokens.neutralColors[.black])
@@ -477,8 +478,11 @@ public final class AliasTokens {
         case .brandForegroundInverted:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm80].light,
                                 dark: strongSelf.globalTokens.neutralColors[.white])
-        case .brandForegroundDisabled:
+        case .brandForegroundDisabled1:
             return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm90].light)
+        case .brandForegroundDisabled2:
+            return DynamicColor(light: strongSelf.globalTokens.brandColors[.comm140].light,
+                                dark: strongSelf.globalTokens.brandColors[.comm40].light)
         // Background colors
         case .background1:
          return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In order to align with new designs for states in Segmented Controls, updates were made to Foreground and BrandForeground colors.

- Changed values for Foreground Disabled 2 dark theme color from Grey 24 -> Grey 18.
- Renamed Brand Foreground Disabled to Brand Foreground Disabled 1.
- Added Brand Foreground Disabled 2 L: Comm 140, D: Comm40

### Verification

Updated the alias demo controller, built and ran simulator, tested in light and dark mode. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 14 34 24](https://user-images.githubusercontent.com/23249106/186023701-e2c44975-f617-4dee-8fd9-3e8a4332d433.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 14 28 44](https://user-images.githubusercontent.com/23249106/186023693-faa5688c-ec36-4555-88ca-58b38e1aa446.png) | 
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 14 38 48](https://user-images.githubusercontent.com/23249106/186023713-cdb3233a-ae67-4212-9301-1863abe7d5f4.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 14 39 37](https://user-images.githubusercontent.com/23249106/186023682-7334fca1-c8a5-4058-8c13-1672a9538c6f.png) |
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 15 01 21](https://user-images.githubusercontent.com/23249106/186026604-9248b3b0-9e5d-473d-9514-52cb5d87917a.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 15 02 00](https://user-images.githubusercontent.com/23249106/186026642-1627c28f-07e7-4ca5-8f79-5ebcdc5ea2b9.png) |
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 15 01 01](https://user-images.githubusercontent.com/23249106/186026627-38235efa-6318-478f-b3c1-bdea39daebbd.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-22 at 15 01 55](https://user-images.githubusercontent.com/23249106/186026654-10acfdab-bbae-4164-b6cc-a8a1f5477574.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1180)