### PR TITLE
Cycle is seen during compilation of FluentUILib with copy phase script for modulemap

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -1213,10 +1213,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8FD0116A228A820600D25925 /* Build configuration list for PBXNativeTarget "FluentUILib" */;
 			buildPhases = (
+				566C664928CB994F0032314C /* Copy module.modulemap */,
 				8FD01162228A820600D25925 /* Sources */,
 				FD256C59218392B800EC9588 /* Run swiftlint */,
 				923DF2E4271166DB00637646 /* Copy FluentUI-Swift.h */,
-				566C664928CB994F0032314C /* Copy module.modulemap */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

A cycle is seen with compiling the iOS FluentUILib during copy build phase for the modulemap.

```
[2022/09/29.17:49:50] Error: Cycle details:

[2022/09/29.17:49:50] Error: → Target 'FluentUILib' has copy command from '.../fluentui_apple/ios/FluentUI/Core/module.modulemap' to .../Debug/build/tmp/FluentUI/Debug-iphonesimulator/include/FluentUI/module.modulemap'

[2022/09/29.17:49:50] Error: ○ Target 'FluentUILib' has Swift tasks blocking downstream compilation

[2022/09/29.17:49:50] STDERR: ** BUILD FAILED **
```

To fix this, I am following Apple's suggestion of moving the copy build phase before the compilation build phase.

### Verification

- Unable to repro the cycle with the fix in place in the FluentUI demo project
- Unable to repro the cycle with the fix in the devmain workspace

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1284)