### PR TITLE
[Fluent 2 iOS] TableViewCellFileAccessoryView colors update

### DIFF
--- a/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
@@ -225,7 +225,8 @@ open class TableViewCellFileAccessoryView: UIView {
 
     private func updateSharedStatus() {
         let imageName = isShared ? "ic_fluent_people_24_regular" : "ic_fluent_person_24_regular"
-        sharedStatusImageView.image = UIImage.staticImageNamed(imageName)?.withTintColor(Colors.gray500, renderingMode: .alwaysOriginal)
+        let imageColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+        sharedStatusImageView.image = UIImage.staticImageNamed(imageName)?.withTintColor(imageColor, renderingMode: .alwaysOriginal)
         sharedStatusLabel.text = isShared ? "Common.Shared".localized : "Common.OnlyMe".localized
     }
 
@@ -490,11 +491,11 @@ private class FileAccessoryViewActionView: UIButton {
         setImage(action.image, for: .normal)
 
         if action.useAppPrimaryColor {
-            tintColor = Colors.primary(for: window)
+            tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
         } else if action.isEnabled {
-            tintColor = Colors.iconSecondary
+            tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
         } else {
-            tintColor = Colors.iconDisabled
+            tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
         }
 
         NSLayoutConstraint.activate([

--- a/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
@@ -135,6 +135,19 @@ open class TableViewCellFileAccessoryView: UIView {
                                                selector: #selector(updateLayout),
                                                name: UIContentSizeCategory.didChangeNotification,
                                                object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+              return
+        }
+
+        updateSharedStatus()
     }
 
     @available(*, unavailable)
@@ -477,8 +490,11 @@ open class TableViewCellFileAccessoryView: UIView {
 
 private class FileAccessoryViewActionView: UIButton {
     fileprivate static let size = CGSize(width: 24, height: 60)
+    private let action: FileAccessoryViewAction
 
     fileprivate init(action: FileAccessoryViewAction, window: UIWindow) {
+        self.action = action
+
         super.init(frame: .zero)
 
         accessibilityLabel = action.title
@@ -490,6 +506,33 @@ private class FileAccessoryViewActionView: UIButton {
         isEnabled = action.isEnabled
         setImage(action.image, for: .normal)
 
+        updateActionColor()
+
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: FileAccessoryViewActionView.size.width),
+            heightAnchor.constraint(greaterThanOrEqualToConstant: FileAccessoryViewActionView.size.height)
+        ])
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
+        showsLargeContentViewer = true
+        scalesLargeContentImage = true
+        largeContentTitle = action.title
+        isPointerInteractionEnabled = true
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+              return
+        }
+
+        updateActionColor()
+    }
+
+    private func updateActionColor() {
         if action.useAppPrimaryColor {
             tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
         } else if action.isEnabled {
@@ -497,16 +540,6 @@ private class FileAccessoryViewActionView: UIButton {
         } else {
             tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
         }
-
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: FileAccessoryViewActionView.size.width),
-            heightAnchor.constraint(greaterThanOrEqualToConstant: FileAccessoryViewActionView.size.height)
-        ])
-
-        showsLargeContentViewer = true
-        scalesLargeContentImage = true
-        largeContentTitle = action.title
-        isPointerInteractionEnabled = true
     }
 
     @available(*, unavailable)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`TableViewCellFileAccessoryView` was updated to match its fluent 2 specs.

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="856" alt="before_normal_light" src="https://user-images.githubusercontent.com/106181067/198695863-e9d8446a-4092-409f-bdee-09ed864a105f.png"> | <img width="856" alt="after_normal_light" src="https://user-images.githubusercontent.com/106181067/198695900-a3b8013f-91ab-4229-b6c0-4da9342691f9.png"> |
| <img width="856" alt="before_normal_dark" src="https://user-images.githubusercontent.com/106181067/198695921-8e6b0be2-7a5f-414b-a102-2b9ceea02f0d.png"> | <img width="856" alt="after_normal_dark" src="https://user-images.githubusercontent.com/106181067/198695957-f0bf0bfe-4495-42ce-8eb7-a1a32bc5b087.png"> |
| <img width="856" alt="before_primary_light" src="https://user-images.githubusercontent.com/106181067/198696008-92fbf645-82a3-4ff6-b7bd-15254221f585.png"> | <img width="856" alt="after_primary_light" src="https://user-images.githubusercontent.com/106181067/198696044-83ba9f7c-2858-43b1-99a3-2a2bd4d1a650.png"> |
| <img width="856" alt="before_primary_dark" src="https://user-images.githubusercontent.com/106181067/198696069-108452f6-5e0a-4a5c-80a8-25e35bac80bf.png"> | <img width="856" alt="after_primary_dark" src="https://user-images.githubusercontent.com/106181067/198696101-cb2c4fd2-26ba-4494-98d9-226894e26c0a.png"> |
| <img width="856" alt="before_disabled_light" src="https://user-images.githubusercontent.com/106181067/198696147-c1abcde0-decf-4e26-b086-e239fc82144b.png"> | <img width="856" alt="after_disabled_light" src="https://user-images.githubusercontent.com/106181067/198696199-4a40a33c-2ba8-4e46-9034-c3b9a5d65165.png"> |
| <img width="856" alt="before_disabled_dark" src="https://user-images.githubusercontent.com/106181067/198696244-79e9af21-079f-4b35-9aa8-6600b2efca5b.png"> | <img width="856" alt="after_disabled_dark" src="https://user-images.githubusercontent.com/106181067/198696268-12e25b23-428f-41fe-b256-c386ac0c2e11.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1329)