### PR TITLE
make sure macOS Avatar respect custom color

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -80,6 +80,7 @@ open class AvatarView: NSView {
 			guard oldValue != avatarBackgroundColor else {
 				return
 			}
+			isCustomAvatarBackgroundColorConfigured = true
 			needsDisplay = true
 			initialsTextField.backgroundColor = avatarBackgroundColor
 		}
@@ -92,6 +93,7 @@ open class AvatarView: NSView {
 			guard oldValue != initialsFontColor else {
 				return
 			}
+			isCustomAvatarInitialColorConfigured = true
 			needsDisplay = true
 			initialsTextField.textColor = initialsFontColor
 		}
@@ -209,6 +211,9 @@ open class AvatarView: NSView {
 			updateViewStyle()
 		}
 	}
+
+	private var isCustomAvatarBackgroundColorConfigured: Bool = false
+	private var isCustomAvatarInitialColorConfigured: Bool = false
 
 	private lazy var contentView: NSView = {
 		let contentView = NSView()
@@ -355,9 +360,20 @@ open class AvatarView: NSView {
 	}
 
 	private func updateAppearance(_ appearance: NSAppearance? = nil) {
+		if isCustomAvatarBackgroundColorConfigured && isCustomAvatarInitialColorConfigured {
+			return
+		}
+
 		let color = AvatarView.getInitialsColorSet(fromPrimaryText: contactEmail, secondaryText: contactName)
-		avatarBackgroundColor = color.background.resolvedColor(appearance)
-		initialsFontColor = color.foreground.resolvedColor(appearance)
+		if !isCustomAvatarBackgroundColorConfigured {
+			initialsTextField.backgroundColor = color.background.resolvedColor(appearance)
+		}
+
+		if !isCustomAvatarInitialColorConfigured {
+			initialsTextField.textColor = color.foreground.resolvedColor(appearance)
+		}
+
+		needsDisplay = true
 	}
 
 	private func updateHeight() {

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -68,9 +68,6 @@ open class AvatarView: NSView {
 		}
 		// Disable animations for this change
 		CATransaction.setDisableActions(true)
-		if displayStyle == .initials {
-			initialsView.layer?.backgroundColor = avatarBackgroundColor.cgColor
-		}
 	}
 
 	/// The background color of the avatar view when no image is provided.
@@ -82,7 +79,7 @@ open class AvatarView: NSView {
 			}
 			isCustomAvatarBackgroundColorConfigured = true
 			needsDisplay = true
-			initialsTextField.backgroundColor = avatarBackgroundColor
+			initialsView.layer?.backgroundColor = avatarBackgroundColor.cgColor
 		}
 	}
 
