### PR TITLE
[main_0.8] Cherry-picking PillButton changes + versioning updates

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { "Microsoft" => "fluentuinativeowners@microsoft.com"}
   s.source       = { :git => "https://github.com/microsoft/fluentui-apple.git", :tag => "#{s.version}" }
-  s.swift_version = "5.6"
+  s.swift_version = "5.7"
   s.module_name = 'FluentUI'
 
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Fluent UI Apple contains native UIKit and AppKit controls aligned with [Microsof
 #### Requirements
 
 - iOS 14+ or macOS 10.15+
-- Xcode 13+
-- Swift 5.4+
+- Xcode 14+
+- Swift 5.7+
 
 #### Using Swift Package Manager
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -125,6 +125,7 @@ open class PillButtonBar: UIScrollView {
 
     private var stackView: UIStackView = {
         let view = UIStackView()
+        view.distribution = .fillProportionally
         view.alignment = .center
         view.spacing = Constants.minButtonsSpacing
         return view
@@ -411,8 +412,15 @@ open class PillButtonBar: UIScrollView {
         buttonExtraSidePadding = ceil(totalPadding / CGFloat(buttonEdges))
         for button in buttons {
             button.layoutIfNeeded()
-            button.contentEdgeInsets.right += buttonExtraSidePadding
-            button.contentEdgeInsets.left += buttonExtraSidePadding
+
+            if #available(iOS 15.0, *) {
+                button.configuration?.contentInsets.leading += buttonExtraSidePadding
+                button.configuration?.contentInsets.trailing += buttonExtraSidePadding
+            } else {
+                button.contentEdgeInsets.right += buttonExtraSidePadding
+                button.contentEdgeInsets.left += buttonExtraSidePadding
+            }
+
             button.layoutIfNeeded()
         }
     }
@@ -453,8 +461,15 @@ open class PillButtonBar: UIScrollView {
             let buttonWidth = button.frame.width
             if buttonWidth > 0, buttonWidth < Constants.minButtonWidth {
                 let extraInset = floor((Constants.minButtonWidth - button.frame.width) / 2)
-                button.contentEdgeInsets.left += extraInset
-                button.contentEdgeInsets.right = button.contentEdgeInsets.left
+
+                if #available(iOS 15.0, *) {
+                    button.configuration?.contentInsets.leading += extraInset
+                    button.configuration?.contentInsets.trailing = button.configuration?.contentInsets.leading ?? extraInset
+                } else {
+                    button.contentEdgeInsets.left += extraInset
+                    button.contentEdgeInsets.right = button.contentEdgeInsets.left
+                }
+
                 button.layoutIfNeeded()
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- #1244
- #1272
- #1273

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1274)