### PR TITLE
Merge tokenized Shimmer into main

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -33,21 +33,26 @@ class ShimmerViewDemoController: DemoController {
 
         let shimmeringContentView = { (shimmersLeafViews: Bool) -> UIStackView in
             let containerView = contentView()
-            let shimmerView = ShimmerView(containerView: containerView, excludedViews: [], animationSynchronizer: nil)
+            let shimmerView = ShimmerView(containerView: containerView,
+                                          excludedViews: [],
+                                          animationSynchronizer: nil,
+                                          shimmersLeafViews: shimmersLeafViews,
+                                          usesTextHeightForLabels: true)
             shimmerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            shimmerView.shimmersLeafViews = shimmersLeafViews
-            shimmerView.usesTextHeightForLabels = true
-            shimmerView.labelHeight = -1 // Must be < 0 so we actually use the bool usesTextHeightForLabels
             containerView.addSubview(shimmerView)
             return containerView
         }
 
-        let shimmeringImageView = { (shimmerStyle: ShimmerStyle) -> UIView in
-            let imageView = UIImageView(image: UIImage(named: "PlaceholderImage")?.withTintColor(Colors.Shimmer.tint, renderingMode: .alwaysOriginal))
+        let shimmeringImageView = { (shimmerStyle: MSFShimmerStyle) -> UIView in
+            // Uses a nice gray color that happens to match the gray of the shimmer control. Any color can be used here though.
+            let tintColor = UIColor(colorValue: ColorValue(0xF1F1F1))
+            let imageView = UIImageView(image: UIImage(named: "PlaceholderImage")?.withTintColor(tintColor, renderingMode: .alwaysOriginal))
             let containerView = UIStackView(arrangedSubviews: [imageView])
-            let shimmerView = ShimmerView(containerView: containerView, excludedViews: [], animationSynchronizer: nil, shimmerStyle: shimmerStyle)
+            let shimmerView = ShimmerView(containerView: containerView,
+                                          excludedViews: [],
+                                          animationSynchronizer: nil,
+                                          shimmerStyle: shimmerStyle)
             shimmerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            shimmerView.shimmerStyle = shimmerStyle
             containerView.addSubview(shimmerView)
             return containerView
         }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		43488C46270FAD1300124C71 /* FluentNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43488C44270FAD0200124C71 /* FluentNotification.swift */; };
 		4B53505F27F63E3F0033B47F /* NotificationModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B53505E27F63E3F0033B47F /* NotificationModifiers.swift */; };
 		4BBD651F2755FD9500A8B09E /* MSFNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBD651E2755FD9500A8B09E /* MSFNotification.swift */; };
+		4BDBE18928EC9E6F00314696 /* ShimmerTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDBE18828EC9E6F00314696 /* ShimmerTokenSet.swift */; };
 		4BF01D9A27B37CF8005B32F2 /* NotificationTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF01D9927B37CF8005B32F2 /* NotificationTokenSet.swift */; };
 		4BF01DA027B3A862005B32F2 /* UIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF01D9F27B3A861005B32F2 /* UIApplication+Extensions.swift */; };
 		5303259B26B31B6B00611D05 /* AvatarModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5303259926B31B6B00611D05 /* AvatarModifiers.swift */; };
@@ -236,6 +237,7 @@
 		497DC2D824185885008D86F8 /* PillButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButton.swift; sourceTree = "<group>"; };
 		4B53505E27F63E3F0033B47F /* NotificationModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModifiers.swift; sourceTree = "<group>"; };
 		4BBD651E2755FD9500A8B09E /* MSFNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFNotification.swift; sourceTree = "<group>"; };
+		4BDBE18828EC9E6F00314696 /* ShimmerTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerTokenSet.swift; sourceTree = "<group>"; };
 		4BF01D9927B37CF8005B32F2 /* NotificationTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationTokenSet.swift; sourceTree = "<group>"; };
 		4BF01D9F27B3A861005B32F2 /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
 		5303259926B31B6B00611D05 /* AvatarModifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarModifiers.swift; sourceTree = "<group>"; };
@@ -1007,6 +1009,7 @@
 			children = (
 				C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */,
 				C0A0D76B233AEF6C00F432FD /* ShimmerLinesView.swift */,
+				4BDBE18828EC9E6F00314696 /* ShimmerTokenSet.swift */,
 			);
 			path = Shimmer;
 			sourceTree = "<group>";
@@ -1478,6 +1481,7 @@
 				5373D56B2694D65C0032A3B4 /* MSFAvatarPresence.swift in Sources */,
 				EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */,
 				5314E0AA25F010070099271A /* DrawerShadowView.swift in Sources */,
+				4BDBE18928EC9E6F00314696 /* ShimmerTokenSet.swift in Sources */,
 				2A9745DE281733D700E1A1FD /* TableViewCellTokenSet.swift in Sources */,
 				530D9C5127EE388200BDCBBF /* SwiftUI+ViewPresentation.swift in Sources */,
 				5314E0E725F012C00099271A /* UINavigationItem+Navigation.swift in Sources */,

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -11,111 +11,111 @@ import UIKit
 @objc(MSFShimmerLinesView)
 open class ShimmerLinesView: ShimmerView {
 
-	open override func layoutSubviews() {
-		super.layoutSubviews()
+    open override func layoutSubviews() {
+        super.layoutSubviews()
 
-		var currentTop: CGFloat = 0
-		for (index, linelayer) in viewCoverLayers.enumerated() {
-			let fillPercent: CGFloat = {
-				if index == 0 && viewCoverLayers.count > 2 {
-					guard let firstLineFillPercent = firstLineFillPercent else {
-						return 1
-					}
+        var currentTop: CGFloat = 0
+        for (index, linelayer) in viewCoverLayers.enumerated() {
+            let fillPercent: CGFloat = {
+                if index == 0 && viewCoverLayers.count > 2 {
+                    guard let firstLineFillPercent = firstLineFillPercent else {
+                        return 1
+                    }
 
-					return firstLineFillPercent
-				} else if index == viewCoverLayers.count - 1 {
-					guard let lastLineFillPercent = lastLineFillPercent else {
-						return 1
-					}
+                    return firstLineFillPercent
+                } else if index == viewCoverLayers.count - 1 {
+                    guard let lastLineFillPercent = lastLineFillPercent else {
+                        return 1
+                    }
 
-					return lastLineFillPercent
-				} else {
-					return 1
-				}
-			}()
+                    return lastLineFillPercent
+                } else {
+                    return 1
+                }
+            }()
 
-			let labelHeight = tokenSet[.labelHeight].float
-			linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: labelHeight)
+            let labelHeight = tokenSet[.labelHeight].float
+            linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: labelHeight)
 
-			currentTop += labelHeight + tokenSet[.labelSpacing].float
-		}
+            currentTop += labelHeight + tokenSet[.labelSpacing].float
+        }
 
-		shimmeringLayer.frame = CGRect(x: -tokenSet[.shimmerWidth].float, y: 0.0, width: frame.width + 2 * tokenSet[.shimmerWidth].float, height: frame.height)
-		viewCoverLayers.forEach { $0.frame = flipRectForRTL($0.frame) }
+        shimmeringLayer.frame = CGRect(x: -tokenSet[.shimmerWidth].float, y: 0.0, width: frame.width + 2 * tokenSet[.shimmerWidth].float, height: frame.height)
+        viewCoverLayers.forEach { $0.frame = flipRectForRTL($0.frame) }
 
-		updateShimmeringLayer()
-		updateShimmeringAnimation()
-	}
+        updateShimmeringLayer()
+        updateShimmeringAnimation()
+    }
 
-	open override func sizeThatFits(_ size: CGSize) -> CGSize {
-		let desiredLineCount = CGFloat(lineCount(for: size.height))
-		let height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * tokenSet[.labelSpacing].float
-		return CGSize(width: size.width, height: height)
-	}
+    open override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let desiredLineCount = CGFloat(lineCount(for: size.height))
+        let height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * tokenSet[.labelSpacing].float
+        return CGSize(width: size.width, height: height)
+    }
 
-	open override var intrinsicContentSize: CGSize {
-		return CGSize(width: UIView.noIntrinsicMetric, height: sizeThatFits(CGSize(width: frame.width, height: .infinity)).height)
-	}
+    open override var intrinsicContentSize: CGSize {
+        return CGSize(width: UIView.noIntrinsicMetric, height: sizeThatFits(CGSize(width: frame.width, height: .infinity)).height)
+    }
 
