### PR TITLE
Make ShimmerLinesView inherit ShimmerView init

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -30,6 +30,7 @@ struct Demos {
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
+        DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
         DemoDescriptor("TypographyTokens", TypographyTokensDemoController.self)
     ]
@@ -54,7 +55,6 @@ struct Demos {
         DemoDescriptor("PopupMenuController", PopupMenuDemoController.self),
         DemoDescriptor("SearchBar", SearchBarDemoController.self),
         DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
-        DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TabBarView", TabBarViewDemoController.self),
         DemoDescriptor("TableViewCellFileAccessoryView", TableViewCellFileAccessoryViewDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -69,6 +69,15 @@ class ShimmerViewDemoController: DemoController {
         container.addArrangedSubview(ShimmerLinesView())
         container.addArrangedSubview(dividers[1])
 
+        container.addArrangedSubview(shimmerViewLabel("The middle lines of ShimmerLinesView are always at 100% width"))
+        container.addArrangedSubview(dividers[0])
+        let shimmerLinesView = ShimmerLinesView(containerView: nil,
+                                                excludedViews: [],
+                                                animationSynchronizer: nil)
+        shimmerLinesView.lineCount = 6
+        container.addArrangedSubview(shimmerLinesView)
+        container.addArrangedSubview(dividers[1])
+
         container.addArrangedSubview(shimmerViewLabel("ShimmerView shimmers all the top level subviews of its container view"))
         container.addArrangedSubview(dividers[2])
         container.addArrangedSubview(shimmeringContentView(false))

--- a/ios/FluentUI/Shimmer/ShimmerLinesView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerLinesView.swift
@@ -11,6 +11,26 @@ import UIKit
 @objc(MSFShimmerLinesView)
 open class ShimmerLinesView: ShimmerView {
 
+    /// Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+    @objc open var lineCount: Int = 3 {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    /// The percent the first line (if 2+ lines) should fill the available horizontal space
+    @objc open var firstLineFillPercent: CGFloat = 0.94 {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
+    /// The percent the last line should fill the available horizontal space.
+    @objc open var lastLineFillPercent: CGFloat = 0.6 {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
     open override func layoutSubviews() {
         super.layoutSubviews()
 
@@ -18,16 +38,8 @@ open class ShimmerLinesView: ShimmerView {
         for (index, linelayer) in viewCoverLayers.enumerated() {
             let fillPercent: CGFloat = {
                 if index == 0 && viewCoverLayers.count > 2 {
-                    guard let firstLineFillPercent = firstLineFillPercent else {
-                        return 1
-                    }
-
                     return firstLineFillPercent
                 } else if index == viewCoverLayers.count - 1 {
-                    guard let lastLineFillPercent = lastLineFillPercent else {
-                        return 1
-                    }
-
                     return lastLineFillPercent
                 } else {
                     return 1
@@ -55,34 +67,6 @@ open class ShimmerLinesView: ShimmerView {
 
     open override var intrinsicContentSize: CGSize {
         return CGSize(width: UIView.noIntrinsicMetric, height: sizeThatFits(CGSize(width: frame.width, height: .infinity)).height)
-    }
-
-    /// Creates the ShimmerLinesView.
-    /// - Parameters:
-    ///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-    @objc public init(lineCount: Int) {
-        self.lineCount = lineCount
-
-        super.init()
-    }
-
-    /// Creates the ShimmerLinesView.
-    /// - Parameters:
-    ///   - lineCount: Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
-    ///   - firstLineFillPercent: The percent the first line (if 2+ lines) should fill the available horizontal space.
-    ///   - lastLineFillPercent: The percent the last line should fill the available horizontal space.
-    @objc public convenience init(lineCount: Int = 3,
-                                  firstLineFillPercent: CGFloat = 0.94,
-                                  lastLineFillPercent: CGFloat = 0.6) {
-        self.init(lineCount: lineCount)
-
-        self.firstLineFillPercent = firstLineFillPercent
-        self.lastLineFillPercent = lastLineFillPercent
-    }
-
-    @available(*, unavailable)
-    required public init?(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
     }
 
     override func updateViewCoverLayers() {
@@ -114,8 +98,4 @@ open class ShimmerLinesView: ShimmerView {
             return lineCount
         }
     }
-
-    private var lineCount: Int
-    private var firstLineFillPercent: CGFloat?
-    private var lastLineFillPercent: CGFloat?
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

According to [Apple docs](https://docs.swift.org/swift-book/LanguageGuide/Initialization.html), "superclass initializers are automatically inherited if certain conditions are met." A couple things were wrong with the implementation done during tokenization that didn't meet those conditions and thus would break API upon going into devmain:
1. lineCount, firstLineFillPercent, and lastLineFillPercent need to be properties so that they can have a default value
2. ShimmerLinesView cannot have its own init

### Verification

Tested init of ShimmerLinesView

| Before | After |
|----------------------------------------------|--------------------------------------------|
|  ![image](https://user-images.githubusercontent.com/31874971/201836632-86802c1a-acfa-432b-9a9e-f80b0d0c4603.png) | ![simulator_screenshot_0C7244D1-C7D7-495D-92DC-F9FE5A37262C](https://user-images.githubusercontent.com/31874971/201836479-f40bc2ba-f68b-40a4-b6fa-16d374e61c54.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1362)