### PR TITLE
[Fluent 2 iOS] Fix Avatar colors

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -141,21 +141,19 @@ public struct Avatar: View, TokenizedControlView {
         let presenceIconFrameSideRelativeToOuterRing: CGFloat = presenceIconFrameSideRelativeToInnerRing + outerGapAndRingThicknesCombined
         let overallFrameSide = max(ringOuterGapSize, presenceIconFrameSideRelativeToOuterRing)
 
+        let colorHashCode = CalculatedColors.initialsHashCode(fromPrimaryText: state.primaryText, secondaryText: state.secondaryText)
+
         let foregroundColor = state.foregroundColor?.dynamicColor ?? (
             !shouldUseCalculatedColors ? tokenSet[.foregroundDefaultColor].dynamicColor :
-                CalculatedColors.foregroundColor(fromPrimaryText: state.primaryText,
-                                                 secondaryText: state.secondaryText,
-                                                 fluentTheme: fluentTheme))
+                CalculatedColors.foregroundColor(hashCode: colorHashCode))
         let backgroundColor = state.backgroundColor?.dynamicColor ?? (
             !shouldUseCalculatedColors ? tokenSet[.backgroundDefaultColor].dynamicColor :
-                CalculatedColors.backgroundColor(fromPrimaryText: state.primaryText,
-                                                 secondaryText: state.secondaryText,
-                                                 fluentTheme: fluentTheme))
+                CalculatedColors.backgroundColor(hashCode: colorHashCode))
         let ringGapColor = Color(dynamicColor: tokenSet[.ringGapColor].dynamicColor).opacity(isTransparent ? 0 : 1)
         let ringColor = !isRingVisible ? Color.clear :
         Color(dynamicColor: state.ringColor?.dynamicColor ?? ( !shouldUseCalculatedColors ?
                                                                tokenSet[.ringDefaultColor].dynamicColor :
-                                                                backgroundColor))
+                                                               CalculatedColors.ringColor(hashCode: colorHashCode)))
 
         let shouldUseDefaultImage = (state.image == nil && initialsString.isEmpty && style != .overflow)
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
@@ -396,27 +394,25 @@ public struct Avatar: View, TokenizedControlView {
 
     /// Handles calculating colors for Avatar foreground and background.
     private struct CalculatedColors {
-        static func backgroundColor(fromPrimaryText primaryText: String?,
-                                    secondaryText: String?,
-                                    fluentTheme: FluentTheme) -> DynamicColor {
-            // Set the color based on the primary text and secondary text
-            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+        static func backgroundColor(hashCode: Int) -> DynamicColor {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .tint40),
                                 dark: GlobalTokens.sharedColors(colorSet, .shade30))
         }
 
-        static func foregroundColor(fromPrimaryText primaryText: String?,
-                                    secondaryText: String?,
-                                    fluentTheme: FluentTheme) -> DynamicColor {
-            // Set the color based on the primary text and secondary text
-            let hashCode = initialsHashCode(fromPrimaryText: primaryText, secondaryText: secondaryText)
+        static func foregroundColor(hashCode: Int) -> DynamicColor {
             let colorSet = colors[hashCode % colors.count]
             return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .shade30),
                                 dark: GlobalTokens.sharedColors(colorSet, .tint40))
         }
 
