### PR TITLE
Merge `main` to `fluent2-tokens`, fix `GlobalTokens` across controls

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -276,14 +276,14 @@ extension ActivityIndicatorDemoController: DemoAppearanceDelegate {
 
     private var themeWideOverrideActivityIndicatorTokens: [ActivityIndicatorTokenSet.Tokens: ControlTokenValue] {
         return [
-            .defaultColor: .dynamicColor { DynamicColor(light: GlobalTokens().sharedColors[.red][.primary]) },
+            .defaultColor: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.red, .primary)) },
             .thickness: .float { 20.0 }
         ]
     }
 
     private var perControlOverrideActivityIndicatorTokens: [ActivityIndicatorTokenSet.Tokens: ControlTokenValue] {
         return [
-            .defaultColor: .dynamicColor { DynamicColor(light: GlobalTokens().sharedColors[.green][.primary]) },
+            .defaultColor: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.green, .primary)) },
             .thickness: .float { 10.0 }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -252,30 +252,27 @@ extension CardNudgeDemoController: DemoAppearanceDelegate {
     // MARK: - Custom tokens
 
     private var themeWideOverrideCardNudgeTokens: [CardNudgeTokenSet.Tokens: ControlTokenValue] {
-        let globalTokens = GlobalTokens()
         return [
             .backgroundColor: .dynamicColor {
-                DynamicColor(light: globalTokens.sharedColors[.hotPink][.tint50],
-                             dark: globalTokens.sharedColors[.hotPink][.shade40])
+                DynamicColor(light: GlobalTokens.sharedColors(.hotPink, .tint50),
+                             dark: GlobalTokens.sharedColors(.hotPink, .shade40))
             },
             .outlineWidth: .float {
                 10.0
             },
             .outlineColor: .dynamicColor {
-                DynamicColor(light: globalTokens.sharedColors[.darkRed][.tint50],
-                             dark: globalTokens.sharedColors[.darkRed][.shade40])
+                DynamicColor(light: GlobalTokens.sharedColors(.darkRed, .tint50),
+                             dark: GlobalTokens.sharedColors(.darkRed, .shade40))
             }
         ]
     }
 
     private var perControlOverrideCardNudgeTokens: [CardNudgeTokenSet.Tokens: ControlTokenValue] {
-        let globalTokens = GlobalTokens()
         return [
             .backgroundColor: .dynamicColor {
-                DynamicColor(light: globalTokens.sharedColors[.seafoam][.tint50],
-                             dark: globalTokens.sharedColors[.seafoam][.shade40])
+                DynamicColor(light: GlobalTokens.sharedColors(.seafoam, .tint50),
+                             dark: GlobalTokens.sharedColors(.seafoam, .shade40))
             }
         ]
     }
-
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorTokensDemoController.swift
@@ -29,7 +29,7 @@ class ColorTokensDemoController: DemoTableViewController {
         let colorSet = GlobalTokens.SharedColorSets.allCases[indexPath.section]
         let colorToken = GlobalTokens.SharedColorsTokens.allCases[indexPath.row]
 
-        cell.backgroundConfiguration?.backgroundColor = UIColor(colorValue: globalTokens.sharedColors[colorSet][colorToken])
+        cell.backgroundConfiguration?.backgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(colorSet, colorToken))
         cell.selectionStyle = .none
 
         var contentConfiguration = cell.defaultContentConfiguration()
@@ -61,13 +61,6 @@ class ColorTokensDemoController: DemoTableViewController {
                 return .black
             }
         }
-    }
-
-    private var globalTokens: GlobalTokens {
-        guard let fluentTheme = self.view.window?.fluentTheme else {
-            return GlobalTokens()
-        }
-        return fluentTheme.globalTokens
     }
 
     private struct Constants {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -79,6 +79,8 @@ class CommandBarDemoController: DemoController {
                 return TextStyle.body.textRepresentation
             case .disabledText:
                 return "Search"
+            case .add:
+                return "Add"
             default:
                 return nil
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -111,7 +111,7 @@ class DividerDemoController: DemoTableViewController {
 
     private func makeDivider(orientation: MSFDividerOrientation = .horizontal, spacing: MSFDividerSpacing, customColor: Bool) -> MSFDivider {
         let divider = MSFDivider(orientation: orientation, spacing: spacing)
-        if customColor, let color = self.view.window?.fluentTheme.globalTokens.brandColors[.primary] {
+        if customColor, let color = self.view.window?.fluentTheme.aliasTokens.brandColors[.primary] {
             divider.tokenSet[.color] = .dynamicColor({ color })
         }
 
@@ -212,13 +212,13 @@ extension DividerDemoController: DemoAppearanceDelegate {
 
     private var themeWideOverrideDividerTokens: [DividerTokenSet.Tokens: ControlTokenValue] {
         return [
-            .color: .dynamicColor { DynamicColor(light: GlobalTokens().sharedColors[.red][.primary]) }
+            .color: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.red, .primary)) }
         ]
     }
 
     private var perControlOverrideDividerTokens: [DividerTokenSet.Tokens: ControlTokenValue] {
         return [
-            .color: .dynamicColor { DynamicColor(light: GlobalTokens().sharedColors[.green][.primary]) }
+            .color: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.green, .primary)) }
         ]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -286,17 +286,17 @@ extension HUDDemoController: DemoAppearanceDelegate {
     // MARK: - Custom tokens
 
     private var themeWideOverrideActivityHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
-        let aliasTokens = AliasTokens()
+        let aliasTokens = self.view.fluentTheme.aliasTokens
         return [
             .backgroundColor: .dynamicColor { aliasTokens.backgroundColors[.brandHover] }
         ]
     }
 
     private var perControlOverrideHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
-        let globalTokens = GlobalTokens()
+        let aliasTokens = self.view.fluentTheme.aliasTokens
         return [
-            .cornerRadius: .float { globalTokens.borderRadius[.xLarge] },
-            .foregroundColor: .dynamicColor { globalTokens.brandColors[.primary] }
+            .cornerRadius: .float { GlobalTokens.borderRadius(.xLarge) },
+            .foregroundColor: .dynamicColor { aliasTokens.brandColors[.primary] }
         ]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LeftNavDemoController.swift
@@ -197,7 +197,7 @@ class LeftNavMenuViewController: UIViewController {
             }
         }
 
-        let aliasTokens = AliasTokens()
+        let aliasTokens = contentView.fluentTheme.aliasTokens
         let tintDynamicColor = aliasTokens.foregroundColors[.neutral4]
         let tintColor = UIColor(dynamicColor: tintDynamicColor)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -243,17 +243,17 @@ class NotificationViewDemoController: DemoController {
     private var notificationOverrideTokens: [NotificationTokenSet.Tokens: ControlTokenValue] {
         return [
             .imageColor: .dynamicColor {
-                return DynamicColor(light: GlobalTokens().sharedColors[.orange][.primary])
+                return DynamicColor(light: GlobalTokens.sharedColors(.orange, .primary))
             },
             .horizontalSpacing: .float {
                 return 5.0
             },
             .shadow: .shadowInfo {
-                return ShadowInfo(colorOne: DynamicColor(light: GlobalTokens().sharedColors[.hotPink][.primary]),
+                return ShadowInfo(colorOne: DynamicColor(light: GlobalTokens.sharedColors(.hotPink, .primary)),
                                   blurOne: 10.0,
                                   xOne: 10.0,
                                   yOne: 10.0,
-                                  colorTwo: DynamicColor(light: GlobalTokens().sharedColors[.teal][.primary]),
+                                  colorTwo: DynamicColor(light: GlobalTokens.sharedColors(.teal, .primary)),
                                   blurTwo: 100.0,
                                   xTwo: -10.0,
                                   yTwo: -10.0)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -21,6 +21,7 @@ class NotificationViewDemoController: DemoController {
         case primaryToastWithStrikethroughAttribute
         case neutralBarWithFontAttribute
         case neutralToastWithOverriddenTokens
+        case neutralToastWithGradientBackground
         case warningToastWithFlexibleWidth
 
         var displayText: String {
@@ -51,6 +52,8 @@ class NotificationViewDemoController: DemoController {
                 return "Neutral Bar with Font Attribute"
             case .neutralToastWithOverriddenTokens:
                 return "Neutral Toast With Overridden Tokens"
+            case .neutralToastWithGradientBackground:
+                return "Neutral Toast With Gradient Background"
             case .warningToastWithFlexibleWidth:
                 return "Warning Toast With Flexible Width"
             }
@@ -202,6 +205,23 @@ class NotificationViewDemoController: DemoController {
             notification.state.message = "The image color and spacing between the elements of this notification have been customized with override tokens."
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             notification.tokenSet.replaceAllOverrides(with: notificationOverrideTokens)
+            notification.state.actionButtonAction = { [weak self] in
+                self?.showMessage("`Dismiss` tapped")
+                notification.hide()
+            }
+            return notification
+        case .neutralToastWithGradientBackground:
+            let notification = MSFNotification(style: .neutralToast)
+            notification.state.message = "The background of this notification has been customized with a gradient."
+            notification.state.image = UIImage(named: "play-in-circle-24x24")
+            // It's a lovely blue-to-pink gradient
+            let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens.sharedColors(.pink, .tint50),
+                                                       dark: GlobalTokens.sharedColors(.pink, .shade40)),
+                                          DynamicColor(light: GlobalTokens.sharedColors(.cyan, .tint50),
+                                                       dark: GlobalTokens.sharedColors(.cyan, .shade40))]
+            notification.state.backgroundGradient = GradientInfo(colors: colors,
+                                                                 startPoint: .init(x: 0.0, y: 1.0),
+                                                                 endPoint: .init(x: 1.0, y: 0.0))
             notification.state.actionButtonAction = { [weak self] in
                 self?.showMessage("`Dismiss` tapped")
                 notification.hide()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -59,21 +59,22 @@ struct NotificationDemoView: View {
         VStack {
             Rectangle()
                 .foregroundColor(.clear)
-                .presentNotification(style: style,
-                                     isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
-                                     message: hasMessage ? message : nil,
-                                     attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
-                                     isBlocking: false,
-                                     isPresented: .constant(true),
-                                     title: hasTitle ? title : nil,
-                                     attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
-                                     image: image,
-                                     trailingImage: trailingImage,
-                                     trailingImageAccessibilityLabel: trailingImageLabel,
-                                     actionButtonTitle: actionButtonTitle,
-                                     actionButtonAction: actionButtonAction,
-                                     messageButtonAction: messageButtonAction,
-                                     overrideTokens: $overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
+                .presentNotification(isPresented: .constant(true), isBlocking: false) {
+                    FluentNotification(style: style,
+                                       isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
+                                       message: hasMessage ? message : nil,
+                                       attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
+                                       title: hasTitle ? title : nil,
+                                       attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
+                                       image: image,
+                                       trailingImage: trailingImage,
+                                       trailingImageAccessibilityLabel: trailingImageLabel,
+                                       actionButtonTitle: actionButtonTitle,
+                                       actionButtonAction: actionButtonAction,
+                                       messageButtonAction: messageButtonAction)
+                    .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
+                    .overrideTokens($overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
+                }
                 .frame(maxWidth: .infinity, maxHeight: 150, alignment: .center)
                 .alert(isPresented: $showAlert, content: {
                     Alert(title: Text("Button tapped"))
@@ -182,7 +183,7 @@ struct NotificationDemoView: View {
                              messageButtonAction: messageButtonAction,
                              showFromBottom: showFromBottom)
             .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
-            .overrideTokens($overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+            .overrideTokens($overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
         }
     }
 
@@ -197,13 +198,24 @@ struct NotificationDemoView: View {
                             endPoint: .init(x: 1.0, y: 0.0))
     }
 
-    private class NotificationOverrideTokens: NotificationTokens {
-        override var imageColor: DynamicColor {
-            return DynamicColor(light: GlobalTokens.sharedColors(.orange, .primary))
-        }
-
-        override var horizontalSpacing: CGFloat {
-            return 5.0
-        }
+    private var notificationOverrideTokens: [NotificationTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .imageColor: .dynamicColor {
+                return DynamicColor(light: GlobalTokens.sharedColors(.orange, .primary))
+            },
+            .horizontalSpacing: .float {
+                return 5.0
+            },
+            .shadow: .shadowInfo {
+                return ShadowInfo(colorOne: DynamicColor(light: GlobalTokens.sharedColors(.hotPink, .primary)),
+                                  blurOne: 10.0,
+                                  xOne: 10.0,
+                                  yOne: 10.0,
+                                  colorTwo: DynamicColor(light: GlobalTokens.sharedColors(.teal, .primary)),
+                                  blurTwo: 100.0,
+                                  xTwo: -10.0,
+                                  yTwo: -10.0)
+            }
+        ]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -38,6 +38,7 @@ struct NotificationDemoView: View {
     @State var isFlexibleWidthToast: Bool = false
     @State var showDefaultDismissActionButton: Bool = true
     @State var showFromBottom: Bool = true
+    @State var showBackgroundGradient: Bool = false
 
     public var body: some View {
         let hasAttribute = hasBlueStrikethroughAttribute || hasLargeRedPapyrusFontAttribute
@@ -157,16 +158,18 @@ struct NotificationDemoView: View {
                         FluentUIDemoToggle(titleKey: "Override Tokens (Image Color and Horizontal Spacing)", isOn: $overrideTokens)
                         FluentUIDemoToggle(titleKey: "Flexible Width Toast", isOn: $isFlexibleWidthToast)
                         FluentUIDemoToggle(titleKey: "Present From Bottom", isOn: $showFromBottom)
+                        FluentUIDemoToggle(titleKey: "Background Gradient", isOn: $showBackgroundGradient)
                     }
                 }
                 .padding()
             }
         }
-        .presentNotification(style: style,
+        .presentNotification(isPresented: $isPresented,
+                             isBlocking: false) {
+            FluentNotification(style: style,
                              isFlexibleWidthToast: $isFlexibleWidthToast.wrappedValue,
                              message: hasMessage ? message : nil,
                              attributedMessage: hasAttribute && hasMessage ? attributedMessage : nil,
-                             isBlocking: false,
                              isPresented: $isPresented,
                              title: hasTitle ? title : nil,
                              attributedTitle: hasAttribute && hasTitle ? attributedTitle : nil,
@@ -177,28 +180,30 @@ struct NotificationDemoView: View {
                              actionButtonAction: actionButtonAction,
                              showDefaultDismissActionButton: showDefaultDismissActionButton,
                              messageButtonAction: messageButtonAction,
-                             showFromBottom: showFromBottom,
-                             overrideTokens: $overrideTokens.wrappedValue ? notificationOverrideTokens : nil)
+                             showFromBottom: showFromBottom)
+            .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)
+            .overrideTokens($overrideTokens.wrappedValue ? NotificationOverrideTokens() : nil)
+        }
     }
 
-    private var notificationOverrideTokens: [NotificationTokenSet.Tokens: ControlTokenValue] {
-        return [
-            .imageColor: .dynamicColor {
-                return DynamicColor(light: GlobalTokens().sharedColors[.orange][.primary])
-            },
-            .horizontalSpacing: .float {
-                return 5.0
-            },
-            .shadow: .shadowInfo {
-                return ShadowInfo(colorOne: DynamicColor(light: GlobalTokens().sharedColors[.hotPink][.primary]),
-                                  blurOne: 10.0,
-                                  xOne: 10.0,
-                                  yOne: 10.0,
-                                  colorTwo: DynamicColor(light: GlobalTokens().sharedColors[.teal][.primary]),
-                                  blurTwo: 100.0,
-                                  xTwo: -10.0,
-                                  yTwo: -10.0)
-            }
-        ]
+    private var backgroundGradient: GradientInfo {
+        // It's a lovely blue-to-pink gradient
+        let colors: [DynamicColor] = [DynamicColor(light: GlobalTokens.sharedColors(.pink, .tint50),
+                                                   dark: GlobalTokens.sharedColors(.pink, .shade40)),
+                                      DynamicColor(light: GlobalTokens.sharedColors(.cyan, .tint50),
+                                                   dark: GlobalTokens.sharedColors(.cyan, .shade40))]
+        return GradientInfo(colors: colors,
+                            startPoint: .init(x: 0.0, y: 1.0),
+                            endPoint: .init(x: 1.0, y: 0.0))
+    }
+
+    private class NotificationOverrideTokens: NotificationTokens {
+        override var imageColor: DynamicColor {
+            return DynamicColor(light: GlobalTokens.sharedColors(.orange, .primary))
+        }
+
+        override var horizontalSpacing: CGFloat {
+            return 5.0
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -58,8 +58,8 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
         return [
             .mainBrandColor: .dynamicColor {
                 // "Charcoal"
-                return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
-                                    dark: GlobalTokens().sharedColors[.charcoal][.shade40])
+                return DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint50),
+                                    dark: GlobalTokens.sharedColors(.charcoal, .shade40))
             }
         ]
     }
@@ -68,8 +68,8 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
         return [
             .cellBackgroundGroupedColor: .dynamicColor {
                 // "Charcoal"
-                return DynamicColor(light: GlobalTokens().sharedColors[.charcoal][.tint50],
-                                    dark: GlobalTokens().sharedColors[.charcoal][.shade40])
+                return DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint50),
+                                    dark: GlobalTokens.sharedColors(.charcoal, .shade40))
             }
         ]
     }
@@ -78,8 +78,8 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
         return [
             .cellBackgroundGroupedColor: .dynamicColor {
                 // "Burgundy"
-                return DynamicColor(light: GlobalTokens().sharedColors[.burgundy][.tint50],
-                                    dark: GlobalTokens().sharedColors[.burgundy][.shade40])
+                return DynamicColor(light: GlobalTokens.sharedColors(.burgundy, .tint50),
+                                    dark: GlobalTokens.sharedColors(.burgundy, .shade40))
             }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -244,28 +244,27 @@ extension PillButtonBarDemoController: DemoAppearanceDelegate {
     }
 
     private var perControlOverridePillButtonTokens: [PillButtonTokenSet.Tokens: ControlTokenValue] {
-        let globalTokens = GlobalTokens()
         return [
             .backgroundColor: .pillButtonDynamicColors {
-                return .init(rest: DynamicColor(light: globalTokens.sharedColors[.steel][.tint40],
-                                                dark: globalTokens.sharedColors[.steel][.shade30]),
-                             selected: DynamicColor(light: globalTokens.sharedColors[.pumpkin][.tint40],
-                                                    dark: globalTokens.sharedColors[.pumpkin][.shade30]),
-                             disabled: DynamicColor(light: globalTokens.sharedColors[.darkTeal][.tint40],
-                                                    dark: globalTokens.sharedColors[.darkTeal][.shade30]),
-                             selectedDisabled: DynamicColor(light: globalTokens.sharedColors[.orchid][.tint40],
-                                                            dark: globalTokens.sharedColors[.orchid][.shade30]))
+                return .init(rest: DynamicColor(light: GlobalTokens.sharedColors(.steel, .tint40),
+                                                dark: GlobalTokens.sharedColors(.steel, .shade30)),
+                             selected: DynamicColor(light: GlobalTokens.sharedColors(.pumpkin, .tint40),
+                                                    dark: GlobalTokens.sharedColors(.pumpkin, .shade30)),
+                             disabled: DynamicColor(light: GlobalTokens.sharedColors(.darkTeal, .tint40),
+                                                    dark: GlobalTokens.sharedColors(.darkTeal, .shade30)),
+                             selectedDisabled: DynamicColor(light: GlobalTokens.sharedColors(.orchid, .tint40),
+                                                            dark: GlobalTokens.sharedColors(.orchid, .shade30)))
             },
 
             .titleColor: .pillButtonDynamicColors {
-                return .init(rest: DynamicColor(light: globalTokens.sharedColors[.steel][.shade30],
-                                                dark: globalTokens.sharedColors[.steel][.tint40]),
-                             selected: DynamicColor(light: globalTokens.sharedColors[.pumpkin][.shade30],
-                                                    dark: globalTokens.sharedColors[.pumpkin][.tint40]),
-                             disabled: DynamicColor(light: globalTokens.sharedColors[.darkTeal][.shade30],
-                                                    dark: globalTokens.sharedColors[.darkTeal][.tint40]),
-                             selectedDisabled: DynamicColor(light: globalTokens.sharedColors[.orchid][.shade30],
-                                                            dark: globalTokens.sharedColors[.orchid][.tint40]))
+                return .init(rest: DynamicColor(light: GlobalTokens.sharedColors(.steel, .shade30),
+                                                dark: GlobalTokens.sharedColors(.steel, .tint40)),
+                             selected: DynamicColor(light: GlobalTokens.sharedColors(.pumpkin, .shade30),
+                                                    dark: GlobalTokens.sharedColors(.pumpkin, .tint40)),
+                             disabled: DynamicColor(light: GlobalTokens.sharedColors(.darkTeal, .shade30),
+                                                    dark: GlobalTokens.sharedColors(.darkTeal, .tint40)),
+                             selectedDisabled: DynamicColor(light: GlobalTokens.sharedColors(.orchid, .shade30),
+                                                            dark: GlobalTokens.sharedColors(.orchid, .tint40)))
             },
 
             .font: .fontInfo {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -246,16 +246,16 @@ extension PopupMenuDemoController: DemoAppearanceDelegate {
 
     private var themeWideOverridePopupMenuTokens: [PopupMenuTokenSet.Tokens: ControlTokenValue] {
         return [
-            .drawerContentBackground: .dynamicColor { DynamicColor(light: GlobalTokens().sharedColors[.plum][.shade30],
-                                                                   dark: GlobalTokens().sharedColors[.plum][.tint60])
+            .drawerContentBackground: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.plum, .shade30),
+                                                                   dark: GlobalTokens.sharedColors(.plum, .tint60))
             }
         ]
     }
 
     private var perControlOverridePopupMenuTokens: [PopupMenuTokenSet.Tokens: ControlTokenValue] {
         return [
-            .drawerContentBackground: .dynamicColor { DynamicColor(light: GlobalTokens().sharedColors[.forest][.shade40],
-                                                                   dark: GlobalTokens().sharedColors[.forest][.tint60])
+            .drawerContentBackground: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.forest, .shade40),
+                                                                   dark: GlobalTokens.sharedColors(.forest, .tint60))
             }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -346,19 +346,18 @@ extension SideTabBarDemoController: DemoAppearanceDelegate {
 
     // MARK: - Custom tokens
     private var themeWideOverrideSideTabBarTokens: [SideTabBarTokenSet.Tokens: ControlTokenValue] {
-        let globalTokens = GlobalTokens()
         return [
             .tabBarItemSelectedColor: .dynamicColor {
-                return .init(light: globalTokens.sharedColors[.burgundy][.tint10],
-                             lightHighContrast: globalTokens.sharedColors[.pumpkin][.tint10],
-                             dark: globalTokens.sharedColors[.darkTeal][.tint40],
-                             darkHighContrast: globalTokens.sharedColors[.teal][.tint40])
+                return .init(light: GlobalTokens.sharedColors(.burgundy, .tint10),
+                             lightHighContrast: GlobalTokens.sharedColors(.pumpkin, .tint10),
+                             dark: GlobalTokens.sharedColors(.darkTeal, .tint40),
+                             darkHighContrast: GlobalTokens.sharedColors(.teal, .tint40))
             },
             .tabBarItemUnselectedColor: .dynamicColor {
-                return .init(light: globalTokens.sharedColors[.darkTeal][.tint20],
-                             lightHighContrast: globalTokens.sharedColors[.teal][.tint40],
-                             dark: globalTokens.sharedColors[.pumpkin][.tint40],
-                             darkHighContrast: globalTokens.sharedColors[.burgundy][.tint40])
+                return .init(light: GlobalTokens.sharedColors(.darkTeal, .tint20),
+                             lightHighContrast: GlobalTokens.sharedColors(.teal, .tint40),
+                             dark: GlobalTokens.sharedColors(.pumpkin, .tint40),
+                             darkHighContrast: GlobalTokens.sharedColors(.burgundy, .tint40))
             }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -229,19 +229,18 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
 
     // MARK: - Custom tokens
     private var themeWideOverrideTabBarTokens: [TabBarTokenSet.Tokens: ControlTokenValue] {
-        let globalTokens = GlobalTokens()
         return [
             .tabBarItemSelectedColor: .dynamicColor {
-                return .init(light: globalTokens.sharedColors[.burgundy][.tint10],
-                             lightHighContrast: globalTokens.sharedColors[.pumpkin][.tint10],
-                             dark: globalTokens.sharedColors[.darkTeal][.tint40],
-                             darkHighContrast: globalTokens.sharedColors[.teal][.tint40])
+                return .init(light: GlobalTokens.sharedColors(.burgundy, .tint10),
+                             lightHighContrast: GlobalTokens.sharedColors(.pumpkin, .tint10),
+                             dark: GlobalTokens.sharedColors(.darkTeal, .tint40),
+                             darkHighContrast: GlobalTokens.sharedColors(.teal, .tint40))
             },
             .tabBarItemUnselectedColor: .dynamicColor {
-                return .init(light: globalTokens.sharedColors[.darkTeal][.tint20],
-                             lightHighContrast: globalTokens.sharedColors[.teal][.tint40],
-                             dark: globalTokens.sharedColors[.pumpkin][.tint40],
-                             darkHighContrast: globalTokens.sharedColors[.burgundy][.tint40])
+                return .init(light: GlobalTokens.sharedColors(.darkTeal, .tint20),
+                             lightHighContrast: GlobalTokens.sharedColors(.teal, .tint40),
+                             dark: GlobalTokens.sharedColors(.pumpkin, .tint40),
+                             darkHighContrast: GlobalTokens.sharedColors(.burgundy, .tint40))
             }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -134,8 +134,8 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
         return [
             .cellBackgroundColor: .dynamicColor {
                 // "Berry"
-                return DynamicColor(light: GlobalTokens().sharedColors[.berry][.tint50],
-                                    dark: GlobalTokens().sharedColors[.berry][.shade40])
+                return DynamicColor(light: GlobalTokens.sharedColors(.berry, .tint50),
+                                    dark: GlobalTokens.sharedColors(.berry, .shade40))
             }
         ]
     }
@@ -144,13 +144,13 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
         return [
             .cellBackgroundColor: .dynamicColor {
                 // "Brass"
-                return DynamicColor(light: GlobalTokens().sharedColors[.brass][.tint50],
-                                    dark: GlobalTokens().sharedColors[.brass][.shade40])
+                return DynamicColor(light: GlobalTokens.sharedColors(.brass, .tint50),
+                                    dark: GlobalTokens.sharedColors(.brass, .shade40))
             },
             .accessoryDisclosureIndicatorColor: .dynamicColor {
                 // "Forest"
-                return DynamicColor(light: GlobalTokens().sharedColors[.forest][.tint10],
-                                    dark: GlobalTokens().sharedColors[.forest][.shade40])
+                return DynamicColor(light: GlobalTokens.sharedColors(.forest, .tint10),
+                                    dark: GlobalTokens.sharedColors(.forest, .shade40))
             },
             .customViewTrailingMargin: .float {
                 return 0

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -37,6 +37,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         container.spacing = 0
 
         navigationController?.navigationBar.shadowImage = UIImage()
+        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
         container.addArrangedSubview(segmentedControl)
         container.setCustomSpacing(8, after: segmentedControl)
         container.backgroundColor = Colors.navigationBarBackground

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TypographyTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TypographyTokensDemoController.swift
@@ -39,10 +39,7 @@ class TypographyTokensDemoController: DemoTableViewController {
     }
 
     private var aliasTokens: AliasTokens {
-        guard let fluentTheme = self.view.window?.fluentTheme else {
-            return AliasTokens()
-        }
-        return fluentTheme.aliasTokens
+        return self.view.fluentTheme.aliasTokens
     }
 
     private struct Constants {

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D49054278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */; };
 		92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598026A0FD2800328FD3 /* CardNudge.swift */; };
+		92D5FDFB28A713990087894B /* GradientInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5FDFA28A713990087894B /* GradientInfo.swift */; };
 		92DEE2252723D34400E31ED0 /* ControlTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DEE2232723D34400E31ED0 /* ControlTokenSet.swift */; };
 		92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
@@ -344,6 +345,7 @@
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselModifiers.swift; sourceTree = "<group>"; };
 		92D5598026A0FD2800328FD3 /* CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudge.swift; sourceTree = "<group>"; };
+		92D5FDFA28A713990087894B /* GradientInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientInfo.swift; sourceTree = "<group>"; };
 		92DEE2232723D34400E31ED0 /* ControlTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlTokenSet.swift; sourceTree = "<group>"; };
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
@@ -870,6 +872,7 @@
 				92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */,
 				925728F8276D6B5800EE1019 /* FontInfo.swift */,
 				925D461B26FD133600179583 /* GlobalTokens.swift */,
+				92D5FDFA28A713990087894B /* GradientInfo.swift */,
 				925728F6276D6AF800EE1019 /* ShadowInfo.swift */,
 				923DB9D2274CB65700D8E58A /* TokenizedControl.swift */,
 				922A34DE27BB87990062721F /* TokenizedControlView.swift */,
@@ -1548,6 +1551,7 @@
 				5314E1A725F01A7C0099271A /* ActionsCell.swift in Sources */,
 				5314E07B25F00F1A0099271A /* DateTimePickerViewDataSource.swift in Sources */,
 				532FE3D426EA6D74007539C0 /* ActivityIndicatorTokenSet.swift in Sources */,
+				92D5FDFB28A713990087894B /* GradientInfo.swift in Sources */,
 				53E2EE07278799B30086D30D /* MSFIndeterminateProgressBar.swift in Sources */,
 				532FE3D626EA6D74007539C0 /* ActivityIndicatorModifiers.swift in Sources */,
 				5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */,

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -401,8 +401,8 @@ public struct Avatar: View, TokenizedControlView {
             // Set the color based on the primary text and secondary text
             let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
             let colorSet = colors[hashCode % colors.count]
-            return DynamicColor(light: fluentTheme.globalTokens.sharedColors[colorSet][.tint40],
-                                dark: fluentTheme.globalTokens.sharedColors[colorSet][.shade30])
+            return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .tint40),
+                                dark: GlobalTokens.sharedColors(colorSet, .shade30))
         }
 
         static func foregroundColor(fromPrimaryText primaryText: String?,
@@ -411,8 +411,8 @@ public struct Avatar: View, TokenizedControlView {
             // Set the color based on the primary text and secondary text
             let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
             let colorSet = colors[hashCode % colors.count]
-            return DynamicColor(light: fluentTheme.globalTokens.sharedColors[colorSet][.shade30],
-                                dark: fluentTheme.globalTokens.sharedColors[colorSet][.tint40])
+            return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .shade30),
+                                dark: GlobalTokens.sharedColors(colorSet, .tint40))
         }
 
         private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -77,17 +77,17 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch style() {
                     case .default, .accent, .outlined, .outlinedPrimary, .overflow:
-                        return theme.globalTokens.borderRadius[.none]
+                        return GlobalTokens.borderRadius(.none)
                     case .group:
                         switch size() {
                         case .xsmall:
-                            return theme.globalTokens.borderRadius[.small]
+                            return GlobalTokens.borderRadius(.small)
                         case .small, .medium:
-                            return theme.globalTokens.borderRadius[.medium]
+                            return GlobalTokens.borderRadius(.medium)
                         case .large, .xlarge:
-                            return theme.globalTokens.borderRadius[.large]
+                            return GlobalTokens.borderRadius(.large)
                         case .xxlarge:
-                            return theme.globalTokens.borderRadius[.xLarge]
+                            return GlobalTokens.borderRadius(.xLarge)
                         }
                     }
                 })
@@ -96,7 +96,7 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .fontInfo({
                     switch size() {
                     case .xsmall:
-                        return .init(size: 9, weight: theme.globalTokens.fontWeight[.regular])
+                        return .init(size: 9, weight: GlobalTokens.fontWeight(.regular))
                     case .small:
                         return theme.aliasTokens.typography[.caption2]
                     case .medium:
@@ -104,9 +104,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                     case .large:
                         return theme.aliasTokens.typography[.body2]
                     case .xlarge:
-                        return .init(size: theme.globalTokens.fontSize[.size500], weight: theme.globalTokens.fontWeight[.regular])
+                        return .init(size: GlobalTokens.fontSize(.size500), weight: GlobalTokens.fontWeight(.regular))
                     case .xxlarge:
-                        return .init(size: theme.globalTokens.fontSize[.size700], weight: theme.globalTokens.fontWeight[.semibold])
+                        return .init(size: GlobalTokens.fontSize(.size700), weight: GlobalTokens.fontWeight(.semibold))
                     }
                 })
 
@@ -114,13 +114,13 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .dynamicColor({
                     switch style() {
                     case .default, .group:
-                        return theme.globalTokens.brandColors[.tint10]
+                        return theme.aliasTokens.brandColors[.tint10]
                     case .accent:
-                        return theme.globalTokens.brandColors[.shade10]
+                        return theme.aliasTokens.brandColors[.shade10]
                     case .outlined, .overflow:
                         return theme.aliasTokens.backgroundColors[.neutralDisabled]
                     case .outlinedPrimary:
-                        return .init(light: theme.globalTokens.brandColors[.tint10].light, dark: theme.globalTokens.neutralColors[.grey78])
+                        return .init(light: theme.aliasTokens.brandColors[.tint10].light, dark: GlobalTokens.neutralColors(.grey78))
                     }
                 })
 
@@ -133,11 +133,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .xsmall, .small:
-                        return theme.globalTokens.borderSize[.thin]
+                        return GlobalTokens.borderSize(.thin)
                     case .medium, .large, .xlarge:
-                        return theme.globalTokens.borderSize[.thick]
+                        return GlobalTokens.borderSize(.thick)
                     case .xxlarge:
-                        return theme.globalTokens.borderSize[.thicker]
+                        return GlobalTokens.borderSize(.thicker)
                     }
                 })
 
@@ -145,9 +145,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .xsmall, .small, .medium, .large, .xlarge:
-                        return theme.globalTokens.borderSize[.thick]
+                        return GlobalTokens.borderSize(.thick)
                     case .xxlarge:
-                        return theme.globalTokens.borderSize[.thicker]
+                        return GlobalTokens.borderSize(.thicker)
                     }
                 })
 
@@ -155,9 +155,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .xsmall, .small, .medium, .large, .xlarge:
-                        return theme.globalTokens.borderSize[.thick]
+                        return GlobalTokens.borderSize(.thick)
                     case .xxlarge:
-                        return theme.globalTokens.borderSize[.thicker]
+                        return GlobalTokens.borderSize(.thicker)
                     }
                 })
 