-	/// Creates the ShimmerLinesView.
-	/// - Parameters:
-	///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-	@objc public init(lineCount: Int) {
-		self.lineCount = lineCount
+    /// Creates the ShimmerLinesView.
+    /// - Parameters:
+    ///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+    @objc public init(lineCount: Int) {
+        self.lineCount = lineCount
 
-		super.init()
-	}
+        super.init()
+    }
 
-	/// Creates the ShimmerLinesView.
-	/// - Parameters:
-	///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-	///   - firstLineFillPercent: The percent the first line (if 2+ lines) should fill the available horizontal space.
-	///   - lastLineFillPercent: The percent the last line should fill the available horizontal space.
-	@objc public convenience init(lineCount: Int = 3,
-								  firstLineFillPercent: CGFloat = 0.94,
-								  lastLineFillPercent: CGFloat = 0.6) {
-		self.init(lineCount: lineCount)
+    /// Creates the ShimmerLinesView.
+    /// - Parameters:
+    ///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+    ///   - firstLineFillPercent: The percent the first line (if 2+ lines) should fill the available horizontal space.
+    ///   - lastLineFillPercent: The percent the last line should fill the available horizontal space.
+    @objc public convenience init(lineCount: Int = 3,
+                                  firstLineFillPercent: CGFloat = 0.94,
+                                  lastLineFillPercent: CGFloat = 0.6) {
+        self.init(lineCount: lineCount)
 
-		self.firstLineFillPercent = firstLineFillPercent
-		self.lastLineFillPercent = lastLineFillPercent
-	}
+        self.firstLineFillPercent = firstLineFillPercent
+        self.lastLineFillPercent = lastLineFillPercent
+    }
 
-	@available(*, unavailable)
-	required public init?(coder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
-	}
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
 
-	override func updateViewCoverLayers() {
-		var newLineLayers = [CALayer]()
-		let desiredLineCount = lineCount(for: frame.height)
+    override func updateViewCoverLayers() {
+        var newLineLayers = [CALayer]()
+        let desiredLineCount = lineCount(for: frame.height)
 
-		for i in 0..<desiredLineCount {
-			let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
-			lineLayer.cornerRadius = tokenSet[.labelCornerRadius].float >= 0 ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
-			lineLayer.backgroundColor = UIColor(dynamicColor: tokenSet[.tintColor].dynamicColor).cgColor
+        for i in 0..<desiredLineCount {
+            let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
+            lineLayer.cornerRadius = tokenSet[.labelCornerRadius].float >= 0 ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
+            lineLayer.backgroundColor = UIColor(dynamicColor: tokenSet[.tintColor].dynamicColor).cgColor
 
-			// Add layer
-			newLineLayers.append(lineLayer)
-			layer.addSublayer(lineLayer)
-		}
+            // Add layer
+            newLineLayers.append(lineLayer)
+            layer.addSublayer(lineLayer)
+        }
 
-		Set(viewCoverLayers).subtracting(Set(newLineLayers)).forEach { $0.removeFromSuperlayer() }
+        Set(viewCoverLayers).subtracting(Set(newLineLayers)).forEach { $0.removeFromSuperlayer() }
 
-		viewCoverLayers = newLineLayers
-	}
+        viewCoverLayers = newLineLayers
+    }
 
-	@objc private func lineCount(for availableHeight: CGFloat) -> Int {
-		if lineCount == 0 {
-			let lineSpacing = tokenSet[.labelSpacing].float
-			// Deduce lines count based on available height.
-			return Int(floor((availableHeight + lineSpacing) / (tokenSet[.labelHeight].float + lineSpacing)))
-		} else {
-			// Hardcoded lines count.
-			return lineCount
-		}
-	}
+    @objc private func lineCount(for availableHeight: CGFloat) -> Int {
+        if lineCount == 0 {
+            let lineSpacing = tokenSet[.labelSpacing].float
+            // Deduce lines count based on available height.
+            return Int(floor((availableHeight + lineSpacing) / (tokenSet[.labelHeight].float + lineSpacing)))
+        } else {
+            // Hardcoded lines count.
+            return lineCount
+        }
+    }
 
-	private var lineCount: Int
-	private var firstLineFillPercent: CGFloat?
-	private var lastLineFillPercent: CGFloat?
+    private var lineCount: Int
+    private var firstLineFillPercent: CGFloat?
+    private var lastLineFillPercent: CGFloat?
 }

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -11,41 +11,6 @@ import UIKit
 @objc(MSFShimmerLinesView)
 open class ShimmerLinesView: ShimmerView {
 
-	/// Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-	@objc open var lineCount: Int = 3 {
-		didSet {
-			setNeedsLayout()
-		}
-	}
-
-	/// Height of shimmering line
-	@objc open var lineHeight: CGFloat = 11 {
-		didSet {
-			setNeedsLayout()
-		}
-	}
-
-	/// Spacing between lines (if lines > 1)
-	@objc open var lineSpacing: CGFloat = 11 {
-		didSet {
-			setNeedsLayout()
-		}
-	}
-
-	/// The percent the first line (if 2+ lines) should fill the available horizontal space
-	@objc open var firstLineFillPercent: CGFloat = 0.94 {
-		didSet {
-			setNeedsLayout()
-		}
-	}
-
-	/// The percent the last line should fill the available horizontal space.
-	@objc open var lastLineFillPercent: CGFloat = 0.6 {
-		didSet {
-			setNeedsLayout()
-		}
-	}
-
 	open override func layoutSubviews() {
 		super.layoutSubviews()
 
@@ -53,21 +18,29 @@ open class ShimmerLinesView: ShimmerView {
 		for (index, linelayer) in viewCoverLayers.enumerated() {
 			let fillPercent: CGFloat = {
 				if index == 0 && viewCoverLayers.count > 2 {
+					guard let firstLineFillPercent = firstLineFillPercent else {
+						return 1
+					}
+
 					return firstLineFillPercent
 				} else if index == viewCoverLayers.count - 1 {
+					guard let lastLineFillPercent = lastLineFillPercent else {
+						return 1
+					}
+
 					return lastLineFillPercent
 				} else {
 					return 1
 				}
 			}()
 
-			linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: lineHeight)
+			let labelHeight = tokenSet[.labelHeight].float
+			linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: labelHeight)
 
-			currentTop += lineHeight + lineSpacing
+			currentTop += labelHeight + tokenSet[.labelSpacing].float
 		}
 
-		shimmeringLayer.frame = CGRect(x: -shimmerWidth, y: 0.0, width: frame.width + 2 * shimmerWidth, height: frame.height)
-
+		shimmeringLayer.frame = CGRect(x: -tokenSet[.shimmerWidth].float, y: 0.0, width: frame.width + 2 * tokenSet[.shimmerWidth].float, height: frame.height)
 		viewCoverLayers.forEach { $0.frame = flipRectForRTL($0.frame) }
 
 		updateShimmeringLayer()
