### PR TITLE
Remove UIEdgeInsets from SegmentedPillButton

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -32,7 +32,17 @@ class SegmentPillButton: UIButton {
         self.item = item
         super.init(frame: .zero)
 
-        self.contentEdgeInsets = Constants.insets
+        if #available(iOS 15.0, *) {
+            var configuration = UIButton.Configuration.plain()
+            configuration.contentInsets = Constants.insets
+            configuration.background.backgroundColor = .clear
+            self.configuration = configuration
+        } else {
+            self.contentEdgeInsets = UIEdgeInsets(top: Constants.insets.top,
+                                                  left: Constants.insets.leading,
+                                                  bottom: Constants.insets.bottom,
+                                                  right: Constants.insets.trailing)
+        }
 
         let title = item.title
         if let image = item.image {
@@ -93,6 +103,6 @@ class SegmentPillButton: UIButton {
         static let fontSize: CGFloat = 16
         static let unreadDotOffset = CGPoint(x: 6, y: 3)
         static let unreadDotSize: CGFloat = 6
-        static let insets = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
+        static let insets = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16)
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -44,6 +44,7 @@ class SegmentPillButton: UIButton {
                                                   right: Constants.insets.trailing)
         }
 
+        // TODO: Once iOS 14 support is dropped, set title, etc., in configuration
         let title = item.title
         if let image = item.image {
             self.setImage(image, for: .normal)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated the UIEdgeInsets in the SegmentedPillButton to be NSDirectionalEdgeInsets, and set the insets using the configuration on iOS 15.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_Before](https://user-images.githubusercontent.com/67026548/188761199-95b498e7-4013-4a8b-9d66-75a6171e8e0d.gif) | ![SegmentedControl_After](https://user-images.githubusercontent.com/67026548/188761208-c8a41359-76ae-4543-8759-c7722dcc9066.gif) |
| ![SegmentedControl_RTL_Before](https://user-images.githubusercontent.com/67026548/188967383-d1d1b18f-d876-4b41-9f65-581aab1bfa44.png) | ![SegmentedControl_RTL_After](https://user-images.githubusercontent.com/67026548/188967392-38527dbd-bbd0-4db3-92ab-471d2de44d48.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1221)