@@ -167,11 +167,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                     case .xsmall:
                         return 0
                     case .small, .medium:
-                        return theme.globalTokens.iconSize[.xxxSmall]
+                        return GlobalTokens.iconSize(.xxxSmall)
                     case .large, .xlarge:
-                        return theme.globalTokens.iconSize[.xxSmall]
+                        return GlobalTokens.iconSize(.xxSmall)
                     case .xxlarge:
-                        return theme.globalTokens.iconSize[.small]
+                        return GlobalTokens.iconSize(.small)
                     }
                 })
 
@@ -179,9 +179,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .xsmall:
-                        return theme.globalTokens.borderSize[.none]
+                        return GlobalTokens.borderSize(.none)
                     case .small, .medium, .large, .xlarge, .xxlarge:
-                        return theme.globalTokens.borderSize[.thick]
+                        return GlobalTokens.borderSize(.thick)
                     }
                 })
 
@@ -194,13 +194,13 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .dynamicColor({
                     switch style() {
                     case .default, .group:
-                        return .init(light: theme.globalTokens.neutralColors[.white], dark: theme.globalTokens.brandColors[.primary].dark)
+                        return .init(light: GlobalTokens.neutralColors(.white), dark: theme.aliasTokens.brandColors[.primary].dark)
                     case .accent:
-                        return theme.globalTokens.brandColors[.primary]
+                        return theme.aliasTokens.brandColors[.primary]
                     case .outlined:
-                        return .init(light: theme.globalTokens.neutralColors[.grey94], dark: theme.globalTokens.neutralColors[.grey26])
+                        return .init(light: GlobalTokens.neutralColors(.grey94), dark: GlobalTokens.neutralColors(.grey26))
                     case .outlinedPrimary:
-                        return .init(light: theme.globalTokens.brandColors[.tint40].light, dark: theme.globalTokens.neutralColors[.grey26])
+                        return .init(light: theme.aliasTokens.brandColors[.tint40].light, dark: GlobalTokens.neutralColors(.grey26))
                     case .overflow:
                         return theme.aliasTokens.backgroundColors[.neutral4]
                     }
@@ -210,13 +210,13 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .dynamicColor({
                     switch style() {
                     case .default, .group:
-                        return .init(light: theme.globalTokens.brandColors[.primary].light, dark: theme.globalTokens.neutralColors[.black])
+                        return .init(light: theme.aliasTokens.brandColors[.primary].light, dark: GlobalTokens.neutralColors(.black))
                     case .accent:
                         return theme.aliasTokens.foregroundColors[.neutralInverted]
                     case .outlined:
-                        return .init(light: theme.globalTokens.neutralColors[.grey42], dark: theme.globalTokens.neutralColors[.grey78])
+                        return .init(light: GlobalTokens.neutralColors(.grey42), dark: GlobalTokens.neutralColors(.grey78))
                     case .outlinedPrimary:
-                        return .init(light: theme.globalTokens.brandColors[.primary].light, dark: theme.globalTokens.neutralColors[.grey78])
+                        return .init(light: theme.aliasTokens.brandColors[.primary].light, dark: GlobalTokens.neutralColors(.grey78))
                     case .overflow:
                         return theme.aliasTokens.foregroundColors[.neutral3]
                     }

--- a/ios/FluentUI/AvatarGroup/AvatarGroupTokenSet.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroupTokenSet.swift
@@ -17,7 +17,7 @@ public class AvatarGroupTokenSet: ControlTokenSet<AvatarGroupTokenSet.Tokens> {
          size: @escaping () -> MSFAvatarSize) {
         self.style = style
         self.size = size
-        super.init { [style, size] token, theme in
+        super.init { [style, size] token, _ in
             return .float {
                 switch token {
                 case .interspace:
@@ -25,21 +25,21 @@ public class AvatarGroupTokenSet: ControlTokenSet<AvatarGroupTokenSet.Tokens> {
                     case .stack:
                         switch size() {
                         case .xsmall, .small:
-                            return -theme.globalTokens.spacing[.xxxSmall]
+                            return -GlobalTokens.spacing(.xxxSmall)
                         case .medium:
-                            return -theme.globalTokens.spacing[.xxSmall]
+                            return -GlobalTokens.spacing(.xxSmall)
                         case .large:
-                            return -theme.globalTokens.spacing[.xSmall]
+                            return -GlobalTokens.spacing(.xSmall)
                         case .xlarge, .xxlarge:
-                            return -theme.globalTokens.spacing[.small]
+                            return -GlobalTokens.spacing(.small)
                         }
 
                     case .pile:
                         switch size() {
                         case .xsmall, .small:
-                            return theme.globalTokens.spacing[.xxSmall]
+                            return GlobalTokens.spacing(.xxSmall)
                         case .medium, .large, .xlarge, .xxlarge:
-                            return theme.globalTokens.spacing[.xSmall]
+                            return GlobalTokens.spacing(.xSmall)
                         }
                     }
                 }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -44,17 +44,17 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
             switch token {
             case .accentColor:
                 return .dynamicColor {
-                    theme.globalTokens.brandColors[.shade20]
+                    theme.aliasTokens.brandColors[.shade20]
                 }
 
             case .accentIconSize:
                 return .float {
-                    theme.globalTokens.iconSize[.xxSmall]
+                    GlobalTokens.iconSize(.xxSmall)
                 }
 
             case .accentPadding:
                 return .float {
-                    theme.globalTokens.spacing[.xxSmall]
+                    GlobalTokens.spacing(.xxSmall)
                 }
 
             case .backgroundColor:
@@ -71,47 +71,47 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
                 }
             case .buttonBackgroundColor:
                 return .dynamicColor {
-                    theme.globalTokens.brandColors[.tint30]
+                    theme.aliasTokens.brandColors[.tint30]
                 }
 
             case .buttonInnerPaddingHorizontal:
                 return .float {
-                    theme.globalTokens.spacing[.small]
+                    GlobalTokens.spacing(.small)
                 }
 
             case .circleRadius:
                 return .float {
-                    theme.globalTokens.borderRadius[.circle]
+                    GlobalTokens.borderRadius(.circle)
                 }
 
             case .circleSize:
                 return .float {
-                    theme.globalTokens.iconSize[.xxLarge]
+                    GlobalTokens.iconSize(.xxLarge)
                 }
 
             case .cornerRadius:
                 return .float {
-                    theme.globalTokens.borderRadius[.xLarge]
+                    GlobalTokens.borderRadius(.xLarge)
                 }
 
             case .horizontalPadding:
                 return .float {
-                    theme.globalTokens.spacing[.medium]
+                    GlobalTokens.spacing(.medium)
                 }
 
             case .iconSize:
                 return .float {
-                    theme.globalTokens.iconSize[.xSmall]
+                    GlobalTokens.iconSize(.xSmall)
                 }
 
             case .interTextVerticalPadding:
                 return .float {
-                    theme.globalTokens.spacing[.xxxSmall]
+                    GlobalTokens.spacing(.xxxSmall)
                 }
 
             case .mainContentVerticalPadding:
                 return .float {
-                    theme.globalTokens.spacing[.small]
+                    GlobalTokens.spacing(.small)
                 }
 
             case .minimumHeight:
@@ -133,7 +133,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .outlineWidth:
                 return .float {
-                    theme.globalTokens.borderSize[.thin]
+                    GlobalTokens.borderSize(.thin)
                 }
 
             case .subtitleTextColor:
@@ -149,13 +149,13 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
                     }
                 case .outline:
                     return .dynamicColor {
-                        theme.globalTokens.brandColors[.shade20]
+                        theme.aliasTokens.brandColors[.shade20]
                     }
                 }
 
             case .verticalPadding:
                 return .float {
-                    theme.globalTokens.spacing[.xSmall]
+                    GlobalTokens.spacing(.xSmall)
                 }
             }
         }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -82,7 +82,7 @@ class CommandBarButton: UIButton {
 
         if #available(iOS 15.0, *) {
             configuration?.image = iconImage
-            configuration?.title = title
+            configuration?.title = iconImage != nil ? nil : title
 
             if let font = item.titleFont {
                 let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])

--- a/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
+++ b/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
@@ -24,10 +24,10 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarTokenSet.Tokens> {
                 return .dynamicColor { theme.aliasTokens.backgroundColors[.neutral1] }
 
             case .groupBorderRadius:
-                return .float { theme.globalTokens.borderRadius[.xLarge] }
+                return .float { GlobalTokens.borderRadius(.xLarge) }
 
             case .groupInterspace:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .itemBackgroundColor:
                 return .buttonDynamicColors {
@@ -56,7 +56,7 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarTokenSet.Tokens> {
                 }
 
             case .itemInterspace:
-                return .float { theme.globalTokens.spacing[.xxxSmall] }
+                return .float { GlobalTokens.spacing(.xxxSmall) }
             }
         }
     }

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -27,9 +27,8 @@ public protocol ColorProviding {
     @objc func primaryShade30Color(for window: UIWindow) -> UIColor?
 }
 
-private func brandedGlobalTokens(provider: ColorProviding, for window: UIWindow) -> GlobalTokens {
-    let globalTokens = GlobalTokens()
-    let brandColors = globalTokens.brandColors
+private func brandColorOverrides(provider: ColorProviding, for window: UIWindow) -> [AliasTokens.BrandColorsTokens: DynamicColor] {
+    var brandColors: [AliasTokens.BrandColorsTokens: DynamicColor] = [:]
     if let primary = provider.primaryColor(for: window)?.dynamicColor {
         brandColors[.primary] = primary
     }
@@ -54,7 +53,7 @@ private func brandedGlobalTokens(provider: ColorProviding, for window: UIWindow)
     if let shade30 = provider.primaryShade30Color(for: window)?.dynamicColor {
         brandColors[.shade30] = shade30
     }
-    return globalTokens
+    return brandColors
 }
 
 // MARK: Colors
@@ -489,8 +488,12 @@ public final class Colors: NSObject {
         colorProvidersMap.setObject(provider, forKey: window)
 
         // Create an updated fluent theme as well
-        let globalTokens = brandedGlobalTokens(provider: provider, for: window)
-        window.fluentTheme = FluentTheme(globalTokens: globalTokens)
+        let brandColors = brandColorOverrides(provider: provider, for: window)
+        let fluentTheme = FluentTheme()
+        brandColors.forEach { token, value in
+            fluentTheme.aliasTokens.brandColors[token] = value
+        }
+        window.fluentTheme = fluentTheme
     }
 
     /// Removes any associated `ColorProvider` from the given `UIWindow` instance.

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -7,17 +7,14 @@ import SwiftUI
 
 /// Base class that allows for customization of global, alias, and control tokens.
 @objc public class FluentTheme: NSObject, ObservableObject {
-    /// Initializes and returns a new `FluentTheme`, with optional custom global and alias tokens.
+    /// Initializes and returns a new `FluentTheme`.
     ///
-    /// - Parameters globalTokens: An optional customized instance of `GlobalTokens`.
-    /// - Parameters aliasTokens: An optional customized instance of `AliasTokens`.
+    /// Once created, a `FluentTheme` can have its `AliasTokens` customized by setting custom values on the
+    ///  `aliasTokens` property. Control tokens can be customized via `register(controlType:tokens:) `.
+    ///  See the descriptions of those two for additional information.
     ///
-    /// - Returns: An initialized `FluentTheme` instance that leverages the aforementioned global and alias token overrides.
-    public init(globalTokens: GlobalTokens? = nil, aliasTokens: AliasTokens? = nil) {
-        self.globalTokens = globalTokens ?? .init()
-        self.aliasTokens = aliasTokens ?? .init()
-        self.aliasTokens.globalTokens = self.globalTokens
-    }
+    /// - Returns: An initialized `FluentTheme` instance.
+    public override init() { }
 
     /// Registers a custom set of `ControlTokenValue` instances for a given `ControlTokenSet`.
     ///
@@ -37,10 +34,10 @@ import SwiftUI
         return controlTokenSets[tokenKey(tokenSetType)] as? [T: ControlTokenValue]
     }
 
-    static var shared: FluentTheme = .init()
+    /// The associated `AliasTokens` for this theme.
+    public let aliasTokens: AliasTokens = .init()
 
-    public private(set) var globalTokens: GlobalTokens
-    public private(set) var aliasTokens: AliasTokens
+    static var shared: FluentTheme = .init()
 
     private func tokenKey<T: TokenSetKey>(_ tokenSetType: ControlTokenSet<T>.Type) -> String {
         return "\(tokenSetType)"

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -7,6 +7,39 @@ import SwiftUI
 
 public final class AliasTokens {
 
+    // MARK: - BrandColors
+
+    public enum BrandColorsTokens: TokenSetKey {
+        case primary
+        case shade10
+        case shade20
+        case shade30
+        case tint10
+        case tint20
+        case tint30
+        case tint40
+    }
+    public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
+        switch token {
+        case .primary:
+            return DynamicColor(light: ColorValue(0x0078D4), dark: ColorValue(0x0086F0))
+        case .shade10:
+            return DynamicColor(light: ColorValue(0x106EBE), dark: ColorValue(0x1890F1))
+        case .shade20:
+            return DynamicColor(light: ColorValue(0x005A9E), dark: ColorValue(0x3AA0F3))
+        case .shade30:
+            return DynamicColor(light: ColorValue(0x004578), dark: ColorValue(0x6CB8F6))
+        case .tint10:
+            return DynamicColor(light: ColorValue(0x2B88D8), dark: ColorValue(0x0074D3))
+        case .tint20:
+            return DynamicColor(light: ColorValue(0xC7E0F4), dark: ColorValue(0x004F90))
+        case .tint30:
+            return DynamicColor(light: ColorValue(0xDEECF9), dark: ColorValue(0x002848))
+        case .tint40:
+            return DynamicColor(light: ColorValue(0xEFF6FC), dark: ColorValue(0x001526))
+        }
+    }
+
     // MARK: ForegroundColors
 
     public enum ForegroundColorsTokens: TokenSetKey {
@@ -26,49 +59,49 @@ public final class AliasTokens {
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .neutral1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey14],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
-                                dark: strongSelf.globalTokens.neutralColors[.white],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey14),
+                                lightHighContrast: GlobalTokens.neutralColors(.black),
+                                dark: GlobalTokens.neutralColors(.white),
+                                darkHighContrast: GlobalTokens.neutralColors(.white))
         case .neutral2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey26],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.black],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.white])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey26),