@@ -76,12 +49,40 @@ open class ShimmerLinesView: ShimmerView {
 
 	open override func sizeThatFits(_ size: CGSize) -> CGSize {
 		let desiredLineCount = CGFloat(lineCount(for: size.height))
-		let height = desiredLineCount * lineHeight + (desiredLineCount - 1) * lineSpacing
+		let height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * tokenSet[.labelSpacing].float
 		return CGSize(width: size.width, height: height)
 	}
 
 	open override var intrinsicContentSize: CGSize {
 		return CGSize(width: UIView.noIntrinsicMetric, height: sizeThatFits(CGSize(width: frame.width, height: .infinity)).height)
+	}
+
+	/// Creates the ShimmerLinesView.
+	/// - Parameters:
+	///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+	@objc public init(lineCount: Int) {
+		self.lineCount = lineCount
+
+		super.init()
+	}
+
+	/// Creates the ShimmerLinesView.
+	/// - Parameters:
+	///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+	///   - firstLineFillPercent: The percent the first line (if 2+ lines) should fill the available horizontal space.
+	///   - lastLineFillPercent: The percent the last line should fill the available horizontal space.
+	@objc public convenience init(lineCount: Int = 3,
+								  firstLineFillPercent: CGFloat = 0.94,
+								  lastLineFillPercent: CGFloat = 0.6) {
+		self.init(lineCount: lineCount)
+
+		self.firstLineFillPercent = firstLineFillPercent
+		self.lastLineFillPercent = lastLineFillPercent
+	}
+
+	@available(*, unavailable)
+	required public init?(coder: NSCoder) {
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 
 	override func updateViewCoverLayers() {
@@ -90,9 +91,8 @@ open class ShimmerLinesView: ShimmerView {
 
 		for i in 0..<desiredLineCount {
 			let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
-
-			lineLayer.cornerRadius = labelCornerRadius >= 0 ? labelCornerRadius : cornerRadius
-			lineLayer.backgroundColor = viewTintColor.cgColor
+			lineLayer.cornerRadius = tokenSet[.labelCornerRadius].float >= 0 ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
+			lineLayer.backgroundColor = UIColor(dynamicColor: tokenSet[.tintColor].dynamicColor).cgColor
 
 			// Add layer
 			newLineLayers.append(lineLayer)
@@ -106,11 +106,16 @@ open class ShimmerLinesView: ShimmerView {
 
 	@objc private func lineCount(for availableHeight: CGFloat) -> Int {
 		if lineCount == 0 {
-			// Deduce lines count based on available height
-			return Int(floor((availableHeight + lineSpacing) / (lineHeight + lineSpacing)))
+			let lineSpacing = tokenSet[.labelSpacing].float
+			// Deduce lines count based on available height.
+			return Int(floor((availableHeight + lineSpacing) / (tokenSet[.labelHeight].float + lineSpacing)))
 		} else {
-			// Hardcoded lines count
+			// Hardcoded lines count.
 			return lineCount
 		}
 	}
+
+	private var lineCount: Int
+	private var firstLineFillPercent: CGFloat?
+	private var lastLineFillPercent: CGFloat?
 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -1,0 +1,119 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Shimmer style can be either concealing or revealing.
+/// The style affects the default shimmer alpha value and the default shimmer tint color.
+@objc public enum MSFShimmerStyle: Int, CaseIterable {
+	/// Concealing shimmer: the gradient conceals parts of the subviews as it moves leaving most parts of the subviews unblocked.
+	case concealing
+
+	/// Revealing shimmer: the gradient reveals parts of the subviews as it moves leaving most parts of the subview blocked.
+	case revealing
+}
+
+/// Design token set for the `Shimmer` control.
+public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
+	public enum Tokens: TokenSetKey {
+		/// The alpha value of the center of the gradient in the animation if shimmer is revealing shimmer.
+		/// The alpha value of the view other than the gradient if shimmer is concealing shimmer.
+		case shimmerAlpha
+
+		/// Tint color of the view if shimmer is revealing shimmer.
+		/// Tint color of the middle of the gradient if shimmer is concealing shimmer.
+		case tintColor
+
+		///  Color of the darkest part of the shimmer's gradient.
+		case darkGradient
+
+		/// The width of the gradient in the animation.
+		case shimmerWidth
+
+		/// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
+		case shimmerAngle
+
+		/// Speed of the animation, in point/seconds.
+		case shimmerSpeed
+
+		/// Delay between the end of a shimmering animation and the beginning of the next one.
+		case shimmerDelay
+
+		/// Corner radius on each view.
+		case cornerRadius
+
+		/// Corner radius on each UILabel. Set to  0 to disable and use default `cornerRadius`.
+		case labelCornerRadius
+
+		/// Height of shimmering labels.
+		case labelHeight
+
+		/// Spacing between (if lines > 1).
+		case labelSpacing
+	}
+
+	init(style: @escaping () -> MSFShimmerStyle) {
+		self.style = style
+		super.init { [style] token, theme in
+			switch token {
+			case .shimmerAlpha:
+				return .float {
+					switch style() {
+					case .concealing:
+						return 0
+					case .revealing:
+						return 0.4
+					}
+				}
+
+			case .tintColor:
+				return .dynamicColor {
+					switch style() {
+					case .concealing:
+						return DynamicColor(light: GlobalTokens.neutralColors(.white),
+											dark: GlobalTokens.neutralColors(.grey8))
+					case .revealing:
+						return DynamicColor(light: ColorValue(0xF1F1F1) /* gray50 */,
+											lightHighContrast: ColorValue(0x919191) /* gray400 */,
+											dark: ColorValue(0x404040) /* gray600 */,
+											darkHighContrast: ColorValue(0x919191) /* gray400 */)
+					}
+				}
+
+			case .darkGradient:
+				return .dynamicColor {
+					return DynamicColor(light: GlobalTokens.neutralColors(.black))
+				}
+
+			case .shimmerWidth:
+				return .float { 180.0 }
+
+			case .shimmerAngle:
+				return .float { -(CGFloat.pi / 45.0) }
+
+			case .shimmerSpeed:
+				return .float { 350.0 }
+
+			case .shimmerDelay:
+				return .float { 0.4 }
+
+			case .cornerRadius:
+				return .float { GlobalTokens.borderRadius(.medium) }
+
+			case .labelCornerRadius:
+				return .float { GlobalTokens.borderRadius(.small) }
+
+			case .labelHeight:
+				return .float { 11.0 }
+
+			case .labelSpacing:
+				return .float { GlobalTokens.spacing(.small) }
+			}
+		}
+	}
+
+	/// Determines whether the shimmer is a revealing shimmer or a concealing shimmer.
+	var style: () -> MSFShimmerStyle
+}

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -8,112 +8,112 @@ import UIKit
 /// Shimmer style can be either concealing or revealing.
 /// The style affects the default shimmer alpha value and the default shimmer tint color.
 @objc public enum MSFShimmerStyle: Int, CaseIterable {
-	/// Concealing shimmer: the gradient conceals parts of the subviews as it moves leaving most parts of the subviews unblocked.
-	case concealing
+    /// Concealing shimmer: the gradient conceals parts of the subviews as it moves leaving most parts of the subviews unblocked.
+    case concealing
 
-	/// Revealing shimmer: the gradient reveals parts of the subviews as it moves leaving most parts of the subview blocked.
-	case revealing
+    /// Revealing shimmer: the gradient reveals parts of the subviews as it moves leaving most parts of the subview blocked.
+    case revealing
 }
 
 /// Design token set for the `Shimmer` control.
 public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
-	public enum Tokens: TokenSetKey {
-		/// The alpha value of the center of the gradient in the animation if shimmer is revealing shimmer.
-		/// The alpha value of the view other than the gradient if shimmer is concealing shimmer.
-		case shimmerAlpha
+    public enum Tokens: TokenSetKey {
+        /// The alpha value of the center of the gradient in the animation if shimmer is revealing shimmer.
+        /// The alpha value of the view other than the gradient if shimmer is concealing shimmer.
+        case shimmerAlpha
 
-		/// Tint color of the view if shimmer is revealing shimmer.
-		/// Tint color of the middle of the gradient if shimmer is concealing shimmer.
-		case tintColor
+        /// Tint color of the view if shimmer is revealing shimmer.
+        /// Tint color of the middle of the gradient if shimmer is concealing shimmer.
+        case tintColor
 
-		///  Color of the darkest part of the shimmer's gradient.
-		case darkGradient
+        ///  Color of the darkest part of the shimmer's gradient.
+        case darkGradient
 
-		/// The width of the gradient in the animation.
-		case shimmerWidth
+        /// The width of the gradient in the animation.
+        case shimmerWidth
 
-		/// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
-		case shimmerAngle
+        /// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
+        case shimmerAngle
 
-		/// Speed of the animation, in point/seconds.
-		case shimmerSpeed
+        /// Speed of the animation, in point/seconds.
+        case shimmerSpeed
 
-		/// Delay between the end of a shimmering animation and the beginning of the next one.
-		case shimmerDelay
+        /// Delay between the end of a shimmering animation and the beginning of the next one.
+        case shimmerDelay
 
-		/// Corner radius on each view.
-		case cornerRadius
+        /// Corner radius on each view.
+        case cornerRadius
 
-		/// Corner radius on each UILabel. Set to  0 to disable and use default `cornerRadius`.
-		case labelCornerRadius
+        /// Corner radius on each UILabel. Set to  0 to disable and use default `cornerRadius`.
+        case labelCornerRadius
 
-		/// Height of shimmering labels.
-		case labelHeight
+        /// Height of shimmering labels.
+        case labelHeight
 
-		/// Spacing between (if lines > 1).
-		case labelSpacing
-	}
+        /// Spacing between (if lines > 1).
+        case labelSpacing
+    }
 
-	init(style: @escaping () -> MSFShimmerStyle) {
-		self.style = style
-		super.init { [style] token, theme in
-			switch token {
-			case .shimmerAlpha:
-				return .float {
-					switch style() {
-					case .concealing:
-						return 0
-					case .revealing:
-						return 0.4
-					}
-				}
+    init(style: @escaping () -> MSFShimmerStyle) {
+        self.style = style
+        super.init { [style] token, _ in
+            switch token {
+            case .shimmerAlpha:
+                return .float {
+                    switch style() {
+                    case .concealing:
+                        return 0
+                    case .revealing:
+                        return 0.4
+                    }
+                }
 
-			case .tintColor:
-				return .dynamicColor {
-					switch style() {
-					case .concealing:
-						return DynamicColor(light: GlobalTokens.neutralColors(.white),
-											dark: GlobalTokens.neutralColors(.grey8))
-					case .revealing:
-						return DynamicColor(light: ColorValue(0xF1F1F1) /* gray50 */,
-											lightHighContrast: ColorValue(0x919191) /* gray400 */,
-											dark: ColorValue(0x404040) /* gray600 */,
-											darkHighContrast: ColorValue(0x919191) /* gray400 */)
-					}
-				}
+            case .tintColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .concealing:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                            dark: GlobalTokens.neutralColors(.grey8))
+                    case .revealing:
+                        return DynamicColor(light: ColorValue(0xF1F1F1) /* gray50 */,
+                                            lightHighContrast: ColorValue(0x919191) /* gray400 */,
+                                            dark: ColorValue(0x404040) /* gray600 */,
+                                            darkHighContrast: ColorValue(0x919191) /* gray400 */)
+                    }
+                }
 
-			case .darkGradient:
-				return .dynamicColor {
-					return DynamicColor(light: GlobalTokens.neutralColors(.black))
-				}
+            case .darkGradient:
+                return .dynamicColor {
+                    return DynamicColor(light: GlobalTokens.neutralColors(.black))
+                }
 
-			case .shimmerWidth:
-				return .float { 180.0 }
+            case .shimmerWidth:
+                return .float { 180.0 }
 
-			case .shimmerAngle:
-				return .float { -(CGFloat.pi / 45.0) }
+            case .shimmerAngle:
+                return .float { -(CGFloat.pi / 45.0) }
 
-			case .shimmerSpeed:
-				return .float { 350.0 }
+            case .shimmerSpeed:
+                return .float { 350.0 }
 
-			case .shimmerDelay:
-				return .float { 0.4 }
+            case .shimmerDelay:
+                return .float { 0.4 }
 
-			case .cornerRadius:
-				return .float { GlobalTokens.borderRadius(.medium) }
+            case .cornerRadius:
+                return .float { GlobalTokens.borderRadius(.medium) }
 
-			case .labelCornerRadius:
-				return .float { GlobalTokens.borderRadius(.small) }
+            case .labelCornerRadius:
+                return .float { GlobalTokens.borderRadius(.small) }
 
-			case .labelHeight:
-				return .float { 11.0 }
+            case .labelHeight:
+                return .float { 11.0 }
 
-			case .labelSpacing:
-				return .float { GlobalTokens.spacing(.small) }
-			}
-		}
-	}
+            case .labelSpacing:
+                return .float { GlobalTokens.spacing(.small) }
+            }
+        }
+    }
 
-	/// Determines whether the shimmer is a revealing shimmer or a concealing shimmer.
-	var style: () -> MSFShimmerStyle
+    /// Determines whether the shimmer is a revealing shimmer or a concealing shimmer.
+    var style: () -> MSFShimmerStyle
 }

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -10,216 +10,216 @@ import Combine
 @objc(MSFShimmerView)
 open class ShimmerView: UIView, TokenizedControlInternal {
 
-	/// Optional synchronizer to sync multiple shimmer views.
-	@objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
+    /// Optional synchronizer to sync multiple shimmer views.
+    @objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
 
-	open override var intrinsicContentSize: CGSize { return bounds.size }
+    open override var intrinsicContentSize: CGSize { return bounds.size }
 
-	open override func layoutSubviews() {
-		super.layoutSubviews()
+    open override func layoutSubviews() {
+        super.layoutSubviews()
 
-		updateViewCoverLayers()
+        updateViewCoverLayers()
 
-		let viewToCover = containerView ?? self
+        let viewToCover = containerView ?? self
 
-		shimmeringLayer.frame = CGRect(x: -viewToCover.frame.width,
-									   y: 0.0,
-									   width: viewToCover.bounds.width + 2 * viewToCover.frame.width,
-									   height: viewToCover.frame.height)
+        shimmeringLayer.frame = CGRect(x: -viewToCover.frame.width,
+                                       y: 0.0,
+                                       width: viewToCover.bounds.width + 2 * viewToCover.frame.width,
+                                       height: viewToCover.frame.height)
 
-		updateShimmeringLayer()
-		updateShimmeringAnimation()
-	}
+        updateShimmeringLayer()
+        updateShimmeringAnimation()
+    }
 
-	/// Create a shimmer view
-	/// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored.
-	/// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer.
-	/// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views.
-	/// - Parameter shimmerStyle: determines whether the shimmer is a revealing shimmer or a concealing shimmer.
-	/// - Parameter shimmersLeafViews: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box.
-	/// - Parameter usesTextHeightForLabels: Determines whether we shimmer the top level subviews, or the leaf nodes of the view hierarchy. If false, we use default height of 11.0.
-	@objc public init(containerView: UIView? = nil,
-					  excludedViews: [UIView] = [],
-					  animationSynchronizer: AnimationSynchronizerProtocol? = nil,
-					  shimmerStyle: MSFShimmerStyle = .revealing,
-					  shimmersLeafViews: Bool = false,
-					  usesTextHeightForLabels: Bool = false) {
-		self.style = shimmerStyle
+    /// Create a shimmer view
+    /// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored.
+    /// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer.
+    /// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views.
+    /// - Parameter shimmerStyle: determines whether the shimmer is a revealing shimmer or a concealing shimmer.
+    /// - Parameter shimmersLeafViews: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box.
+    /// - Parameter usesTextHeightForLabels: Determines whether we shimmer the top level subviews, or the leaf nodes of the view hierarchy. If false, we use default height of 11.0.
+    @objc public init(containerView: UIView? = nil,
+                      excludedViews: [UIView] = [],
+                      animationSynchronizer: AnimationSynchronizerProtocol? = nil,
+                      shimmerStyle: MSFShimmerStyle = .revealing,
+                      shimmersLeafViews: Bool = false,
+                      usesTextHeightForLabels: Bool = false) {
+        self.style = shimmerStyle
 
-		self.containerView = containerView
-		self.excludedViews = excludedViews
-		self.animationSynchronizer = animationSynchronizer
-		self.shimmersLeafViews = shimmersLeafViews
-		self.usesTextHeightForLabels = usesTextHeightForLabels
-		super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
+        self.containerView = containerView
+        self.excludedViews = excludedViews
+        self.animationSynchronizer = animationSynchronizer
+        self.shimmersLeafViews = shimmersLeafViews
+        self.usesTextHeightForLabels = usesTextHeightForLabels
+        super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
 
-		NotificationCenter.default.addObserver(self,
-											   selector: #selector(syncAnimation),
-											   name: UIAccessibility.reduceMotionStatusDidChangeNotification,
-											   object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(syncAnimation),
+                                               name: UIAccessibility.reduceMotionStatusDidChangeNotification,
+                                               object: nil)
 
-		// Update appearance whenever `tokenSet` changes.
-		tokenSetSink = tokenSet.sinkChanges { [weak self] in
-			self?.updateShimmeringAnimation()
-		}
-	}
+        // Update appearance whenever `tokenSet` changes.
+        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+            self?.updateShimmeringAnimation()
+        }
+    }
 
