### PR TITLE
Update AttributedText to scale

### DIFF
--- a/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
@@ -50,6 +50,7 @@ struct AttributedText: UIViewRepresentable {
         label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated `AttributedText` to set `.adjustsFontForContentSizeCategory` to true so it would change size when the user changes their text size.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AttributedTextScaling_Before](https://user-images.githubusercontent.com/67026548/189453567-ecedf6d9-47b9-477e-9773-26df680c3cc0.gif) | ![AttributedTextScaling_After](https://user-images.githubusercontent.com/67026548/189453579-90d9a758-d34f-49e7-96fb-54defa8ca131.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1234)