### PR TITLE
Fix SearchBar placeholder text contrast issue

### DIFF
--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -57,7 +57,7 @@ open class SearchBar: UIView {
         func placeholderColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .lightContent, .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .brandContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The `SearchBar`'s placeholder text had a contrast ratio issue with the light background. Its color token has been updated to fix the issue.

### Verification

The change was tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_searchbar_light" src="https://user-images.githubusercontent.com/106181067/198140321-53a68fd4-7cca-462c-b0fe-17a3ba3af4d4.png"> | <img width="487" alt="after_searchbar_light" src="https://user-images.githubusercontent.com/106181067/198140351-0762f4d2-0c6e-4b90-99ab-62999892112a.png"> |
| <img width="487" alt="before_searchbar_dark" src="https://user-images.githubusercontent.com/106181067/198140394-b6251eb8-a2e6-47c2-93d9-401c4b7eeb4b.png"> | <img width="487" alt="after_searchbar_dark" src="https://user-images.githubusercontent.com/106181067/198140434-2fd65681-8c61-4a2a-9a2d-f6de9a45ac79.png"> |
| <img width="592" alt="before_cca" src="https://user-images.githubusercontent.com/106181067/198140464-a72834ce-8d23-4cde-a689-a19baa5ead6a.png"> | <img width="592" alt="after_cca" src="https://user-images.githubusercontent.com/106181067/198140490-a21fc7fa-ab55-4bbb-ac81-15e34d99f7c5.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)