-	required public init?(coder: NSCoder) {
-		preconditionFailure("init(coder:) has not been implemented")
-	}
+    required public init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
 
-	/// Manaully sync with the synchronizer.
-	@objc public func syncAnimation() {
-		updateShimmeringAnimation()
-	}
+    /// Manaully sync with the synchronizer.
+    @objc public func syncAnimation() {
+        updateShimmeringAnimation()
+    }
 
-	// MARK: - TokenizedControl
-	public typealias TokenSetKeyType = ShimmerTokenSet.Tokens
-	public lazy var tokenSet: ShimmerTokenSet = .init(style: { self.style })
+    // MARK: - TokenizedControl
+    public typealias TokenSetKeyType = ShimmerTokenSet.Tokens
+    public lazy var tokenSet: ShimmerTokenSet = .init(style: { self.style })
 
-	var tokenSetSink: AnyCancellable?
+    var tokenSetSink: AnyCancellable?
 
-	/// Style to draw the control.
-	public let style: MSFShimmerStyle
+    /// Style to draw the control.
+    public let style: MSFShimmerStyle
 
-	/// Update the frame of each layer covering views in the containerView.
-	func updateViewCoverLayers() {
-		let viewToCover = containerView ?? self
+    /// Update the frame of each layer covering views in the containerView.
+    func updateViewCoverLayers() {
+        let viewToCover = containerView ?? self
 
-		viewCoverLayers.forEach { $0.removeFromSuperlayer() }
+        viewCoverLayers.forEach { $0.removeFromSuperlayer() }
 
-		let subviews: Set<UIView> = {
-			if shimmersLeafViews {
-				var leaves = [UIView]()
-				searchLeaves(in: viewToCover, output: &leaves)
-				return Set(leaves).subtracting(Set(excludedViews))
-			} else {
-				return Set(viewToCover.subviews).subtracting(Set(excludedViews))
-			}
-		}()
+        let subviews: Set<UIView> = {
+            if shimmersLeafViews {
+                var leaves = [UIView]()
+                searchLeaves(in: viewToCover, output: &leaves)
+                return Set(leaves).subtracting(Set(excludedViews))
+            } else {
+                return Set(viewToCover.subviews).subtracting(Set(excludedViews))
+            }
+        }()
 
-		viewCoverLayers = subviews.filter({ !$0.isHidden && !($0 is ShimmerView) }).map { subview in
-			let coverLayer = CALayer()
+        viewCoverLayers = subviews.filter({ !$0.isHidden && !($0 is ShimmerView) }).map { subview in
+            let coverLayer = CALayer()
 
-			let shouldApplyLabelCornerRadius = subview is UILabel && tokenSet[.labelCornerRadius].float >= 0
-			coverLayer.cornerRadius = shouldApplyLabelCornerRadius ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
-			coverLayer.backgroundColor = UIColor(dynamicColor: tokenSet[.tintColor].dynamicColor).cgColor
+            let shouldApplyLabelCornerRadius = subview is UILabel && tokenSet[.labelCornerRadius].float >= 0
+            coverLayer.cornerRadius = shouldApplyLabelCornerRadius ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
+            coverLayer.backgroundColor = UIColor(dynamicColor: tokenSet[.tintColor].dynamicColor).cgColor
 
-			var coverFrame = viewToCover.convert(subview.bounds, from: subview)
-			if let label = subview as? UILabel {
-				let viewLabelHeight: CGFloat? = {
-					if usesTextHeightForLabels {
-						return ceil(label.font.lineHeight)
-					} else {
-						return tokenSet[.labelHeight].float
-					}
-				}()
+            var coverFrame = viewToCover.convert(subview.bounds, from: subview)
+            if let label = subview as? UILabel {
+                let viewLabelHeight: CGFloat? = {
+                    if usesTextHeightForLabels {
+                        return ceil(label.font.lineHeight)
+                    } else {
+                        return tokenSet[.labelHeight].float
+                    }
+                }()
 
-				if let viewLabelHeight = viewLabelHeight {
-					let delta = coverFrame.height - viewLabelHeight
-					coverFrame.size.height = viewLabelHeight
-					coverFrame.origin.y += delta / 2
-				}
-			}
-			coverLayer.frame = coverFrame
+                if let viewLabelHeight = viewLabelHeight {
+                    let delta = coverFrame.height - viewLabelHeight
+                    coverFrame.size.height = viewLabelHeight
+                    coverFrame.origin.y += delta / 2
+                }
+            }
+            coverLayer.frame = coverFrame
 
-			return coverLayer
-		}
+            return coverLayer
+        }
 
-		viewCoverLayers.forEach { layer.addSublayer($0) }
-	}
+        viewCoverLayers.forEach { layer.addSublayer($0) }
+    }
 