+                                lightHighContrast: GlobalTokens.neutralColors(.black),
+                                dark: GlobalTokens.neutralColors(.grey84),
+                                darkHighContrast: GlobalTokens.neutralColors(.white))
         case .neutral3:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey38],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey14],
-                                dark: strongSelf.globalTokens.neutralColors[.grey68],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey38),
+                                lightHighContrast: GlobalTokens.neutralColors(.grey14),
+                                dark: GlobalTokens.neutralColors(.grey68),
+                                darkHighContrast: GlobalTokens.neutralColors(.grey84))
         case .neutral4:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey50],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey26],
-                                dark: strongSelf.globalTokens.neutralColors[.grey52],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey50),
+                                lightHighContrast: GlobalTokens.neutralColors(.grey26),
+                                dark: GlobalTokens.neutralColors(.grey52),
+                                darkHighContrast: GlobalTokens.neutralColors(.grey84))
         case .neutralDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey62])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
+                                lightHighContrast: GlobalTokens.neutralColors(.grey38),
+                                dark: GlobalTokens.neutralColors(.grey36),
+                                darkHighContrast: GlobalTokens.neutralColors(.grey62))
         case .neutralInverted:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.black],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.black])
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                lightHighContrast: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.black),
+                                darkHighContrast: GlobalTokens.neutralColors(.black))
         case .brandRest:
-            return DynamicColor(light: strongSelf.globalTokens.brandColors[.primary].light,
-                                lightHighContrast: strongSelf.globalTokens.brandColors[.shade20].light,
-                                dark: strongSelf.globalTokens.brandColors[.primary].dark,
-                                darkHighContrast: strongSelf.globalTokens.brandColors[.tint20].dark)
+            return DynamicColor(light: strongSelf.brandColors[.primary].light,
+                                lightHighContrast: strongSelf.brandColors[.shade20].light,
+                                dark: strongSelf.brandColors[.primary].dark,
+                                darkHighContrast: strongSelf.brandColors[.tint20].dark)
         case .brandHover:
-            return strongSelf.globalTokens.brandColors[.shade10]
+            return strongSelf.brandColors[.shade10]
         case .brandPressed:
-            return strongSelf.globalTokens.brandColors[.shade30]
+            return strongSelf.brandColors[.shade30]
         case .brandSelected:
-            return strongSelf.globalTokens.brandColors[.shade20]
+            return strongSelf.brandColors[.shade20]
         case .brandDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey74],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
+                                dark: GlobalTokens.neutralColors(.grey36))
         }
     }
 
@@ -92,43 +125,43 @@ public final class AliasTokens {
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .neutral1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.white],
-                                dark: strongSelf.globalTokens.neutralColors[.black],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey4])
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.black),
+                                darkElevated: GlobalTokens.neutralColors(.grey4))
         case .neutral2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey98],
-                                dark: strongSelf.globalTokens.neutralColors[.grey4],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey8])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
+                                dark: GlobalTokens.neutralColors(.grey4),
+                                darkElevated: GlobalTokens.neutralColors(.grey8))
         case .neutral3:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey96],
-                                dark: strongSelf.globalTokens.neutralColors[.grey8],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey12])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey96),
+                                dark: GlobalTokens.neutralColors(.grey8),
+                                darkElevated: GlobalTokens.neutralColors(.grey12))
         case .neutral4:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
-                                dark: strongSelf.globalTokens.neutralColors[.grey12],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey16])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                dark: GlobalTokens.neutralColors(.grey12),
+                                darkElevated: GlobalTokens.neutralColors(.grey16))
         case .neutral5:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey92],
-                                dark: strongSelf.globalTokens.neutralColors[.grey36],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
+                                dark: GlobalTokens.neutralColors(.grey36),
+                                darkElevated: GlobalTokens.neutralColors(.grey36))
         case .neutralDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey84),
+                                darkElevated: GlobalTokens.neutralColors(.grey84))
         case .brandRest:
-            return strongSelf.globalTokens.brandColors[.primary]
+            return strongSelf.brandColors[.primary]
         case .brandHover:
-            return strongSelf.globalTokens.brandColors[.shade10]
+            return strongSelf.brandColors[.shade10]
         case .brandPressed:
-            return strongSelf.globalTokens.brandColors[.shade30]
+            return strongSelf.brandColors[.shade30]
         case .brandSelected:
-            return strongSelf.globalTokens.brandColors[.shade20]
+            return strongSelf.brandColors[.shade20]
         case .brandDisabled:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey84])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey84))
         case .surfaceQuaternary:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                dark: strongSelf.globalTokens.neutralColors[.grey26])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey26))
         }
     }
 
@@ -142,17 +175,17 @@ public final class AliasTokens {
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .neutral1:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey94],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey24],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey32])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                lightHighContrast: GlobalTokens.neutralColors(.grey38),
+                                dark: GlobalTokens.neutralColors(.grey24),
+                                darkHighContrast: GlobalTokens.neutralColors(.grey68),
+                                darkElevated: GlobalTokens.neutralColors(.grey32))
         case .neutral2:
-            return DynamicColor(light: strongSelf.globalTokens.neutralColors[.grey88],
-                                lightHighContrast: strongSelf.globalTokens.neutralColors[.grey38],
-                                dark: strongSelf.globalTokens.neutralColors[.grey32],
-                                darkHighContrast: strongSelf.globalTokens.neutralColors[.grey68],
-                                darkElevated: strongSelf.globalTokens.neutralColors[.grey36])
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                lightHighContrast: GlobalTokens.neutralColors(.grey38),
+                                dark: GlobalTokens.neutralColors(.grey32),
+                                darkHighContrast: GlobalTokens.neutralColors(.grey68),
+                                darkElevated: GlobalTokens.neutralColors(.grey36))
         }
     }
 
@@ -218,41 +251,41 @@ public final class AliasTokens {
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
         case .display:
-            return .init(size: strongSelf.globalTokens.fontSize[.size900],
-                         weight: strongSelf.globalTokens.fontWeight[.bold])
+            return .init(size: GlobalTokens.fontSize(.size900),
+                         weight: GlobalTokens.fontWeight(.bold))
         case .largeTitle:
-            return .init(size: strongSelf.globalTokens.fontSize[.size800],
-                         weight: strongSelf.globalTokens.fontWeight[.bold])
+            return .init(size: GlobalTokens.fontSize(.size800),
+                         weight: GlobalTokens.fontWeight(.bold))
         case .title1:
-            return .init(size: strongSelf.globalTokens.fontSize[.size700],
-                         weight: strongSelf.globalTokens.fontWeight[.bold])
+            return .init(size: GlobalTokens.fontSize(.size700),
+                         weight: GlobalTokens.fontWeight(.bold))
         case .title2:
-            return .init(size: strongSelf.globalTokens.fontSize[.size600],
-                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+            return .init(size: GlobalTokens.fontSize(.size600),
+                         weight: GlobalTokens.fontWeight(.semibold))
         case .title3:
-            return .init(size: strongSelf.globalTokens.fontSize[.size500],
-                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+            return .init(size: GlobalTokens.fontSize(.size500),
+                         weight: GlobalTokens.fontWeight(.semibold))
         case .body1Strong:
-            return .init(size: strongSelf.globalTokens.fontSize[.size400],
-                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+            return .init(size: GlobalTokens.fontSize(.size400),
+                         weight: GlobalTokens.fontWeight(.semibold))
         case .body1:
-            return .init(size: strongSelf.globalTokens.fontSize[.size400],
-                         weight: strongSelf.globalTokens.fontWeight[.regular])
+            return .init(size: GlobalTokens.fontSize(.size400),
+                         weight: GlobalTokens.fontWeight(.regular))
         case .body2Strong:
-            return .init(size: strongSelf.globalTokens.fontSize[.size300],
-                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+            return .init(size: GlobalTokens.fontSize(.size300),
+                         weight: GlobalTokens.fontWeight(.semibold))
         case .body2:
-            return .init(size: strongSelf.globalTokens.fontSize[.size300],
-                         weight: strongSelf.globalTokens.fontWeight[.regular])
+            return .init(size: GlobalTokens.fontSize(.size300),
+                         weight: GlobalTokens.fontWeight(.regular))
         case .caption1Strong:
-            return .init(size: strongSelf.globalTokens.fontSize[.size200],
-                         weight: strongSelf.globalTokens.fontWeight[.semibold])
+            return .init(size: GlobalTokens.fontSize(.size200),
+                         weight: GlobalTokens.fontWeight(.semibold))
         case .caption1:
-            return .init(size: strongSelf.globalTokens.fontSize[.size200],
-                         weight: strongSelf.globalTokens.fontWeight[.regular])
+            return .init(size: GlobalTokens.fontSize(.size200),
+                         weight: GlobalTokens.fontWeight(.regular))
         case .caption2:
-            return .init(size: strongSelf.globalTokens.fontSize[.size100],
-                         weight: strongSelf.globalTokens.fontWeight[.regular])
+            return .init(size: GlobalTokens.fontSize(.size100),
+                         weight: GlobalTokens.fontWeight(.regular))
         }
     }
 
@@ -363,7 +396,5 @@ public final class AliasTokens {
 
     // MARK: Initialization
 
-    public init() {}
-
-    lazy var globalTokens: GlobalTokens = FluentTheme.shared.globalTokens
+    init() {}
 }

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -6,40 +6,7 @@
 import SwiftUI
 
 /// Global Tokens represent a unified set of constants to be used by Fluent UI.
-public final class GlobalTokens {
-
-    // MARK: - BrandColors
-
-    public enum BrandColorsTokens: TokenSetKey {
-        case primary
-        case shade10
-        case shade20
-        case shade30
-        case tint10
-        case tint20
-        case tint30
-        case tint40
-    }
-    lazy public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
-        switch token {
-        case .primary:
-            return DynamicColor(light: ColorValue(0x0078D4), dark: ColorValue(0x0086F0))
-        case .shade10:
-            return DynamicColor(light: ColorValue(0x106EBE), dark: ColorValue(0x1890F1))
-        case .shade20:
-            return DynamicColor(light: ColorValue(0x005A9E), dark: ColorValue(0x3AA0F3))
-        case .shade30:
-            return DynamicColor(light: ColorValue(0x004578), dark: ColorValue(0x6CB8F6))
-        case .tint10:
-            return DynamicColor(light: ColorValue(0x2B88D8), dark: ColorValue(0x0074D3))
-        case .tint20:
-            return DynamicColor(light: ColorValue(0xC7E0F4), dark: ColorValue(0x004F90))
-        case .tint30:
-            return DynamicColor(light: ColorValue(0xDEECF9), dark: ColorValue(0x002848))
-        case .tint40:
-            return DynamicColor(light: ColorValue(0xEFF6FC), dark: ColorValue(0x001526))
-        }
-    }
+public struct GlobalTokens {
 
     // MARK: - NeutralColors
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -96,7 +96,7 @@ public final class GlobalTokens {
         case grey98
         case white
     }
-    lazy public var neutralColors: TokenSet<NeutralColorsToken, ColorValue> = .init { token in
+    public static func neutralColors(_ token: NeutralColorsToken) -> ColorValue {
         switch token {
         case .black:
             return ColorValue(0x000000)
@@ -272,1428 +272,1330 @@ public final class GlobalTokens {
         case tint60
     }
 
-    lazy public var sharedColors: TokenSet<SharedColorSets, TokenSet<SharedColorsTokens, ColorValue>> = .init { sharedColor in
+    public static func sharedColors(_ sharedColor: SharedColorSets, _ token: SharedColorsTokens) -> ColorValue {
         switch sharedColor {
         case .anchor:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x394146)
-                case .shade10:
-                    return ColorValue(0x333A3F)
-                case .shade20:
-                    return ColorValue(0x2B3135)
-                case .shade30:
-                    return ColorValue(0x202427)
-                case .shade40:
-                    return ColorValue(0x111315)
-                case .shade50:
-                    return ColorValue(0x090A0B)
-                case .tint10:
-                    return ColorValue(0x4D565C)
-                case .tint20:
-                    return ColorValue(0x626C72)
-                case .tint30:
-                    return ColorValue(0x808A90)
-                case .tint40:
-                    return ColorValue(0xBCC3C7)
-                case .tint50:
-                    return ColorValue(0xDBDFE1)
-                case .tint60:
-                    return ColorValue(0xF6F7F8)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x394146)
+            case .shade10:
+                return ColorValue(0x333A3F)
+            case .shade20:
+                return ColorValue(0x2B3135)
+            case .shade30:
+                return ColorValue(0x202427)
+            case .shade40:
+                return ColorValue(0x111315)
+            case .shade50:
+                return ColorValue(0x090A0B)
+            case .tint10:
+                return ColorValue(0x4D565C)
+            case .tint20:
+                return ColorValue(0x626C72)
+            case .tint30:
+                return ColorValue(0x808A90)
+            case .tint40:
+                return ColorValue(0xBCC3C7)
+            case .tint50:
+                return ColorValue(0xDBDFE1)
+            case .tint60:
+                return ColorValue(0xF6F7F8)
             }
         case .beige:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x7A7574)
-                case .shade10:
-                    return ColorValue(0x6E6968)
-                case .shade20:
-                    return ColorValue(0x5D5958)
-                case .shade30:
-                    return ColorValue(0x444241)
-                case .shade40:
-                    return ColorValue(0x252323)
-                case .shade50:
-                    return ColorValue(0x141313)
-                case .tint10:
-                    return ColorValue(0x8A8584)
-                case .tint20:
-                    return ColorValue(0x9A9594)
-                case .tint30:
-                    return ColorValue(0xAFABAA)
-                case .tint40:
-                    return ColorValue(0xD7D4D4)
-                case .tint50:
-                    return ColorValue(0xEAE8E8)
-                case .tint60:
-                    return ColorValue(0xFAF9F9)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x7A7574)
+            case .shade10:
+                return ColorValue(0x6E6968)
+            case .shade20:
+                return ColorValue(0x5D5958)
+            case .shade30:
+                return ColorValue(0x444241)
+            case .shade40:
+                return ColorValue(0x252323)
+            case .shade50:
+                return ColorValue(0x141313)
+            case .tint10:
+                return ColorValue(0x8A8584)
+            case .tint20:
+                return ColorValue(0x9A9594)
+            case .tint30:
+                return ColorValue(0xAFABAA)
+            case .tint40:
+                return ColorValue(0xD7D4D4)
+            case .tint50:
+                return ColorValue(0xEAE8E8)
+            case .tint60:
+                return ColorValue(0xFAF9F9)
             }
         case .berry:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xC239B3)
-                case .shade10:
-                    return ColorValue(0xAF33A1)
-                case .shade20:
-                    return ColorValue(0x932B88)
-                case .shade30:
-                    return ColorValue(0x6D2064)
-                case .shade40:
-                    return ColorValue(0x3A1136)
-                case .shade50:
-                    return ColorValue(0x1F091D)
-                case .tint10:
-                    return ColorValue(0xC94CBC)
-                case .tint20:
-                    return ColorValue(0xD161C4)
-                case .tint30:
-                    return ColorValue(0xDA7ED0)
-                case .tint40:
-                    return ColorValue(0xEDBBE7)
-                case .tint50:
-                    return ColorValue(0xF5DAF2)
-                case .tint60:
-                    return ColorValue(0xFDF5FC)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xC239B3)
+            case .shade10:
+                return ColorValue(0xAF33A1)
+            case .shade20:
+                return ColorValue(0x932B88)
+            case .shade30:
+                return ColorValue(0x6D2064)
+            case .shade40:
+                return ColorValue(0x3A1136)
+            case .shade50:
+                return ColorValue(0x1F091D)
+            case .tint10:
+                return ColorValue(0xC94CBC)
+            case .tint20:
+                return ColorValue(0xD161C4)
+            case .tint30:
+                return ColorValue(0xDA7ED0)
+            case .tint40:
+                return ColorValue(0xEDBBE7)
+            case .tint50:
+                return ColorValue(0xF5DAF2)
+            case .tint60:
+                return ColorValue(0xFDF5FC)
             }
         case .blue:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x0078D4)
-                case .shade10:
-                    return ColorValue(0x006CBF)
-                case .shade20:
-                    return ColorValue(0x005BA1)
-                case .shade30:
-                    return ColorValue(0x004377)
-                case .shade40:
-                    return ColorValue(0x002440)
-                case .shade50:
-                    return ColorValue(0x001322)
-                case .tint10:
-                    return ColorValue(0x1A86D9)
-                case .tint20:
-                    return ColorValue(0x3595DE)
-                case .tint30:
-                    return ColorValue(0x5CAAE5)
-                case .tint40:
-                    return ColorValue(0xA9D3F2)
-                case .tint50:
-                    return ColorValue(0xD0E7F8)
-                case .tint60:
-                    return ColorValue(0xF3F9FD)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x0078D4)
+            case .shade10:
+                return ColorValue(0x006CBF)
+            case .shade20:
+                return ColorValue(0x005BA1)
+            case .shade30:
+                return ColorValue(0x004377)
+            case .shade40:
+                return ColorValue(0x002440)
+            case .shade50:
+                return ColorValue(0x001322)
+            case .tint10:
+                return ColorValue(0x1A86D9)
+            case .tint20:
+                return ColorValue(0x3595DE)
+            case .tint30:
+                return ColorValue(0x5CAAE5)
+            case .tint40:
+                return ColorValue(0xA9D3F2)
+            case .tint50:
+                return ColorValue(0xD0E7F8)
+            case .tint60:
+                return ColorValue(0xF3F9FD)
             }
         case .brass:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x986F0B)
-                case .shade10:
-                    return ColorValue(0x89640A)
-                case .shade20:
-                    return ColorValue(0x745408)
-                case .shade30:
-                    return ColorValue(0x553E06)
-                case .shade40:
-                    return ColorValue(0x2E2103)
-                case .shade50:
-                    return ColorValue(0x181202)
-                case .tint10:
-                    return ColorValue(0xA47D1E)
-                case .tint20:
-                    return ColorValue(0xB18C34)
-                case .tint30:
-                    return ColorValue(0xC1A256)
-                case .tint40:
-                    return ColorValue(0xE0CEA2)
-                case .tint50:
-                    return ColorValue(0xEFE4CB)
-                case .tint60:
-                    return ColorValue(0xFBF8F2)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x986F0B)
+            case .shade10:
+                return ColorValue(0x89640A)
+            case .shade20:
+                return ColorValue(0x745408)
+            case .shade30:
+                return ColorValue(0x553E06)
+            case .shade40:
+                return ColorValue(0x2E2103)
+            case .shade50:
+                return ColorValue(0x181202)
+            case .tint10:
+                return ColorValue(0xA47D1E)
+            case .tint20:
+                return ColorValue(0xB18C34)
+            case .tint30:
+                return ColorValue(0xC1A256)
+            case .tint40:
+                return ColorValue(0xE0CEA2)
+            case .tint50:
+                return ColorValue(0xEFE4CB)
+            case .tint60:
+                return ColorValue(0xFBF8F2)
             }
         case .bronze:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xA74109)
