### PR TITLE
[Fluent 2 iOS] Adding guard to Button themeDidChange

### DIFF
--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -274,6 +274,9 @@ open class Button: UIButton {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard window?.isEqual(notification.object) == true else {
+            return
+        }
         updateBackgroundColor()
         updateTitleColors()
         updateImage()

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -274,7 +274,7 @@ open class Button: UIButton {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard window?.isEqual(notification.object) == true else {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
         updateBackgroundColor()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change adds a guard to ensure that the view that's updating the button's theme is the view's actual parent view.

### Verification

Built and ran simulator, testing the app. No visual changes were made.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1342)