-	/// Update the gradient layer that animates to provide the shimmer effect (also updates the animation).
-	func updateShimmeringLayer() {
-		let light = UIColor.white.withAlphaComponent(tokenSet[.shimmerAlpha].float).cgColor
-		let dark = UIColor(dynamicColor: tokenSet[.darkGradient].dynamicColor).cgColor
-		shimmeringLayer.colors = self.style == .concealing ? [light, dark, light] : [dark, light, dark]
+    /// Update the gradient layer that animates to provide the shimmer effect (also updates the animation).
+    func updateShimmeringLayer() {
+        let light = UIColor.white.withAlphaComponent(tokenSet[.shimmerAlpha].float).cgColor
+        let dark = UIColor(dynamicColor: tokenSet[.darkGradient].dynamicColor).cgColor
+        shimmeringLayer.colors = self.style == .concealing ? [light, dark, light] : [dark, light, dark]
 
-		let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
-		let startPoint = CGPoint(x: 0.0, y: 0.5)
-		let endPoint = CGPoint(x: 1.0, y: 0.5 - tan(tokenSet[.shimmerAngle].float * (isRTL ? -1 : 1)))
-		if isRTL {
-			shimmeringLayer.startPoint = endPoint
-			shimmeringLayer.endPoint = startPoint
-		} else {
-			shimmeringLayer.startPoint = startPoint
-			shimmeringLayer.endPoint = endPoint
-		}
+        let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
+        let startPoint = CGPoint(x: 0.0, y: 0.5)
+        let endPoint = CGPoint(x: 1.0, y: 0.5 - tan(tokenSet[.shimmerAngle].float * (isRTL ? -1 : 1)))
+        if isRTL {
+            shimmeringLayer.startPoint = endPoint
+            shimmeringLayer.endPoint = startPoint
+        } else {
+            shimmeringLayer.startPoint = startPoint
+            shimmeringLayer.endPoint = endPoint
+        }
 
-		let widthPercentage = Float(tokenSet[.shimmerWidth].float / shimmeringLayer.frame.width)
-		let locationStart = NSNumber(value: 0.5 - widthPercentage / 2)
-		let locationMiddle = NSNumber(value: 0.5)
-		let locationEnd = NSNumber(value: 0.5 + widthPercentage / 2)
+        let widthPercentage = Float(tokenSet[.shimmerWidth].float / shimmeringLayer.frame.width)
+        let locationStart = NSNumber(value: 0.5 - widthPercentage / 2)
+        let locationMiddle = NSNumber(value: 0.5)
+        let locationEnd = NSNumber(value: 0.5 + widthPercentage / 2)
 
-		let locations = [locationStart, locationMiddle, locationEnd]
-		shimmeringLayer.locations = isRTL ? locations.reversed() : locations
+        let locations = [locationStart, locationMiddle, locationEnd]
+        shimmeringLayer.locations = isRTL ? locations.reversed() : locations
 
-		layer.mask = shimmeringLayer
+        layer.mask = shimmeringLayer
 
-		updateShimmeringAnimation()
-	}
+        updateShimmeringAnimation()
+    }
 
-	/// Update the shimmer animation.
-	func updateShimmeringAnimation() {
-		shimmeringLayer.removeAnimation(forKey: "shimmering")
+    /// Update the shimmer animation.
+    func updateShimmeringAnimation() {
+        shimmeringLayer.removeAnimation(forKey: "shimmering")
 
-		// For usability/accessibility reasons, the animation is not added if the user.
-		// has the "reduce motion" enabled on the device.
-		guard !UIAccessibility.isReduceMotionEnabled else {
-			return
-		}
+        // For usability/accessibility reasons, the animation is not added if the user.
+        // has the "reduce motion" enabled on the device.
+        guard !UIAccessibility.isReduceMotionEnabled else {
+            return
+        }
 
-		if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
-			animationSynchronizer.referenceLayer = shimmeringLayer
-		}
+        if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
+            animationSynchronizer.referenceLayer = shimmeringLayer
+        }
 
-		let animation = CABasicAnimation(keyPath: "locations")
+        let animation = CABasicAnimation(keyPath: "locations")
 
-		let widthPercentage = Float(tokenSet[.shimmerWidth].float / shimmeringLayer.frame.width)
+        let widthPercentage = Float(tokenSet[.shimmerWidth].float / shimmeringLayer.frame.width)
 
-		let fromLocationStart = NSNumber(value: 0.0)
-		let fromLocationMiddle = NSNumber(value: widthPercentage / 2.0)
-		let fromLocationEnd = NSNumber(value: widthPercentage)
+        let fromLocationStart = NSNumber(value: 0.0)
+        let fromLocationMiddle = NSNumber(value: widthPercentage / 2.0)
+        let fromLocationEnd = NSNumber(value: widthPercentage)
 
