### PR TITLE
[main_0.8] Cherry-picking BottomSheet and CommandBar changes

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -84,19 +84,20 @@ class BottomSheetDemoController: UIViewController {
     @objc private func showTransientSheet() {
         let sheetContentView = UIView()
 
+        // This is the bottom sheet that will temporarily be displayed after tapping the "Show transient sheet" button.
+        // There can be multiple of these on screen at the same time. All the currently presented transient sheets
+        // are tracked in presentedTransientSheets.
         let secondarySheetController = BottomSheetController(expandedContentView: sheetContentView)
+        secondarySheetController.delegate = self
         secondarySheetController.collapsedContentHeight = 250
         secondarySheetController.isHidden = true
         secondarySheetController.shouldAlwaysFillWidth = false
         secondarySheetController.shouldHideCollapsedContent = false
         secondarySheetController.isFlexibleHeight = true
+        secondarySheetController.allowsSwipeToHide = true
 
         let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { _ in
-            secondarySheetController.setIsHidden(true, animated: true) { _ in
-                secondarySheetController.willMove(toParent: nil)
-                secondarySheetController.removeFromParent()
-                secondarySheetController.view.removeFromSuperview()
-            }
+            secondarySheetController.setIsHidden(true, animated: true)
         }))
 
         dismissButton.style = .primaryFilled
@@ -130,6 +131,7 @@ class BottomSheetDemoController: UIViewController {
         // has a meaningful initial frame to use for the animation.
         view.layoutIfNeeded()
         secondarySheetController.isHidden = false
+        presentedTransientSheets.append(secondarySheetController)
     }
 
     private lazy var personaListView: UIScrollView = {
@@ -219,6 +221,8 @@ class BottomSheetDemoController: UIViewController {
             ]
         ]
     }
+
+    private var presentedTransientSheets = [BottomSheetController]()
 
     private static let headerHeight: CGFloat = 30
 
@@ -352,5 +356,16 @@ extension BottomSheetDemoController: BottomSheetControllerDelegate {
         if let tableView = mainTableView {
             tableView.contentInset.bottom = bottomSheetController.collapsedHeightInSafeArea
         }
+    }
+
+    func bottomSheetController(_ bottomSheetController: BottomSheetController, didMoveTo expansionState: BottomSheetExpansionState, interaction: BottomSheetInteraction) {
+        guard expansionState == .hidden, let index = presentedTransientSheets.firstIndex(of: bottomSheetController) else {
+            return
+        }
+
+        presentedTransientSheets.remove(at: index)
+        bottomSheetController.willMove(toParent: nil)
+        bottomSheetController.removeFromParent()
+        bottomSheetController.view.removeFromSuperview()
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -24,8 +24,10 @@ class BottomSheetDemoController: UIViewController {
         let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: expandedContentView)
         bottomSheetViewController.hostedScrollView = personaListView
         bottomSheetViewController.headerContentHeight = BottomSheetDemoController.headerHeight
-        bottomSheetViewController.collapsedContentHeight = 70
         bottomSheetViewController.delegate = self
+        bottomSheetViewController.collapsedHeightResolver = { context in
+            return context.containerTraitCollection.verticalSizeClass == .regular ? 100 : 70
+        }
 
         self.bottomSheetViewController = bottomSheetViewController
 
@@ -352,7 +354,7 @@ extension BottomSheetDemoController: UIScrollViewDelegate {
 }
 
 extension BottomSheetDemoController: BottomSheetControllerDelegate {
-    func bottomSheetControllerCollapsedSheetHeightDidChange(_ bottomSheetController: BottomSheetController) {
+    func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController) {
         if let tableView = mainTableView {
             tableView.contentInset.bottom = bottomSheetController.collapsedHeightInSafeArea
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -218,7 +218,7 @@ class CommandBarDemoController: DemoController {
         itemCustomizationContainer.addArrangedSubview(itemEnabledStackView)
 
         let itemHiddenStackView = createHorizontalStackView()
-        itemHiddenStackView.addArrangedSubview(createLabelWithText("'+' Hidden"))
+        itemHiddenStackView.addArrangedSubview(createLabelWithText("'Delete' Hidden"))
         let itemHiddenSwitch: UISwitch = UISwitch()
         itemHiddenSwitch.isOn = false
         itemHiddenSwitch.addTarget(self, action: #selector(itemHiddenValueChanged), for: .valueChanged)
@@ -389,7 +389,7 @@ class CommandBarDemoController: DemoController {
     }
 
     @objc func itemHiddenValueChanged(sender: UISwitch!) {
-        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[0][0] else {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[5][0] else {
             return
         }
 

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		8035CAB62633A4DB007B3FD1 /* BottomCommandingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8035CAAA2633A442007B3FD1 /* BottomCommandingController.swift */; };
 		8035CAD026377C17007B3FD1 /* CommandingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8035CACA26377C14007B3FD1 /* CommandingItem.swift */; };
 		8035CADE2638E435007B3FD1 /* CommandingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8035CADC2638E435007B3FD1 /* CommandingSection.swift */; };
+		804EDE1528C00CA400371C6B /* ContentHeightResolutionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804EDE1428C00CA400371C6B /* ContentHeightResolutionContext.swift */; };
 		80AECC21263339E3005AF2F3 /* BottomSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECBD82629F18E005AF2F3 /* BottomSheetController.swift */; };
 		80AECC22263339E5005AF2F3 /* BottomSheetPassthroughView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECBF1262FC34E005AF2F3 /* BottomSheetPassthroughView.swift */; };
 		8FA3CB5B246B19EA0049E431 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA3CB5A246B19EA0049E431 /* ColorTests.swift */; };
@@ -278,6 +279,7 @@
 		8035CAAA2633A442007B3FD1 /* BottomCommandingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomCommandingController.swift; sourceTree = "<group>"; };
 		8035CACA26377C14007B3FD1 /* CommandingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandingItem.swift; sourceTree = "<group>"; };
 		8035CADC2638E435007B3FD1 /* CommandingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandingSection.swift; sourceTree = "<group>"; };
+		804EDE1428C00CA400371C6B /* ContentHeightResolutionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentHeightResolutionContext.swift; sourceTree = "<group>"; };
 		80AECBD82629F18E005AF2F3 /* BottomSheetController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetController.swift; sourceTree = "<group>"; };
 		80AECBF1262FC34E005AF2F3 /* BottomSheetPassthroughView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPassthroughView.swift; sourceTree = "<group>"; };
 		86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtonStyle.swift; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 			children = (
 				80AECBD82629F18E005AF2F3 /* BottomSheetController.swift */,
 				80AECBF1262FC34E005AF2F3 /* BottomSheetPassthroughView.swift */,
+				804EDE1428C00CA400371C6B /* ContentHeightResolutionContext.swift */,
 			);
 			path = "Bottom Sheet";
 			sourceTree = "<group>";
