### PR TITLE
Remove code signing identity for resource bundle

### DIFF
--- a/ios/xcode/FluentUIResources.xcconfig
+++ b/ios/xcode/FluentUIResources.xcconfig
@@ -3,8 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-CODE_SIGN_IDENTITY = ""
-DEVELOPMENT_TEAM = ""
+CODE_SIGNING_ALLOWED = NO
 INFOPLIST_FILE = FluentUI.Resources/Info.plist
 INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Bundles
 PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.FluentUIResources-ios

--- a/ios/xcode/FluentUIResources.xcconfig
+++ b/ios/xcode/FluentUIResources.xcconfig
@@ -3,7 +3,8 @@
 //  Licensed under the MIT License.
 //
 
-DEVELOPMENT_TEAM = UBF8T346G9
+CODE_SIGN_IDENTITY = ""
+DEVELOPMENT_TEAM = ""
 INFOPLIST_FILE = FluentUI.Resources/Info.plist
 INSTALL_PATH = $(LOCAL_LIBRARY_DIR)/Bundles
 PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.FluentUIResources-ios


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Per issue #1239, Xcode 14 now attempts to codesign resource bundles. There's no reason for us to be signing ours, so stop doing it.

### Verification

Ensured that device builds still build, and that resources still load as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1289)