### PR TITLE
Hide CommandBarButtonGroupView if all CommandBarButtons are hidden

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -218,7 +218,7 @@ class CommandBarDemoController: DemoController {
         itemCustomizationContainer.addArrangedSubview(itemEnabledStackView)
 
         let itemHiddenStackView = createHorizontalStackView()
-        itemHiddenStackView.addArrangedSubview(createLabelWithText("'+' Hidden"))
+        itemHiddenStackView.addArrangedSubview(createLabelWithText("'Delete' Hidden"))
         let itemHiddenSwitch: UISwitch = UISwitch()
         itemHiddenSwitch.isOn = false
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
@@ -389,7 +389,7 @@ class CommandBarDemoController: DemoController {
     }
 
     @objc func itemHiddenValueChanged(sender: UISwitch!) {
-        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[5][0] else {
             return
         }
 

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -28,15 +28,6 @@ class CommandBarButtonGroupView: UIView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    /// Update the passed button and hide the group view if requested
-    func update(_ button: CommandBarButton, updateGroupView: Bool) {
-        button.updateState()
-
-        if updateGroupView {
-            hideGroupIfNeeded()
-        }
-    }
-
     /// Hides the group view if all the views inside the `stackView` are hidden
      func hideGroupIfNeeded() {
         var allViewsHidden = true

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -20,11 +20,21 @@ class CommandBarButtonGroupView: UIView {
 
         configureHierarchy()
         applyInsets()
+        hideGroupIfNeeded()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    /// Update the passed button and hide the group view if requested
+    func update(_ button: CommandBarButton, updateGroupView: Bool) {
+        button.updateState()
+
+        if updateGroupView {
+            hideGroupIfNeeded()
+        }
     }
 
     private lazy var stackView: UIStackView = {
@@ -54,6 +64,20 @@ class CommandBarButtonGroupView: UIView {
             buttons.first?.contentEdgeInsets.left += LayoutConstants.leftRightBuffer
             buttons.last?.contentEdgeInsets.right += LayoutConstants.leftRightBuffer
         }
+    }
+
+    /// If all views inside the `stackView` are hidden, the group itself should also be hidden. Otherwise the system spacers
+    /// will remain unhidden and cause additional visible space in the layout.
+    private func hideGroupIfNeeded() {
+        var allViewsHidden = true
+        for view in stackView.arrangedSubviews {
+            if !view.isHidden {
+                allViewsHidden = false
+                break
+            }
+        }
+
+        isHidden = allViewsHidden
     }
 
     private struct LayoutConstants {

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -29,7 +29,7 @@ class CommandBarButtonGroupView: UIView {
     }
 
     /// Hides the group view if all the views inside the `stackView` are hidden
-     func hideGroupIfNeeded() {
+    func hideGroupIfNeeded() {
         var allViewsHidden = true
         for view in stackView.arrangedSubviews {
             if !view.isHidden {

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -37,6 +37,19 @@ class CommandBarButtonGroupView: UIView {
         }
     }
 
+    /// Hides the group view if all the views inside the `stackView` are hidden
+     func hideGroupIfNeeded() {
+        var allViewsHidden = true
+        for view in stackView.arrangedSubviews {
+            if !view.isHidden {
+                allViewsHidden = false
+                break
+            }
+        }
+
+        isHidden = allViewsHidden
+    }
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -64,19 +77,6 @@ class CommandBarButtonGroupView: UIView {
             buttons.first?.contentEdgeInsets.left += LayoutConstants.leftRightBuffer
             buttons.last?.contentEdgeInsets.right += LayoutConstants.leftRightBuffer
         }
-    }
-
-    /// If all views inside the `stackView` are hidden, the group itself should also be hidden.
-    private func hideGroupIfNeeded() {
-        var allViewsHidden = true
-        for view in stackView.arrangedSubviews {
-            if !view.isHidden {
-                allViewsHidden = false
-                break
-            }
-        }
-
-        isHidden = allViewsHidden
     }
 
     private struct LayoutConstants {

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -66,8 +66,7 @@ class CommandBarButtonGroupView: UIView {
         }
     }
 
-    /// If all views inside the `stackView` are hidden, the group itself should also be hidden. Otherwise the system spacers
-    /// will remain unhidden and cause additional visible space in the layout.
+    /// If all views inside the `stackView` are hidden, the group itself should also be hidden.
     private func hideGroupIfNeeded() {
         var allViewsHidden = true
         for view in stackView.arrangedSubviews {

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -88,10 +88,10 @@ class CommandBarCommandGroupsView: UIView {
 
             for item in items {
                 if let button = itemsToButtonsMap[item] {
-                    item.propertyChangedUpdateBlock = { _, updateGroupViewState in
+                    item.propertyChangedUpdateBlock = { _, shouldUpdateGroupState in
                         button.updateState()
 
-                        if updateGroupViewState {
+                        if shouldUpdateGroupState {
                             group.hideGroupIfNeeded()
                         }
                     }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -77,15 +77,24 @@ class CommandBarCommandGroupsView: UIView {
     private func updateButtonGroupViews() {
         updateItemsToButtonsMap()
         buttonGroupViews = itemGroups.map { items in
-                CommandBarButtonGroupView(buttons: items.compactMap { item in
-                    guard let button = itemsToButtonsMap[item] else {
-                        preconditionFailure("Button is not initialized in map")
+            let buttons: [CommandBarButton] = items.compactMap { item in
+                guard let button = itemsToButtonsMap[item] else {
+                    preconditionFailure("Button is not initialized in map")
+                }
+                return button
+            }
+
+            let group = CommandBarButtonGroupView(buttons: buttons)
+
+            for item in items {
+                if let button = itemsToButtonsMap[item] {
+                    item.propertyChangedUpdateBlock = { _, updateGroupView in
+                        group.update(button, updateGroupView: updateGroupView)
                     }
-                    item.propertyChangedUpdateBlock = { _ in
-                        button.updateState()
-                    }
-                    return button
-                })
+                }
+            }
+
+            return group
         }
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -88,8 +88,12 @@ class CommandBarCommandGroupsView: UIView {
 
             for item in items {
                 if let button = itemsToButtonsMap[item] {
-                    item.propertyChangedUpdateBlock = { _, updateGroupView in
-                        group.update(button, updateGroupView: updateGroupView)
+                    item.propertyChangedUpdateBlock = { _, updateGroupViewState in
+                        button.updateState()
+
+                        if updateGroupViewState {
+                            group.hideGroupIfNeeded()
+                        }
                     }
                 }
             }

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -125,9 +125,9 @@ open class CommandBarItem: NSObject {
     }
 
     /// Called after a property is changed to trigger the update of a corresponding button
-    /// - Parameter CommandBarItem: Instance of `CommandBarItem` the closure is being invoked from
-    /// - Parameter Bool: Indicates if the item's group state should also be updated
-    var propertyChangedUpdateBlock: ((_: CommandBarItem, _: Bool) -> Void)?
+    /// - Parameter item: Instance of `CommandBarItem` the closure is being invoked from
+    /// - Parameter shouldUpdateGroupState: Indicates if the item's group state should be updated
+    var propertyChangedUpdateBlock: ((_ item: CommandBarItem, _ shouldUpdateGroupState: Bool) -> Void)?
 
     /// Indicates whether the `itemTappedHandler` should be called as the item's tap handler
     var shouldUseItemTappedHandler: Bool {

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -125,6 +125,8 @@ open class CommandBarItem: NSObject {
     }
 
     /// Called after a property is changed to trigger the update of a corresponding button
+    /// - Parameter CommandBarItem: Instance of `CommandBarItem` the closure is being invoked from
+    /// - Parameter Bool: Indicates if the item's group state should also be updated
     var propertyChangedUpdateBlock: ((_: CommandBarItem, _: Bool) -> Void)?
 
     /// Indicates whether the `itemTappedHandler` should be called as the item's tap handler

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -64,7 +64,7 @@ open class CommandBarItem: NSObject {
     @objc public var iconImage: UIImage? {
         didSet {
             if iconImage != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, false)
             }
         }
     }
@@ -73,7 +73,7 @@ open class CommandBarItem: NSObject {
     @objc public var title: String? {
         didSet {
             if title != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, false)
             }
         }
     }
@@ -83,7 +83,7 @@ open class CommandBarItem: NSObject {
     @objc public var isEnabled: Bool {
         didSet {
             if isEnabled != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, false)
             }
         }
     }
@@ -91,7 +91,7 @@ open class CommandBarItem: NSObject {
     @objc public var isHidden: Bool = false {
         didSet {
             if isHidden != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, true)
             }
         }
     }
@@ -100,7 +100,7 @@ open class CommandBarItem: NSObject {
     @objc public var isSelected: Bool {
         didSet {
             if isSelected != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, false)
             }
         }
     }
@@ -124,8 +124,8 @@ open class CommandBarItem: NSObject {
         itemTappedHandler(sender, self)
     }
 
-    /// Called after a property is changed to trigger the update of a corresponding button
-    var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
+	/// Called after a property is changed to trigger the update of a corresponding button
+	var propertyChangedUpdateBlock: ((_: CommandBarItem, _: Bool) -> Void)?
 
     /// Indicates whether the `itemTappedHandler` should be called as the item's tap handler
     var shouldUseItemTappedHandler: Bool {

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -124,8 +124,8 @@ open class CommandBarItem: NSObject {
         itemTappedHandler(sender, self)
     }
 
-	/// Called after a property is changed to trigger the update of a corresponding button
-	var propertyChangedUpdateBlock: ((_: CommandBarItem, _: Bool) -> Void)?
+    /// Called after a property is changed to trigger the update of a corresponding button
+    var propertyChangedUpdateBlock: ((_: CommandBarItem, _: Bool) -> Void)?
 
     /// Indicates whether the `itemTappedHandler` should be called as the item's tap handler
     var shouldUseItemTappedHandler: Bool {

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -64,7 +64,7 @@ open class CommandBarItem: NSObject {
     @objc public var iconImage: UIImage? {
         didSet {
             if iconImage != oldValue {
-                propertyChangedUpdateBlock?(self, false)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -73,7 +73,7 @@ open class CommandBarItem: NSObject {
     @objc public var title: String? {
         didSet {
             if title != oldValue {
-                propertyChangedUpdateBlock?(self, false)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -83,7 +83,7 @@ open class CommandBarItem: NSObject {
     @objc public var isEnabled: Bool {
         didSet {
             if isEnabled != oldValue {
-                propertyChangedUpdateBlock?(self, false)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -91,7 +91,7 @@ open class CommandBarItem: NSObject {
     @objc public var isHidden: Bool = false {
         didSet {
             if isHidden != oldValue {
-                propertyChangedUpdateBlock?(self, true)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ true)
             }
         }
     }
@@ -100,7 +100,7 @@ open class CommandBarItem: NSObject {
     @objc public var isSelected: Bool {
         didSet {
             if isSelected != oldValue {
-                propertyChangedUpdateBlock?(self, false)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

**Issue:** 
If all the items in a `CommandBarButtonGroupView` are hidden, the system spacers are still shown in the stack view and create visible empty space. See video below for example.

This is a bug with the `CommandBar`. Not technically a regression since the ability to hide a `CommandBarButton` was introduced with [this commit](https://github.com/microsoft/fluentui-apple/commit/061da18cf8b15b59ea6b3affd1f59e3414f9b43b) and this change is fixing a case that was missed with the original commit.

**Root Cause:** 
The `CommandBarItem.propertyChangedUpdateBlock` was calling `CommandBarButton.updateState()` directly to update the `isHidden` state of a `CommandBarButton`. This works to hide each of the individual buttons, but the superview, the `CommadBarButtonGroupView.stackView`, isn't aware of when its subviews change their hidden state. If all of the subviews are hidden, the superview needs to also mark itself as hidden so that the system spacers inside the stackView do not remain visible.

**Fix:**
- The `CommandBarItem.propertyChangedUpdateBlock` block that calls `CommandBarButton.updateState()` now takes an additional `Bool` parameter to indicate if the  `CommadBarButtonGroupView` should also update its state. If the parameter is `true` the block calls `hideGroupIfNeeded()` on the group.
- Add a call to `hideGroupIfNeeded()` from `CommadBarButtonGroupView. init(buttons:)` to ensure the group view is hidden if it is initialized with buttons that are set as hidden.
- Modified the loop used to create a `CommadBarButtonGroupView` so that an update call can be made on the group if needed.
- Updated `CommandBarDemoController` to hide the `"Delete"` item instead of the `"+"` item. Since the `"Delete"` item is the item in its own group, the `CommadBarButtonGroupView` will have to hide itself when the `"Delete"` item is hidden, testing the functionality added in this PR.

### Verification

**Before (Observe space before the Delete item):**

https://user-images.githubusercontent.com/10938746/190278112-bc926e97-86a2-4161-94f7-5da78b853f0c.mov

**After (Observe space before the Delete item):**

https://user-images.githubusercontent.com/10938746/190278101-a59f7b84-1b1e-4b8d-9c73-317e2dd0a42c.mov

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1254)