### PR TITLE
[Draft] Apply multiple shadows in UIKit

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardViewDemoController.swift
@@ -75,6 +75,11 @@ class CardViewDemoController: DemoController {
                         colorStyle: .custom)
                     cardWithLongTitle.twoLineTitle = true
                     cardWithLongTitle.delegate = self
+
+                    let shadowLayers = ShadowUtil.getShadowLayers(shadowInfo: cardWithLongTitle.fluentTheme.aliasTokens.shadow[.shadow28])
+                    cardWithLongTitle.layer.insertSublayer(shadowLayers[1], at: 0)
+                    cardWithLongTitle.layer.insertSublayer(shadowLayers[0], below: shadowLayers[1])
+
                     let cardWithLongTitleAndSubtitle = CardView(
                         size: size,
                         title: "Title that is very very very very long",

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreGraphics
+import UIKit
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
@@ -59,4 +60,13 @@ public struct ShadowInfo {
 
     /// The vertical offset of the shadow for shadow 2.
     public let yTwo: CGFloat
+
+    /// Applies the chosen shadow to a specified view
+    public func applyShadow(for view: UIView, isShadowOne: Bool) {
+        view.layer.shadowColor = isShadowOne ? UIColor(dynamicColor: colorOne).cgColor : UIColor(dynamicColor: colorTwo).cgColor
+        view.layer.shadowRadius = isShadowOne ? (blurOne / 2) : (blurTwo / 2)
+        view.layer.shadowOpacity = 1
+        view.layer.shadowOffset = CGSize(width: isShadowOne ? xOne : xTwo,
+                                         height: isShadowOne ? yOne : yTwo)
+    }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -4,7 +4,6 @@
 //
 
 import CoreGraphics
-import UIKit
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
@@ -60,13 +59,4 @@ public struct ShadowInfo {
 
     /// The vertical offset of the shadow for shadow 2.
     public let yTwo: CGFloat
-
-    /// Applies the chosen shadow to a specified view
-    public func applyShadow(for view: UIView, isShadowOne: Bool) {
-        view.layer.shadowColor = isShadowOne ? UIColor(dynamicColor: colorOne).cgColor : UIColor(dynamicColor: colorTwo).cgColor
-        view.layer.shadowRadius = isShadowOne ? (blurOne / 2) : (blurTwo / 2)
-        view.layer.shadowOpacity = 1
-        view.layer.shadowOffset = CGSize(width: isShadowOne ? xOne : xTwo,
-                                         height: isShadowOne ? yOne : yTwo)
-    }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreGraphics
+import UIKit
 
 /// Represents a two-part shadow as used by FluentUI.
 public struct ShadowInfo {
@@ -59,4 +60,23 @@ public struct ShadowInfo {
 
     /// The vertical offset of the shadow for shadow 2.
     public let yTwo: CGFloat
+}
+
+public class ShadowUtil {
+    public static func getShadowLayers(shadowInfo: ShadowInfo) -> [CALayer] {
+        let shadow1 = CALayer()
+        let shadow2 = CALayer()
+
+        shadow1.shadowColor = UIColor(dynamicColor: shadowInfo.colorOne).cgColor
+        shadow1.shadowOffset = CGSize(width: shadowInfo.xOne, height: shadowInfo.yOne)
+        shadow1.shadowRadius = shadowInfo.blurOne
+        shadow1.shadowOpacity = 1
+
+        shadow2.shadowColor = UIColor(dynamicColor: shadowInfo.colorTwo).cgColor
+        shadow2.shadowOffset = CGSize(width: shadowInfo.xTwo, height: shadowInfo.yTwo)
+        shadow2.shadowRadius = shadowInfo.blurTwo
+        shadow2.shadowOpacity = 1
+
+        return [shadow1, shadow2]
+    }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -64,7 +64,6 @@ public struct ShadowInfo {
     /// Applies the chosen shadow to a specified view
     public func applyShadow(for view: UIView, isShadowOne: Bool) {
         view.layer.shadowColor = isShadowOne ? UIColor(dynamicColor: colorOne).cgColor : UIColor(dynamicColor: colorTwo).cgColor
-        /// The chosen blur value needs to be halved to correctly display the Fluent shadows
         view.layer.shadowRadius = isShadowOne ? (blurOne / 2) : (blurTwo / 2)
         view.layer.shadowOpacity = 1
         view.layer.shadowOffset = CGSize(width: isShadowOne ? xOne : xTwo,

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -64,6 +64,7 @@ public struct ShadowInfo {
     /// Applies the chosen shadow to a specified view
     public func applyShadow(for view: UIView, isShadowOne: Bool) {
         view.layer.shadowColor = isShadowOne ? UIColor(dynamicColor: colorOne).cgColor : UIColor(dynamicColor: colorTwo).cgColor
+        /// The chosen blur value needs to be halved to correctly display the Fluent shadows
         view.layer.shadowRadius = isShadowOne ? (blurOne / 2) : (blurTwo / 2)
         view.layer.shadowOpacity = 1
         view.layer.shadowOffset = CGSize(width: isShadowOne ? xOne : xTwo,


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

I created a function that returns an array of layers with pre applied shadows. However, when I insert those sublayers to a card's base layer the shadows don't display at all.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="Screen Shot 2022-09-13 at 1 19 07 PM" src="https://user-images.githubusercontent.com/106181067/190001488-2f763a56-0f59-4368-9161-227943bf5c9b.png"> | <img width="488" alt="Screen Shot 2022-09-13 at 1 20 49 PM" src="https://user-images.githubusercontent.com/106181067/190001535-d1d17f38-5f1a-4a69-a9fc-34a37ec5771c.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1240)