-		let toLocationStart = NSNumber(value: 1.0 - widthPercentage)
-		let toLocationMiddle = NSNumber(value: 1.0 - (widthPercentage / 2.0))
-		let toLocationEnd = NSNumber(value: 1.0)
+        let toLocationStart = NSNumber(value: 1.0 - widthPercentage)
+        let toLocationMiddle = NSNumber(value: 1.0 - (widthPercentage / 2.0))
+        let toLocationEnd = NSNumber(value: 1.0)
 
-		// Do not flip values from / to for RTL. These are already relative to the layout direction.
-		animation.fromValue = [fromLocationStart, fromLocationMiddle, fromLocationEnd]
-		animation.toValue = [toLocationStart, toLocationMiddle, toLocationEnd]
+        // Do not flip values from / to for RTL. These are already relative to the layout direction.
+        animation.fromValue = [fromLocationStart, fromLocationMiddle, fromLocationEnd]
+        animation.toValue = [toLocationStart, toLocationMiddle, toLocationEnd]
 
-		let distance = (frame.width + tokenSet[.shimmerWidth].float) / cos(tokenSet[.shimmerAngle].float)
-		animation.duration = CFTimeInterval(distance / tokenSet[.shimmerSpeed].float)
-		animation.fillMode = .forwards
+        let distance = (frame.width + tokenSet[.shimmerWidth].float) / cos(tokenSet[.shimmerAngle].float)
+        animation.duration = CFTimeInterval(distance / tokenSet[.shimmerSpeed].float)
+        animation.fillMode = .forwards
 
-		// Add animation (use a group to add a delay between animations).
-		let animationGroup = CAAnimationGroup()
-		animationGroup.animations = [animation]
-		animationGroup.duration = animation.duration + tokenSet[.shimmerDelay].float
-		animationGroup.repeatCount = .infinity
-		animationGroup.timeOffset = animationSynchronizer?.timeOffset(for: shimmeringLayer) ?? 0
-		shimmeringLayer.add(animationGroup, forKey: "shimmering")
-	}
+        // Add animation (use a group to add a delay between animations).
+        let animationGroup = CAAnimationGroup()
+        animationGroup.animations = [animation]
+        animationGroup.duration = animation.duration + tokenSet[.shimmerDelay].float
+        animationGroup.repeatCount = .infinity
+        animationGroup.timeOffset = animationSynchronizer?.timeOffset(for: shimmeringLayer) ?? 0
+        shimmeringLayer.add(animationGroup, forKey: "shimmering")
+    }
 
-	/// Layers covering the subviews of the container.
-	var viewCoverLayers = [CALayer]()
+    /// Layers covering the subviews of the container.
+    var viewCoverLayers = [CALayer]()
 
-	/// Layer that slides to provide the "shimmer" effect.
-	var shimmeringLayer = CAGradientLayer()
+    /// Layer that slides to provide the "shimmer" effect.
+    var shimmeringLayer = CAGradientLayer()
 
-	private func searchLeaves(in view: UIView, output: inout [UIView]) {
-		for v in view.subviews {
-			if v.subviews.isEmpty && v != self {
-				output.append(v)
-			} else if !v.isHidden {
-				searchLeaves(in: v, output: &output)
-			}
-		}
-	}
+    private func searchLeaves(in view: UIView, output: inout [UIView]) {
+        for v in view.subviews {
+            if v.subviews.isEmpty && v != self {
+                output.append(v)
+            } else if !v.isHidden {
+                searchLeaves(in: v, output: &output)
+            }
+        }
+    }
 
-	private var shimmersLeafViews: Bool
-	private var usesTextHeightForLabels: Bool
-	private var excludedViews: [UIView]
-	private weak var containerView: UIView?
+    private var shimmersLeafViews: Bool
+    private var usesTextHeightForLabels: Bool
+    private var excludedViews: [UIView]
+    private weak var containerView: UIView?
 }

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -4,335 +4,222 @@
 //
 
 import UIKit
+import Combine
 
-/// Shimmer style can be either concealing or revealing
-/// The style affects the default shimmer alpha value and the default shimmer tint color
-@objc(MSFShimmerViewStyle)
-public enum ShimmerStyle: Int, CaseIterable {
-    /// Concealing shimmer: the gradient conceals parts of the subviews as it moves leaving most parts of the subviews unblocked.
-    case concealing
-
-    /// Revealing shimmer: the gradient reveals parts of the subviews as it moves leaving most parts of the subview blocked.
-    case revealing
-
-    var defaultAlphaValue: CGFloat {
-        switch self {
-        case .concealing:
-            return 0
-        case .revealing:
-            return 0.4
-        }
-    }
-
-    var defaultTintColor: UIColor {
-        switch self {
-        case .concealing:
-            return Colors.Shimmer.gradientCenter
-        case .revealing:
-            return Colors.Shimmer.tint
-        }
-    }
-}
-
-/// View that converts the subviews of a container view into a loading state with the "shimmering" effect
+/// View that converts the subviews of a container view into a loading state with the "shimmering" effect.
 @objc(MSFShimmerView)
