### PR TITLE
[Fluent 2 iOS] Update shared alias colors names and values

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -657,69 +657,81 @@ public final class AliasTokens {
     // MARK: Shared Colors
 
     public enum SharedColorsTokens: CaseIterable {
-        // Red (Danger)
-        case redBackground1
-        case redBackground3
-        case redForeground1
-        case redForeground3
-        // Dark orange (Severe)
-        case darkOrangeBackground1
-        case darkOrangeBackground3
-        case darkOrangeForeground1
-        // Yellow (Warning)
-        case yellowBackground1
-        case yellowBackground3
-        case yellowForeground1
-        // Green (Success)
-        case greenBackground1
-        case greenBackground2
-        case greenForeground1
+        // Danger (Red)
+        case dangerBackground1
+        case dangerBackground2
+        case dangerForeground1
+        case dangerForeground2
+        // Severe (Dark Orange)
+        case severeBackground1
+        case severeBackground2
+        case severeForeground1
+        case severeForeground2
+        // Warning (Yellow)
+        case warningBackground1
+        case warningBackground2
+        case warningForeground1
+        case warningForeground2
+        // Success (Green)
+        case successBackground1
+        case successBackground2
+        case successForeground1
+        case successForeground2
     }
     public lazy var sharedColors: TokenSet<SharedColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
-        // Red
-        case .redBackground1:
+        // Danger
+        case .dangerBackground1:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.red][.tint60],
                                 dark: strongSelf.globalTokens.sharedColors[.red][.shade40])
-        case .redBackground3:
+        case .dangerBackground2:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.red][.primary],
                                 dark: strongSelf.globalTokens.sharedColors[.red][.shade10])
-        case .redForeground1:
-            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.red][.shade20],
+        case .dangerForeground1:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.red][.shade10],
                                 dark: strongSelf.globalTokens.sharedColors[.red][.tint30])
-        case .redForeground3:
+        case .dangerForeground2:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.red][.primary],
-                                dark: strongSelf.globalTokens.sharedColors[.red][.tint20])
-        // Green
-        case .greenBackground1:
+                                dark: strongSelf.globalTokens.sharedColors[.red][.tint30])
+        // Success
+        case .successBackground1:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.green][.tint60],
                                 dark: strongSelf.globalTokens.sharedColors[.green][.shade40])
-        case .greenBackground2:
-            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.green][.tint40],
-                                dark: strongSelf.globalTokens.sharedColors[.green][.shade30])
-        case .greenForeground1:
-            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.green][.shade20],
+        case .successBackground2:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.green][.primary],
+                                dark: strongSelf.globalTokens.sharedColors[.green][.shade10])
+        case .successForeground1:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.green][.shade10],
                                 dark: strongSelf.globalTokens.sharedColors[.green][.tint30])
-        // Dark orange
-        case .darkOrangeBackground1:
+        case .successForeground2:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.green][.primary],
+                                dark: strongSelf.globalTokens.sharedColors[.green][.tint30])
+        // Severe
+        case .severeBackground1:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.darkOrange][.tint60],
                                 dark: strongSelf.globalTokens.sharedColors[.darkOrange][.shade40])
-        case .darkOrangeBackground3:
+        case .severeBackground2:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.darkOrange][.primary],
                                 dark: strongSelf.globalTokens.sharedColors[.darkOrange][.shade10])
-        case .darkOrangeForeground1:
+        case .severeForeground1:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.darkOrange][.shade10],
+                                dark: strongSelf.globalTokens.sharedColors[.darkOrange][.tint30])
+        case .severeForeground2:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.darkOrange][.shade20],
                                 dark: strongSelf.globalTokens.sharedColors[.darkOrange][.tint30])
-        // Yellow
-        case .yellowBackground1:
-            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.yellow][.tint50],
+        // Warning
+        case .warningBackground1:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.yellow][.tint60],
                                 dark: strongSelf.globalTokens.sharedColors[.yellow][.shade40])
-        case .yellowBackground3:
+        case .warningBackground2:
             return DynamicColor(light: strongSelf.globalTokens.sharedColors[.yellow][.primary],
                                 dark: strongSelf.globalTokens.sharedColors[.yellow][.shade10])
-        case .yellowForeground1:
-            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.yellow][.shade40],
+        case .warningForeground1:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.yellow][.shade30],
+                                dark: strongSelf.globalTokens.sharedColors[.yellow][.tint30])
+        case .warningForeground2:
+            return DynamicColor(light: strongSelf.globalTokens.sharedColors[.yellow][.shade30],
                                 dark: strongSelf.globalTokens.sharedColors[.yellow][.tint30])
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The shared colors in AliasTokens have been updated with their new values and semantic names.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1201)