### PR TITLE
[Fluent 2 iOS] SegmentedControl colors update

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -168,7 +168,7 @@ class ColorDemoController: UIViewController {
                 colorView.updateBackgroundColor()
             }
         }
-        segmentedControl.updateWindowSpecificColors()
+        segmentedControl.updateColors()
     }
 
     private let tableView = UITableView(frame: .zero, style: .grouped)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -69,9 +69,9 @@ class SegmentedControlDemoController: DemoController {
 
         let backgroundView = UIView()
         if style == .primaryPill {
-            backgroundView.backgroundColor = Colors.navigationBarBackground
+            backgroundView.backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: view.fluentTheme)
         } else {
-            backgroundView.backgroundColor = UIColor(light: Colors.communicationBlue, dark: Colors.navigationBarBackground)
+            backgroundView.backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: view.fluentTheme)
         }
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -69,10 +69,9 @@ class SegmentedControlDemoController: DemoController {
 
         let backgroundView = UIView()
         if style == .primaryPill {
-            backgroundView.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+            backgroundView.backgroundColor = Colors.navigationBarBackground
         } else {
-            backgroundView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.aliasTokens.colors[.brandBackground1].light,
-                                                                                dark: view.fluentTheme.aliasTokens.colors[.background3].dark))
+            backgroundView.backgroundColor = UIColor(light: Colors.communicationBlue, dark: Colors.navigationBarBackground)
         }
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -69,9 +69,10 @@ class SegmentedControlDemoController: DemoController {
 
         let backgroundView = UIView()
         if style == .primaryPill {
-            backgroundView.backgroundColor = Colors.navigationBarBackground
+            backgroundView.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
         } else {
-            backgroundView.backgroundColor = UIColor(light: Colors.communicationBlue, dark: Colors.navigationBarBackground)
+            backgroundView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.aliasTokens.colors[.brandBackground1].light,
+                                                                                dark: view.fluentTheme.aliasTokens.colors[.background3].dark))
         }
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -82,7 +82,7 @@ public struct DynamicColor {
     }
 
     /// The default color for a light context. Required.
-    public var light: ColorValue
+    var light: ColorValue
 
     /// The override color for a light, high contrast context. Optional.
     var lightHighContrast: ColorValue?
@@ -94,7 +94,7 @@ public struct DynamicColor {
     var lightElevatedHighContrast: ColorValue?
 
     /// The override color for a dark context. Optional.
-    public var dark: ColorValue?
+    var dark: ColorValue?
 
     /// The override color for a dark, high contrast context. Optional.
     var darkHighContrast: ColorValue?

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -82,7 +82,7 @@ public struct DynamicColor {
     }
 
     /// The default color for a light context. Required.
-    var light: ColorValue
+    public var light: ColorValue
 
     /// The override color for a light, high contrast context. Optional.
     var lightHighContrast: ColorValue?
@@ -94,7 +94,7 @@ public struct DynamicColor {
     var lightElevatedHighContrast: ColorValue?
 
     /// The override color for a dark context. Optional.
-    var dark: ColorValue?
+    public var dark: ColorValue?
 
     /// The override color for a dark, high contrast context. Optional.
     var darkHighContrast: ColorValue?

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -80,7 +80,7 @@ open class NavigationBar: UINavigationBar {
             }
         }
 
-        func backgroundColor(fluentTheme: FluentTheme, customColor: UIColor?) -> UIColor {
+        public func backgroundColor(fluentTheme: FluentTheme, customColor: UIColor? = nil) -> UIColor {
             let defaultColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground1].light, dark: fluentTheme.aliasTokens.colors[.background3].dark))
             switch self {
             case .primary, .default:

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -245,6 +245,15 @@ open class SegmentedControl: UIControl {
         addSubview(pillContainerView)
 
         setupLayoutConstraints()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        updateWindowSpecificColors()
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -56,12 +56,13 @@ open class SegmentedControl: UIControl {
                 return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.backgroundDisabled)
             }
         }
-        func selectionColor(for window: UIWindow) -> UIColor {
+        func selectionColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
-                return Colors.primary(for: window)
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
             case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.selection
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.background5Selected].dark))
             }
         }
         var selectionColorDisabled: UIColor {
@@ -72,12 +73,13 @@ open class SegmentedControl: UIControl {
                 return Colors.SegmentedControl.OnBrandPill.selectionDisabled
             }
         }