@@ -236,7 +233,6 @@ open class AvatarView: NSView {
 		let initialsView = NSView()
 		initialsView.wantsLayer = true
 		initialsView.translatesAutoresizingMaskIntoConstraints = false
-		initialsView.layer?.backgroundColor = avatarBackgroundColor.cgColor
 
 		let textView = initialsTextField
 		initialsView.addSubview(textView)
@@ -276,8 +272,6 @@ open class AvatarView: NSView {
 		textView.translatesAutoresizingMaskIntoConstraints = false
 		textView.font = font(forCircleDiameter: diameterForContentCircle())
 		textView.textColor = initialsFontColor
-		textView.drawsBackground = true
-		textView.backgroundColor = avatarBackgroundColor
 		return textView
 	}()
 
@@ -355,24 +349,31 @@ open class AvatarView: NSView {
 		}
 
 		initialsTextField.stringValue = AvatarView.initialsWithFallback(name: contactName, email: contactEmail)
-		updateAppearance(window?.effectiveAppearance)
 		displayStyle = hasImage ? .image : .initials
+		updateAppearance(window?.effectiveAppearance)
 	}
 
 	private func updateAppearance(_ appearance: NSAppearance? = nil) {
-		if isCustomAvatarBackgroundColorConfigured && isCustomAvatarInitialColorConfigured {
+		if displayStyle != .initials {
 			return
 		}
 
-		let color = AvatarView.getInitialsColorSet(fromPrimaryText: contactEmail, secondaryText: contactName)
-		if !isCustomAvatarBackgroundColorConfigured {
-			initialsTextField.backgroundColor = color.background.resolvedColor(appearance)
+		var updatedBackgroundColor = avatarBackgroundColor
+		var updatedInitialsColor = initialsFontColor
+		if !isCustomAvatarBackgroundColorConfigured || !isCustomAvatarInitialColorConfigured {
+			let defaultColorSet = AvatarView.getInitialsColorSet(fromPrimaryText: contactEmail, secondaryText: contactName)
+
+			if !isCustomAvatarBackgroundColorConfigured {
+				updatedBackgroundColor = defaultColorSet.background.resolvedColor(appearance)
+			}
+
+			if !isCustomAvatarInitialColorConfigured {
+				updatedInitialsColor = defaultColorSet.foreground.resolvedColor(appearance)
+			}
 		}
 
-		if !isCustomAvatarInitialColorConfigured {
-			initialsTextField.textColor = color.foreground.resolvedColor(appearance)
-		}
-
+		initialsView.layer?.backgroundColor = updatedBackgroundColor.cgColor
+		initialsTextField.textColor = updatedInitialsColor
 		needsDisplay = true
 	}
 

--- a/macos/FluentUITestViewControllers/TestAvatarViewController.swift
+++ b/macos/FluentUITestViewControllers/TestAvatarViewController.swift
@@ -59,7 +59,8 @@ class TestAvatarViewController: NSViewController {
 			NSButton(title: "Update Avatar Images", target: self, action: #selector(updateAvatarImages)),
 			NSButton(title: "Update Avatar Background Colors", target: self, action: #selector(updateAvatarBackgroundColors)),
 			NSButton(title: "Repurpose Avatar View", target: self, action: #selector(reuseAvatarView)),
-			NSButton(title: "Show custom border", target: self, action: #selector(showCustomBorder))
+			NSButton(title: "Show custom border", target: self, action: #selector(showCustomBorder)),
+			NSButton(title: "Show Avatar in popover", target: self, action: #selector(showPopover))
 			])
 
 		containerView.orientation = .vertical
@@ -141,10 +142,35 @@ class TestAvatarViewController: NSViewController {
 		}
 	}
 
+	@objc private func showPopover(_ sender: NSButton) {
+		let popover = NSPopover()
+		popover.behavior = .transient
+		popover.contentViewController = CustomAvatarViewController()
+		popover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
+	}
+
 	static let testDataIndexForImages: Int = 1
 	static let testDataIndexForBackroundColor: Int = 2
 	static let testDataIndexForReuse: Int = 3
 	static let testDataIndexForBorderColor: Int = 4
 	static let personaMale: String = "persona-male"
 	static let personaFemale: String = "persona-female"
+}
+
+class CustomAvatarViewController: NSViewController {
+	override func loadView() {
+		let containerView = NSStackView(frame: .zero)
+		containerView.addView(NSView(), in: .center)
+		containerView.addView(NSTextField(labelWithString: "Avatar with custom background color"), in: .center)
+		let avatarView = AvatarView(avatarSize: 25,
+									contactName: "Ted Randall",
+									contactEmail: "ted.randall@example.com")
+		avatarView.avatarBackgroundColor = .red
+
+		containerView.addView(avatarView, in: .center)
+		containerView.addView(NSView(), in: .center)
+		containerView.orientation = .vertical
+		containerView.distribution = .gravityAreas
+		view = containerView
+	}
 }

--- a/macos/FluentUITestViewControllers/TestAvatarViewController.swift
+++ b/macos/FluentUITestViewControllers/TestAvatarViewController.swift
@@ -165,7 +165,7 @@ class CustomAvatarViewController: NSViewController {
 		let avatarView = AvatarView(avatarSize: 25,
 									contactName: "Ted Randall",
 									contactEmail: "ted.randall@example.com")
-		avatarView.avatarBackgroundColor = .red
+		avatarView.avatarBackgroundColor = .systemRed
 
 		containerView.addView(avatarView, in: .center)
 		containerView.addView(NSView(), in: .center)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

We want all of our clients to use the default avatar colors for consistency. However, if they choose to change it, we should make sure we listen to them.
There was a bug when updateAppearance was being called because Avatar was hosted in a NSPopover it will reset to the default color configuration

Changes:
- new private var to bookkeep when the colors are meant to be custom vs default
- remove unnecessary initialsTextField background coloring. It should be just handled by the initailsView itself.
- add a test case in TestAvatarController to have avatar hosted by NSPopover

### Verification


|theme| Before                                       | After                                      |
|---|----------------------------------------------|--------------------------------------------|
|light|  ![before_light](https://user-images.githubusercontent.com/20715435/186995422-0070062f-c5ed-4342-bb0b-921808b62229.png)  | ![after_light](https://user-images.githubusercontent.com/20715435/186995459-101556be-8675-4020-a813-f10af4089e78.png) |
|dark| ![before_dark](https://user-images.githubusercontent.com/20715435/186995503-24221f58-42cd-4b7d-adb1-6664e435add8.png) | ![after_dark](https://user-images.githubusercontent.com/20715435/186995529-eea41f41-ee4a-47f4-8f4c-d2c721f516ce.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)