### PR TITLE
Fix tokens, text width, and showDefaultDismissActionButton demo

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -71,6 +71,7 @@ struct NotificationDemoView: View {
                                        trailingImageAccessibilityLabel: trailingImageLabel,
                                        actionButtonTitle: actionButtonTitle,
                                        actionButtonAction: actionButtonAction,
+                                       showDefaultDismissActionButton: showDefaultDismissActionButton,
                                        messageButtonAction: messageButtonAction,
                                        showFromBottom: showFromBottom)
                     .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -138,7 +138,6 @@ public struct FluentNotification: View, TokenizedControlView {
                                height: imageSize.height,
                                alignment: .center)
                         .foregroundColor(Color(dynamicColor: tokenSet[.imageColor].dynamicColor))
-                        .padding(.vertical, tokenSet[.verticalPadding].float)
                 }
             }
         }
@@ -185,7 +184,7 @@ public struct FluentNotification: View, TokenizedControlView {
                 }
                 messageLabel
             }
-            .padding(.vertical, hasSecondTextRow ? tokenSet[.verticalPadding].float : tokenSet[.verticalPaddingForOneLine].float)
+            .padding(.vertical, tokenSet[.verticalPadding].float)
         }
 
         @ViewBuilder
@@ -238,7 +237,7 @@ public struct FluentNotification: View, TokenizedControlView {
                         image
                         textContainer
                         if !isFlexibleWidthToast {
-                            Spacer(minLength: horizontalSpacing)
+                            Spacer(minLength: 0)
                         }
                     }
                     .accessibilityElement(children: .combine)

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -87,17 +87,11 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
         /// The value for the vertical padding between the elements within a multi-line notification and its frame
         case verticalPadding
 
-        /// The value for the horizontal padding between the elements within a single-line notification and its frame
-        case verticalPaddingForOneLine
-
         /// The value for the horizontal spacing between the elements within a notification
         case horizontalSpacing
 
         /// The value for the minimum height of a multi-line notification
         case minimumHeight
-
-        /// The value for the minimum height of a single-line notification
-        case minimumHeightForOneLine
 
         /// The color of the outline around the frame of a notification
         case outlineColor
@@ -113,9 +107,6 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
 
         /// The font for regular text within a notification
         case regularTextFont
-
-        /// The font for footnote text within a notification
-        case footnoteTextFont
     }
 
     init(style: @escaping () -> MSFNotificationStyle) {
@@ -223,25 +214,19 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .bottomPresentationPadding:
-                return .float { 20.0 }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .horizontalPadding:
-                return .float { 19.0 }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .verticalPadding:
-                return .float { 14.0 }
-
-            case .verticalPaddingForOneLine:
-                return .float { 18.0 }
+                return .float { GlobalTokens.spacing(.small) }
 
             case .horizontalSpacing:
-                return .float { 19.0 }
+                return .float { GlobalTokens.spacing(.medium) }
 
             case .minimumHeight:
-                return .float { 64.0 }
-
-            case .minimumHeightForOneLine:
-                return .float { 56.0 }
+                return .float { 52.0 }
 
             case .outlineColor:
                 return .dynamicColor {
@@ -270,9 +255,6 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
 
             case .regularTextFont:
                 return .fontInfo { theme.aliasTokens.typography[.body2] }
-
-            case .footnoteTextFont:
-                return .fontInfo { theme.aliasTokens.typography[.caption1] }
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- Token changes made in #1159 were accidentally reverted during token merge #1206, let's restore those.
- There was double spacing (HStack spacing and Spacer spacing) that caused the text to not use all of the available width.
- There was an issue with the SwiftUI demo where the showDefaultDismissActionButton bool wasn't set, so the toggle didn't do anything.


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1215)