### PR TITLE
[fluent2 tokens] Tokenize PopupMenuItem/Cell

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		EC02A5F327472EF400E81B3E /* DividerTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F227472EF400E81B3E /* DividerTokenSet.swift */; };
 		EC02A5F5274DD19600E81B3E /* MSFDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F4274DD19500E81B3E /* MSFDivider.swift */; };
 		EC24DBC828BD95980026EF92 /* PopupMenuTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */; };
+		EC24DBCA28BD99860026EF92 /* PopupMenuItemTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC928BD99860026EF92 /* PopupMenuItemTokenSet.swift */; };
 		EC27B8662807A63C00A40B9A /* ResizingHandleTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC27B8652807A63C00A40B9A /* ResizingHandleTokenSet.swift */; };
 		EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D727BF348700FD048D /* MSFAvatar.swift */; };
 		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
@@ -419,6 +420,7 @@
 		EC02A5F227472EF400E81B3E /* DividerTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerTokenSet.swift; sourceTree = "<group>"; };
 		EC02A5F4274DD19500E81B3E /* MSFDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFDivider.swift; sourceTree = "<group>"; };
 		EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuTokenSet.swift; sourceTree = "<group>"; };
+		EC24DBC928BD99860026EF92 /* PopupMenuItemTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuItemTokenSet.swift; sourceTree = "<group>"; };
 		EC27B8652807A63C00A40B9A /* ResizingHandleTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleTokenSet.swift; sourceTree = "<group>"; };
 		EC5982D727BF348700FD048D /* MSFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatar.swift; sourceTree = "<group>"; };
 		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
@@ -911,6 +913,7 @@
 				A5961F9C218A254D00E2A506 /* PopupMenuController.swift */,
 				EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */,
 				A5961F9E218A256B00E2A506 /* PopupMenuItem.swift */,
+				EC24DBC928BD99860026EF92 /* PopupMenuItemTokenSet.swift */,
 				A5961FA0218A25C400E2A506 /* PopupMenuSection.swift */,
 				A5961FA2218A25D100E2A506 /* PopupMenuItemCell.swift */,
 				A5961FA4218A260500E2A506 /* PopupMenuSectionHeaderView.swift */,
@@ -1632,6 +1635,7 @@
 				2A9745DE281733D700E1A1FD /* TableViewCellTokenSet.swift in Sources */,
 				530D9C5127EE388200BDCBBF /* SwiftUI+ViewPresentation.swift in Sources */,
 				5314E0E725F012C00099271A /* UINavigationItem+Navigation.swift in Sources */,
+				EC24DBCA28BD99860026EF92 /* PopupMenuItemTokenSet.swift in Sources */,
 				920945492703DDA000B38E1A /* CardNudgeTokenSet.swift in Sources */,
 				92D49054278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift in Sources */,
 				5314E25D25F0238E0099271A /* UIFont+Extension.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		D6F4098F274F1A1C001B80D4 /* PillButtonBarTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F4098E274F1A1C001B80D4 /* PillButtonBarTokenSet.swift */; };
 		EC02A5F327472EF400E81B3E /* DividerTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F227472EF400E81B3E /* DividerTokenSet.swift */; };
 		EC02A5F5274DD19600E81B3E /* MSFDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F4274DD19500E81B3E /* MSFDivider.swift */; };
+		EC24DBC828BD95980026EF92 /* PopupMenuTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */; };
 		EC27B8662807A63C00A40B9A /* ResizingHandleTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC27B8652807A63C00A40B9A /* ResizingHandleTokenSet.swift */; };
 		EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D727BF348700FD048D /* MSFAvatar.swift */; };
 		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
