### PR TITLE
[Fluent 2 iOS] Add new alias tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -100,6 +100,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandBackgroundInverted,
              .brandBackgroundInvertedDisabled,
              .foregroundInverted1,
+             .foregroundLightStatic,
              .brandForeground3:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundContrast])
         case .foregroundContrast,
@@ -117,6 +118,8 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandBackground2Selected,
              .brandBackground3,
              .strokeAccessible,
+             .backgroundDarkStatic,
+             .foregroundDarkStatic,
              .background5BrandFilledSelected:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundInverted1])
         }
@@ -178,7 +181,8 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .backgroundDisabled,
                     .canvasBackground,
                     .stencil1,
-                    .stencil2]
+                    .stencil2,
+                    .backgroundDarkStatic]
         case .brandBackgrounds:
             return [.brandBackground1,
                     .brandBackground1Pressed,
@@ -206,7 +210,9 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .foregroundContrast,
                     .foregroundOnColor,
                     .foregroundInverted1,
-                    .foregroundInverted2]
+                    .foregroundInverted2,
+                    .foregroundLightStatic,
+                    .foregroundDarkStatic]
         case .brandForegrounds:
             return [.brandForeground1,
                     .brandForeground1Pressed,
@@ -372,6 +378,12 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Stroke 1 Pressed"
         case .brandStroke1Selected:
             return "Brand Stroke 1 Selected"
+        case .foregroundDarkStatic:
+            return "Foreground Dark Static"
+        case .foregroundLightStatic:
+            return "Foreground Light Static"
+        case .backgroundDarkStatic:
+            return "Background Dark Static"
         }
     }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -455,6 +455,8 @@ public final class AliasTokens {
         case brandForegroundInverted
         case brandForegroundDisabled1
         case brandForegroundDisabled2
+        case foregroundDarkStatic
+        case foregroundLightStatic
         // Background colors
         case background1
         case background1Pressed
@@ -496,6 +498,7 @@ public final class AliasTokens {
         case stencil1
         case stencil2
         case canvasBackground
+        case backgroundDarkStatic
         // Stroke colors
         case stroke1
         case stroke2
@@ -564,6 +567,12 @@ public final class AliasTokens {
         case .brandForegroundDisabled2:
             return DynamicColor(light: strongSelf.brandColors[.comm140].light,
                                 dark: strongSelf.brandColors[.comm40].light)
+        case .foregroundDarkStatic:
+            return DynamicColor(light: GlobalTokens.neutralColors(.black),
+                                dark: GlobalTokens.neutralColors(.black))
+        case .foregroundLightStatic:
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.white))
         // Background colors
         case .background1:
          return DynamicColor(light: GlobalTokens.neutralColors(.white),
@@ -646,9 +655,9 @@ public final class AliasTokens {
                              dark: GlobalTokens.neutralColors(.grey50),
                              darkElevated: GlobalTokens.neutralColors(.grey50))
         case .backgroundInverted:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey14),
-                             dark: GlobalTokens.neutralColors(.grey34),
-                             darkElevated: GlobalTokens.neutralColors(.grey30))
+         return DynamicColor(light: GlobalTokens.neutralColors(.grey46),
+                             dark: GlobalTokens.neutralColors(.grey72),
+                             darkElevated: GlobalTokens.neutralColors(.grey78))
         case .backgroundDisabled:
          return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
                              dark: GlobalTokens.neutralColors(.grey32),
@@ -700,6 +709,14 @@ public final class AliasTokens {
         case .stencil2:
          return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
                              dark: GlobalTokens.neutralColors(.grey20))
+        case .canvasBackground:
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey96),
+                                dark: GlobalTokens.neutralColors(.grey8),
+                                darkElevated: GlobalTokens.neutralColors(.grey14))
+        case .backgroundDarkStatic:
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey14),
+                                dark: GlobalTokens.neutralColors(.grey24),
+                                darkElevated: GlobalTokens.neutralColors(.grey30))
         // Stroke colors
         case .stroke1:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
@@ -728,10 +745,6 @@ public final class AliasTokens {
         case .brandStroke1Selected:
             return DynamicColor(light: strongSelf.brandColors[.comm60].light,
                                 dark: strongSelf.brandColors[.comm120].light)
-        case .canvasBackground:
-            return DynamicColor(light: GlobalTokens.neutralColors(.grey96),
-                                dark: GlobalTokens.neutralColors(.grey12),
-                                darkElevated: GlobalTokens.neutralColors(.grey16))
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

New alias color tokens were added to `ColorTokens`

### Verification

The color tokens were added and tested on the demo app

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="bg_light" src="https://user-images.githubusercontent.com/106181067/192374940-daccc8e1-33c9-47b4-985c-23f9f1b945b2.png"> | <img width="487" alt="bg_dark" src="https://user-images.githubusercontent.com/106181067/192374968-b59ebb75-2f77-4c7b-b437-e0eb3a94c28a.png"> |
| <img width="487" alt="fg_light" src="https://user-images.githubusercontent.com/106181067/192374992-b495612a-d02e-48bf-b2f9-45e57363d1e4.png"> | <img width="487" alt="fg_dark" src="https://user-images.githubusercontent.com/106181067/192375023-120e4541-283b-4726-bbb0-02dad8ef4f52.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1270)