-        private static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
+        static func ringColor(hashCode: Int) -> DynamicColor {
+            let colorSet = colors[hashCode % colors.count]
+            return DynamicColor(light: GlobalTokens.sharedColors(colorSet, .primary),
+                                dark: GlobalTokens.sharedColors(colorSet, .tint30))
+        }
+
+        static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
             var combined: String
             if let secondaryText = secondaryText, let primaryText = primaryText, secondaryText.count > 0 {
                 combined = primaryText + secondaryText

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -89,20 +89,16 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
             case .ringDefaultColor:
                 return .dynamicColor({
                     switch style() {
-                    case .default, .group:
-                        return theme.aliasTokens.brandColors[.tint10]
-                    case .accent:
-                        return theme.aliasTokens.brandColors[.shade10]
+                    case .default, .group, .accent, .outlinedPrimary:
+                        return theme.aliasTokens.colors[.brandStroke1]
                     case .outlined, .overflow:
-                        return theme.aliasTokens.backgroundColors[.neutralDisabled]
-                    case .outlinedPrimary:
-                        return .init(light: theme.aliasTokens.brandColors[.tint10].light, dark: GlobalTokens.neutralColors(.grey78))
+                        return theme.aliasTokens.colors[.stroke1]
                     }
                 })
 
             case .ringGapColor:
                 return .dynamicColor({
-                    theme.aliasTokens.backgroundColors[.neutral1]
+                    theme.aliasTokens.colors[.background1]
                 })
 
             case .ringThickness:
@@ -149,22 +145,20 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
 
             case .presenceOutlineColor:
                 return .dynamicColor({
-                    theme.aliasTokens.backgroundColors[.neutral1]
+                    theme.aliasTokens.colors[.background1]
                 })
 
             case .backgroundDefaultColor:
                 return .dynamicColor({
                     switch style() {
                     case .default, .group:
-                        return .init(light: GlobalTokens.neutralColors(.white), dark: theme.aliasTokens.brandColors[.primary].dark)
+                        return theme.aliasTokens.colors[.background1]
                     case .accent:
-                        return theme.aliasTokens.brandColors[.primary]
-                    case .outlined:
-                        return .init(light: GlobalTokens.neutralColors(.grey94), dark: GlobalTokens.neutralColors(.grey26))
+                        return theme.aliasTokens.colors[.brandBackground1]
+                    case .outlined, .overflow:
+                        return theme.aliasTokens.colors[.background5]
                     case .outlinedPrimary:
-                        return .init(light: theme.aliasTokens.brandColors[.tint40].light, dark: GlobalTokens.neutralColors(.grey26))
-                    case .overflow:
-                        return theme.aliasTokens.backgroundColors[.neutral4]
+                        return theme.aliasTokens.colors[.brandBackgroundTint]
                     }
                 })
 
@@ -178,7 +172,7 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                     case .outlined, .overflow:
                         return theme.aliasTokens.colors[.foreground2]
                     case .outlinedPrimary:
-                        return theme.aliasTokens.colors[.brandForeground4]
+                        return theme.aliasTokens.colors[.brandForegroundTint]
                     }
                 })
             }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

`Avatar` colors were overwritten by a merge and this PR fixes them. 
This PR also brings in the avatar ring changes from #1346 

**NOTE**: There is a contrast issue with the `outlined` and `overflow` styles' ring. A design ticket has already been created to address it.

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="688" alt="before_avatar_light" src="https://user-images.githubusercontent.com/106181067/200424958-e043624f-971f-4adf-884b-fa2ba6068f34.png"> | <img width="688" alt="after_avatar_light" src="https://user-images.githubusercontent.com/106181067/200424975-66d7b09b-c329-4652-a3ea-ec5fbad2ff73.png"> |
| <img width="688" alt="before_avatar_dark" src="https://user-images.githubusercontent.com/106181067/200425009-57742def-cbf8-4f2a-9a1f-276ec7cc95c8.png"> | <img width="688" alt="after_avatar_dark" src="https://user-images.githubusercontent.com/106181067/200425040-98907177-7c0c-42df-b4bb-32f825b7cfbe.png"> |
| <img width="688" alt="before_avatar_ring_light" src="https://user-images.githubusercontent.com/106181067/200425092-675e1bbd-fbe4-4647-b381-d6da31b19408.png"> | <img width="688" alt="after_avatar_ring_light" src="https://user-images.githubusercontent.com/106181067/200425117-cb95e31d-bcd0-4842-8fbf-a32955d8d55a.png"> |
| <img width="688" alt="before_avatar_ring_dark" src="https://user-images.githubusercontent.com/106181067/200425151-feb38eab-0096-4d28-b53d-5f5406b0098d.png"> | <img width="688" alt="after_avatar_ring_dark" src="https://user-images.githubusercontent.com/106181067/200425163-090c5ee1-5148-4fa4-ace5-921ec7570dee.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1348)