### PR TITLE
Use NSLayoutContraint.activateConstraints to for CommandBarButton customControlView

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -165,10 +165,12 @@ class CommandBarButton: UIButton {
         addSubview(view)
 
         /// Constrain view to edges of the button
-        view.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-        view.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-        view.topAnchor.constraint(equalTo: topAnchor).isActive = true
-        view.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            view.topAnchor.constraint(equalTo: topAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
     }
 
     private struct LayoutConstants {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Small perf gains are seen by using `NSLayoutConstraint.activateConstraints()` instead of individually activating each constraint by setting the `NSLayoutConstraint.isActive` property. This change updates the `CommandBarButton` to constrain the `customControlView` using `NSLayoutConstraint.activateConstraints()` to activate the constraints.

### Verification

**Before**
<img width="314" alt="Original" src="https://user-images.githubusercontent.com/10938746/192324343-a77d4440-64c9-478b-a55d-b920d498b30e.png">

**After**
<img width="316" alt="Updated" src="https://user-images.githubusercontent.com/10938746/192324325-81dda3ff-765a-4458-91c1-2b7429f6a291.png">

- Verified layout in test app. No changes in layout are expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1269)