@@ -417,6 +418,7 @@
 		D6F4098E274F1A1C001B80D4 /* PillButtonBarTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarTokenSet.swift; sourceTree = "<group>"; };
 		EC02A5F227472EF400E81B3E /* DividerTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerTokenSet.swift; sourceTree = "<group>"; };
 		EC02A5F4274DD19500E81B3E /* MSFDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFDivider.swift; sourceTree = "<group>"; };
+		EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuTokenSet.swift; sourceTree = "<group>"; };
 		EC27B8652807A63C00A40B9A /* ResizingHandleTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleTokenSet.swift; sourceTree = "<group>"; };
 		EC5982D727BF348700FD048D /* MSFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatar.swift; sourceTree = "<group>"; };
 		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
@@ -907,6 +909,7 @@
 			isa = PBXGroup;
 			children = (
 				A5961F9C218A254D00E2A506 /* PopupMenuController.swift */,
+				EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */,
 				A5961F9E218A256B00E2A506 /* PopupMenuItem.swift */,
 				A5961FA0218A25C400E2A506 /* PopupMenuSection.swift */,
 				A5961FA2218A25D100E2A506 /* PopupMenuItemCell.swift */,
@@ -1703,6 +1706,7 @@
 				4BBD651F2755FD9500A8B09E /* MSFNotification.swift in Sources */,
 				53097D0D270288FB00A6E4DC /* ButtonTokenSet.swift in Sources */,
 				5314E09525F00FA30099271A /* DimmingView.swift in Sources */,
+				EC24DBC828BD95980026EF92 /* PopupMenuTokenSet.swift in Sources */,
 				5306075326A1E6A4002D49CF /* AvatarGroupTokenSet.swift in Sources */,
 				5314E11825F015EA0099271A /* PeoplePicker.swift in Sources */,
 				5303259B26B31B6B00611D05 /* AvatarModifiers.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -911,13 +911,13 @@
 			isa = PBXGroup;
 			children = (
 				A5961F9C218A254D00E2A506 /* PopupMenuController.swift */,
-				EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */,
 				A5961F9E218A256B00E2A506 /* PopupMenuItem.swift */,
-				EC24DBC928BD99860026EF92 /* PopupMenuItemTokenSet.swift */,
-				A5961FA0218A25C400E2A506 /* PopupMenuSection.swift */,
 				A5961FA2218A25D100E2A506 /* PopupMenuItemCell.swift */,
-				A5961FA4218A260500E2A506 /* PopupMenuSectionHeaderView.swift */,
+				EC24DBC928BD99860026EF92 /* PopupMenuItemTokenSet.swift */,
 				0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */,
+				A5961FA0218A25C400E2A506 /* PopupMenuSection.swift */,
+				A5961FA4218A260500E2A506 /* PopupMenuSectionHeaderView.swift */,
+				EC24DBC728BD95980026EF92 /* PopupMenuTokenSet.swift */,
 			);
 			path = "Popup Menu";
 			sourceTree = "<group>";

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -92,5 +92,3 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
         }
     }
 }
-
-public class PopupMenuTokenSet: DrawerTokenSet {}

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -35,9 +35,7 @@ open class PopupMenuController: DrawerController {
             return popupTokenSet
         }
         set {
-#if DEBUG
-            preconditionFailure("PopupMenuController tokens must be set through popupTokenSet")
-#endif
+            assertionFailure("PopupMenuController tokens must be set through popupTokenSet")
         }
     }
     public var popupTokenSet: PopupMenuTokenSet = .init()

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -67,4 +67,8 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
         let selectedImage = generateSelectedImage ? nil : image
         self.init(image: image, selectedImage: selectedImage, title: title, subtitle: subtitle, isEnabled: isEnabled, isSelected: isSelected, executes: executionMode, onSelected: onSelected, isAccessoryCheckmarkVisible: isAccessoryCheckmarkVisible)
     }
+
+    lazy var tokenSet: PopupMenuItemTokenSet = {
+        PopupMenuItemTokenSet(customViewSize: { self.image != nil ? .small : .zero })
+    }()
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -26,20 +26,20 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
     @objc public var isSelected: Bool = false
 
     /// `title` color
-    @objc public var titleColor: UIColor = Colors.Table.Cell.title
+    @objc public lazy var titleColor: UIColor = UIColor(dynamicColor: tokenSet[.titleColor].dynamicColor)
     /// `subtitle` color
