### PR TITLE
[Fluent 2 iOS] DateTimePicker + CalendarView update

### DIFF
--- a/ios/FluentUI.Tests/DatePickerControllerTests.swift
+++ b/ios/FluentUI.Tests/DatePickerControllerTests.swift
@@ -99,15 +99,6 @@ class MockCalendarViewStyleDataSource: CalendarViewStyleDataSource {
         }
     }
 
-    func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents
-    ) -> CalendarViewDayCellBackgroundStyle {
-        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
-            return .primary
-        } else {
-            return .secondary
-        }
-    }
-
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, selectionStyleForDayWithStart dayStartDate: Date, end: Date) -> CalendarViewDayCellSelectionStyle {
         return .normal
     }

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -34,7 +34,6 @@ class CalendarView: UIView {
         collectionViewLayout = CalendarViewLayout()
 
         collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: collectionViewLayout)
-        collectionView.backgroundColor = Colors.Calendar.background
         collectionView.showsVerticalScrollIndicator = false
         collectionView.scrollsToTop = false
         // Enable multiple selection to allow for one cell to be selected and another cell to be highlighted simultaneously
@@ -43,6 +42,8 @@ class CalendarView: UIView {
         collectionViewSeparator = Separator(style: .default)
 
         super.init(frame: .zero)
+
+        collectionView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
 
         addSubview(weekdayHeadingView)
         addSubview(collectionView)

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -43,7 +43,7 @@ class CalendarView: UIView {
 
         super.init(frame: .zero)
 
-        collectionView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        updateCollectionViewBackgroundColor()
 
         addSubview(weekdayHeadingView)
         addSubview(collectionView)
@@ -53,6 +53,19 @@ class CalendarView: UIView {
         if headerStyle == .light {
             addSubview(headingViewSeparator)
         }
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateCollectionViewBackgroundColor()
+    }
+
+    private func updateCollectionViewBackgroundColor() {
+        collectionView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Calendar/CalendarViewDataSource.swift
+++ b/ios/FluentUI/Calendar/CalendarViewDataSource.swift
@@ -10,9 +10,6 @@ import UIKit
 protocol CalendarViewStyleDataSource: AnyObject {
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, textStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellTextStyle
 
-    // Suggestion: Use provided components for performance improvements. Check where it's called to see what's available
-    func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellBackgroundStyle
-
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, selectionStyleForDayWithStart dayStartDate: Date, end: Date) -> CalendarViewDayCellSelectionStyle
 }
 
@@ -158,8 +155,6 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
         // Calculate style parameters
         let textStyle = styleDataSource.calendarViewDataSource(self, textStyleForDayWithStart: dayStartDate, end: dayEndDate, dayStartComponents: dayStartDateComponents, todayComponents: todayDateComponents)
 
-        let backgroundStyle = styleDataSource.calendarViewDataSource(self, backgroundStyleForDayWithStart: dayStartDate, end: dayEndDate, dayStartComponents: dayStartDateComponents, todayComponents: todayDateComponents)
-
         let selectionStyle = styleDataSource.calendarViewDataSource(self, selectionStyleForDayWithStart: dayStartDate, end: dayEndDate)
 
         let monthLabelIndex = dayStartDateComponents.month! - 1
@@ -177,7 +172,7 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
             guard let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as? CalendarViewDayCell else {
                 return UICollectionViewCell()
             }
-            dayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: "", indicatorLevel: 0)
+            dayCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: "", indicatorLevel: 0)
             return dayCell
         }
 
@@ -185,7 +180,7 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
             guard let dayTodayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayTodayCell.identifier, for: indexPath) as? CalendarViewDayTodayCell else {
                 return UICollectionViewCell()
             }
-            dayTodayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+            dayTodayCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
             return dayTodayCell
         }
 
@@ -194,13 +189,13 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
                 guard let dayMonthYearCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthYearCell.identifier, for: indexPath) as? CalendarViewDayMonthYearCell else {
                     return UICollectionViewCell()
                 }
-                dayMonthYearCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, yearLabelText: yearLabelText, indicatorLevel: indicatorLevel)
+                dayMonthYearCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, yearLabelText: yearLabelText, indicatorLevel: indicatorLevel)
                 return dayMonthYearCell
             } else {
                 guard let dayMonthCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthCell.identifier, for: indexPath) as? CalendarViewDayMonthCell else {
                     return UICollectionViewCell()
                 }
-                dayMonthCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+                dayMonthCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
                 return dayMonthCell
             }
         }
@@ -208,7 +203,7 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
         guard let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as? CalendarViewDayCell else {
             return UICollectionViewCell()
         }
-        dayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+        dayCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
         return dayCell
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -12,13 +12,6 @@ enum CalendarViewDayCellTextStyle {
     case secondary
 }
 
