### PR TITLE
Fix bottom sheet VO order when it's hosting a navigation controller

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -21,7 +21,7 @@ class BottomSheetDemoController: UIViewController {
         view.addSubview(optionTableView)
         mainTableView = optionTableView
 
-        let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: expandedContentView)
+        let bottomSheetViewController = BottomSheetController(headerContentView: headerView, expandedContentView: contentNavigationController.view)
         bottomSheetViewController.hostedScrollView = personaListView
         bottomSheetViewController.headerContentHeight = BottomSheetDemoController.headerHeight
         bottomSheetViewController.delegate = self
@@ -173,6 +173,27 @@ class BottomSheetDemoController: UIViewController {
             label.centerYAnchor.constraint(equalTo: bottomView.centerYAnchor)
         ])
         return view
+    }()
+
+    private lazy var contentNavigationController: UIViewController = {
+        let contentVC = UIViewController()
+        let contentVCView: UIView = contentVC.view
+        let barButtonItem = UIBarButtonItem(title: "Sample", style: .done, target: nil, action: nil)
+
+        contentVC.navigationItem.title = "Nav title"
+        contentVC.navigationItem.rightBarButtonItem = barButtonItem
+        contentVCView.addSubview(expandedContentView)
+
+        expandedContentView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            expandedContentView.leadingAnchor.constraint(equalTo: contentVCView.leadingAnchor),
+            expandedContentView.trailingAnchor.constraint(equalTo: contentVCView.trailingAnchor),
+            expandedContentView.topAnchor.constraint(equalTo: contentVCView.topAnchor),
+            expandedContentView.bottomAnchor.constraint(equalTo: contentVCView.bottomAnchor)
+        ])
+
+        return UINavigationController(rootViewController: contentVC)
     }()
 
     private let headerView: UIView = {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -417,6 +417,8 @@ public class BottomSheetController: UIViewController {
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
+        // Some types of content (like navigation controllers) can mess up the VO order.
+        // Explicitly specifying a11y elements helps prevents this.
         bottomSheetContentView.accessibilityElements = [resizingHandleView]
 
         if let headerView = headerContentView {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -417,11 +417,15 @@ public class BottomSheetController: UIViewController {
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
+        bottomSheetContentView.accessibilityElements = [resizingHandleView]
+
         if let headerView = headerContentView {
             stackView.addArrangedSubview(headerView)
+            bottomSheetContentView.accessibilityElements?.append(headerView)
         }
 
         stackView.addArrangedSubview(expandedContentView)
+        bottomSheetContentView.accessibilityElements?.append(expandedContentView)
         bottomSheetContentView.addSubview(stackView)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Bottom sheet VO order is incorrect when a navigation controller is hosted in the sheet. It seems like there is some default system behavior that gives nested navigation controllers a higher VO priority.

#### In regular use, VO order is:
Parent nav controller
main content (or dimming view when visible)
sheet resizing handle
sheet header view (if present)
sheet expanded content.

#### But when the sheet hosts a navigation controller, the order changes to this:
Parent nav controller
(skips main content, resizing handle, and sheet header)
Sheet-hosted nav controller
the rest

To fix this, let's explicitly specify the order of a11y elements in the bottom sheet view.

### Verification

Modified the demo app to include nav controller case.

#### Broken - before

https://user-images.githubusercontent.com/3610850/197902663-55a95c16-1c6d-4dc4-a7ac-825f1da96f66.mov


#### Fixed - after

https://user-images.githubusercontent.com/3610850/197902697-8b86ba31-3c75-46c8-b87d-c1197a9fb457.mov

Tested on device and simulator with a11y inspector.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1321)