### PR TITLE
Exposing attributedString properties in TableViewCell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -734,6 +734,36 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     /// Text that appears as the third line of text
     @objc public var footer: String { return footerLabel.text ?? "" }
 
+    @objc public var attributedTitle: NSAttributedString? {
+        get {
+            return titleLabel.attributedText
+        }
+        set {
+            titleLabel.attributedText = newValue
+            isAttributedTitleSet = newValue == nil ? false : true
+        }
+    }
+
+    @objc public var attributedSubtitle: NSAttributedString? {
+        get {
+            return subtitleLabel.attributedText
+        }
+        set {
+            subtitleLabel.attributedText = newValue
+            isAttributedSubtitleSet = newValue == nil ? false : true
+        }
+    }
+
+    @objc public var attributedFooter: NSAttributedString? {
+        get {
+            return footerLabel.attributedText
+        }
+        set {
+            footerLabel.attributedText = newValue
+            isAttributedFooterSet = newValue == nil ? false : true
+        }
+    }
+
     /// The leading padding.
     @objc public var paddingLeading: CGFloat {
         get {
@@ -1403,39 +1433,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
     private var isUsingCustomTextColors: Bool = false
 
-    private var attributedTitle: NSAttributedString? {
-        get {
-            return titleLabel.attributedText
-        }
-        set {
-            titleLabel.attributedText = newValue
-            isAttributedTitleSet = newValue == nil ? false : true
-        }
-    }
-
     private var isAttributedTitleSet: Bool = false
 
-    private var attributedSubtitle: NSAttributedString? {
-        get {
-            return subtitleLabel.attributedText
-        }
-        set {
-            subtitleLabel.attributedText = newValue
-            isAttributedSubtitleSet = newValue == nil ? false : true
-        }
-    }
-
     private var isAttributedSubtitleSet: Bool = false
-
-    private var attributedFooter: NSAttributedString? {
-        get {
-            return footerLabel.attributedText
-        }
-        set {
-            footerLabel.attributedText = newValue
-            isAttributedFooterSet = newValue == nil ? false : true
-        }
-    }
 
     private var isAttributedFooterSet: Bool = false
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -734,6 +734,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     /// Text that appears as the third line of text
     @objc public var footer: String { return footerLabel.text ?? "" }
 
+    /// The attributedText for the title.
     @objc public var attributedTitle: NSAttributedString? {
         get {
             return titleLabel.attributedText
@@ -744,6 +745,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
+    /// The attributedText for the subtitle.
     @objc public var attributedSubtitle: NSAttributedString? {
         get {
             return subtitleLabel.attributedText
@@ -754,6 +756,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
+    /// The attributedText for the footer.
     @objc public var attributedFooter: NSAttributedString? {
         get {
             return footerLabel.attributedText


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Exposing attributedString properties as `public` in TableViewCell to make the property more accessible for downstream dependencies.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/199127254-7f0da33e-8e50-47d8-a788-ab65f7aafb54.png) | ![image](https://user-images.githubusercontent.com/22566866/199127168-7bc5d5e0-2d86-40b6-ae80-8d969864c7ef.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1335)