### PR TITLE
[Fluent 2 iOS] Calendar & DateTimePicker updates

### DIFF
--- a/ios/FluentUI.Tests/DatePickerControllerTests.swift
+++ b/ios/FluentUI.Tests/DatePickerControllerTests.swift
@@ -99,6 +99,15 @@ class MockCalendarViewStyleDataSource: CalendarViewStyleDataSource {
         }
     }
 
+    func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents
+    ) -> CalendarViewDayCellBackgroundStyle {
+        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
+            return .primary
+        } else {
+            return .secondary
+        }
+    }
+
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, selectionStyleForDayWithStart dayStartDate: Date, end: Date) -> CalendarViewDayCellSelectionStyle {
         return .normal
     }

--- a/ios/FluentUI.Tests/DatePickerControllerTests.swift
+++ b/ios/FluentUI.Tests/DatePickerControllerTests.swift
@@ -92,7 +92,7 @@ class DatePickerControllerTests: XCTestCase {
 
 class MockCalendarViewStyleDataSource: CalendarViewStyleDataSource {
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, textStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellTextStyle {
-        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
+        if dayStartComponents.dateIsInCurrentMonth(todayDateComponents: todayComponents) {
             return .primary
         } else {
             return .secondary
@@ -101,7 +101,7 @@ class MockCalendarViewStyleDataSource: CalendarViewStyleDataSource {
 
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents
     ) -> CalendarViewDayCellBackgroundStyle {
-        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
+        if dayStartComponents.dateIsInCurrentMonth(todayDateComponents: todayComponents) {
             return .primary
         } else {
             return .secondary

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -61,6 +61,9 @@ class CalendarView: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateCollectionViewBackgroundColor()
     }
 

--- a/ios/FluentUI/Calendar/CalendarViewDataSource.swift
+++ b/ios/FluentUI/Calendar/CalendarViewDataSource.swift
@@ -10,6 +10,9 @@ import UIKit
 protocol CalendarViewStyleDataSource: AnyObject {
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, textStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellTextStyle
 
+    // Suggestion: Use provided components for performance improvements. Check where it's called to see what's available
+    func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellBackgroundStyle
+
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, selectionStyleForDayWithStart dayStartDate: Date, end: Date) -> CalendarViewDayCellSelectionStyle
 }
 
@@ -155,6 +158,8 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
         // Calculate style parameters
         let textStyle = styleDataSource.calendarViewDataSource(self, textStyleForDayWithStart: dayStartDate, end: dayEndDate, dayStartComponents: dayStartDateComponents, todayComponents: todayDateComponents)
 
+        let backgroundStyle = styleDataSource.calendarViewDataSource(self, backgroundStyleForDayWithStart: dayStartDate, end: dayEndDate, dayStartComponents: dayStartDateComponents, todayComponents: todayDateComponents)
+
         let selectionStyle = styleDataSource.calendarViewDataSource(self, selectionStyleForDayWithStart: dayStartDate, end: dayEndDate)
 
         let monthLabelIndex = dayStartDateComponents.month! - 1
@@ -172,7 +177,7 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
             guard let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as? CalendarViewDayCell else {
                 return UICollectionViewCell()
             }
-            dayCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: "", indicatorLevel: 0)
+            dayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: "", indicatorLevel: 0)
             return dayCell
         }
 
@@ -180,7 +185,7 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
             guard let dayTodayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayTodayCell.identifier, for: indexPath) as? CalendarViewDayTodayCell else {
                 return UICollectionViewCell()
             }
-            dayTodayCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+            dayTodayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
             return dayTodayCell
         }
 
@@ -189,13 +194,13 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
                 guard let dayMonthYearCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthYearCell.identifier, for: indexPath) as? CalendarViewDayMonthYearCell else {
                     return UICollectionViewCell()
                 }
-                dayMonthYearCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, yearLabelText: yearLabelText, indicatorLevel: indicatorLevel)
+                dayMonthYearCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, yearLabelText: yearLabelText, indicatorLevel: indicatorLevel)
                 return dayMonthYearCell
             } else {
                 guard let dayMonthCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayMonthCell.identifier, for: indexPath) as? CalendarViewDayMonthCell else {
                     return UICollectionViewCell()
                 }
-                dayMonthCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+                dayMonthCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
                 return dayMonthCell
             }
         }
@@ -203,7 +208,7 @@ extension CalendarViewDataSource: UICollectionViewDataSource {
         guard let dayCell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarViewDayCell.identifier, for: indexPath) as? CalendarViewDayCell else {
             return UICollectionViewCell()
         }
