### PR TITLE
fix accessibilityElements for BottomCommandingController

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -1036,6 +1036,19 @@ extension BottomCommandingController: BottomSheetControllerDelegate {
     }
 
     public func bottomSheetController(_ bottomSheetController: BottomSheetController, didMoveTo expansionState: BottomSheetExpansionState, interaction: BottomSheetInteraction) {
+
+        // bottomSheetView is purposefully the sibling of contentViewController's view so that users can interact with UIControls behind the sheet.
+        // However, when bottomSheet is expanded and VoiceOver is on, users can still interact with the elements behind the sheet which is confusing
+        // because visual users DimmingView blocks the interaction. The work around is to temporarily hide other accessibilityElements outside of bottomSheetController's view.
+        if expansionState == .expanded {
+            contentViewController?.view.accessibilityElementsHidden = true
+            navigationController?.navigationBar.accessibilityElementsHidden = true
+        } else {
+            contentViewController?.view.accessibilityElementsHidden = false
+            navigationController?.navigationBar.accessibilityElementsHidden = false
+        }
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+
         let commandingInteraction: BottomCommandingInteraction = interaction == .noUserAction ? .noUserAction : .sheetInteraction
         delegate?.bottomCommandingController?(self, sheetDidMoveTo: expansionState, commandingInteraction: commandingInteraction, sheetInteraction: interaction)
     }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -579,7 +579,7 @@ public class BottomSheetController: UIViewController {
     }
 
     // When the bottomsheet is expanded and dimmingView is shown, we should make dimmingView accessibility
-    // DimmingView is technially full screen. However, for accessibility users, we should update the dimmingView's accessibilityFrame to be only the offset from bottomsheet's frame.
+    // DimmingView is technically full screen. However, for accessibility users, we should update the dimmingView's accessibilityFrame to be only the offset from bottomsheet's frame.
     private func updateDimmingViewAccessibility() {
         guard shouldShowDimmingView else {
             return

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -387,6 +387,10 @@ public class BottomSheetController: UIViewController {
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
         dimmingView.alpha = 0.0
 
+        dimmingView.accessibilityLabel = "Accessibility.Dismiss.Label".localized
+        dimmingView.accessibilityHint = "Accessibility.Dismiss.Hint".localized
+        dimmingView.accessibilityTraits = .button
+
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleDimmingViewTap))
         dimmingView.addGestureRecognizer(tapGesture)
         return dimmingView
@@ -467,6 +471,7 @@ public class BottomSheetController: UIViewController {
             updateSheetLayoutGuideTopConstraint()
             updateExpandedContentAlpha()
             updateDimmingViewAlpha()
+            updateDimmingViewAccessibility()
         }
         collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
     }
@@ -573,6 +578,25 @@ public class BottomSheetController: UIViewController {
         dimmingView.alpha = targetAlpha
     }
 
+    // When the bottomsheet is expanded and dimmingView is shown, we should make dimmingView accessibility
+    // DimmingView is technially full screen. However, for accessibility users, we should update the dimmingView's accessibilityFrame to be only the offset from bottomsheet's frame.
+    private func updateDimmingViewAccessibility() {
+        guard shouldShowDimmingView else {
+            return
+        }
+
+        if dimmingView.alpha == 0 {
+            dimmingView.isAccessibilityElement = false
+            view.accessibilityViewIsModal = false
+        } else {
+            dimmingView.isAccessibilityElement = true
+            var margins: UIEdgeInsets = .zero
+            margins.bottom = bottomSheetView.frame.height
+            dimmingView.accessibilityFrame = view.frame.inset(by: margins)
+            view.accessibilityViewIsModal = true
+        }
+    }
+
     private func updateSheetLayoutGuideTopConstraint() {
         if sheetLayoutGuideTopConstraint.constant != currentSheetVerticalOffset {
             sheetLayoutGuideTopConstraint.constant = currentSheetVerticalOffset
@@ -614,6 +638,7 @@ public class BottomSheetController: UIViewController {
         updateSheetLayoutGuideTopConstraint()
         updateExpandedContentAlpha()
         updateDimmingViewAlpha()
+        updateDimmingViewAccessibility()
     }
 
     // Source of truth for the sheet frame at a given offset from the top of the root view bounds.
@@ -752,6 +777,7 @@ public class BottomSheetController: UIViewController {
             strongSelf.updateDimmingViewAlpha()
             strongSelf.updateExpandedContentAlpha()
             strongSelf.view.layoutIfNeeded()
+            strongSelf.updateDimmingViewAccessibility()
         }
 
         translationAnimator.addCompletion({ [weak self] finalPosition in


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
When bottomsheet was expanded, if user swipes left via Voiceover gestures, they can still access the elements behind the dimmingView. 

- Add accessiblityLabel and hints similar to DrawerController
- When dimmingView is shown with alpha =1, make dimmingView accessible
- Update dimmingView accessibility frame that matches the visuals
- When expanded, hide all other sibling accessibilityElements from the VoiceOver tree

### Verification

Test BottomCommandingController  demo app on iPhone and iPad device

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://user-images.githubusercontent.com/20715435/197261281-4ad52d02-fbfd-4301-aaa0-ddb49bf2a2de.MP4 |  https://user-images.githubusercontent.com/20715435/197260325-862e5d84-eb85-4d48-8da1-c1c293147b29.MP4|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1302)