### PR TITLE
Merge `PopUpMenuObjCDemoController` to `fluent2-tokens`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842973247B672000A29C40 /* SceneDelegate.swift */; };
 		E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemes.swift */; };
 		EC02A5F9274EED9200E81B3E /* DividerDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */; };
+		EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */; };
 		EC6A71EC273DE6DF0076A586 /* DividerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */; };
 		ECCABFB227DFFA070037C70C /* ColoredPillBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCABFB127DFFA070037C70C /* ColoredPillBackgroundView.swift */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
@@ -150,6 +151,8 @@
 		E6842973247B672000A29C40 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E6842995247C350700A29C40 /* DemoColorThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoColorThemes.swift; sourceTree = "<group>"; };
 		EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividerDemoController_SwiftUI.swift; sourceTree = "<group>"; };
+		EC24DBC428B97E950026EF92 /* PopupMenuObjCDemoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopupMenuObjCDemoController.h; sourceTree = "<group>"; };
+		EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PopupMenuObjCDemoController.m; sourceTree = "<group>"; };
 		EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController.swift; sourceTree = "<group>"; };
 		EC8EA6AF2580D82A00F191CE /* ListDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDemoController.swift; sourceTree = "<group>"; };
 		ECCABFB127DFFA070037C70C /* ColoredPillBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredPillBackgroundView.swift; sourceTree = "<group>"; };
@@ -356,6 +359,8 @@
 				B4EF53C4215C45C400573E8F /* PersonaListViewDemoController.swift */,
 				497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */,
 				A5961FA8218A61BB00E2A506 /* PopupMenuDemoController.swift */,
+				EC24DBC428B97E950026EF92 /* PopupMenuObjCDemoController.h */,
+				EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */,
 				2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */,
 				FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */,
 				C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */,
@@ -538,6 +543,7 @@
 				53097D3527028A7B00A6E4DC /* ButtonLegacyDemoController.swift in Sources */,
 				92B45E4E279A1A0B00E72517 /* DemoAppearanceController.swift in Sources */,
 				E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */,
