### PR TITLE
[main_0.8] Cherrypicking TableViewCell regression changes

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -404,15 +404,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - title: The title string
     ///   - subtitle: The subtitle string
     ///   - footer: The footer string
-    ///   - attributedTitle: The attributed title
-    ///   - attributedSubtitle: The attributed subtitle
-    ///   - attributedFooter: The attributed footer
-    ///   - isAttributedTitleSet: Boolean defining whether or not the `attributedTitle` has been set
-    ///   - isAttributedSubtitleSet: Boolean defining whether or not the `attributedSubtitle` has been set
-    ///   - isAttributedFooterSet: Boolean defining whether or not the `attributedFooter` has been set
-    ///   - titleFont: The title font; If not set, it will default to the font definition in tokens
-    ///   - subtitleFont: The subtitle font; If not set, it will default to the font definition in tokens
-    ///   - footerFont: The footer font; If not set, it will default to the font definition in tokens
     ///   - titleLeadingAccessoryView: The accessory view on the leading edge of the title
     ///   - titleTrailingAccessoryView: The accessory view on the trailing edge of the title
     ///   - subtitleLeadingAccessoryView: The accessory view on the leading edge of the subtitle
@@ -428,15 +419,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public class func preferredWidth(title: String,
                                            subtitle: String = "",
                                            footer: String = "",
-                                           attributedTitle: NSAttributedString? = nil,
-                                           attributedSubtitle: NSAttributedString? = nil,
-                                           attributedFooter: NSAttributedString? = nil,
-                                           isAttributedTitleSet: Bool = false,
-                                           isAttributedSubtitleSet: Bool = false,
-                                           isAttributedFooterSet: Bool = false,
-                                           titleFont: UIFont? = nil,
-                                           subtitleFont: UIFont? = nil,
-                                           footerFont: UIFont? = nil,
                                            titleLeadingAccessoryView: UIView? = nil,
                                            titleTrailingAccessoryView: UIView? = nil,
                                            subtitleLeadingAccessoryView: UIView? = nil,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherrypicking changes from #1248 (c9fb1c82e78f8b7203a218a5cbed0c67f54f23e1)

### Verification
pod lib lint, test app build success

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1251)