### PR TITLE
[main_0.8] Cherrypicking #1204 & #1236

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -232,9 +232,7 @@ open class CommandBar: UIView {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
             let flipTransform = CGAffineTransform(scaleX: -1, y: 1)
             scrollView.transform = flipTransform
-            leadingCommandGroupsView.transform = flipTransform
             mainCommandGroupsView.transform = flipTransform
-            trailingCommandGroupsView.transform = flipTransform
             containerMaskLayer.setAffineTransform(flipTransform)
         }
 

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -342,10 +342,13 @@ open class Button: NSButton {
 
 	private static let borderWidth: CGFloat = 1
 
+	private var minButtonHeight: CGFloat = ButtonSizeParameters.large.minButtonHeight
+
 	private func setSizeParameters(forSize: ButtonSize) {
 		let parameters = ButtonSizeParameters.parameters(forSize: size)
 		font = NSFont.systemFont(ofSize: parameters.fontSize)
 		cornerRadius = parameters.cornerRadius
+		minButtonHeight = parameters.minButtonHeight
 		guard let cell = cell as? ButtonCell else {
 			return
 		}
@@ -367,6 +370,12 @@ open class Button: NSButton {
 			invalidateIntrinsicContentSize()
 			needsDisplay = true
 		}
+	}
+
+	open override var intrinsicContentSize: CGSize {
+		let superSize = super.intrinsicContentSize
+		return CGSize(width: superSize.width,
+					  height: superSize.height < minButtonHeight ? minButtonHeight : superSize.height)
 	}
 }
 
@@ -523,7 +532,14 @@ class ButtonCell: NSButtonCell {
 /// Indicates the size of the button
 @objc(MSFButtonSize)
 public enum ButtonSize: Int, CaseIterable {
+
+	/// Minimum Button Height - 28 pts
 	case large
+
+	/// Minimum Button Height - 24 pts
+	case medium
+
+	/// Minimum Button Height - 20 pts
 	case small
 }
 
@@ -587,6 +603,7 @@ private struct ButtonSizeParameters {
 	fileprivate let titleVerticalPositionAdjustment: CGFloat
 	fileprivate let titleToImageSpacing: CGFloat
 	fileprivate let titleToImageVerticalSpacingAdjustment: CGFloat
+	fileprivate var minButtonHeight: CGFloat
 
 	static let large = ButtonSizeParameters(
 		fontSize: 15,  // line height: 19
@@ -595,7 +612,19 @@ private struct ButtonSizeParameters {
 		horizontalPadding: 36,
 		titleVerticalPositionAdjustment: -0.25,
 		titleToImageSpacing: 10,
-		titleToImageVerticalSpacingAdjustment: 7
+		titleToImageVerticalSpacingAdjustment: 7,
+		minButtonHeight: 28
+	)
+
+	static let medium = ButtonSizeParameters(
+		fontSize: 13,  // line height: 17
+		cornerRadius: 6,
+		verticalPadding: 2.0, // overall height: 24
+		horizontalPadding: 5,
+		titleVerticalPositionAdjustment: 0,
+		titleToImageSpacing: 3,
+		titleToImageVerticalSpacingAdjustment: 7,
+		minButtonHeight: 24
 	)
 
 	static let small = ButtonSizeParameters(
@@ -605,13 +634,16 @@ private struct ButtonSizeParameters {
 		horizontalPadding: 14,
 		titleVerticalPositionAdjustment: 0,
 		titleToImageSpacing: 6,
-		titleToImageVerticalSpacingAdjustment: 7
+		titleToImageVerticalSpacingAdjustment: 7,
+		minButtonHeight: 20
 	)
 
 	static func parameters(forSize: ButtonSize) -> ButtonSizeParameters {
 		switch forSize {
 		case .large:
 			return .large
+		case .medium:
+			return .medium
 		case .small:
 			return .small
 		}

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -171,6 +171,10 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 		let largeSecondary = ButtonFormat(size: .large, style: .secondary, accentColor: communicationBlue)
 		let largeAcrylic = ButtonFormat(size: .large, style: .acrylic, accentColor: communicationBlue)
 		let largeBorderless = ButtonFormat(size: .large, style: .borderless, accentColor: communicationBlue)
+		let mediumPrimary = ButtonFormat(size: .medium, style: .primary, accentColor: communicationBlue)
+		let mediumSecondary = ButtonFormat(size: .medium, style: .secondary, accentColor: communicationBlue)
+		let mediumAcrylic = ButtonFormat(size: .medium, style: .acrylic, accentColor: communicationBlue)
+		let mediumBorderless = ButtonFormat(size: .medium, style: .borderless, accentColor: communicationBlue)
 		let smallPrimary = ButtonFormat(size: .small, style: .primary, accentColor: Colors.primary)
 		let smallSecondary = ButtonFormat(size: .small, style: .secondary, accentColor: Colors.primary)
 		let smallAcrylic = ButtonFormat(size: .small, style: .acrylic, accentColor: Colors.primary)
@@ -183,6 +187,10 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 			largeSecondary,
 			largeAcrylic,
 			largeBorderless,
+			mediumPrimary,
+			mediumSecondary,
+			mediumAcrylic,
+			mediumBorderless,
 			smallPrimary,
 			smallSecondary,
 			smallAcrylic,
@@ -195,6 +203,10 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 			NSTextField(labelWithString: "Large Secondary"),
 			NSTextField(labelWithString: "Large Acrylic"),
 			NSTextField(labelWithString: "Large Borderless"),
+			NSTextField(labelWithString: "Medium Primary"),
+			NSTextField(labelWithString: "Medium Secondary"),
+			NSTextField(labelWithString: "Medium Acrylic"),
+			NSTextField(labelWithString: "Medium Borderless"),
 			NSTextField(labelWithString: "Small Primary"),
 			NSTextField(labelWithString: "Small Secondary"),
 			NSTextField(labelWithString: "Small Acrylic"),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picked bc3a4c2ebe03764e8b47c9f2ba623e656cab5e35 (#1204) & 8273727afd7902fbe4054ddaa6c0a10c3419a7e5 (#1236)

### Verification

pod lib lint

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1237)