### PR TITLE
[Fluent 2 iOS] Contextual Command Bar colors update

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -58,6 +58,18 @@ class CommandBarButton: UIButton {
         showsMenuAsPrimaryAction = item.showsMenuAsPrimaryAction
 
         updateState()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        updateStyle()
     }
 
     @available(*, unavailable)

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -152,12 +152,4 @@ class CommandBarButton: UIButton {
                                                     bottom: 8.0,
                                                     right: 10.0)
     }
-
-    private struct ColorConstants {
-        static let normalTintColor: UIColor = Colors.textPrimary
-        static let normalBackgroundColor = UIColor(light: Colors.gray50,
-                                                   dark: Colors.gray600)
-        static let highlightedBackgroundColor = UIColor(light: Colors.gray100,
-                                                        dark: Colors.gray900)
-    }
 }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -113,13 +113,23 @@ class CommandBarButton: UIButton {
     }
 
     private var selectedTintColor: UIColor {
+        guard let darkColorValue = fluentTheme.aliasTokens.colors[.foreground1].dark else {
+            return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground4].light),
+                           dark: UIColor(colorValue: GlobalTokens.neutralColors(.white)))
+        }
+
         return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground4].light),
-                       dark: UIColor(colorValue: fluentTheme.aliasTokens.colors[.foreground1].dark!))
+                       dark: UIColor(colorValue: darkColorValue))
     }
 
     private var selectedBackgroundColor: UIColor {
+        guard let darkColorValue = fluentTheme.aliasTokens.colors[.background5Selected].dark else {
+            return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandBackground4].light),
+                           dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey38)))
+        }
+
         return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandBackground4].light),
-                       dark: UIColor(colorValue: fluentTheme.aliasTokens.colors[.background5Selected].dark!))
+                       dark: UIColor(colorValue: darkColorValue))
     }
 
     private var normalBackgroundColor: UIColor {

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -113,23 +113,13 @@ class CommandBarButton: UIButton {
     }
 
     private var selectedTintColor: UIColor {
-        guard let darkColorValue = fluentTheme.aliasTokens.colors[.foreground1].dark else {
-            return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground4].light),
-                           dark: UIColor(colorValue: GlobalTokens.neutralColors(.white)))
-        }
-
-        return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground4].light),
-                       dark: UIColor(colorValue: darkColorValue))
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground4].light,
+                                                  dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
     }
 
     private var selectedBackgroundColor: UIColor {
-        guard let darkColorValue = fluentTheme.aliasTokens.colors[.background5Selected].dark else {
-            return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandBackground4].light),
-                           dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey38)))
-        }
-
-        return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandBackground4].light),
-                       dark: UIColor(colorValue: darkColorValue))
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground4].light,
+                                                 dark: fluentTheme.aliasTokens.colors[.background5Selected].dark))
     }
 
     private var normalBackgroundColor: UIColor {

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -96,48 +96,49 @@ class CommandBarButton: UIButton {
 
     private let isPersistSelection: Bool
 
-    private var selectedTintColor: UIColor {
-        guard let window = window else {
-            return UIColor(light: Colors.communicationBlue,
-                           dark: .black)
-        }
+    private var normalTintColor: UIColor {
+        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+    }
 
-        return UIColor(light: Colors.primary(for: window),
-                       dark: .black)
+    private var selectedTintColor: UIColor {
+        return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground4].light),
+                       dark: UIColor(colorValue: fluentTheme.aliasTokens.colors[.foreground1].dark!))
     }
 
     private var selectedBackgroundColor: UIColor {
-        guard let window = window else {
-            return UIColor(light: Colors.Palette.communicationBlueTint30.color,
-                           dark: Colors.Palette.communicationBlue.color)
-        }
+        return UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandBackground4].light),
+                       dark: UIColor(colorValue: fluentTheme.aliasTokens.colors[.background5Selected].dark!))
+    }
 
-        return  UIColor(light: Colors.primaryTint30(for: window),
-                        dark: Colors.primary(for: window))
+    private var normalBackgroundColor: UIColor {
+        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+    }
+
+    private var highlightedBackgroundColor: UIColor {
+        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5Pressed])
     }
 
     private func updateStyle() {
         // TODO: Once iOS 14 support is dropped, this should be converted to a constant (let) that will be initialized by the logic below.
         var resolvedBackgroundColor: UIColor = .clear
-        let resolvedTintColor: UIColor = isSelected ? selectedTintColor : ColorConstants.normalTintColor
+        let resolvedTintColor: UIColor = isSelected ? selectedTintColor : normalTintColor
 
         if isPersistSelection {
             if isSelected {
                 resolvedBackgroundColor = selectedBackgroundColor
             } else if isHighlighted {
-                resolvedBackgroundColor = ColorConstants.highlightedBackgroundColor
+                resolvedBackgroundColor = highlightedBackgroundColor
             } else {
-                resolvedBackgroundColor = ColorConstants.normalBackgroundColor
+                resolvedBackgroundColor = normalBackgroundColor
             }
         }
 
-        tintColor = resolvedTintColor
         if #available(iOS 15.0, *) {
             configuration?.baseForegroundColor = resolvedTintColor
             configuration?.background.backgroundColor = resolvedBackgroundColor
         } else {
             backgroundColor = resolvedBackgroundColor
-            setTitleColor(tintColor, for: .normal)
+            setTitleColor(resolvedTintColor, for: .normal)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The CCB was updated to use Fluent 2 tokens.

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_normal_light" src="https://user-images.githubusercontent.com/106181067/188933795-255ffa3a-221f-4d0c-9e14-5d9ef65c8f76.png"> | <img width="488" alt="after_normal_light" src="https://user-images.githubusercontent.com/106181067/188933842-aaccfaf4-2cdc-46ea-bb77-d0a4b7440ece.png"> |
| <img width="488" alt="before_normal_dark" src="https://user-images.githubusercontent.com/106181067/188933866-66b87126-f09d-447e-beaf-6a4e5a563d06.png"> | <img width="488" alt="after_normal_dark" src="https://user-images.githubusercontent.com/106181067/188933911-c7720089-ca6e-4a67-b34e-ec9c956da948.png"> |
| ![before](https://user-images.githubusercontent.com/106181067/188935140-0066aec3-ed86-4831-a985-73894eaec3b3.gif) | ![after](https://user-images.githubusercontent.com/106181067/188935188-d18ae1d8-3067-4a73-bf70-a50061bbe877.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1223)