-open class ShimmerView: UIView {
+open class ShimmerView: UIView, TokenizedControlInternal {
 
-    /// The alpha value of the center of the gradient in the animation if shimmer is revealing shimmer
-    /// The alpha value of the view other than the gradient if shimmer is concealing shimmer
-    @objc open var shimmerAlpha: CGFloat {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+	/// Optional synchronizer to sync multiple shimmer views.
+	@objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
 
-    /// the width of the gradient in the animation
-    @objc open var shimmerWidth: CGFloat = defaultWidth {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+	open override var intrinsicContentSize: CGSize { return bounds.size }
 
-    /// Angle of the direction of the gradient, in radian. 0 means horizontal, Pi/2 means vertical.
-    @objc open var shimmerAngle: CGFloat = defaultAngle {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+	open override func layoutSubviews() {
+		super.layoutSubviews()
 
-    /// Speed of the animation, in point/seconds.
-    @objc open var shimmerSpeed: CGFloat = defaultSpeed {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		updateViewCoverLayers()
 
-    /// Delay between the end of a shimmering animation and the beginning of the next one.
-    @objc open var shimmerDelay: TimeInterval = defaultDelay {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		let viewToCover = containerView ?? self
 
-    /// Tint color of the view if shimmer is revealing shimmer
-    /// Tint color of the middle of the gradient if shimmer is concealing shimmer
-    @objc open var viewTintColor: UIColor = Colors.Shimmer.tint {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		shimmeringLayer.frame = CGRect(x: -viewToCover.frame.width,
+									   y: 0.0,
+									   width: viewToCover.bounds.width + 2 * viewToCover.frame.width,
+									   height: viewToCover.frame.height)
 
-    /// Corner radius on each view.
-    @objc open var cornerRadius: CGFloat = defaultCornerRadius {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		updateShimmeringLayer()
+		updateShimmeringAnimation()
+	}
 
-    /// Corner radius on each UILabel. Set to  0 to disable and use default `cornerRadius`.
-    @objc open var labelCornerRadius: CGFloat = defaultLabelCornerRadius {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+	/// Create a shimmer view
+	/// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored.
+	/// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer.
+	/// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views.
+	/// - Parameter shimmerStyle: determines whether the shimmer is a revealing shimmer or a concealing shimmer.
+	/// - Parameter shimmersLeafViews: True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box.
+	/// - Parameter usesTextHeightForLabels: Determines whether we shimmer the top level subviews, or the leaf nodes of the view hierarchy. If false, we use default height of 11.0.
+	@objc public init(containerView: UIView? = nil,
+					  excludedViews: [UIView] = [],
+					  animationSynchronizer: AnimationSynchronizerProtocol? = nil,
+					  shimmerStyle: MSFShimmerStyle = .revealing,
+					  shimmersLeafViews: Bool = false,
+					  usesTextHeightForLabels: Bool = false) {
+		self.style = shimmerStyle
 
-    /// True to enable shimmers to auto-adjust to font height for a UILabel -- this will more accurately reflect the text in the label rect rather than using the bounding box.
-    /// `labelHeight` will take precendence over this property.
-    @objc open var usesTextHeightForLabels: Bool = defaultUsesTextHeightForLabels {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		self.containerView = containerView
+		self.excludedViews = excludedViews
+		self.animationSynchronizer = animationSynchronizer
+		self.shimmersLeafViews = shimmersLeafViews
+		self.usesTextHeightForLabels = usesTextHeightForLabels
+		super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
 
-    /// If greater than 0, a fixed height to use for all UILabels. This will take precedence over `usesTextHeightForLabels`. Set to less than 0 to disable.
-    @objc open var labelHeight: CGFloat = defaultLabelHeight {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		NotificationCenter.default.addObserver(self,
+											   selector: #selector(syncAnimation),
+											   name: UIAccessibility.reduceMotionStatusDidChangeNotification,
+											   object: nil)
 
-    /// Determines whether we shimmer the top level subviews, or the leaf nodes of the view heirarchy
-    @objc open var shimmersLeafViews: Bool = defaultShimmersLeafViews {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+		// Update appearance whenever `tokenSet` changes.
+		tokenSetSink = tokenSet.sinkChanges { [weak self] in
+			self?.updateShimmeringAnimation()
+		}
+	}
 
-    /// Determines whether the shimmer is a revealing shimmer or a concealing shimmer
-    @objc open var shimmerStyle: ShimmerStyle {
-        didSet {
-            setNeedsLayout()
-        }
-    }
+	required public init?(coder: NSCoder) {
+		preconditionFailure("init(coder:) has not been implemented")
+	}
 
-    /// Optional synchronizer to sync multiple shimmer views
-    @objc open weak var animationSynchronizer: AnimationSynchronizerProtocol?
+	/// Manaully sync with the synchronizer.
+	@objc public func syncAnimation() {
+		updateShimmeringAnimation()
+	}
 
-    open override var intrinsicContentSize: CGSize { return bounds.size }
+	// MARK: - TokenizedControl
+	public typealias TokenSetKeyType = ShimmerTokenSet.Tokens
+	public lazy var tokenSet: ShimmerTokenSet = .init(style: { self.style })
 
-    /// Layers covering the subviews of the container
-    var viewCoverLayers = [CALayer]()
+	var tokenSetSink: AnyCancellable?
 
-    /// Layer that slides to provide the "shimmer" effect
-    var shimmeringLayer = CAGradientLayer()
+	/// Style to draw the control.
+	public let style: MSFShimmerStyle
 
-    private weak var containerView: UIView?
-    private var excludedViews: [UIView]
+	/// Update the frame of each layer covering views in the containerView.
+	func updateViewCoverLayers() {
+		let viewToCover = containerView ?? self
 
-    /// Create a shimmer view
-    /// - Parameter containerView: view to convert layout into a shimmer -- each of containerView's first-level subviews will be mirrored
-    /// - Parameter excludedViews: subviews of `containerView` to exclude from shimmer
-    /// - Parameter animationSynchronizer: optional synchronizer to sync multiple shimmer views
-    @objc public init(containerView: UIView? = nil,
-                      excludedViews: [UIView] = [],
-                      animationSynchronizer: AnimationSynchronizerProtocol? = nil,
-                      shimmerStyle: ShimmerStyle = .revealing) {
-        self.containerView = containerView
-        self.excludedViews = excludedViews
-        self.animationSynchronizer = animationSynchronizer
-        self.shimmerStyle = shimmerStyle
-        self.viewTintColor = shimmerStyle.defaultTintColor
-        self.shimmerAlpha = shimmerStyle.defaultAlphaValue
-        super.init(frame: CGRect(origin: .zero, size: containerView?.bounds.size ?? .zero))
+		viewCoverLayers.forEach { $0.removeFromSuperlayer() }
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(syncAnimation),
-                                               name: UIAccessibility.reduceMotionStatusDidChangeNotification,
-                                               object: nil)
-    }
+		let subviews: Set<UIView> = {
+			if shimmersLeafViews {
+				var leaves = [UIView]()
+				searchLeaves(in: viewToCover, output: &leaves)
+				return Set(leaves).subtracting(Set(excludedViews))
+			} else {
+				return Set(viewToCover.subviews).subtracting(Set(excludedViews))
+			}
+		}()
 
-    required public init?(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
+		viewCoverLayers = subviews.filter({ !$0.isHidden && !($0 is ShimmerView) }).map { subview in
+			let coverLayer = CALayer()
 
-    open override func layoutSubviews() {
-        super.layoutSubviews()
+			let shouldApplyLabelCornerRadius = subview is UILabel && tokenSet[.labelCornerRadius].float >= 0
+			coverLayer.cornerRadius = shouldApplyLabelCornerRadius ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
+			coverLayer.backgroundColor = UIColor(dynamicColor: tokenSet[.tintColor].dynamicColor).cgColor
 
-        updateViewCoverLayers()
+			var coverFrame = viewToCover.convert(subview.bounds, from: subview)
+			if let label = subview as? UILabel {
+				let viewLabelHeight: CGFloat? = {
+					if usesTextHeightForLabels {
+						return ceil(label.font.lineHeight)
+					} else {
+						return tokenSet[.labelHeight].float
+					}
+				}()
 
-        let viewToCover = containerView ?? self
+				if let viewLabelHeight = viewLabelHeight {
+					let delta = coverFrame.height - viewLabelHeight
+					coverFrame.size.height = viewLabelHeight
+					coverFrame.origin.y += delta / 2
+				}
+			}
+			coverLayer.frame = coverFrame
 
-        shimmeringLayer.frame = CGRect(x: -viewToCover.frame.width,
-                                       y: 0.0,
-                                       width: viewToCover.bounds.width + 2 * viewToCover.frame.width,
-                                       height: viewToCover.frame.height)
+			return coverLayer
+		}
 
-        updateShimmeringLayer()
-        updateShimmeringAnimation()
-    }
+		viewCoverLayers.forEach { layer.addSublayer($0) }
+	}
 
-    /// Manaully sync with the synchronizer
-    @objc open func syncAnimation() {
-        updateShimmeringAnimation()
-    }
+	/// Update the gradient layer that animates to provide the shimmer effect (also updates the animation).
+	func updateShimmeringLayer() {
+		let light = UIColor.white.withAlphaComponent(tokenSet[.shimmerAlpha].float).cgColor
+		let dark = UIColor(dynamicColor: tokenSet[.darkGradient].dynamicColor).cgColor
+		shimmeringLayer.colors = self.style == .concealing ? [light, dark, light] : [dark, light, dark]
 
-    /// Update the frame of each layer covering views in the containerView
-    func updateViewCoverLayers() {
-        let viewToCover = containerView ?? self
+		let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
+		let startPoint = CGPoint(x: 0.0, y: 0.5)
+		let endPoint = CGPoint(x: 1.0, y: 0.5 - tan(tokenSet[.shimmerAngle].float * (isRTL ? -1 : 1)))
+		if isRTL {
+			shimmeringLayer.startPoint = endPoint
+			shimmeringLayer.endPoint = startPoint
+		} else {
+			shimmeringLayer.startPoint = startPoint
+			shimmeringLayer.endPoint = endPoint
+		}
 
-        viewCoverLayers.forEach { $0.removeFromSuperlayer() }
+		let widthPercentage = Float(tokenSet[.shimmerWidth].float / shimmeringLayer.frame.width)
+		let locationStart = NSNumber(value: 0.5 - widthPercentage / 2)
+		let locationMiddle = NSNumber(value: 0.5)
+		let locationEnd = NSNumber(value: 0.5 + widthPercentage / 2)
 
-        let subviews: Set<UIView> = {
-            if shimmersLeafViews {
-                var leaves = [UIView]()
-                searchLeaves(in: viewToCover, output: &leaves)
-                return Set(leaves).subtracting(Set(excludedViews))
-            } else {
-                return Set(viewToCover.subviews).subtracting(Set(excludedViews))
-            }
-        }()
+		let locations = [locationStart, locationMiddle, locationEnd]
+		shimmeringLayer.locations = isRTL ? locations.reversed() : locations
 
-        viewCoverLayers = subviews.filter({ !$0.isHidden && !($0 is ShimmerView) }).map { subview in
-            let coverLayer = CALayer()
+		layer.mask = shimmeringLayer
 
-            let shouldApplyLabelCornerRadius = subview is UILabel && labelCornerRadius >= 0
-            coverLayer.cornerRadius = shouldApplyLabelCornerRadius ? labelCornerRadius : cornerRadius
-            coverLayer.backgroundColor = viewTintColor.cgColor
+		updateShimmeringAnimation()
+	}
 
-            var coverFrame = viewToCover.convert(subview.bounds, from: subview)
-            if let label = subview as? UILabel {
-                let viewLabelHeight: CGFloat? = {
-                    if labelHeight >= 0 {
-                        return labelHeight
-                    } else if usesTextHeightForLabels {
-                        return ceil(label.font.lineHeight)
-                    }
-                    return nil
-                }()
+	/// Update the shimmer animation.
+	func updateShimmeringAnimation() {
+		shimmeringLayer.removeAnimation(forKey: "shimmering")
 
-                if let viewLabelHeight = viewLabelHeight {
-                    let delta = coverFrame.height - viewLabelHeight
-                    coverFrame.size.height = viewLabelHeight
-                    coverFrame.origin.y += delta / 2
-                }
-            }
-            coverLayer.frame = coverFrame
+		// For usability/accessibility reasons, the animation is not added if the user.
+		// has the "reduce motion" enabled on the device.
+		guard !UIAccessibility.isReduceMotionEnabled else {
+			return
+		}
 
-            return coverLayer
-        }
+		if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
+			animationSynchronizer.referenceLayer = shimmeringLayer
+		}
 
-        viewCoverLayers.forEach { layer.addSublayer($0) }
-    }
+		let animation = CABasicAnimation(keyPath: "locations")
 
-    /// Update the gradient layer that animates to provide the shimmer effect (also updates the animation)
-    func updateShimmeringLayer() {
-        let light = UIColor.white.withAlphaComponent(shimmerAlpha).cgColor
-        let dark = Colors.Shimmer.darkGradient.cgColor
-        shimmeringLayer.colors = shimmerStyle == .concealing ? [light, dark, light] : [dark, light, dark]
+		let widthPercentage = Float(tokenSet[.shimmerWidth].float / shimmeringLayer.frame.width)
 
-        let isRTL = effectiveUserInterfaceLayoutDirection == .rightToLeft
-        let startPoint = CGPoint(x: 0.0, y: 0.5)
-        let endPoint = CGPoint(x: 1.0, y: 0.5 - tan(shimmerAngle * (isRTL ? -1 : 1)))
-        if isRTL {
-            shimmeringLayer.startPoint = endPoint
-            shimmeringLayer.endPoint = startPoint
-        } else {
-            shimmeringLayer.startPoint = startPoint
-            shimmeringLayer.endPoint = endPoint
-        }
+		let fromLocationStart = NSNumber(value: 0.0)
+		let fromLocationMiddle = NSNumber(value: widthPercentage / 2.0)
+		let fromLocationEnd = NSNumber(value: widthPercentage)
 
-        let widthPercentage = Float(shimmerWidth / shimmeringLayer.frame.width)
-        let locationStart = NSNumber(value: 0.5 - widthPercentage / 2)
-        let locationMiddle = NSNumber(value: 0.5)
-        let locationEnd = NSNumber(value: 0.5 + widthPercentage / 2)
+		let toLocationStart = NSNumber(value: 1.0 - widthPercentage)
+		let toLocationMiddle = NSNumber(value: 1.0 - (widthPercentage / 2.0))
+		let toLocationEnd = NSNumber(value: 1.0)
 
-        let locations = [locationStart, locationMiddle, locationEnd]
-        shimmeringLayer.locations = isRTL ? locations.reversed() : locations
+		// Do not flip values from / to for RTL. These are already relative to the layout direction.
+		animation.fromValue = [fromLocationStart, fromLocationMiddle, fromLocationEnd]
+		animation.toValue = [toLocationStart, toLocationMiddle, toLocationEnd]
 
-        layer.mask = shimmeringLayer
+		let distance = (frame.width + tokenSet[.shimmerWidth].float) / cos(tokenSet[.shimmerAngle].float)
+		animation.duration = CFTimeInterval(distance / tokenSet[.shimmerSpeed].float)
+		animation.fillMode = .forwards
 
-        updateShimmeringAnimation()
-    }
+		// Add animation (use a group to add a delay between animations).
+		let animationGroup = CAAnimationGroup()
+		animationGroup.animations = [animation]
+		animationGroup.duration = animation.duration + tokenSet[.shimmerDelay].float
+		animationGroup.repeatCount = .infinity
+		animationGroup.timeOffset = animationSynchronizer?.timeOffset(for: shimmeringLayer) ?? 0
+		shimmeringLayer.add(animationGroup, forKey: "shimmering")
+	}
 
-    /// Update the shimmer animation
-    func updateShimmeringAnimation() {
-        shimmeringLayer.removeAnimation(forKey: "shimmering")
+	/// Layers covering the subviews of the container.
+	var viewCoverLayers = [CALayer]()
 
-        // For usability/accessibility reasons, the animation is not added if the user
-        // has the "reduce motion" enabled on the device.
-        guard !UIAccessibility.isReduceMotionEnabled else {
-            return
-        }
+	/// Layer that slides to provide the "shimmer" effect.
+	var shimmeringLayer = CAGradientLayer()
 
-        if let animationSynchronizer = animationSynchronizer, animationSynchronizer.referenceLayer == nil {
-            animationSynchronizer.referenceLayer = shimmeringLayer
-        }
+	private func searchLeaves(in view: UIView, output: inout [UIView]) {
+		for v in view.subviews {
+			if v.subviews.isEmpty && v != self {
+				output.append(v)
+			} else if !v.isHidden {
+				searchLeaves(in: v, output: &output)
+			}
+		}
+	}
 
-        let animation = CABasicAnimation(keyPath: "locations")
-
-        let widthPercentage = Float(shimmerWidth / shimmeringLayer.frame.width)
-
-        let fromLocationStart = NSNumber(value: 0.0)
-        let fromLocationMiddle = NSNumber(value: widthPercentage / 2.0)
-        let fromLocationEnd = NSNumber(value: widthPercentage)
-
-        let toLocationStart = NSNumber(value: 1.0 - widthPercentage)
-        let toLocationMiddle = NSNumber(value: 1.0 - (widthPercentage / 2.0))
-        let toLocationEnd = NSNumber(value: 1.0)
-
-        // Do not flip values from / to for RTL. These are already relative to the layout direction.
-        animation.fromValue = [fromLocationStart, fromLocationMiddle, fromLocationEnd]
-        animation.toValue = [toLocationStart, toLocationMiddle, toLocationEnd]
-
-        let distance = (frame.width + shimmerWidth) / cos(shimmerAngle)
-        animation.duration = CFTimeInterval(distance / shimmerSpeed)
-        animation.fillMode = .forwards
-
-        // Add animation (use a group to add a delay between animations)
-        let animationGroup = CAAnimationGroup()
-        animationGroup.animations = [animation]
-        animationGroup.duration = animation.duration + shimmerDelay
-        animationGroup.repeatCount = .infinity
-        animationGroup.timeOffset = animationSynchronizer?.timeOffset(for: shimmeringLayer) ?? 0
-        shimmeringLayer.add(animationGroup, forKey: "shimmering")
-    }
-
-    private func searchLeaves(in view: UIView, output: inout [UIView]) {
-        for v in view.subviews {
-            if v.subviews.isEmpty && v != self {
-                output.append(v)
-            } else if !v.isHidden {
-                searchLeaves(in: v, output: &output)
-            }
-        }
-    }
-
-    private static let defaultWidth: CGFloat = 180
-    private static let defaultAngle: CGFloat = -(CGFloat.pi / 45.0)
-    private static let defaultSpeed: CGFloat = 350
-    private static let defaultDelay: TimeInterval = 0.4
-    private static let defaultCornerRadius: CGFloat = 4.0
-    private static let defaultLabelCornerRadius: CGFloat = 2.0
-    private static let defaultUsesTextHeightForLabels: Bool = false
-    private static let defaultLabelHeight: CGFloat = 11
-
-    private static let defaultShimmersLeafViews: Bool = false
-}
-
-public extension Colors {
-    struct Shimmer {
-        internal static var darkGradient: UIColor = .black
-        internal static var gradientCenter = UIColor(light: .white, dark: gray950)
-        public static var tint = UIColor(light: surfaceTertiary, lightHighContrast: Colors.Palette.gray400.color, dark: surfaceQuaternary, darkHighContrast: Colors.Palette.gray400.color)
-    }
+	private var shimmersLeafViews: Bool
+	private var usesTextHeightForLabels: Bool
+	private var excludedViews: [UIView]
+	private weak var containerView: UIView?
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Merge tokenized UIKit Shimmer/ShimmerLines controls from fluent2-tokens branch
- #1004
- #1135 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1286)