### PR TITLE
Update avatar ring color

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -155,7 +155,9 @@ public struct Avatar: View, TokenizedControlView {
         let ringColor = !isRingVisible ? Color.clear :
         Color(dynamicColor: state.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                tokenSet[.ringDefaultColor].dynamicColor :
-                                                                backgroundColor))
+                                                                CalculatedColors.ringColor(fromPrimaryText: state.primaryText,
+                                                                                           secondaryText: state.secondaryText,
+                                                                                           fluentTheme: fluentTheme)))
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
@@ -414,6 +416,16 @@ public struct Avatar: View, TokenizedControlView {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .shade30),
                                 dark: GlobalTokens.sharedColors(colorSet, .tint40))
+        }
+
+        static func ringColor(fromPrimaryText primaryText: String?,
+                              secondaryText: String?,
+                              fluentTheme: FluentTheme) -> DynamicColor {
+            // Set the color based on the primary text and secondary text
+            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+            let colorSet = colors[hashCode % colors.count]
+            return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .primary),
+                                dark: GlobalTokens.sharedColors(colorSet, .tint30))
         }
 
         private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -141,23 +141,19 @@ public struct Avatar: View, TokenizedControlView {
         let presenceIconFrameSideRelativeToOuterRing: CGFloat = presenceIconFrameSideRelativeToInnerRing + outerGapAndRingThicknesCombined
         let overallFrameSide = max(ringOuterGapSize, presenceIconFrameSideRelativeToOuterRing)
 
+        let colorHashCode = CalculatedColors.initialsHashCode(fromPrimaryText: state.primaryText, secondaryText: state.secondaryText)
+
         let foregroundColor = state.foregroundColor?.dynamicColor ?? (
             !shouldUseCalculatedColors ? tokenSet[.foregroundDefaultColor].dynamicColor :
-                CalculatedColors.foregroundColor(fromPrimaryText: state.primaryText,
-                                                 secondaryText: state.secondaryText,
-                                                 fluentTheme: fluentTheme))
+                CalculatedColors.foregroundColor(hashCode: colorHashCode))
         let backgroundColor = state.backgroundColor?.dynamicColor ?? (
             !shouldUseCalculatedColors ? tokenSet[.backgroundDefaultColor].dynamicColor :
-                CalculatedColors.backgroundColor(fromPrimaryText: state.primaryText,
-                                                 secondaryText: state.secondaryText,
-                                                 fluentTheme: fluentTheme))
+                CalculatedColors.backgroundColor(hashCode: colorHashCode))
         let ringGapColor = Color(dynamicColor: tokenSet[.ringGapColor].dynamicColor).opacity(isTransparent ? 0 : 1)
         let ringColor = !isRingVisible ? Color.clear :
         Color(dynamicColor: state.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                tokenSet[.ringDefaultColor].dynamicColor :
-                                                                CalculatedColors.ringColor(fromPrimaryText: state.primaryText,
-                                                                                           secondaryText: state.secondaryText,
-                                                                                           fluentTheme: fluentTheme)))
+                                                                CalculatedColors.ringColor(hashCode: colorHashCode)))
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
@@ -398,37 +394,25 @@ public struct Avatar: View, TokenizedControlView {
 
     /// Handles calculating colors for Avatar foreground and background.
     private struct CalculatedColors {
-        static func backgroundColor(fromPrimaryText primaryText: String?,
-                                    secondaryText: String?,
-                                    fluentTheme: FluentTheme) -> DynamicColor {
-            // Set the color based on the primary text and secondary text
-            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+        static func backgroundColor(hashCode: Int) -> DynamicColor {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .tint40),
                                 dark: GlobalTokens.sharedColors(colorSet, .shade30))
         }
 
-        static func foregroundColor(fromPrimaryText primaryText: String?,
-                                    secondaryText: String?,
-                                    fluentTheme: FluentTheme) -> DynamicColor {
-            // Set the color based on the primary text and secondary text
-            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+        static func foregroundColor(hashCode: Int) -> DynamicColor {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .shade30),
                                 dark: GlobalTokens.sharedColors(colorSet, .tint40))
         }
 
-        static func ringColor(fromPrimaryText primaryText: String?,
-                              secondaryText: String?,
-                              fluentTheme: FluentTheme) -> DynamicColor {
-            // Set the color based on the primary text and secondary text
-            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+        static func ringColor(hashCode: Int) -> DynamicColor {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .primary),
                                 dark: GlobalTokens.sharedColors(colorSet, .tint30))
         }
 
-        private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
+        static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
             var combined: String
             if let secondaryText = secondaryText, let primaryText = primaryText, secondaryText.count > 0 {
                 combined = primaryText + secondaryText

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -153,7 +153,7 @@ public struct Avatar: View, TokenizedControlView {
         let ringColor = !isRingVisible ? Color.clear :
         Color(dynamicColor: state.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                tokenSet[.ringDefaultColor].dynamicColor :
-                                                                CalculatedColors.ringColor(hashCode: colorHashCode)))
+                                                               CalculatedColors.ringColor(hashCode: colorHashCode)))
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

(Original PR #1344 )

The `Avatar` ring no longer uses the `Avatar`'s background color. 
The ring has been updated to now use the proper tokens: `primary` for light and `tint 30` for dark mode.

### Verification

Couldn't validate for every single shared set, but here are a few cases from the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_kl_light](https://user-images.githubusercontent.com/106181067/199858629-976b1eb5-80e8-42a7-8077-ad4fe99178e3.png) | ![after_kl_light](https://user-images.githubusercontent.com/106181067/199858641-1dcce376-9168-48d3-aa39-6ad442e6e5b9.png) |
| ![before_kl_dark](https://user-images.githubusercontent.com/106181067/199858671-54b8e18c-68bd-42f6-9ca6-34282251523c.png) | ![after_kl_dark](https://user-images.githubusercontent.com/106181067/199858680-7024f851-75c4-436d-88c7-f38d1857a49f.png) |
| ![before_th_light](https://user-images.githubusercontent.com/106181067/199858711-fa7e6ada-9712-44af-8489-fb85d5e3731c.png) | ![after_th_light](https://user-images.githubusercontent.com/106181067/199858725-5ccda407-04a9-4c2b-9f91-16cbe836b4ea.png) |
| ![before_th_dark](https://user-images.githubusercontent.com/106181067/199858749-8b78df86-6f27-436d-ad28-400b3b8150c3.png) | ![after_th_dark](https://user-images.githubusercontent.com/106181067/199858754-bd01270e-5627-4680-b024-c265c40deac8.png) |
| ![before_sm_light](https://user-images.githubusercontent.com/106181067/199858772-0ebf470c-1237-450a-889c-590415c9ab71.png) | ![after_sm_light](https://user-images.githubusercontent.com/106181067/199858777-f48b23e5-f1bd-4387-9b4d-1466571c2940.png) |
| ![before_sm_dark](https://user-images.githubusercontent.com/106181067/199858793-5e4abcaf-4bc6-4f31-a267-eee4dbb78595.png) | ![after_sm_dark](https://user-images.githubusercontent.com/106181067/199858800-deca6637-6f0d-4415-b6d0-85b3d93ab9c1.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1346)