### PR TITLE
Fix RTL behavior for CommandBar leading and trailing Items

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -232,9 +232,7 @@ open class CommandBar: UIView {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
             let flipTransform = CGAffineTransform(scaleX: -1, y: 1)
             scrollView.transform = flipTransform
-            leadingCommandGroupsView.transform = flipTransform
             mainCommandGroupsView.transform = flipTransform
-            trailingCommandGroupsView.transform = flipTransform
             containerMaskLayer.setAffineTransform(flipTransform)
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

It was discovered that the RTL behavior for the leading/trailing items in the `CommandBar` was off. The leading and trailing groups are switching sides as expected, but the additional transform being applied in `configureHierarchy` is causing the views inside the groups to be shown in LTR order when the device is using a RTL language.

**Fix:**
Remove the transform for the leading and trailing groups inside `configureHierarchy` and let the default behavior from the `UIStackView` handle the transition.

**Regression Info:**
This regression was originally introduced with commit [1e8d6806062c12aee072caff2b10cf8254e9a51b](https://github.com/microsoft/fluentui-apple/commit/1e8d6806062c12aee072caff2b10cf8254e9a51b). The 0.6, 0.7 and 0.8 versions will be updated with this fix.

Only consumers who have updated use cases to show more than 1 item in the leading or trailing positions of the `CommandBar` will see this regression, otherwise it is unobservable in an application.

### Verification

Verified in the `CommandBarDemoController` with both LTR and RTL languages. Confirmed that when there is more than 1 item in the leading or trailing item group, that the items are shown in reversed order.

Before LTR Screenshot:
![before-ltr](https://user-images.githubusercontent.com/10938746/189704147-e490035e-db03-4e7c-a64e-ee3e716419a8.png)

Before RTL Screenshot (note: the keyboard icon should be in the rightmost position):
![before-rtl](https://user-images.githubusercontent.com/10938746/189704160-dd6c1061-4452-4f8f-894c-7b289b98c2ce.png)

After LTR Screenshot:
![after-ltr](https://user-images.githubusercontent.com/10938746/189704312-677593db-3781-4931-be5c-5ba3f298bcf4.png)

After RTL Screenshot (note: the keyboard icon is in the rightmost position):
![after-rtl](https://user-images.githubusercontent.com/10938746/189704349-4fe94308-528c-45b2-8ec7-c8f43b1dd2ff.png)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1236)