### PR TITLE
CommandBar: Fixing iOS 15 specific logic for icon and label.

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -79,6 +79,8 @@ class CommandBarDemoController: DemoController {
                 return TextStyle.body.textRepresentation
             case .disabledText:
                 return "Search"
+            case .add:
+                return "Add"
             default:
                 return nil
             }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -77,7 +77,7 @@ class CommandBarButton: UIButton {
 
         if #available(iOS 15.0, *) {
             configuration?.image = iconImage
-            configuration?.title = title
+            configuration?.title = iconImage != nil ? nil : title
 
             if let font = item.titleFont {
                 let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

54f3e8116586ec5660279c4ef3cd2e9397c5368b (#1172) introduced a regression where the logic below was not honored:

If an icon is provided, the label should be hidden. The label is used only in the case where the icon is not provided.

This change fixes the regression and introduces a test case in the demo app for the Add button of the CCB.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ccb_before](https://user-images.githubusercontent.com/68076145/186765902-47d5eb9a-571a-4dbc-b64d-5afe5115107a.png) | ![ccb_after](https://user-images.githubusercontent.com/68076145/186765913-22d0d756-7d81-4491-a29c-fed3ae638c50.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1191)