### PR TITLE
[Fluent 2 iOS] CardNudge Update

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -81,6 +81,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .stroke2,
              .strokeDisabled,
              .strokeFocus1,
+             .brandBackgroundTint,
              .foregroundDisabled1:
             return UIColor(dynamicColor: aliasTokens.colors[.foreground1])
         case .brandBackground3Pressed,
@@ -94,6 +95,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandForeground1Pressed,
              .brandStroke1Pressed,
              .brandStroke1,
+             .brandForegroundTint,
              .brandStroke1Selected:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundOnColor])
         case .brandBackground3Selected,
@@ -184,7 +186,8 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .stencil2,
                     .backgroundDarkStatic]
         case .brandBackgrounds:
-            return [.brandBackground1,
+            return [.brandBackgroundTint,
+                    .brandBackground1,
                     .brandBackground1Pressed,
                     .brandBackground1Selected,
                     .brandBackground2,
@@ -214,7 +217,8 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .foregroundLightStatic,
                     .foregroundDarkStatic]
         case .brandForegrounds:
-            return [.brandForeground1,
+            return [.brandForegroundTint,
+                    .brandForeground1,
                     .brandForeground1Pressed,
                     .brandForeground1Selected,
                     .brandForeground2,
@@ -354,6 +358,10 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Background Disabled"
         case .brandBackgroundInvertedDisabled:
             return "Brand Background Inverted Disabled"
+        case .brandBackgroundTint:
+            return "Brand Background Tint"
+        case .brandForegroundTint:
+            return "Brand Foreground Tint"
         case .stencil1:
             return "Stencil 1"
         case .stencil2:

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -61,7 +61,7 @@ public struct CardNudge: View, TokenizedControlView {
                 Image(uiImage: icon)
                     .renderingMode(.template)
                     .frame(width: CardNudgeTokenSet.iconSize, height: CardNudgeTokenSet.iconSize, alignment: .center)
-                    .foregroundColor(Color(dynamicColor: tokenSet[.accentColor].dynamicColor))
+                    .foregroundColor(Color(dynamicColor: tokenSet[.buttonForegroundColor].dynamicColor))
             }
             .padding(.trailing, CardNudgeTokenSet.horizontalPadding)
             .showsLargeContentViewer(text: state.title, image: state.mainIcon)
@@ -117,7 +117,7 @@ public struct CardNudge: View, TokenizedControlView {
                 .lineLimit(1)
                 .padding(.horizontal, CardNudgeTokenSet.buttonInnerPaddingHorizontal)
                 .padding(.vertical, CardNudgeTokenSet.verticalPadding)
-                .foregroundColor(Color(dynamicColor: tokenSet[.accentColor].dynamicColor))
+                .foregroundColor(Color(dynamicColor: tokenSet[.buttonForegroundColor].dynamicColor))
                 .background(
                     RoundedRectangle(cornerRadius: tokenSet[.circleRadius].float)
                         .foregroundColor(Color(dynamicColor: tokenSet[.buttonBackgroundColor].dynamicColor))
@@ -137,7 +137,7 @@ public struct CardNudge: View, TokenizedControlView {
                 .padding(.horizontal, CardNudgeTokenSet.buttonInnerPaddingHorizontal)
                 .padding(.vertical, CardNudgeTokenSet.verticalPadding)
                 .accessibility(identifier: dismissLabel)
-                .foregroundColor(Color(dynamicColor: tokenSet[.textColor].dynamicColor))
+                .foregroundColor(Color(dynamicColor: tokenSet[.subtitleTextColor].dynamicColor))
                 .showsLargeContentViewer(text: dismissLabel, image: dismissImage)
             }
         }

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -79,6 +79,7 @@ public struct CardNudge: View, TokenizedControlView {
                 .lineLimit(1)
                 .foregroundColor(Color(dynamicColor: tokenSet[.textColor].dynamicColor))
                 .showsLargeContentViewer(text: state.title, image: state.mainIcon)
+                .font(.fluent(tokenSet[.titleFont].fontInfo))
 
             if hasSecondTextRow {
                 HStack(spacing: CardNudgeTokenSet.accentPadding) {
@@ -94,12 +95,14 @@ public struct CardNudge: View, TokenizedControlView {
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokenSet[.accentColor].dynamicColor))
                             .showsLargeContentViewer(text: accent, image: state.accentIcon)
+                            .font(.fluent(tokenSet[.subtitleFont].fontInfo))
                     }
                     if let subtitle = state.subtitle {
                         Text(subtitle)
                             .lineLimit(1)
                             .foregroundColor(Color(dynamicColor: tokenSet[.subtitleTextColor].dynamicColor))
                             .showsLargeContentViewer(text: subtitle)
+                            .font(.fluent(tokenSet[.subtitleFont].fontInfo))
                     }
                 }
             }
@@ -118,6 +121,7 @@ public struct CardNudge: View, TokenizedControlView {
                 .padding(.horizontal, CardNudgeTokenSet.buttonInnerPaddingHorizontal)
                 .padding(.vertical, CardNudgeTokenSet.verticalPadding)
                 .foregroundColor(Color(dynamicColor: tokenSet[.buttonForegroundColor].dynamicColor))
+                .font(.fluent(tokenSet[.titleFont].fontInfo))
                 .background(
                     RoundedRectangle(cornerRadius: tokenSet[.circleRadius].float)
                         .foregroundColor(Color(dynamicColor: tokenSet[.buttonBackgroundColor].dynamicColor))

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -27,6 +27,8 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
         case circleRadius
         case cornerRadius
         case outlineWidth
+        case titleFont
+        case subtitleFont
     }
 
     init(style: @escaping () -> MSFCardNudgeStyle) {
@@ -95,6 +97,16 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
             case .textColor:
                 return .dynamicColor {
                     theme.aliasTokens.colors[.foreground1]
+                }
+
+            case .titleFont:
+                return .fontInfo {
+                    theme.aliasTokens.typography[.body2Strong]
+                }
+
+            case .subtitleFont:
+                return .fontInfo {
+                    theme.aliasTokens.typography[.caption1]
                 }
             }
         }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -17,17 +17,40 @@ import SwiftUI
 /// Design token set for the `CardNudge` control.
 public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
+        /// The  color applied to the accent text and icon
         case accentColor
+
+        /// The background color of the`CardNudge` control
         case backgroundColor
+
+        /// The background color of the action button and main icon
         case buttonBackgroundColor
+
+        /// The foreground color of the action button and main icon
         case buttonForegroundColor
+
+        /// The color of the outline of the`CardNudge` control
         case outlineColor
+
+        /// The color of the subtitle text and dismiss icon
         case subtitleTextColor
+
+        /// The color of the title text
         case textColor
+
+        /// The circle radius of the main icon
         case circleRadius
+
+        /// The corner radius of the action button and the`CardNudge` control
         case cornerRadius
+
+        /// The width of the`CardNudge` control outline
         case outlineWidth
+
+        /// The font applied to the title text and action button text
         case titleFont
+
+        /// The font applied to the subtitle text and the accent text
         case subtitleFont
     }
 

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -20,6 +20,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
         case accentColor
         case backgroundColor
         case buttonBackgroundColor
+        case buttonForegroundColor
         case outlineColor
         case subtitleTextColor
         case textColor
@@ -34,24 +35,29 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
             switch token {
             case .accentColor:
                 return .dynamicColor {
-                    theme.aliasTokens.brandColors[.shade20]
+                    theme.aliasTokens.colors[.brandForeground1]
                 }
 
             case .backgroundColor:
                 switch style() {
                 case .standard:
                     return .dynamicColor {
-                        theme.aliasTokens.backgroundColors[.neutral2]
+                        theme.aliasTokens.colors[.canvasBackground]
                     }
                 case .outline:
                     return .dynamicColor {
-                        theme.aliasTokens.backgroundColors[.neutral1]
+                        theme.aliasTokens.colors[.background1]
                     }
+            }
 
-                }
             case .buttonBackgroundColor:
                 return .dynamicColor {
-                    theme.aliasTokens.brandColors[.tint30]
+                    theme.aliasTokens.colors[.brandBackgroundTint]
+                }
+
+            case .buttonForegroundColor:
+                return .dynamicColor {
+                    theme.aliasTokens.colors[.brandForegroundTint]
                 }
 
             case .circleRadius:
@@ -83,19 +89,12 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .subtitleTextColor:
                 return .dynamicColor {
-                    theme.aliasTokens.foregroundColors[.neutral3]
+                    theme.aliasTokens.colors[.foreground2]
                 }
 
             case .textColor:
-                switch style() {
-                case .standard:
-                    return .dynamicColor {
-                        theme.aliasTokens.foregroundColors[.neutral1]
-                    }
-                case .outline:
-                    return .dynamicColor {
-                        theme.aliasTokens.brandColors[.shade20]
-                    }
+                return .dynamicColor {
+                    theme.aliasTokens.colors[.foreground1]
                 }
             }
         }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -74,11 +74,11 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
                 switch style() {
                 case .standard:
                     return .dynamicColor {
-                        theme.aliasTokens.backgroundColors[.neutral2]
+                        theme.aliasTokens.colors[.canvasBackground]
                     }
                 case .outline:
                     return .dynamicColor {
-                        theme.aliasTokens.strokeColors[.neutral1]
+                        theme.aliasTokens.colors[.stroke2]
                     }
                 }
 
@@ -107,7 +107,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 // MARK: - Constants
 
 extension CardNudgeTokenSet {
-    static let iconSize: CGFloat = GlobalTokens.iconSize(.xSmall)
+    static let iconSize: CGFloat = GlobalTokens.iconSize(.medium)
     static let circleSize: CGFloat = GlobalTokens.iconSize(.xxLarge)
     static let accentIconSize: CGFloat = GlobalTokens.iconSize(.xxSmall)
     static let accentPadding: CGFloat = GlobalTokens.spacing(.xxSmall)

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -455,6 +455,7 @@ public final class AliasTokens {
         case foregroundOnColor
         case foregroundInverted1
         case foregroundInverted2
+        case brandForegroundTint
         case brandForeground1
         case brandForeground1Pressed
         case brandForeground1Selected
@@ -490,6 +491,7 @@ public final class AliasTokens {
         case background6Selected
         case backgroundInverted
         case backgroundDisabled
+        case brandBackgroundTint
         case brandBackground1
         case brandBackground1Pressed
         case brandBackground1Selected
@@ -550,6 +552,9 @@ public final class AliasTokens {
         case .foregroundInverted2:
             return DynamicColor(light: strongSelf.brandColors[.comm80].light,
                                 dark: GlobalTokens.neutralColors(.white))
+        case .brandForegroundTint:
+            return DynamicColor(light: strongSelf.brandColors[.comm60].light,
+                                dark: strongSelf.brandColors[.comm130].light)
         case .brandForeground1:
             return DynamicColor(light: strongSelf.brandColors[.comm80].light,
                                 dark: strongSelf.brandColors[.comm100].light)
@@ -672,6 +677,9 @@ public final class AliasTokens {
          return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
                              dark: GlobalTokens.neutralColors(.grey32),
                              darkElevated: GlobalTokens.neutralColors(.grey32))
+        case .brandBackgroundTint:
+            return DynamicColor(light: strongSelf.brandColors[.comm150].light,
+                                dark: strongSelf.brandColors[.comm40].light)
         case .brandBackground1:
             return DynamicColor(light: strongSelf.brandColors[.comm80].light,
                                 dark: strongSelf.brandColors[.comm100].light)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`CardNudge` was updated to match fluent 2 specs. I also added of `brandBackgroundTint` and `brandForegroundTint` to `AliasTokens` as part of this PR.

### Verification

The changes were tested on the demo app.

**Alias Color Tokens**
| Brand Background Tint                                       | Brand Foreground Tint                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="brand_background_light" src="https://user-images.githubusercontent.com/106181067/196785003-cb023ba8-4de5-49ee-a0de-639154b9f90a.png"> | <img width="488" alt="brand_foreground_light" src="https://user-images.githubusercontent.com/106181067/196785098-ec5abc23-4bd2-4e11-98f2-d8a28abba339.png"> |
| <img width="488" alt="brand_background_dark" src="https://user-images.githubusercontent.com/106181067/196785158-80a07876-0366-4021-a569-b0ce63057bb2.png"> | <img width="488" alt="brand_foreground_dark" src="https://user-images.githubusercontent.com/106181067/196785209-8310a7e7-5e59-4b40-8e84-12bc10bf9f0e.png"> |

**Card Nudge**
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_light" src="https://user-images.githubusercontent.com/106181067/196785758-16edca5a-58b1-4ba2-8ed3-e83ab2cb08cd.png"> | <img width="488" alt="after_light" src="https://user-images.githubusercontent.com/106181067/196785806-f3eaf597-e510-4ca0-8808-1ce6dc6847ae.png"> |
| <img width="488" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/196785860-de78bd0d-16fb-4c34-bef9-a7fd0958f2b1.png"> | <img width="488" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/196785910-7d4396b0-abd4-4c78-8f31-f2632138acdf.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)