-// MARK: - CalendarViewDayCellBackgroundStyle
-
-enum CalendarViewDayCellBackgroundStyle {
-    case primary
-    case secondary
-}
-
 // MARK: - CalendarViewDayCellVisualState
 
 enum CalendarViewDayCellVisualState {
@@ -74,7 +67,6 @@ class CalendarViewDayCell: UICollectionViewCell {
     }
 
     private(set) var textStyle: CalendarViewDayCellTextStyle = .primary
-    private(set) var backgroundStyle: CalendarViewDayCellBackgroundStyle = .primary
 
     private var visibleDotViewAlpha: CGFloat = 1.0
 
@@ -127,9 +119,8 @@ class CalendarViewDayCell: UICollectionViewCell {
     }
 
     // Only supports indicator levels from 0...4
-    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+    func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
         self.textStyle = textStyle
-        self.backgroundStyle = backgroundStyle
         selectionOverlayView.selectionStyle = selectionStyle
 
         // Assign text content

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -189,9 +189,9 @@ class CalendarViewDayCell: UICollectionViewCell {
     private func updateViews() {
         switch textStyle {
         case .primary:
-            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-        case .secondary:
             dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+        case .secondary:
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         }
 
         contentView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -116,7 +116,7 @@ class CalendarViewDayCell: UICollectionViewCell {
                                                object: nil)
     }
 
-    @objc private func themeDidChange(_ notification: Notification) {
+    @objc func themeDidChange(_ notification: Notification) {
         updateViews()
         dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -96,15 +96,16 @@ class CalendarViewDayCell: UICollectionViewCell {
         dateLabel = UILabel(frame: .zero)
         dateLabel.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
         dateLabel.textAlignment = .center
-        dateLabel.textColor = Colors.Calendar.Day.textPrimary
         dateLabel.showsLargeContentViewer = true
 
         dotView = DotView()
-        dotView.color = Colors.Calendar.Day.textPrimary
         dotView.alpha = 0.0  // Initial `visualState` is `.Normal` without dots
         dotView.isUserInteractionEnabled = false
 
         super.init(frame: frame)
+
+        dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
 
         contentView.addSubview(selectionOverlayView)
         contentView.addSubview(dateLabel)
@@ -187,21 +188,16 @@ class CalendarViewDayCell: UICollectionViewCell {
     private func updateViews() {
         switch textStyle {
         case .primary:
-            dateLabel.textColor = Colors.Calendar.Day.textPrimary
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         case .secondary:
-            dateLabel.textColor = Colors.Calendar.Day.textSecondary
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         }
 
-        switch backgroundStyle {
-        case .primary:
-            contentView.backgroundColor = Colors.Calendar.Day.backgroundPrimary
-        case .secondary:
-            contentView.backgroundColor = Colors.Calendar.Day.backgroundSecondary
-        }
+        contentView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
 
         if isHighlighted || isSelected {
             dotView.isHidden = true
-            dateLabel.textColor = Colors.Calendar.Day.textSelected
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
         } else {
             dotView.isHidden = false
         }
@@ -237,11 +233,7 @@ private class SelectionOverlayView: UIView {
     }
 
     private var activeColor: UIColor {
-        if selected,
-            let window = window {
-            return Colors.primary(for: window)
-        }
-        return Colors.Calendar.Day.circleHighlighted
+        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
     }
 
     // Lazy load views as every additional subview impacts the "Calendar"

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -109,6 +109,17 @@ class CalendarViewDayCell: UICollectionViewCell {
         contentView.addSubview(selectionOverlayView)
         contentView.addSubview(dateLabel)
         contentView.addSubview(dotView)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateViews()
+        dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -55,7 +55,6 @@ class CalendarViewDayCell: UICollectionViewCell {
         static let borderWidth: CGFloat = UIScreen.main.devicePixel
         static let dotDiameter: CGFloat = 4.0
         static let fadedVisualStateAlphaMultiplier: CGFloat = 0.2
-        static let maximumFontSize: CGFloat = 33.0
     }
 
     class var identifier: String { return "CalendarViewDayCell" }
@@ -94,7 +93,6 @@ class CalendarViewDayCell: UICollectionViewCell {
         selectionOverlayView.isUserInteractionEnabled = false
 
         dateLabel = UILabel(frame: .zero)
-        dateLabel.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
         dateLabel.textAlignment = .center
         dateLabel.showsLargeContentViewer = true
 
@@ -104,6 +102,7 @@ class CalendarViewDayCell: UICollectionViewCell {
 
         super.init(frame: frame)
 
+        dateLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
         dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -58,13 +58,13 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, indicatorLevel) instead")
     }
 
     // Only supports indicator levels from 0...4
-    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+    func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
+        super.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         updateMonthLabelColor(textStyle: textStyle)
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -5,36 +5,6 @@
 
 import UIKit
 
-// MARK: Calendar Colors
-
-public extension Colors {
-    struct Calendar {
-        public struct Day {
-            public static var textPrimary = UIColor(light: Colors.textSecondary, dark: Colors.textPrimary)
-            public static var textSecondary = UIColor(light: Colors.textPrimary, dark: Colors.textSecondary)
-            public static var textSelected: UIColor = textOnAccent
-            public static var backgroundPrimary = UIColor(light: Calendar.background, dark: surfaceSecondary)
-            public static var backgroundSecondary = UIColor(light: surfaceSecondary, dark: Calendar.background)
-            public static var circleHighlighted: UIColor = gray400
-        }
-        public struct Today {
-            public static var background: UIColor = Calendar.Day.backgroundPrimary
-        }
-        public struct WeekdayHeading {
-            public struct Light {
-                public static var textRegular = UIColor(light: gray600, lightHighContrast: gray700, dark: textPrimary)
-                public static var textWeekend: UIColor = textSecondary
-                public static var background: UIColor = NavigationBar.background
-            }
-            public struct Dark {
-                public static var textRegular: UIColor = textOnAccent
-                public static var textWeekend: UIColor = textOnAccent.withAlphaComponent(0.7)
-            }
-        }
-        public static var background = UIColor(light: surfacePrimary, dark: surfaceTertiary)
-    }
-}
-
 // MARK: - CalendarViewDayMonthCell
 
 class CalendarViewDayMonthCell: CalendarViewDayCell {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -60,13 +60,13 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
 
     override init(frame: CGRect) {
         monthLabel = UILabel(frame: CGRect.zero)
-        monthLabel.font = Fonts.caption1.withSize(12)
         monthLabel.textAlignment = .center
-        monthLabel.textColor = Colors.Calendar.Day.textPrimary
         monthLabel.showsLargeContentViewer = true
 
         super.init(frame: frame)
 
+        monthLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
+        monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         contentView.addSubview(monthLabel)
     }
 
@@ -84,9 +84,9 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
 
         switch textStyle {
         case .primary:
-            monthLabel.textColor = Colors.Calendar.Day.textPrimary
+            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         case .secondary:
-            monthLabel.textColor = Colors.Calendar.Day.textSecondary
+            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         }
 
         monthLabel.text = monthLabelText

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -38,11 +38,6 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
         monthLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
         monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         contentView.addSubview(monthLabel)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
     }
 
     @objc override func themeDidChange(_ notification: Notification) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -46,6 +46,7 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
     }
 
     @objc override func themeDidChange(_ notification: Notification) {
+        super.themeDidChange(notification)
         updateMonthLabelColor(textStyle: textStyle)
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -38,6 +38,24 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
         monthLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
         monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         contentView.addSubview(monthLabel)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc override func themeDidChange(_ notification: Notification) {
+        updateMonthLabelColor(textStyle: textStyle)
+    }
+
+    private func updateMonthLabelColor(textStyle: CalendarViewDayCellTextStyle) {
+        switch textStyle {
+        case .primary:
+            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        case .secondary:
+            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -52,12 +70,7 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
     func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
         super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
-        switch textStyle {
-        case .primary:
-            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-        case .secondary:
-            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-        }
+        updateMonthLabelColor(textStyle: textStyle)
 
         monthLabel.text = monthLabelText
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -41,6 +41,7 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
     }
 
     @objc override func themeDidChange(_ notification: Notification) {
+        super.themeDidChange(notification)
         updateYearLabelColor(textStyle: textStyle)
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -62,7 +62,13 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
     }
 
     // Only supports indicator levels from 0...4
-    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, yearLabelText: String, indicatorLevel: Int) {
+    func setup(textStyle: CalendarViewDayCellTextStyle,
+               backgroundStyle: CalendarViewDayCellBackgroundStyle,
+               selectionStyle: CalendarViewDayCellSelectionStyle,
+               monthLabelText: String,
+               dateLabelText: String,
+               yearLabelText: String,
+               indicatorLevel: Int) {
         super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         updateYearLabelColor(textStyle: textStyle)

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -33,11 +33,6 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
         yearLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
         yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         contentView.addSubview(yearLabel)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
     }
 
     @objc override func themeDidChange(_ notification: Notification) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -44,11 +44,11 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, yearLabelText, indicatorLevel) instead")
     }
 
-    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
+    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, yearLabelText, indicatorLevel) instead")
     }
 
@@ -63,13 +63,12 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
 
     // Only supports indicator levels from 0...4
     func setup(textStyle: CalendarViewDayCellTextStyle,
-               backgroundStyle: CalendarViewDayCellBackgroundStyle,
                selectionStyle: CalendarViewDayCellSelectionStyle,
                monthLabelText: String,
                dateLabelText: String,
                yearLabelText: String,
                indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+        super.setup(textStyle: textStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         updateYearLabelColor(textStyle: textStyle)
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -33,6 +33,15 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
         yearLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
         yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         contentView.addSubview(yearLabel)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc override func themeDidChange(_ notification: Notification) {
+        updateYearLabelColor(textStyle: textStyle)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -47,16 +56,20 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, yearLabelText, indicatorLevel) instead")
     }
 
-    // Only supports indicator levels from 0...4
-    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, yearLabelText: String, indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
-
+    private func updateYearLabelColor(textStyle: CalendarViewDayCellTextStyle) {
         switch textStyle {
         case .primary:
             yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         case .secondary:
             yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         }
+    }
+
+    // Only supports indicator levels from 0...4
+    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, yearLabelText: String, indicatorLevel: Int) {
+        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+
+        updateYearLabelColor(textStyle: textStyle)
 
         yearLabel.text = yearLabelText
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -26,12 +26,12 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
 
     override init(frame: CGRect) {
         yearLabel = UILabel(frame: .zero)
-        yearLabel.font = Fonts.caption1
         yearLabel.textAlignment = .center
-        yearLabel.textColor = Colors.Calendar.Day.textPrimary
 
         super.init(frame: frame)
 
+        yearLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
+        yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         contentView.addSubview(yearLabel)
     }
 
@@ -53,9 +53,9 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
 
         switch textStyle {
         case .primary:
-            yearLabel.textColor = Colors.Calendar.Day.textPrimary
+            yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         case .secondary:
-            yearLabel.textColor = Colors.Calendar.Day.textSecondary
+            yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         }
 
         yearLabel.text = yearLabelText

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -25,8 +25,8 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
     }
 
     // Only supports indicator levels from 0...4
-    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+        super.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         configureBackgroundColor()
         configureFontColor()

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -33,32 +33,21 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
     }
 
     private func configureBackgroundColor() {
-        if isHighlighted || isSelected {
-            switch backgroundStyle {
-            case .primary:
-                contentView.backgroundColor = Colors.Calendar.Day.backgroundPrimary
-            case .secondary:
-                contentView.backgroundColor = Colors.Calendar.Day.backgroundSecondary
-            }
-        } else {
-            contentView.backgroundColor = Colors.Calendar.Today.background
-        }
+        contentView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
     }
 
     private func configureFontColor() {
+        dateLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
+
         if isHighlighted || isSelected {
-            dateLabel.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
-            dateLabel.textColor = Colors.Calendar.Day.textSelected
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
             dateLabel.showsLargeContentViewer = true
         } else {
-            dateLabel.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: Fonts.headline, maximumPointSize: Constants.maximumFontSize)
             switch textStyle {
             case .primary:
-                dateLabel.textColor = Colors.Calendar.Day.textPrimary
-                dotView.color = Colors.Calendar.Day.textPrimary
+                dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             case .secondary:
-                dateLabel.textColor = Colors.Calendar.Day.textSecondary
-                dotView.color = Colors.Calendar.Day.textSecondary
+                dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             }
         }
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -32,6 +32,12 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
         configureFontColor()
     }
 
+    @objc override func themeDidChange(_ notification: Notification) {
+        super.themeDidChange(notification)
+        configureBackgroundColor()
+        configureFontColor()
+    }
+
     private func configureBackgroundColor() {
         contentView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -29,6 +29,19 @@ class CalendarViewWeekdayHeadingView: UIView {
         self.headerStyle = headerStyle
 
         super.init(frame: .zero)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateBackgroundColor()
+    }
+
+    private func updateBackgroundColor() {
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -70,7 +83,7 @@ class CalendarViewWeekdayHeadingView: UIView {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        updateBackgroundColor()
     }
 
     func setup(horizontalSizeClass: UIUserInterfaceSizeClass, firstWeekday: Int) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -18,8 +18,6 @@ class CalendarViewWeekdayHeadingView: UIView {
             static let compactHeight: CGFloat = 26.0
             static let regularHeight: CGFloat = 48.0
         }
-
-        static let maximumFontSize: CGFloat = 26.0
     }
 
     private var firstWeekday: Int?

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -72,9 +72,7 @@ class CalendarViewWeekdayHeadingView: UIView {
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
-        if let window = window {
-            backgroundColor = headerStyle == .dark ? Colors.primary(for: window) : Colors.Calendar.WeekdayHeading.Light.background
-        }
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
     }
 
     func setup(horizontalSizeClass: UIUserInterfaceSizeClass, firstWeekday: Int) {
@@ -92,21 +90,13 @@ class CalendarViewWeekdayHeadingView: UIView {
 
         let weekdaySymbols: [String] = horizontalSizeClass == .regular ? Calendar.current.shortStandaloneWeekdaySymbols : Calendar.current.veryShortStandaloneWeekdaySymbols
 
-        for (index, weekdaySymbol) in weekdaySymbols.enumerated() {
+        for weekdaySymbol in weekdaySymbols {
             let label = UILabel()
             label.textAlignment = .center
             label.text = weekdaySymbol
-            label.font = UIFontMetrics(forTextStyle: .caption1).scaledFont(for: Fonts.caption1, maximumPointSize: Constants.maximumFontSize)
+            label.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
             label.showsLargeContentViewer = true
-
-            switch headerStyle {
-            case .light:
-                label.textColor = (index == 0 || index == 6) ? Colors.Calendar.WeekdayHeading.Light.textWeekend : Colors.Calendar.WeekdayHeading.Light.textRegular
-
-            case .dark:
-                label.textColor = (index == 0 || index == 6) ? Colors.Calendar.WeekdayHeading.Dark.textWeekend : Colors.Calendar.WeekdayHeading.Dark.textRegular
-            }
-
+            label.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             headingLabels.append(label)
             addSubview(label)
         }

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -61,6 +61,20 @@ public class FluentUIFramework: NSObject {
         initializeAppearance(with: Colors.primary)
     }
 
+    enum NavigationBarStyle {
+        case normal
+        case dateTimePicker
+
+        func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
+            switch self {
+            case .normal:
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
+            case.dateTimePicker:
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+            }
+        }
+    }
+
     @objc public static func initializeAppearance(with primaryColor: UIColor, whenContainedInInstancesOf containerTypes: [UIAppearanceContainer.Type]? = nil) {
         let navigationBarAppearance = containerTypes != nil ? UINavigationBar.appearance(whenContainedInInstancesOf: containerTypes!) : UINavigationBar.appearance()
         initializeUINavigationBarAppearance(navigationBarAppearance)
@@ -91,13 +105,17 @@ public class FluentUIFramework: NSObject {
         progressViewAppearance.trackTintColor = Colors.Progress.trackTint
     }
 
-    static func initializeUINavigationBarAppearance(_ navigationBar: UINavigationBar, traits: UITraitCollection? = nil) {
+    static func initializeUINavigationBarAppearance(_ navigationBar: UINavigationBar, traits: UITraitCollection? = nil, navigationBarStyle: NavigationBarStyle = .normal, fluentTheme: FluentTheme? = nil) {
         navigationBar.isTranslucent = false
 
         let standardAppearance = navigationBar.standardAppearance
         navigationBar.tintColor = Colors.NavigationBar.tint
 
-        navigationBar.standardAppearance.backgroundColor = Colors.NavigationBar.background
+        if let fluentTheme = fluentTheme {
+            navigationBar.standardAppearance.backgroundColor = navigationBarStyle.backgroundColor(fluentTheme: fluentTheme)
+        } else {
+            navigationBar.standardAppearance.backgroundColor = Colors.NavigationBar.background
+        }
 
         let traits = traits ?? navigationBar.traitCollection
         // Removing built-in shadow for Dark Mode

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -126,6 +126,10 @@ public class FluentUIFramework: NSObject {
         titleAttributes[.foregroundColor] = Colors.NavigationBar.title
         standardAppearance.titleTextAttributes = titleAttributes
 
+        if navigationBarStyle == .dateTimePicker {
+            standardAppearance.shadowColor = .clear
+        }
+
         navigationBar.backIndicatorImage = UIImage.staticImageNamed("back-24x24")
         navigationBar.backIndicatorTransitionMaskImage = navigationBar.backIndicatorImage
 

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -69,7 +69,7 @@ public class FluentUIFramework: NSObject {
             switch self {
             case .normal:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
-            case.dateTimePicker:
+            case .dateTimePicker:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
             }
         }

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -168,7 +168,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
         if let segmentedControl = segmentedControl {
             view.addSubview(segmentedControl)
-            view.backgroundColor = Colors.Toolbar.background
+            view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
         }
         view.addSubview(calendarView)
 
@@ -198,9 +198,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if let window = view.window {
-            navigationItem.rightBarButtonItem?.tintColor = UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
-        }
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandBackground2])
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -505,16 +505,6 @@ extension DatePickerController: CalendarViewStyleDataSource {
         }
     }
 
-    func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents
-    ) -> CalendarViewDayCellBackgroundStyle {
-
-        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
-            return .primary
-        } else {
-            return .secondary
-        }
-    }
-
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, selectionStyleForDayWithStart dayStartDate: Date, end: Date) -> CalendarViewDayCellSelectionStyle {
         return .normal
     }

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -141,6 +141,16 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         if !mode.singleSelection && rangePresentation == .tabbed {
             initSegmentedControl()
         }
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateBackgroundColor()
+        updateBarButtonColors()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -168,11 +178,15 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
         if let segmentedControl = segmentedControl {
             view.addSubview(segmentedControl)
-            view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+            updateBackgroundColor()
         }
         view.addSubview(calendarView)
 
         initNavigationBar()
+    }
+
+    private func updateBackgroundColor() {
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -198,7 +212,12 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandBackground2])
+        updateBarButtonColors()
+    }
+
+    private func updateBarButtonColors() {
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground1])
+        navigationItem.leftBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -186,7 +186,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBackgroundColor() {
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -178,8 +178,8 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
 
         if let segmentedControl = segmentedControl {
             view.addSubview(segmentedControl)
-            updateBackgroundColor()
         }
+        updateBackgroundColor()
         view.addSubview(calendarView)
 
         initNavigationBar()

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -120,7 +120,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             view.addSubview(segmentedControl)
             // Hide default bottom border of navigation bar
             navigationController?.navigationBar.shadowImage = UIImage()
-            view.backgroundColor = Colors.Toolbar.background
+            view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
         }
         view.addSubview(dateTimePickerView)
         dateTimePickerView.setupComponents(for: self)