-        var segmentTextColor: UIColor {
+        func segmentTextColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.segmentText
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.segmentText
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             }
         }
         func segmentTextColorSelected(for window: UIWindow) -> UIColor {
@@ -284,7 +286,7 @@ open class SegmentedControl: UIControl {
             return
         }
 
-        pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(for: window) : style.selectionColorDisabled)
+        pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(fluentTheme: fluentTheme) : style.selectionColorDisabled)
         backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(fluentTheme: fluentTheme) : style.backgroundColorDisabled(for: window))
         let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(for: window)) : style.segmentTextColorSelectedAndDisabled(for: window)
         for maskedLabel in pillMaskedLabels {
@@ -299,7 +301,7 @@ open class SegmentedControl: UIControl {
             }
             maskedImage.tintColor = maskedContentColor
         }
-        let contentColor = isEnabled ? (customSegmentedControlButtonTextColor ?? style.segmentTextColor) : style.segmentTextColorDisabled(for: window)
+        let contentColor = isEnabled ? (customSegmentedControlButtonTextColor ?? style.segmentTextColor(fluentTheme: fluentTheme)) : style.segmentTextColorDisabled(for: window)
         for button in buttons {
             button.setTitleColor(contentColor, for: .normal)
             button.tintColor = contentColor

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -106,7 +106,7 @@ open class SegmentedControl: UIControl {
             for button in buttons {
                 button.isEnabled = isEnabled
             }
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
 
@@ -142,7 +142,7 @@ open class SegmentedControl: UIControl {
     private var items = [SegmentItem]()
     internal var style: Style {
         didSet {
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
 
@@ -245,6 +245,7 @@ open class SegmentedControl: UIControl {
         addSubview(pillContainerView)
 
         setupLayoutConstraints()
+        updateColors()
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(themeDidChange),
@@ -253,14 +254,14 @@ open class SegmentedControl: UIControl {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        updateWindowSpecificColors()
+        updateColors()
     }
 
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    public func updateWindowSpecificColors() {
+    public func updateColors() {
 
         pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? style.selectionColor(fluentTheme: fluentTheme)
         backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? style.backgroundColor(fluentTheme: fluentTheme)
@@ -458,11 +459,6 @@ open class SegmentedControl: UIControl {
         maxButtonHeight += (contentInset.top + contentInset.bottom)
 
         return CGSize(width: min(maxButtonWidth, size.width), height: min(maxButtonHeight, size.height))
-    }
-
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateWindowSpecificColors()
     }
 
     func intrinsicContentSizeInvalidatedForChildView() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -48,14 +48,7 @@ open class SegmentedControl: UIControl {
                                                           dark: fluentTheme.aliasTokens.colors[.background5].dark))
             }
         }
-        func backgroundColorDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.backgroundDisabled
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.backgroundDisabled)
-            }
-        }
+
         func selectionColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
@@ -65,14 +58,7 @@ open class SegmentedControl: UIControl {
                                                           dark: fluentTheme.aliasTokens.colors[.background5Selected].dark))
             }
         }
-        var selectionColorDisabled: UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.selectionDisabled
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.selectionDisabled
-            }
-        }
+
         func segmentTextColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
@@ -82,37 +68,42 @@ open class SegmentedControl: UIControl {
                                                           dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             }
         }
-        func segmentTextColorSelected(for window: UIWindow) -> UIColor {
+        func segmentTextColorSelected(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
-                return Colors.textOnAccent
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
             case .onBrandPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
             }
         }
-        func segmentTextColorDisabled(for window: UIWindow) -> UIColor {
+        func segmentTextColorDisabled(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
-                return Colors.textDisabled
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
             case .onBrandPill:
-                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
-            }
-        }
-        func segmentTextColorSelectedAndDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.foregroundDisabled1].dark))
             }
         }
 
-        func segmentUnreadDotColor(for window: UIWindow) -> UIColor {
+        func segmentTextColorSelectedAndDisabled(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.gray100)
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1])
             case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.segmentText
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundDisabled2].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.foregroundDisabled2].dark))
+            }
+        }
+
+        func segmentUnreadDotColor(fluentTheme: FluentTheme) -> UIColor {
+            switch self {
+            case .primaryPill:
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundInverted])
+            case .onBrandPill:
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.brandForegroundInverted].dark))
             }
         }
 
