### PR TITLE
Restore PillButtonBar changes (#1165) that were reverted with (#1213)

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -125,6 +125,7 @@ open class PillButtonBar: UIScrollView {
 
     private var stackView: UIStackView = {
         let view = UIStackView()
+        view.distribution = .fillProportionally
         view.alignment = .center
         view.spacing = Constants.minButtonsSpacing
         return view
@@ -411,8 +412,15 @@ open class PillButtonBar: UIScrollView {
         buttonExtraSidePadding = ceil(totalPadding / CGFloat(buttonEdges))
         for button in buttons {
             button.layoutIfNeeded()
-            button.contentEdgeInsets.right += buttonExtraSidePadding
-            button.contentEdgeInsets.left += buttonExtraSidePadding
+
+            if #available(iOS 15.0, *) {
+                button.configuration?.contentInsets.leading += buttonExtraSidePadding
+                button.configuration?.contentInsets.trailing += buttonExtraSidePadding
+            } else {
+                button.contentEdgeInsets.right += buttonExtraSidePadding
+                button.contentEdgeInsets.left += buttonExtraSidePadding
+            }
+
             button.layoutIfNeeded()
         }
     }
@@ -453,8 +461,15 @@ open class PillButtonBar: UIScrollView {
             let buttonWidth = button.frame.width
             if buttonWidth > 0, buttonWidth < Constants.minButtonWidth {
                 let extraInset = floor((Constants.minButtonWidth - button.frame.width) / 2)
-                button.contentEdgeInsets.left += extraInset
-                button.contentEdgeInsets.right = button.contentEdgeInsets.left
+
+                if #available(iOS 15.0, *) {
+                    button.configuration?.contentInsets.leading += extraInset
+                    button.configuration?.contentInsets.trailing = button.configuration?.contentInsets.leading ?? extraInset
+                } else {
+                    button.contentEdgeInsets.left += extraInset
+                    button.contentEdgeInsets.right = button.contentEdgeInsets.left
+                }
+
                 button.layoutIfNeeded()
             }
         }


### PR DESCRIPTION
This reverts commit 518bdc6f97b1d242ffb81b62a8838185b1c8bde4.
- #1165 
- #1213 

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Restores the changes to prep the PillButtonBar for iOS 15.

### Verification
| iOS Version | Before | After |
|---|---|---|
| 15.5 | ![PillButtonBar_Before](https://user-images.githubusercontent.com/67026548/190031487-066fb71a-d9c8-4f9a-acd9-7fb62318011e.png) | ![PillButtonBar_After](https://user-images.githubusercontent.com/67026548/190031493-1b625356-1aca-4dd2-bf97-6827825c71c7.png) |
| 15.5. | ![PillButtonBar_RTL_Before](https://user-images.githubusercontent.com/67026548/190033507-22617962-7da6-4988-a012-ddfdc0339cbe.png) | ![PillButtonBar_RTL_After](https://user-images.githubusercontent.com/67026548/190033517-4e98d8d6-b29b-4474-ae86-fb02bc7253cd.png) |
| 14.5 | ![PillButtonBar_14_Before](https://user-images.githubusercontent.com/67026548/190031499-070cf408-049d-47fb-84f7-589a5ab32073.png) | ![PillButtonBar_14_After](https://user-images.githubusercontent.com/67026548/190031505-21f11ce5-8a40-44e7-beeb-23a9b9717984.png) |
| 14.5 | ![PillButtonBar_14_RTL_Before](https://user-images.githubusercontent.com/67026548/190033521-cc437c15-3f5c-4c28-bad8-3f879b14869a.png) | ![PillButtonBar_14_RTL_After](https://user-images.githubusercontent.com/67026548/190033525-2595ac5b-773f-4d81-92a8-f79a9d89b14b.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1244)