### PR TITLE
partial revert of PR#974 reexpose SearchDirectoryState as public

### DIFF
--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -25,7 +25,7 @@ public protocol PersonaListViewSearchDirectoryDelegate {
 @objc(MSFPersonaListView)
 open class PersonaListView: UITableView {
     /// SearchDirectory button state enum
-    enum SearchDirectoryState {
+    public enum SearchDirectoryState {
         case idle
         case searching
         case displayingSearchResults
@@ -44,7 +44,7 @@ open class PersonaListView: UITableView {
     }
 
     /// searchDIrectoryState variable (persona list to reload rows on state change)
-    var searchDirectoryState: SearchDirectoryState = .idle {
+    public var searchDirectoryState: SearchDirectoryState = .idle {
         didSet {
             if searchDirectoryState != oldValue {
                 UIView.performWithoutAnimation {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

partial revert of https://github.com/microsoft/fluentui-apple/pull/974
There was a client using SearchDirectoryState. Make it public again


### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/197651324-c70412ff-baba-4523-a2c6-e3e802f92df8.png) | ![image](https://user-images.githubusercontent.com/20715435/197651307-3aa23841-05e7-4df1-9f3f-9b10182e2e34.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1315)