-    @objc public var subtitleColor: UIColor = Colors.Table.Cell.subtitle
+    @objc public lazy var subtitleColor: UIColor = UIColor(dynamicColor: tokenSet[.subtitleColor].dynamicColor)
     /// `image` tint color if it is rendered as template
-    @objc public var imageColor: UIColor = Colors.Table.Cell.image
-    /// `title` color when`isSelected` is true. If unset, Colors.primary will be used
+    @objc public lazy var imageColor: UIColor = UIColor(dynamicColor: tokenSet[.imageColor].dynamicColor)
+    /// `title` color when`isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var titleSelectedColor: UIColor?
-    /// `subtitle` color when`isSelected` is true.  If unset, Colors.primary will be used
+    /// `subtitle` color when`isSelected` is true.  If unset,PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var subtitleSelectedColor: UIColor?
-    /// tint color if `selectedImage` is rendered as template and `isSelected` is true.  Is unset, Colors.primary will be used
+    /// tint color if `selectedImage` is rendered as template and `isSelected` is true.  Is unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var imageSelectedColor: UIColor?
     /// background color of PopupMenuItem corresponding cell
-    @objc public var backgroundColor: UIColor = .clear
-    /// checkmark color `isAccessoryCheckmarkVisible` and `isSelected` is true. If unset, Colors.primary will be used
+    @objc public lazy var backgroundColor: UIColor = UIColor(dynamicColor: tokenSet[.cellBackgroundColor].dynamicColor)
+    /// checkmark color `isAccessoryCheckmarkVisible` and `isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var accessoryCheckmarkColor: UIColor?
 
     @objc public let onSelected: (() -> Void)?

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -26,11 +26,41 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
     @objc public var isSelected: Bool = false
 
     /// `title` color
-    @objc public lazy var titleColor: UIColor = UIColor(dynamicColor: tokenSet[.titleColor].dynamicColor)
+    @objc public var titleColor: UIColor {
+        get {
+            return UIColor(dynamicColor: tokenSet[.titleColor].dynamicColor)
+        }
+        set {
+            guard let newColor = newValue.dynamicColor else {
+                return
+            }
+            tokenSet[.titleColor] = .dynamicColor { newColor }
+        }
+    }
     /// `subtitle` color
-    @objc public lazy var subtitleColor: UIColor = UIColor(dynamicColor: tokenSet[.subtitleColor].dynamicColor)
+    @objc public var subtitleColor: UIColor {
+        get {
+            return UIColor(dynamicColor: tokenSet[.subtitleColor].dynamicColor)
+        }
+        set {
+            guard let newColor = newValue.dynamicColor else {
+                return
+            }
+            tokenSet[.subtitleColor] = .dynamicColor { newColor }
+        }
+    }
     /// `image` tint color if it is rendered as template
-    @objc public lazy var imageColor: UIColor = UIColor(dynamicColor: tokenSet[.imageColor].dynamicColor)
+    @objc public var imageColor: UIColor {
+        get {
+            return UIColor(dynamicColor: tokenSet[.imageColor].dynamicColor)
+        }
+        set {
+            guard let newColor = newValue.dynamicColor else {
+                return
+            }
+            tokenSet[.imageColor] = .dynamicColor { newColor }
+        }
+    }
     /// `title` color when`isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var titleSelectedColor: UIColor?
     /// `subtitle` color when`isSelected` is true.  If unset,PopupMenuItemTokenSet.mainBrandColor will be used
@@ -38,7 +68,17 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
     /// tint color if `selectedImage` is rendered as template and `isSelected` is true.  Is unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var imageSelectedColor: UIColor?
     /// background color of PopupMenuItem corresponding cell
-    @objc public lazy var backgroundColor: UIColor = UIColor(dynamicColor: tokenSet[.cellBackgroundColor].dynamicColor)
+    @objc public var backgroundColor: UIColor {
+        get {
+            return UIColor(dynamicColor: tokenSet[.cellBackgroundColor].dynamicColor)
+        }
+        set {
+            guard let newColor = newValue.dynamicColor else {
+                return
+            }
+            tokenSet[.cellBackgroundColor] = .dynamicColor { newColor }
+        }
+    }
     /// checkmark color `isAccessoryCheckmarkVisible` and `isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var accessoryCheckmarkColor: UIColor?
 

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -63,9 +63,9 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem {
     }
     /// `title` color when`isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var titleSelectedColor: UIColor?
