### PR TITLE
Fix Voice Over accessibility for title in TableViewHeaderFooterView w…

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -365,15 +365,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     private func setup(style: Style, accessoryButtonTitle: String, leadingView: UIView? = nil) {
         updateTitleViewFont()
-        switch style {
-        case .header, .divider, .dividerHighlighted, .headerPrimary:
-            titleView.accessibilityTraits.insert(.header)
-        case .footer:
-            titleView.accessibilityTraits.remove(.header)
-            // Bug in iOS - need to manually refresh VoiceOver text for accessibilityTraits
-            titleView.isAccessibilityElement = false
-            titleView.isAccessibilityElement = true
-        }
 
         accessoryButton = !accessoryButtonTitle.isEmpty ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
         self.leadingView = leadingView
@@ -543,7 +534,6 @@ private class TableViewHeaderFooterTitleView: UITextView {
         isEditable = false
         isScrollEnabled = false
         clipsToBounds = false    // to avoid clipping of "deep-touch" UI for links
-        isAccessibilityElement = true
         self.textContainer.lineBreakMode = .byTruncatingTail
         self.textContainer.lineFragmentPadding = 0
         textContainerInset = .zero

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -366,6 +366,16 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     private func setup(style: Style, accessoryButtonTitle: String, leadingView: UIView? = nil) {
         updateTitleViewFont()
 
+        switch style {
+        case .header, .divider, .dividerHighlighted, .headerPrimary:
+            titleView.accessibilityTraits.insert(.header)
+        case .footer:
+            titleView.accessibilityTraits.remove(.header)
+            // Bug in iOS - need to manually refresh VoiceOver text for accessibilityTraits
+            titleView.isAccessibilityElement = false
+            titleView.isAccessibilityElement = true
+        }
+
         accessoryButton = !accessoryButtonTitle.isEmpty ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
         self.leadingView = leadingView
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -365,15 +365,11 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     private func setup(style: Style, accessoryButtonTitle: String, leadingView: UIView? = nil) {
         updateTitleViewFont()
-
         switch style {
         case .header, .divider, .dividerHighlighted, .headerPrimary:
             titleView.accessibilityTraits.insert(.header)
         case .footer:
             titleView.accessibilityTraits.remove(.header)
-            // Bug in iOS - need to manually refresh VoiceOver text for accessibilityTraits
-            titleView.isAccessibilityElement = false
-            titleView.isAccessibilityElement = true
         }
 
         accessoryButton = !accessoryButtonTitle.isEmpty ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil


### PR DESCRIPTION
…hen presented in popover

### Platforms Impacted

- [x] iOS

### Description of changes

ISSUE

- When Voice Over accessibility is enabled, the TableViewHeaderFooterView title
has a wrong selection when presented in a popover on iPad.

- The title in this header/footer is a UITextView and in the existing implementation we override the default accessibility behavior by making the UITextView an accessibility element.
This implementation leads to a wrong text selection for title in popover on iPad.

FIX

- The fix is to remove the accessibility element assignment from UITextView and keep the accessibility trait insertion as .header when TableViewHeaderFooterView is used as header and remove the accessibility trait insertion when the view is used as footer. This implementation already exists but it was followed by a 'Bug in iOS - ...' implementation where  accessibility element for UITextView was set up to 'false' and then back to 'true'. That implementation broke the VO selection for multi-line of text title for both header and footer scenarios. Removing that logic fixed the issue properly.

A NICE TO HAVE
- Replace the UITextView with a UILabel for the title. That would imply custom implementation for hyper-texts and would impact the TableViewHeaderFooterView interface signature because we would have to mention the clickable portion for the label text in order to specify it in the attributed string range and then would be assigned to the label. (Maybe that can be done later.)

### Verification

- Verified the change for Voice Over accessibility in table header and footer in popovers or in presented controllers.
- Verified that the Voice Over selection works well for header and footer when there is a single line title and multiple lines title only; multiple lines and single line title with accessory view.
- Verified that Voice Over accessibility works well in portrait/landscape and split view modes for iPad and iPhone.


| Before                                                                  | After                                                                  |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/65185855/187558496-8ed11cb6-871b-4941-af84-bd151e7f30a4.mov | https://user-images.githubusercontent.com/65185855/187559563-a43665bd-f8ff-4c52-8997-13f26ccd278b.mov |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1197)