### PR TITLE
ability to customize resizehandle a11ylabel for BottomCommandingController

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -322,6 +322,22 @@ open class BottomCommandingController: UIViewController {
         updateSheetHeaderSizingParameters()
     }
 
+    /// A string to optionally customize the accessibility label of the bottom sheet handle.
+    /// The message should convey the "Expand" action and will be used when the bottom sheet is collapsed.
+    @objc public var handleExpandCustomAccessibilityLabel: String? {
+        didSet {
+            bottomSheetController?.handleExpandCustomAccessibilityLabel = handleExpandCustomAccessibilityLabel
+        }
+    }
+
+    /// A string to optionally customize the accessibility label of the bottom sheet handle.
+    /// The message should convey the "Collapse" action and will be used when the bottom sheet is expanded.
+    @objc public var handleCollapseCustomAccessibilityLabel: String? {
+        didSet {
+            bottomSheetController?.handleCollapseCustomAccessibilityLabel = handleCollapseCustomAccessibilityLabel
+        }
+    }
+
     private func setupCommandingLayout(traitCollection: UITraitCollection, forceLayoutPass: Bool = false) {
         if traitCollection.horizontalSizeClass == .regular && traitCollection.userInterfaceIdiom == .pad {
             setupBottomBarLayout(forceLayoutPass: forceLayoutPass)


### PR DESCRIPTION
…ndingController.swift

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

While BottomSheetController had  `handleExpandCustomAccessibilityLabel` and `handleCollapseCustomAccessibilityLabel` they weren't available in BottomCommandingController. 

### Verification

iPhone Device testing on collapsed and expanded commanding bar

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/197307022-5eeb4f79-0067-4538-b000-363f0c97737b.png) | ![image](https://user-images.githubusercontent.com/20715435/197306750-347351db-f7d5-4e60-923a-2f7d22f9fc30.png) |
| ![image](https://user-images.githubusercontent.com/20715435/197307044-cdd267cc-6081-4dcb-ab9c-01cde2cb1df9.png) | ![image](https://user-images.githubusercontent.com/20715435/197306776-a6c100b0-cfe8-4027-befc-3163ba1c7288.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1310)