-    /// `subtitle` color when`isSelected` is true.  If unset,PopupMenuItemTokenSet.mainBrandColor will be used
+    /// `subtitle` color when`isSelected` is true.  If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var subtitleSelectedColor: UIColor?
-    /// tint color if `selectedImage` is rendered as template and `isSelected` is true.  Is unset, PopupMenuItemTokenSet.mainBrandColor will be used
+    /// tint color if `selectedImage` is rendered as template and `isSelected` is true.  If unset, PopupMenuItemTokenSet.mainBrandColor will be used
     @objc public var imageSelectedColor: UIColor?
     /// background color of PopupMenuItem corresponding cell
     @objc public var backgroundColor: UIColor {

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -200,26 +200,33 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
 
     private func updateSelectionColors() {
-        if let window = window {
-            if let item = item {
-                _imageView.tintColor = isSelected
-                    ? item.imageSelectedColor ?? Colors.primary(for: window)
-                    : item.imageColor
-                titleLabel.textColor = isSelected
-                    ? item.titleSelectedColor ?? Colors.primary(for: window)
-                    : item.titleColor
-                subtitleLabel.textColor = isSelected
-                    ? item.subtitleSelectedColor ?? Colors.primary(for: window)
-                    : item.subtitleColor
-                backgroundColor = item.backgroundColor
-            }
-
-            if isSelected && item?.isAccessoryCheckmarkVisible == true {
-                _accessoryType = .checkmark
-                accessoryTypeView?.customTintColor = item?.accessoryCheckmarkColor ?? Colors.primary(for: window)
-            } else {
-                _accessoryType = .none
-            }
+        guard let item = item else {
+            _accessoryType = .none
+            return
         }
+        let brandColor = UIColor(dynamicColor: item.tokenSet[.mainBrandColor].dynamicColor)
+        let imageColor: UIColor
+        let titleColor: UIColor
+        let subtitleColor: UIColor
+        var accessoryType: TableViewCellAccessoryType = .none
+        if isSelected {
+            imageColor = item.imageSelectedColor ?? brandColor
+            titleColor = item.titleSelectedColor ?? brandColor
+            subtitleColor = item.subtitleSelectedColor ?? brandColor
+            if item.isAccessoryCheckmarkVisible,
+               let accessoryTypeView = accessoryTypeView {
+                accessoryType = .checkmark
+                accessoryTypeView.customTintColor = item.accessoryCheckmarkColor ?? brandColor
+            }
+        } else {
+            imageColor = item.imageColor
+            titleColor = item.titleColor
+            subtitleColor = item.subtitleColor
+        }
+
+        _imageView.tintColor = imageColor
+        titleLabel.textColor = titleColor
+        subtitleLabel.textColor = subtitleColor
+        _accessoryType = accessoryType
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -242,5 +242,6 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         titleLabel.textColor = titleColor
         subtitleLabel.textColor = subtitleColor
         _accessoryType = accessoryType
+        backgroundColor = item.backgroundColor
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -69,6 +69,18 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         set { super.isUserInteractionEnabled = newValue }
     }
 
+    override var tokenSet: TableViewCellTokenSet {
+        get {
+            guard let item = item else {
+                return super.tokenSet
+            }
+            return item.tokenSet
+        }
+        set {
+            assertionFailure("PopupMenuItemCell tokens must be set through PopupMenuItem.tokenSet")
+        }
+    }
+
     private var item: PopupMenuItem?
 
     // Cannot use imageView since it exists in superclass
@@ -87,6 +99,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     override func initialize() {
         super.initialize()
+        tokenSet.customViewSize = { self.customViewSize }
 
         selectionStyle = .none
 
@@ -104,6 +117,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             return
         }
 
+        item.tokenSet.customViewSize = { self.customViewSize }
         self.item = item
 
         _imageView.image = item.image

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -227,10 +227,8 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             imageColor = item.imageSelectedColor ?? brandColor
             titleColor = item.titleSelectedColor ?? brandColor
             subtitleColor = item.subtitleSelectedColor ?? brandColor
-            if item.isAccessoryCheckmarkVisible,
-               let accessoryTypeView = accessoryTypeView {
+            if item.isAccessoryCheckmarkVisible {
                 accessoryType = .checkmark
-                accessoryTypeView.customTintColor = item.accessoryCheckmarkColor ?? brandColor
             }
         } else {
             imageColor = item.imageColor
@@ -241,7 +239,10 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         _imageView.tintColor = imageColor
         titleLabel.textColor = titleColor
         subtitleLabel.textColor = subtitleColor
-        _accessoryType = accessoryType
         backgroundColor = item.backgroundColor
+        _accessoryType = accessoryType
+        if let accessoryTypeView = accessoryTypeView {
+            accessoryTypeView.customTintColor = item.accessoryCheckmarkColor ?? brandColor
+        }
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
@@ -24,8 +24,7 @@ class PopupMenuItemTokenSet: TableViewCellTokenSet {
                              dark: ColorValue(0x6E6E6E /* gray500 */),
                              darkHighContrast: ColorValue(0xACACAC /* gray300 */),
                              darkElevated: ColorValue(0x919191 /* gray400 */)) },
-            .cellBackgroundColor: .dynamicColor { DynamicColor(light: .clear) },
-            .labelVerticalMarginForOneAndThreeLines: .float { 15.0 },
+            .cellBackgroundColor: .dynamicColor { DynamicColor(light: .clear) }
         ])
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
@@ -1,0 +1,6 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+class PopupMenuItemTokenSet: TableViewCellTokenSet {}

