### PR TITLE
[Fluent 2 iOS] 'Other cells' colors update

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -56,7 +56,7 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
     // MARK: - Custom tokens
     private var themeWideOverrideTableViewCellTokenSet: [TableViewCellTokenSet.Tokens: ControlTokenValue] {
         return [
-            .mainBrandColor: .dynamicColor {
+            .brandTextColor: .dynamicColor {
                 // "Charcoal"
                 return DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint50),
                                     dark: GlobalTokens.sharedColors(.charcoal, .shade40))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -60,6 +60,11 @@ extension OtherCellsDemoController: DemoAppearanceDelegate {
                 // "Charcoal"
                 return DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint50),
                                     dark: GlobalTokens.sharedColors(.charcoal, .shade40))
+            },
+            .booleanCellBrandColor: .dynamicColor {
+                // "Charcoal"
+                return DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint50),
+                                    dark: GlobalTokens.sharedColors(.charcoal, .shade40))
             }
         ]
     }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -26,9 +26,9 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         func highlightedTextColor(tokenSet: TableViewCellTokenSet) -> UIColor {
             switch self {
             case .regular:
-                return UIColor(dynamicColor: tokenSet[.mainBrandColor].dynamicColor).withAlphaComponent(0.4)
+                return UIColor(dynamicColor: tokenSet[.brandTextColor].dynamicColor).withAlphaComponent(0.4)
             case .destructive:
-                return UIColor(dynamicColor: tokenSet[.destructiveTextColor].dynamicColor).withAlphaComponent(0.4)
+                return UIColor(dynamicColor: tokenSet[.dangerTextColor].dynamicColor).withAlphaComponent(0.4)
             case .communication:
                 return UIColor(dynamicColor: tokenSet[.communicationTextColor].dynamicColor).withAlphaComponent(0.4)
             }
@@ -37,9 +37,9 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         func textColor(tokenSet: TableViewCellTokenSet) -> UIColor {
             switch self {
             case .regular:
-                return UIColor(dynamicColor: tokenSet[.mainBrandColor].dynamicColor)
+                return UIColor(dynamicColor: tokenSet[.brandTextColor].dynamicColor)
             case .destructive:
-                return UIColor(dynamicColor: tokenSet[.destructiveTextColor].dynamicColor)
+                return UIColor(dynamicColor: tokenSet[.dangerTextColor].dynamicColor)
             case .communication:
                 return UIColor(dynamicColor: tokenSet[.communicationTextColor].dynamicColor)
             }

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -89,7 +89,7 @@ open class BooleanCell: TableViewCell {
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        `switch`.onTintColor = UIColor(dynamicColor: tokenSet[.mainBrandColor].dynamicColor)
+        `switch`.onTintColor = UIColor(dynamicColor: tokenSet[.booleanCellBrandColor].dynamicColor)
     }
 
     private func updateAccessibility() {

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -27,7 +27,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     private func updateAppearance() {
         setupBackgroundColors()
         label.font = UIFont.fluent(tokenSet[.titleFont].fontInfo)
-        label.textColor = UIColor(dynamicColor: tokenSet[.mainBrandColor].dynamicColor)
+        label.textColor = UIColor(dynamicColor: tokenSet[.brandTextColor].dynamicColor)
     }
 
     // Public to be able to change style without wrapping every property
@@ -75,7 +75,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     @objc open func setup(text: String) {
         label.text = text
         label.font = UIFont.fluent(tokenSet[.titleFont].fontInfo)
-        label.textColor = UIColor(dynamicColor: tokenSet[.mainBrandColor].dynamicColor)
+        label.textColor = UIColor(dynamicColor: tokenSet[.brandTextColor].dynamicColor)
         setNeedsLayout()
     }
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1939,7 +1939,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     }
 
     private func updateSelectionImageColor() {
-        selectionImageView.tintColor = UIColor(dynamicColor: isSelected ? tokenSet[.mainBrandColor].dynamicColor : tokenSet[.selectionIndicatorOffColor].dynamicColor)
+        selectionImageView.tintColor = UIColor(dynamicColor: isSelected ? tokenSet[.brandTextColor].dynamicColor : tokenSet[.selectionIndicatorOffColor].dynamicColor)
     }
 
     private func updateSeparator(_ separator: Separator, with type: SeparatorType) {

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -60,11 +60,14 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         /// The color for the accessoryDetailButtonColor.
         case accessoryDetailButtonColor
 
-        /// The main primary brand color of the theme.
-        case mainBrandColor
+        /// The main brand text color..
+        case brandTextColor
 
-        /// The destructive text color in an ActionsCell.
-        case destructiveTextColor
+        /// The brand background color for the boolean cell.
+        case booleanCellBrandColor
+
+        /// The danger text color in an ActionsCell.
+        case dangerTextColor
 
         /// The communication text color in an ActionsCell.
         case communicationTextColor
@@ -146,19 +149,19 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
             case .accessoryDetailButtonColor:
                 return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
 
-            case .mainBrandColor:
+            case .dangerTextColor:
+                return .dynamicColor { theme.aliasTokens.sharedColors[.dangerForeground2] }
+
+            case .brandTextColor:
                 return .dynamicColor { theme.aliasTokens.colors[.brandForeground1] }
 
-            case .destructiveTextColor:
-                return .dynamicColor {
-                    DynamicColor(light: ColorValue(0xD92C2C),
-                                 dark: ColorValue(0xE83A3A))
-                }
+            case .booleanCellBrandColor:
+                return .dynamicColor { theme.aliasTokens.colors[.brandBackground1] }
 
             case .communicationTextColor:
                 return .dynamicColor {
-                    DynamicColor(light: ColorValue(0x0078D4),
-                                 dark: ColorValue(0x0086F0))
+                    DynamicColor(light: theme.aliasTokens.brandColors[.comm80].light,
+                                 dark: theme.aliasTokens.brandColors[.comm100].light)
                 }
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`ActionsCell`, `BooleanCell` and `CenteredLabelCell` were updated to match the fluent 2 designs. 
The new `booleanCellBrandColor` token has been added to `themeWideOverrideTableViewCellTokenSet` in `OtherCellsDemoController` for testing purposes.

### Verification

Tests were run on the demo app.


**Default cells**

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_main_light" src="https://user-images.githubusercontent.com/106181067/193367040-e1680197-b5b0-4748-8f29-8b2c2120cccb.png"> | <img width="488" alt="after_main_light" src="https://user-images.githubusercontent.com/106181067/193367056-5aace073-513d-4e34-be76-64822c9c48da.png"> |
| <img width="488" alt="before_main_dark" src="https://user-images.githubusercontent.com/106181067/193367066-42f8acaf-3a46-4c03-b14b-dc47e093fcad.png"> | <img width="488" alt="after_main_dark" src="https://user-images.githubusercontent.com/106181067/193367077-4fcc9236-26c3-40f3-bae6-9675396daf98.png"> |


**Communication style**

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_comm_light" src="https://user-images.githubusercontent.com/106181067/193367116-a982c9fa-0053-46c3-8f7d-15c05511cda1.png"> | <img width="488" alt="after_comm_light" src="https://user-images.githubusercontent.com/106181067/193367128-4c53780e-575c-4730-88c7-a0dba7baafbf.png"> |
| <img width="488" alt="before_comm_dark" src="https://user-images.githubusercontent.com/106181067/193367136-cc5af29a-1437-47a3-820c-a6d9a64d97e3.png"> | <img width="488" alt="after_comm_dark" src="https://user-images.githubusercontent.com/106181067/193367143-dfebdffa-ab38-4640-b623-24f3b630f1f2.png"> |


**Theme-wide override**

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_override_light" src="https://user-images.githubusercontent.com/106181067/193367190-92299ca5-58ed-419f-b9d1-ed94e4600242.png"> | <img width="488" alt="after_override_light" src="https://user-images.githubusercontent.com/106181067/193367204-c681f12a-9f54-4e16-bb43-98e77e11dc0a.png"> |
| <img width="488" alt="before_override_dark" src="https://user-images.githubusercontent.com/106181067/193367223-1e2fee6e-dc2b-4cf9-ab67-ac67915ff334.png"> | <img width="488" alt="after_override_dark" src="https://user-images.githubusercontent.com/106181067/193367232-ed594a8f-487d-46aa-a6d2-54f2066a2b48.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1280)