### PR TITLE
Revert "PillButtonBar: Fixing warnings for iOS 15 target deployment

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -116,7 +116,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleAppendPersona() {
-        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
             let random = Int.random(in: 0...personas.count - 1)
             let persona = personas[random]
             add(persona, to: carousel)
@@ -124,7 +124,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleRemovePersona() {
-        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
             let state = carousel.state
             let count = state.count
             if count > 0 {

--- a/ios/FluentUI/Navigation/Helpers/NavigationAnimator.swift
+++ b/ios/FluentUI/Navigation/Helpers/NavigationAnimator.swift
@@ -50,7 +50,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
         let isTemporary: Bool
 
         /// A custom animation block executed during the animation
-        var customAnimation : (() -> Void)?
+        var customAnimation: (() -> Void)?
     }
 
     private typealias ViewFrameTransitionGroups = (group1: [ViewFrameTransition], group2: [ViewFrameTransition])
@@ -138,7 +138,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
 
     /// Creates a transition for two background views that are placed under the "to" and "from" view controllers, and the navigation controller's subviews.
     /// The background that appears on top has a shadow that fades out during the transition.
-    private func createBackgroundTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createBackgroundTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         let frame = transitionContext.containerView.bounds
 
         let fromBgView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 1.0, height: 1.0)))
@@ -174,7 +174,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
     }
 
     /// Creates the transitions for the "to" and "from" view controllers.
-    private func createViewControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createViewControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         guard let fromVC = transitionContext.viewController(forKey: .from), let toVC = transitionContext.viewController(forKey: .to) else {
             return
         }
@@ -188,7 +188,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
 
     /// Creates the transitions for the Navigation Controller which must be an instance of `NavigationController`.
     /// All subviews including Navigation Bar and Toolbar are animated.
-    private func createNavigationControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createNavigationControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         guard let navigationController = navigationController as? NavigationController else {
             return
         }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -51,8 +51,7 @@ open class PillButton: UIButton {
         updateAppearance()
     }
 
