### PR TITLE
Expose resetScrollPosition API on CommandBar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -404,7 +404,7 @@ class CommandBarDemoController: DemoController {
     }
 
     @objc func resetScrollPosition(sender: UIButton!) {
-        defaultCommandBar?.resetScrollPosition()
+        defaultCommandBar?.resetScrollPosition(true)
     }
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -200,6 +200,11 @@ class CommandBarDemoController: DemoController {
         refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
+        let resetScrollPositionButton = Button(style: .tertiaryOutline)
+        resetScrollPositionButton.setTitle("Reset Scroll Position", for: .normal)
+        resetScrollPositionButton.addTarget(self, action: #selector(resetScrollPosition), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(resetScrollPositionButton)
+
         let itemEnabledStackView = createHorizontalStackView()
         itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Enabled"))
         let itemEnabledSwitch: UISwitch = UISwitch()
@@ -396,6 +401,10 @@ class CommandBarDemoController: DemoController {
 
     @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
         defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    @objc func resetScrollPosition(sender: UIButton!) {
+        defaultCommandBar?.resetScrollPosition()
     }
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -96,8 +96,9 @@ open class CommandBar: UIView {
     }
 
     /// Sets the scoll position  to the start of the scroll view
-    @objc public func resetScrollPosition() {
-        scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: false)
+    @objc public func resetScrollPosition(_ animated: Bool = false) {
+        /// A `CGRect` with a `width` and `height` both greater than `0` is required for the scrolling to occur
+        scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: animated)
     }
 
     // MARK: Overrides

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -95,6 +95,11 @@ open class CommandBar: UIView {
         trailingCommandGroupsView.updateButtonsState()
     }
 
+    /// Sets the scoll position  to the start of the scroll view
+    @objc public func resetScrollPosition() {
+        scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: false)
+    }
+
     // MARK: Overrides
 
     public override var intrinsicContentSize: CGSize {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In some use cases a consumer may want to reset the scroll position of the scrollable items. This can be achieved by calling `UIScrollView.scrollRectToVisible(x: Int, y: Int, width: Int, height: Int)`.  

A method, `resetScrollPosition`, is exposed on the `CommandBar` which calls `UIScrollView.scrollRectToVisible(...)` on the internal `UIScrollView`. The `UIScrollView` supports RTL by default so the `x` position does not need to be calculated. `0` works in all cases.

This new method is not called as part of the `itemGroups` `didSet` functionality because we do not want this to be the default. Consumers can call this as needed to suit their needs.

### Verification

- Build static library
- Updated and verified in `CommandBarDemoController`
- Verified behavior with devmain applications

https://user-images.githubusercontent.com/10938746/186038274-534df813-8db9-4424-8dd9-70879fb8e6f8.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1181)