### PR TITLE
[Fluent 2 iOS] Bottom Commanding Controller

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -116,7 +116,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleAppendPersona() {
-        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
             let random = Int.random(in: 0...personas.count - 1)
             let persona = personas[random]
             add(persona, to: carousel)
@@ -124,7 +124,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleRemovePersona() {
-        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
             let state = carousel.state
             let count = state.count
             if count > 0 {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -419,6 +419,7 @@ open class BottomCommandingController: UIViewController {
         let shadow28 = view.fluentTheme.aliasTokens.shadow[.shadow28]
         bottomBarLayer.shadowColor = UIColor(dynamicColor: shadow28.colorTwo).cgColor
         bottomBarLayer.shadowRadius = shadow28.blurTwo
+        bottomBarLayer.shadowOpacity = 1
 
         let roundedCornerView = UIView()
         roundedCornerView.backgroundColor = bottomBarBackgroundColor

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -869,7 +869,7 @@ open class BottomCommandingController: UIViewController {
         static let heroButtonMaxTitleLines: Int = 2
 
         struct BottomBar {
-            static let height: CGFloat = 74
+            static let height: CGFloat = 80
             static let cornerRadius: CGFloat = 14
 
             static let bottomOffset: CGFloat = 8

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -650,6 +650,7 @@ open class BottomCommandingController: UIViewController {
         }
         cell.isEnabled = item.isEnabled
         cell.backgroundStyleType = .clear
+        cell.backgroundColor = tableViewBackgroundColor
 
         let shouldShowSeparator = expandedListSections
             .prefix(expandedListSections.count - 1)
@@ -857,10 +858,8 @@ open class BottomCommandingController: UIViewController {
     }
 
     private lazy var tableViewIconTintColor: UIColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey50))
-    private lazy var tableViewBackgroundColor: UIColor = UIColor(light: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1]),
-                                                                 dark: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4]))
-    private lazy var bottomBarBackgroundColor: UIColor = UIColor(light: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1]),
-                                                                 dark: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4]))
+    private lazy var tableViewBackgroundColor: UIColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
+    private lazy var bottomBarBackgroundColor: UIColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
 
     private struct Constants {
         static let defaultHeroButtonHeight: CGFloat = 40

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -855,7 +855,7 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    private lazy var tableViewIconTintColor: UIColor = UIColor(colorValue: view.fluentTheme.globalTokens.neutralColors[.grey50])
+    private lazy var tableViewIconTintColor: UIColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey50))
     private lazy var tableViewBackgroundColor: UIColor = UIColor(light: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1]),
                                                                  dark: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4]))
     private lazy var bottomBarBackgroundColor: UIColor = UIColor(light: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1]),

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -855,9 +855,11 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
-    private lazy var tableViewIconTintColor: UIColor = Colors.textSecondary
-    private lazy var tableViewBackgroundColor: UIColor = Colors.NavigationBar.background
-    private lazy var bottomBarBackgroundColor: UIColor = Colors.NavigationBar.background
+    private lazy var tableViewIconTintColor: UIColor = UIColor(colorValue: view.fluentTheme.globalTokens.neutralColors[.grey50])
+    private lazy var tableViewBackgroundColor: UIColor = UIColor(light: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1]),
+                                                                 dark: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4]))
+    private lazy var bottomBarBackgroundColor: UIColor = UIColor(light: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1]),
+                                                                 dark: UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4]))
 
     private struct Constants {
         static let defaultHeroButtonHeight: CGFloat = 40
@@ -866,10 +868,10 @@ open class BottomCommandingController: UIViewController {
         static let heroButtonMaxTitleLines: Int = 2
 
         struct BottomBar {
-            static let height: CGFloat = 80
+            static let height: CGFloat = 74
             static let cornerRadius: CGFloat = 14
 
-            static let bottomOffset: CGFloat = 10
+            static let bottomOffset: CGFloat = 8
             static let hiddenBottomOffset: CGFloat = -110
             static let heroStackLeadingTrailingMargin: CGFloat = 8
             static let heroStackTopMargin: CGFloat = 20
@@ -882,8 +884,8 @@ open class BottomCommandingController: UIViewController {
         }
 
         struct BottomSheet {
-            static let headerHeight: CGFloat = 64
-            static let headerTopMargin: CGFloat = 4
+            static let headerHeight: CGFloat = 66
+            static let headerTopMargin: CGFloat = 8
             static let headerLeadingTrailingMargin: CGFloat = 8
         }
     }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -415,12 +415,13 @@ open class BottomCommandingController: UIViewController {
     private func makeBottomBarByEmbedding(contentView: UIView) -> UIView {
         let bottomBarView = UIView()
         let bottomBarLayer = bottomBarView.layer
-        bottomBarLayer.shadowColor = Constants.BottomBar.Shadow.color
-        bottomBarLayer.shadowOpacity = Constants.BottomBar.Shadow.opacity
-        bottomBarLayer.shadowRadius = Constants.BottomBar.Shadow.radius
+
+        let shadow28 = view.fluentTheme.aliasTokens.shadow[.shadow28]
+        bottomBarLayer.shadowColor = UIColor(dynamicColor: shadow28.colorTwo).cgColor
+        bottomBarLayer.shadowRadius = shadow28.blurTwo
 
         let roundedCornerView = UIView()
-        roundedCornerView.backgroundColor = Constants.BottomBar.backgroundColor
+        roundedCornerView.backgroundColor = bottomBarBackgroundColor
         roundedCornerView.translatesAutoresizingMaskIntoConstraints = false
         roundedCornerView.layer.cornerRadius = Constants.BottomBar.cornerRadius
         roundedCornerView.layer.cornerCurve = .continuous
@@ -505,7 +506,7 @@ open class BottomCommandingController: UIViewController {
         tableView.separatorStyle = .none
         tableView.alwaysBounceVertical = false
         tableView.sectionFooterHeight = 0
-        tableView.backgroundColor = Constants.tableViewBackgroundColor
+        tableView.backgroundColor = tableViewBackgroundColor
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
@@ -635,7 +636,7 @@ open class BottomCommandingController: UIViewController {
 
     private func setupTableViewCell(_ cell: TableViewCell, with item: CommandingItem) {
         let iconView = UIImageView(image: item.image)
-        iconView.tintColor = Constants.tableViewIconTintColor
+        iconView.tintColor = tableViewIconTintColor
 
         if item.isToggleable, let booleanCell = cell as? BooleanCell {
             booleanCell.setup(title: item.title ?? "", customView: iconView, isOn: item.isOn)
@@ -854,19 +855,19 @@ open class BottomCommandingController: UIViewController {
         }
     }
 
+    private lazy var tableViewIconTintColor: UIColor = Colors.textSecondary
+    private lazy var tableViewBackgroundColor: UIColor = Colors.NavigationBar.background
+    private lazy var bottomBarBackgroundColor: UIColor = Colors.NavigationBar.background
+
     private struct Constants {
         static let defaultHeroButtonHeight: CGFloat = 40
         static let heroButtonWidth: CGFloat = 96
         static let heroButtonLabelMaxWidth: CGFloat = 72
         static let heroButtonMaxTitleLines: Int = 2
 
-        static let tableViewIconTintColor: UIColor = Colors.textSecondary
-        static let tableViewBackgroundColor: UIColor = Colors.NavigationBar.background
-
         struct BottomBar {
             static let height: CGFloat = 80
             static let cornerRadius: CGFloat = 14
-            static let backgroundColor: UIColor = Colors.NavigationBar.background
 
             static let bottomOffset: CGFloat = 10
             static let hiddenBottomOffset: CGFloat = -110
@@ -878,12 +879,6 @@ open class BottomCommandingController: UIViewController {
 
             static let moreButtonIcon: UIImage? = UIImage.staticImageNamed("more-24x24")
             static let moreButtonTitle: String = "CommandingBottomBar.More".localized
-
-            struct Shadow {
-                static let color: CGColor = UIColor.black.cgColor
-                static let opacity: Float = 0.14
-                static let radius: CGFloat = 8
-            }
         }
 
         struct BottomSheet {

--- a/ios/FluentUI/Navigation/Helpers/NavigationAnimator.swift
+++ b/ios/FluentUI/Navigation/Helpers/NavigationAnimator.swift
@@ -50,7 +50,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
         let isTemporary: Bool
 
         /// A custom animation block executed during the animation
-        var customAnimation : (() -> Void)?
+        var customAnimation: (() -> Void)?
     }
 
     private typealias ViewFrameTransitionGroups = (group1: [ViewFrameTransition], group2: [ViewFrameTransition])
@@ -138,7 +138,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
 
     /// Creates a transition for two background views that are placed under the "to" and "from" view controllers, and the navigation controller's subviews.
     /// The background that appears on top has a shadow that fades out during the transition.
-    private func createBackgroundTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createBackgroundTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         let frame = transitionContext.containerView.bounds
 
         let fromBgView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 1.0, height: 1.0)))
@@ -174,7 +174,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
     }
 
     /// Creates the transitions for the "to" and "from" view controllers.
-    private func createViewControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createViewControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         guard let fromVC = transitionContext.viewController(forKey: .from), let toVC = transitionContext.viewController(forKey: .to) else {
             return
         }
@@ -188,7 +188,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
 
     /// Creates the transitions for the Navigation Controller which must be an instance of `NavigationController`.
     /// All subviews including Navigation Bar and Toolbar are animated.
-    private func createNavigationControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createNavigationControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         guard let navigationController = navigationController as? NavigationController else {
             return
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update the Bottom Commanding Controller to Fluent 2 designs. This builds off of Bottom Sheet.

### Verification

Built and ran the simulator, using the BottomCommandingControllerDemo in light and dark mode on multiple screens and different orientations. Double checked color values with colour value analyser to ensure colors match figma.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 13 04](https://user-images.githubusercontent.com/23249106/186533629-e79c9019-4f92-4750-95d4-b971b459f916.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 11 21](https://user-images.githubusercontent.com/23249106/186533643-02d7dffb-d649-467e-8fd7-4baf2df80f49.png) |
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 13 07](https://user-images.githubusercontent.com/23249106/186533496-1c486824-c2cd-40d1-98c1-96a53516238a.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 11 25](https://user-images.githubusercontent.com/23249106/186533554-d4a6c45d-e78a-4418-9acf-36d861cceb58.png) |
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 13 34](https://user-images.githubusercontent.com/23249106/186533514-2b3a3200-c277-463d-a0be-4d38432b4562.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 11 55](https://user-images.githubusercontent.com/23249106/186533540-75cf8066-1608-4f8d-b6f6-fcd14cbe0938.png) |
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-08-24 at 15 13 38](https://user-images.githubusercontent.com/23249106/186533521-95693862-b7e0-48d5-adfe-104700e267ed.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-09-02 at 13 40 55](https://user-images.githubusercontent.com/23249106/188232675-c5386728-b825-424b-bc12-e93b133af245.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1187)