### PR TITLE
Extract NavigationBar type to convenience init

### DIFF
--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -47,11 +47,11 @@ open class NavigationController: UINavigationController {
     private var navigationBarWasHiddenBySearchBar: Bool = false
 
     @objc public convenience init() {
-        self.init(navigationBarClass: nil, toolbarClass: nil)
+        self.init(navigationBarClass: NavigationBar.self, toolbarClass: nil)
     }
 
     @objc public override init(navigationBarClass: AnyClass?, toolbarClass: AnyClass?) {
-        super.init(navigationBarClass: NavigationBar.self, toolbarClass: toolbarClass)
+        super.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
     }
 
     @objc public convenience override init(rootViewController: UIViewController) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Extract NavigationBar type to `convenience init` to have ability to inherit NavigationBar and override init.

### Verification


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| You can't override NavigationBar, because NavigationController ignores any type which you pass to its constructor ![Simulator Screen Shot - iPhone 14 Pro - 2022-09-15 at 20 14 24](https://user-images.githubusercontent.com/17963739/190479308-bc04f1d3-554b-48b9-8240-aa51a4ea7163.png) | Now you can inherit NavigationController, override init and pass custom NavigationBar to it. Nothing changed in UI of NavigationBar. ![Simulator Screen Shot - iPhone 14 Pro - 2022-09-15 at 20 08 11](https://user-images.githubusercontent.com/17963739/190478904-77e3d68a-ad64-47b5-9ad4-2d427edf1656.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1245)