### PR TITLE
Create function in ShadowInfo to apply chosen shadow to a specified view 

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreGraphics
+import UIKit
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
@@ -59,4 +60,13 @@ public struct ShadowInfo {
 
     /// The vertical offset of the shadow for shadow 2.
     public let yTwo: CGFloat
+
+    /// Applies the chosen shadow to a specified view
+    public func applyShadow(for view: UIView, isShadowOne: Bool) {
+        view.layer.shadowColor = isShadowOne ? UIColor(dynamicColor: colorOne).cgColor : UIColor(dynamicColor: colorTwo).cgColor
+        view.layer.shadowRadius = isShadowOne ? (blurOne / 2) : (blurTwo / 2)
+        view.layer.shadowOpacity = 1
+        view.layer.shadowOffset = CGSize(width: isShadowOne ? xOne : xTwo,
+                                         height: isShadowOne ? yOne : yTwo)
+    }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -64,6 +64,7 @@ public struct ShadowInfo {
     /// Applies the chosen shadow to a specified view
     public func applyShadow(for view: UIView, isShadowOne: Bool) {
         view.layer.shadowColor = isShadowOne ? UIColor(dynamicColor: colorOne).cgColor : UIColor(dynamicColor: colorTwo).cgColor
+        /// The chosen blur value needs to be halved to correctly display the Fluent shadows
         view.layer.shadowRadius = isShadowOne ? (blurOne / 2) : (blurTwo / 2)
         view.layer.shadowOpacity = 1
         view.layer.shadowOffset = CGSize(width: isShadowOne ? xOne : xTwo,


### PR DESCRIPTION
`###` Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

I've added the applyShadow function which applies one of the shadows in ShadowInfo to a specified view. 
- This change makes it easier for us and customers to apply shadows to views. I will make sure to use this function for all UIKit controls using shadows as part of the fluent 2 colors effort. 
- The blur values of our shadow tokens need to be halved in order to display shadows properly. This wasn't public knowledge and adding this function will reduce the risk of misuse of these values for us and our customers.

### Verification

Used the new function to apply shadow 28 to large cards in the demo app.

| Shadow 1                                       | Shadow 2                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="482" alt="shadow1" src="https://user-images.githubusercontent.com/106181067/186972547-5adc5596-e726-4616-b8bb-c1560eba3dbe.png"> | <img width="482" alt="shadow2" src="https://user-images.githubusercontent.com/106181067/186972580-746852e7-4376-4d83-a83b-7fe3cecc03c1.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1195)