### PR TITLE
Fix TableViewCell grouped style header color

### DIFF
--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -81,10 +81,16 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1] }
+                return .dynamicColor {
+                    DynamicColor(light: theme.aliasTokens.colors[.background1].light,
+                                 dark: theme.aliasTokens.colors[.background1].dark)
+                }
 
             case .backgroundGroupedColor:
-                return .dynamicColor { theme.aliasTokens.colors[.canvasBackground] }
+                return .dynamicColor {
+                    DynamicColor(light: theme.aliasTokens.colors[.canvasBackground].light,
+                                 dark: theme.aliasTokens.colors[.canvasBackground].dark)
+                }
 
             case .cellBackgroundColor:
                 return .dynamicColor { theme.aliasTokens.colors[.background1] }

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -81,16 +81,10 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor {
-                    DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                 dark: theme.aliasTokens.colors[.background1].dark)
-                }
+                return .dynamicColor { theme.aliasTokens.colors[.background1] }
 
             case .backgroundGroupedColor:
-                return .dynamicColor {
-                    DynamicColor(light: theme.aliasTokens.colors[.canvasBackground].light,
-                                 dark: theme.aliasTokens.colors[.canvasBackground].dark)
-                }
+                return .dynamicColor { theme.aliasTokens.colors[.canvasBackground] }
 
             case .cellBackgroundColor:
                 return .dynamicColor { theme.aliasTokens.colors[.background1] }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -49,7 +49,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .header, .footer, .headerPrimary:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+                return .clear
             case .divider:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
             case .dividerHighlighted:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A bug was filed pointing out that the `TableViewCell` grouped style looked incorrect as the background was all white instead of being light grey in the header/footer areas. To fix the issue, `TableViewHeaderFooterView` background has been reverted to clear color as it used to be in fluent 1. 

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_light" src="https://user-images.githubusercontent.com/106181067/197873871-99fc31cc-5393-433c-b7b0-e3a9bb7b610f.png"> | <img width="488" alt="after_light" src="https://user-images.githubusercontent.com/106181067/197873946-3420c657-a55c-48e3-8f4c-3fcc8acbda29.png"> |
| <img width="488" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/197873995-6b615abb-c0da-4826-8b75-2f3ef2db5f8f.png"> | <img width="488" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/197874034-65fc3c6b-f573-4815-bd9b-21bf77af7f56.png"> |
| ![before_keyboard_light](https://user-images.githubusercontent.com/106181067/198134620-ace79fb2-54da-41a6-a393-29e54435069b.gif) | ![after_keyboard_light](https://user-images.githubusercontent.com/106181067/198134655-466117eb-f4d1-4842-a444-5c431a7b7fad.gif) |
| ![before_keyboard_dark](https://user-images.githubusercontent.com/106181067/198134686-63adfa01-61ac-467b-ac0c-f00668562390.gif) | ![after_keyboard_dark](https://user-images.githubusercontent.com/106181067/198134717-c612bb77-c42a-4db4-bb5a-e6368776394b.gif) |
| <img width="856" alt="before_grouped_tvc_light" src="https://user-images.githubusercontent.com/106181067/198134783-a34c7d81-c534-468f-89d6-18b61d082675.png"> | <img width="856" alt="tvc_light" src="https://user-images.githubusercontent.com/106181067/198163140-e5b54b4a-ba60-4633-929c-777656e791fc.png"> |
| <img width="856" alt="before_grouped_tvc_dark" src="https://user-images.githubusercontent.com/106181067/198134874-961f8ec8-4870-476e-9a3d-415529838b13.png"> | <img width="856" alt="tvc_dark" src="https://user-images.githubusercontent.com/106181067/198163163-33028255-61e8-4b50-a418-d9e9084c58a7.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1320)