### PR TITLE
[main_0.8] Cherrypick paddingLeading tokens exposure

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -170,7 +170,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public static let defaultNumberOfLinesForLargerDynamicType: Int = -1
 
     /// The default leading padding in the cell.
-    @objc public static var defaultPaddingLeading: CGFloat { TableViewCellTokenSet.paddingLeading }
+    @objc public static let defaultPaddingLeading: CGFloat = {
+        let tokenSet = TableViewCellTokenSet(customViewSize: { .default })
+        return tokenSet[.paddingLeading].float
+    }()
 
     /// The default trailing padding in the cell.
     @objc public static var defaultPaddingTrailing: CGFloat { TableViewCellTokenSet.paddingTrailing }
@@ -641,9 +644,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     private static func customViewLeadingOffset(isInSelectionMode: Bool,
                                                 tokenSet: TableViewCellTokenSet) -> CGFloat {
-        return TableViewCellTokenSet.paddingLeading + selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
-                                                            selectionImageMarginTrailing: TableViewCellTokenSet.selectionImageMarginTrailing,
-                                                            selectionImageSize: TableViewCellTokenSet.selectionImageSize)
+        return tokenSet[.paddingLeading].float + selectionModeAreaWidth(isInSelectionMode: isInSelectionMode,
+                                                                        selectionImageMarginTrailing: TableViewCellTokenSet.selectionImageMarginTrailing,
+                                                                        selectionImageSize: TableViewCellTokenSet.selectionImageSize)
     }
 
     private static func textAreaLeadingOffset(customViewSize: MSFTableViewCellCustomViewSize,
@@ -734,7 +737,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     /// The leading padding.
     @objc public var paddingLeading: CGFloat {
         get {
-            return _paddingLeading ?? TableViewCellTokenSet.paddingLeading
+            return _paddingLeading ?? tokenSet[.paddingLeading].float
         }
         set {
             if newValue != _paddingLeading {

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -68,6 +68,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
 
         /// The communication text color in an ActionsCell.
         case communicationTextColor
+
+        /// The leading padding in the cell.
+        case paddingLeading
     }
 
     init(customViewSize: @escaping () -> MSFTableViewCellCustomViewSize) {
@@ -174,6 +177,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                     DynamicColor(light: ColorValue(0x0078D4),
                                  dark: ColorValue(0x0086F0))
                 }
+
+            case .paddingLeading:
+                return .float { GlobalTokens.spacing(.medium) }
             }
         }
     }
@@ -196,9 +202,6 @@ extension TableViewCellTokenSet {
 
     /// The default horizontal spacing in the cell.
     static let horizontalSpacing: CGFloat = GlobalTokens.spacing(.medium)
-
-    /// The leading padding in the cell.
-    static let paddingLeading: CGFloat = GlobalTokens.spacing(.medium)
 
     /// The vertical padding in the cell.
     static let paddingVertical: CGFloat = 11.0


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking: 397717512afda6cdacf56ca642e68ab703932a8a
- #1262 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1263)