### PR TITLE
Exposing SwiftUI AvatarGroup `.init()` as public

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -96,8 +96,8 @@ public struct AvatarGroup: View, TokenizedControlView {
     /// - Parameters:
     ///   - style: The style of the avatar group.
     ///   - size: The size of the avatars displayed in the avatar group.
-    init(style: MSFAvatarGroupStyle,
-         size: MSFAvatarSize) {
+    public init(style: MSFAvatarGroupStyle,
+                size: MSFAvatarSize) {
         let state = MSFAvatarGroupStateImpl(style: style,
                                             size: size)
         self.state = state


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Exposing `AvatarGroup` initializer as public.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1328)