### PR TITLE
fix HUD demo crash

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -104,14 +104,14 @@ class HUDDemoController: DemoTableViewController {
 
     @objc private func showCustomHUD(sender: UIButton) {
         HUD.shared.show(from: self, with: HUDParams(caption: "Custom",
-                                                    image: UIImage(named: "flag-40x40"),
+                                                    image: UIImage(named: "flag-48x48"),
                                                     isPersistent: false))
     }
 
     @objc private func showCustomNonBlockingHUD(sender: UIButton) {
         HUD.shared.show(from: self,
                         with: HUDParams(caption: "Custom image non-blocking",
-                                        image: UIImage(named: "flag-40x40"),
+                                        image: UIImage(named: "flag-48x48"),
                                         isBlocking: false))
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             HUD.shared.hide()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController_SwiftUI.swift
@@ -78,7 +78,7 @@ struct HUDDemoView: View {
                             Text(".activity").tag(HUDType.activity)
                             Text(".success").tag(HUDType.success)
                             Text(".failure").tag(HUDType.failure)
-                            Text(".custom").tag(HUDType.custom(image: UIImage(named: "flag-40x40")!))
+                            Text(".custom").tag(HUDType.custom(image: UIImage(named: "flag-48x48")!))
                         }
                         .labelsHidden()
                         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Regressed by commit 6b205e9b386a476af4f2699c18d9d195d5132b07 when updating HUD to swiftui control it wasn't referring the the correct fluent demo app asset icon.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| HUD > SwiftUI Demo > Crashed | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-23 at 18 11 26](https://user-images.githubusercontent.com/20715435/186295722-b79bb09d-ab4f-44e4-8c3d-6efe94d5f109.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1183)