### PR TITLE
Creating `GradientInfo` and exposing as optional override on `FluentNotification`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -200,8 +200,10 @@ class NotificationViewDemoController: DemoController {
             notification.state.message = "The background of this notification has been customized with a gradient."
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             // It's a lovely blue-to-pink gradient
-            let colors: [DynamicColor] = [DynamicColor(light: ColorValue(0xFFF1FA), dark: ColorValue(0x601044)),
-                                          DynamicColor(light: ColorValue(0xE0F6FF), dark: ColorValue(0x005A7F))]
+            let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens().sharedColors[.pink][.tint50],
+                                                       dark: GlobalTokens().sharedColors[.pink][.shade40]),
+                                          DynamicColor(light: GlobalTokens().sharedColors[.cyan][.tint50],
+                                                       dark: GlobalTokens().sharedColors[.cyan][.shade40])]
             notification.state.backgroundGradient = GradientInfo(colors: colors,
                                                                  startPoint: .init(x: 0.0, y: 1.0),
                                                                  endPoint: .init(x: 1.0, y: 0.0))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -200,10 +200,10 @@ class NotificationViewDemoController: DemoController {
             notification.state.message = "The background of this notification has been customized with a gradient."
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             // It's a lovely blue-to-pink gradient
-            let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens().sharedColors[.pink][.tint50],
-                                                       dark: GlobalTokens().sharedColors[.pink][.shade40]),
-                                          DynamicColor(light: GlobalTokens().sharedColors[.cyan][.tint50],
-                                                       dark: GlobalTokens().sharedColors[.cyan][.shade40])]
+            let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens.sharedColors(.pink, .tint50),
+                                                       dark: GlobalTokens.sharedColors(.pink, .shade40)),
+                                          DynamicColor(light: GlobalTokens.sharedColors(.cyan, .tint50),
+                                                       dark: GlobalTokens.sharedColors(.cyan, .shade40))]
             notification.state.backgroundGradient = GradientInfo(colors: colors,
                                                                  startPoint: .init(x: 0.0, y: 1.0),
                                                                  endPoint: .init(x: 1.0, y: 0.0))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -21,6 +21,7 @@ class NotificationViewDemoController: DemoController {
         case primaryToastWithStrikethroughAttribute
         case neutralBarWithFontAttribute
         case neutralToastWithOverriddenTokens
+        case neutralToastWithGradientBackground
         case warningToastWithFlexibleWidth
 
         var displayText: String {
@@ -51,6 +52,8 @@ class NotificationViewDemoController: DemoController {
                 return "Neutral Bar with Font Attribute"
             case .neutralToastWithOverriddenTokens:
                 return "Neutral Toast With Overridden Tokens"
+            case .neutralToastWithGradientBackground:
+                return "Neutral Toast With Gradient Background"
             case .warningToastWithFlexibleWidth:
                 return "Warning Toast With Flexible Width"
             }
@@ -187,6 +190,21 @@ class NotificationViewDemoController: DemoController {
             notification.state.message = "The image color and spacing between the elements of this notification have been customized with override tokens."
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             notification.state.overrideTokens = NotificationOverrideTokens()
+            notification.state.actionButtonAction = { [weak self] in
+                self?.showMessage("`Dismiss` tapped")
+                notification.hide()
+            }
+            return notification
+        case .neutralToastWithGradientBackground:
+            let notification = MSFNotification(style: .neutralToast)
+            notification.state.message = "The image color and spacing between the elements of this notification have been customized with override tokens."
+            notification.state.image = UIImage(named: "play-in-circle-24x24")
+            // It's a lovely blue-to-pink gradient
+            let colors: [DynamicColor] = [DynamicColor(light: ColorValue(0xFFF1FA), dark: ColorValue(0x601044)),
+                                          DynamicColor(light: ColorValue(0xE0F6FF), dark: ColorValue(0x005A7F))]
+            notification.state.backgroundGradient = GradientInfo(colors: colors,
+                                                                 startPoint: .init(x: 0.0, y: 1.0),
+                                                                 endPoint: .init(x: 1.0, y: 0.0))
             notification.state.actionButtonAction = { [weak self] in
                 self?.showMessage("`Dismiss` tapped")
                 notification.hide()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -197,7 +197,7 @@ class NotificationViewDemoController: DemoController {
             return notification
         case .neutralToastWithGradientBackground:
             let notification = MSFNotification(style: .neutralToast)
-            notification.state.message = "The image color and spacing between the elements of this notification have been customized with override tokens."
+            notification.state.message = "The background of this notification has been customized with a gradient."
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             // It's a lovely blue-to-pink gradient
             let colors: [DynamicColor] = [DynamicColor(light: ColorValue(0xFFF1FA), dark: ColorValue(0x601044)),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -38,6 +38,7 @@ struct NotificationDemoView: View {
     @State var isFlexibleWidthToast: Bool = false
     @State var showDefaultDismissActionButton: Bool = true
     @State var showFromBottom: Bool = true
+    @State var showBackgroundGradient: Bool = false
 
     public var body: some View {
         let hasAttribute = hasBlueStrikethroughAttribute || hasLargeRedPapyrusFontAttribute
@@ -58,21 +59,22 @@ struct NotificationDemoView: View {
         VStack {
             Rectangle()
                 .foregroundColor(.clear)
-                .presentNotification(style: style,
-                                     isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
-                                     message: hasMessage ? message : nil,
-                                     attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
-                                     isBlocking: false,
-                                     isPresented: .constant(true),
-                                     title: hasTitle ? title : nil,
-                                     attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
-                                     image: image,
-                                     trailingImage: trailingImage,
-                                     trailingImageAccessibilityLabel: trailingImageLabel,
-                                     actionButtonTitle: actionButtonTitle,
-                                     actionButtonAction: actionButtonAction,
-                                     messageButtonAction: messageButtonAction,
-                                     overrideTokens: $overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+                .presentNotification(isPresented: .constant(true), isBlocking: false) {
+                    FluentNotification(style: style,
+                                       isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
+                                       message: hasMessage ? message : nil,
+                                       attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
+                                       title: hasTitle ? title : nil,
+                                       attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
+                                       image: image,
+                                       trailingImage: trailingImage,
+                                       trailingImageAccessibilityLabel: trailingImageLabel,
+                                       actionButtonTitle: actionButtonTitle,
+                                       actionButtonAction: actionButtonAction,
+                                       messageButtonAction: messageButtonAction)
+                    .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
+                    .overrideTokens($overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+                }
                 .frame(maxWidth: .infinity, maxHeight: 150, alignment: .center)
                 .alert(isPresented: $showAlert, content: {
                     Alert(title: Text("Button tapped"))
@@ -155,16 +157,18 @@ struct NotificationDemoView: View {
                         FluentUIDemoToggle(titleKey: "Override Tokens (Image Color and Horizontal Spacing)", isOn: $overrideTokens)
                         FluentUIDemoToggle(titleKey: "Flexible Width Toast", isOn: $isFlexibleWidthToast)
                         FluentUIDemoToggle(titleKey: "Present From Bottom", isOn: $showFromBottom)
+                        FluentUIDemoToggle(titleKey: "Background Gradient", isOn: $showBackgroundGradient)
                     }
                 }
                 .padding()
             }
         }
-        .presentNotification(style: style,
+        .presentNotification(isPresented: $isPresented,
+                             isBlocking: false) {
+            FluentNotification(style: style,
                              isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
                              message: hasMessage ? message : nil,
                              attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
-                             isBlocking: false,
                              isPresented: $isPresented,
                              title: hasTitle ? title : nil,
                              attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
@@ -175,8 +179,19 @@ struct NotificationDemoView: View {
                              actionButtonAction: actionButtonAction,
                              showDefaultDismissActionButton: showDefaultDismissActionButton,
                              messageButtonAction: messageButtonAction,
-                             showFromBottom: showFromBottom,
-                             overrideTokens: $overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+                             showFromBottom: showFromBottom)
+            .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
+            .overrideTokens($overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+        }
+    }
+
+    private var backgroundGradient: GradientInfo {
+        // It's a lovely blue-to-pink gradient
+        let colors: [DynamicColor] = [DynamicColor(light: ColorValue(0xFFF1FA), dark: ColorValue(0x601044)),
+                                      DynamicColor(light: ColorValue(0xE0F6FF), dark: ColorValue(0x005A7F))]
+        return GradientInfo(colors: colors,
+                            startPoint: .init(x: 0.0, y: 1.0),
+                            endPoint: .init(x: 1.0, y: 0.0))
     }
 
     private class NotificationOverrideTokens: NotificationTokens {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -187,8 +187,10 @@ struct NotificationDemoView: View {
 
     private var backgroundGradient: GradientInfo {
         // It's a lovely blue-to-pink gradient
-        let colors: [DynamicColor] = [DynamicColor(light: ColorValue(0xFFF1FA), dark: ColorValue(0x601044)),
-                                      DynamicColor(light: ColorValue(0xE0F6FF), dark: ColorValue(0x005A7F))]
+        let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens().sharedColors[.pink][.tint50],
+                                                   dark: GlobalTokens().sharedColors[.pink][.shade40]),
+                                      DynamicColor(light: GlobalTokens().sharedColors[.cyan][.tint50],
+                                                   dark: GlobalTokens().sharedColors[.cyan][.shade40])]
         return GradientInfo(colors: colors,
                             startPoint: .init(x: 0.0, y: 1.0),
                             endPoint: .init(x: 1.0, y: 0.0))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -187,10 +187,10 @@ struct NotificationDemoView: View {
 
     private var backgroundGradient: GradientInfo {
         // It's a lovely blue-to-pink gradient
-        let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens().sharedColors[.pink][.tint50],
-                                                   dark: GlobalTokens().sharedColors[.pink][.shade40]),
-                                      DynamicColor(light: GlobalTokens().sharedColors[.cyan][.tint50],
-                                                   dark: GlobalTokens().sharedColors[.cyan][.shade40])]
+        let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens.sharedColors(.pink, .tint50),
+                                                   dark: GlobalTokens.sharedColors(.pink, .shade40)),
+                                      DynamicColor(light: GlobalTokens.sharedColors(.cyan, .tint50),
+                                                   dark: GlobalTokens.sharedColors(.cyan, .shade40))]
         return GradientInfo(colors: colors,
                             startPoint: .init(x: 0.0, y: 1.0),
                             endPoint: .init(x: 1.0, y: 0.0))

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D49054278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */; };
 		92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598026A0FD2800328FD3 /* CardNudge.swift */; };
+		92D5FDFB28A713990087894B /* GradientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5FDFA28A713990087894B /* GradientInfo.swift */; };
 		92DEE2252723D34400E31ED0 /* ControlTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE2232723D34400E31ED0 /* ControlTokens.swift */; };
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
@@ -289,6 +290,7 @@
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselModifiers.swift; sourceTree = "<group>"; };
 		92D5598026A0FD2800328FD3 /* CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudge.swift; sourceTree = "<group>"; };
+		92D5FDFA28A713990087894B /* GradientInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientInfo.swift; sourceTree = "<group>"; };
 		92DEE2232723D34400E31ED0 /* ControlTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokens.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 				92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */,
 				925728F8276D6B5800EE1019 /* FontInfo.swift */,
 				925D461B26FD133600179583 /* GlobalTokens.swift */,
+				92D5FDFA28A713990087894B /* GradientInfo.swift */,
 				925728F6276D6AF800EE1019 /* ShadowInfo.swift */,
 				923DB9D2274CB65700D8E58A /* TokenizedControl.swift */,
 				92EE82AC27025A94009D52B5 /* TokenSet.swift */,
@@ -1396,6 +1399,7 @@
 				5314E1A725F01A7C0099271A /* ActionsCell.swift in Sources */,
 				5314E07B25F00F1A0099271A /* DateTimePickerViewDataSource.swift in Sources */,
 				532FE3D426EA6D74007539C0 /* ActivityIndicatorTokens.swift in Sources */,
+				92D5FDFB28A713990087894B /* GradientInfo.swift in Sources */,
 				53E2EE07278799B30086D30D /* MSFIndeterminateProgressBar.swift in Sources */,
 				532FE3D626EA6D74007539C0 /* ActivityIndicatorModifiers.swift in Sources */,
 				5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */,

--- a/ios/FluentUI/Core/Theme/Tokens/GradientInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GradientInfo.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+/// Represents a gradient as used by FluentUI.
+@objc public class GradientInfo: NSObject {
+    /// Initializes a gradient to be used in Fluent.
+    ///
+    /// - Parameters:
+    ///   - colors: The color of the shadow for shadow 1.
+    ///   - startPoint: The blur of the shadow for shadow 1.
+    ///   - endPoint: The horizontal offset of the shadow for shadow 1.
+    public init(colors: [DynamicColor],
+                startPoint: CGPoint,
+                endPoint: CGPoint) {
+        self.colors = colors
+        self.startPoint = startPoint
+        self.endPoint = endPoint
+    }
+
+    /// The array of colors to apply to this linear gradient.
+    public let colors: [DynamicColor]
+
+    /// The starting point for this gradient. Values should range from 0.0 to 1.0.
+    public let startPoint: CGPoint
+
+    /// The ending point for this gradient. Values should range from 0.0 to 1.0.
+    public let endPoint: CGPoint
+}
+
+// MARK: - Extensions
+
+extension LinearGradient {
+    /// Internal property to generate a SwiftUI `LinearGradient` from a gradient info.
+    init(gradientInfo: GradientInfo) {
+        self.init(colors: gradientInfo.colors.map({ Color(dynamicColor: $0) }),
+                  startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
+                  endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
+    }
+}

--- a/ios/FluentUI/Core/Theme/Tokens/GradientInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GradientInfo.swift
@@ -12,19 +12,27 @@ import SwiftUI
     /// Initializes a gradient to be used in Fluent.
     ///
     /// - Parameters:
-    ///   - colors: The color of the shadow for shadow 1.
-    ///   - startPoint: The blur of the shadow for shadow 1.
-    ///   - endPoint: The horizontal offset of the shadow for shadow 1.
+    ///   - colors: The array of colors to apply to this linear gradient.
+    ///   - locations: An optional array of values defining the location of each gradient stop. Must be in the range `[0, 1]`.
+    ///   - startPoint: The starting point for this gradient. Values should range from 0.0 to 1.0.
+    ///   - endPoint: The ending point for this gradient. Values should range from 0.0 to 1.0.
     public init(colors: [DynamicColor],
+                locations: [CGFloat]? = nil,
                 startPoint: CGPoint,
                 endPoint: CGPoint) {
         self.colors = colors
+        self.locations = locations
         self.startPoint = startPoint
         self.endPoint = endPoint
     }
 
     /// The array of colors to apply to this linear gradient.
     public let colors: [DynamicColor]
+
+    /// An optional array of values defining the location of each gradient stop.
+    ///
+    /// Must be in the range `[0, 1]`.
+    public let locations: [CGFloat]?
 
     /// The starting point for this gradient. Values should range from 0.0 to 1.0.
     public let startPoint: CGPoint
@@ -38,8 +46,19 @@ import SwiftUI
 extension LinearGradient {
     /// Internal property to generate a SwiftUI `LinearGradient` from a gradient info.
     init(gradientInfo: GradientInfo) {
-        self.init(colors: gradientInfo.colors.map({ Color(dynamicColor: $0) }),
-                  startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
-                  endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
+        if let locations = gradientInfo.locations {
+            // Map the colors and locations together.
+            let stops: [Gradient.Stop] = zip(gradientInfo.colors, locations).map({ (color, location) in
+                return Gradient.Stop(color: Color(dynamicColor: color),
+                                     location: location)
+            })
+            self.init(stops: stops,
+                      startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
+                      endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
+        } else {
+            self.init(colors: gradientInfo.colors.map({ Color(dynamicColor: $0) }),
+                      startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
+                      endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
+        }
     }
 }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -53,6 +53,11 @@ import SwiftUI
 
     /// Defines whether the notification shows from the bottom of the presenting view or the top.
     var showFromBottom: Bool { get set }
+
+    /// An optional gradient to use as the background of the notification.
+    ///
+    /// If this property is nil, then we will use the background color defined by our design tokens.
+    var backgroundGradient: GradientInfo? { get set }
 }
 
 /// View that represents the Notification.
@@ -252,14 +257,29 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
         }
 
         @ViewBuilder
+        var backgroundFill: some View {
+            if let backgroundGradient = state.backgroundGradient {
+                GeometryReader { g in
+                    // The gradient needs to be rendered square, then scaled to fit the containing view.
+                    // Otherwise SwiftUI will crop the gradient view, which is not what we want!
+                    LinearGradient(gradientInfo: backgroundGradient)
+                        .frame(width: g.size.width, height: g.size.width)
+                        .scaleEffect(x: 1.0, y: g.size.height / g.size.width, anchor: .top)
+                }
+            } else {
+                Color(dynamicColor: tokens.backgroundColor)
+            }
+        }
+
+        @ViewBuilder
         var notification: some View {
             innerContents
                 .background(
                     RoundedRectangle(cornerRadius: tokens.cornerRadius)
                         .strokeBorder(Color(dynamicColor: tokens.outlineColor), lineWidth: tokens.outlineWidth)
                         .background(
-                            RoundedRectangle(cornerRadius: tokens.cornerRadius)
-                                .fill(Color(dynamicColor: tokens.backgroundColor))
+                            backgroundFill
+                                .clipShape(RoundedRectangle(cornerRadius: tokens.cornerRadius))
                         )
                         .shadow(color: Color(dynamicColor: tokens.ambientShadowColor),
                                 radius: tokens.ambientShadowBlur,
@@ -389,34 +409,35 @@ public struct FluentNotification: View, ConfigurableTokenizedControl {
 }
 
 class MSFNotificationStateImpl: NSObject, ControlConfiguration, MSFNotificationState {
-    @Published public var message: String?
-    @Published public var attributedMessage: NSAttributedString?
-    @Published public var title: String?
-    @Published public var attributedTitle: NSAttributedString?
-    @Published public var image: UIImage?
-    @Published public var trailingImage: UIImage?
-    @Published public var trailingImageAccessibilityLabel: String?
-    @Published public var showDefaultDismissActionButton: Bool
-    @Published public var showFromBottom: Bool = true
+    @Published var message: String?
+    @Published var attributedMessage: NSAttributedString?
+    @Published var title: String?
+    @Published var attributedTitle: NSAttributedString?
+    @Published var image: UIImage?
+    @Published var trailingImage: UIImage?
+    @Published var trailingImageAccessibilityLabel: String?
+    @Published var showDefaultDismissActionButton: Bool
+    @Published var showFromBottom: Bool = true
+    @Published var backgroundGradient: GradientInfo?
 
     /// Title to display in the action button on the trailing edge of the control.
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
-    @Published public var actionButtonTitle: String?
+    @Published var actionButtonTitle: String?
 
     /// Action to be dispatched by the action button on the trailing edge of the control.
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
-    @Published public var actionButtonAction: (() -> Void)?
+    @Published var actionButtonAction: (() -> Void)?
 
     /// Action to be dispatched by tapping on the toast/bar notification.
-    @Published public var messageButtonAction: (() -> Void)?
+    @Published var messageButtonAction: (() -> Void)?
 
     /// Design token set for this control, to use in place of the control's default Fluent tokens.
     @Published var overrideTokens: NotificationTokens?
 
     /// Style to draw the control.
-    @Published public var style: MSFNotificationStyle
+    @Published var style: MSFNotificationStyle
 
     @objc convenience init(style: MSFNotificationStyle) {
         self.init(style: style,

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -56,7 +56,7 @@ import SwiftUI
 
     /// An optional gradient to use as the background of the notification.
     ///
-    /// If this property is nil, then we will use the background color defined by our design tokens.
+    /// If this property is nil, then this notification will use the background color defined by its design tokens.
     var backgroundGradient: GradientInfo? { get set }
 }
 

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -66,6 +66,12 @@ public extension View {
 }
 
 public extension FluentNotification {
+    ///
+    func backgroundGradient(_ gradientInfo: GradientInfo?) -> FluentNotification {
+        state.backgroundGradient = gradientInfo
+        return self
+    }
+
     /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: NotificationTokens?) -> FluentNotification {
         state.overrideTokens = tokens

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -8,71 +8,28 @@ import SwiftUI
 public extension View {
     /// Presents a Notification on top of the modified View.
     /// - Parameters:
-    ///   - style: `MSFNotificationStyle` enum value that defines the style of the Notification being presented.
-    ///   - isFlexibleWidthToast: Whether the width of the toast is set based on the width of the screen or on its contents/
-    ///   - message: Optional text for the main title area of the control. If there is a title, the message becomes subtext.
-    ///   - attributedMessage: Optional attributed text for the main title area of the control. If there is a title, the message becomes subtext.
-    ///   - isBlocking: Whether the interaction with the view will be blocked while the Notification is being presented.
-    ///   - isPresented: Controls whether the Notification is being presented.
-    ///   - title: Optional text to draw above the message area.
-    ///   - attributedTitle: Optional attributed text to draw above the message area.
-    ///   - image: Optional icon to draw at the leading edge of the control.
-    ///   - trailingImage: Optional icon to show in the action button if no button title is provided.
-    ///   - trailingImageAccessibilityLabel: Optional localized accessibility label for the trailing image.
-    ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
-    ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
-    ///   - showDefaultDismissActionButton: Bool to control if the Notification has a dismiss action by default.
-    ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
-    ///   - showFromBottom: Defines whether the notification shows from the bottom of the presenting view or the top.
-    ///   - overrideTokens: Custom NotificationTokens class that will override the default tokens.
+    ///   - notification: The `FluentNotification` instance to present.
     /// - Returns: The modified view with the capability of presenting a Notification.
-    func presentNotification(style: MSFNotificationStyle,
-                             isFlexibleWidthToast: Bool,
-                             message: String? = nil,
-                             attributedMessage: NSAttributedString? = nil,
+    func presentNotification(isPresented: Binding<Bool>,
                              isBlocking: Bool = true,
-                             isPresented: Binding<Bool>,
-                             title: String? = nil,
-                             attributedTitle: NSAttributedString? = nil,
-                             image: UIImage? = nil,
-                             trailingImage: UIImage? = nil,
-                             trailingImageAccessibilityLabel: String? = nil,
-                             actionButtonTitle: String? = nil,
-                             actionButtonAction: (() -> Void)? = nil,
-                             showDefaultDismissActionButton: Bool? = nil,
-                             messageButtonAction: (() -> Void)? = nil,
-                             showFromBottom: Bool = true,
-                             overrideTokens: NotificationTokens? = nil) -> some View {
+                             @ViewBuilder notification: @escaping () -> FluentNotification) -> some View {
         self.presentingView(isPresented: isPresented,
                             isBlocking: isBlocking) {
-            FluentNotification(style: style,
-                               isFlexibleWidthToast: isFlexibleWidthToast,
-                               message: message,
-                               attributedMessage: attributedMessage,
-                               isPresented: isPresented,
-                               title: title,
-                               attributedTitle: attributedTitle,
-                               image: image,
-                               trailingImage: trailingImage,
-                               trailingImageAccessibilityLabel: trailingImageAccessibilityLabel,
-                               actionButtonTitle: actionButtonTitle,
-                               actionButtonAction: actionButtonAction,
-                               showDefaultDismissActionButton: showDefaultDismissActionButton,
-                               messageButtonAction: messageButtonAction,
-                               showFromBottom: showFromBottom)
-            .overrideTokens(overrideTokens)
+            notification()
         }
     }
 }
 
 public extension FluentNotification {
-    ///
+    /// Specifies a custom background 
     func backgroundGradient(_ gradientInfo: GradientInfo?) -> FluentNotification {
         state.backgroundGradient = gradientInfo
         return self
     }
 
-    /// Provides a custom design token set to be used when drawing this control.
+    /// An optional gradient to use as the background of the notification.
+    ///
+    /// If this property is nil, then this notification will use the background color defined by its design tokens.
     func overrideTokens(_ tokens: NotificationTokens?) -> FluentNotification {
         state.overrideTokens = tokens
         return self

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -21,15 +21,15 @@ public extension View {
 }
 
 public extension FluentNotification {
-    /// Specifies a custom background 
+    /// An optional gradient to use as the background of the notification.
+    ///
+    /// If this property is nil, then this notification will use the background color defined by its design tokens.
     func backgroundGradient(_ gradientInfo: GradientInfo?) -> FluentNotification {
         state.backgroundGradient = gradientInfo
         return self
     }
 
-    /// An optional gradient to use as the background of the notification.
-    ///
-    /// If this property is nil, then this notification will use the background color defined by its design tokens.
+    /// Provides a custom design token set to be used when drawing this control.
     func overrideTokens(_ tokens: NotificationTokens?) -> FluentNotification {
         state.overrideTokens = tokens
         return self


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change introduces a new struct, `GradientInfo`, to represent the building blocks of a gradient in Fluent. It comes with three properties: 

* `colors`: an array of `DynamicColor`  values to represent each color stop in the gradient.
* `startPoint`: a point representing the starting point of the gradient.
* `endPoint`: a point representing the ending point of the gradient.

As per Apple docs, `startPoint` and `endpoint` should both range from `(0.0, 0.0)` to `(1.0, 1.0)`, representing a percentage along both the `x` and `y` axes.

Additionally, this change adds an optional background gradient to `FluentNotification`, and maps its setting across SwiftUI and UIKit. Some notes here:

* This gradient is _not_ a Fluent design token--that system does not currently support gradients. Instead, this value is stored as a settable state property in UIKit and a view modifier in SwiftUI.
* I had to do some minor refactoring of notification presentation in SwiftUI to allow for arbitrary view modifiers to be expressed. Eventually I'd like most of the values currently passed into `FluentNotification.init()` to move to view modifiers, but for now I've left them as-is. If reviewers would like me to move more then I will gladly do so in a follow-up PR.

### Verification

New gradient works in light and dark modes, in both UIKit and SwiftUI.

Package size is _reduced_ by 2 kB, from 30,450 kB to 30,448 kB 🥳

| UIKit                                        | SwiftUI                                      |
|----------------------------------------------|--------------------------------------------|
| ![UIKit](https://user-images.githubusercontent.com/4934719/186536687-fb239b1a-7f57-4123-9fe1-1bbf86e9762a.gif) | ![SwiftUI](https://user-images.githubusercontent.com/4934719/186536496-8affc270-8e86-4239-92ad-76b532294379.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1188)