### PR TITLE
Main 0.7 cherry pick ccb changes

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -144,7 +144,6 @@ class CommandBarDemoController: DemoController {
     }
 
     var defaultCommandBar: CommandBar?
-    var animateCommandBarDelegateEvents: Bool = false
 
     let textField: UITextField = {
         let textField = UITextField()
@@ -164,7 +163,6 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(createLabelWithText("Default"))
 
         let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
-        commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
         commandBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(commandBar)
@@ -217,14 +215,6 @@ class CommandBarDemoController: DemoController {
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
         itemHiddenStackView.addArrangedSubview(itemHiddenSwitch)
         itemCustomizationContainer.addArrangedSubview(itemHiddenStackView)
-
-        let commandBarDelegateEventAnimationView = createHorizontalStackView()
-        commandBarDelegateEventAnimationView.addArrangedSubview(createLabelWithText("Animate CommandBarDelegate Events"))
-        let commandBarDelegateEventAnimationSwitch: UISwitch = UISwitch()
-        commandBarDelegateEventAnimationSwitch.isOn = animateCommandBarDelegateEvents
-        commandBarDelegateEventAnimationSwitch.addTarget(self, action: #selector(animateCommandBarDelegateEventsValueChanged), for: .valueChanged)
-        commandBarDelegateEventAnimationView.addArrangedSubview(commandBarDelegateEventAnimationSwitch)
-        itemCustomizationContainer.addArrangedSubview(commandBarDelegateEventAnimationView)
 
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
@@ -376,10 +366,6 @@ class CommandBarDemoController: DemoController {
         item.isHidden = sender.isOn
     }
 
-    @objc func animateCommandBarDelegateEventsValueChanged(sender: UISwitch!) {
-        animateCommandBarDelegateEvents = sender.isOn
-    }
-
     @objc func refreshDefaultBarItems(sender: UIButton!) {
         defaultCommandBar?.itemGroups = createItemGroups()
     }
@@ -402,18 +388,4 @@ class CommandBarDemoController: DemoController {
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0
     private static let verticalStackViewSpacing: CGFloat = 8.0
-}
-
-extension CommandBarDemoController: CommandBarDelegate {
-    func commandBarDidScroll(_ commandBar: CommandBar) {
-        if animateCommandBarDelegateEvents {
-            let originalBackgroundColor = commandBar.backgroundColor
-
-            UIView.animate(withDuration: 1.0, delay: 0.0, options: [.allowUserInteraction]) {
-                commandBar.backgroundColor = Colors.communicationBlue
-            } completion: { _ in
-                commandBar.backgroundColor = originalBackgroundColor
-            }
-        }
-    }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -142,6 +142,7 @@ class CommandBarDemoController: DemoController {
     }
 
     var defaultCommandBar: CommandBar?
+    var animateCommandBarDelegateEvents: Bool = false
 
     let textField: UITextField = {
         let textField = UITextField()
@@ -161,6 +162,7 @@ class CommandBarDemoController: DemoController {
         container.addArrangedSubview(createLabelWithText("Default"))
 
         let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
         commandBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(commandBar)
@@ -213,6 +215,14 @@ class CommandBarDemoController: DemoController {
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
         itemHiddenStackView.addArrangedSubview(itemHiddenSwitch)
         itemCustomizationContainer.addArrangedSubview(itemHiddenStackView)
+
+        let commandBarDelegateEventAnimationView = createHorizontalStackView()
+        commandBarDelegateEventAnimationView.addArrangedSubview(createLabelWithText("Animate CommandBarDelegate Events"))
+        let commandBarDelegateEventAnimationSwitch: UISwitch = UISwitch()
+        commandBarDelegateEventAnimationSwitch.isOn = animateCommandBarDelegateEvents
+        commandBarDelegateEventAnimationSwitch.addTarget(self, action: #selector(animateCommandBarDelegateEventsValueChanged), for: .valueChanged)
+        commandBarDelegateEventAnimationView.addArrangedSubview(commandBarDelegateEventAnimationSwitch)
+        itemCustomizationContainer.addArrangedSubview(commandBarDelegateEventAnimationView)
 
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
@@ -364,6 +374,10 @@ class CommandBarDemoController: DemoController {
         item.isHidden = sender.isOn
     }
 
+    @objc func animateCommandBarDelegateEventsValueChanged(sender: UISwitch!) {
+        animateCommandBarDelegateEvents = sender.isOn
+    }
+
     @objc func refreshDefaultBarItems(sender: UIButton!) {
         defaultCommandBar?.itemGroups = createItemGroups()
     }
@@ -386,4 +400,18 @@ class CommandBarDemoController: DemoController {
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0
     private static let verticalStackViewSpacing: CGFloat = 8.0
+}
+
+extension CommandBarDemoController: CommandBarDelegate {
+    func commandBarDidScroll(_ commandBar: CommandBar) {
+        if animateCommandBarDelegateEvents {
+            let originalBackgroundColor = commandBar.backgroundColor
+
+            UIView.animate(withDuration: 1.0, delay: 0.0, options: [.allowUserInteraction]) {
+                commandBar.backgroundColor = Colors.communicationBlue
+            } completion: { _ in
+                commandBar.backgroundColor = originalBackgroundColor
+            }
+        }
+    }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -79,6 +79,8 @@ class CommandBarDemoController: DemoController {
                 return TextStyle.body.textRepresentation
             case .disabledText:
                 return "Search"
+            case .add:
+                return "Add"
             default:
                 return nil
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -200,6 +200,11 @@ class CommandBarDemoController: DemoController {
         refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
+        let resetScrollPositionButton = Button(style: .tertiaryOutline)
+        resetScrollPositionButton.setTitle("Reset Scroll Position", for: .normal)
+        resetScrollPositionButton.addTarget(self, action: #selector(resetScrollPosition), for: .touchUpInside)
+        itemCustomizationContainer.addArrangedSubview(resetScrollPositionButton)
+
         let itemEnabledStackView = createHorizontalStackView()
         itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Enabled"))
         let itemEnabledSwitch: UISwitch = UISwitch()
@@ -396,6 +401,10 @@ class CommandBarDemoController: DemoController {
 
     @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
         defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
+    }
+
+    @objc func resetScrollPosition(sender: UIButton!) {
+        defaultCommandBar?.resetScrollPosition(true)
     }
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -202,11 +202,6 @@ class CommandBarDemoController: DemoController {
         refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
-        let resetScrollPositionButton = Button(style: .tertiaryOutline)
-        resetScrollPositionButton.setTitle("Reset Scroll Position", for: .normal)
-        resetScrollPositionButton.addTarget(self, action: #selector(resetScrollPosition), for: .touchUpInside)
-        itemCustomizationContainer.addArrangedSubview(resetScrollPositionButton)
-
         let itemEnabledStackView = createHorizontalStackView()
         itemEnabledStackView.addArrangedSubview(createLabelWithText("'+' Enabled"))
         let itemEnabledSwitch: UISwitch = UISwitch()
@@ -403,10 +398,6 @@ class CommandBarDemoController: DemoController {
 
     @objc func refreshDefaultLeadingBarItems(sender: UIButton!) {
         defaultCommandBar?.leadingItemGroups = [[newItem(for: .keyboard)]]
-    }
-
-    @objc func resetScrollPosition(sender: UIButton!) {
-        defaultCommandBar?.resetScrollPosition(true)
     }
 
     private static let horizontalStackViewSpacing: CGFloat = 16.0

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -95,6 +95,12 @@ open class CommandBar: UIView {
         trailingCommandGroupsView.updateButtonsState()
     }
 
+    /// Sets the scoll position  to the start of the scroll view
+    @objc public func resetScrollPosition(_ animated: Bool = false) {
+        /// A `CGRect` with a `width` and `height` both greater than `0` is required for the scrolling to occur
+        scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: animated)
+    }
+
     // MARK: Overrides
 
     public override var intrinsicContentSize: CGSize {

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -5,9 +5,16 @@
 
 import UIKit
 
+/// `CommandBarDelegate` is used to notify consumers of the `CommandBar` of certain events occurring within the `CommandBar`
+public protocol CommandBarDelegate: AnyObject {
+    /// Called when a scroll occurs in the `CommandBar`
+    /// - Parameter commandBar: the instance of `CommandBar` that received the scroll
+    func commandBarDidScroll(_ commandBar: CommandBar)
+}
+
 /**
  `CommandBar` is a horizontal scrollable list of icon buttons divided by groups.
- Set the `delegate` property to determine whether a button can be selected and deselected, and listen to selection changes.
+ Set the `delegate` property to receive callbacks when scroll events occur.
  Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItemGroups` and `trailingItemGroups` add buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  */
 @objc(MSFCommandBar)
@@ -129,6 +136,9 @@ open class CommandBar: UIView {
             setupGroupsView(trailingCommandGroupsView, with: newValue)
         }
     }
+
+    /// Delegate object that notifies consumers of events occuring inside the `CommandBar`
+    public weak var delegate: CommandBarDelegate?
 
     // MARK: - Private properties
 
@@ -273,6 +283,8 @@ open class CommandBar: UIView {
 extension CommandBar: UIScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateShadow()
+
+        delegate?.commandBarDidScroll(self)
     }
 }
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -5,16 +5,9 @@
 
 import UIKit
 
-/// `CommandBarDelegate` is used to notify consumers of the `CommandBar` of certain events occurring within the `CommandBar`
-public protocol CommandBarDelegate: AnyObject {
-    /// Called when a scroll occurs in the `CommandBar`
-    /// - Parameter commandBar: the instance of `CommandBar` that received the scroll
-    func commandBarDidScroll(_ commandBar: CommandBar)
-}
-
 /**
  `CommandBar` is a horizontal scrollable list of icon buttons divided by groups.
- Set the `delegate` property to receive callbacks when scroll events occur.
+ Set the `delegate` property to determine whether a button can be selected and deselected, and listen to selection changes.
  Provide `itemGroups` in `init` to set the buttons in the scrollable area. Optional `leadingItemGroups` and `trailingItemGroups` add buttons in leading and trailing positions. Each `CommandBarItem` will be represented as a button.
  */
 @objc(MSFCommandBar)
@@ -136,9 +129,6 @@ open class CommandBar: UIView {
             setupGroupsView(trailingCommandGroupsView, with: newValue)
         }
     }
-
-    /// Delegate object that notifies consumers of events occuring inside the `CommandBar`
-    public weak var delegate: CommandBarDelegate?
 
     // MARK: - Private properties
 
@@ -283,8 +273,6 @@ open class CommandBar: UIView {
 extension CommandBar: UIScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         updateShadow()
-
-        delegate?.commandBarDidScroll(self)
     }
 }
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -95,12 +95,6 @@ open class CommandBar: UIView {
         trailingCommandGroupsView.updateButtonsState()
     }
 
-    /// Sets the scoll position  to the start of the scroll view
-    @objc public func resetScrollPosition(_ animated: Bool = false) {
-        /// A `CGRect` with a `width` and `height` both greater than `0` is required for the scrolling to occur
-        scrollView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: animated)
-    }
-
     // MARK: Overrides
 
     public override var intrinsicContentSize: CGSize {

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -77,7 +77,7 @@ class CommandBarButton: UIButton {
 
         if #available(iOS 15.0, *) {
             configuration?.image = iconImage
-            configuration?.title = title
+            configuration?.title = iconImage != nil ? nil : title
 
             if let font = item.titleFont {
                 let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
git cherry-pick 77423c8


### Verification

basic testing on reset scrolling testing

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-26 at 09 09 51](https://user-images.githubusercontent.com/20715435/186947664-622b584f-0f30-4e7f-90b5-837c42f2ed2b.png)|![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-08-26 at 09 09 51](https://user-images.githubusercontent.com/20715435/186952499-22ac4d82-0429-4b58-b58b-c3cc9f0172e1.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1192)