### PR TITLE
Instantiating state variables in HUD

### DIFF
--- a/ios/FluentUI/HUD/HeadsUpDisplay.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplay.swift
@@ -171,8 +171,8 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
         }
     }
 
-    @State private var opacity: Double
-    @State private var presentationScaleFactor: CGFloat
+    @State private var opacity: Double = HeadsUpDisplayTokenSet.opacityPresented
+    @State private var presentationScaleFactor: CGFloat = HeadsUpDisplayTokenSet.presentationScaleFactorDefault
 }
 
 /// Properties available to customize the state of the HUD


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Bringing back HUD's state variable instantiation from #1206, which was causing some errors in downstream dependencies.

### Verification

pod lib lint, passed build in demo test app, passed builds in downstream dependencies.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1233)