-        dayCell.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+        dayCell.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
         return dayCell
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -200,7 +200,7 @@ class CalendarViewDayCell: UICollectionViewCell {
         case .primary:
             dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         case .secondary:
-            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
         }
 
         switch backgroundStyle {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -117,6 +117,9 @@ class CalendarViewDayCell: UICollectionViewCell {
     }
 
     @objc func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateViews()
         dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -203,7 +203,12 @@ class CalendarViewDayCell: UICollectionViewCell {
             dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         }
 
-        contentView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        switch backgroundStyle {
+        case .primary:
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        case .secondary:
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.canvasBackground].light, dark: fluentTheme.aliasTokens.colors[.canvasBackground].dark))
+        }
 
         if isHighlighted || isSelected {
             dotView.isHidden = true

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -53,7 +53,7 @@ let calendarViewDayCellVisualStateTransitionDuration: TimeInterval = 0.3
 class CalendarViewDayCell: UICollectionViewCell {
     struct Constants {
         static let borderWidth: CGFloat = 0.5
-        static let dotDiameter: CGFloat = 4.0
+        static let dotDiameter: CGFloat = 6.0
         static let fadedVisualStateAlphaMultiplier: CGFloat = 0.2
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -12,6 +12,13 @@ enum CalendarViewDayCellTextStyle {
     case secondary
 }
 
+// MARK: - CalendarViewDayCellBackgroundStyle
+
+enum CalendarViewDayCellBackgroundStyle {
+    case primary
+    case secondary
+}
+
 // MARK: - CalendarViewDayCellVisualState
 
 enum CalendarViewDayCellVisualState {
@@ -67,6 +74,7 @@ class CalendarViewDayCell: UICollectionViewCell {
     }
 
     private(set) var textStyle: CalendarViewDayCellTextStyle = .primary
+    private(set) var backgroundStyle: CalendarViewDayCellBackgroundStyle = .primary
 
     private var visibleDotViewAlpha: CGFloat = 1.0
 
@@ -119,8 +127,9 @@ class CalendarViewDayCell: UICollectionViewCell {
     }
 
     // Only supports indicator levels from 0...4
-    func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
         self.textStyle = textStyle
+        self.backgroundStyle = backgroundStyle
         selectionOverlayView.selectionStyle = selectionStyle
 
         // Assign text content

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -58,13 +58,13 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, indicatorLevel) instead")
     }
 
     // Only supports indicator levels from 0...4
-    func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+    func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
+        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         updateMonthLabelColor(textStyle: textStyle)
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -36,22 +36,17 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
         super.init(frame: frame)
 
         monthLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
-        monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        updateMonthLabelColor()
         contentView.addSubview(monthLabel)
     }
 
     @objc override func themeDidChange(_ notification: Notification) {
         super.themeDidChange(notification)
-        updateMonthLabelColor(textStyle: textStyle)
+        updateMonthLabelColor()
     }
 
-    private func updateMonthLabelColor(textStyle: CalendarViewDayCellTextStyle) {
-        switch textStyle {
-        case .primary:
-            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-        case .secondary:
-            monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-        }
+    private func updateMonthLabelColor() {
+        monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -66,9 +61,9 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
     func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
         super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
-        updateMonthLabelColor(textStyle: textStyle)
+        updateMonthLabelColor()
 
-        monthLabel.text = monthLabelText
+        monthLabel.text = monthLabelText.uppercased()
     }
 
     override func layoutSubviews() {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -44,11 +44,11 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, yearLabelText, indicatorLevel) instead")
     }
 
-    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
+    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, monthLabelText: String, dateLabelText: String, indicatorLevel: Int) {
         preconditionFailure("Use setup(textStyle, backgroundStyle, selectionStyle, monthLabelText, dateLabelText, yearLabelText, indicatorLevel) instead")
     }
 
@@ -63,12 +63,13 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
 
     // Only supports indicator levels from 0...4
     func setup(textStyle: CalendarViewDayCellTextStyle,
+               backgroundStyle: CalendarViewDayCellBackgroundStyle,
                selectionStyle: CalendarViewDayCellSelectionStyle,
                monthLabelText: String,
                dateLabelText: String,
                yearLabelText: String,
                indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, monthLabelText: monthLabelText, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         updateYearLabelColor(textStyle: textStyle)
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -25,8 +25,8 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
     }
 
     // Only supports indicator levels from 0...4
