### PR TITLE
[main_0.8] Cherry-picking TabBar + PillButton changes

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -109,6 +109,10 @@ open class PillButton: UIButton {
         if #available(iOS 15.0, *) {
             var configuration = UIButton.Configuration.plain()
             configuration.attributedTitle = AttributedString(pillBarItem.title)
+
+            // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically
+            accessibilityLabel = pillBarItem.title
+
             configuration.contentInsets = NSDirectionalEdgeInsets(top: Constants.topInset,
                                                                   leading: Constants.horizontalInset,
                                                                   bottom: Constants.bottomInset,

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -20,6 +20,7 @@ class TabBarItemView: UIControl {
         didSet {
             titleLabel.isHighlighted = isSelected
             imageView.isHighlighted = isSelected
+            updateImage()
             updateColors()
             if isSelected {
                 accessibilityTraits.insert(.selected)
@@ -242,10 +243,16 @@ class TabBarItemView: UIControl {
         }
     }
 
-    private func updateLayout() {
-        imageView.image = item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
-        imageView.highlightedImage = item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
+    private func updateImage() {
+        // Normally we'd set imageView.image and imageView.highlightedImage separately. However, there's a known issue with
+        // UIImageView in iOS 16 where highlighted images lose their tint color in certain scenarios. While we wait for a fix,
+        // this is a straightforward workaround that gets us the same effect without triggering the bug.
+        imageView.image = imageView.isHighlighted ?
+                            item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden) :
+                            item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
+    }
 
+    private func updateLayout() {
         if isInPortraitMode {
             container.axis = .vertical
             container.spacing = Constants.spacingVertical
@@ -266,6 +273,7 @@ class TabBarItemView: UIControl {
             }
         }
 
+        updateImage()
         updateBadgeView()
         invalidateIntrinsicContentSize()
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- #1300 
- #1302 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1304)