### PR TITLE
[Fluent 2 iOS] Avatar presence colors update

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -261,7 +261,7 @@ public struct Avatar: View, TokenizedControlView {
                                                     .interpolation(.high)
                                                     .resizable()
                                                     .frame(width: presenceIconSize, height: presenceIconSize, alignment: .center)
-                                                    .foregroundColor(presence.color(isOutOfOffice: isOutOfOffice)))
+                                                    .foregroundColor(presence.color(isOutOfOffice: isOutOfOffice, fluentTheme: fluentTheme)))
                                         .contentShape(Circle())
                                         .frame(width: presenceIconFrameSideRelativeToOuterRing, height: presenceIconFrameSideRelativeToOuterRing,
                                                alignment: .bottomTrailing),

--- a/ios/FluentUI/Avatar/MSFAvatarPresence.swift
+++ b/ios/FluentUI/Avatar/MSFAvatarPresence.swift
@@ -16,26 +16,22 @@ import SwiftUI
     case offline
     case unknown
 
-    func color(isOutOfOffice: Bool) -> Color {
+    func color(isOutOfOffice: Bool, fluentTheme: FluentTheme) -> Color {
         var color = UIColor.clear
 
         switch self {
         case .none:
             break
         case .available:
-            color = Colors.Palette.presenceAvailable.color
+            color = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceAvailable])
         case .away:
-            color = isOutOfOffice ? Colors.Palette.presenceOof.color : Colors.Palette.presenceAway.color
-        case .busy:
-            color = Colors.Palette.presenceBusy.color
-        case .blocked:
-            color = Colors.Palette.presenceBlocked.color
-        case .doNotDisturb:
-            color = Colors.Palette.presenceDnd.color
+            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceAway])
+        case .busy, .blocked, .doNotDisturb:
+            color = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceDnd])
         case .offline:
-            color = isOutOfOffice ? Colors.Palette.presenceOof.color : Colors.Palette.presenceOffline.color
+            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         case .unknown:
-            color = Colors.Palette.presenceUnknown.color
+            color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         }
 
         return Color(color)

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -789,6 +789,11 @@ public final class AliasTokens {
         case successBackground2
         case successForeground1
         case successForeground2
+        // Presence
+        case presenceAway
+        case presenceDnd
+        case presenceAvailable
+        case presenceOof
     }
     public lazy var sharedColors: TokenSet<SharedColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
@@ -845,6 +850,18 @@ public final class AliasTokens {
         case .warningForeground2:
             return DynamicColor(light: GlobalTokens.sharedColors(.yellow, .shade30),
                                 dark: GlobalTokens.sharedColors(.yellow, .tint30))
+        // Presence
+        case .presenceAway:
+            return DynamicColor(light: GlobalTokens.sharedColors(.marigold, .primary))
+        case .presenceDnd:
+            return DynamicColor(light: GlobalTokens.sharedColors(.red, .primary),
+                                dark: GlobalTokens.sharedColors(.red, .tint10))
+        case .presenceAvailable:
+            return DynamicColor(light: GlobalTokens.sharedColors(.lightGreen, .primary),
+                                dark: GlobalTokens.sharedColors(.lightGreen, .tint20))
+        case .presenceOof:
+            return DynamicColor(light: GlobalTokens.sharedColors(.berry, .primary),
+                                dark: GlobalTokens.sharedColors(.berry, .tint20))
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`Presence` was updated to use fluent 2 tokens.

### Verification

The test were run on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="653" alt="before_1_light" src="https://user-images.githubusercontent.com/106181067/199617283-36b21e30-0812-44a2-b62a-43f56f6b15b0.png"> | <img width="653" alt="after_1_light" src="https://user-images.githubusercontent.com/106181067/199617319-d5c5fc54-56c3-421e-b1eb-ab2035be8d36.png"> |
| <img width="653" alt="before_1_dark" src="https://user-images.githubusercontent.com/106181067/199617356-f5b96054-5f73-4368-8c75-2f7bfdafb326.png"> | <img width="653" alt="after_1_dark" src="https://user-images.githubusercontent.com/106181067/199617376-f065f2bb-877c-4dd9-9c06-bf6c5eb1a1d9.png"> |
| <img width="653" alt="before_1_oof_light" src="https://user-images.githubusercontent.com/106181067/199617418-e656d1eb-5ba7-44ad-a39d-8b2f131c9c0e.png"> | <img width="653" alt="after_1_oof_light" src="https://user-images.githubusercontent.com/106181067/199617445-3093479c-e7de-4153-849d-4a88de2007ef.png"> |
| <img width="653" alt="before_1_oof_dark" src="https://user-images.githubusercontent.com/106181067/199617467-f17a4c96-51a9-438e-a5bf-c1e0d471da89.png"> | <img width="653" alt="after_1_oof_dark" src="https://user-images.githubusercontent.com/106181067/199617483-46bde235-d903-440b-80ce-fd7b320c2ac2.png"> |
| <img width="653" alt="before_2_light" src="https://user-images.githubusercontent.com/106181067/199617509-ecf15fc1-5a66-4ec3-83fe-c5974db26b09.png"> | <img width="653" alt="after_2_light" src="https://user-images.githubusercontent.com/106181067/199617543-57e251b1-0089-47e8-9a92-b5be9dbd4a24.png"> |
| <img width="653" alt="before_2_dark" src="https://user-images.githubusercontent.com/106181067/199617572-f1d51cd2-3a9b-4876-83f5-8cefa813f669.png"> | <img width="653" alt="after_2_dark" src="https://user-images.githubusercontent.com/106181067/199617593-f124a64e-15b5-46ce-9aa6-d375be0cf259.png"> |
| <img width="653" alt="before_2_oof_light" src="https://user-images.githubusercontent.com/106181067/199617615-c69d4dcf-1731-4189-b5da-edd0698e9edb.png"> | <img width="653" alt="after_2_oof_light" src="https://user-images.githubusercontent.com/106181067/199617667-220e3553-71f8-4646-997f-bb923aece094.png"> |
| <img width="653" alt="before_2_oof_dark" src="https://user-images.githubusercontent.com/106181067/199617690-40f96bba-304b-4b77-935f-00a24708dfd4.png"> | <img width="653" alt="after_2_oof_dark" src="https://user-images.githubusercontent.com/106181067/199617714-4aeb23d9-57bd-41de-9533-aaef722815d1.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1340)