### PR TITLE
[Fluent 2 iOS] ResizingHandleView color update

### DIFF
--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -33,7 +33,19 @@ open class ResizingHandleView: UIView {
         isUserInteractionEnabled = false
         updateMarkLayerBackgroundColor()
         layer.addSublayer(markLayer)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
     }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+       guard let window = window, window.isEqual(notification.object) else {
+           return
+       }
+        updateMarkLayerBackgroundColor()
+   }
 
     private func updateMarkLayerBackgroundColor() {
         markLayer.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -48,7 +48,7 @@ open class ResizingHandleView: UIView {
    }
 
     private func updateMarkLayerBackgroundColor() {
-        markLayer.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+        markLayer.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.strokeAccessible]).cgColor
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -5,14 +5,6 @@
 
 import UIKit
 
-// MARK: ResizingHandle Colors
-
-private extension Colors {
-    struct ResizingHandle {
-        public static var mark: UIColor = iconSecondary
-    }
-}
-
 // MARK: - ResizingHandleView
 
 @objc(MSFResizingHandleView)
@@ -28,7 +20,6 @@ open class ResizingHandleView: UIView {
         let markLayer = CALayer()
         markLayer.bounds.size = Constants.markSize
         markLayer.cornerRadius = Constants.markCornerRadius
-        markLayer.backgroundColor = Colors.ResizingHandle.mark.cgColor
         return markLayer
     }()
 
@@ -40,7 +31,12 @@ open class ResizingHandleView: UIView {
         setContentHuggingPriority(.required, for: .vertical)
         setContentCompressionResistancePriority(.required, for: .vertical)
         isUserInteractionEnabled = false
+        updateMarkLayerBackgroundColor()
         layer.addSublayer(markLayer)
+    }
+
+    private func updateMarkLayerBackgroundColor() {
+        markLayer.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
     }
 
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The handle view was updated to match fluent 2 specs.

### Verification

The change was tested on the BottomSheet demo

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_light" src="https://user-images.githubusercontent.com/106181067/188994850-083e7419-359e-4fa9-b7df-d93a476a0eab.png"> | <img width="487" alt="Screen Shot 2022-09-26 at 10 59 47 AM" src="https://user-images.githubusercontent.com/106181067/192347767-9e5d9c75-ade5-462c-aacd-2e9785e8af01.png"> |
| <img width="488" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/188994909-ce67c227-4b28-4313-b247-10b9fee32864.png"> | <img width="487" alt="Screen Shot 2022-09-26 at 11 00 05 AM" src="https://user-images.githubusercontent.com/106181067/192347861-54674a93-4894-4ad1-a7ed-d75d1a5218c1.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1224)