### PR TITLE
Make PillButtonBarItem title mutable and set its font earlier

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		5336B17D27F7817300B01E0D /* HUDDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17B27F7817300B01E0D /* HUDDemoController_SwiftUI.swift */; };
 		5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */; };
 		7D0931C124AAA3D30072458A /* SideTabBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */; };
+		807E8B4528F9F8B8002B8F84 /* PillButtonDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807E8B4428F9F8B8002B8F84 /* PillButtonDemoController.swift */; };
 		80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */; };
 		80B1F7012628D8BB004DFEE5 /* BottomSheetDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */; };
 		8F0B81122670200300463726 /* AppCenterDistribute in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0B81112670200300463726 /* AppCenterDistribute */; };
@@ -95,6 +96,7 @@
 		5373F95626F28D9B007F1410 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
 		7D0931C024AAA3D30072458A /* SideTabBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideTabBarDemoController.swift; sourceTree = "<group>"; };
 		7DC2FB2A24C0F4FD00367A55 /* TableViewCellFileAccessoryViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellFileAccessoryViewDemoController.swift; sourceTree = "<group>"; };
+		807E8B4428F9F8B8002B8F84 /* PillButtonDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtonDemoController.swift; sourceTree = "<group>"; };
 		80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCommandingDemoController.swift; sourceTree = "<group>"; };
 		80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetDemoController.swift; sourceTree = "<group>"; };
 		923DF2DA271158C900637646 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -336,6 +338,7 @@
 				92E4784B2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift */,
 				B4EF53C4215C45C400573E8F /* PersonaListViewDemoController.swift */,
 				497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */,
+				807E8B4428F9F8B8002B8F84 /* PillButtonDemoController.swift */,
 				A5961FA8218A61BB00E2A506 /* PopupMenuDemoController.swift */,
 				EC24DBC428B97E950026EF92 /* PopupMenuObjCDemoController.h */,
 				EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */,
@@ -535,6 +538,7 @@
 				C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */,
 				53097D3D27028AD800A6E4DC /* NavigationControllerDemoController.swift in Sources */,
 				532FE3DC26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift in Sources */,