-    override func setup(textStyle: CalendarViewDayCellTextStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
-        super.setup(textStyle: textStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
+    override func setup(textStyle: CalendarViewDayCellTextStyle, backgroundStyle: CalendarViewDayCellBackgroundStyle, selectionStyle: CalendarViewDayCellSelectionStyle, dateLabelText: String, indicatorLevel: Int) {
+        super.setup(textStyle: textStyle, backgroundStyle: backgroundStyle, selectionStyle: selectionStyle, dateLabelText: dateLabelText, indicatorLevel: indicatorLevel)
 
         configureBackgroundColor()
         configureFontColor()

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -39,7 +39,7 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
     }
 
     private func configureBackgroundColor() {
-        contentView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
     }
 
     private func configureFontColor() {

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -41,7 +41,7 @@ class CalendarViewWeekdayHeadingView: UIView {
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -37,6 +37,9 @@ class CalendarViewWeekdayHeadingView: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateBackgroundColor()
     }
 

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -70,7 +70,7 @@ public class FluentUIFramework: NSObject {
             case .normal:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
             case .dateTimePicker:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
             }
         }
     }

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -149,6 +149,9 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, view.isDescendant(of: themeView) else {
+            return
+        }
         updateBackgroundColor()
         updateBarButtonColors()
     }

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -498,7 +498,7 @@ extension DatePickerController: CalendarViewLayoutDelegate {
 extension DatePickerController: CalendarViewStyleDataSource {
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, textStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents) -> CalendarViewDayCellTextStyle {
 
-        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
+        if dayStartComponents.dateIsInCurrentMonth(todayDateComponents: todayComponents) {
             return .primary
         } else {
             return .secondary
@@ -508,7 +508,7 @@ extension DatePickerController: CalendarViewStyleDataSource {
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents
     ) -> CalendarViewDayCellBackgroundStyle {
 
-        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
+        if dayStartComponents.dateIsInCurrentMonth(todayDateComponents: todayComponents) {
             return .primary
         } else {
             return .secondary

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -186,7 +186,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBackgroundColor() {
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
+        view.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.aliasTokens.colors[.background2].light, dark: view.fluentTheme.aliasTokens.colors[.background2].dark))
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -505,6 +505,16 @@ extension DatePickerController: CalendarViewStyleDataSource {
         }
     }
 
+    func calendarViewDataSource(_ dataSource: CalendarViewDataSource, backgroundStyleForDayWithStart dayStartDate: Date, end: Date, dayStartComponents: DateComponents, todayComponents: DateComponents
+    ) -> CalendarViewDayCellBackgroundStyle {
+
+        if dayStartComponents.dateIsTodayOrLater(todayDateComponents: todayComponents) {
+            return .primary
+        } else {
+            return .secondary
+        }
+    }
+
     func calendarViewDataSource(_ dataSource: CalendarViewDataSource, selectionStyleForDayWithStart dayStartDate: Date, end: Date) -> CalendarViewDayCellSelectionStyle {
         return .normal
     }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -140,7 +140,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBackgroundColor() {
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
+        view.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.aliasTokens.colors[.background2].light, dark: view.fluentTheme.aliasTokens.colors[.background2].dark))
     }
 
     override func viewWillLayoutSubviews() {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -115,6 +115,9 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, view.isDescendant(of: themeView) else {
+            return
+        }
         updateBackgroundColor()
         updateBarButtonColors()
     }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -89,6 +89,9 @@ class DateTimePickerView: UIControl {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateBackgroundColor()
         updateGradientLayerColors(gradientLayer: gradientLayer)
     }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -59,7 +59,7 @@ class DateTimePickerView: UIControl {
     }
 
     private func updateGradientLayerColors(gradientLayer: CAGradientLayer) {
-        let backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].darkElevated))
+        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
         let transparentColor = backgroundColor.withAlphaComponent(0)
         gradientLayer.colors = [backgroundColor.cgColor, transparentColor.cgColor, transparentColor.cgColor, backgroundColor.cgColor]
     }
@@ -94,7 +94,7 @@ class DateTimePickerView: UIControl {
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -75,6 +75,6 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     }
 
     private func updateTextLabelColor() {
-        textLabel?.textColor = emphasized ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        textLabel?.textColor = emphasized ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
     }
 }

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -44,6 +44,9 @@ class DateTimePickerViewComponentCell: UITableViewCell {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateTextLabelColor()
     }
 