-                case .shade10:
-                    return ColorValue(0x963A08)
-                case .shade20:
-                    return ColorValue(0x7F3107)
-                case .shade30:
-                    return ColorValue(0x5E2405)
-                case .shade40:
-                    return ColorValue(0x321303)
-                case .shade50:
-                    return ColorValue(0x1B0A01)
-                case .tint10:
-                    return ColorValue(0xB2521E)
-                case .tint20:
-                    return ColorValue(0xBC6535)
-                case .tint30:
-                    return ColorValue(0xCA8057)
-                case .tint40:
-                    return ColorValue(0xE5BBA4)
-                case .tint50:
-                    return ColorValue(0xF1D9CC)
-                case .tint60:
-                    return ColorValue(0xFBF5F2)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xA74109)
+            case .shade10:
+                return ColorValue(0x963A08)
+            case .shade20:
+                return ColorValue(0x7F3107)
+            case .shade30:
+                return ColorValue(0x5E2405)
+            case .shade40:
+                return ColorValue(0x321303)
+            case .shade50:
+                return ColorValue(0x1B0A01)
+            case .tint10:
+                return ColorValue(0xB2521E)
+            case .tint20:
+                return ColorValue(0xBC6535)
+            case .tint30:
+                return ColorValue(0xCA8057)
+            case .tint40:
+                return ColorValue(0xE5BBA4)
+            case .tint50:
+                return ColorValue(0xF1D9CC)
+            case .tint60:
+                return ColorValue(0xFBF5F2)
             }
         case .brown:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x8E562E)
-                case .shade10:
-                    return ColorValue(0x804D29)
-                case .shade20:
-                    return ColorValue(0x6C4123)
-                case .shade30:
-                    return ColorValue(0x50301A)
-                case .shade40:
-                    return ColorValue(0x2B1A0E)
-                case .shade50:
-                    return ColorValue(0x170E07)
-                case .tint10:
-                    return ColorValue(0x9C663F)
-                case .tint20:
-                    return ColorValue(0xA97652)
-                case .tint30:
-                    return ColorValue(0xBB8F6F)
-                case .tint40:
-                    return ColorValue(0xDDC3B0)
-                case .tint50:
-                    return ColorValue(0xEDDED3)
-                case .tint60:
-                    return ColorValue(0xFAF7F4)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x8E562E)
+            case .shade10:
+                return ColorValue(0x804D29)
+            case .shade20:
+                return ColorValue(0x6C4123)
+            case .shade30:
+                return ColorValue(0x50301A)
+            case .shade40:
+                return ColorValue(0x2B1A0E)
+            case .shade50:
+                return ColorValue(0x170E07)
+            case .tint10:
+                return ColorValue(0x9C663F)
+            case .tint20:
+                return ColorValue(0xA97652)
+            case .tint30:
+                return ColorValue(0xBB8F6F)
+            case .tint40:
+                return ColorValue(0xDDC3B0)
+            case .tint50:
+                return ColorValue(0xEDDED3)
+            case .tint60:
+                return ColorValue(0xFAF7F4)
             }
         case .burgundy:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xA4262C)
-                case .shade10:
-                    return ColorValue(0x942228)
-                case .shade20:
-                    return ColorValue(0x7D1D21)
-                case .shade30:
-                    return ColorValue(0x5C1519)
-                case .shade40:
-                    return ColorValue(0x310B0D)
-                case .shade50:
-                    return ColorValue(0x1A0607)
-                case .tint10:
-                    return ColorValue(0xAF393E)
-                case .tint20:
-                    return ColorValue(0xBA4D52)
-                case .tint30:
-                    return ColorValue(0xC86C70)
-                case .tint40:
-                    return ColorValue(0xE4AFB2)
-                case .tint50:
-                    return ColorValue(0xF0D3D4)
-                case .tint60:
-                    return ColorValue(0xFBF4F4)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xA4262C)
+            case .shade10:
+                return ColorValue(0x942228)
+            case .shade20:
+                return ColorValue(0x7D1D21)
+            case .shade30:
+                return ColorValue(0x5C1519)
+            case .shade40:
+                return ColorValue(0x310B0D)
+            case .shade50:
+                return ColorValue(0x1A0607)
+            case .tint10:
+                return ColorValue(0xAF393E)
+            case .tint20:
+                return ColorValue(0xBA4D52)
+            case .tint30:
+                return ColorValue(0xC86C70)
+            case .tint40:
+                return ColorValue(0xE4AFB2)
+            case .tint50:
+                return ColorValue(0xF0D3D4)
+            case .tint60:
+                return ColorValue(0xFBF4F4)
             }
         case .charcoal:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x393939)
-                case .shade10:
-                    return ColorValue(0x333333)
-                case .shade20:
-                    return ColorValue(0x2B2B2B)
-                case .shade30:
-                    return ColorValue(0x202020)
-                case .shade40:
-                    return ColorValue(0x111111)
-                case .shade50:
-                    return ColorValue(0x090909)
-                case .tint10:
-                    return ColorValue(0x515151)
-                case .tint20:
-                    return ColorValue(0x686868)
-                case .tint30:
-                    return ColorValue(0x888888)
-                case .tint40:
-                    return ColorValue(0xC4C4C4)
-                case .tint50:
-                    return ColorValue(0xDFDFDF)
-                case .tint60:
-                    return ColorValue(0xF7F7F7)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x393939)
+            case .shade10:
+                return ColorValue(0x333333)
+            case .shade20:
+                return ColorValue(0x2B2B2B)
+            case .shade30:
+                return ColorValue(0x202020)
+            case .shade40:
+                return ColorValue(0x111111)
+            case .shade50:
+                return ColorValue(0x090909)
+            case .tint10:
+                return ColorValue(0x515151)
+            case .tint20:
+                return ColorValue(0x686868)
+            case .tint30:
+                return ColorValue(0x888888)
+            case .tint40:
+                return ColorValue(0xC4C4C4)
+            case .tint50:
+                return ColorValue(0xDFDFDF)
+            case .tint60:
+                return ColorValue(0xF7F7F7)
             }
         case .cornflower:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x4F6BED)
-                case .shade10:
-                    return ColorValue(0x4760D5)
-                case .shade20:
-                    return ColorValue(0x3C51B4)
-                case .shade30:
-                    return ColorValue(0x2C3C85)
-                case .shade40:
-                    return ColorValue(0x182047)
-                case .shade50:
-                    return ColorValue(0x0D1126)
-                case .tint10:
-                    return ColorValue(0x637CEF)
-                case .tint20:
-                    return ColorValue(0x778DF1)
-                case .tint30:
-                    return ColorValue(0x93A4F4)
-                case .tint40:
-                    return ColorValue(0xC8D1FA)
-                case .tint50:
-                    return ColorValue(0xE1E6FC)
-                case .tint60:
-                    return ColorValue(0xF7F9FE)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x4F6BED)
+            case .shade10:
+                return ColorValue(0x4760D5)
+            case .shade20:
+                return ColorValue(0x3C51B4)
+            case .shade30:
+                return ColorValue(0x2C3C85)
+            case .shade40:
+                return ColorValue(0x182047)
+            case .shade50:
+                return ColorValue(0x0D1126)
+            case .tint10:
+                return ColorValue(0x637CEF)
+            case .tint20:
+                return ColorValue(0x778DF1)
+            case .tint30:
+                return ColorValue(0x93A4F4)
+            case .tint40:
+                return ColorValue(0xC8D1FA)
+            case .tint50:
+                return ColorValue(0xE1E6FC)
+            case .tint60:
+                return ColorValue(0xF7F9FE)
             }
         case .cranberry:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xC50F1F)
-                case .shade10:
-                    return ColorValue(0xB10E1C)
-                case .shade20:
-                    return ColorValue(0x960B18)
-                case .shade30:
-                    return ColorValue(0x6E0811)
-                case .shade40:
-                    return ColorValue(0x3B0509)
-                case .shade50:
-                    return ColorValue(0x200205)
-                case .tint10:
-                    return ColorValue(0xCC2635)
-                case .tint20:
-                    return ColorValue(0xD33F4C)
-                case .tint30:
-                    return ColorValue(0xDC626D)
-                case .tint40:
-                    return ColorValue(0xEEACB2)
-                case .tint50:
-                    return ColorValue(0xF6D1D5)
-                case .tint60:
-                    return ColorValue(0xFDF3F4)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xC50F1F)
+            case .shade10:
+                return ColorValue(0xB10E1C)
+            case .shade20:
+                return ColorValue(0x960B18)
+            case .shade30:
+                return ColorValue(0x6E0811)
+            case .shade40:
+                return ColorValue(0x3B0509)
+            case .shade50:
+                return ColorValue(0x200205)
+            case .tint10:
+                return ColorValue(0xCC2635)
+            case .tint20:
+                return ColorValue(0xD33F4C)
+            case .tint30:
+                return ColorValue(0xDC626D)
+            case .tint40:
+                return ColorValue(0xEEACB2)
+            case .tint50:
+                return ColorValue(0xF6D1D5)
+            case .tint60:
+                return ColorValue(0xFDF3F4)
             }
         case .cyan:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x0099BC)
-                case .shade10:
-                    return ColorValue(0x008AA9)
-                case .shade20:
-                    return ColorValue(0x00748F)
-                case .shade30:
-                    return ColorValue(0x005669)
-                case .shade40:
-                    return ColorValue(0x002E38)
-                case .shade50:
-                    return ColorValue(0x00181E)
-                case .tint10:
-                    return ColorValue(0x18A4C4)
-                case .tint20:
-                    return ColorValue(0x31AFCC)
-                case .tint30:
-                    return ColorValue(0x56BFD7)
-                case .tint40:
-                    return ColorValue(0xA4DEEB)
-                case .tint50:
-                    return ColorValue(0xCDEDF4)
-                case .tint60:
-                    return ColorValue(0xF2FAFC)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x0099BC)
+            case .shade10:
+                return ColorValue(0x008AA9)
+            case .shade20:
+                return ColorValue(0x00748F)
+            case .shade30:
+                return ColorValue(0x005669)
+            case .shade40:
+                return ColorValue(0x002E38)
+            case .shade50:
+                return ColorValue(0x00181E)
+            case .tint10:
+                return ColorValue(0x18A4C4)
+            case .tint20:
+                return ColorValue(0x31AFCC)
+            case .tint30:
+                return ColorValue(0x56BFD7)
+            case .tint40:
+                return ColorValue(0xA4DEEB)
+            case .tint50:
+                return ColorValue(0xCDEDF4)
+            case .tint60:
+                return ColorValue(0xF2FAFC)
             }
         case .darkBlue:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x003966)
-                case .shade10:
-                    return ColorValue(0x00335C)
-                case .shade20:
-                    return ColorValue(0x002B4E)
-                case .shade30:
-                    return ColorValue(0x002039)
-                case .shade40:
-                    return ColorValue(0x00111F)
-                case .shade50:
-                    return ColorValue(0x000910)
-                case .tint10:
-                    return ColorValue(0x0E4A78)
-                case .tint20:
-                    return ColorValue(0x215C8B)
-                case .tint30:
-                    return ColorValue(0x4178A3)
-                case .tint40:
-                    return ColorValue(0x92B5D1)
-                case .tint50:
-                    return ColorValue(0xC2D6E7)
-                case .tint60:
-                    return ColorValue(0xEFF4F9)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x003966)
+            case .shade10:
+                return ColorValue(0x00335C)
+            case .shade20:
+                return ColorValue(0x002B4E)
+            case .shade30:
+                return ColorValue(0x002039)
+            case .shade40:
+                return ColorValue(0x00111F)
+            case .shade50:
+                return ColorValue(0x000910)
+            case .tint10:
+                return ColorValue(0x0E4A78)
+            case .tint20:
+                return ColorValue(0x215C8B)
+            case .tint30:
+                return ColorValue(0x4178A3)
+            case .tint40:
+                return ColorValue(0x92B5D1)
+            case .tint50:
+                return ColorValue(0xC2D6E7)
+            case .tint60:
+                return ColorValue(0xEFF4F9)
             }
         case .darkBrown:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x4D291C)
-                case .shade10:
-                    return ColorValue(0x452519)
-                case .shade20:
-                    return ColorValue(0x3A1F15)
-                case .shade30:
-                    return ColorValue(0x2B1710)
-                case .shade40:
-                    return ColorValue(0x170C08)
-                case .shade50:
-                    return ColorValue(0x0C0704)
-                case .tint10:
-                    return ColorValue(0x623A2B)
-                case .tint20:
-                    return ColorValue(0x784D3E)
-                case .tint30:
-                    return ColorValue(0x946B5C)
-                case .tint40:
-                    return ColorValue(0xCAADA3)
-                case .tint50:
-                    return ColorValue(0xE3D2CB)
-                case .tint60:
-                    return ColorValue(0xF8F3F2)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x4D291C)
+            case .shade10:
+                return ColorValue(0x452519)
+            case .shade20:
+                return ColorValue(0x3A1F15)
+            case .shade30:
+                return ColorValue(0x2B1710)
+            case .shade40:
+                return ColorValue(0x170C08)
+            case .shade50:
+                return ColorValue(0x0C0704)
+            case .tint10:
+                return ColorValue(0x623A2B)
+            case .tint20:
+                return ColorValue(0x784D3E)
+            case .tint30:
+                return ColorValue(0x946B5C)
+            case .tint40:
+                return ColorValue(0xCAADA3)
+            case .tint50:
+                return ColorValue(0xE3D2CB)
+            case .tint60:
+                return ColorValue(0xF8F3F2)
             }
         case .darkGreen:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x0B6A0B)
-                case .shade10:
-                    return ColorValue(0x0A5F0A)
-                case .shade20:
-                    return ColorValue(0x085108)
-                case .shade30:
-                    return ColorValue(0x063B06)
-                case .shade40:
-                    return ColorValue(0x032003)
-                case .shade50:
-                    return ColorValue(0x021102)
-                case .tint10:
-                    return ColorValue(0x1A7C1A)
-                case .tint20:
-                    return ColorValue(0x2D8E2D)
-                case .tint30:
-                    return ColorValue(0x4DA64D)
-                case .tint40:
-                    return ColorValue(0x9AD29A)
-                case .tint50:
-                    return ColorValue(0xC6E7C6)
-                case .tint60:
-                    return ColorValue(0xF0F9F0)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x0B6A0B)
+            case .shade10:
+                return ColorValue(0x0A5F0A)
+            case .shade20:
+                return ColorValue(0x085108)
+            case .shade30:
+                return ColorValue(0x063B06)
+            case .shade40:
+                return ColorValue(0x032003)
+            case .shade50:
+                return ColorValue(0x021102)
+            case .tint10:
+                return ColorValue(0x1A7C1A)
+            case .tint20:
+                return ColorValue(0x2D8E2D)
+            case .tint30:
+                return ColorValue(0x4DA64D)
+            case .tint40:
+                return ColorValue(0x9AD29A)
+            case .tint50:
+                return ColorValue(0xC6E7C6)
+            case .tint60:
+                return ColorValue(0xF0F9F0)
             }
         case .darkOrange:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xDA3B01)
-                case .shade10:
-                    return ColorValue(0xC43501)
-                case .shade20:
-                    return ColorValue(0xA62D01)
-                case .shade30:
-                    return ColorValue(0x7A2101)
-                case .shade40:
-                    return ColorValue(0x411200)
-                case .shade50:
-                    return ColorValue(0x230900)
-                case .tint10:
-                    return ColorValue(0xDE501C)
-                case .tint20:
-                    return ColorValue(0xE36537)
-                case .tint30:
-                    return ColorValue(0xE9835E)
-                case .tint40:
-                    return ColorValue(0xF4BFAB)
-                case .tint50:
-                    return ColorValue(0xF9DCD1)
-                case .tint60:
-                    return ColorValue(0xFDF6F3)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xDA3B01)
+            case .shade10:
+                return ColorValue(0xC43501)
+            case .shade20:
+                return ColorValue(0xA62D01)
+            case .shade30:
+                return ColorValue(0x7A2101)
+            case .shade40:
+                return ColorValue(0x411200)
+            case .shade50:
+                return ColorValue(0x230900)
+            case .tint10:
+                return ColorValue(0xDE501C)
+            case .tint20:
+                return ColorValue(0xE36537)
+            case .tint30:
+                return ColorValue(0xE9835E)
+            case .tint40:
+                return ColorValue(0xF4BFAB)
+            case .tint50:
+                return ColorValue(0xF9DCD1)
+            case .tint60:
+                return ColorValue(0xFDF6F3)
             }
         case .darkPurple:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x401B6C)
-                case .shade10:
-                    return ColorValue(0x3A1861)
-                case .shade20:
-                    return ColorValue(0x311552)
-                case .shade30:
-                    return ColorValue(0x240F3C)
-                case .shade40:
-                    return ColorValue(0x130820)
-                case .shade50:
-                    return ColorValue(0x0A0411)
-                case .tint10:
-                    return ColorValue(0x512B7E)
-                case .tint20:
-                    return ColorValue(0x633E8F)
-                case .tint30:
-                    return ColorValue(0x7E5CA7)
-                case .tint40:
-                    return ColorValue(0xB9A3D3)
-                case .tint50:
-                    return ColorValue(0xD8CCE7)
-                case .tint60:
-                    return ColorValue(0xF5F2F9)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x401B6C)
+            case .shade10:
+                return ColorValue(0x3A1861)
+            case .shade20:
+                return ColorValue(0x311552)
+            case .shade30:
+                return ColorValue(0x240F3C)
+            case .shade40:
+                return ColorValue(0x130820)
+            case .shade50:
+                return ColorValue(0x0A0411)
+            case .tint10:
+                return ColorValue(0x512B7E)
+            case .tint20:
+                return ColorValue(0x633E8F)
+            case .tint30:
+                return ColorValue(0x7E5CA7)
+            case .tint40:
+                return ColorValue(0xB9A3D3)
+            case .tint50:
+                return ColorValue(0xD8CCE7)
+            case .tint60:
+                return ColorValue(0xF5F2F9)
             }
         case .darkRed:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x750B1C)
-                case .shade10:
-                    return ColorValue(0x690A19)
-                case .shade20:
-                    return ColorValue(0x590815)
-                case .shade30:
-                    return ColorValue(0x420610)
-                case .shade40:
-                    return ColorValue(0x230308)
-                case .shade50:
-                    return ColorValue(0x130204)
-                case .tint10:
-                    return ColorValue(0x861B2C)
-                case .tint20:
-                    return ColorValue(0x962F3F)
-                case .tint30:
-                    return ColorValue(0xAC4F5E)
-                case .tint40:
-                    return ColorValue(0xD69CA5)
-                case .tint50:
-                    return ColorValue(0xE9C7CD)
-                case .tint60:
-                    return ColorValue(0xF9F0F2)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x750B1C)
+            case .shade10:
+                return ColorValue(0x690A19)
+            case .shade20:
+                return ColorValue(0x590815)
+            case .shade30:
+                return ColorValue(0x420610)
+            case .shade40:
+                return ColorValue(0x230308)
+            case .shade50:
+                return ColorValue(0x130204)
+            case .tint10:
+                return ColorValue(0x861B2C)
+            case .tint20:
+                return ColorValue(0x962F3F)
+            case .tint30:
+                return ColorValue(0xAC4F5E)
+            case .tint40:
+                return ColorValue(0xD69CA5)
+            case .tint50:
+                return ColorValue(0xE9C7CD)
+            case .tint60:
+                return ColorValue(0xF9F0F2)
             }
         case .darkTeal:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x006666)
-                case .shade10:
-                    return ColorValue(0x005C5C)
-                case .shade20:
-                    return ColorValue(0x004E4E)
-                case .shade30:
-                    return ColorValue(0x003939)
-                case .shade40:
-                    return ColorValue(0x001F1F)
-                case .shade50:
-                    return ColorValue(0x001010)
-                case .tint10:
-                    return ColorValue(0x0E7878)
-                case .tint20:
-                    return ColorValue(0x218B8B)
-                case .tint30:
-                    return ColorValue(0x41A3A3)
-                case .tint40:
-                    return ColorValue(0x92D1D1)
-                case .tint50:
-                    return ColorValue(0xC2E7E7)
-                case .tint60:
-                    return ColorValue(0xEFF9F9)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x006666)
+            case .shade10:
+                return ColorValue(0x005C5C)
+            case .shade20:
+                return ColorValue(0x004E4E)
+            case .shade30:
+                return ColorValue(0x003939)
+            case .shade40:
+                return ColorValue(0x001F1F)
+            case .shade50:
+                return ColorValue(0x001010)
+            case .tint10:
+                return ColorValue(0x0E7878)
+            case .tint20:
+                return ColorValue(0x218B8B)
+            case .tint30:
+                return ColorValue(0x41A3A3)
+            case .tint40:
+                return ColorValue(0x92D1D1)
+            case .tint50:
+                return ColorValue(0xC2E7E7)
+            case .tint60:
+                return ColorValue(0xEFF9F9)
             }
         case .forest:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x498205)
-                case .shade10:
-                    return ColorValue(0x427505)
-                case .shade20:
-                    return ColorValue(0x376304)
-                case .shade30:
-                    return ColorValue(0x294903)
-                case .shade40:
-                    return ColorValue(0x162702)
-                case .shade50:
-                    return ColorValue(0x0C1501)
-                case .tint10:
-                    return ColorValue(0x599116)
-                case .tint20:
-                    return ColorValue(0x6BA02B)
-                case .tint30:
-                    return ColorValue(0x85B44C)
-                case .tint40:
-                    return ColorValue(0xBDD99B)
-                case .tint50:
-                    return ColorValue(0xDBEBC7)
-                case .tint60:
-                    return ColorValue(0xF6FAF0)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x498205)
+            case .shade10:
+                return ColorValue(0x427505)
+            case .shade20:
+                return ColorValue(0x376304)
+            case .shade30:
+                return ColorValue(0x294903)
+            case .shade40:
+                return ColorValue(0x162702)
+            case .shade50:
+                return ColorValue(0x0C1501)
+            case .tint10:
+                return ColorValue(0x599116)
+            case .tint20:
+                return ColorValue(0x6BA02B)
+            case .tint30:
+                return ColorValue(0x85B44C)
+            case .tint40:
+                return ColorValue(0xBDD99B)
+            case .tint50:
+                return ColorValue(0xDBEBC7)
+            case .tint60:
+                return ColorValue(0xF6FAF0)
             }
         case .gold:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xC19C00)
