### PR TITLE
[Fluent 2 iOS] Separator color update

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -107,7 +107,7 @@ class ColorDemoController: UIViewController {
         tableView.allowsSelection = false
         tableView.backgroundColor = TableViewCell.tableBackgroundColor
 
-        let separator = Separator(style: .shadow, orientation: .horizontal)
+        let separator = Separator(orientation: .horizontal)
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])
         stackView.setCustomSpacing(8, after: segmentedControl)
         stackView.axis = .vertical

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -28,7 +28,7 @@ class OtherCellsDemoController: DemoController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
-        tableView.separatorColor = Colors.Separator.default
+        tableView.separatorColor = Separator.separatorDefaultColor(fluentTheme: view.fluentTheme)
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -38,7 +38,7 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         container.setCustomSpacing(8, after: segmentedControl)
         container.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1])
 
-        let separator = Separator(style: .shadow, orientation: .horizontal)
+        let separator = Separator(orientation: .horizontal)
         container.addArrangedSubview(separator)
 
         container.addArrangedSubview(groupedTableView)

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -29,7 +29,7 @@ class CalendarView: UIView {
     init(headerStyle: DatePickerHeaderStyle = .light) {
         weekdayHeadingView = CalendarViewWeekdayHeadingView(headerStyle: headerStyle)
 
-        headingViewSeparator = Separator(style: .shadow)
+        headingViewSeparator = Separator()
 
         collectionViewLayout = CalendarViewLayout()
 
@@ -39,7 +39,7 @@ class CalendarView: UIView {
         // Enable multiple selection to allow for one cell to be selected and another cell to be highlighted simultaneously
         collectionView.allowsMultipleSelection = true
 
-        collectionViewSeparator = Separator(style: .default)
+        collectionViewSeparator = Separator()
 
         super.init(frame: .zero)
 

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -90,7 +90,7 @@ class DrawerPresentationController: UIPresentationController {
         return DrawerShadowView(shadowDirection: actualPresentationOffset == 0 ? presentationDirection : nil)
     }()
     // Imitates the bottom shadow of navigation bar or top shadow of toolbar because original ones are hidden by presented view
-    private lazy var separator = Separator(style: .shadow)
+    private lazy var separator = Separator()
 
     // MARK: Presentation
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -152,7 +152,7 @@ class ShyHeaderView: UIView {
     }
 
     private let contentStackView = UIStackView()
-    private let shadow = Separator(style: .shadow)
+    private let shadow = Separator()
 
     private var needsShadow: Bool {
         switch navigationBarShadow {

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -122,9 +122,9 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     private var action1Type: ActionType = .regular
     private var action2Type: ActionType = .regular
 
-    private let topSeparator = Separator(style: .default, orientation: .horizontal)
-    private let bottomSeparator = Separator(style: .default, orientation: .horizontal)
-    private let verticalSeparator = Separator(style: .default, orientation: .vertical)
+    private let topSeparator = Separator(orientation: .horizontal)
+    private let bottomSeparator = Separator(orientation: .horizontal)
+    private let verticalSeparator = Separator(orientation: .vertical)
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         self.tokenSet = TableViewCellTokenSet(customViewSize: { .default })

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -117,7 +117,7 @@ open class PopupMenuController: DrawerController {
     }
 
     /// set `separatorColor` to customize separator colors of  PopupMenuItem cells and the drawer
-    @objc open var separatorColor: UIColor = Colors.Separator.default {
+    @objc open var separatorColor: UIColor = Separator.separatorDefaultColor(fluentTheme: FluentTheme.shared) {
         didSet {
             separator?.backgroundColor = separatorColor
         }

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -5,17 +5,6 @@
 
 import UIKit
 
-// MARK: Separator Colors
-
-public extension Colors {
-    struct Separator {
-        public static var `default`: UIColor = dividerOnPrimary
-        public static var shadow: UIColor = dividerOnSecondary
-    }
-    // Objective-C support
-    @objc static var separatorDefault: UIColor { return Separator.default }
-}
-
 // MARK: - SeparatorOrientation
 
 @objc(MSFSeparatorOrientation)
@@ -49,8 +38,12 @@ open class Separator: UIView {
     */
     @objc public static var thickness: CGFloat { return 0.5 }
 
+    @objc public static func separatorDefaultColor(fluentTheme: FluentTheme) -> UIColor {
+        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
+    }
+
     private func initialize(orientation: SeparatorOrientation) {
-        super.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
+        super.backgroundColor = Separator.separatorDefaultColor(fluentTheme: fluentTheme)
         self.orientation = orientation
         switch orientation {
         case .horizontal:

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -63,6 +63,9 @@ open class Separator: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         super.backgroundColor = Separator.separatorDefaultColor(fluentTheme: fluentTheme)
     }
 

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -16,23 +16,6 @@ public extension Colors {
     @objc static var separatorDefault: UIColor { return Separator.default }
 }
 
-// MARK: - SeparatorStyle
-
-@objc(MSFSeparatorStyle)
-public enum SeparatorStyle: Int {
-    case `default`
-    case shadow
-
-    fileprivate var color: UIColor {
-        switch self {
-        case .default:
-            return Colors.Separator.default
-        case .shadow:
-            return Colors.Separator.shadow
-        }
-    }
-}
-
 // MARK: - SeparatorOrientation
 
 @objc(MSFSeparatorOrientation)
@@ -49,12 +32,12 @@ open class Separator: UIView {
 
     @objc public override init(frame: CGRect) {
         super.init(frame: frame)
-        initialize(style: .default, orientation: .horizontal)
+        initialize(orientation: .horizontal)
     }
 
-    @objc public init(style: SeparatorStyle = .default, orientation: SeparatorOrientation = .horizontal) {
+    @objc public init(orientation: SeparatorOrientation = .horizontal) {
         super.init(frame: .zero)
-        initialize(style: style, orientation: orientation)
+        initialize(orientation: orientation)
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -66,8 +49,8 @@ open class Separator: UIView {
     */
     @objc public static var thickness: CGFloat { return 0.5 }
 
-    private func initialize(style: SeparatorStyle, orientation: SeparatorOrientation) {
-        super.backgroundColor = style.color
+    private func initialize(orientation: SeparatorOrientation) {
+        super.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
         self.orientation = orientation
         switch orientation {
         case .horizontal:

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -55,6 +55,15 @@ open class Separator: UIView {
         }
         isAccessibilityElement = false
         isUserInteractionEnabled = false
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        super.backgroundColor = Separator.separatorDefaultColor(fluentTheme: fluentTheme)
     }
 
     open override var intrinsicContentSize: CGSize {

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -162,7 +162,7 @@ open class SideTabBar: UIView {
     }
 
     private var layoutConstraints: [NSLayoutConstraint] = []
-    private let borderLine = Separator(style: .shadow, orientation: .vertical)
+    private let borderLine = Separator(orientation: .vertical)
 
     private let backgroundView: UIVisualEffectView = {
         var style = UIBlurEffect.Style.regular

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -155,7 +155,7 @@ open class TabBarView: UIView {
         return stackView
     }()
 
-    private let topBorderLine = Separator(style: .shadow, orientation: .horizontal)
+    private let topBorderLine = Separator(orientation: .horizontal)
 
     private func updateHeight() {
         if traitCollection.userInterfaceIdiom == .phone {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1219,8 +1219,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         return imageView
     }()
 
-    internal let topSeparator = Separator(style: .default, orientation: .horizontal)
-    internal let bottomSeparator = Separator(style: .default, orientation: .horizontal)
+    internal let topSeparator = Separator(orientation: .horizontal)
+    internal let bottomSeparator = Separator(orientation: .horizontal)
 
     private var superTableView: UITableView? {
         return findSuperview(of: UITableView.self) as? UITableView


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The `Separator` has been updated to match its fluent 2 design. 
Design requested the shadow style be removed since it's unused in fluent 2. The affected controls are `TabBar`, `SideTabBar` and `ShyHeaderView`. They will now be using the default separator. 
Following the previous discussions on how to deal with objc colors, the `Colors` extension was removed and I created a static objc function which takes in a FluentTheme and returns the right token. As a consequence in PopupMenuController, I called `FluentTheme.shared` since I couldn't access the `FluentTheme` from a view.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_tvc_light" src="https://user-images.githubusercontent.com/106181067/193122836-015dcd74-e41f-4077-8de1-4364a31769aa.png"> | <img width="487" alt="after_tvc_light" src="https://user-images.githubusercontent.com/106181067/193122875-df5ddc09-87b7-4b14-9cb2-bd8c95ea4910.png"> |
| <img width="487" alt="before_tvc_dark" src="https://user-images.githubusercontent.com/106181067/193122924-961c6b58-b8b4-4d5e-8056-1f5bd75f08ed.png"> | <img width="487" alt="after_tvc_dark" src="https://user-images.githubusercontent.com/106181067/193122959-7bd14cbf-b3ad-4f6a-84ce-23f29de38a7e.png"> |
| <img width="487" alt="before_tabbar_light" src="https://user-images.githubusercontent.com/106181067/193122999-19df5058-f823-4752-a926-d6fb66aa07ff.png"> | <img width="487" alt="after_tabbar_light" src="https://user-images.githubusercontent.com/106181067/193123037-02c1d874-8a27-460a-b10b-227548f73a58.png"> |
| <img width="487" alt="before_tabbar_dark" src="https://user-images.githubusercontent.com/106181067/193123083-bd2f777c-748a-4130-b068-bdbc79cc6dbc.png"> | <img width="487" alt="after_tabbar_dark" src="https://user-images.githubusercontent.com/106181067/193123127-0b5ff0e7-643f-4bfb-bffc-c5de604e9a56.png"> |
| <img width="487" alt="before_sidetabbar_light" src="https://user-images.githubusercontent.com/106181067/193123176-033869fa-e914-433e-9c30-4e1e72f0cf03.png"> | <img width="487" alt="after_sidetabbar_light" src="https://user-images.githubusercontent.com/106181067/193123203-01028b2d-7e63-4360-8dde-6a0782e0fd91.png"> |
| <img width="487" alt="before_sidetabbar_dark" src="https://user-images.githubusercontent.com/106181067/193123308-7a406d63-01db-4855-89a7-b19434f96797.png"> | <img width="487" alt="after_sidetabbar_dark" src="https://user-images.githubusercontent.com/106181067/193123333-8a2bf1e7-7480-4c73-b2b1-a009796af7c2.png"> |
| <img width="487" alt="before_searchbar_light" src="https://user-images.githubusercontent.com/106181067/193123366-fe6084cb-3cc5-416d-8ef7-f2788efaf940.png"> | <img width="487" alt="after_searchbar_light" src="https://user-images.githubusercontent.com/106181067/193123397-048656e4-5793-4540-ac32-b6719d4660f1.png"> |
| <img width="487" alt="before_searchbar_dark" src="https://user-images.githubusercontent.com/106181067/193123429-a0f3b34b-174b-4387-b742-089455722c6e.png"> | <img width="487" alt="after_searchbar_dark" src="https://user-images.githubusercontent.com/106181067/193123464-db641e76-c7da-4d4a-bcc8-e38f29050ded.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1277)