--- a/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
@@ -12,18 +12,21 @@ class PopupMenuItemTokenSet: TableViewCellTokenSet {
                 DynamicColor(light: ColorValue(0x212121 /* gray900 */),
                              lightHighContrast: GlobalTokens.neutralColors(.black),
                              dark: ColorValue(0xE1E1E1 /* gray100 */),
-                             darkHighContrast: GlobalTokens.neutralColors(.white)) },
+                             darkHighContrast: GlobalTokens.neutralColors(.white))
+            },
             .subtitleColor: .dynamicColor { /* textSecondary */
                 DynamicColor(light: ColorValue(0x6E6E6E /* gray500 */),
                              lightHighContrast: ColorValue(0x303030 /* gray700 */),
                              dark: ColorValue(0x919191 /* gray400 */),
-                             darkHighContrast: ColorValue(0xC8C8C8 /* gray200 */)) },
+                             darkHighContrast: ColorValue(0xC8C8C8 /* gray200 */))
+            },
             .imageColor: .dynamicColor { /* iconSecondary */
                 DynamicColor(light: ColorValue(0x919191 /* gray400 */),
                              lightHighContrast: ColorValue(0x404040 /* gray600 */),
                              dark: ColorValue(0x6E6E6E /* gray500 */),
                              darkHighContrast: ColorValue(0xACACAC /* gray300 */),
-                             darkElevated: ColorValue(0x919191 /* gray400 */)) },
+                             darkElevated: ColorValue(0x919191 /* gray400 */))
+            },
             .cellBackgroundColor: .dynamicColor { DynamicColor(light: .clear) }
         ])
     }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
@@ -3,4 +3,29 @@
 //  Licensed under the MIT License.
 //
 
