### PR TITLE
Fix secondary label contrast issue

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -19,7 +19,7 @@ public enum TextColorStyle: Int, CaseIterable {
         case .regular:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         case .secondary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
         case .white:
             return .white
         case .primary:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Secondary `Label` was changed to use FG2 since FG3 fails contrast tests against the white background.

### Verification

The change was tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="592" alt="before_cca" src="https://user-images.githubusercontent.com/106181067/198357599-a4b0f92e-4bd5-4cfa-b8a3-da6d08405053.png"> | <img width="592" alt="after_cca" src="https://user-images.githubusercontent.com/106181067/198357630-5d87b9d7-75bc-4350-9159-fefcb3c06aca.png"> |
| <img width="444" alt="before_label_light" src="https://user-images.githubusercontent.com/106181067/198357677-9dbdc047-7585-492f-bae2-b9b21f14105f.png"> | <img width="488" alt="after_label_light" src="https://user-images.githubusercontent.com/106181067/198357719-50280672-8b53-4125-bd63-c27402358fbe.png"> |
| <img width="488" alt="before_label_dark" src="https://user-images.githubusercontent.com/106181067/198357749-79eb8056-5c36-43ac-b901-77e4e487973b.png"> | <img width="488" alt="after_label_dark" src="https://user-images.githubusercontent.com/106181067/198357776-e9d650cc-bf7e-424d-807c-cdad98d2ef12.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1325)