### PR TITLE
Add swipe to hide API to bottom sheet

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -84,6 +84,9 @@ class BottomSheetDemoController: UIViewController {
     @objc private func showTransientSheet() {
         let sheetContentView = UIView()
 
+        // This is the bottom sheet that will temporarily be displayed after tapping the "Show transient sheet" button.
+        // There can be multiple of these on screen at the same time. All the currently presented transient sheets
+        // are tracked in presentedTransientSheets.
         let secondarySheetController = BottomSheetController(expandedContentView: sheetContentView)
         secondarySheetController.delegate = self
         secondarySheetController.collapsedContentHeight = 250
@@ -94,11 +97,7 @@ class BottomSheetDemoController: UIViewController {
         secondarySheetController.allowsSwipeToHide = true
 
         let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { _ in
-            secondarySheetController.setIsHidden(true, animated: true) { _ in
-                secondarySheetController.willMove(toParent: nil)
-                secondarySheetController.removeFromParent()
-                secondarySheetController.view.removeFromSuperview()
-            }
+            secondarySheetController.setIsHidden(true, animated: true)
         }))
 
         dismissButton.style = .primaryFilled

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -85,11 +85,13 @@ class BottomSheetDemoController: UIViewController {
         let sheetContentView = UIView()
 
         let secondarySheetController = BottomSheetController(expandedContentView: sheetContentView)
+        secondarySheetController.delegate = self
         secondarySheetController.collapsedContentHeight = 250
         secondarySheetController.isHidden = true
         secondarySheetController.shouldAlwaysFillWidth = false
         secondarySheetController.shouldHideCollapsedContent = false
         secondarySheetController.isFlexibleHeight = true
+        secondarySheetController.allowsSwipeToHide = true
 
         let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { _ in
             secondarySheetController.setIsHidden(true, animated: true) { _ in
@@ -130,6 +132,7 @@ class BottomSheetDemoController: UIViewController {
         // has a meaningful initial frame to use for the animation.
         view.layoutIfNeeded()
         secondarySheetController.isHidden = false
+        presentedTransientSheets.append(secondarySheetController)
     }
 
     private lazy var personaListView: UIScrollView = {
@@ -219,6 +222,8 @@ class BottomSheetDemoController: UIViewController {
             ]
         ]
     }
+
+    private var presentedTransientSheets = [BottomSheetController]()
 
     private static let headerHeight: CGFloat = 30
 
@@ -352,5 +357,16 @@ extension BottomSheetDemoController: BottomSheetControllerDelegate {
         if let tableView = mainTableView {
             tableView.contentInset.bottom = bottomSheetController.collapsedHeightInSafeArea
         }
+    }
+
+    func bottomSheetController(_ bottomSheetController: BottomSheetController, didMoveTo expansionState: BottomSheetExpansionState, interaction: BottomSheetInteraction) {
+        guard expansionState == .hidden, let index = presentedTransientSheets.firstIndex(of: bottomSheetController) else {
+            return
+        }
+
+        presentedTransientSheets.remove(at: index)
+        bottomSheetController.willMove(toParent: nil)
+        bottomSheetController.removeFromParent()
+        bottomSheetController.view.removeFromSuperview()
     }
 }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -198,6 +198,9 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// When enabled, users will be able to move the sheet to the hidden state by swiping down.
+    @objc open var allowsSwipeToHide: Bool = false
+
     /// Current height of the portion of a collapsed sheet that's in the safe area.
     @objc public private(set) var collapsedHeightInSafeArea: CGFloat = 0 {
         didSet {
@@ -572,11 +575,13 @@ public class BottomSheetController: UIViewController {
     private func translateSheet(by translationDelta: CGPoint) {
         let expandedOffset = offset(for: .expanded)
         let collapsedOffset = offset(for: .collapsed)
+        let hiddenOffset = offset(for: .hidden)
+
         let minOffset = expandedOffset - Constants.maxRubberBandOffset
-        let maxOffset = collapsedOffset + Constants.maxRubberBandOffset
+        let maxOffset = allowsSwipeToHide ? hiddenOffset : (collapsedOffset + Constants.maxRubberBandOffset)
 
         var offsetDelta = translationDelta.y
-        if currentSheetVerticalOffset >= collapsedOffset || currentSheetVerticalOffset <= expandedOffset {
+        if (currentSheetVerticalOffset >= collapsedOffset && !allowsSwipeToHide) || currentSheetVerticalOffset <= expandedOffset {
             offsetDelta *= translationRubberBandFactor(for: currentSheetVerticalOffset)
         }
 
@@ -626,15 +631,26 @@ public class BottomSheetController: UIViewController {
 
     private func completePan(with velocity: CGFloat) {
         var targetState: BottomSheetExpansionState
+
         if abs(velocity) < Constants.directionOverrideVelocityThreshold {
-            // Velocity too low, snap to the closest offset
-            targetState =
-                abs(offset(for: .collapsed) - currentSheetVerticalOffset) < abs(offset(for: .expanded) - currentSheetVerticalOffset)
-                ? .collapsed
-                : .expanded
+            // Velocity too low, snap to the closest expansion state
+            var distances: [BottomSheetExpansionState: CGFloat] = [
+                .expanded: abs(offset(for: .expanded) - currentSheetVerticalOffset),
+                .collapsed: abs(offset(for: .collapsed) - currentSheetVerticalOffset),
+            ]
+
+            if allowsSwipeToHide {
+                distances[.hidden] = abs(offset(for: .hidden) - currentSheetVerticalOffset)
+            }
+
+            targetState = distances.min(by: { $0.value < $1.value })?.key ?? .collapsed
         } else {
-            // Velocity high enough, animate to the offset we're swiping towards
-            targetState = velocity > 0 ? .collapsed : .expanded
+            // Velocity high enough, animate to the state we're swiping towards
+            if currentSheetVerticalOffset > offset(for: .collapsed) && allowsSwipeToHide {
+                targetState = velocity > 0 ? .hidden : .collapsed
+            } else {
+                targetState = velocity > 0 ? .collapsed : .expanded
+            }
         }
         move(to: targetState, velocity: velocity, interaction: .swipe)
     }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -636,7 +636,7 @@ public class BottomSheetController: UIViewController {
             // Velocity too low, snap to the closest expansion state
             var distances: [BottomSheetExpansionState: CGFloat] = [
                 .expanded: abs(offset(for: .expanded) - currentSheetVerticalOffset),
-                .collapsed: abs(offset(for: .collapsed) - currentSheetVerticalOffset),
+                .collapsed: abs(offset(for: .collapsed) - currentSheetVerticalOffset)
             ]
 
             if allowsSwipeToHide {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds a new `allowsSwipeToHide` bool prop to `BottomSheetController` which allows the user to drag the sheet below its collapsed state and fully hide it. The default value is `false`, which preserves the old behavior.

I also added an example in the demo controller, where every transient sheet now has this enabled.

### Verification

https://user-images.githubusercontent.com/3610850/190024741-bde61a5c-1cd0-4f02-b7c1-850302136737.mov

https://user-images.githubusercontent.com/3610850/190027691-b1c8b7b4-1e06-443b-b006-1cb3211eca1b.mov


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1242)