### PR TITLE
Revert Notification Colors to Fluent 1 Tokens

### DIFF
--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -116,80 +116,69 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
             case .backgroundColor:
                 return .dynamicColor {
                     switch style() {
-                    case .primaryToast:
-                        return theme.aliasTokens.brandColors[.tint40]
-                    case .neutralToast:
-                        return DynamicColor(light: ColorValue(0xF7F7F7),
-                                            dark: ColorValue(0x393939))
-                    case .primaryBar:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.tint40].light,
-                                            dark: theme.aliasTokens.brandColors[.tint10].dark)
+                    case .primaryToast,
+                            .primaryBar:
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.tint30].light,
+                                            dark: theme.aliasTokens.brandColors[.primary].dark)
+                    case .neutralToast,
+                            .neutralBar:
+                        return DynamicColor(light: ColorValue(0xE1E1E1),
+                                            dark: ColorValue(0x404040))
                     case .primaryOutlineBar:
-                        return DynamicColor(light: ColorValue(0xFFFFFF),
-                                            dark: ColorValue(0x393939))
-                    case .neutralBar:
-                        return DynamicColor(light: ColorValue(0xDFDFDF),
-                                            dark: ColorValue(0x393939))
+                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                            dark: ColorValue(0x404040))
                     case .dangerToast:
-                        return DynamicColor(light: ColorValue(0xFDF6F6),
-                                            dark: ColorValue(0x3F1011))
+                        return DynamicColor(light: ColorValue(0xF9D9D9),
+                                            dark: ColorValue(0xE83A3A))
                     case .warningToast:
-                        return DynamicColor(light: ColorValue(0xFFFBD6),
-                                            dark: ColorValue(0x4C4400))
+                        return DynamicColor(light: ColorValue(0xFFF8DF),
+                                            dark: ColorValue(0xFFC328))
                     }
                 }
 
             case .foregroundColor:
                 return .dynamicColor {
                     switch style() {
-                    case .primaryToast:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
-                                            dark: theme.aliasTokens.brandColors[.shade30].dark)
-                    case .neutralToast:
-                        return DynamicColor(light: ColorValue(0x393939),
-                                            dark: ColorValue(0xF7F7F7))
-                    case .primaryBar:
+                    case .primaryToast,
+                            .primaryBar:
                         return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
-                                            dark: ColorValue(0x000000))
+                                            dark: GlobalTokens.neutralColors(.black))
+                    case .neutralToast,
+                            .neutralBar:
+                        return DynamicColor(light: ColorValue(0x212121),
+                                            dark: GlobalTokens.neutralColors(.white))
                     case .primaryOutlineBar:
                         return DynamicColor(light: theme.aliasTokens.brandColors[.primary].light,
-                                            dark: ColorValue(0xF7F7F7))
-                    case .neutralBar:
-                        return DynamicColor(light: ColorValue(0x090909),
-                                            dark: ColorValue(0xF7F7F7))
+                                            dark: GlobalTokens.neutralColors(.white))
                     case .dangerToast:
-                        return DynamicColor(light: ColorValue(0xBC2F34),
-                                            dark: ColorValue(0xDC5F63))
+                        return DynamicColor(light: ColorValue(0xA52121),
+                                            dark: GlobalTokens.neutralColors(.black))
                     case .warningToast:
-                        return DynamicColor(light: ColorValue(0x4C4400),
-                                            dark: ColorValue(0xFDEA3D))
+                        return DynamicColor(light: ColorValue(0x8F761E),
+                                            dark: GlobalTokens.neutralColors(.black))
                     }
                 }
 
             case .imageColor:
                 return .dynamicColor {
                     switch style() {
-                    case .primaryToast:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
-                                            dark: theme.aliasTokens.brandColors[.shade30].dark)
-                    case .neutralToast:
-                        return DynamicColor(light: ColorValue(0x393939),
-                                            dark: ColorValue(0xF7F7F7))
-                    case .primaryBar:
+                    case .primaryToast,
+                            .primaryBar:
                         return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
-                                            dark: ColorValue(0x000000))
+                                            dark: GlobalTokens.neutralColors(.black))
+                    case .neutralToast,
+                            .neutralBar:
+                        return DynamicColor(light: ColorValue(0x212121),
+                                            dark: GlobalTokens.neutralColors(.white))
                     case .primaryOutlineBar:
                         return DynamicColor(light: theme.aliasTokens.brandColors[.primary].light,
-                                            dark: ColorValue(0xF7F7F7))
-                    case .neutralBar:
-                        return DynamicColor(light: ColorValue(0x090909),
-                                            dark: ColorValue(0xF7F7F7))
+                                            dark: GlobalTokens.neutralColors(.white))
                     case .dangerToast:
-                        return DynamicColor(light: ColorValue(0xBC2F34),
-                                            dark: ColorValue(0xDC5F63))
+                        return DynamicColor(light: ColorValue(0xA52121),
+                                            dark: GlobalTokens.neutralColors(.black))
                     case .warningToast:
-                        return DynamicColor(light: ColorValue(0x4C4400),
-                                            dark: ColorValue(0xFDEA3D))
+                        return DynamicColor(light: ColorValue(0x8F761E),
+                                            dark: GlobalTokens.neutralColors(.black))
                     }
                 }
 
@@ -234,7 +223,8 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case .primaryToast, .neutralToast, .primaryBar, .neutralBar, .dangerToast, .warningToast:
                         return DynamicColor(light: ColorValue.clear)
                     case .primaryOutlineBar:
-                        return theme.aliasTokens.strokeColors[.neutral2]
+                        return DynamicColor(light: ColorValue(0xE1E1E1),
+                                            dark: ColorValue(0x303030))
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fluent 2 colors weren't meant to go main yet. Let's revert the colors to Fluent 1 colors so we can address some color regressions in devmain.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/31874971/189011698-56eef36d-9a8d-4d3e-b3c7-abec58bd1ca1.mp4 | https://user-images.githubusercontent.com/31874971/189011733-cab36906-6501-4c4e-8f04-1260f0225ed3.mp4 |
| https://user-images.githubusercontent.com/31874971/189011787-41ac5c61-0cbb-485e-9006-252823ef9667.mp4 | https://user-images.githubusercontent.com/31874971/189011773-17df8d63-3b81-4ba5-851c-34f58529128f.mp4 |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1226)