@@ -142,9 +142,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if let window = view.window {
-            navigationItem.rightBarButtonItem?.tintColor = UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
-        }
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandBackground2])
     }
 
     override func accessibilityPerformEscape() -> Bool {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -107,6 +107,16 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
         if self.mode != .single {
             initSegmentedControl(includesTime: mode.includesTime)
         }
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateBackgroundColor()
+        updateBarButtonColors()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -120,13 +130,17 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             view.addSubview(segmentedControl)
             // Hide default bottom border of navigation bar
             navigationController?.navigationBar.shadowImage = UIImage()
-            view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
+            updateBackgroundColor()
         }
         view.addSubview(dateTimePickerView)
         dateTimePickerView.setupComponents(for: self)
         initNavigationBar()
 
         updateNavigationBar()
+    }
+
+    private func updateBackgroundColor() {
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
     }
 
     override func viewWillLayoutSubviews() {
@@ -142,7 +156,12 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandBackground2])
+        updateBarButtonColors()
+    }
+
+    private func updateBarButtonColors() {
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground1])
+        navigationItem.leftBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
     }
 
     override func accessibilityPerformEscape() -> Bool {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -130,8 +130,8 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             view.addSubview(segmentedControl)
             // Hide default bottom border of navigation bar
             navigationController?.navigationBar.shadowImage = UIImage()
-            updateBackgroundColor()
         }
