### PR TITLE
Update Shimmer colors

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -27,6 +27,7 @@ struct Demos {
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
+        DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self)
     ]
 
@@ -58,7 +59,6 @@ struct Demos {
         DemoDescriptor("PopupMenuController", PopupMenuDemoController.self),
         DemoDescriptor("SearchBar", SearchBarDemoController.self),
         DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
-        DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TabBarView", TabBarViewDemoController.self),
         DemoDescriptor("TableViewCellFileAccessoryView", TableViewCellFileAccessoryViewDemoController.self),

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -56,7 +56,7 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
 
     init(style: @escaping () -> MSFShimmerStyle) {
         self.style = style
-        super.init { [style] token, _ in
+        super.init { [style] token, theme in
             switch token {
             case .shimmerAlpha:
                 return .float {
@@ -72,13 +72,9 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .concealing:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                                            dark: GlobalTokens.neutralColors(.grey8))
+                        return theme.aliasTokens.colors[.stencil2]
                     case .revealing:
-                        return DynamicColor(light: ColorValue(0xF1F1F1) /* gray50 */,
-                                            lightHighContrast: ColorValue(0x919191) /* gray400 */,
-                                            dark: ColorValue(0x404040) /* gray600 */,
-                                            darkHighContrast: ColorValue(0x919191) /* gray400 */)
+                        return theme.aliasTokens.colors[.stencil1]
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`Shimmer` colors were updated to fluent 2. The Shimmer demo was added to the fluent 2 section in the demo app.

### Verification

The changes were tested on the demo app

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_shimmer1_light](https://user-images.githubusercontent.com/106181067/198137519-87a12503-a3e6-42a7-9caa-fb84498de4ce.gif) | ![after_shimmer1_light](https://user-images.githubusercontent.com/106181067/198137573-49989c58-2065-43b2-b6a4-f2aee2ad4b13.gif) |
| ![before_shimmer1_dark](https://user-images.githubusercontent.com/106181067/198137693-eb39c960-58c5-48a2-9744-cb2f8c5e3d53.gif) | ![after_shimmer1_dark](https://user-images.githubusercontent.com/106181067/198137723-9f7ffd86-14ad-46c2-ae97-7416b8b1a349.gif) |
| ![before_shimmer2_light](https://user-images.githubusercontent.com/106181067/198137851-4c03c56a-77a4-41f3-9b23-f8c51503ace2.gif) | ![after_shimmer2_light](https://user-images.githubusercontent.com/106181067/198137962-6ec75c13-b206-4a61-99b5-ac10ecea02e8.gif) |
| ![before_shimmer2_dark](https://user-images.githubusercontent.com/106181067/198138079-cf0e2512-6f79-4c96-9fe6-7638c95c0eae.gif) | ![after_shimmer2_dark](https://user-images.githubusercontent.com/106181067/198138186-f2756eb3-3bc7-4b48-a453-e1d399c5de8d.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1322)