@@ -1489,6 +1492,7 @@
 				5306076126A201C8002D49CF /* Persona.swift in Sources */,
 				92E7AD5026FE51FF00AE7FF8 /* DynamicColor.swift in Sources */,
 				5314E14E25F016CD0099271A /* ResizingHandleView.swift in Sources */,
+				804EDE1528C00CA400371C6B /* ContentHeightResolutionContext.swift in Sources */,
 				5314E1A625F01A7C0099271A /* BooleanCell.swift in Sources */,
 				92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */,
 				925D461D26FD133600179583 /* GlobalTokens.swift in Sources */,

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -165,6 +165,15 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// A closure for resolving the desired collapsed sheet height given a resolution context.
+    @objc open var collapsedHeightResolver: ((ContentHeightResolutionContext) -> CGFloat)? {
+        didSet {
+            if isViewLoaded {
+                invalidateSheetSize()
+            }
+        }
+    }
+
     /// Height of the top portion of the content view that should be visible when the bottom sheet is collapsed.
     ///
     /// When set to 0, `headerContentHeight` will be used.
@@ -298,6 +307,20 @@ public class BottomSheetController: UIViewController {
         }
 
         return animator
+    }
+
+    /// Forces a call to `collapsedHeightResolver` to fetch the latest desired sheet height.
+    @objc public func invalidateSheetSize() {
+        guard isViewLoaded else {
+            return
+        }
+
+        lastCollapsedSheetHeightResolutionContext = nil
+
+        // If we are animating to .collapsed or already collapsed, we need to move to refresh the animation target.
+        if targetExpansionState == .collapsed || (currentExpansionState == .collapsed && targetExpansionState == nil) {
+            move(to: .collapsed)
+        }
     }
 
     // MARK: - View loading
