### PR TITLE
[Draft] WIP: `@objc` for `GlobalTokens`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorTokensDemoController.swift
@@ -13,33 +13,33 @@ class ColorTokensDemoController: DemoTableViewController {
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return GlobalTokens.SharedColorSets.allCases.count
+        return 5 //GlobalTokens.SharedColorSets.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return GlobalTokens.SharedColorSets.allCases[section].text
+        return "WIP" //GlobalTokens.SharedColorSets.allCases[section].text
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return GlobalTokens.SharedColorsTokens.allCases.count
+        return 5 //GlobalTokens.SharedColorsTokens.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellID, for: indexPath)
-        let colorSet = GlobalTokens.SharedColorSets.allCases[indexPath.section]
-        let colorToken = GlobalTokens.SharedColorsTokens.allCases[indexPath.row]
-
-        cell.backgroundConfiguration?.backgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(colorSet, colorToken))
-        cell.selectionStyle = .none
-
-        var contentConfiguration = cell.defaultContentConfiguration()
-        let text = "\(colorSet.text) \(colorToken.text)"
-        contentConfiguration.attributedText = NSAttributedString(string: text,
-                                                                 attributes: [
-                                                                    .foregroundColor: textColor(for: colorToken, in: colorSet)
-                                                                 ])
-        contentConfiguration.textProperties.alignment = .center
-        cell.contentConfiguration = contentConfiguration
+//        let colorSet = GlobalTokens.SharedColorSets.allCases[indexPath.section]
+//        let colorToken = GlobalTokens.SharedColorsTokens.allCases[indexPath.row]
+//
+//        cell.backgroundConfiguration?.backgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(colorSet, colorToken))
+//        cell.selectionStyle = .none
+//
+//        var contentConfiguration = cell.defaultContentConfiguration()
+//        let text = "\(colorSet.text) \(colorToken.text)"
+//        contentConfiguration.attributedText = NSAttributedString(string: text,
+//                                                                 attributes: [
+//                                                                    .foregroundColor: textColor(for: colorToken, in: colorSet)
+//                                                                 ])
+//        contentConfiguration.textProperties.alignment = .center
+//        cell.contentConfiguration = contentConfiguration
 
         return cell
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -60,6 +60,9 @@
 
 - (MSFButton *)createButtonWithTitle:(NSString *)title action:(SEL)action {
     MSFButton* button = [[MSFButton alloc] init];
+    MSFColorValue *colorValue = [MSFGlobalTokens colorForSharedColorSet:MSFSharedColorSetsPink
+                                                                  token:MSFSharedColorsTokensPrimary];
+    button.titleLabel.textColor = [[UIColor alloc] initWithColorValue:colorValue];
     button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     [button setTitle:title forState:UIControlStateNormal];
     [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -6,7 +6,8 @@
 import SwiftUI
 
 /// A platform-agnostic representation of a 32-bit RGBA color value.
-public struct ColorValue: Equatable {
+@objc(MSFColorValue)
+public class ColorValue: NSObject {
 
     public static let clear: ColorValue = .init(r: 0.0, g: 0.0, b: 0.0, a: 0.0)
 
@@ -18,7 +19,7 @@ public struct ColorValue: Equatable {
     /// - Parameter hexValue: The color value to store, in 24-bit (three-channel, 8-bit) RGB.
     ///
     /// - Returns: A color object that stores the provided color information.
-    public init(_ hexValue: UInt32) {
+    @objc public init(_ hexValue: UInt32) {
         self.hexValue = hexValue << 8 | 0xFF
     }
 
@@ -33,10 +34,10 @@ public struct ColorValue: Equatable {
     /// - Parameter a: The alpha channel.
     ///
     /// - Returns: A color object that stores the provided color information.
-    public init(r: CGFloat,
-                g: CGFloat,
-                b: CGFloat,
-                a: CGFloat) {
+    @objc public init(r: CGFloat,
+                      g: CGFloat,
+                      b: CGFloat,
+                      a: CGFloat) {
         hexValue = (min(UInt32(r * 255.0), 0xFF) << 24) |
                    (min(UInt32(g * 255.0), 0xFF) << 16) |
                    (min(UInt32(b * 255.0), 0xFF) << 8) |

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -6,11 +6,13 @@
 import SwiftUI
 
 /// Global Tokens represent a unified set of constants to be used by Fluent UI.
-public struct GlobalTokens {
+@objc(MSFGlobalTokens)
+public class GlobalTokens: NSObject {
 
     // MARK: - NeutralColors
 
-    public enum NeutralColorsToken: TokenSetKey {
+    @objc(MSFNeutralColorsToken)
+    public enum NeutralColorsToken: Int {
         case black
         case grey2
         case grey4
@@ -63,6 +65,7 @@ public struct GlobalTokens {
         case grey98
         case white
     }
+    @objc(colorForNeutralColorsToken:)
     public static func neutralColors(_ token: NeutralColorsToken) -> ColorValue {
         switch token {
         case .black:
@@ -172,7 +175,8 @@ public struct GlobalTokens {
 
     // MARK: - SharedColors
 
-    public enum SharedColorSets: TokenSetKey {
+    @objc(MSFSharedColorSets)
+    public enum SharedColorSets: Int {
         case darkRed
         case burgundy
         case cranberry
@@ -224,7 +228,8 @@ public struct GlobalTokens {
         case charcoal
     }
 
-    public enum SharedColorsTokens: TokenSetKey {
+    @objc(MSFSharedColorsTokens)
+    public enum SharedColorsTokens: Int {
         case shade50
         case shade40
         case shade30
@@ -239,6 +244,7 @@ public struct GlobalTokens {
         case tint60
     }
 
+    @objc(colorForSharedColorSet:token:)
     public static func sharedColors(_ sharedColor: SharedColorSets, _ token: SharedColorsTokens) -> ColorValue {
         switch sharedColor {
         case .anchor:
@@ -1756,7 +1762,7 @@ public struct GlobalTokens {
     // MARK: Initialization
 
     @available(*, unavailable)
-    private init() {
+    private override init() {
         preconditionFailure("GlobalTokens should never be initialized!")
     }
 }

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -90,7 +90,7 @@ extension UIColor {
     /// Creates a UIColor from a `ColorValue` instance.
     ///
     /// - Parameter colorValue: Color value to use to initialize this color.
-    public convenience init(colorValue: ColorValue) {
+    @objc public convenience init(colorValue: ColorValue) {
         self.init(
             red: colorValue.r,
             green: colorValue.g,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Making `GlobalTokens` be accessible from Objective-C.

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)