@@ -282,13 +273,10 @@ open class SegmentedControl: UIControl {
     }
 
     public func updateWindowSpecificColors() {
-        guard let window = window else {
-            return
-        }
 
-        pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(fluentTheme: fluentTheme) : style.selectionColorDisabled)
-        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(fluentTheme: fluentTheme) : style.backgroundColorDisabled(for: window))
-        let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(for: window)) : style.segmentTextColorSelectedAndDisabled(for: window)
+        pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? style.selectionColor(fluentTheme: fluentTheme)
+        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? style.backgroundColor(fluentTheme: fluentTheme)
+        let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(fluentTheme: fluentTheme)) : style.segmentTextColorSelectedAndDisabled(fluentTheme: fluentTheme)
         for maskedLabel in pillMaskedLabels {
             guard let maskedLabel = maskedLabel else {
                 continue
@@ -301,13 +289,13 @@ open class SegmentedControl: UIControl {
             }
             maskedImage.tintColor = maskedContentColor
         }
-        let contentColor = isEnabled ? (customSegmentedControlButtonTextColor ?? style.segmentTextColor(fluentTheme: fluentTheme)) : style.segmentTextColorDisabled(for: window)
+        let contentColor = isEnabled ? (customSegmentedControlButtonTextColor ?? style.segmentTextColor(fluentTheme: fluentTheme)) : style.segmentTextColorDisabled(fluentTheme: fluentTheme)
         for button in buttons {
             button.setTitleColor(contentColor, for: .normal)
             button.tintColor = contentColor
 
             if let switchButton = button as? SegmentPillButton {
-                switchButton.unreadDotColor = isEnabled ? style.segmentUnreadDotColor(for: window) : style.segmentTextColorDisabled(for: window)
+                switchButton.unreadDotColor = isEnabled ? style.segmentUnreadDotColor(fluentTheme: fluentTheme) : style.segmentTextColorDisabled(fluentTheme: fluentTheme)
             }
         }
     }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -39,12 +39,13 @@ open class SegmentedControl: UIControl {
 
         var backgroundHasRoundedCorners: Bool { return self == .primaryPill || self == .onBrandPill }
 
-        func backgroundColor(for window: UIWindow) -> UIColor {
+        func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.background
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
             case .onBrandPill:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.background)
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2].light,
+                                                          dark: fluentTheme.aliasTokens.colors[.background5].dark))
             }
         }
         func backgroundColorDisabled(for window: UIWindow) -> UIColor {
@@ -284,7 +285,7 @@ open class SegmentedControl: UIControl {
         }
 
         pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(for: window) : style.selectionColorDisabled)
-        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(for: window) : style.backgroundColorDisabled(for: window))
+        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(fluentTheme: fluentTheme) : style.backgroundColorDisabled(for: window))
         let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(for: window)) : style.segmentTextColorSelectedAndDisabled(for: window)
         for maskedLabel in pillMaskedLabels {
             guard let maskedLabel = maskedLabel else {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -4,27 +4,6 @@
 //
 import UIKit
 
-// MARK: SegmentedControl Colors
-
-private extension Colors {
-    struct SegmentedControl {
-        struct PrimaryPill {
-            static let background = UIColor(light: surfaceTertiary, dark: gray950)
-            static let backgroundDisabled: UIColor = background
-            static let segmentText = UIColor(light: textSecondary, dark: textPrimary)
-            static let selectionDisabled: UIColor = surfaceQuaternary
-        }
-
-        struct OnBrandPill {
-            static let background: UIColor = PrimaryPill.background
-            static let backgroundDisabled: UIColor = PrimaryPill.backgroundDisabled
-            static let segmentText = UIColor(light: textOnAccent, dark: textPrimary)
-            static let selection = UIColor(light: surfacePrimary, dark: surfaceQuaternary)
-            static let selectionDisabled = UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        }
-    }
-}
-
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.
 @objc(MSFSegmentedControl)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`SegmentedControl` was updated to match fluent 2 specs.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_light_1" src="https://user-images.githubusercontent.com/106181067/190478067-837d11c6-d186-4545-bec0-79057c8eaf1d.png"> | <img width="488" alt="after_light_1" src="https://user-images.githubusercontent.com/106181067/190478096-259a3286-10d3-4903-b24c-39e25e23891e.png"> |
| <img width="488" alt="before_light_2" src="https://user-images.githubusercontent.com/106181067/190478128-b194de57-3b61-4cb4-be6f-76b5ddc2921e.png"> | <img width="488" alt="after_light_2" src="https://user-images.githubusercontent.com/106181067/190478158-7dd8f9c0-66c6-4a4e-9c65-2d8e4bb405eb.png"> |
| <img width="488" alt="before_dark_1" src="https://user-images.githubusercontent.com/106181067/190478194-6aa0c7c3-c217-4f09-835b-a2ffdf549f21.png"> | <img width="488" alt="after_dark_1" src="https://user-images.githubusercontent.com/106181067/190478232-6bf490cb-d04d-4a5a-b289-8c931635c343.png"> |
| <img width="488" alt="before_dark_2" src="https://user-images.githubusercontent.com/106181067/190478256-3a3f35f2-39ca-4135-82ff-77ecc9dee357.png"> | <img width="488" alt="after_dark_2" src="https://user-images.githubusercontent.com/106181067/190478280-c4fff725-beb1-4cf4-bfdb-344b2cf3ea62.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)