### PR TITLE
Restore lost code in separator merge

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1513,6 +1513,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         layoutContentSubviews()
         contentView.flipSubviewsForRTL()
+
+        layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
+        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)
     }
 
     open func layoutContentSubviews() {
@@ -1688,20 +1691,17 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             width: frame.width - separatorLeadingInset(for: type),
             height: separator.frame.height
         )
+        separator.flipForRTL()
     }
 
     func separatorLeadingInset(for type: SeparatorType) -> CGFloat {
-        switch type {
-        case .none:
+        guard type == .inset else {
             return 0
-        case .inset:
-            let baseOffset = TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
-                                                              selectionImageMarginTrailing: tokenSet[.selectionImageMarginTrailing].float,
-                                                              selectionImageSize: tokenSet[.selectionImageSize].float)
-            return baseOffset + paddingLeading + tokenSet[.customViewDimensions].float + tokenSet[.customViewTrailingMargin].float
-        case .full:
-            return effectiveUserInterfaceLayoutDirection == .rightToLeft ? -safeAreaInsets.right : -safeAreaInsets.left
         }
+        let baseOffset = safeAreaInsets.left + TableViewCell.selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
+                                                                                    selectionImageMarginTrailing: tokenSet[.selectionImageMarginTrailing].float,
+                                                                                    selectionImageSize: tokenSet[.selectionImageSize].float)
+        return baseOffset + paddingLeading + tokenSet[.customViewDimensions].float + tokenSet[.customViewTrailingMargin].float
     }
 
     open override func prepareForReuse() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Merge #1206 broke separator layout in `TableViewCell`. This restores the missing code.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 13 - 2022-09-01 at 15 05 40](https://user-images.githubusercontent.com/4934719/188022418-b96c9a8b-38a3-4943-a00e-da3865472901.png) | ![Simulator Screen Shot - iPhone 13 - 2022-09-01 at 15 17 37](https://user-images.githubusercontent.com/4934719/188022475-2b4939ef-89a6-4d96-b744-5fa79802c893.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1212)