-    @objc public init(pillBarItem: PillButtonBarItem,
-                      style: PillButtonStyle = .primary) {
+    @objc public init(pillBarItem: PillButtonBarItem, style: PillButtonStyle = .primary) {
         self.pillBarItem = pillBarItem
         self.style = style
         super.init(frame: .zero)
@@ -106,34 +105,20 @@ open class PillButton: UIButton {
     }
 
     private func setupView() {
-        if #available(iOS 15.0, *) {
-            var configuration = UIButton.Configuration.plain()
-            configuration.attributedTitle = AttributedString(pillBarItem.title)
-            configuration.contentInsets = NSDirectionalEdgeInsets(top: Constants.topInset,
-                                                                  leading: Constants.horizontalInset,
-                                                                  bottom: Constants.bottomInset,
-                                                                  trailing: Constants.horizontalInset)
-            self.configuration = configuration
-
-            configurationUpdateHandler = { [weak self] _ in
-                self?.updateAppearance()
-            }
-        } else {
-            setTitle(pillBarItem.title, for: .normal)
-            titleLabel?.font = Constants.font
-
-            contentEdgeInsets = UIEdgeInsets(top: Constants.topInset,
-                                             left: Constants.horizontalInset,
-                                             bottom: Constants.bottomInset,
-                                             right: Constants.horizontalInset)
-        }
-
+        setTitle(pillBarItem.title, for: .normal)
+        titleLabel?.font = Constants.font
         layer.cornerRadius = PillButton.cornerRadius
         clipsToBounds = true
 
         layer.cornerCurve = .continuous
         largeContentTitle = titleLabel?.text
         showsLargeContentViewer = true
+
+        contentEdgeInsets = UIEdgeInsets(top: Constants.topInset,
+                                         left: Constants.horizontalInset,
+                                         bottom: Constants.bottomInset,
+                                         right: Constants.horizontalInset)
+
     }
 
     private func updateAccessibilityTraits() {
@@ -190,93 +175,47 @@ open class PillButton: UIButton {
     }
 
     private func updateAppearance() {
-        guard let window = window else {
-            return
-        }
+        if let window = window {
+            if isSelected {
+                if isEnabled {
+                    if let customSelectedBackgroundColor = customSelectedBackgroundColor {
+                        backgroundColor = customSelectedBackgroundColor
+                    } else {
+                        backgroundColor = isHighlighted
+                            ? PillButton.selectedHighlightedBackgroundColor(for: window, for: style)
+                            : PillButton.selectedBackgroundColor(for: window, for: style)
+                    }
 
-        // TODO: Once iOS 14 support is dropped, these should be converted to constants (let) that will be initialized by the logic below.
-        var resolvedBackgroundColor: UIColor = .clear
-        var resolvedTitleColor: UIColor = .clear
-
-        if isSelected {
-            if isEnabled {
-                resolvedBackgroundColor = customSelectedBackgroundColor ?? (isHighlighted
-                                                                            ? PillButton.selectedHighlightedBackgroundColor(for: window, for: style)
-                                                                            : PillButton.selectedBackgroundColor(for: window, for: style))
-                if #available(iOS 15.0, *) {
-                    resolvedTitleColor = customSelectedTextColor ?? (isHighlighted ? PillButton.selectedHighlightedTitleColor(for: window,
-                                                                                                                              for: style)
-                                                                     : PillButton.selectedTitleColor(for: window,
-                                                                                                     for: style))
+                    setTitleColor(customSelectedTextColor ?? PillButton.selectedTitleColor(for: window, for: style), for: .normal)
+                    setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: window, for: style), for: .highlighted)
                 } else {
-                    setTitleColor(customSelectedTextColor ?? PillButton.selectedTitleColor(for: window,
-                                                                                           for: style),
-                                  for: .normal)
-                    setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: window,
-                                                                                                      for: style),
-                                  for: .highlighted)
+                    backgroundColor = PillButton.selectedDisabledBackgroundColor(for: window, for: style)
+                    setTitleColor(PillButton.selectedDisabledTitleColor(for: window, for: style), for: .normal)
                 }
             } else {
-                resolvedBackgroundColor = PillButton.selectedDisabledBackgroundColor(for: window,
-                                                                                     for: style)
-                if #available(iOS 15.0, *) {
-                    resolvedTitleColor = PillButton.selectedDisabledTitleColor(for: window,
-                                                                       for: style)
+                if let customBackgroundColor = customBackgroundColor {
+                    backgroundColor = customBackgroundColor
                 } else {
-                    setTitleColor(PillButton.selectedDisabledTitleColor(for: window,
-                                                                        for: style),
-                                  for: .normal)
+                    backgroundColor = isEnabled
+                        ? (isHighlighted
+                            ? PillButton.highlightedBackgroundColor(for: window, for: style)
+                            : PillButton.normalBackgroundColor(for: window, for: style))
+                        : PillButton.disabledBackgroundColor(for: window, for: style)
                 }
-            }
-        } else {
-            if isEnabled {
-                unreadDotColor = customUnreadDotColor ?? PillButton.enabledUnreadDotColor(for: window,
-                                                                                          for: style)
-                resolvedBackgroundColor = customBackgroundColor ?? (isHighlighted
-                                                                    ? PillButton.highlightedBackgroundColor(for: window,
-                                                                                                            for: style)
-                                                                    : PillButton.normalBackgroundColor(for: window,
-                                                                                                       for: style))
-                if #available(iOS 15.0, *) {
-                    resolvedTitleColor = {
-                        guard let customTextColor = customTextColor else {
-                            if isHighlighted {
-                                return PillButton.highlightedTitleColor(for: window,
-                                                                        for: style)
-                            }
 
-                            return PillButton.titleColor(for: style)
-                        }
-
-                        return customTextColor
-                    }()
-                } else {
-                    setTitleColor(customTextColor ?? PillButton.titleColor(for: style),
-                                  for: .normal)
-                    setTitleColor(customTextColor ?? PillButton.highlightedTitleColor(for: window,
-                                                                                      for: style),
-                                  for: .highlighted)
-                }
-            } else {
-                unreadDotColor = customUnreadDotColor ?? PillButton.disabledUnreadDotColor(for: window,
-                                                                                           for: style)
-                resolvedBackgroundColor = customBackgroundColor ?? PillButton.disabledBackgroundColor(for: window,
-                                                                                                      for: style)
-                if #available(iOS 15.0, *) {
-                    resolvedTitleColor = PillButton.disabledTitleColor(for: window,
-                                                               for: style)
+                if isEnabled {
+                    setTitleColor(customTextColor ?? PillButton.titleColor(for: style), for: .normal)
+                    setTitleColor(customTextColor ?? PillButton.highlightedTitleColor(for: window, for: style), for: .highlighted)
                 } else {
                     setTitleColor(PillButton.disabledTitleColor(for: window, for: style), for: .disabled)
                 }
-            }
-        }
 
