### PR TITLE
CommandBar: Update group spacing and add large content viewer support

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -59,6 +59,13 @@ class CommandBarButton: UIButton {
             accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
             accessibilityHint = item.accessibilityHint
 
+            /// Large content viewer
+            addInteraction(UILargeContentViewerInteraction())
+            showsLargeContentViewer = true
+            scalesLargeContentImage = true
+            largeContentImage = item.iconImage
+            largeContentTitle = item.title
+
             menu = item.menu
             showsMenuAsPrimaryAction = item.showsMenuAsPrimaryAction
         }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -111,7 +111,7 @@ class CommandBarCommandGroupsView: UIView {
     }
 
     private struct LayoutConstants {
-		static let buttonGroupSpacing: CGFloat = 8.0
+        static let buttonGroupSpacing: CGFloat = 8.0
         static let insets = UIEdgeInsets(top: 8.0,
                                          left: 8.0,
                                          bottom: 8.0,

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -111,7 +111,7 @@ class CommandBarCommandGroupsView: UIView {
     }
 
     private struct LayoutConstants {
-        static let buttonGroupSpacing: CGFloat = 16
+		static let buttonGroupSpacing: CGFloat = 8.0
         static let insets = UIEdgeInsets(top: 8.0,
                                          left: 8.0,
                                          bottom: 8.0,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change addresses two things:

1. Feedback was received that the spacing between item groups was too large. A new spacing of `8 pts` was proposed to and approved by the Fluent Design team.
2. Add Large Content Viewer support to `CommandBarButton`s that do not show custom views. This is currently not supported on the `CommandBar`. It's a common accessibility feature seen on tab bars, toolbars, etc..

### Verification

Verified behavior on iPad and iPhone using demo controllers.

### Spacing Demo
iPhone Before (16 pt):
![Before - 16pt](https://user-images.githubusercontent.com/10938746/189256189-f6a8f478-e0cb-4e39-82e8-d77352ea0f7d.png)

iPhone After (8 pt):
![After - 8PT](https://user-images.githubusercontent.com/10938746/189255950-2679f5aa-353a-4814-8ea3-96a4d18d4003.png)

iPad Before (16pt):
![Before - 16pt (iPad)](https://user-images.githubusercontent.com/10938746/189256012-f80bc369-0d2e-41cf-af8e-d647edcc9b25.png)

iPad After (8 pt):
![After - 8pt (iPad)](https://user-images.githubusercontent.com/10938746/189256082-b7518bf9-d0e1-4f27-869a-36c772ce3977.png)

### Large Content View Demo

(Note: A title of "Default Title" was provided for all demo items without titles for this video)

https://user-images.githubusercontent.com/10938746/189256436-0b21c84a-8442-43c1-9e72-f6e18d45659b.mov



### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [X] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [X] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1229)