### PR TITLE
allow colorful image in notification toast

### DIFF
--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -132,8 +132,7 @@ public struct FluentNotification: View, TokenizedControlView {
             if state.style.isToast {
                 if let image = state.image {
                     let imageSize = image.size
-                    Image(uiImage: image)
-                        .renderingMode(.template)
+                    Image(uiImage: image.renderingMode == .automatic ? image.withRenderingMode(.alwaysTemplate) : image)
                         .frame(width: imageSize.width,
                                height: imageSize.height,
                                alignment: .center)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Currently we always render the toast image as template. If the client team pass in image that is set "renderAsOriginal" respect that mode.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 11 Pro - 2022-09-07 at 18 11 14](https://user-images.githubusercontent.com/20715435/189011881-a18a833c-27e9-48f7-ac99-887ef58caa73.png)|![Simulator Screen Shot - iPhone 11 Pro - 2022-09-07 at 18 10 36](https://user-images.githubusercontent.com/20715435/189011903-881d1398-e1c1-40a4-a15b-96999b830c97.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1225)