-        if #available(iOS 15.0, *) {
-            configuration?.background.backgroundColor = resolvedBackgroundColor
-            configuration?.attributedTitle?.setAttributes(AttributeContainer([NSAttributedString.Key.foregroundColor: resolvedTitleColor,
-                                                                              NSAttributedString.Key.font: Constants.font]))
-        } else {
-            backgroundColor = resolvedBackgroundColor
+                if isEnabled {
+                    unreadDotColor = customUnreadDotColor ?? PillButton.enabledUnreadDotColor(for: window, for: style)
+                } else {
+                    unreadDotColor = customUnreadDotColor ?? PillButton.disabledUnreadDotColor(for: window, for: style)
+                }
+            }
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -125,7 +125,6 @@ open class PillButtonBar: UIScrollView {
 
     private var stackView: UIStackView = {
         let view = UIStackView()
-        view.distribution = .fillProportionally
         view.alignment = .center
         view.spacing = Constants.minButtonsSpacing
         return view
@@ -412,15 +411,8 @@ open class PillButtonBar: UIScrollView {
         buttonExtraSidePadding = ceil(totalPadding / CGFloat(buttonEdges))
         for button in buttons {
             button.layoutIfNeeded()
-
-            if #available(iOS 15.0, *) {
-                button.configuration?.contentInsets.leading += buttonExtraSidePadding
-                button.configuration?.contentInsets.trailing += buttonExtraSidePadding
-            } else {
-                button.contentEdgeInsets.right += buttonExtraSidePadding
-                button.contentEdgeInsets.left += buttonExtraSidePadding
-            }
-
+            button.contentEdgeInsets.right += buttonExtraSidePadding
+            button.contentEdgeInsets.left += buttonExtraSidePadding
             button.layoutIfNeeded()
         }
     }
@@ -461,15 +453,8 @@ open class PillButtonBar: UIScrollView {
             let buttonWidth = button.frame.width
             if buttonWidth > 0, buttonWidth < Constants.minButtonWidth {
                 let extraInset = floor((Constants.minButtonWidth - button.frame.width) / 2)
-
-                if #available(iOS 15.0, *) {
-                    button.configuration?.contentInsets.leading += extraInset
-                    button.configuration?.contentInsets.trailing = button.configuration?.contentInsets.leading ?? extraInset
-                } else {
-                    button.contentEdgeInsets.left += extraInset
-                    button.contentEdgeInsets.right = button.contentEdgeInsets.left
-                }
-
+                button.contentEdgeInsets.left += extraInset
+                button.contentEdgeInsets.right = button.contentEdgeInsets.left
                 button.layoutIfNeeded()
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This reverts commit 8d26fe7949e49da37dc4e66b18d88390e85ec5bb.
Cherry-picking from main branch 518bdc6f9

swiftlint --fix changes

### Verification

run the app check pillbuttonbar


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1214)