### PR TITLE
Fix `TabBarItemView` losing tint color when backgrounded

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -20,6 +20,7 @@ class TabBarItemView: UIControl {
         didSet {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected
+            updateImage()
             updateColors()
             if isSelected {
                 accessibilityTraits.insert(.selected)
@@ -242,10 +243,13 @@ class TabBarItemView: UIControl {
         }
     }
 
-    private func updateLayout() {
-        imageView.image = item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
-        imageView.highlightedImage = item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
+    private func updateImage() {
+        imageView.image = imageView.isHighlighted ?
+                            item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden) :
+                            item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
+    }
 
+    private func updateLayout() {
         if isInPortraitMode {
             container.axis = .vertical
             container.spacing = Constants.spacingVertical
@@ -266,6 +270,7 @@ class TabBarItemView: UIControl {
             }
         }
 
+        updateImage()
         updateBadgeView()
         invalidateIntrinsicContentSize()
     }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -244,6 +244,9 @@ class TabBarItemView: UIControl {
     }
 
     private func updateImage() {
+        // Normally we'd set imageView.image and imageView.highlightedImage separately. However, there's a known issue with
+        // UIImageView in iOS 16 where highlighted images lose their tint color in certain scenarios. While we wait for a fix,
+        // this is a straightforward workaround that gets us the same effect without triggering the bug.
         imageView.image = imageView.isHighlighted ?
                             item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden) :
                             item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There's a known issue with iOS 16 instances of `UIImageView` dropping the `tintColor` of their `highlightedImage`, especially when the app is backgrounded and restored. While we wait for an official fix, we can work around the issue by manually swapping out the main `image` property.

### Verification

Verified that the old issue does not repro, and that images continue to highlight as expected.

#### Before:
https://user-images.githubusercontent.com/4934719/197026053-e3083e3d-130c-481a-9148-0be1f9d64517.mp4

#### After:
https://user-images.githubusercontent.com/4934719/197026049-2b4f3c63-e99f-40ff-ae74-818511905800.mp4

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1300)