### PR TITLE
Add accessibilityIdentifier property to CommandBarItem

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -116,6 +116,7 @@ class CommandBarButton: UIButton {
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
         accessibilityHint = item.accessibilityHint
         accessibilityValue = item.accessibilityValue
+        accessibilityIdentifier = item.accessibilityIdentifier
     }
 
     private let isPersistSelection: Bool

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -124,7 +124,7 @@ open class CommandBarItem: NSObject {
         }
     }
 
-    /// A string that uniquely identiifes the element, typically for automation purposes
+    /// A string that uniquely identifies the element, typically for automation purposes
     @objc public var accessibilityIdentifier: String? {
         didSet {
             if accessibilityIdentifier != oldValue {

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -124,6 +124,15 @@ open class CommandBarItem: NSObject {
         }
     }
 
+    /// A string that uniquely identiifes the element, typically for automation purposes
+    @objc public var accessibilityIdentifier: String? {
+        didSet {
+            if accessibilityIdentifier != oldValue {
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
+            }
+        }
+    }
+
     open override var accessibilityValue: String? {
         didSet {
             if accessibilityValue != oldValue {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

This change adds a public `accessibilityIdentifier` property to `CommandBarItem` and propagates the value to the corresponding `CommandBarButton`. This change enables users of the `CommandBar` to set identifiers that uniquely identify the element for automation purposes.

### Verification
Property functionality was verified in devmain applications using Accessibility Inspector.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1326)