-                case .shade10:
-                    return ColorValue(0xAE8C00)
-                case .shade20:
-                    return ColorValue(0x937700)
-                case .shade30:
-                    return ColorValue(0x6C5700)
-                case .shade40:
-                    return ColorValue(0x3A2F00)
-                case .shade50:
-                    return ColorValue(0x1F1900)
-                case .tint10:
-                    return ColorValue(0xC8A718)
-                case .tint20:
-                    return ColorValue(0xD0B232)
-                case .tint30:
-                    return ColorValue(0xDAC157)
-                case .tint40:
-                    return ColorValue(0xECDFA5)
-                case .tint50:
-                    return ColorValue(0xF5EECE)
-                case .tint60:
-                    return ColorValue(0xFDFBF2)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xC19C00)
+            case .shade10:
+                return ColorValue(0xAE8C00)
+            case .shade20:
+                return ColorValue(0x937700)
+            case .shade30:
+                return ColorValue(0x6C5700)
+            case .shade40:
+                return ColorValue(0x3A2F00)
+            case .shade50:
+                return ColorValue(0x1F1900)
+            case .tint10:
+                return ColorValue(0xC8A718)
+            case .tint20:
+                return ColorValue(0xD0B232)
+            case .tint30:
+                return ColorValue(0xDAC157)
+            case .tint40:
+                return ColorValue(0xECDFA5)
+            case .tint50:
+                return ColorValue(0xF5EECE)
+            case .tint60:
+                return ColorValue(0xFDFBF2)
             }
         case .grape:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x881798)
-                case .shade10:
-                    return ColorValue(0x7A1589)
-                case .shade20:
-                    return ColorValue(0x671174)
-                case .shade30:
-                    return ColorValue(0x4C0D55)
-                case .shade40:
-                    return ColorValue(0x29072E)
-                case .shade50:
-                    return ColorValue(0x160418)
-                case .tint10:
-                    return ColorValue(0x952AA4)
-                case .tint20:
-                    return ColorValue(0xA33FB1)
-                case .tint30:
-                    return ColorValue(0xB55FC1)
-                case .tint40:
-                    return ColorValue(0xD9A7E0)
-                case .tint50:
-                    return ColorValue(0xEACEEF)
-                case .tint60:
-                    return ColorValue(0xFAF2FB)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x881798)
+            case .shade10:
+                return ColorValue(0x7A1589)
+            case .shade20:
+                return ColorValue(0x671174)
+            case .shade30:
+                return ColorValue(0x4C0D55)
+            case .shade40:
+                return ColorValue(0x29072E)
+            case .shade50:
+                return ColorValue(0x160418)
+            case .tint10:
+                return ColorValue(0x952AA4)
+            case .tint20:
+                return ColorValue(0xA33FB1)
+            case .tint30:
+                return ColorValue(0xB55FC1)
+            case .tint40:
+                return ColorValue(0xD9A7E0)
+            case .tint50:
+                return ColorValue(0xEACEEF)
+            case .tint60:
+                return ColorValue(0xFAF2FB)
             }
         case .green:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x107C10)
-                case .shade10:
-                    return ColorValue(0x0E700E)
-                case .shade20:
-                    return ColorValue(0x0C5E0C)
-                case .shade30:
-                    return ColorValue(0x094509)
-                case .shade40:
-                    return ColorValue(0x052505)
-                case .shade50:
-                    return ColorValue(0x031403)
-                case .tint10:
-                    return ColorValue(0x218C21)
-                case .tint20:
-                    return ColorValue(0x359B35)
-                case .tint30:
-                    return ColorValue(0x54B054)
-                case .tint40:
-                    return ColorValue(0x9FD89F)
-                case .tint50:
-                    return ColorValue(0xC9EAC9)
-                case .tint60:
-                    return ColorValue(0xF1FAF1)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x107C10)
+            case .shade10:
+                return ColorValue(0x0E700E)
+            case .shade20:
+                return ColorValue(0x0C5E0C)
+            case .shade30:
+                return ColorValue(0x094509)
+            case .shade40:
+                return ColorValue(0x052505)
+            case .shade50:
+                return ColorValue(0x031403)
+            case .tint10:
+                return ColorValue(0x218C21)
+            case .tint20:
+                return ColorValue(0x359B35)
+            case .tint30:
+                return ColorValue(0x54B054)
+            case .tint40:
+                return ColorValue(0x9FD89F)
+            case .tint50:
+                return ColorValue(0xC9EAC9)
+            case .tint60:
+                return ColorValue(0xF1FAF1)
             }
         case .hotPink:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xE3008C)
-                case .shade10:
-                    return ColorValue(0xCC007E)
-                case .shade20:
-                    return ColorValue(0xAD006A)
-                case .shade30:
-                    return ColorValue(0x7F004E)
-                case .shade40:
-                    return ColorValue(0x44002A)
-                case .shade50:
-                    return ColorValue(0x240016)
-                case .tint10:
-                    return ColorValue(0xE61C99)
-                case .tint20:
-                    return ColorValue(0xEA38A6)
-                case .tint30:
-                    return ColorValue(0xEE5FB7)
-                case .tint40:
-                    return ColorValue(0xF7ADDA)
-                case .tint50:
-                    return ColorValue(0xFBD2EB)
-                case .tint60:
-                    return ColorValue(0xFEF4FA)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xE3008C)
+            case .shade10:
+                return ColorValue(0xCC007E)
+            case .shade20:
+                return ColorValue(0xAD006A)
+            case .shade30:
+                return ColorValue(0x7F004E)
+            case .shade40:
+                return ColorValue(0x44002A)
+            case .shade50:
+                return ColorValue(0x240016)
+            case .tint10:
+                return ColorValue(0xE61C99)
+            case .tint20:
+                return ColorValue(0xEA38A6)
+            case .tint30:
+                return ColorValue(0xEE5FB7)
+            case .tint40:
+                return ColorValue(0xF7ADDA)
+            case .tint50:
+                return ColorValue(0xFBD2EB)
+            case .tint60:
+                return ColorValue(0xFEF4FA)
             }
         case .lavender:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x7160E8)
-                case .shade10:
-                    return ColorValue(0x6656D1)
-                case .shade20:
-                    return ColorValue(0x5649B0)
-                case .shade30:
-                    return ColorValue(0x3F3682)
-                case .shade40:
-                    return ColorValue(0x221D46)
-                case .shade50:
-                    return ColorValue(0x120F25)
-                case .tint10:
-                    return ColorValue(0x8172EB)
-                case .tint20:
-                    return ColorValue(0x9184EE)
-                case .tint30:
-                    return ColorValue(0xA79CF1)
-                case .tint40:
-                    return ColorValue(0xD2CCF8)
-                case .tint50:
-                    return ColorValue(0xE7E4FB)
-                case .tint60:
-                    return ColorValue(0xF9F8FE)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x7160E8)
+            case .shade10:
+                return ColorValue(0x6656D1)
+            case .shade20:
+                return ColorValue(0x5649B0)
+            case .shade30:
+                return ColorValue(0x3F3682)
+            case .shade40:
+                return ColorValue(0x221D46)
+            case .shade50:
+                return ColorValue(0x120F25)
+            case .tint10:
+                return ColorValue(0x8172EB)
+            case .tint20:
+                return ColorValue(0x9184EE)
+            case .tint30:
+                return ColorValue(0xA79CF1)
+            case .tint40:
+                return ColorValue(0xD2CCF8)
+            case .tint50:
+                return ColorValue(0xE7E4FB)
+            case .tint60:
+                return ColorValue(0xF9F8FE)
             }
         case .lightBlue:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x3A96DD)
-                case .shade10:
-                    return ColorValue(0x3487C7)
-                case .shade20:
-                    return ColorValue(0x2C72A8)
-                case .shade30:
-                    return ColorValue(0x20547C)
-                case .shade40:
-                    return ColorValue(0x112D42)
-                case .shade50:
-                    return ColorValue(0x091823)
-                case .tint10:
-                    return ColorValue(0x4FA1E1)
-                case .tint20:
-                    return ColorValue(0x65ADE5)
-                case .tint30:
-                    return ColorValue(0x83BDEB)
-                case .tint40:
-                    return ColorValue(0xBFDDF5)
-                case .tint50:
-                    return ColorValue(0xDCEDFA)
-                case .tint60:
-                    return ColorValue(0xF6FAFE)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x3A96DD)
+            case .shade10:
+                return ColorValue(0x3487C7)
+            case .shade20:
+                return ColorValue(0x2C72A8)
+            case .shade30:
+                return ColorValue(0x20547C)
+            case .shade40:
+                return ColorValue(0x112D42)
+            case .shade50:
+                return ColorValue(0x091823)
+            case .tint10:
+                return ColorValue(0x4FA1E1)
+            case .tint20:
+                return ColorValue(0x65ADE5)
+            case .tint30:
+                return ColorValue(0x83BDEB)
+            case .tint40:
+                return ColorValue(0xBFDDF5)
+            case .tint50:
+                return ColorValue(0xDCEDFA)
+            case .tint60:
+                return ColorValue(0xF6FAFE)
             }
         case .lightGreen:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x13A10E)
-                case .shade10:
-                    return ColorValue(0x11910D)
-                case .shade20:
-                    return ColorValue(0x0E7A0B)
-                case .shade30:
-                    return ColorValue(0x0B5A08)
-                case .shade40:
-                    return ColorValue(0x063004)
-                case .shade50:
-                    return ColorValue(0x031A02)
-                case .tint10:
-                    return ColorValue(0x27AC22)
-                case .tint20:
-                    return ColorValue(0x3DB838)
-                case .tint30:
-                    return ColorValue(0x5EC75A)
-                case .tint40:
-                    return ColorValue(0xA7E3A5)
-                case .tint50:
-                    return ColorValue(0xCEF0CD)
-                case .tint60:
-                    return ColorValue(0xF2FBF2)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x13A10E)
+            case .shade10:
+                return ColorValue(0x11910D)
+            case .shade20:
+                return ColorValue(0x0E7A0B)
+            case .shade30:
+                return ColorValue(0x0B5A08)
+            case .shade40:
+                return ColorValue(0x063004)
+            case .shade50:
+                return ColorValue(0x031A02)
+            case .tint10:
+                return ColorValue(0x27AC22)
+            case .tint20:
+                return ColorValue(0x3DB838)
+            case .tint30:
+                return ColorValue(0x5EC75A)
+            case .tint40:
+                return ColorValue(0xA7E3A5)
+            case .tint50:
+                return ColorValue(0xCEF0CD)
+            case .tint60:
+                return ColorValue(0xF2FBF2)
             }
         case .lightTeal:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x00B7C3)
-                case .shade10:
-                    return ColorValue(0x00A5AF)
-                case .shade20:
-                    return ColorValue(0x008B94)
-                case .shade30:
-                    return ColorValue(0x00666D)
-                case .shade40:
-                    return ColorValue(0x00373A)
-                case .shade50:
-                    return ColorValue(0x001D1F)
-                case .tint10:
-                    return ColorValue(0x18BFCA)
-                case .tint20:
-                    return ColorValue(0x32C8D1)
-                case .tint30:
-                    return ColorValue(0x58D3DB)
-                case .tint40:
-                    return ColorValue(0xA6E9ED)
-                case .tint50:
-                    return ColorValue(0xCEF3F5)
-                case .tint60:
-                    return ColorValue(0xF2FCFD)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x00B7C3)
+            case .shade10:
+                return ColorValue(0x00A5AF)
+            case .shade20:
+                return ColorValue(0x008B94)
+            case .shade30:
+                return ColorValue(0x00666D)
+            case .shade40:
+                return ColorValue(0x00373A)
+            case .shade50:
+                return ColorValue(0x001D1F)
+            case .tint10:
+                return ColorValue(0x18BFCA)
+            case .tint20:
+                return ColorValue(0x32C8D1)
+            case .tint30:
+                return ColorValue(0x58D3DB)
+            case .tint40:
+                return ColorValue(0xA6E9ED)
+            case .tint50:
+                return ColorValue(0xCEF3F5)
+            case .tint60:
+                return ColorValue(0xF2FCFD)
             }
         case .lilac:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xB146C2)
-                case .shade10:
-                    return ColorValue(0x9F3FAF)
-                case .shade20:
-                    return ColorValue(0x863593)
-                case .shade30:
-                    return ColorValue(0x63276D)
-                case .shade40:
-                    return ColorValue(0x35153A)
-                case .shade50:
-                    return ColorValue(0x1C0B1F)
-                case .tint10:
-                    return ColorValue(0xBA58C9)
-                case .tint20:
-                    return ColorValue(0xC36BD1)
-                case .tint30:
-                    return ColorValue(0xCF87DA)
-                case .tint40:
-                    return ColorValue(0xE6BFED)
-                case .tint50:
-                    return ColorValue(0xF2DCF5)
-                case .tint60:
-                    return ColorValue(0xFCF6FD)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xB146C2)
+            case .shade10:
+                return ColorValue(0x9F3FAF)
+            case .shade20:
+                return ColorValue(0x863593)
+            case .shade30:
+                return ColorValue(0x63276D)
+            case .shade40:
+                return ColorValue(0x35153A)
+            case .shade50:
+                return ColorValue(0x1C0B1F)
+            case .tint10:
+                return ColorValue(0xBA58C9)
+            case .tint20:
+                return ColorValue(0xC36BD1)
+            case .tint30:
+                return ColorValue(0xCF87DA)
+            case .tint40:
+                return ColorValue(0xE6BFED)
+            case .tint50:
+                return ColorValue(0xF2DCF5)
+            case .tint60:
+                return ColorValue(0xFCF6FD)
             }
         case .lime:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x73AA24)
-                case .shade10:
-                    return ColorValue(0x689920)
-                case .shade20:
-                    return ColorValue(0x57811B)
-                case .shade30:
-                    return ColorValue(0x405F14)
-                case .shade40:
-                    return ColorValue(0x23330B)
-                case .shade50:
-                    return ColorValue(0x121B06)
-                case .tint10:
-                    return ColorValue(0x81B437)
-                case .tint20:
-                    return ColorValue(0x90BE4C)
-                case .tint30:
-                    return ColorValue(0xA4CC6C)
-                case .tint40:
-                    return ColorValue(0xCFE5AF)
-                case .tint50:
-                    return ColorValue(0xE5F1D3)
-                case .tint60:
-                    return ColorValue(0xF8FCF4)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x73AA24)
+            case .shade10:
+                return ColorValue(0x689920)
+            case .shade20:
+                return ColorValue(0x57811B)
+            case .shade30:
+                return ColorValue(0x405F14)
+            case .shade40:
+                return ColorValue(0x23330B)
+            case .shade50:
+                return ColorValue(0x121B06)
+            case .tint10:
+                return ColorValue(0x81B437)
+            case .tint20:
+                return ColorValue(0x90BE4C)
+            case .tint30:
+                return ColorValue(0xA4CC6C)
+            case .tint40:
+                return ColorValue(0xCFE5AF)
+            case .tint50:
+                return ColorValue(0xE5F1D3)
+            case .tint60:
+                return ColorValue(0xF8FCF4)
             }
         case .magenta:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xBF0077)
-                case .shade10:
-                    return ColorValue(0xAC006B)
-                case .shade20:
-                    return ColorValue(0x91005A)
-                case .shade30:
-                    return ColorValue(0x6B0043)
-                case .shade40:
-                    return ColorValue(0x390024)
-                case .shade50:
-                    return ColorValue(0x1F0013)
-                case .tint10:
-                    return ColorValue(0xC71885)
-                case .tint20:
-                    return ColorValue(0xCE3293)
-                case .tint30:
-                    return ColorValue(0xD957A8)
-                case .tint40:
-                    return ColorValue(0xECA5D1)
-                case .tint50:
-                    return ColorValue(0xF5CEE6)
-                case .tint60:
-                    return ColorValue(0xFCF2F9)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xBF0077)
+            case .shade10:
+                return ColorValue(0xAC006B)
+            case .shade20:
+                return ColorValue(0x91005A)
+            case .shade30:
+                return ColorValue(0x6B0043)
+            case .shade40:
+                return ColorValue(0x390024)
+            case .shade50:
+                return ColorValue(0x1F0013)
+            case .tint10:
+                return ColorValue(0xC71885)
+            case .tint20:
+                return ColorValue(0xCE3293)
+            case .tint30:
+                return ColorValue(0xD957A8)
+            case .tint40:
+                return ColorValue(0xECA5D1)
+            case .tint50:
+                return ColorValue(0xF5CEE6)
+            case .tint60:
+                return ColorValue(0xFCF2F9)
             }
         case .marigold:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xEAA300)
-                case .shade10:
-                    return ColorValue(0xD39300)
-                case .shade20:
-                    return ColorValue(0xB27C00)
-                case .shade30:
-                    return ColorValue(0x835B00)
-                case .shade40:
-                    return ColorValue(0x463100)
-                case .shade50:
-                    return ColorValue(0x251A00)
-                case .tint10:
-                    return ColorValue(0xEDAD1C)
-                case .tint20:
-                    return ColorValue(0xEFB839)
-                case .tint30:
-                    return ColorValue(0xF2C661)
-                case .tint40:
-                    return ColorValue(0xF9E2AE)
-                case .tint50:
-                    return ColorValue(0xFCEFD3)
-                case .tint60:
-                    return ColorValue(0xFEFBF4)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xEAA300)
+            case .shade10:
+                return ColorValue(0xD39300)
+            case .shade20:
+                return ColorValue(0xB27C00)
+            case .shade30:
+                return ColorValue(0x835B00)
+            case .shade40:
+                return ColorValue(0x463100)
+            case .shade50:
+                return ColorValue(0x251A00)
+            case .tint10:
+                return ColorValue(0xEDAD1C)
+            case .tint20:
+                return ColorValue(0xEFB839)
+            case .tint30:
+                return ColorValue(0xF2C661)
+            case .tint40:
+                return ColorValue(0xF9E2AE)
+            case .tint50:
+                return ColorValue(0xFCEFD3)
+            case .tint60:
+                return ColorValue(0xFEFBF4)
             }
         case .mink:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x5D5A58)
-                case .shade10:
-                    return ColorValue(0x54514F)
-                case .shade20:
-                    return ColorValue(0x474443)
-                case .shade30:
-                    return ColorValue(0x343231)
-                case .shade40:
-                    return ColorValue(0x1C1B1A)
-                case .shade50:
-                    return ColorValue(0x0F0E0E)
-                case .tint10:
-                    return ColorValue(0x706D6B)
-                case .tint20:
-                    return ColorValue(0x84817E)
-                case .tint30:
-                    return ColorValue(0x9E9B99)
-                case .tint40:
-                    return ColorValue(0xCECCCB)
-                case .tint50:
-                    return ColorValue(0xE5E4E3)
-                case .tint60:
-                    return ColorValue(0xF8F8F8)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x5D5A58)
+            case .shade10:
+                return ColorValue(0x54514F)
+            case .shade20:
+                return ColorValue(0x474443)
+            case .shade30:
+                return ColorValue(0x343231)
+            case .shade40:
+                return ColorValue(0x1C1B1A)
+            case .shade50:
+                return ColorValue(0x0F0E0E)
+            case .tint10:
+                return ColorValue(0x706D6B)
+            case .tint20:
+                return ColorValue(0x84817E)
+            case .tint30:
+                return ColorValue(0x9E9B99)
+            case .tint40:
+                return ColorValue(0xCECCCB)
+            case .tint50:
+                return ColorValue(0xE5E4E3)
+            case .tint60:
+                return ColorValue(0xF8F8F8)
             }
         case .navy:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x0027B4)
-                case .shade10:
-                    return ColorValue(0x0023A2)
-                case .shade20:
-                    return ColorValue(0x001E89)
-                case .shade30:
-                    return ColorValue(0x001665)
-                case .shade40:
-                    return ColorValue(0x000C36)
-                case .shade50:
-                    return ColorValue(0x00061D)
-                case .tint10:
-                    return ColorValue(0x173BBD)
-                case .tint20:
-                    return ColorValue(0x3050C6)
-                case .tint30:
-                    return ColorValue(0x546FD2)
-                case .tint40:
-                    return ColorValue(0xA3B2E8)
-                case .tint50:
-                    return ColorValue(0xCCD5F3)
-                case .tint60:
-                    return ColorValue(0xF2F4FC)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x0027B4)
+            case .shade10:
+                return ColorValue(0x0023A2)
+            case .shade20:
+                return ColorValue(0x001E89)
+            case .shade30:
+                return ColorValue(0x001665)
+            case .shade40:
+                return ColorValue(0x000C36)
+            case .shade50:
+                return ColorValue(0x00061D)
+            case .tint10:
+                return ColorValue(0x173BBD)
+            case .tint20:
+                return ColorValue(0x3050C6)
+            case .tint30:
+                return ColorValue(0x546FD2)
+            case .tint40:
+                return ColorValue(0xA3B2E8)
+            case .tint50:
+                return ColorValue(0xCCD5F3)
+            case .tint60:
+                return ColorValue(0xF2F4FC)
             }
         case .orange:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xF7630C)
-                case .shade10:
-                    return ColorValue(0xDE590B)
-                case .shade20:
-                    return ColorValue(0xBC4B09)
-                case .shade30:
-                    return ColorValue(0x8A3707)
-                case .shade40:
-                    return ColorValue(0x4A1E04)
-                case .shade50:
-                    return ColorValue(0x271002)
-                case .tint10:
-                    return ColorValue(0xF87528)
-                case .tint20:
-                    return ColorValue(0xF98845)
-                case .tint30:
-                    return ColorValue(0xFAA06B)
-                case .tint40:
-                    return ColorValue(0xFDCFB4)
-                case .tint50:
-                    return ColorValue(0xFEE5D7)
-                case .tint60:
-                    return ColorValue(0xFFF9F5)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xF7630C)
+            case .shade10:
+                return ColorValue(0xDE590B)
+            case .shade20:
+                return ColorValue(0xBC4B09)
+            case .shade30:
+                return ColorValue(0x8A3707)
+            case .shade40:
+                return ColorValue(0x4A1E04)
+            case .shade50:
+                return ColorValue(0x271002)
+            case .tint10:
+                return ColorValue(0xF87528)
+            case .tint20:
+                return ColorValue(0xF98845)
+            case .tint30:
+                return ColorValue(0xFAA06B)
+            case .tint40:
+                return ColorValue(0xFDCFB4)
+            case .tint50:
+                return ColorValue(0xFEE5D7)
+            case .tint60:
+                return ColorValue(0xFFF9F5)
             }
         case .orchid:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x8764B8)