-class PopupMenuItemTokenSet: TableViewCellTokenSet {}
+class PopupMenuItemTokenSet: TableViewCellTokenSet {
+    override init(customViewSize: @escaping () -> MSFTableViewCellCustomViewSize) {
+        super.init(customViewSize: customViewSize)
+
+        self.replaceAllOverrides(with: [
+            .titleColor: .dynamicColor { /* textPrimary */
+                DynamicColor(light: ColorValue(0x212121 /* gray900 */),
+                             lightHighContrast: GlobalTokens.neutralColors(.black),
+                             dark: ColorValue(0xE1E1E1 /* gray100 */),
+                             darkHighContrast: GlobalTokens.neutralColors(.white)) },
+            .subtitleColor: .dynamicColor { /* textSecondary */
+                DynamicColor(light: ColorValue(0x6E6E6E /* gray500 */),
+                             lightHighContrast: ColorValue(0x303030 /* gray700 */),
+                             dark: ColorValue(0x919191 /* gray400 */),
+                             darkHighContrast: ColorValue(0xC8C8C8 /* gray200 */)) },
+            .imageColor: .dynamicColor { /* iconSecondary */
+                DynamicColor(light: ColorValue(0x919191 /* gray400 */),
+                             lightHighContrast: ColorValue(0x404040 /* gray600 */),
+                             dark: ColorValue(0x6E6E6E /* gray500 */),
+                             darkHighContrast: ColorValue(0xACACAC /* gray300 */),
+                             darkElevated: ColorValue(0x919191 /* gray400 */)) },
+            .cellBackgroundColor: .dynamicColor { DynamicColor(light: .clear) },
+            .labelVerticalMarginForOneAndThreeLines: .float { 15.0 },
+        ])
+    }
+}

--- a/ios/FluentUI/Popup Menu/PopupMenuTokenSet.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuTokenSet.swift
@@ -1,0 +1,6 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+public class PopupMenuTokenSet: DrawerTokenSet {}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added tokens to the `PopupMenuItem`, and used them in the `PopupMenuItemCell`. These tokens are a subclass of the `TableVIewCell` tokens, since the `PopupMenuItemCell` is a subview of `TableViewCell`. Looks like there was also some sort of color regression, and this tokenizing change conveniently fixes it, in the cells, at least. Looks like the shadow got darker, though.

### Verification

| Main | Tokens | After |
|---|---|---|
| ![PopupItem_Section_Main_Light](https://user-images.githubusercontent.com/67026548/187576399-f522ae8d-21f9-467a-8e25-f11b8c8837cb.png) | ![PopupItem_Section_Tokens_Light](https://user-images.githubusercontent.com/67026548/187576408-9e79fb42-3b8c-4887-b31b-91ca1e2197ce.png) | ![PopupItem_Sections_After_Light](https://user-images.githubusercontent.com/67026548/187576411-c64d30a8-2dff-4821-9a71-8cc45739ac6d.png) |
| ![PopupItem_Section_Main_Dark](https://user-images.githubusercontent.com/67026548/187576417-e8c06e09-799a-4295-8536-4db8ad03bbe5.png) | ![PopupItem_Section_Tokens_Dark](https://user-images.githubusercontent.com/67026548/187576421-0359f596-ce6a-4790-bf7a-f3e39f34d240.png) | ![PopupItem_Sections_After_Dark](https://user-images.githubusercontent.com/67026548/187576430-289702b0-5241-4658-a826-f20afb303384.png) |
| ![PopupItem_Custom_Main_Light](https://user-images.githubusercontent.com/67026548/187576438-8e947d8f-3176-4ab9-aad3-3de0f5c982d8.png) | ![PopupItem_Custom_Tokens_Light](https://user-images.githubusercontent.com/67026548/187576443-8e370c8c-53b9-46c3-9146-118bfd925c0e.png) | ![PopupItem_Custom_After_Light](https://user-images.githubusercontent.com/67026548/187576451-cae6b333-45e3-4fc6-8c97-7faa23deb736.png) |
| ![PopupItem_Custom_Main_Dark](https://user-images.githubusercontent.com/67026548/187576459-739b1cf0-7268-4122-8524-ecf57854f229.png) | ![PopupItem_Custom_Tokens_Dark](https://user-images.githubusercontent.com/67026548/187576466-31f176d1-ac7b-4d9f-abaf-17bf3fb6e760.png) | ![PopupItem_Custom_AfterDark](https://user-images.githubusercontent.com/67026548/187576478-04ed2714-7357-44d0-95b5-e678f001d975.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1205)