### PR TITLE
Simplify FluentButton, reducing binary size

### DIFF
--- a/ios/FluentUI/Vnext/Button/Button.swift
+++ b/ios/FluentUI/Vnext/Button/Button.swift
@@ -107,12 +107,17 @@ class MSFButtonStateImpl: ControlState, MSFButtonState {
     }
 }
 
-/// Body of the button adjusted for pressed or rest state
-struct FluentButtonBody: View {
+/// ButtonStyle which configures the Button View according to its state and design tokens.
+struct FluentButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) var isEnabled: Bool
     @ObservedObject var state: MSFButtonStateImpl
     @ObservedObject var tokenSet: ButtonTokenSet
-    let isPressed: Bool
+    @State var isPressed: Bool = false
+
+    func makeBody(configuration: Self.Configuration) -> some View {
+        isPressed = configuration.isPressed
+        return body
+    }
 
     var body: some View {
         let isDisabled = !isEnabled
@@ -211,16 +216,5 @@ struct FluentButtonBody: View {
         return button
             .pointerInteraction(isEnabled)
     }
-}
 
-/// ButtonStyle which configures the Button View according to its state and design tokens.
-struct FluentButtonStyle: ButtonStyle {
-    @ObservedObject var state: MSFButtonStateImpl
-    @ObservedObject var tokenSet: ButtonTokenSet
-
-    func makeBody(configuration: Self.Configuration) -> some View {
-        FluentButtonBody(state: state,
-                         tokenSet: tokenSet,
-                         isPressed: configuration.isPressed)
-    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Reduce 5kB of binary size in FluentButton by compressing two structs in `FluentButton` into one.

### Verification

No behavioral change to FluentButton after change.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/4934719/187979408-a00e428b-ebdf-46f2-8c99-c2999c0d6b72.png) | ![after](https://user-images.githubusercontent.com/4934719/187979270-c7fbd89c-0214-43ba-8e44-d26a32d68ece.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1211)