### PR TITLE
Fix TableViewHeaderFooterView demo controller colors

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -33,9 +33,10 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         container.spacing = 0
 
         navigationController?.navigationBar.shadowImage = UIImage()
+        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(segmentedControl)
         container.setCustomSpacing(8, after: segmentedControl)
-        container.backgroundColor = Colors.tableBackground
+        container.backgroundColor = Colors.navigationBarBackground
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         container.addArrangedSubview(separator)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -35,7 +35,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         navigationController?.navigationBar.shadowImage = UIImage()
         container.addArrangedSubview(segmentedControl)
         container.setCustomSpacing(8, after: segmentedControl)
-        container.backgroundColor = Colors.navigationBarBackground
+        container.backgroundColor = Colors.tableBackground
 
         let separator = Separator(style: .shadow, orientation: .horizontal)
         container.addArrangedSubview(separator)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The background of the navigation controller behind the segmented control in the TableViewHeaderFooterView demo controller was not the correct color. Simple fix to make it match the expected design values.

### Verification

Built and ran simulator demo app, dark and light mode, and side-by-side

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPad Air (5th generation) - 2022-08-24 at 13 15 34](https://user-images.githubusercontent.com/23249106/186514810-5ebb0d57-8556-4a81-9e15-9b9b04acfd5a.png) | ![Simulator Screen Shot - iPad Air (5th generation) - 2022-08-24 at 13 13 49](https://user-images.githubusercontent.com/23249106/186514833-c73ad733-1e60-49af-a953-0406dd9bae91.png) | 
![Simulator Screen Shot - iPad Air (5th generation) - 2022-08-24 at 13 15 39](https://user-images.githubusercontent.com/23249106/186514792-e7bff48e-988f-4cc1-a702-db16288915f7.png) | ![Simulator Screen Shot - iPad Air (5th generation) - 2022-08-24 at 13 13 45](https://user-images.githubusercontent.com/23249106/186514816-b303c983-bb98-4b86-a370-a1e9c1e666a9.png) |
![Simulator Screen Shot - iPad Air (5th generation) - 2022-08-24 at 13 18 00](https://user-images.githubusercontent.com/23249106/186515206-1ce938b5-d9f3-4a46-8967-3d3135188a97.png) | ![Simulator Screen Shot - iPad Air (5th generation) - 2022-08-24 at 13 13 11](https://user-images.githubusercontent.com/23249106/186514846-ce3294b4-6448-47b8-a2db-be72f319fc16.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1186)