### PR TITLE
Implement functionality to show a custom view within a CommandBarItem

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -32,6 +32,8 @@ class CommandBarDemoController: DemoController {
 
         case textStyle
 
+        case customView
+
         case disabledText
 
         var iconImage: UIImage? {
@@ -68,7 +70,7 @@ class CommandBarDemoController: DemoController {
                 return UIImage(named: "link24Regular")
             case .keyboard:
                 return UIImage(named: "keyboardDock24Regular")
-            case .textStyle, .disabledText:
+            case .textStyle, .disabledText, .customView:
                 return nil
             }
         }
@@ -99,7 +101,7 @@ class CommandBarDemoController: DemoController {
 
         var isPersistSelection: Bool {
             switch self {
-            case .add, .mention, .calendar, .arrowUndo, .arrowRedo, .copy, .delete, .link, .keyboard, .textStyle, .disabledText:
+            case .add, .mention, .calendar, .arrowUndo, .arrowRedo, .copy, .delete, .link, .keyboard, .textStyle, .disabledText, .customView:
                 return false
             case .textBold, .textItalic, .textUnderline, .textStrikethrough, .checklist, .bulletList, .numberList:
                 return true
@@ -292,6 +294,9 @@ class CommandBarDemoController: DemoController {
                 .bulletList,
                 .numberList,
                 .link
+            ],
+            [
+                .customView
             ]
         ]
 
@@ -321,7 +326,7 @@ class CommandBarDemoController: DemoController {
     }
 
     func newItem(for command: Command, isEnabled: Bool = true, isSelected: Bool = false) -> CommandBarItem {
-        CommandBarItem(
+        let commandBarItem = CommandBarItem(
             iconImage: command.iconImage,
             title: command.title,
             titleFont: command.titleFont,
@@ -332,6 +337,17 @@ class CommandBarDemoController: DemoController {
             },
             accessibilityHint: "sample accessibility hint"
         )
+
+        if command == .customView {
+            commandBarItem.customControlView = { () -> UIView in
+                let label = self.createLabelWithText("Custom View")
+                label.translatesAutoresizingMaskIntoConstraints = false
+                return label
+            }
+            commandBarItem.ignoresItemTappedHandler = true
+        }
+
+        return commandBarItem
     }
 
     func handleCommandItemTapped(command: Command, item: CommandBarItem) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -344,7 +344,6 @@ class CommandBarDemoController: DemoController {
                 label.translatesAutoresizingMaskIntoConstraints = false
                 return label
             }
-            commandBarItem.ignoresItemTappedHandler = true
         }
 
         return commandBarItem

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -76,31 +76,34 @@ class CommandBarButton: UIButton {
         isSelected = isPersistSelection && item.isSelected
         isHidden = item.isHidden
 
-        if item.customControlView == nil {
-            // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
-            let iconImage = item.iconImage
-            let title = item.title
-            let accessibilityDescription = item.accessibilityLabel
-
-            if #available(iOS 15.0, *) {
-                configuration?.image = iconImage
-                configuration?.title = iconImage != nil ? nil : title
-
-                if let font = item.titleFont {
-                    let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])
-                    configuration?.attributedTitle?.setAttributes(attributeContainer)
-                }
-            } else {
-                setImage(iconImage, for: .normal)
-                setTitle(iconImage != nil ? nil : title, for: .normal)
-                titleLabel?.font = item.titleFont
-            }
-
-            titleLabel?.isEnabled = isEnabled
-
-            accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
-            accessibilityHint = item.accessibilityHint
+        /// Additional state update is not needed if the `customControlView` is being shown
+        guard item.customControlView == nil else {
+            return
         }
+
+        // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
+        let iconImage = item.iconImage
+        let title = item.title
+        let accessibilityDescription = item.accessibilityLabel
+
+        if #available(iOS 15.0, *) {
+            configuration?.image = iconImage
+            configuration?.title = iconImage != nil ? nil : title
+
+            if let font = item.titleFont {
+                let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])
+                configuration?.attributedTitle?.setAttributes(attributeContainer)
+            }
+        } else {
+            setImage(iconImage, for: .normal)
+            setTitle(iconImage != nil ? nil : title, for: .normal)
+            titleLabel?.font = item.titleFont
+        }
+
+        titleLabel?.isEnabled = isEnabled
+
+        accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
+        accessibilityHint = item.accessibilityHint
     }
 
     private let isPersistSelection: Bool

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -97,16 +97,17 @@ class CommandBarCommandGroupsView: UIView {
 
     private func createButton(forItem item: CommandBarItem, isPersistSelection: Bool = true) -> CommandBarButton {
         let button = CommandBarButton(item: item, isPersistSelection: isPersistSelection)
-        button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
+
+        if item.shouldUseItemTappedHandler {
+            button.addTarget(self, action: #selector(handleCommandButtonTapped(_:)), for: .touchUpInside)
+        }
 
         return button
     }
 
     @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
-        if !sender.item.ignoresItemTappedHandler {
-            sender.item.handleTapped(sender)
-            sender.updateState()
-        }
+        sender.item.handleTapped(sender)
+        sender.updateState()
     }
 
     private struct LayoutConstants {

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -103,8 +103,10 @@ class CommandBarCommandGroupsView: UIView {
     }
 
     @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
-        sender.item.handleTapped(sender)
-        sender.updateState()
+        if !sender.item.ignoresItemTappedHandler {
+            sender.item.handleTapped(sender)
+            sender.updateState()
+        }
     }
 
     private struct LayoutConstants {

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -108,6 +108,12 @@ open class CommandBarItem: NSObject {
     /// Set `isSelected` to desired value in this handler. Default implementation is toggling `isSelected` property.
     @objc public var itemTappedHandler: ItemTappedHandler
 
+    /// If set, the `UIView` returned from the closure will be shown inside `CommandBarButton` instead of the `title` and `image`
+    @objc public var customControlView: (() -> UIView)?
+
+    /// If set to `true` and `customControlerView` is non-nil, the `CommandBarButton` will not call the provided `itemTappedHandler`
+    @objc public var ignoresItemTappedHandler: Bool = false
+
     @objc public lazy var menu: UIMenu? = nil // Only lazy property can be used with @available
 
     @objc public lazy var showsMenuAsPrimaryAction: Bool = false

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -108,11 +108,9 @@ open class CommandBarItem: NSObject {
     /// Set `isSelected` to desired value in this handler. Default implementation is toggling `isSelected` property.
     @objc public var itemTappedHandler: ItemTappedHandler
 
-    /// If set, the `UIView` returned from the closure will be shown inside `CommandBarButton` instead of the `title` and `image`
+    /// If set, the `UIView` returned from the closure will be shown inside `CommandBarButton` instead of the `title` and `image`. Setting this
+	/// property will disable the `itemTappedHandler`. The customControlView must manually handle gesutres.
     @objc public var customControlView: (() -> UIView)?
-
-    /// If set to `true` and `customControlerView` is non-nil, the `CommandBarButton` will not call the provided `itemTappedHandler`
-    @objc public var ignoresItemTappedHandler: Bool = false
 
     @objc public lazy var menu: UIMenu? = nil // Only lazy property can be used with @available
 
@@ -128,4 +126,9 @@ open class CommandBarItem: NSObject {
 
     /// Called after a property is changed to trigger the update of a corresponding button
     var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
+
+    /// Indicates whether the `itemTappedHandler` should be called as the item's tap handler
+    var shouldUseItemTappedHandler: Bool {
+        return customControlView == nil
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In some cases, users may want to display a custom view for a control inside of the `CommandBar`. This change aims to address that. 

Two new properties are exposed on the public `CommandBarItem` interface to support this:
1. `@objc public var customControlView: (() -> UIView)?` -- This closure allows consumers to provide a block which returns a `UIView` when called. Internally, this closure is called when creating the buttons for the `CommandBar` view and the view returned is constrained to the edge of the buttons.

When a `customControlView` is provided by the consumer, the `isAccessibilityElement` property is set to `false` for the `CommandBarButton` object so that the custom view can provide itself or its subviews as the accessibility elements. This is important for voice over mode otherwise users cannot navigate through the contents of the provided view.

### Verification
![Screen Shot 2022-08-31 at 8 17 24 PM](https://user-images.githubusercontent.com/10938746/187824576-eeb8923a-e2de-485c-850b-bbe6319c357f.png)

- Verified in devmain apps with a real-world use case
- Added usage to the demo controller and verified in the demo controller

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] VoiceOver and Keyboard Accessibility
- [X] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1210)