### PR TITLE
Move width constraint for MSFNotification with flexible width from show() to a var

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -217,6 +217,8 @@ class NotificationViewDemoController: DemoController {
                                                isFlexibleWidthToast: true)
             notification.state.message = "This toast has a flexible width which means the width is based on the content rather than the screen size."
             notification.tokenSet.replaceAllOverrides(with: notificationOverrideTokens)
+            let widthConstraint = notification.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -2 * notification.tokenSet[.presentationOffset].float)
+            notification.flexibleWidthConstraints = [widthConstraint]
             notification.state.actionButtonAction = { [weak self] in
                 self?.showMessage("`Dismiss` tapped")
                 notification.hide()

--- a/ios/FluentUI/Notification/MSFNotification.swift
+++ b/ios/FluentUI/Notification/MSFNotification.swift
@@ -100,12 +100,12 @@ import UIKit
         constraints.append(animated ? constraintWhenHidden : constraintWhenShown)
         constraints.append(self.centerXAnchor.constraint(equalTo: view.centerXAnchor))
 
-        let horizontalPadding = -2 * notification.tokenSet[.presentationOffset].float
-        let widthAnchor = self.widthAnchor
-        let viewWidthAnchor = view.widthAnchor
-        if isFlexibleWidthToast {
-            constraints.append(widthAnchor.constraint(lessThanOrEqualTo: viewWidthAnchor, constant: horizontalPadding))
+        if isFlexibleWidthToast, let widthConstraints = flexibleWidthConstraints {
+            constraints.append(contentsOf: widthConstraints)
         } else {
+            let horizontalPadding = -2 * notification.tokenSet[.presentationOffset].float
+            let widthAnchor = self.widthAnchor
+            let viewWidthAnchor = view.widthAnchor
             let isHalfLength = state.style.isToast && traitCollection.horizontalSizeClass == .regular
             if isHalfLength {
                 constraints.append(widthAnchor.constraint(equalTo: viewWidthAnchor, multiplier: 0.5))
@@ -196,6 +196,12 @@ import UIKit
     }
 
     @objc public static var allowsMultipleToasts: Bool = false
+
+    /// Only to be used when `isFlexibleWidthToast` is `true`
+    /// A set of constraints to be applied to the `MSFNotification`
+    /// in `show` after it has been added to the view hierarchy.
+    @objc public var flexibleWidthConstraints: [NSLayoutConstraint]?
+
     var isFlexibleWidthToast: Bool
 
     // MARK: - Private variables


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adding our own width constraint was causing the Notification to stay squished if the user made the available width smaller, then increased it again. Allowing the user to set the only width constraint allows the Notification to resize properly.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![NotificationWidth_Before](https://user-images.githubusercontent.com/67026548/190019352-e6d258b9-30de-4aeb-bcea-bc0fa879a3aa.gif) | ![NotificationWidth_After](https://user-images.githubusercontent.com/67026548/190019379-adb93606-387a-4ef2-b502-d61d15e4b925.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)