-                case .shade10:
-                    return ColorValue(0x795AA6)
-                case .shade20:
-                    return ColorValue(0x674C8C)
-                case .shade30:
-                    return ColorValue(0x4C3867)
-                case .shade40:
-                    return ColorValue(0x281E37)
-                case .shade50:
-                    return ColorValue(0x16101D)
-                case .tint10:
-                    return ColorValue(0x9373C0)
-                case .tint20:
-                    return ColorValue(0xA083C9)
-                case .tint30:
-                    return ColorValue(0xB29AD4)
-                case .tint40:
-                    return ColorValue(0xD7CAEA)
-                case .tint50:
-                    return ColorValue(0xE9E2F4)
-                case .tint60:
-                    return ColorValue(0xF9F8FC)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x8764B8)
+            case .shade10:
+                return ColorValue(0x795AA6)
+            case .shade20:
+                return ColorValue(0x674C8C)
+            case .shade30:
+                return ColorValue(0x4C3867)
+            case .shade40:
+                return ColorValue(0x281E37)
+            case .shade50:
+                return ColorValue(0x16101D)
+            case .tint10:
+                return ColorValue(0x9373C0)
+            case .tint20:
+                return ColorValue(0xA083C9)
+            case .tint30:
+                return ColorValue(0xB29AD4)
+            case .tint40:
+                return ColorValue(0xD7CAEA)
+            case .tint50:
+                return ColorValue(0xE9E2F4)
+            case .tint60:
+                return ColorValue(0xF9F8FC)
             }
         case .peach:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xFF8C00)
-                case .shade10:
-                    return ColorValue(0xE67E00)
-                case .shade20:
-                    return ColorValue(0xC26A00)
-                case .shade30:
-                    return ColorValue(0x8F4E00)
-                case .shade40:
-                    return ColorValue(0x4D2A00)
-                case .shade50:
-                    return ColorValue(0x291600)
-                case .tint10:
-                    return ColorValue(0xFF9A1F)
-                case .tint20:
-                    return ColorValue(0xFFA83D)
-                case .tint30:
-                    return ColorValue(0xFFBA66)
-                case .tint40:
-                    return ColorValue(0xFFDDB3)
-                case .tint50:
-                    return ColorValue(0xFFEDD6)
-                case .tint60:
-                    return ColorValue(0xFFFAF5)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xFF8C00)
+            case .shade10:
+                return ColorValue(0xE67E00)
+            case .shade20:
+                return ColorValue(0xC26A00)
+            case .shade30:
+                return ColorValue(0x8F4E00)
+            case .shade40:
+                return ColorValue(0x4D2A00)
+            case .shade50:
+                return ColorValue(0x291600)
+            case .tint10:
+                return ColorValue(0xFF9A1F)
+            case .tint20:
+                return ColorValue(0xFFA83D)
+            case .tint30:
+                return ColorValue(0xFFBA66)
+            case .tint40:
+                return ColorValue(0xFFDDB3)
+            case .tint50:
+                return ColorValue(0xFFEDD6)
+            case .tint60:
+                return ColorValue(0xFFFAF5)
             }
         case .pink:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xE43BA6)
-                case .shade10:
-                    return ColorValue(0xCD3595)
-                case .shade20:
-                    return ColorValue(0xAD2D7E)
-                case .shade30:
-                    return ColorValue(0x80215D)
-                case .shade40:
-                    return ColorValue(0x441232)
-                case .shade50:
-                    return ColorValue(0x24091B)
-                case .tint10:
-                    return ColorValue(0xE750B0)
-                case .tint20:
-                    return ColorValue(0xEA66BA)
-                case .tint30:
-                    return ColorValue(0xEF85C8)
-                case .tint40:
-                    return ColorValue(0xF7C0E3)
-                case .tint50:
-                    return ColorValue(0xFBDDF0)
-                case .tint60:
-                    return ColorValue(0xFEF6FB)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xE43BA6)
+            case .shade10:
+                return ColorValue(0xCD3595)
+            case .shade20:
+                return ColorValue(0xAD2D7E)
+            case .shade30:
+                return ColorValue(0x80215D)
+            case .shade40:
+                return ColorValue(0x441232)
+            case .shade50:
+                return ColorValue(0x24091B)
+            case .tint10:
+                return ColorValue(0xE750B0)
+            case .tint20:
+                return ColorValue(0xEA66BA)
+            case .tint30:
+                return ColorValue(0xEF85C8)
+            case .tint40:
+                return ColorValue(0xF7C0E3)
+            case .tint50:
+                return ColorValue(0xFBDDF0)
+            case .tint60:
+                return ColorValue(0xFEF6FB)
             }
         case .platinum:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x69797E)
-                case .shade10:
-                    return ColorValue(0x5F6D71)
-                case .shade20:
-                    return ColorValue(0x505C60)
-                case .shade30:
-                    return ColorValue(0x3B4447)
-                case .shade40:
-                    return ColorValue(0x1F2426)
-                case .shade50:
-                    return ColorValue(0x111314)
-                case .tint10:
-                    return ColorValue(0x79898D)
-                case .tint20:
-                    return ColorValue(0x89989D)
-                case .tint30:
-                    return ColorValue(0xA0ADB2)
-                case .tint40:
-                    return ColorValue(0xCDD6D8)
-                case .tint50:
-                    return ColorValue(0xE4E9EA)
-                case .tint60:
-                    return ColorValue(0xF8F9FA)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x69797E)
+            case .shade10:
+                return ColorValue(0x5F6D71)
+            case .shade20:
+                return ColorValue(0x505C60)
+            case .shade30:
+                return ColorValue(0x3B4447)
+            case .shade40:
+                return ColorValue(0x1F2426)
+            case .shade50:
+                return ColorValue(0x111314)
+            case .tint10:
+                return ColorValue(0x79898D)
+            case .tint20:
+                return ColorValue(0x89989D)
+            case .tint30:
+                return ColorValue(0xA0ADB2)
+            case .tint40:
+                return ColorValue(0xCDD6D8)
+            case .tint50:
+                return ColorValue(0xE4E9EA)
+            case .tint60:
+                return ColorValue(0xF8F9FA)
             }
         case .plum:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x77004D)
-                case .shade10:
-                    return ColorValue(0x6B0045)
-                case .shade20:
-                    return ColorValue(0x5A003B)
-                case .shade30:
-                    return ColorValue(0x43002B)
-                case .shade40:
-                    return ColorValue(0x240017)
-                case .shade50:
-                    return ColorValue(0x13000C)
-                case .tint10:
-                    return ColorValue(0x87105D)
-                case .tint20:
-                    return ColorValue(0x98246F)
-                case .tint30:
-                    return ColorValue(0xAD4589)
-                case .tint40:
-                    return ColorValue(0xD696C0)
-                case .tint50:
-                    return ColorValue(0xE9C4DC)
-                case .tint60:
-                    return ColorValue(0xFAF0F6)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x77004D)
+            case .shade10:
+                return ColorValue(0x6B0045)
+            case .shade20:
+                return ColorValue(0x5A003B)
+            case .shade30:
+                return ColorValue(0x43002B)
+            case .shade40:
+                return ColorValue(0x240017)
+            case .shade50:
+                return ColorValue(0x13000C)
+            case .tint10:
+                return ColorValue(0x87105D)
+            case .tint20:
+                return ColorValue(0x98246F)
+            case .tint30:
+                return ColorValue(0xAD4589)
+            case .tint40:
+                return ColorValue(0xD696C0)
+            case .tint50:
+                return ColorValue(0xE9C4DC)
+            case .tint60:
+                return ColorValue(0xFAF0F6)
             }
         case .pumpkin:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xCA5010)
-                case .shade10:
-                    return ColorValue(0xB6480E)
-                case .shade20:
-                    return ColorValue(0x9A3D0C)
-                case .shade30:
-                    return ColorValue(0x712D09)
-                case .shade40:
-                    return ColorValue(0x3D1805)
-                case .shade50:
-                    return ColorValue(0x200D03)
-                case .tint10:
-                    return ColorValue(0xD06228)
-                case .tint20:
-                    return ColorValue(0xD77440)
-                case .tint30:
-                    return ColorValue(0xDF8E64)
-                case .tint40:
-                    return ColorValue(0xEFC4AD)
-                case .tint50:
-                    return ColorValue(0xF7DFD2)
-                case .tint60:
-                    return ColorValue(0xFDF7F4)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xCA5010)
+            case .shade10:
+                return ColorValue(0xB6480E)
+            case .shade20:
+                return ColorValue(0x9A3D0C)
+            case .shade30:
+                return ColorValue(0x712D09)
+            case .shade40:
+                return ColorValue(0x3D1805)
+            case .shade50:
+                return ColorValue(0x200D03)
+            case .tint10:
+                return ColorValue(0xD06228)
+            case .tint20:
+                return ColorValue(0xD77440)
+            case .tint30:
+                return ColorValue(0xDF8E64)
+            case .tint40:
+                return ColorValue(0xEFC4AD)
+            case .tint50:
+                return ColorValue(0xF7DFD2)
+            case .tint60:
+                return ColorValue(0xFDF7F4)
             }
         case .purple:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x5C2E91)
-                case .shade10:
-                    return ColorValue(0x532982)
-                case .shade20:
-                    return ColorValue(0x46236E)
-                case .shade30:
-                    return ColorValue(0x341A51)
-                case .shade40:
-                    return ColorValue(0x1C0E2B)
-                case .shade50:
-                    return ColorValue(0x0F0717)
-                case .tint10:
-                    return ColorValue(0x6B3F9E)
-                case .tint20:
-                    return ColorValue(0x7C52AB)
-                case .tint30:
-                    return ColorValue(0x9470BD)
-                case .tint40:
-                    return ColorValue(0xC6B1DE)
-                case .tint50:
-                    return ColorValue(0xE0D3ED)
-                case .tint60:
-                    return ColorValue(0xF7F4FB)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x5C2E91)
+            case .shade10:
+                return ColorValue(0x532982)
+            case .shade20:
+                return ColorValue(0x46236E)
+            case .shade30:
+                return ColorValue(0x341A51)
+            case .shade40:
+                return ColorValue(0x1C0E2B)
+            case .shade50:
+                return ColorValue(0x0F0717)
+            case .tint10:
+                return ColorValue(0x6B3F9E)
+            case .tint20:
+                return ColorValue(0x7C52AB)
+            case .tint30:
+                return ColorValue(0x9470BD)
+            case .tint40:
+                return ColorValue(0xC6B1DE)
+            case .tint50:
+                return ColorValue(0xE0D3ED)
+            case .tint60:
+                return ColorValue(0xF7F4FB)
             }
         case .red:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xD13438)
-                case .shade10:
-                    return ColorValue(0xBC2F32)
-                case .shade20:
-                    return ColorValue(0x9F282B)
-                case .shade30:
-                    return ColorValue(0x751D1F)
-                case .shade40:
-                    return ColorValue(0x3F1011)
-                case .shade50:
-                    return ColorValue(0x210809)
-                case .tint10:
-                    return ColorValue(0xD7494C)
-                case .tint20:
-                    return ColorValue(0xDC5E62)
-                case .tint30:
-                    return ColorValue(0xE37D80)
-                case .tint40:
-                    return ColorValue(0xF1BBBC)
-                case .tint50:
-                    return ColorValue(0xF8DADB)
-                case .tint60:
-                    return ColorValue(0xFDF6F6)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xD13438)
+            case .shade10:
+                return ColorValue(0xBC2F32)
+            case .shade20:
+                return ColorValue(0x9F282B)
+            case .shade30:
+                return ColorValue(0x751D1F)
+            case .shade40:
+                return ColorValue(0x3F1011)
+            case .shade50:
+                return ColorValue(0x210809)
+            case .tint10:
+                return ColorValue(0xD7494C)
+            case .tint20:
+                return ColorValue(0xDC5E62)
+            case .tint30:
+                return ColorValue(0xE37D80)
+            case .tint40:
+                return ColorValue(0xF1BBBC)
+            case .tint50:
+                return ColorValue(0xF8DADB)
+            case .tint60:
+                return ColorValue(0xFDF6F6)
             }
         case .royalBlue:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x004E8C)
-                case .shade10:
-                    return ColorValue(0x00467E)
-                case .shade20:
-                    return ColorValue(0x003B6A)
-                case .shade30:
-                    return ColorValue(0x002C4E)
-                case .shade40:
-                    return ColorValue(0x00172A)
-                case .shade50:
-                    return ColorValue(0x000C16)
-                case .tint10:
-                    return ColorValue(0x125E9A)
-                case .tint20:
-                    return ColorValue(0x286FA8)
-                case .tint30:
-                    return ColorValue(0x4A89BA)
-                case .tint40:
-                    return ColorValue(0x9ABFDC)
-                case .tint50:
-                    return ColorValue(0xC7DCED)
-                case .tint60:
-                    return ColorValue(0xF0F6FA)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x004E8C)
+            case .shade10:
+                return ColorValue(0x00467E)
+            case .shade20:
+                return ColorValue(0x003B6A)
+            case .shade30:
+                return ColorValue(0x002C4E)
+            case .shade40:
+                return ColorValue(0x00172A)
+            case .shade50:
+                return ColorValue(0x000C16)
+            case .tint10:
+                return ColorValue(0x125E9A)
+            case .tint20:
+                return ColorValue(0x286FA8)
+            case .tint30:
+                return ColorValue(0x4A89BA)
+            case .tint40:
+                return ColorValue(0x9ABFDC)
+            case .tint50:
+                return ColorValue(0xC7DCED)
+            case .tint60:
+                return ColorValue(0xF0F6FA)
             }
         case .seafoam:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x00CC6A)
-                case .shade10:
-                    return ColorValue(0x00B85F)
-                case .shade20:
-                    return ColorValue(0x009B51)
-                case .shade30:
-                    return ColorValue(0x00723B)
-                case .shade40:
-                    return ColorValue(0x003D20)
-                case .shade50:
-                    return ColorValue(0x002111)
-                case .tint10:
-                    return ColorValue(0x19D279)
-                case .tint20:
-                    return ColorValue(0x34D889)
-                case .tint30:
-                    return ColorValue(0x5AE0A0)
-                case .tint40:
-                    return ColorValue(0xA8F0CD)
-                case .tint50:
-                    return ColorValue(0xCFF7E4)
-                case .tint60:
-                    return ColorValue(0xF3FDF8)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x00CC6A)
+            case .shade10:
+                return ColorValue(0x00B85F)
+            case .shade20:
+                return ColorValue(0x009B51)
+            case .shade30:
+                return ColorValue(0x00723B)
+            case .shade40:
+                return ColorValue(0x003D20)
+            case .shade50:
+                return ColorValue(0x002111)
+            case .tint10:
+                return ColorValue(0x19D279)
+            case .tint20:
+                return ColorValue(0x34D889)
+            case .tint30:
+                return ColorValue(0x5AE0A0)
+            case .tint40:
+                return ColorValue(0xA8F0CD)
+            case .tint50:
+                return ColorValue(0xCFF7E4)
+            case .tint60:
+                return ColorValue(0xF3FDF8)
             }
         case .silver:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x859599)
-                case .shade10:
-                    return ColorValue(0x78868A)
-                case .shade20:
-                    return ColorValue(0x657174)
-                case .shade30:
-                    return ColorValue(0x4A5356)
-                case .shade40:
-                    return ColorValue(0x282D2E)
-                case .shade50:
-                    return ColorValue(0x151818)
-                case .tint10:
-                    return ColorValue(0x92A1A5)
-                case .tint20:
-                    return ColorValue(0xA0AEB1)
-                case .tint30:
-                    return ColorValue(0xB3BFC2)
-                case .tint40:
-                    return ColorValue(0xD8DFE0)
-                case .tint50:
-                    return ColorValue(0xEAEEEF)
-                case .tint60:
-                    return ColorValue(0xFAFBFB)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x859599)
+            case .shade10:
+                return ColorValue(0x78868A)
+            case .shade20:
+                return ColorValue(0x657174)
+            case .shade30:
+                return ColorValue(0x4A5356)
+            case .shade40:
+                return ColorValue(0x282D2E)
+            case .shade50:
+                return ColorValue(0x151818)
+            case .tint10:
+                return ColorValue(0x92A1A5)
+            case .tint20:
+                return ColorValue(0xA0AEB1)
+            case .tint30:
+                return ColorValue(0xB3BFC2)
+            case .tint40:
+                return ColorValue(0xD8DFE0)
+            case .tint50:
+                return ColorValue(0xEAEEEF)
+            case .tint60:
+                return ColorValue(0xFAFBFB)
             }
         case .steel:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x005B70)
-                case .shade10:
-                    return ColorValue(0x005265)
-                case .shade20:
-                    return ColorValue(0x004555)
-                case .shade30:
-                    return ColorValue(0x00333F)
-                case .shade40:
-                    return ColorValue(0x001B22)
-                case .shade50:
-                    return ColorValue(0x000F12)
-                case .tint10:
-                    return ColorValue(0x0F6C81)
-                case .tint20:
-                    return ColorValue(0x237D92)
-                case .tint30:
-                    return ColorValue(0x4496A9)
-                case .tint40:
-                    return ColorValue(0x94C8D4)
-                case .tint50:
-                    return ColorValue(0xC3E1E8)
-                case .tint60:
-                    return ColorValue(0xEFF7F9)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x005B70)
+            case .shade10:
+                return ColorValue(0x005265)
+            case .shade20:
+                return ColorValue(0x004555)
+            case .shade30:
+                return ColorValue(0x00333F)
+            case .shade40:
+                return ColorValue(0x001B22)
+            case .shade50:
+                return ColorValue(0x000F12)
+            case .tint10:
+                return ColorValue(0x0F6C81)
+            case .tint20:
+                return ColorValue(0x237D92)
+            case .tint30:
+                return ColorValue(0x4496A9)
+            case .tint40:
+                return ColorValue(0x94C8D4)
+            case .tint50:
+                return ColorValue(0xC3E1E8)
+            case .tint60:
+                return ColorValue(0xEFF7F9)
             }
         case .teal:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0x038387)
-                case .shade10:
-                    return ColorValue(0x037679)
-                case .shade20:
-                    return ColorValue(0x026467)
-                case .shade30:
-                    return ColorValue(0x02494C)
-                case .shade40:
-                    return ColorValue(0x012728)
-                case .shade50:
-                    return ColorValue(0x001516)
-                case .tint10:
-                    return ColorValue(0x159195)
-                case .tint20:
-                    return ColorValue(0x2AA0A4)
-                case .tint30:
-                    return ColorValue(0x4CB4B7)
-                case .tint40:
-                    return ColorValue(0x9BD9DB)
-                case .tint50:
-                    return ColorValue(0xC7EBEC)
-                case .tint60:
-                    return ColorValue(0xF0FAFA)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0x038387)
+            case .shade10:
+                return ColorValue(0x037679)
+            case .shade20:
+                return ColorValue(0x026467)
+            case .shade30:
+                return ColorValue(0x02494C)
+            case .shade40:
+                return ColorValue(0x012728)
+            case .shade50:
+                return ColorValue(0x001516)
+            case .tint10:
+                return ColorValue(0x159195)
+            case .tint20:
+                return ColorValue(0x2AA0A4)
+            case .tint30:
+                return ColorValue(0x4CB4B7)
+            case .tint40:
+                return ColorValue(0x9BD9DB)
+            case .tint50:
+                return ColorValue(0xC7EBEC)
+            case .tint60:
+                return ColorValue(0xF0FAFA)
             }
         case .yellow:
-            return TokenSet<SharedColorsTokens, ColorValue>.init { token in
-                switch token {
-                case .primary:
-                    return ColorValue(0xFDE300)
-                case .shade10:
-                    return ColorValue(0xE4CC00)
-                case .shade20:
-                    return ColorValue(0xC0AD00)
-                case .shade30:
-                    return ColorValue(0x8E7F00)
-                case .shade40:
-                    return ColorValue(0x4C4400)
-                case .shade50:
-                    return ColorValue(0x282400)
-                case .tint10:
-                    return ColorValue(0xFDE61E)
-                case .tint20:
-                    return ColorValue(0xFDEA3D)
-                case .tint30:
-                    return ColorValue(0xFEEE66)
-                case .tint40:
-                    return ColorValue(0xFEF7B2)
-                case .tint50:
-                    return ColorValue(0xFFFAD6)
-                case .tint60:
-                    return ColorValue(0xFFFEF5)
-                }
+            switch token {
+            case .primary:
+                return ColorValue(0xFDE300)
+            case .shade10:
+                return ColorValue(0xE4CC00)
+            case .shade20:
+                return ColorValue(0xC0AD00)
+            case .shade30:
+                return ColorValue(0x8E7F00)
+            case .shade40:
+                return ColorValue(0x4C4400)
+            case .shade50:
+                return ColorValue(0x282400)
+            case .tint10:
+                return ColorValue(0xFDE61E)
+            case .tint20:
+                return ColorValue(0xFDEA3D)
+            case .tint30:
+                return ColorValue(0xFEEE66)
+            case .tint40:
+                return ColorValue(0xFEF7B2)
+            case .tint50:
+                return ColorValue(0xFFFAD6)
+            case .tint60:
+                return ColorValue(0xFFFEF5)
             }
         }
     }
@@ -1711,7 +1613,7 @@ public final class GlobalTokens {
         case size800
         case size900
     }