--- a/ios/FluentUI/Date Time Pickers/DateComponents+Extensions.swift
+++ b/ios/FluentUI/Date Time Pickers/DateComponents+Extensions.swift
@@ -6,28 +6,24 @@
 import Foundation
 
 extension DateComponents {
-    /// Determines if a set of date components including day, month, and year is equal to or later than today's date.
+    /// Determines if a set of date components including month, and year is equal to the current month or not.
     ///
     /// - Parameter todayDateComponents: A set of date components including day, month, and year
-    /// - Returns: A bool describing if self is equal to or later than today's date.
-    func dateIsTodayOrLater(todayDateComponents: DateComponents) -> Bool {
+    /// - Returns: A bool describing if self is equal to the current month or not.
+    func dateIsInCurrentMonth(todayDateComponents: DateComponents) -> Bool {
         guard let year = self.year,
             let month = self.month,
-            let day = self.day,
             let todayYear = todayDateComponents.year,
-            let todayMonth = todayDateComponents.month,
-            let today = todayDateComponents.day else {
-                assertionFailure("Date and today's date requires year, month, and day components")
+            let todayMonth = todayDateComponents.month else {
+                assertionFailure("Date and today's date requires year and month components")
                 return false
         }
 
-        if year > todayYear ||
-            (year == todayYear && month > todayMonth) ||
-            (year == todayYear && month == todayMonth && day >= today) {
-            // Present or future
+        if year == todayYear, month == todayMonth {
+            // Current month
             return true
         }
-        // Past
+        // Past or future months
         return false
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR addresses recent design changes to `DateTimePicker` and `CalendarView`.

- `CalendarViewDayCellBackgroundStyle` which was removed in #1246 has been added back 
- `dateIsTodayOrLater` function has been changed to `dateIsInCurrentMonth` that returns whether the date is in the current month or not
- Since design requested NOT to use elevated colors, we needed to specify the dark token inside the `DynamicColor` initializer for background colors
- As part of the #1219 change, I added the checks for whether the view is a descendent of the changing view in `themeDidChange` functions

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="after_calendar_light" src="https://user-images.githubusercontent.com/106181067/193146376-589b7d70-8f7d-4869-8365-ed21926dacbf.png"> | <img width="488" alt="after_calendar_light" src="https://user-images.githubusercontent.com/106181067/193146423-f1d462c8-86da-42bc-9c84-cf2c566ed415.png"> |
| <img width="488" alt="after_calendar_dark" src="https://user-images.githubusercontent.com/106181067/193146465-35a5595c-28bc-4e38-9ca7-04f1844da951.png"> | <img width="488" alt="after_calendar_dark" src="https://user-images.githubusercontent.com/106181067/193146490-d2fe0482-51fc-4f4e-9d9a-e811b9a5d970.png"> |
| <img width="488" alt="after_calendar_segmented_light" src="https://user-images.githubusercontent.com/106181067/193146545-07e18a35-56eb-4169-a517-10840612e9f3.png"> | <img width="488" alt="after_calendar_segmented_light" src="https://user-images.githubusercontent.com/106181067/193146584-d6c08f7e-0fed-4171-ac1c-d96c90c8023e.png"> |
| <img width="488" alt="after_calendar_segmented_dark" src="https://user-images.githubusercontent.com/106181067/193146622-dbd90e2e-b635-40df-88e0-437ffe546aea.png"> | <img width="488" alt="after_calendar_segmented_dark" src="https://user-images.githubusercontent.com/106181067/193146663-3aa153df-59a4-486b-941f-823fb896a081.png"> |
| <img width="488" alt="after_date_time_light" src="https://user-images.githubusercontent.com/106181067/193146711-7cadef6e-20f9-4add-a73e-2174ff6b6a0d.png"> | <img width="488" alt="after_date_time_light" src="https://user-images.githubusercontent.com/106181067/193146741-0ad82da0-fa9a-47b9-9979-534bb60d1a27.png"> |
| <img width="488" alt="after_date_time_dark" src="https://user-images.githubusercontent.com/106181067/193146776-0ab06a65-0914-4904-957d-1f21327a0c7c.png"> | <img width="488" alt="after_date_time_dark" src="https://user-images.githubusercontent.com/106181067/193146808-5e22d583-b9c5-4d5b-a4ec-81c7655c5bc3.png"> |
| <img width="488" alt="after_date_time_segmented_light" src="https://user-images.githubusercontent.com/106181067/193146847-dcf1130f-67e2-4443-8183-d345ab864430.png"> | <img width="488" alt="after_date_time_segmented_light" src="https://user-images.githubusercontent.com/106181067/193146868-441afa0b-d354-4e07-aa9f-b64a0fcd57f5.png"> |
| <img width="488" alt="after_date_time_segmented_dark" src="https://user-images.githubusercontent.com/106181067/193146915-b5b2b22b-be32-45e0-949f-8f2233dd3e15.png"> | <img width="488" alt="after_date_time_segmented_dark" src="https://user-images.githubusercontent.com/106181067/193146941-51e5270c-1552-44fa-88de-66a5759c2dfe.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)