### PR TITLE
re-expose public enum for personaviewlist

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -116,7 +116,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleAppendPersona() {
-        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
             let random = Int.random(in: 0...personas.count - 1)
             let persona = personas[random]
             add(persona, to: carousel)
@@ -124,7 +124,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleRemovePersona() {
-        carousels.forEach { (_ : MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
             let state = carousel.state
             let count = state.count
             if count > 0 {

--- a/ios/FluentUI/Navigation/Helpers/NavigationAnimator.swift
+++ b/ios/FluentUI/Navigation/Helpers/NavigationAnimator.swift
@@ -50,7 +50,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
         let isTemporary: Bool
 
         /// A custom animation block executed during the animation
-        var customAnimation : (() -> Void)?
+        var customAnimation: (() -> Void)?
     }
 
     private typealias ViewFrameTransitionGroups = (group1: [ViewFrameTransition], group2: [ViewFrameTransition])
@@ -138,7 +138,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
 
     /// Creates a transition for two background views that are placed under the "to" and "from" view controllers, and the navigation controller's subviews.
     /// The background that appears on top has a shadow that fades out during the transition.
-    private func createBackgroundTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createBackgroundTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         let frame = transitionContext.containerView.bounds
 
         let fromBgView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 1.0, height: 1.0)))
@@ -174,7 +174,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
     }
 
     /// Creates the transitions for the "to" and "from" view controllers.
-    private func createViewControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createViewControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         guard let fromVC = transitionContext.viewController(forKey: .from), let toVC = transitionContext.viewController(forKey: .to) else {
             return
         }
@@ -188,7 +188,7 @@ class NavigationAnimator: UIPercentDrivenInteractiveTransition, UIViewController
 
     /// Creates the transitions for the Navigation Controller which must be an instance of `NavigationController`.
     /// All subviews including Navigation Bar and Toolbar are animated.
-    private func createNavigationControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions : inout ViewFrameTransitionGroups) {
+    private func createNavigationControllerTransitions(_ transitionContext: UIViewControllerContextTransitioning, frameTransitions: inout ViewFrameTransitionGroups) {
         guard let navigationController = navigationController as? NavigationController else {
             return
         }

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -25,7 +25,7 @@ public protocol PersonaListViewSearchDirectoryDelegate {
 @objc(MSFPersonaListView)
 open class PersonaListView: UITableView {
     /// SearchDirectory button state enum
-    enum SearchDirectoryState {
+    public enum SearchDirectoryState {
         case idle
         case searching
         case displayingSearchResults
@@ -44,7 +44,7 @@ open class PersonaListView: UITableView {
     }
 
     /// searchDIrectoryState variable (persona list to reload rows on state change)
-    var searchDirectoryState: SearchDirectoryState = .idle {
+    public var searchDirectoryState: SearchDirectoryState = .idle {
         didSet {
             if searchDirectoryState != oldValue {
                 UIView.performWithoutAnimation {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

partial revert of https://github.com/microsoft/fluentui-apple/pull/974
re expose SearchDirectoryState
miscellaneous : fix swiftlint issues on this branch

### Verification
run iphone personaviewlist.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1313)