-    lazy public var fontSize: TokenSet<FontSizeToken, CGFloat> = .init { token in
+    public static func fontSize(_ token: FontSizeToken) -> CGFloat {
         switch token {
         case .size100:
             return 12.0
@@ -1742,7 +1644,7 @@ public final class GlobalTokens {
         case semibold
         case bold
     }
-    lazy public var fontWeight: TokenSet<FontWeightToken, Font.Weight> = .init { token in
+    public static func fontWeight(_ token: FontWeightToken) -> Font.Weight {
         switch token {
         case .regular:
             return .regular
@@ -1768,7 +1670,7 @@ public final class GlobalTokens {
         case xxLarge
         case xxxLarge
     }
-    lazy public var iconSize: TokenSet<IconSizeToken, CGFloat> = .init { token in
+    public static func iconSize(_ token: IconSizeToken) -> CGFloat {
         switch token {
         case .xxxSmall:
             return 10
@@ -1806,7 +1708,7 @@ public final class GlobalTokens {
         case xxxLarge
         case xxxxLarge
     }
-    lazy public var spacing: TokenSet<SpacingToken, CGFloat> = .init { token in
+    public static func spacing(_ token: SpacingToken) -> CGFloat {
         switch token {
         case .none:
             return 0
@@ -1843,7 +1745,7 @@ public final class GlobalTokens {
         case xLarge
         case circle
     }
-    lazy public var borderRadius: TokenSet<BorderRadiusToken, CGFloat> = .init { token in
+    public static func borderRadius(_ token: BorderRadiusToken) -> CGFloat {
         switch token {
         case .none:
             return 0
@@ -1869,7 +1771,7 @@ public final class GlobalTokens {
         case thicker
         case thickest
     }
-    lazy public var borderSize: TokenSet<BorderSizeToken, CGFloat> = .init { token in
+    public static func borderSize(_ token: BorderSizeToken) -> CGFloat {
         switch token {
         case .none:
             return 0
@@ -1886,5 +1788,8 @@ public final class GlobalTokens {
 
     // MARK: Initialization
 
-    public init() {}
+    @available(*, unavailable)
+    private init() {
+        preconditionFailure("GlobalTokens should never be initialized!")
+    }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/GradientInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GradientInfo.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+/// Represents a gradient as used by FluentUI.
+@objc public class GradientInfo: NSObject {
+    /// Initializes a gradient to be used in Fluent.
+    ///
+    /// - Parameters:
+    ///   - colors: The array of colors to apply to this linear gradient.
+    ///   - locations: An optional array of values defining the location of each gradient stop. Must be in the range `[0, 1]`.
+    ///   - startPoint: The starting point for this gradient. Values should range from 0.0 to 1.0.
+    ///   - endPoint: The ending point for this gradient. Values should range from 0.0 to 1.0.
+    public init(colors: [DynamicColor],
+                locations: [CGFloat]? = nil,
+                startPoint: CGPoint,
+                endPoint: CGPoint) {
+        self.colors = colors
+        self.locations = locations
+        self.startPoint = startPoint
+        self.endPoint = endPoint
+    }
+
+    /// The array of colors to apply to this linear gradient.
+    public let colors: [DynamicColor]
+
+    /// An optional array of values defining the location of each gradient stop.
+    ///
+    /// Must be in the range `[0, 1]`.
+    public let locations: [CGFloat]?
+
+    /// The starting point for this gradient. Values should range from 0.0 to 1.0.
+    public let startPoint: CGPoint
+
+    /// The ending point for this gradient. Values should range from 0.0 to 1.0.
+    public let endPoint: CGPoint
+}
+
+// MARK: - Extensions
+
+extension LinearGradient {
+    /// Internal property to generate a SwiftUI `LinearGradient` from a gradient info.
+    init(gradientInfo: GradientInfo) {
+        if let locations = gradientInfo.locations {
+            // Map the colors and locations together.
+            let stops: [Gradient.Stop] = zip(gradientInfo.colors, locations).map({ (color, location) in
+                return Gradient.Stop(color: Color(dynamicColor: color),
+                                     location: location)
+            })
+            self.init(stops: stops,
+                      startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
+                      endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
+        } else {
+            self.init(colors: gradientInfo.colors.map({ Color(dynamicColor: $0) }),
+                      startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
+                      endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
+        }
+    }
+}

--- a/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
@@ -3,13 +3,11 @@
 //  Licensed under the MIT License.
 //
 
-import Combine
-
 /// Defines the key used for token value indexing.
 public typealias TokenSetKey = Hashable & CaseIterable
 
 /// Template for all token sets, both global and alias. This ensures a unified return type for any given token set.
-public class TokenSet<T: TokenSetKey, V>: ObservableObject {
+public final class TokenSet<T: TokenSetKey, V> {
 
     /// Allows us to index into this token set using square brackets.
     ///

--- a/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License.
 //
 
+import Combine
+
 /// Defines the key used for token value indexing.
 public typealias TokenSetKey = Hashable & CaseIterable
 

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -74,20 +74,20 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
             case .navigationBarBackground:
                 return .dynamicColor({
                     DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                 dark: theme.globalTokens.neutralColors[.grey14])
+                                 dark: GlobalTokens.neutralColors(.grey14))
                 })
 
             case .cornerRadius:
                 return .float({ 14 })
 
             case .minHorizontalMargin:
-                return .float({ theme.globalTokens.spacing[.xxxLarge] })
+                return .float({ GlobalTokens.spacing(.xxxLarge) })
 
             case .minVerticalMargin:
-                return .float({ theme.globalTokens.spacing[.large] })
+                return .float({ GlobalTokens.spacing(.large) })
 
             case .shadowOffset:
-                return .float({ theme.globalTokens.spacing[.xSmall] })
+                return .float({ GlobalTokens.spacing(.xSmall) })
             }
         }
     }

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokenSet.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokenSet.swift
@@ -29,7 +29,7 @@ public class IndeterminateProgressBarTokenSet: ControlTokenSet<IndeterminateProg
 
             case .gradientColor:
                 return .dynamicColor {
-                    theme.globalTokens.brandColors[.primary]
+                    theme.aliasTokens.brandColors[.primary]
                 }
 
             case .height:

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -50,6 +50,11 @@ import SwiftUI
 
     /// Defines whether the notification shows from the bottom of the presenting view or the top.
     var showFromBottom: Bool { get set }
+
+    /// An optional gradient to use as the background of the notification.
+    ///
+    /// If this property is nil, then this notification will use the background color defined by its design tokens.
+    var backgroundGradient: GradientInfo? { get set }
 }
 
 /// View that represents the Notification.
@@ -254,6 +259,21 @@ public struct FluentNotification: View, TokenizedControlView {
         }
 
         @ViewBuilder
+        var backgroundFill: some View {
+            if let backgroundGradient = state.backgroundGradient {
+                GeometryReader { g in
+                    // The gradient needs to be rendered square, then scaled to fit the containing view.
+                    // Otherwise SwiftUI will crop the gradient view, which is not what we want!
+                    LinearGradient(gradientInfo: backgroundGradient)
+                        .frame(width: g.size.width, height: g.size.width)
+                        .scaleEffect(x: 1.0, y: g.size.height / g.size.width, anchor: .top)
+                }
+            } else {
+                Color(dynamicColor: tokens.backgroundColor)
+            }
+        }
+
+        @ViewBuilder
         var notification: some View {
             let shadowInfo = tokenSet[.shadow].shadowInfo
             innerContents
@@ -261,8 +281,8 @@ public struct FluentNotification: View, TokenizedControlView {
                     RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
                         .strokeBorder(Color(dynamicColor: tokenSet[.outlineColor].dynamicColor), lineWidth: tokenSet[.outlineWidth].float)
                         .background(
-                            RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
-                                .fill(Color(dynamicColor: tokenSet[.backgroundColor].dynamicColor))
+                            backgroundFill
+                                .clipShape(RoundedRectangle(cornerRadius: tokens.cornerRadius))
                         )
                         .shadow(color: Color(dynamicColor: shadowInfo.colorOne),
                                 radius: shadowInfo.blurOne,
@@ -383,31 +403,32 @@ public struct FluentNotification: View, TokenizedControlView {
 }
 
 class MSFNotificationStateImpl: ControlState, MSFNotificationState {
-    @Published public var message: String?
-    @Published public var attributedMessage: NSAttributedString?
-    @Published public var title: String?
-    @Published public var attributedTitle: NSAttributedString?
-    @Published public var image: UIImage?
-    @Published public var trailingImage: UIImage?
-    @Published public var trailingImageAccessibilityLabel: String?
-    @Published public var showDefaultDismissActionButton: Bool
-    @Published public var showFromBottom: Bool = true
+    @Published var message: String?
+    @Published var attributedMessage: NSAttributedString?
+    @Published var title: String?
+    @Published var attributedTitle: NSAttributedString?
+    @Published var image: UIImage?
+    @Published var trailingImage: UIImage?
+    @Published var trailingImageAccessibilityLabel: String?
+    @Published var showDefaultDismissActionButton: Bool
+    @Published var showFromBottom: Bool = true
+    @Published var backgroundGradient: GradientInfo?
 
     /// Title to display in the action button on the trailing edge of the control.
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
-    @Published public var actionButtonTitle: String?
+    @Published var actionButtonTitle: String?
 
     /// Action to be dispatched by the action button on the trailing edge of the control.
     ///
     /// To show an action button, provide values for both `actionButtonTitle` and  `actionButtonAction`.
-    @Published public var actionButtonAction: (() -> Void)?
+    @Published var actionButtonAction: (() -> Void)?
 
     /// Action to be dispatched by tapping on the toast/bar notification.
-    @Published public var messageButtonAction: (() -> Void)?
+    @Published var messageButtonAction: (() -> Void)?
 
     /// Style to draw the control.
-    @Published public var style: MSFNotificationStyle
+    @Published var style: MSFNotificationStyle
 
     @objc convenience init(style: MSFNotificationStyle) {
         self.init(style: style,

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -269,7 +269,7 @@ public struct FluentNotification: View, TokenizedControlView {
                         .scaleEffect(x: 1.0, y: g.size.height / g.size.width, anchor: .top)
                 }
             } else {
-                Color(dynamicColor: tokens.backgroundColor)
+                Color(dynamicColor: tokenSet[.backgroundColor].dynamicColor)
             }
         }
 
@@ -282,7 +282,7 @@ public struct FluentNotification: View, TokenizedControlView {
                         .strokeBorder(Color(dynamicColor: tokenSet[.outlineColor].dynamicColor), lineWidth: tokenSet[.outlineWidth].float)
                         .background(
                             backgroundFill
-                                .clipShape(RoundedRectangle(cornerRadius: tokens.cornerRadius))
+                                .clipShape(RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
                         )
                         .shadow(color: Color(dynamicColor: shadowInfo.colorOne),
                                 radius: shadowInfo.blurOne,

--- a/ios/FluentUI/Notification/NotificationModifiers.swift
+++ b/ios/FluentUI/Notification/NotificationModifiers.swift
@@ -8,62 +8,24 @@ import SwiftUI
 public extension View {
     /// Presents a Notification on top of the modified View.
     /// - Parameters:
-    ///   - style: `MSFNotificationStyle` enum value that defines the style of the Notification being presented.
-    ///   - isFlexibleWidthToast: Whether the width of the toast is set based on the width of the screen or on its contents/
-    ///   - message: Optional text for the main title area of the control. If there is a title, the message becomes subtext.
-    ///   - attributedMessage: Optional attributed text for the main title area of the control. If there is a title, the message becomes subtext.
-    ///   - isBlocking: Whether the interaction with the view will be blocked while the Notification is being presented.
-    ///   - isPresented: Controls whether the Notification is being presented.
-    ///   - title: Optional text to draw above the message area.
-    ///   - attributedTitle: Optional attributed text to draw above the message area.
-    ///   - image: Optional icon to draw at the leading edge of the control.
-    ///   - trailingImage: Optional icon to show in the action button if no button title is provided.
-    ///   - trailingImageAccessibilityLabel: Optional localized accessibility label for the trailing image.
-    ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
-    ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
-    ///   - showDefaultDismissActionButton: Bool to control if the Notification has a dismiss action by default.
-    ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
-    ///   - showFromBottom: Defines whether the notification shows from the bottom of the presenting view or the top.
-    ///   - overrideTokens: Custom NotificationTokens class that will override the default tokens.
+    ///   - notification: The `FluentNotification` instance to present.
     /// - Returns: The modified view with the capability of presenting a Notification.
-    func presentNotification(style: MSFNotificationStyle,
-                             isFlexibleWidthToast: Bool,
-                             message: String? = nil,
-                             attributedMessage: NSAttributedString? = nil,
+    func presentNotification(isPresented: Binding<Bool>,
                              isBlocking: Bool = true,
-                             isPresented: Binding<Bool>,
-                             title: String? = nil,
-                             attributedTitle: NSAttributedString? = nil,
-                             image: UIImage? = nil,
-                             trailingImage: UIImage? = nil,
-                             trailingImageAccessibilityLabel: String? = nil,
-                             actionButtonTitle: String? = nil,
-                             actionButtonAction: (() -> Void)? = nil,
-                             showDefaultDismissActionButton: Bool? = nil,
-                             messageButtonAction: (() -> Void)? = nil,
-                             showFromBottom: Bool = true,
-                             overrideTokens: [NotificationTokenSet.Tokens: ControlTokenValue]? = nil) -> some View {
+                             @ViewBuilder notification: @escaping () -> FluentNotification) -> some View {
         self.presentingView(isPresented: isPresented,
                             isBlocking: isBlocking) {
-            FluentNotification(style: style,
-                               isFlexibleWidthToast: isFlexibleWidthToast,
-                               message: message,
-                               attributedMessage: attributedMessage,
-                               isPresented: isPresented,
-                               title: title,
-                               attributedTitle: attributedTitle,
-                               image: image,
-                               trailingImage: trailingImage,
-                               trailingImageAccessibilityLabel: trailingImageAccessibilityLabel,
-                               actionButtonTitle: actionButtonTitle,
-                               actionButtonAction: actionButtonAction,
-                               showDefaultDismissActionButton: showDefaultDismissActionButton,
-                               messageButtonAction: messageButtonAction,
-                               showFromBottom: showFromBottom)
-            .overrideTokens(overrideTokens)
+            notification()
         }
     }
 }
 
 public extension FluentNotification {
+    /// An optional gradient to use as the background of the notification.
+    ///
+    /// If this property is nil, then this notification will use the background color defined by its design tokens.
+    func backgroundGradient(_ gradientInfo: GradientInfo?) -> FluentNotification {
+        state.backgroundGradient = gradientInfo
+        return self
+    }
 }

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -126,13 +126,13 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .dynamicColor {
                     switch style() {
                     case .primaryToast:
-                        return theme.globalTokens.brandColors[.tint40]
+                        return theme.aliasTokens.brandColors[.tint40]
                     case .neutralToast:
                         return DynamicColor(light: ColorValue(0xF7F7F7),
                                             dark: ColorValue(0x393939))
                     case .primaryBar:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.tint40].light,
-                                            dark: theme.globalTokens.brandColors[.tint10].dark)
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.tint40].light,
+                                            dark: theme.aliasTokens.brandColors[.tint10].dark)
                     case .primaryOutlineBar:
                         return DynamicColor(light: ColorValue(0xFFFFFF),
                                             dark: ColorValue(0x393939))
@@ -152,16 +152,16 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .dynamicColor {
                     switch style() {
                     case .primaryToast:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade10].light,
-                                            dark: theme.globalTokens.brandColors[.shade30].dark)
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
+                                            dark: theme.aliasTokens.brandColors[.shade30].dark)
                     case .neutralToast:
                         return DynamicColor(light: ColorValue(0x393939),
                                             dark: ColorValue(0xF7F7F7))
                     case .primaryBar:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade20].light,
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
                                             dark: ColorValue(0x000000))
                     case .primaryOutlineBar:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.primary].light,
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.primary].light,
                                             dark: ColorValue(0xF7F7F7))
                     case .neutralBar:
                         return DynamicColor(light: ColorValue(0x090909),
@@ -179,16 +179,16 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .dynamicColor {
                     switch style() {
                     case .primaryToast:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade10].light,
-                                            dark: theme.globalTokens.brandColors[.shade30].dark)
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
+                                            dark: theme.aliasTokens.brandColors[.shade30].dark)
                     case .neutralToast:
                         return DynamicColor(light: ColorValue(0x393939),
                                             dark: ColorValue(0xF7F7F7))
                     case .primaryBar:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade20].light,
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
                                             dark: ColorValue(0x000000))
                     case .primaryOutlineBar:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.primary].light,
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.primary].light,
                                             dark: ColorValue(0xF7F7F7))
                     case .neutralBar:
                         return DynamicColor(light: ColorValue(0x090909),
@@ -206,9 +206,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return theme.globalTokens.borderRadius[.xLarge]
+                        return GlobalTokens.borderRadius(.xLarge)
                     case false:
-                        return theme.globalTokens.borderSize[.none]
+                        return GlobalTokens.borderSize(.none)
                     }
                 }
 
@@ -216,9 +216,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return theme.globalTokens.spacing[.medium]
+                        return GlobalTokens.spacing(.medium)
                     case false:
-                        return theme.globalTokens.spacing[.none]
+                        return GlobalTokens.spacing(.none)
                     }
                 }
 
@@ -254,7 +254,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .outlineWidth:
-                return .float { theme.globalTokens.borderSize[.thin] }
+                return .float { GlobalTokens.borderSize(.thin) }
 
             case .shadow:
                 return .shadowInfo {

--- a/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
@@ -68,9 +68,9 @@ public class PersonaButtonTokenSet: ControlTokenSet<PersonaButtonTokenSet.Tokens
                 return .float {
                     switch size() {
                     case .small:
-                        return theme.globalTokens.spacing[.xSmall]
+                        return GlobalTokens.spacing(.xSmall)
                     case .large:
-                        return theme.globalTokens.spacing[.small]
+                        return GlobalTokens.spacing(.small)
                     }
                 }
 
@@ -81,14 +81,14 @@ public class PersonaButtonTokenSet: ControlTokenSet<PersonaButtonTokenSet.Tokens
                 return .float {
                     switch size() {
                     case .small:
-                        return theme.globalTokens.spacing[.medium]
+                        return GlobalTokens.spacing(.medium)
                     case .large:
-                        return theme.globalTokens.spacing[.xSmall]
+                        return GlobalTokens.spacing(.xSmall)
                     }
                 }
 
             case .horizontalTextPadding:
-                return .float { theme.globalTokens.spacing[.xxxSmall] }
+                return .float { GlobalTokens.spacing(.xxxSmall) }
 
             case .labelColor:
                 return .dynamicColor { theme.aliasTokens.foregroundColors[.neutral1] }
@@ -110,7 +110,7 @@ public class PersonaButtonTokenSet: ControlTokenSet<PersonaButtonTokenSet.Tokens
                 return .fontInfo { theme.aliasTokens.typography[.caption1] }
 
             case .verticalPadding:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
             }
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBarTokenSet.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBarTokenSet.swift
@@ -28,7 +28,7 @@ public class PillButtonBarTokenSet: ControlTokenSet<PillButtonBarTokenSet.Tokens
     }
 
     init() {
-        super.init { token, theme in
+        super.init { token, _ in
             switch token {
             case .maxButtonsSpacing:
                 return .float {
@@ -37,12 +37,12 @@ public class PillButtonBarTokenSet: ControlTokenSet<PillButtonBarTokenSet.Tokens
 
             case .minButtonsSpacing:
                 return .float {
-                    theme.globalTokens.spacing[.xSmall]
+                    GlobalTokens.spacing(.xSmall)
                 }
 
             case .minButtonVisibleWidth:
                 return .float {
-                    theme.globalTokens.spacing[.large]
+                    GlobalTokens.spacing(.large)
                 }
 
             case .minButtonWidth:
@@ -57,7 +57,7 @@ public class PillButtonBarTokenSet: ControlTokenSet<PillButtonBarTokenSet.Tokens
 
             case .sideInset:
                 return .float {
-                    theme.globalTokens.spacing[.medium]
+                    GlobalTokens.spacing(.medium)
                 }
             }
         }

--- a/ios/FluentUI/Pill Button Bar/PillButtonTokenSet.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonTokenSet.swift
@@ -53,19 +53,19 @@ public class PillButtonTokenSet: ControlTokenSet<PillButtonTokenSet.Tokens> {
                         return .init(rest: DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral4].light,
                                                         dark: theme.aliasTokens.backgroundColors[.neutral3].dark),
                                      selected: theme.aliasTokens.foregroundColors[.brandRest],
-                                     disabled: DynamicColor(light: theme.globalTokens.neutralColors[.grey94],
-                                                            dark: theme.globalTokens.neutralColors[.grey8]),
-                                     selectedDisabled: DynamicColor(light: theme.globalTokens.neutralColors[.grey80],
-                                                                    dark: theme.globalTokens.neutralColors[.grey30]))
+                                     disabled: DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                                            dark: GlobalTokens.neutralColors(.grey8)),
+                                     selectedDisabled: DynamicColor(light: GlobalTokens.neutralColors(.grey80),
+                                                                    dark: GlobalTokens.neutralColors(.grey30)))
                     case .onBrand:
                         return .init(rest: DynamicColor(light: theme.aliasTokens.backgroundColors[.brandHover].light,
                                                         dark: theme.aliasTokens.backgroundColors[.neutral3].dark),
                                      selected: DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                                            dark: theme.globalTokens.neutralColors[.grey32]),
-                                     disabled: DynamicColor(light: theme.globalTokens.brandColors[.shade20].light,
-                                                            dark: theme.globalTokens.neutralColors[.grey8]),
-                                     selectedDisabled: DynamicColor(light: theme.globalTokens.neutralColors[.white],
-                                                                    dark: theme.globalTokens.neutralColors[.grey30]))
+                                                            dark: GlobalTokens.neutralColors(.grey32)),
+                                     disabled: DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
+                                                            dark: GlobalTokens.neutralColors(.grey8)),
+                                     selectedDisabled: DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                                                    dark: GlobalTokens.neutralColors(.grey30)))
                     }
                 }
 
@@ -77,19 +77,19 @@ public class PillButtonTokenSet: ControlTokenSet<PillButtonTokenSet.Tokens> {
                                                         dark: theme.aliasTokens.foregroundColors[.neutral2].dark),
                                      selected: DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
                                                             dark: theme.aliasTokens.foregroundColors[.neutralInverted].dark),
-                                     disabled: DynamicColor(light: theme.globalTokens.neutralColors[.grey70],
-                                                            dark: theme.globalTokens.neutralColors[.grey26]),
-                                     selectedDisabled: DynamicColor(light: theme.globalTokens.neutralColors[.grey94],
-                                                                    dark: theme.globalTokens.neutralColors[.grey44]))
+                                     disabled: DynamicColor(light: GlobalTokens.neutralColors(.grey70),
+                                                            dark: GlobalTokens.neutralColors(.grey26)),
+                                     selectedDisabled: DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                                                    dark: GlobalTokens.neutralColors(.grey44)))
                     case .onBrand:
                         return .init(rest: DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
                                                         dark: theme.aliasTokens.foregroundColors[.neutral2].dark),
                                      selected: DynamicColor(light: theme.aliasTokens.foregroundColors[.brandRest].light,
                                                             dark: theme.aliasTokens.foregroundColors[.neutral1].dark),