+				EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */,
 				53097D3C27028AD000A6E4DC /* HUDDemoController.swift in Sources */,
 				92E977B826C7144F008E10A8 /* DemoControllerScrollView.swift in Sources */,
 				92E977B726C7144F008E10A8 /* UIResponder+Extensions.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -159,7 +159,9 @@ class PopupMenuDemoController: DemoController {
         }))
 
         container.addArrangedSubview(UIView())
-        container.addArrangedSubview(createButton(title: "Objective-C Demo", action: #selector(showObjCDemo)))
+        container.addArrangedSubview(createButton(title: "Objective-C Demo", action: { [weak self] _ in
+            self?.navigationController?.pushViewController(PopupMenuObjCDemoController(), animated: true)
+        }))
         addTitle(text: "Show with...")
     }
 
@@ -259,9 +261,5 @@ extension PopupMenuDemoController: DemoAppearanceDelegate {
                                                                    dark: GlobalTokens.sharedColors(.forest, .tint60))
             }
         ]
-    }
-
-    @objc private func showObjCDemo(sender: UIButton) {
-        navigationController?.pushViewController(PopupMenuObjCDemoController(), animated: true)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -159,6 +159,7 @@ class PopupMenuDemoController: DemoController {
         }))
 
         container.addArrangedSubview(UIView())
+        container.addArrangedSubview(createButton(title: "Objective-C Demo", action: #selector(showObjCDemo)))
         addTitle(text: "Show with...")
     }
 
@@ -258,5 +259,9 @@ extension PopupMenuDemoController: DemoAppearanceDelegate {
                                                                    dark: GlobalTokens.sharedColors(.forest, .tint60))
             }
         ]
+    }
+
+    @objc private func showObjCDemo(sender: UIButton) {
+        navigationController?.pushViewController(PopupMenuObjCDemoController(), animated: true)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.h
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.h
@@ -1,0 +1,15 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PopupMenuObjCDemoController : UIViewController
+@property NSIndexPath *selectedCityIndex;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
@@ -1,0 +1,128 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#import "PopupMenuObjCDemoController.h"
+#import <FluentUI/FluentUI-Swift.h>
+
+@implementation PopupMenuObjCDemoController
+
+- (instancetype)init {
+    self = [super init];
+    if (self != nil)
+    {
+        _selectedCityIndex = [[NSIndexPath alloc] initWithIndex:0];
+    }
+    return self;
+}
+
+- (void)loadView {
+    [super loadView];
+    MSFButton *demoButton = [[MSFButton alloc] initWithStyle:MSFButtonStylePrimaryOutline];
+    [demoButton setTitle:@"Show PopupMenu" forState:UIControlStateNormal];
+    [demoButton addTarget:self action:@selector(showPopupMenu) forControlEvents:UIControlEventTouchUpInside];
+
+    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[demoButton]];
+    [stack setAlignment:UIStackViewAlignmentTop];
+    [stack setTranslatesAutoresizingMaskIntoConstraints:NO];
+    UIView *view = [self view];
+    [view addSubview:stack];
+    [view setBackgroundColor:[MSFColors surfacePrimary]];
+    UILayoutGuide *safeArea = [view safeAreaLayoutGuide];
+    [NSLayoutConstraint activateConstraints:@[
+        [[stack topAnchor] constraintEqualToAnchor:[safeArea topAnchor] constant:10],
+        [[stack leadingAnchor] constraintEqualToAnchor:[safeArea leadingAnchor] constant:10],
+        [[stack trailingAnchor] constraintEqualToAnchor:[safeArea trailingAnchor] constant:-10],
+        [[stack bottomAnchor] constraintEqualToAnchor:[safeArea bottomAnchor] constant:10]
+    ]];
+}
+
+- (void)showPopupMenu {
+    MSFPopupMenuItem *montreal = [[MSFPopupMenuItem alloc] initWithImageName:@"Montreal"
+                                                       generateSelectedImage:NO
+                                                                       title:@"Montréal"
+                                                                    subtitle:@"Québec"
+                                                                   isEnabled:YES
+                                                                  isSelected:NO
+                                                                    executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                                  onSelected:nil
+                                                 isAccessoryCheckmarkVisible:YES];
+    UIImage *torontoImage = [UIImage imageNamed:@"Toronto"];
+    MSFPopupMenuItem *toronto = [[MSFPopupMenuItem alloc] initWithImage:torontoImage
+                                                          selectedImage:torontoImage
+                                                         accessoryImage:nil
+                                                                  title:@"Toronto"
+                                                               subtitle:@"Ontario"
+                                                          accessoryView:nil
+                                                              isEnabled:YES
+                                                             isSelected:NO
+                                                               executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                             onSelected:nil
+                                            isAccessoryCheckmarkVisible:YES];
+    MSFPopupMenuItem *vancouver = [[MSFPopupMenuItem alloc] initWithImageName:@"Vancouver"
+                                                        generateSelectedImage:NO
+                                                                        title:@"Vancouver"
+                                                                     subtitle:@"British Columbia"
+                                                                    isEnabled:YES
+                                                                   isSelected:NO
+                                                                     executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                                   onSelected:nil
+                                                  isAccessoryCheckmarkVisible:YES];
+    MSFPopupMenuItem *lasVegas = [[MSFPopupMenuItem alloc] initWithImageName:@"Las Vegas"
+                                                       generateSelectedImage:NO
+                                                                       title:@"Las Vegas"
+                                                                    subtitle:@"Nevada"
+                                                                   isEnabled:YES
+                                                                  isSelected:NO
+                                                                    executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                                  onSelected:nil
+                                                 isAccessoryCheckmarkVisible:YES];
+    MSFPopupMenuItem *phoenix  = [[MSFPopupMenuItem alloc] initWithImageName:@"Phoenix"
+                                                       generateSelectedImage:NO
+                                                                       title:@"Phoenix"
+                                                                    subtitle:@"Arizona"
+                                                                   isEnabled:YES
+                                                                  isSelected:NO
+                                                                    executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                                  onSelected:nil
+                                                 isAccessoryCheckmarkVisible:YES];
+    MSFPopupMenuItem *sanFrancisco  = [[MSFPopupMenuItem alloc] initWithImageName:@"San Francisco"
+                                                            generateSelectedImage:NO
+                                                                            title:@"San Francisco"
+                                                                         subtitle:@"California"
+                                                                        isEnabled:YES
+                                                                       isSelected:NO
+                                                                         executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                                       onSelected:nil
+                                                      isAccessoryCheckmarkVisible:YES];
+    MSFPopupMenuItem *seattle  = [[MSFPopupMenuItem alloc] initWithImageName:@"Seattle"
+                                                       generateSelectedImage:NO
+                                                                       title:@"Seattle"
+                                                                    subtitle:@"Washington"
+                                                                   isEnabled:YES
+                                                                  isSelected:NO
+                                                                    executes:MSFPopupMenuItemExecutionModeOnSelection
+                                                                  onSelected:nil
+                                                 isAccessoryCheckmarkVisible:YES];
+    MSFPopupMenuSection *canada = [[MSFPopupMenuSection alloc] initWithTitle:@"Canada"
+                                                                       items:@[montreal, toronto, vancouver]];
+    MSFPopupMenuSection *unitedStates = [[MSFPopupMenuSection alloc] initWithTitle:@"United States"
+                                                                             items:@[lasVegas, phoenix, sanFrancisco, seattle]];
+    UIView *source = [self view];
+    MSFPopupMenuController *popupMenu = [[MSFPopupMenuController alloc] initWithSourceView:source
+                                                                                sourceRect:[source bounds]
+                                                                        presentationOrigin:-1
+                                                                     presentationDirection:MSFDrawerPresentationDirectionDown
+                                                                    preferredMaximumHeight:-1];
+    [popupMenu addSections:@[canada, unitedStates]];
+    [popupMenu setSelectedItemIndexPath:_selectedCityIndex];
+    __weak MSFPopupMenuController *weakMenu = popupMenu;
+    [popupMenu setOnDismiss:^{
+        [self setSelectedCityIndex:[weakMenu selectedItemIndexPath]];
+    }];
+
+    [[self navigationController] presentViewController:popupMenu animated:YES completion:nil];
+}
+
+@end

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
@@ -19,9 +19,13 @@
 
 - (void)loadView {
     [super loadView];
-    MSFButton *demoButton = [[MSFButton alloc] initWithStyle:MSFButtonStylePrimaryOutline];
-    [demoButton setTitle:@"Show PopupMenu" forState:UIControlStateNormal];
-    [demoButton addTarget:self action:@selector(showPopupMenu) forControlEvents:UIControlEventTouchUpInside];
+    __weak PopupMenuObjCDemoController *weakSelf = self;
+    MSFButton *demoButton = [[MSFButton alloc] initWithStyle:MSFButtonStyleSecondary
+                                                        size:MSFButtonSizeMedium
+                                                      action:^(MSFButton * _Nonnull sender) {
+        [weakSelf showPopupMenu];
+    }];
+    [[demoButton state] setText:@"Show PopupMenu"];
 
     UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[demoButton]];
     [stack setAlignment:UIStackViewAlignmentTop];

--- a/ios/FluentUI.Demo/FluentUI.Demo/FluentUI.Demo-Bridging-Header.h
+++ b/ios/FluentUI.Demo/FluentUI.Demo/FluentUI.Demo-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "ObjectiveCDemoController.h"
+#import "PopupMenuObjCDemoController.h"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Merging `main` into `fluent2-tokens` to pick up `PopUpMenuObjCDemoController`

- #1198 

### Verification

| `main`                                       | `fluent2-tokens`                           |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Recording - iPhone 13 - 2022-08-31 at 17 01 56](https://user-images.githubusercontent.com/4934719/187805666-0c73c8f8-09ae-4387-a918-c363413befba.gif) | ![Simulator Screen Recording - iPhone 13 - 2022-08-31 at 17 02 21](https://user-images.githubusercontent.com/4934719/187805628-204ba82a-2e29-4cea-b174-afbc818d25c9.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1208)