+				807E8B4528F9F8B8002B8F84 /* PillButtonDemoController.swift in Sources */,
 				114CF8B82423E10900D064AA /* ColorDemoController.swift in Sources */,
 				53097D4427028AFA00A6E4DC /* TooltipDemoController.swift in Sources */,
 				A589F856211BA71000471C23 /* LabelDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -48,6 +48,7 @@ struct Demos {
         DemoDescriptor("NavigationController", NavigationControllerDemoController.self),
         DemoDescriptor("PeoplePicker", PeoplePickerDemoController.self),
         DemoDescriptor("PersonaListView", PersonaListViewDemoController.self),
+        DemoDescriptor("PillButton", PillButtonDemoController.self),
         DemoDescriptor("PillButtonBar", PillButtonBarDemoController.self),
         DemoDescriptor("PopupMenuController", PopupMenuDemoController.self),
         DemoDescriptor("SearchBar", SearchBarDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
@@ -15,6 +15,8 @@ class PillButtonDemoController: DemoController {
 
             let pill1 = PillButton(pillBarItem: buttonItems[0], style: style.1)
             let pill2 = PillButton(pillBarItem: buttonItems[1], style: style.1)
+            pill1.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
+            pill2.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
 
             addRow(items: [pill1])
             addRow(items: [pill2])
@@ -39,6 +41,13 @@ class PillButtonDemoController: DemoController {
         }
     }
 
+    @objc private func handleTap() {
+        let alert = UIAlertController(title: "Pill button was tapped", message: nil, preferredStyle: .alert)
+        let action = UIAlertAction(title: "OK", style: .default)
+        alert.addAction(action)
+        present(alert, animated: true)
+    }
+
     private lazy var buttonItems: [PillButtonBarItem] = {
         return [
             PillButtonBarItem(title: tabItemTitles[0]),
@@ -46,9 +55,9 @@ class PillButtonDemoController: DemoController {
         ]
     }()
 
-    private var itemTitlesChanged: Bool = false
+    private var itemTitlesChanged = false
 
-    private var unreadDotsChanged: Bool = false
+    private var unreadDotsChanged = false
 
     private let tabItemTitles = [
         "All",

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
@@ -1,0 +1,64 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+class PillButtonDemoController: DemoController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        for style in buttonStyles {
+            addTitle(text: "\(style.0) style")
+
+            let pill1 = PillButton(pillBarItem: buttonItems[0], style: style.1)
+            let pill2 = PillButton(pillBarItem: buttonItems[1], style: style.1)
+
+            addRow(items: [pill1])
+            addRow(items: [pill2])
+        }
+
+        addTitle(text: "Mutability")
+        addRow(items: [createButton(title: "Change titles", action: #selector(changeItemTitles))], stretchItems: true)
+        addRow(items: [createButton(title: "Change unread dots", action: #selector(changeUnreadDots))], stretchItems: true)
+
+    }
+
+    @objc private func changeItemTitles() {
+        itemTitlesChanged.toggle()
+        buttonItems[0].title = itemTitlesChanged ? tabItemTitles[2] : tabItemTitles[0]
+        buttonItems[1].title = itemTitlesChanged ? tabItemTitles[3] : tabItemTitles[1]
+    }
+
+    @objc private func changeUnreadDots() {
+        unreadDotsChanged.toggle()
+        buttonItems.forEach {
+            $0.isUnread = unreadDotsChanged
+        }
+    }
+
+    private lazy var buttonItems: [PillButtonBarItem] = {
+        return [
+            PillButtonBarItem(title: tabItemTitles[0]),
+            PillButtonBarItem(title: tabItemTitles[1])
+        ]
+    }()
+
+    private var itemTitlesChanged: Bool = false
+
+    private var unreadDotsChanged: Bool = false
+
+    private let tabItemTitles = [
+        "All",
+        "Documents",
+        "Home",
+        "Review"
+    ]
+
+    private let buttonStyles: [(String, PillButtonStyle)] = [
+        ("Primary", .primary),
+        ("onBrand", .onBrand)
+    ]
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
@@ -55,11 +55,11 @@ class PillButtonDemoController: DemoController {
         ]
     }()
 
-    private var itemTitlesChanged = false
+    private var itemTitlesChanged: Bool = false
 
-    private var unreadDotsChanged = false
+    private var unreadDotsChanged: Bool = false
 
-    private let tabItemTitles = [
+    private let tabItemTitles: [String] = [
         "All",
         "Documents",
         "Home",

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -118,6 +118,9 @@ open class PillButton: UIButton {
                                                                   bottom: Constants.bottomInset,
                                                                   trailing: Constants.horizontalInset)
             self.configuration = configuration
+
+            // This updates the attributed title stored in self.configuration,
+            // so it needs to be called after we set it.
             updateAttributedTitle()
 
             configurationUpdateHandler = { [weak self] _ in
@@ -185,7 +188,6 @@ open class PillButton: UIButton {
         } else {
             setTitle(pillBarItem.title, for: .normal)
         }
-
     }
 
     @available(iOS 15, *)

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -62,6 +62,11 @@ open class PillButton: UIButton {
                                                selector: #selector(isUnreadValueDidChange),
                                                name: PillButtonBarItem.isUnreadValueDidChangeNotification,
                                                object: pillBarItem)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(titleValueDidChange),
+                                               name: PillButtonBarItem.titleValueDidChangeNotification,
+                                               object: pillBarItem)
     }
 
     var unreadDotColor: UIColor = Colors.gray100
@@ -108,16 +113,12 @@ open class PillButton: UIButton {
     private func setupView() {
         if #available(iOS 15.0, *) {
             var configuration = UIButton.Configuration.plain()
-            configuration.attributedTitle = AttributedString(pillBarItem.title)
-
-            // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically
-            accessibilityLabel = pillBarItem.title
-
             configuration.contentInsets = NSDirectionalEdgeInsets(top: Constants.topInset,
                                                                   leading: Constants.horizontalInset,
                                                                   bottom: Constants.bottomInset,
                                                                   trailing: Constants.horizontalInset)
             self.configuration = configuration
+            updateAttributedTitle()
 
             configurationUpdateHandler = { [weak self] _ in
                 self?.updateAppearance()
@@ -176,6 +177,29 @@ open class PillButton: UIButton {
     @objc private func isUnreadValueDidChange() {
         isUnreadDotVisible = pillBarItem.isUnread
         setNeedsLayout()
+    }
+
+    @objc private func titleValueDidChange() {
+        if #available(iOS 15.0, *) {
+            updateAttributedTitle()
+        } else {
+            setTitle(pillBarItem.title, for: .normal)
+        }
+
+    }
+
+    @available(iOS 15, *)
+    private func updateAttributedTitle() {
+        let itemTitle = pillBarItem.title
+        var attributedTitle = AttributedString(itemTitle)
+        attributedTitle.font = Constants.font
+        configuration?.attributedTitle = attributedTitle
+        
+        // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically
+        accessibilityLabel = itemTitle
+
+        // This sets colors on the attributed string, so it must run whenever we recreate it.
+        updateAppearance()
     }
 
     private func updateUnreadDot() {
@@ -277,8 +301,7 @@ open class PillButton: UIButton {
 
         if #available(iOS 15.0, *) {
             configuration?.background.backgroundColor = resolvedBackgroundColor
-            configuration?.attributedTitle?.setAttributes(AttributeContainer([NSAttributedString.Key.foregroundColor: resolvedTitleColor,
-                                                                              NSAttributedString.Key.font: Constants.font]))
+            configuration?.attributedTitle?.foregroundColor = resolvedTitleColor
         } else {
             backgroundColor = resolvedBackgroundColor
         }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -196,7 +196,7 @@ open class PillButton: UIButton {
         var attributedTitle = AttributedString(itemTitle)
         attributedTitle.font = Constants.font
         configuration?.attributedTitle = attributedTitle
-        
+
         // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically
         accessibilityLabel = itemTitle
 

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -120,7 +120,7 @@ open class PillButton: UIButton {
             self.configuration = configuration
 
             // This updates the attributed title stored in self.configuration,
-            // so it needs to be called after we set it.
+            // so it needs to be called after we set the configuration.
             updateAttributedTitle()
 
             configurationUpdateHandler = { [weak self] _ in

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -18,7 +18,6 @@ public protocol PillButtonBarDelegate {
 /// `PillButtonBarItem` is an item that can be presented as a pill shaped text button.
 @objc(MSFPillButtonBarItem)
 open class PillButtonBarItem: NSObject {
-    @objc public let title: String
 
     /// Creates a new instance of the PillButtonBarItem that holds data used to create a pill button in a PillButtonBar.
     /// - Parameter title: Title that will be displayed by a pill button in the PillButtonBar.
@@ -36,6 +35,15 @@ open class PillButtonBarItem: NSObject {
         self.isUnread = isUnread
     }
 
+    /// Title that will be displayed in the button.
+    @objc public var title: String {
+        didSet {
+            if oldValue != title {
+                NotificationCenter.default.post(name: PillButtonBarItem.titleValueDidChangeNotification, object: self)
+            }
+        }
+    }
+
     /// This value will determine whether or not to show the mark that represents the "unread" state (dot next to the pill button label).
     /// The default value of this property is false.
     public var isUnread: Bool = false {
@@ -48,6 +56,9 @@ open class PillButtonBarItem: NSObject {
 
     /// Notification sent when item's `isUnread` value changes.
     static let isUnreadValueDidChangeNotification = NSNotification.Name(rawValue: "PillButtonBarItemisUnreadValueDidChangeNotification")
+
+    /// Notification sent when item's `title` value changes.
+    static let titleValueDidChangeNotification = NSNotification.Name(rawValue: "PillButtonBarItemTitleValueDidChangeNotification")
 }
 
 // MARK: PillButtonBar


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Despite the naming, PillButtons and their corresponding PillButtonBarItems get used outside of the PillButtonBar.
We have a specific use where we need the title to be mutable (persistent pill button that represents a current tab switcher selection). This PR adds title mutability to the PillButtonBarItem.

This PR also includes a slight adjustment to how iOS 15+ attribute title creation is done. We now set the font as soon as possible, and only leave the color changing to the updateAppearance function. This resolves a bug where intrinsic size was incorrect before updateAppearance runs when dynamic size was enabled.

### Verification

Made a new demo VC that is tailored to Pill buttons outside of the pill button bar.

![Screenshot 2022-10-14 at 5 46 32 PM](https://user-images.githubusercontent.com/3610850/195961394-713ea881-c6d1-4ea6-b330-28c837acbbb6.png)


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot 2022-10-14 at 5 55 21 PM](https://user-images.githubusercontent.com/3610850/195961788-a5c40325-5233-4052-9888-9512a9bff975.png) | ![Screenshot 2022-10-14 at 5 56 06 PM](https://user-images.githubusercontent.com/3610850/195961822-ee713f42-7475-4ebe-8e60-98da80a879b7.png) |

(no visual change to pill button bar intended)

Tested iOS 14 as well to verify the old non-configuration paths still work.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)