### PR TITLE
Update avatar ring color

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -155,7 +155,9 @@ public struct Avatar: View, TokenizedControlView {
         let ringColor = !isRingVisible ? Color.clear :
         Color(dynamicColor: state.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                tokenSet[.ringDefaultColor].dynamicColor :
-                                                                backgroundColor))
+                                                                CalculatedColors.ringColor(fromPrimaryText: state.primaryText,
+                                                                                           secondaryText: state.secondaryText,
+                                                                                           fluentTheme: fluentTheme)))
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
@@ -414,6 +416,16 @@ public struct Avatar: View, TokenizedControlView {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .shade30),
                                 dark: GlobalTokens.sharedColors(colorSet, .tint40))
+        }
+
+        static func ringColor(fromPrimaryText primaryText: String?,
+                              secondaryText: String?,
+                              fluentTheme: FluentTheme) -> DynamicColor {
+            // Set the color based on the primary text and secondary text
+            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+            let colorSet = colors[hashCode % colors.count]
+            return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .primary),
+                                dark: GlobalTokens.sharedColors(colorSet, .tint30))
         }
 
         private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The `Avatar` ring no longer uses the `Avatar`'s background color in fluent 2. The ring has been updated to now use the proper tokens: `primary` for light and `tint 30` for dark mode.

### Verification

Couldn't validate for every single shared set, but here are a few cases from the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_kl_light](https://user-images.githubusercontent.com/106181067/199840398-69aedde1-8d01-43cb-8b32-443bf51f26d2.png) | ![after_kl_light](https://user-images.githubusercontent.com/106181067/199840460-f566f475-be1d-4064-aa0a-80cfc51fcd15.png) |
| ![before_kl_dark](https://user-images.githubusercontent.com/106181067/199840567-a6f92271-ccb1-4d76-a232-210f37cbc323.png) | ![after_kl_dark](https://user-images.githubusercontent.com/106181067/199840599-a72e8581-0c79-47d8-861a-c4468c8c8c03.png) |
| ![before_ns_light](https://user-images.githubusercontent.com/106181067/199840639-d21ffd17-f9fd-458a-81d7-ccc458d02634.png) | ![after_ns_light](https://user-images.githubusercontent.com/106181067/199840691-d27ff2d1-f81b-400b-b865-e3be520f5393.png) |
| ![before_ns_dark](https://user-images.githubusercontent.com/106181067/199840722-afbc33c9-ef38-4dc8-935e-70652c5c9b5d.png) | ![after_ns_dark](https://user-images.githubusercontent.com/106181067/199840749-ab917ca3-f206-4968-8e8d-6beec1171e51.png) |
| ![before_sj_light](https://user-images.githubusercontent.com/106181067/199840792-1df7e7e4-9ac7-4026-ab3f-f7cb3bc18fab.png) | ![after_sj_light](https://user-images.githubusercontent.com/106181067/199840830-c8ee52ef-2fc5-4d39-926d-671666aef913.png) |
| ![before_sj_dark](https://user-images.githubusercontent.com/106181067/199840866-b3dc3fba-475a-4844-aef6-9d6028f97a0e.png) | ![after_sj_dark](https://user-images.githubusercontent.com/106181067/199840895-6739debd-6c29-431f-9df4-d29090f9cda8.png) |
| ![before_th_light](https://user-images.githubusercontent.com/106181067/199840948-3268ec64-f6ff-4364-8ae4-e76592e1a42b.png) | ![after_th_light](https://user-images.githubusercontent.com/106181067/199840981-702e6a1a-5256-4f2d-857c-e20168cb0217.png) |
| ![before_th_dark](https://user-images.githubusercontent.com/106181067/199841007-f4ece887-b368-4e3d-90b9-b3773cab009b.png) | ![after_th_dark](https://user-images.githubusercontent.com/106181067/199841035-164f5aa5-6faf-4350-b698-f40fa73ee893.png) |
| ![before_guma_light](https://user-images.githubusercontent.com/106181067/199841076-c69e827f-99ac-4120-a892-d7c53586fb27.png) | ![after_guma_light](https://user-images.githubusercontent.com/106181067/199841114-f21dbba6-fa4d-4d7d-af99-d3ebcc24508c.png) |
| ![before_guma_dark](https://user-images.githubusercontent.com/106181067/199841139-f463b3d6-71c1-477b-b6fd-ed6309b44288.png) | ![after_guma_dark](https://user-images.githubusercontent.com/106181067/199841161-b2b59863-eab8-4983-a1de-23a2e1786b7f.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1344)