+        updateBackgroundColor()
         view.addSubview(dateTimePickerView)
         dateTimePickerView.setupComponents(for: self)
         initNavigationBar()

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -120,7 +120,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             view.addSubview(segmentedControl)
             // Hide default bottom border of navigation bar
             navigationController?.navigationBar.shadowImage = UIImage()
-            view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+            view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
         }
         view.addSubview(dateTimePickerView)
         dateTimePickerView.setupComponents(for: self)

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -48,7 +48,9 @@ class DateTimePickerView: UIControl {
     private let selectionTopSeparator = Separator()
     private let selectionBottomSeparator = Separator()
 
-    private func gradientLayer() -> CAGradientLayer {
+    private var gradientLayer = CAGradientLayer()
+
+    private func initGradientLayer() -> CAGradientLayer {
         let gradientLayer = CAGradientLayer()
         let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
         let transparentColor = backgroundColor.withAlphaComponent(0)
@@ -66,7 +68,8 @@ class DateTimePickerView: UIControl {
 
         super.init(frame: .zero)
 
-        layer.addSublayer(gradientLayer())
+        gradientLayer = initGradientLayer()
+        layer.addSublayer(gradientLayer)
         addSubview(selectionTopSeparator)
         addSubview(selectionBottomSeparator)
         addInteraction(UILargeContentViewerInteraction())
@@ -166,8 +169,8 @@ class DateTimePickerView: UIControl {
         )
 
         let gradientOffset = lineOffset - DateTimePickerViewComponentCell.idealHeight
-        gradientLayer().locations = [0, NSNumber(value: Float(gradientOffset / frame.height)), NSNumber(value: Float((frame.height - gradientOffset) / frame.height)), 1]
-        gradientLayer().frame = bounds
+        gradientLayer.locations = [0, NSNumber(value: Float(gradientOffset / frame.height)), NSNumber(value: Float((frame.height - gradientOffset) / frame.height)), 1]
+        gradientLayer.frame = bounds
 
         setDate(date, animated: false)
         setDayOfMonth(dayOfMonth, animated: false)

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -48,15 +48,15 @@ class DateTimePickerView: UIControl {
     private let selectionTopSeparator = Separator()
     private let selectionBottomSeparator = Separator()
 
-    private let gradientLayer: CAGradientLayer = {
+    private func gradientLayer() -> CAGradientLayer {
         let gradientLayer = CAGradientLayer()
-        let backgroundColor = Colors.DateTimePicker.background
+        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
         let transparentColor = backgroundColor.withAlphaComponent(0)
         gradientLayer.colors = [backgroundColor.cgColor, transparentColor.cgColor, transparentColor.cgColor, backgroundColor.cgColor]
         gradientLayer.startPoint = CGPoint(x: 0, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0, y: 1)
         return gradientLayer
-    }()
+    }
 
     init(mode: DateTimePickerViewMode, calendarConfiguration: CalendarConfiguration) {
         self.mode = mode
@@ -66,12 +66,12 @@ class DateTimePickerView: UIControl {
 
         super.init(frame: .zero)
 
-        layer.addSublayer(gradientLayer)
+        layer.addSublayer(gradientLayer())
         addSubview(selectionTopSeparator)
         addSubview(selectionBottomSeparator)
         addInteraction(UILargeContentViewerInteraction())
 
-        backgroundColor = Colors.DateTimePicker.background
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
 
         setDate(date, animated: false)
         setDayOfMonth(dayOfMonth, animated: false)
@@ -166,8 +166,8 @@ class DateTimePickerView: UIControl {
         )
 
         let gradientOffset = lineOffset - DateTimePickerViewComponentCell.idealHeight
-        gradientLayer.locations = [0, NSNumber(value: Float(gradientOffset / frame.height)), NSNumber(value: Float((frame.height - gradientOffset) / frame.height)), 1]
-        gradientLayer.frame = bounds
+        gradientLayer().locations = [0, NSNumber(value: Float(gradientOffset / frame.height)), NSNumber(value: Float((frame.height - gradientOffset) / frame.height)), 1]
+        gradientLayer().frame = bounds
 
         setDate(date, animated: false)
         setDayOfMonth(dayOfMonth, animated: false)

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -52,7 +52,7 @@ class DateTimePickerView: UIControl {
 
     private func createGradientLayer() -> CAGradientLayer {
         let gradientLayer = CAGradientLayer()
-        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        let backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].darkElevated))
         let transparentColor = backgroundColor.withAlphaComponent(0)
         gradientLayer.colors = [backgroundColor.cgColor, transparentColor.cgColor, transparentColor.cgColor, backgroundColor.cgColor]
         gradientLayer.startPoint = CGPoint(x: 0, y: 0)

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -52,12 +52,16 @@ class DateTimePickerView: UIControl {
 
     private func createGradientLayer() -> CAGradientLayer {
         let gradientLayer = CAGradientLayer()
-        let backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].darkElevated))
-        let transparentColor = backgroundColor.withAlphaComponent(0)
-        gradientLayer.colors = [backgroundColor.cgColor, transparentColor.cgColor, transparentColor.cgColor, backgroundColor.cgColor]
+        updateGradientLayerColors(gradientLayer: gradientLayer)
         gradientLayer.startPoint = CGPoint(x: 0, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0, y: 1)
         return gradientLayer
+    }
+
+    private func updateGradientLayerColors(gradientLayer: CAGradientLayer) {
+        let backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].darkElevated))
+        let transparentColor = backgroundColor.withAlphaComponent(0)
+        gradientLayer.colors = [backgroundColor.cgColor, transparentColor.cgColor, transparentColor.cgColor, backgroundColor.cgColor]
     }
 
     init(mode: DateTimePickerViewMode, calendarConfiguration: CalendarConfiguration) {
@@ -73,10 +77,24 @@ class DateTimePickerView: UIControl {
         addSubview(selectionBottomSeparator)
         addInteraction(UILargeContentViewerInteraction())
 
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        updateBackgroundColor()
 
         setDate(date, animated: false)
         setDayOfMonth(dayOfMonth, animated: false)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateBackgroundColor()
+        updateGradientLayerColors(gradientLayer: gradientLayer)
+    }
+
+    private func updateBackgroundColor() {
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -50,7 +50,7 @@ class DateTimePickerView: UIControl {
 
     private var gradientLayer = CAGradientLayer()
 
-    private func initGradientLayer() -> CAGradientLayer {
+    private func createGradientLayer() -> CAGradientLayer {
         let gradientLayer = CAGradientLayer()
         let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
         let transparentColor = backgroundColor.withAlphaComponent(0)
@@ -68,8 +68,7 @@ class DateTimePickerView: UIControl {
 
         super.init(frame: .zero)
 
-        gradientLayer = initGradientLayer()
-        layer.addSublayer(gradientLayer)
+        gradientLayer = createGradientLayer()
         addSubview(selectionTopSeparator)
         addSubview(selectionBottomSeparator)
         addInteraction(UILargeContentViewerInteraction())
@@ -91,6 +90,9 @@ class DateTimePickerView: UIControl {
             addSubview(component.view)
             component.didMove(toParent: viewController)
         }
+
+        // Display the gradient layer above the components
+        layer.addSublayer(gradientLayer)
     }
 
     /// Set the date displayed on the picker. This does not trigger UIControlEventValueChanged

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -36,6 +36,15 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         textLabel?.textAlignment = .center
         textLabel?.showsLargeContentViewer = true
         textLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateTextLabelColor()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -5,14 +5,6 @@
 
 import UIKit
 
-// MARK: DateTimePicker Colors
-public extension Colors {
-  struct DateTimePicker {
-    public static var background = UIColor(light: surfacePrimary, dark: gray900)
-      public static var text: UIColor = textSecondary
-  }
-}
-
 // MARK: - DateTimePickerViewComponentCell
 
 /// TableViewCell representing the cell of component view (should be used only by DateTimePickerViewComponent and not instantiated on its own)
@@ -21,7 +13,6 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         static let baseHeight: CGFloat = 45
         static let verticalPadding: CGFloat = 12
         static let maximumFontSize: CGFloat = 33.0
-        static let normalTextColor: UIColor = Colors.DateTimePicker.text
     }
 
     static let identifier: String = "DateTimePickerViewComponentCell"
@@ -32,11 +23,6 @@ class DateTimePickerViewComponentCell: UITableViewCell {
 
     var emphasized: Bool = false {
         didSet {
-            if emphasized {
-                textLabel?.font = UIFontMetrics(forTextStyle: .headline).scaledFont(for: Fonts.headline, maximumPointSize: Constants.maximumFontSize)
-            } else {
-                textLabel?.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
-            }
             updateTextLabelColor()
         }
     }
@@ -44,12 +30,13 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
-        backgroundColor = Colors.DateTimePicker.background
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+
+        updateTextLabelColor()
 
         textLabel?.textAlignment = .center
-        textLabel?.font = UIFontMetrics.default.scaledFont(for: Fonts.body, maximumPointSize: Constants.maximumFontSize)
-        textLabel?.textColor = Constants.normalTextColor
         textLabel?.showsLargeContentViewer = true
+        textLabel?.font = UIFontMetrics.default.scaledFont(for: UIFont.fluent(fluentTheme.aliasTokens.typography[.body1], shouldScale: false), maximumPointSize: Constants.maximumFontSize)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -80,8 +67,6 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     }
 
     private func updateTextLabelColor() {
-        if let window = window {
-            textLabel?.textColor = emphasized ? Colors.primary(for: window) : Constants.normalTextColor
-        }
+        textLabel?.textColor = emphasized ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
     }
 }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -30,7 +30,7 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        backgroundColor = .clear
 
         updateTextLabelColor()
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -12,7 +12,6 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     private struct Constants {
         static let baseHeight: CGFloat = 45
         static let verticalPadding: CGFloat = 12
-        static let maximumFontSize: CGFloat = 33.0
     }
 
     static let identifier: String = "DateTimePickerViewComponentCell"
@@ -36,7 +35,7 @@ class DateTimePickerViewComponentCell: UITableViewCell {
 
         textLabel?.textAlignment = .center
         textLabel?.showsLargeContentViewer = true
-        textLabel?.font = UIFontMetrics.default.scaledFont(for: UIFont.fluent(fluentTheme.aliasTokens.typography[.body1], shouldScale: false), maximumPointSize: Constants.maximumFontSize)
+        textLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Presenters/CardPresenterNavigationController.swift
+++ b/ios/FluentUI/Presenters/CardPresenterNavigationController.swift
@@ -8,7 +8,7 @@ import UIKit
 class CardPresenterNavigationController: UINavigationController, CardPresentable {
     override func viewDidLoad() {
         super.viewDidLoad()
-        FluentUIFramework.initializeUINavigationBarAppearance(navigationBar)
+        FluentUIFramework.initializeUINavigationBarAppearance(navigationBar, navigationBarStyle: .dateTimePicker, fluentTheme: view.fluentTheme)
     }
 
     func idealSize() -> CGSize {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`DateTimePicker` and `CalendarView` have been updated to match their fluent 2 design. 
The navigation bar for `DateTimePicker` is being set by `FluentUIFramework`. As of now, I have only added functionality to handle the custom nav bar specs for `DateTimePicker`. The entire class will be updated separately to use tokens instead of `Colors` in a separate PR.

### Verification

All the changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_calendar_light" src="https://user-images.githubusercontent.com/106181067/190202510-2506c4a4-3bee-433b-9c93-173f8929ca3c.png"> | <img width="488" alt="after_calendar_light" src="https://user-images.githubusercontent.com/106181067/190705595-afd6be27-0e39-4bbc-b144-b229c36898a7.png"> |
| <img width="488" alt="before_calendar_dark" src="https://user-images.githubusercontent.com/106181067/190202691-aba5239f-1714-4fcb-afc9-9ea525173ad7.png"> | <img width="488" alt="after_calendar_dark" src="https://user-images.githubusercontent.com/106181067/190705620-dfbabc4c-016f-4878-a805-ee20cd21db02.png"> |
| <img width="488" alt="before_calendar_segmented_light" src="https://user-images.githubusercontent.com/106181067/190202955-10077ef7-3221-498c-9098-0b566bc92015.png"> | <img width="488" alt="after_calendar_segmented_light" src="https://user-images.githubusercontent.com/106181067/190705660-d840a80c-2826-4ee2-a43c-88ebde9b9179.png"> |
| <img width="488" alt="before_calendar_segmented_dark" src="https://user-images.githubusercontent.com/106181067/190203148-d6e6a789-f918-4bd5-8cc2-c845019f74b8.png"> | <img width="488" alt="after_calendar_segmented_dark" src="https://user-images.githubusercontent.com/106181067/190705707-e629c984-f240-4f0a-bcad-b73d1dbc8608.png"> |
| <img width="488" alt="before_calendar_subtitle_light" src="https://user-images.githubusercontent.com/106181067/190203422-1b43aed0-1aee-4ee9-b069-5887c808de75.png"> | <img width="488" alt="after_calendar_subtitle_light" src="https://user-images.githubusercontent.com/106181067/190705744-bc0093d9-b481-4577-a902-daf0d7b8f617.png"> |
| <img width="488" alt="before_calendar_subtitle_dark" src="https://user-images.githubusercontent.com/106181067/190203736-b761efcd-0d06-43bc-abc6-c214a9db4c50.png"> | <img width="488" alt="after_calendar_subtitle_dark" src="https://user-images.githubusercontent.com/106181067/190705791-55e3bf62-500e-4edd-b4ef-97a74583489f.png"> |
| <img width="488" alt="before_date_time_light" src="https://user-images.githubusercontent.com/106181067/190203959-7d38249c-9118-4f49-b555-e1c423159adf.png"> | <img width="488" alt="after_date_time_light" src="https://user-images.githubusercontent.com/106181067/190204048-684369df-a072-4a1c-b7bc-ad8e0c7b63dd.png"> |
| <img width="488" alt="before_date_time_dark" src="https://user-images.githubusercontent.com/106181067/190204167-bb0a756e-3958-4c5a-843d-b9b5cdf4bb3c.png"> | <img width="488" alt="after_date_time_dark" src="https://user-images.githubusercontent.com/106181067/190204302-bab44d64-75ed-4f04-b9fe-2c69c88fdcd3.png"> |
| <img width="488" alt="before_date_time_segmented_light" src="https://user-images.githubusercontent.com/106181067/190204421-2c504b58-4710-4d68-9c98-80480185d3a7.png"> | <img width="488" alt="after_date_time_segmented_light" src="https://user-images.githubusercontent.com/106181067/190204520-cde1b760-5eb9-4adf-a0b8-8f0cdb275742.png"> |
| <img width="488" alt="before_date_time_segmented_dark" src="https://user-images.githubusercontent.com/106181067/190204621-2929eff9-5a75-4583-ba3e-39af1c13845b.png"> | <img width="488" alt="after_date_time_segmented_dark" src="https://user-images.githubusercontent.com/106181067/190204730-21d617ae-706b-41b6-be9b-fd5c11b8682f.png"> |
| ![before_light](https://user-images.githubusercontent.com/106181067/190206301-962bdf25-aa8a-46f6-864b-d2ae44fef900.gif) | ![after_light](https://user-images.githubusercontent.com/106181067/190206472-e797790e-ad89-4ee7-a369-e5eb64fabf92.gif) |
| ![before_dark](https://user-images.githubusercontent.com/106181067/190206685-fc8df578-2955-42f2-a7e6-aefab6ba0fc5.gif) | ![after_dark](https://user-images.githubusercontent.com/106181067/190206895-ff8c2cab-1b73-4430-93b9-1cdbe647dcce.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1246)