@@ -842,11 +865,20 @@ public class BottomSheetController: UIViewController {
 
     // Height of the sheet in collapsed state
     private var collapsedSheetHeight: CGFloat {
-        let visibleContentHeight = (collapsedContentHeight > 0) ? collapsedContentHeight : headerContentHeight
-        let idealHeight = currentResizingHandleHeight + visibleContentHeight + view.safeAreaInsets.bottom
+        let safeAreaSheetHeight: CGFloat
+        if resolvedCollapsedSheetHeight > 0 {
+            safeAreaSheetHeight = resolvedCollapsedSheetHeight
+        } else if collapsedContentHeight > 0 {
+            safeAreaSheetHeight = collapsedContentHeight + currentResizingHandleHeight
+        } else {
+            safeAreaSheetHeight = headerContentHeight + currentResizingHandleHeight
+        }
+
+        let idealHeight = safeAreaSheetHeight + view.safeAreaInsets.bottom
         return min(idealHeight, maxSheetHeight)
     }
 
+    // Maximum total sheet height including parts outside of the safe area.
     private var maxSheetHeight: CGFloat {
         let maxHeight: CGFloat
 
@@ -858,6 +890,24 @@ public class BottomSheetController: UIViewController {
 
         return maxHeight
     }
+
+    // Output of `collapsedHeightResolver` wrapped in a cache.
+    private var resolvedCollapsedSheetHeight: CGFloat {
+        let oldContext = lastCollapsedSheetHeightResolutionContext
+        let newContext = ContentHeightResolutionContext(maximumHeight: maxSheetHeight - view.safeAreaInsets.bottom, containerTraitCollection: view.traitCollection)
+
+        if oldContext?.maximumHeight != newContext.maximumHeight || !(oldContext?.containerTraitCollection.containsTraits(in: newContext.containerTraitCollection) ?? false) {
+            lastResolvedCollapsedSheetHeight = collapsedHeightResolver?(newContext) ?? 0
+            lastCollapsedSheetHeightResolutionContext = newContext
+        }
+        return lastResolvedCollapsedSheetHeight
+    }
+
+    // Last output of `collapsedHeightResolver`.
+    private var lastResolvedCollapsedSheetHeight: CGFloat = 0
+
+    // Context we last used for height resolving.
+    private var lastCollapsedSheetHeightResolutionContext: ContentHeightResolutionContext?
 
     private var currentResizingHandleHeight: CGFloat {
         (isExpandable ? ResizingHandleView.height : 0.0)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -198,6 +198,9 @@ public class BottomSheetController: UIViewController {
         }
     }
 
+    /// When enabled, users will be able to move the sheet to the hidden state by swiping down.
+    @objc open var allowsSwipeToHide: Bool = false
+
     /// Current height of the portion of a collapsed sheet that's in the safe area.
     @objc public private(set) var collapsedHeightInSafeArea: CGFloat = 0 {
         didSet {
@@ -572,11 +575,13 @@ public class BottomSheetController: UIViewController {
     private func translateSheet(by translationDelta: CGPoint) {
         let expandedOffset = offset(for: .expanded)
         let collapsedOffset = offset(for: .collapsed)
+        let hiddenOffset = offset(for: .hidden)
+
         let minOffset = expandedOffset - Constants.maxRubberBandOffset
-        let maxOffset = collapsedOffset + Constants.maxRubberBandOffset
+        let maxOffset = allowsSwipeToHide ? hiddenOffset : (collapsedOffset + Constants.maxRubberBandOffset)
 
         var offsetDelta = translationDelta.y
-        if currentSheetVerticalOffset >= collapsedOffset || currentSheetVerticalOffset <= expandedOffset {
+        if (currentSheetVerticalOffset >= collapsedOffset && !allowsSwipeToHide) || currentSheetVerticalOffset <= expandedOffset {
             offsetDelta *= translationRubberBandFactor(for: currentSheetVerticalOffset)
         }
 
@@ -626,15 +631,26 @@ public class BottomSheetController: UIViewController {
 
     private func completePan(with velocity: CGFloat) {
         var targetState: BottomSheetExpansionState
+
         if abs(velocity) < Constants.directionOverrideVelocityThreshold {
-            // Velocity too low, snap to the closest offset
-            targetState =
-                abs(offset(for: .collapsed) - currentSheetVerticalOffset) < abs(offset(for: .expanded) - currentSheetVerticalOffset)
-                ? .collapsed
-                : .expanded
+            // Velocity too low, snap to the closest expansion state
+            var distances: [BottomSheetExpansionState: CGFloat] = [
+                .expanded: abs(offset(for: .expanded) - currentSheetVerticalOffset),
+                .collapsed: abs(offset(for: .collapsed) - currentSheetVerticalOffset)
+            ]
+
+            if allowsSwipeToHide {
+                distances[.hidden] = abs(offset(for: .hidden) - currentSheetVerticalOffset)
+            }
+
+            targetState = distances.min(by: { $0.value < $1.value })?.key ?? .collapsed
         } else {
-            // Velocity high enough, animate to the offset we're swiping towards
-            targetState = velocity > 0 ? .collapsed : .expanded
+            // Velocity high enough, animate to the state we're swiping towards
+            if currentSheetVerticalOffset > offset(for: .collapsed) && allowsSwipeToHide {
+                targetState = velocity > 0 ? .hidden : .collapsed
+            } else {
+                targetState = velocity > 0 ? .collapsed : .expanded
+            }
         }
         move(to: targetState, velocity: velocity, interaction: .swipe)
     }

--- a/ios/FluentUI/Bottom Sheet/ContentHeightResolutionContext.swift
+++ b/ios/FluentUI/Bottom Sheet/ContentHeightResolutionContext.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Contains all information necessary to determine desired height of content inside of a container.
+@objc(MSFContentHeightResolutionContext)
+public class ContentHeightResolutionContext: NSObject {
+
+    /// Init the resolution context.
+    /// - Parameters:
+    ///   - maximumHeight: Maximum height of the content.
+    ///   - containerTraitCollection: Trait collection of the content container.
+    init(maximumHeight: CGFloat, containerTraitCollection: UITraitCollection) {
+        self.maximumHeight = maximumHeight
+        self.containerTraitCollection = containerTraitCollection
+    }
+
+    /// Maximum height of the content.
+    @objc public let maximumHeight: CGFloat
+
+    /// Trait collection of the content container.
+    @objc public let containerTraitCollection: UITraitCollection
+}

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -20,11 +20,25 @@ class CommandBarButtonGroupView: UIView {
 
         configureHierarchy()
         applyInsets()
+        hideGroupIfNeeded()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    /// Hides the group view if all the views inside the `stackView` are hidden
+    func hideGroupIfNeeded() {
+        var allViewsHidden = true
+        for view in stackView.arrangedSubviews {
+            if !view.isHidden {
+                allViewsHidden = false
+                break
+            }
+        }
+
+        isHidden = allViewsHidden
     }
 
     private lazy var stackView: UIStackView = {

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -77,15 +77,28 @@ class CommandBarCommandGroupsView: UIView {
     private func updateButtonGroupViews() {
         updateItemsToButtonsMap()
         buttonGroupViews = itemGroups.map { items in
-                CommandBarButtonGroupView(buttons: items.compactMap { item in
-                    guard let button = itemsToButtonsMap[item] else {
-                        preconditionFailure("Button is not initialized in map")
-                    }
-                    item.propertyChangedUpdateBlock = { _ in
+            let buttons: [CommandBarButton] = items.compactMap { item in
+                guard let button = itemsToButtonsMap[item] else {
+                    preconditionFailure("Button is not initialized in map")
+                }
+                return button
+            }
+
+            let group = CommandBarButtonGroupView(buttons: buttons)
+
+            for item in items {
+                if let button = itemsToButtonsMap[item] {
+                    item.propertyChangedUpdateBlock = { _, shouldUpdateGroupState in
                         button.updateState()
+
+                        if shouldUpdateGroupState {
+                            group.hideGroupIfNeeded()
+                        }
                     }
-                    return button
-                })
+                }
+            }
+
+            return group
         }
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -64,7 +64,7 @@ open class CommandBarItem: NSObject {
     @objc public var iconImage: UIImage? {
         didSet {
             if iconImage != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -73,7 +73,7 @@ open class CommandBarItem: NSObject {
     @objc public var title: String? {
         didSet {
             if title != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -83,7 +83,7 @@ open class CommandBarItem: NSObject {
     @objc public var isEnabled: Bool {
         didSet {
             if isEnabled != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -91,7 +91,7 @@ open class CommandBarItem: NSObject {
     @objc public var isHidden: Bool = false {
         didSet {
             if isHidden != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ true)
             }
         }
     }
@@ -100,7 +100,7 @@ open class CommandBarItem: NSObject {
     @objc public var isSelected: Bool {
         didSet {
             if isSelected != oldValue {
-                propertyChangedUpdateBlock?(self)
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
             }
         }
     }
@@ -125,7 +125,9 @@ open class CommandBarItem: NSObject {
     }
 
     /// Called after a property is changed to trigger the update of a corresponding button
-    var propertyChangedUpdateBlock: ((CommandBarItem) -> Void)?
+    /// - Parameter item: Instance of `CommandBarItem` the closure is being invoked from
+    /// - Parameter shouldUpdateGroupState: Indicates if the item's group state should be updated
+    var propertyChangedUpdateBlock: ((_ item: CommandBarItem, _ shouldUpdateGroupState: Bool) -> Void)?
 
     /// Indicates whether the `itemTappedHandler` should be called as the item's tap handler
     var shouldUseItemTappedHandler: Bool {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- #1207 
- #1242 
- #1254 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1266)