-                                     disabled: DynamicColor(light: theme.globalTokens.brandColors[.shade10].light,
-                                                            dark: theme.globalTokens.neutralColors[.grey26]),
-                                     selectedDisabled: DynamicColor(light: theme.globalTokens.neutralColors[.grey74],
-                                                                    dark: theme.globalTokens.neutralColors[.grey44]))
+                                     disabled: DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
+                                                            dark: GlobalTokens.neutralColors(.grey26)),
+                                     selectedDisabled: DynamicColor(light: GlobalTokens.neutralColors(.grey74),
+                                                                    dark: GlobalTokens.neutralColors(.grey44)))
                     }
                 }
 
@@ -107,9 +107,9 @@ public class PillButtonTokenSet: ControlTokenSet<PillButtonTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .primary:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.grey70], dark: theme.globalTokens.neutralColors[.grey26])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey70), dark: GlobalTokens.neutralColors(.grey26))
                     case .onBrand:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade10].light, dark: theme.globalTokens.neutralColors[.grey26])
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light, dark: GlobalTokens.neutralColors(.grey26))
                     }
                 }
 
@@ -120,7 +120,7 @@ public class PillButtonTokenSet: ControlTokenSet<PillButtonTokenSet.Tokens> {
                 return .float { 6.0 }
 
             case .horizontalInset:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .unreadDotOffsetX:
                 return .float { 6.0 }

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -167,8 +167,8 @@ open class PopupMenuController: DrawerController {
         view.isHidden = true
 
         view.addSubview(descriptionLabel)
-        let verticalMargin = tokenSet.fluentTheme.globalTokens.spacing[.small]
-        let horizontalMargin = tokenSet.fluentTheme.globalTokens.spacing[.medium]
+        let verticalMargin = GlobalTokens.spacing(.small)
+        let horizontalMargin = GlobalTokens.spacing(.medium)
         descriptionLabel.fitIntoSuperview(
             usingConstraints: true,
             margins: UIEdgeInsets(

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -80,7 +80,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.foregroundColors[.brandRest]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                            dark: theme.globalTokens.neutralColors[.grey32])
+                                            dark: GlobalTokens.neutralColors(.grey32))
                     }
                 }
 
@@ -88,11 +88,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.grey94],
-                                            dark: theme.globalTokens.neutralColors[.grey8])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                            dark: GlobalTokens.neutralColors(.grey8))
                     case .onBrandPill:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade20].light,
-                                            dark: theme.globalTokens.neutralColors[.grey8])
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
+                                            dark: GlobalTokens.neutralColors(.grey8))
                     }
                 }
 
@@ -100,11 +100,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.grey80],
-                                            dark: theme.globalTokens.neutralColors[.grey30])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey80),
+                                            dark: GlobalTokens.neutralColors(.grey30))
                     case .onBrandPill:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.white],
-                                            dark: theme.globalTokens.neutralColors[.grey30])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                            dark: GlobalTokens.neutralColors(.grey30))
                     }
                 }
 
@@ -136,11 +136,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.grey70],
-                                            dark: theme.globalTokens.neutralColors[.grey26])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
+                                            dark: GlobalTokens.neutralColors(.grey26))
                     case .onBrandPill:
-                        return DynamicColor(light: theme.globalTokens.brandColors[.shade10].light,
-                                            dark: theme.globalTokens.neutralColors[.grey26])
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
+                                            dark: GlobalTokens.neutralColors(.grey26))
                     }
                 }
 
@@ -148,11 +148,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.grey94],
-                                            dark: theme.globalTokens.neutralColors[.grey44])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                            dark: GlobalTokens.neutralColors(.grey44))
                     case .onBrandPill:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.grey74],
-                                            dark: theme.globalTokens.neutralColors[.grey44])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
+                                            dark: GlobalTokens.neutralColors(.grey44))
                     }
                 }
 
@@ -171,7 +171,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .float { 6.0 }
 
             case .horizontalInset:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .unreadDotOffsetX:
                 return .float { 6.0 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -78,8 +78,8 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .concealing:
-                        return DynamicColor(light: theme.globalTokens.neutralColors[.white],
-                                            dark: theme.globalTokens.neutralColors[.grey8])
+                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                            dark: GlobalTokens.neutralColors(.grey8))
                     case .revealing:
                         return DynamicColor(light: ColorValue(0xF1F1F1) /* gray50 */,
                                             lightHighContrast: ColorValue(0x919191) /* gray400 */,
@@ -98,7 +98,7 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
 
             case .darkGradient:
                 return .dynamicColor {
-                    return DynamicColor(light: theme.globalTokens.neutralColors[.black])
+                    return DynamicColor(light: GlobalTokens.neutralColors(.black))
                 }
 
             case .shimmerWidth:
@@ -117,16 +117,16 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .float { 3.0 }
 
             case .cornerRadius:
-                return .float { theme.globalTokens.borderRadius[.medium] }
+                return .float { GlobalTokens.borderRadius(.medium) }
 
             case .labelCornerRadius:
-                return .float { theme.globalTokens.borderRadius[.small] }
+                return .float { GlobalTokens.borderRadius(.small) }
 
             case .labelHeight:
                 return .float { 11.0 }
 
             case .labelSpacing:
-                return .float { theme.aliasTokens.globalTokens.spacing[.small] }
+                return .float { GlobalTokens.spacing(.small) }
             }
         }
     }

--- a/ios/FluentUI/Tab Bar/SideTabBarTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBarTokenSet.swift
@@ -61,7 +61,7 @@ public class SideTabBarTokenSet: ControlTokenSet<SideTabBarTokenSet.Tokens> {
                 return .float { 18.0 }
 
             case .avatarViewMinTopSpacing:
-                return .float { theme.globalTokens.spacing[.xxLarge] }
+                return .float { GlobalTokens.spacing(.xxLarge) }
 
             case .avatarViewTopStackViewSpacing:
                 return .float { 34.0 }
@@ -70,13 +70,13 @@ public class SideTabBarTokenSet: ControlTokenSet<SideTabBarTokenSet.Tokens> {
                 return .float { 14.0 }
 
             case .bottomStackViewMinSpacing:
-                return .float { theme.globalTokens.spacing[.xLarge] }
+                return .float { GlobalTokens.spacing(.xLarge) }
 
             case .topTabBarItemSpacing:
                 return .float { 32.0 }
 
             case .bottomTabBarItemSpacing:
-                return .float { theme.globalTokens.spacing[.xLarge] }
+                return .float { GlobalTokens.spacing(.xLarge) }
 
             case .badgeTopSectionPadding:
                 return .float { 2.0 }

--- a/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
@@ -86,28 +86,28 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 return .float { 3.0 }
 
             case .spacingHorizontal:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .portraitImageSize:
-                return .float { theme.globalTokens.iconSize[.large] }
+                return .float { GlobalTokens.iconSize(.large) }
 
             case .portraitImageWithLabelSize:
-                return .float { theme.globalTokens.iconSize[.medium] }
+                return .float { GlobalTokens.iconSize(.medium) }
 
             case .landscapeImageSize:
-                return .float { theme.globalTokens.iconSize[.medium] }
+                return .float { GlobalTokens.iconSize(.medium) }
 
             case .badgeVerticalOffset:
-                return .float { -theme.globalTokens.spacing[.xxSmall] }
+                return .float { -GlobalTokens.spacing(.xxSmall) }
 
             case .badgePortraitTitleVerticalOffset:
-                return .float { -theme.globalTokens.spacing[.xxxSmall] }
+                return .float { -GlobalTokens.spacing(.xxxSmall) }
 
             case .singleDigitBadgeHorizontalOffset:
                 return .float { 14.0 }
 
             case .multiDigitBadgeHorizontalOffset:
-                return .float { theme.globalTokens.spacing[.small] }
+                return .float { GlobalTokens.spacing(.small) }
 
             case .badgeHeight:
                 return .float { 16.0 }
@@ -119,7 +119,7 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 return .float { 42.0 }
 
             case .badgeBorderWidth:
-                return .float { theme.globalTokens.borderSize[.thick] }
+                return .float { GlobalTokens.borderSize(.thick) }
 
             case .badgeHorizontalPadding:
                 return .float { 10.0 }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -44,7 +44,7 @@ public enum TableViewCellAccessoryType: Int {
         case .detailButton:
             return UIColor(dynamicColor: tokenSet[.accessoryDetailButtonColor].dynamicColor)
         case .checkmark:
-            return UIColor(dynamicColor: fluentTheme.globalTokens.brandColors[.primary])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.brandColors[.primary])
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -148,8 +148,8 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
             switch token {
             case .backgroundColor:
                 return .dynamicColor {
-                    .init(light: theme.globalTokens.neutralColors[.white],
-                          dark: theme.globalTokens.neutralColors[.black])
+                    .init(light: GlobalTokens.neutralColors(.white),
+                          dark: GlobalTokens.neutralColors(.black))
                 }
 
             case .backgroundGroupedColor:
@@ -184,9 +184,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                     case .zero:
                         return 0.0
                     case .small:
-                        return theme.globalTokens.iconSize[.medium]
+                        return GlobalTokens.iconSize(.medium)
                     case .medium, .default:
-                        return theme.globalTokens.iconSize[.xxLarge]
+                        return GlobalTokens.iconSize(.xxLarge)
                     }
                 }
 
@@ -194,11 +194,11 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .float {
                     switch customViewSize() {
                     case .zero:
-                        return theme.globalTokens.spacing[.none]
+                        return GlobalTokens.spacing(.none)
                     case .small:
-                        return theme.globalTokens.spacing[.medium]
+                        return GlobalTokens.spacing(.medium)
                     case .medium, .default:
-                        return theme.globalTokens.spacing[.small]
+                        return GlobalTokens.spacing(.small)
                     }
                 }
 
@@ -239,13 +239,13 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .float { 18 }
 
             case .labelAccessoryViewMarginLeading:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .labelAccessoryViewMarginTrailing:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .customAccessoryViewMarginLeading:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .customAccessoryViewMinVerticalMargin:
                 return .float { 6 }
@@ -254,13 +254,13 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .float { 11 }
 
             case .labelVerticalMarginForTwoLines:
-                return .float { theme.globalTokens.spacing[.small] }
+                return .float { GlobalTokens.spacing(.small) }
 
             case .labelVerticalSpacing:
-                return .float { theme.globalTokens.spacing[.none] }
+                return .float { GlobalTokens.spacing(.none) }
 
             case .minHeight:
-                return .float { theme.globalTokens.spacing[.xxxLarge] }
+                return .float { GlobalTokens.spacing(.xxxLarge) }
 
             case .mediumHeight:
                 return .float { 64 }
@@ -269,10 +269,10 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .float { 84 }
 
             case .selectionImageMarginTrailing:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .selectionImageSize:
-                return .float { theme.globalTokens.iconSize[.medium] }
+                return .float { GlobalTokens.iconSize(.medium) }
 
             case .selectionModeAnimationDuration:
                 return .float { 0.2 }
@@ -287,16 +287,16 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .float { 0.35 }
 
             case .horizontalSpacing:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .paddingLeading:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .paddingVertical:
                 return .float { 11 }
 
             case .paddingTrailing:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .accessoryDisclosureIndicatorColor:
                 return .dynamicColor { theme.aliasTokens.foregroundColors[.neutral4] }
@@ -305,7 +305,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .dynamicColor { theme.aliasTokens.foregroundColors[.neutral3] }
 
             case .mainBrandColor:
-                return .dynamicColor { theme.globalTokens.brandColors[.primary] }
+                return .dynamicColor { theme.aliasTokens.brandColors[.primary] }
 
             case .destructiveTextColor:
                 return .dynamicColor {

--- a/ios/FluentUI/Vnext/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokenSet.swift
@@ -91,9 +91,9 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                 return .float {
                     switch size() {
                     case .small, .medium:
-                        return theme.globalTokens.borderRadius[.large]
+                        return GlobalTokens.borderRadius(.large)
                     case .large:
-                        return theme.globalTokens.borderRadius[.xLarge]
+                        return GlobalTokens.borderRadius(.xLarge)
                     }
                 }
 
@@ -101,9 +101,9 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                 return .float {
                     switch style() {
                     case .primary, .ghost, .accentFloating, .subtleFloating:
-                        return theme.globalTokens.borderSize[.none]
+                        return GlobalTokens.borderSize(.none)
                     case .secondary:
-                        return theme.globalTokens.borderSize[.thin]
+                        return GlobalTokens.borderSize(.thin)
                     }
                 }
 
@@ -113,13 +113,13 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .primary, .secondary, .ghost:
                         switch size() {
                         case .small:
-                            return theme.globalTokens.iconSize[.xSmall]
+                            return GlobalTokens.iconSize(.xSmall)
                         case .medium,
                                 .large:
-                            return theme.globalTokens.iconSize[.small]
+                            return GlobalTokens.iconSize(.small)
                         }
                     case .accentFloating, .subtleFloating:
-                        return theme.globalTokens.iconSize[.medium]
+                        return GlobalTokens.iconSize(.medium)
                     }
                 }
 
@@ -129,12 +129,12 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .primary, .secondary, .ghost:
                         switch size() {
                         case .small:
-                            return theme.globalTokens.spacing[.xxSmall]
+                            return GlobalTokens.spacing(.xxSmall)
                         case .medium, .large:
-                            return theme.globalTokens.spacing[.xSmall]
+                            return GlobalTokens.spacing(.xSmall)
                         }
                     case .accentFloating, .subtleFloating:
-                        return theme.globalTokens.spacing[.xSmall]
+                        return GlobalTokens.spacing(.xSmall)
                     }
                 }
 
@@ -144,25 +144,25 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .primary, .secondary, .ghost:
                         switch size() {
                         case .small:
-                            return theme.globalTokens.spacing[.xSmall]
+                            return GlobalTokens.spacing(.xSmall)
                         case .medium:
-                            return theme.globalTokens.spacing[.small]
+                            return GlobalTokens.spacing(.small)
                         case .large:
-                            return theme.globalTokens.spacing[.large]
+                            return GlobalTokens.spacing(.large)
                         }
                     case .accentFloating:
                         switch size() {
                         case .small, .medium:
-                            return theme.globalTokens.spacing[.small]
+                            return GlobalTokens.spacing(.small)
                         case .large:
-                            return theme.globalTokens.spacing[.medium]
+                            return GlobalTokens.spacing(.medium)
                         }
                     case .subtleFloating:
                         switch size() {
                         case .small, .medium:
-                            return theme.globalTokens.spacing[.small]
+                            return GlobalTokens.spacing(.small)
                         case .large:
-                            return theme.globalTokens.spacing[.medium]
+                            return GlobalTokens.spacing(.medium)
                         }
                     }
                 }
@@ -195,15 +195,15 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                 }
 
             case .textMinimumHeight:
-                return .float { theme.globalTokens.iconSize[.medium] }
+                return .float { GlobalTokens.iconSize(.medium) }
 
             case .textAdditionalHorizontalPadding:
                 return .float {
                     switch size() {
                     case .small, .medium:
-                        return theme.globalTokens.spacing[.xSmall]
+                        return GlobalTokens.spacing(.xSmall)
                     case .large:
-                        return theme.globalTokens.spacing[.xxSmall]
+                        return GlobalTokens.spacing(.xxSmall)
                     }
                 }
 

--- a/ios/FluentUI/Vnext/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Vnext/Divider/DividerTokenSet.swift
@@ -30,9 +30,9 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
                 return .float {
                     switch spacing() {
                     case .none:
-                        return theme.globalTokens.spacing[.none]
+                        return GlobalTokens.spacing(.none)
                     case .medium:
-                        return theme.globalTokens.spacing[.medium]
+                        return GlobalTokens.spacing(.medium)
                     }
                 }
 

--- a/ios/FluentUI/Vnext/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/Vnext/HUD/HeadsUpDisplayTokenSet.swift
@@ -32,7 +32,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
     }
 
     init() {
-        super.init { token, theme in
+        super.init { token, _ in
             switch token {
             case .backgroundColor:
                 return .dynamicColor {
@@ -42,24 +42,24 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
 
             case .foregroundColor:
                 return .dynamicColor {
-                    DynamicColor(light: theme.globalTokens.neutralColors[.white],
+                    DynamicColor(light: GlobalTokens.neutralColors(.white),
                                  dark: ColorValue(r: 0.882, g: 0.882, b: 0.882, a: 1),
-                                 darkHighContrast: theme.globalTokens.neutralColors[.white])
+                                 darkHighContrast: GlobalTokens.neutralColors(.white))
                 }
 
             case .cornerRadius:
                 return .float {
-                    return theme.globalTokens.borderRadius[.medium]
+                    return GlobalTokens.borderRadius(.medium)
                 }
 
             case .horizontalPadding:
                 return .float {
-                    return theme.globalTokens.spacing[.small]
+                    return GlobalTokens.spacing(.small)
                 }
 
             case .verticalPadding:
                 return .float {
-                    return theme.globalTokens.spacing[.large]
+                    return GlobalTokens.spacing(.large)
                 }
 
             case .minSize:

--- a/ios/FluentUI/Vnext/List/HeaderTokenSet.swift
+++ b/ios/FluentUI/Vnext/List/HeaderTokenSet.swift
@@ -57,26 +57,26 @@ public class HeaderTokenSet: ControlTokenSet<HeaderTokenSet.Tokens> {
                 }
 
             case .headerHeight:
-                return .float { theme.globalTokens.spacing[.xxxLarge] }
+                return .float { GlobalTokens.spacing(.xxxLarge) }
 
             case .topPadding:
                 return .float {
                     switch style() {
                     case .standard:
-                        return theme.globalTokens.spacing[.medium]
+                        return GlobalTokens.spacing(.medium)
                     case .subtle:
-                        return theme.globalTokens.spacing[.xLarge]
+                        return GlobalTokens.spacing(.xLarge)
                     }
                 }
 
             case .leadingPadding:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .bottomPadding:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .trailingPadding:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .textFont:
                 return .fontInfo {

--- a/ios/FluentUI/Vnext/List/ListCellTokenSet.swift
+++ b/ios/FluentUI/Vnext/List/ListCellTokenSet.swift
@@ -164,55 +164,55 @@ public class ListCellTokenSet: ControlTokenSet<ListCellTokenSet.Tokens> {
                 return .dynamicColor { theme.aliasTokens.backgroundColors[.neutral5] }
 
             case .cellHeightOneLine:
-                return .float { theme.globalTokens.spacing[.xxxLarge] }
+                return .float { GlobalTokens.spacing(.xxxLarge) }
 
             case .cellHeightTwoLines:
                 return .float { 64 }
 
             case .cellHeightThreeLines:
-                return .float { theme.globalTokens.spacing[.xxxxLarge] }
+                return .float { GlobalTokens.spacing(.xxxxLarge) }
 
             case .disclosureInterspace:
-                return .float { theme.globalTokens.spacing[.xxSmall] }
+                return .float { GlobalTokens.spacing(.xxSmall) }
 
             case .disclosureSize:
-                return .float { theme.globalTokens.iconSize[.small] }
+                return .float { GlobalTokens.iconSize(.small) }
 
             case .horizontalCellPadding:
-                return .float { theme.globalTokens.spacing[.small] }
+                return .float { GlobalTokens.spacing(.small) }
 
             case .iconInterspace:
-                return .float { theme.globalTokens.spacing[.medium] }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .labelAccessoryInterspace:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .labelAccessorySize:
-                return .float { theme.globalTokens.iconSize[.xxSmall] }
+                return .float { GlobalTokens.iconSize(.xxSmall) }
 
             case .leadingViewSize:
                 return .float {
                     switch cellLeadingViewSize() {
                     case .small:
-                        return theme.globalTokens.iconSize[.xSmall]
+                        return GlobalTokens.iconSize(.xSmall)
                     case .medium:
-                        return theme.globalTokens.iconSize[.medium]
+                        return GlobalTokens.iconSize(.medium)
                     case .large:
-                        return theme.globalTokens.iconSize[.xxLarge]
+                        return GlobalTokens.iconSize(.xxLarge)
                     }
                 }
 
             case .leadingViewAreaSize:
-                return .float { theme.globalTokens.spacing[.xxxLarge] }
+                return .float { GlobalTokens.spacing(.xxxLarge) }
 
             case .sublabelAccessorySize:
-                return .float { theme.globalTokens.iconSize[.xxSmall] }
+                return .float { GlobalTokens.iconSize(.xxSmall) }
 
             case .trailingItemSize:
-                return .float { theme.globalTokens.iconSize[.medium] }
+                return .float { GlobalTokens.iconSize(.medium) }
 
             case .verticalCellPadding:
-                return .float { theme.globalTokens.spacing[.xSmall] }
+                return .float { GlobalTokens.spacing(.xSmall) }
 
             case .footnoteFont:
                 return .fontInfo { theme.aliasTokens.typography[.caption1] }

--- a/ios/FluentUI/Vnext/Persona/PersonaViewTokenSet.swift
+++ b/ios/FluentUI/Vnext/Persona/PersonaViewTokenSet.swift
@@ -12,9 +12,9 @@ public class PersonaViewTokenSet: ListCellTokenSet {
 
         self.replaceAllOverrides(with: [
             .sublabelColor: .dynamicColor { self.fluentTheme.aliasTokens.foregroundColors[.neutral1] },
-            .iconInterspace: .float { self.fluentTheme.globalTokens.spacing[.small] },
-            .labelAccessoryInterspace: .float { self.fluentTheme.globalTokens.spacing[.xxxSmall] },
-            .labelAccessorySize: .float { self.fluentTheme.globalTokens.iconSize[.xSmall] },
+            .iconInterspace: .float { GlobalTokens.spacing(.small) },
+            .labelAccessoryInterspace: .float { GlobalTokens.spacing(.xxxSmall) },
+            .labelAccessorySize: .float { GlobalTokens.iconSize(.xSmall) },
             .labelFont: .fontInfo { self.fluentTheme.aliasTokens.typography[.body1Strong] }
         ])
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This brings the latest `main` into `fluent2-tokens`. Two major changes since last merge:
- #1188
- #1152

#1152 in particular required additional changes across the repo, swapping instances of `theme.globalTokens.TOKEN[.KEY]` for `GlobalTokens.TOKEN(.KEY)`. No functional changes result from this change.

### Verification

New `GradientInfo` property on `FluentNotification` works as expected. Various other controls were tested with no change as well.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1199)