### PR TITLE
Update Tooltip colors

### DIFF
--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -159,10 +159,10 @@ class TooltipView: UIView {
     }
 
     private func updateColors() {
-        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundInverted])
+        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundDarkStatic])
         backgroundView.backgroundColor = backgroundColor
         arrowImageView.image = arrowImageViewBaseImage?.withTintColor(backgroundColor, renderingMode: .alwaysOriginal)
-        messageLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundInverted1])
+        messageLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic])
     }
 
     // MARK: - Accessibility


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`Tooltip` spec has been updated. This PR implements the new color tokens.

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="before_tooltip_light" src="https://user-images.githubusercontent.com/106181067/198147556-dcab23f1-3194-4de2-bf7c-c0a6c1e6865c.png"> | <img width="488" alt="after_tooltip_light" src="https://user-images.githubusercontent.com/106181067/198147598-7b1765cb-264d-4b0f-8afc-14bf7319f721.png"> |
| <img width="488" alt="before_tooltip_dark" src="https://user-images.githubusercontent.com/106181067/198147634-6b0f1d5f-8245-4f1b-8671-fd46e019356b.png"> | <img width="488" alt="after_tooltip_dark" src="https://user-images.githubusercontent.com/106181067/198147666-98a99ea2-9663-4d93-bf12-2631148d2519.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1324)