### PR TITLE
add accessibilityHint on personlistview cells

### DIFF
--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -183,10 +183,12 @@ extension PersonaListView: UITableViewDataSource {
             guard let cell = dequeueReusableCell(withIdentifier: PersonaCell.identifier, for: indexPath) as? PersonaCell else {
                 return UITableViewCell()
             }
-            let persona = personaList[indexPath.row]
+            let index = indexPath.row
+            let persona = personaList[index]
             cell.setup(persona: persona, accessoryType: accessoryType)
             cell.backgroundStyleType = .clear
             cell.accessibilityTraits = .button
+            cell.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, personaList.count)
             return cell
         case .searchDirectory:
             switch searchDirectoryState {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
add the cell index as a hint for Voiceover users.

### Verification
iPhone Device with VoiceOver

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![IMG_0046](https://user-images.githubusercontent.com/20715435/197308624-15adc31b-ea14-4bf2-991b-42a61c0f5189.PNG)| ![IMG_0047](https://user-images.githubusercontent.com/20715435/197308637-fcc0383b-6e81-4b84-bc69-1df617add7a9.PNG) |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1311)