### PR TITLE
Shadows for Tooltip, Notification, BottomSheetController and BottomCommandingController

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -430,12 +430,6 @@ open class BottomCommandingController: UIViewController {
 
     private func makeBottomBarByEmbedding(contentView: UIView) -> UIView {
         let bottomBarView = UIView()
-        let bottomBarLayer = bottomBarView.layer
-
-        let shadow28 = view.fluentTheme.aliasTokens.shadow[.shadow28]
-        bottomBarLayer.shadowColor = UIColor(dynamicColor: shadow28.colorTwo).cgColor
-        bottomBarLayer.shadowRadius = shadow28.blurTwo
-        bottomBarLayer.shadowOpacity = 1
 
         let roundedCornerView = UIView()
         roundedCornerView.backgroundColor = bottomBarBackgroundColor

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -440,12 +440,8 @@ public class BottomSheetController: UIViewController, Shadowable {
             stackView.bottomAnchor.constraint(equalTo: bottomSheetContentView.bottomAnchor)
         ])
 
-        shadowView = bottomSheetContentView
-
         return makeBottomSheetByEmbedding(contentView: bottomSheetContentView)
     }()
-
-    var shadowView: UIView?
 
     private func makeBottomSheetByEmbedding(contentView: UIView) -> UIView {
         let bottomSheetView = UIView()
@@ -455,7 +451,11 @@ public class BottomSheetController: UIViewController, Shadowable {
         contentView.layer.cornerRadius = Constants.cornerRadius
         contentView.layer.cornerCurve = .continuous
         contentView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+        contentView.clipsToBounds = true
 
+        // We need to set the background color of the embedding view otherwise the shadows will not display
+        bottomSheetView.backgroundColor = backgroundColor
+        bottomSheetView.layer.cornerRadius = Constants.cornerRadius
         bottomSheetView.addSubview(contentView)
 
         NSLayoutConstraint.activate([
@@ -483,11 +483,11 @@ public class BottomSheetController: UIViewController, Shadowable {
     }
 
     private func updateShadow() {
-        guard let shadowView = shadowView else {
-            return
-        }
         let shadowInfo = view.fluentTheme.aliasTokens.shadow[.shadow28]
-        shadowInfo.applyShadow(to: shadowView, parentController: self)
+
+        // We need to have the shadow on a parent of the view that does the corner masking.
+        // Otherwise the view will mask its own shadow.
+        shadowInfo.applyShadow(to: bottomSheetView, parentController: self)
     }
 
     public override func viewSafeAreaInsetsDidChange() {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -40,7 +40,10 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 }
 
 @objc(MSFBottomSheetController)
-public class BottomSheetController: UIViewController {
+public class BottomSheetController: UIViewController, Shadowable {
+
+    public var shadow1: CALayer?
+    public var shadow2: CALayer?
 
     /// Initializes the bottom sheet controller
     /// - Parameters:
@@ -437,25 +440,21 @@ public class BottomSheetController: UIViewController {
             stackView.bottomAnchor.constraint(equalTo: bottomSheetContentView.bottomAnchor)
         ])
 
+        shadowView = bottomSheetContentView
+
         return makeBottomSheetByEmbedding(contentView: bottomSheetContentView)
     }()
 
+    var shadowView: UIView?
+
     private func makeBottomSheetByEmbedding(contentView: UIView) -> UIView {
         let bottomSheetView = UIView()
-
-        // We need to have the shadow on a parent of the view that does the corner masking.
-        // Otherwise the view will mask its own shadow.
-        let shadow28 = view.fluentTheme.aliasTokens.shadow[.shadow28]
-        bottomSheetView.layer.shadowColor = UIColor(dynamicColor: shadow28.colorTwo).cgColor
-        bottomSheetView.layer.shadowOffset = CGSize(width: shadow28.xTwo, height: shadow28.yTwo)
-        bottomSheetView.layer.shadowRadius = shadow28.blurTwo
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.backgroundColor = backgroundColor
         contentView.layer.cornerRadius = Constants.cornerRadius
         contentView.layer.cornerCurve = .continuous
         contentView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
-        contentView.clipsToBounds = true
 
         bottomSheetView.addSubview(contentView)
 
@@ -480,6 +479,15 @@ public class BottomSheetController: UIViewController {
             updateDimmingViewAccessibility()
         }
         collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
+        updateShadow()
+    }
+
+    private func updateShadow() {
+        guard let shadowView = shadowView else {
+            return
+        }
+        let shadowInfo = view.fluentTheme.aliasTokens.shadow[.shadow28]
+        shadowInfo.applyShadow(to: shadowView, parentController: self)
     }
 
     public override func viewSafeAreaInsetsDidChange() {

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -67,8 +67,8 @@ public struct ShadowInfo: Equatable {
 
 public extension ShadowInfo {
 
-    func applyShadow(to view: UIView) {
-        guard var shadowable = (view as? Shadowable) ?? (view.superview as? Shadowable) else {
+    func applyShadow(to view: UIView, parentController: UIViewController? = nil) {
+        guard var shadowable = (view as? Shadowable) ?? (view.superview as? Shadowable) ?? (parentController as? Shadowable) else {
             assertionFailure("Cannot apply Fluent shadows to a non-Shadowable view")
             return
         }
@@ -112,6 +112,6 @@ public protocol Shadowable {
     /// The layer on which the perimeter shadow is implemented
     var shadow1: CALayer? { get set }
 
-    /// The layer on which the ambient shadow is implemented
+    /// The layer on which the key shadow is implemented
     var shadow2: CALayer? { get set }
 }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -284,14 +284,7 @@ public struct FluentNotification: View, TokenizedControlView {
                             backgroundFill
                                 .clipShape(RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
                         )
-                        .shadow(color: Color(dynamicColor: shadowInfo.colorOne),
-                                radius: shadowInfo.blurOne,
-                                x: shadowInfo.xOne,
-                                y: shadowInfo.yOne)
-                        .shadow(color: Color(dynamicColor: shadowInfo.colorTwo),
-                                radius: shadowInfo.blurTwo,
-                                x: shadowInfo.xTwo,
-                                y: shadowInfo.yTwo)
+                        .applyShadow(shadowInfo: shadowInfo)
                 )
                 .onTapGesture {
                     if let messageAction = messageButtonAction {

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -7,7 +7,11 @@ import UIKit
 
 // MARK: TooltipView
 
-class TooltipView: UIView {
+class TooltipView: UIView, Shadowable {
+
+    var shadow1: CALayer?
+    var shadow2: CALayer?
+
     private struct Constants {
         static let messageLabelTextStyle: TextStyle = .subhead
 
@@ -93,8 +97,6 @@ class TooltipView: UIView {
         messageLabel.textAlignment = textAlignment
         messageLabel.isAccessibilityElement = false
         addSubview(messageLabel)
-
-        updateShadow()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -128,9 +130,13 @@ class TooltipView: UIView {
         }
 
         messageLabel.frame = backgroundView.frame.insetBy(dx: Constants.paddingHorizontal, dy: 0)
+        updateShadow()
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateColors()
         updateShadow()
     }
@@ -149,13 +155,8 @@ class TooltipView: UIView {
     }
 
     private func updateShadow() {
-        let shadow = fluentTheme.aliasTokens.shadow[.shadow16]
-        let color = UIColor(dynamicColor: shadow.colorOne).cgColor
-
-        layer.shadowColor = color
-        layer.shadowOpacity = Float(color.alpha)
-        layer.shadowRadius = shadow.blurOne
-        layer.shadowOffset = CGSize(width: shadow.xOne, height: shadow.yOne)
+        let shadowInfo = fluentTheme.aliasTokens.shadow[.shadow16]
+        shadowInfo.applyShadow(to: backgroundView)
     }
 
     private func updateColors() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

This PR uses the new shadow API to apply shadows to `Tooltip`, `Notification`, `BottomSheetController` and `BottomCommandingController`.
The `applyShadow` function in `ShadowInfo` now also checks for a `UIViewController` that conforms to `Shadowable`.
The `BottomCommandingController` uses `BottomSheetController`'s shadow.

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_notification](https://user-images.githubusercontent.com/106181067/200966897-7b571fc8-7ddc-4204-9cdf-3fd4b3c72439.gif) | ![after_notification](https://user-images.githubusercontent.com/106181067/200966926-dba3186b-2a24-45bb-be28-be702c8bff9b.gif) |
| ![before_bottom_sheet](https://user-images.githubusercontent.com/106181067/200966964-a96c62cb-7d8f-40b6-abff-15616a0b242b.gif) | ![after_bottom_sheet](https://user-images.githubusercontent.com/106181067/200966987-784ce75f-a920-41f6-a3a7-acf5966762ed.gif) |
| ![before_bcc](https://user-images.githubusercontent.com/106181067/200967217-18b68b11-e4b5-463a-b231-d399c55a4520.gif) | ![after_bcc](https://user-images.githubusercontent.com/106181067/200967044-84d77029-8f75-4eff-a924-7842eeabb1df.gif) |
| <img width="487" alt="before_tooltip" src="https://user-images.githubusercontent.com/106181067/200967257-24c6b8c1-582f-49a8-847a-053a9541509c.png"> | <img width="487" alt="after_tooltip" src="https://user-images.githubusercontent.com/106181067/200967272-77d5b753-d0e4-4eea-9f3e-581d613417e2.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1353)