### PR TITLE
Add transformer for SegmentedControl's button title

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -32,6 +32,17 @@ class SegmentPillButton: UIButton {
         self.item = item
         super.init(frame: .zero)
 
+        // TODO: Once iOS 14 support is dropped, set title, etc., in configuration
+        let title = item.title
+        if let image = item.image {
+            self.setImage(image, for: .normal)
+            self.accessibilityLabel = title
+            self.largeContentTitle = title
+        } else {
+            self.setTitle(title, for: .normal)
+        }
+        self.showsLargeContentViewer = true
+
         if #available(iOS 15.0, *) {
             var configuration = UIButton.Configuration.plain()
             configuration.contentInsets = Constants.insets
@@ -44,23 +55,12 @@ class SegmentPillButton: UIButton {
             configuration.titleTextAttributesTransformer = titleTransformer
             self.configuration = configuration
         } else {
+            self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
             self.contentEdgeInsets = UIEdgeInsets(top: Constants.insets.top,
                                                   left: Constants.insets.leading,
                                                   bottom: Constants.insets.bottom,
                                                   right: Constants.insets.trailing)
         }
-
-        // TODO: Once iOS 14 support is dropped, set title, etc., in configuration
-        let title = item.title
-        if let image = item.image {
-            self.setImage(image, for: .normal)
-            self.accessibilityLabel = title
-            self.largeContentTitle = title
-        } else {
-            self.setTitle(title, for: .normal)
-        }
-        self.showsLargeContentViewer = true
-        self.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize)
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(isUnreadValueDidChange),

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -36,6 +36,12 @@ class SegmentPillButton: UIButton {
             var configuration = UIButton.Configuration.plain()
             configuration.contentInsets = Constants.insets
             configuration.background.backgroundColor = .clear
+            let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.systemFont(ofSize: Constants.fontSize)
+                return outgoing
+            }
+            configuration.titleTextAttributesTransformer = titleTransformer
             self.configuration = configuration
         } else {
             self.contentEdgeInsets = UIEdgeInsets(top: Constants.insets.top,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added a transformer to set the font size of the Segmented Control's buttons so they don't scale, since we use the Large Content Viewer.

### Verification
| iOS Version | Before | After |
|---|---|---|
| 15.5 | ![SegmentedControlLargeText_Before](https://user-images.githubusercontent.com/67026548/190253745-f51082d3-9e0c-4da6-9284-107cc3a57a78.png) | ![SegmentedControlLargeText_After](https://user-images.githubusercontent.com/67026548/190253754-992f3640-ae03-4198-af11-770f0ae41efb.png) |
| 14.5 | ![SegmentedControlLargeText_14_Before](https://user-images.githubusercontent.com/67026548/190253764-0487200d-52d9-4486-840f-120c0672a166.png) | ![SegmentedControlLargeText_14_After](https://user-images.githubusercontent.com/67026548/190253783-70400197-227a-4076-994d-60c64aa4aeef.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1250)