### PR TITLE
ios15+ VoiceOver doesn't seem to read selected PillButton

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -109,6 +109,10 @@ open class PillButton: UIButton {
         if #available(iOS 15.0, *) {
             var configuration = UIButton.Configuration.plain()
             configuration.attributedTitle = AttributedString(pillBarItem.title)
+
+            // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically
+            accessibilityLabel = pillBarItem.title
+
             configuration.contentInsets = NSDirectionalEdgeInsets(top: Constants.topInset,
                                                                   leading: Constants.horizontalInset,
                                                                   bottom: Constants.bottomInset,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There seems to be an Apple bug that selected Button doesn't get read out by VoiceOver when using UIButton.Configuration to set the button title rather using setTitle().  For now the workaround is to manually set the accessibility label.

### Verification
Test both on iOS 16 simulator and on device

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/196593811-3e8de5aa-3981-4def-bd07-5f20909a973d.png) | ![Screen Shot 2022-10-18 at 8 51 44 PM](https://user-images.githubusercontent.com/20715435/196593852-d851060f-e808-4f82-ac4c-dcf1936ba04c.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)