### PR TITLE
Revert "[Fluent 2 iOS] Adding new stroke thickness definitions, updating usage"

### DIFF
--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -109,7 +109,7 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24:
-                        return GlobalTokens.borderSize(.thinner)
+                        return GlobalTokens.borderSize(.thin)
                     case .size32, .size40, .size56:
                         return GlobalTokens.borderSize(.thick)
                     case .size72:

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -78,7 +78,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .outlineWidth:
                 return .float {
-                    GlobalTokens.borderSize(.thinner)
+                    GlobalTokens.borderSize(.thin)
                 }
 
             case .subtitleTextColor:

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1733,8 +1733,6 @@ public struct GlobalTokens {
 
     public enum BorderSizeToken: TokenSetKey {
         case none
-        case thinnest
-        case thinner
         case thin
         case thick
         case thicker
@@ -1744,12 +1742,8 @@ public struct GlobalTokens {
         switch token {
         case .none:
             return 0
-        case .thinnest:
-            return 0.5
-        case .thinner:
-            return 1
         case .thin:
-            return 1.5
+            return 1
         case .thick:
             return 2
         case .thicker:

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -217,7 +217,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .outlineWidth:
-                return .float { GlobalTokens.borderSize(.thinner) }
+                return .float { GlobalTokens.borderSize(.thin) }
 
             case .shadow:
                 return .shadowInfo {

--- a/ios/FluentUI/Vnext/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Vnext/Button/ButtonTokenSet.swift
@@ -103,7 +103,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .primary, .ghost, .accentFloating, .subtleFloating:
                         return GlobalTokens.borderSize(.none)
                     case .secondary:
-                        return GlobalTokens.borderSize(.thinner)
+                        return GlobalTokens.borderSize(.thin)
                     }
                 }
 


### PR DESCRIPTION
Reverts microsoft/fluentui-apple#1281

This was accidentally merged into fluent2-tokens instead of fluent2-colors. Reverting, will merge into fluent2-colors shortly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1282)