### PR TITLE
Bring fluent2-tokens Segmented Control to main

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemes.swift */; };
 		EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */; };
 		EC02A5F9274EED9200E81B3E /* DividerDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */; };
+		EC1C31752923032000CF052C /* ColoredPillBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */; };
 		EC6A71EC273DE6DF0076A586 /* DividerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
 		FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */; };
@@ -142,6 +143,7 @@
 		CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewDemoController.swift; sourceTree = "<group>"; };
 		E6842973247B672000A29C40 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E6842995247C350700A29C40 /* DemoColorThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoColorThemes.swift; sourceTree = "<group>"; };
+		EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredPillBackgroundView.swift; sourceTree = "<group>"; };
 		EC24DBC428B97E950026EF92 /* PopupMenuObjCDemoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopupMenuObjCDemoController.h; sourceTree = "<group>"; };
 		EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PopupMenuObjCDemoController.m; sourceTree = "<group>"; };
 		EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividerDemoController_SwiftUI.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 				B4414793228F6FDF0040E88E /* OtherCellsSampleData.swift */,
 				B4EF66552295F729007FEAB0 /* TableViewHeaderFooterSampleData.swift */,
 				B4C39551227A4AC800539EC2 /* TableViewSampleData.swift */,
+				EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */,
 			);
 			name = Utilities;
 			sourceTree = "<group>";
@@ -542,6 +545,7 @@
 				92DD1E8D279F496300FDEE0F /* DemoAppearanceView.swift in Sources */,
 				53097D4027028AE500A6E4DC /* PersonaButtonCarouselDemoController.swift in Sources */,
 				C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */,
+				EC1C31752923032000CF052C /* ColoredPillBackgroundView.swift in Sources */,
 				80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */,
 				C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */,
 				53097D3D27028AD800A6E4DC /* NavigationControllerDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+enum ColoredPillBackgroundStyle: Int {
+    case neutral
+    case brand
+}
+
+class ColoredPillBackgroundView: UIView {
+    init(style: ColoredPillBackgroundStyle) {
+        self.style = style
+        super.init(frame: .zero)
+        updateBackgroundColor()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateBackgroundColor()
+    }
+
+    @objc func themeDidChange() {
+        updateBackgroundColor()
+    }
+
+    func updateBackgroundColor() {
+        let lightColor: UIColor
+        let darkColor: UIColor
+        switch style {
+        case .neutral:
+            if let fluentTheme = window?.fluentTheme {
+                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral1])
+                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
+            } else {
+                lightColor = Colors.navigationBarBackground
+                darkColor = Colors.navigationBarBackground
+            }
+        case .brand:
+            if let fluentTheme = window?.fluentTheme {
+                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.brandRest])
+                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
+            } else {
+                lightColor = Colors.communicationBlue
+                darkColor = Colors.navigationBarBackground
+            }
+        }
+
+        backgroundColor = UIColor(light: lightColor, dark: darkColor)
+    }
+
+    let style: ColoredPillBackgroundStyle
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -30,6 +30,7 @@ struct Demos {
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),
         DemoDescriptor("Other cells", OtherCellsDemoController.self),
         DemoDescriptor("PersonaButtonCarousel", PersonaButtonCarouselDemoController.self),
+        DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
         DemoDescriptor("TypographyTokens", TypographyTokensDemoController.self)
     ]
@@ -53,7 +54,6 @@ struct Demos {
         DemoDescriptor("PillButtonBar", PillButtonBarDemoController.self),
         DemoDescriptor("PopupMenuController", PopupMenuDemoController.self),
         DemoDescriptor("SearchBar", SearchBarDemoController.self),
-        DemoDescriptor("SegmentedControl", SegmentedControlDemoController.self),
         DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TabBarView", TabBarViewDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -158,7 +158,7 @@ class ColorDemoController: UIViewController {
         }
         return segmentedControl
     }()
-    
+
     @objc private func didChangeTheme() {
         // The controls in this controller are not fully theme-aware yet, so
         // we need to manually poke them and have them refresh their colors.

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -147,18 +147,18 @@ class ColorDemoController: UIViewController {
 
     private lazy var segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: DemoColorTheme.allCases.map({ return SegmentItem(title: $0.name) }), style: .primaryPill)
-        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(sender:)), for: .valueChanged)
+        segmentedControl.onSelectAction = { [weak self] (_, index) in
+            guard let strongSelf = self,
+                  let window = strongSelf.view.window,
+                  let currentDemoListViewController = strongSelf.currentDemoListViewController else {
+                return
+            }
+
+            currentDemoListViewController.updateColorProviderFor(window: window, theme: DemoColorTheme.allCases[index])
+        }
         return segmentedControl
     }()
-
-    @objc private func segmentedControlValueChanged(sender: Any) {
-        if let segmentedControl = sender as? SegmentedControl, let window = self.view.window {
-            if let currentDemoListViewController = currentDemoListViewController {
-                currentDemoListViewController.updateColorProviderFor(window: window, theme: DemoColorTheme.allCases[segmentedControl.selectedSegmentIndex])
-            }
-        }
-    }
-
+    
     @objc private func didChangeTheme() {
         // The controls in this controller are not fully theme-aware yet, so
         // we need to manually poke them and have them refresh their colors.
@@ -167,7 +167,7 @@ class ColorDemoController: UIViewController {
                 colorView.updateBackgroundColor()
             }
         }
-        segmentedControl.updateWindowSpecificColors()
+        segmentedControl.updateColors()
     }
 
     private let tableView = UITableView(frame: .zero, style: .grouped)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -99,11 +99,16 @@ class PillButtonBarDemoController: DemoController {
             items.forEach { bar.disableItem($0) }
         }
 
-        let backgroundView = UIView()
-        if style == .primary {
-            backgroundView.backgroundColor = Colors.navigationBarBackground
-        }
+        let backgroundStyle: ColoredPillBackgroundStyle = {
+            switch style {
+            case .primary:
+                return .neutral
+            case .onBrand:
+                return .brand
+            }
+        }()
 
+        let backgroundView = ColoredPillBackgroundView(style: backgroundStyle)
         backgroundView.addSubview(bar)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0.0)
         fitViewIntoSuperview(bar, margins: margins)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -11,7 +11,13 @@ class SegmentedControlDemoController: DemoController {
         SegmentItem(title: "First"),
         SegmentItem(title: "Second", image: UIImage(named: "Placeholder_20")),
         SegmentItem(title: "Third", isUnread: true),
-        SegmentItem(title: "Fourth")
+        SegmentItem(title: "Fourth"),
+        SegmentItem(title: "Fifth"),
+        SegmentItem(title: "Sixth"),
+        SegmentItem(title: "Seventh"),
+        SegmentItem(title: "Eigth"),
+        SegmentItem(title: "Ninth"),
+        SegmentItem(title: "Tenth")
     ]
 
     var controlLabels = [SegmentedControl: Label]() {
@@ -28,61 +34,106 @@ class SegmentedControlDemoController: DemoController {
         container.layoutMargins.right = 0
 
         addTitle(text: "Primary Pill")
-
-        addPillControl(items: Array(segmentItems.prefix(3)), style: .primaryPill)
+        addDescription(text: "fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(3)),
+                       style: .primaryPill)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "Primary Pill with unequal buttons")
+        addTitle(text: "Primary Pill")
+        addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(10)),
+                       style: .primaryPill,
+                       equalSegments: false,
+                       isFixedWidth: false)
+        container.addArrangedSubview(UIView())
 
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .primaryPill, equalSegments: false)
+        addTitle(text: "Primary Pill")
+        addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .primaryPill,
+                       equalSegments: false,
+                       isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Disabled Primary Pill")
-
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .primaryPill, enabled: false)
+        addDescription(text: "fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .primaryPill,
+                       enabled: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "On Brand Pill")
-
-        addPillControl(items: Array(segmentItems.prefix(4)), style: .onBrandPill)
+        addDescription(text: "not fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(10)),
+                       style: .onBrandPill,
+                       equalSegments: true,
+                       isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "On Brand Pill with unequal buttons")
-
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, equalSegments: false)
+        addTitle(text: "On Brand Pill")
+        addDescription(text: "not fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .onBrandPill,
+                       isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Disabled On Brand Pill")
-
-        addPillControl(items: Array(segmentItems.prefix(2)), style: .onBrandPill, enabled: false)
+        addDescription(text: "fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(2)),
+                       style: .onBrandPill,
+                       enabled: false)
     }
 
     @objc func updateLabel(forControl control: SegmentedControl) {
         controlLabels[control]?.text = "\"\(segmentItems[control.selectedSegmentIndex].title)\" segment is selected"
     }
 
-    func addPillControl(items: [SegmentItem], style: SegmentedControl.Style, equalSegments: Bool = true, enabled: Bool = true) {
+    func addPillControl(items: [SegmentItem], style: SegmentedControlStyle, equalSegments: Bool = true, enabled: Bool = true, isFixedWidth: Bool = true) {
         let pillControl = SegmentedControl(items: items, style: style)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
+        pillControl.isFixedWidth = isFixedWidth
         pillControl.isEnabled = enabled
-        pillControl.addTarget(self, action: #selector(updateLabel(forControl:)), for: .valueChanged)
+        pillControl.onSelectAction = { [weak self] (_, _) in
+            guard let strongSelf = self else {
+                return
+            }
 
-        let backgroundView = UIView()
-        if style == .primaryPill {
-            backgroundView.backgroundColor = Colors.navigationBarBackground
-        } else {
-            backgroundView.backgroundColor = UIColor(light: Colors.communicationBlue, dark: Colors.navigationBarBackground)
+            strongSelf.updateLabel(forControl: pillControl)
         }
+
+        let backgroundStyle: ColoredPillBackgroundStyle = {
+            switch style {
+            case .primaryPill:
+                return .neutral
+            case .onBrandPill:
+                return .brand
+            }
+        }()
+        let backgroundView = ColoredPillBackgroundView(style: backgroundStyle)
+        segmentedControls.append(pillControl)
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
         pillControl.translatesAutoresizingMaskIntoConstraints = false
         backgroundView.addSubview(pillControl)
         container.addArrangedSubview(backgroundView)
         let margins = UIEdgeInsets(top: 16.0, left: 0, bottom: 16.0, right: 0)
-        var constraints = [backgroundView.topAnchor.constraint(equalTo: pillControl.topAnchor, constant: -margins.top),
-                           backgroundView.bottomAnchor.constraint(equalTo: pillControl.bottomAnchor, constant: margins.bottom)]
+        var constraints = [backgroundView.topAnchor.constraint(equalTo: pillControl.topAnchor,
+                                                               constant: -margins.top),
+                           backgroundView.bottomAnchor.constraint(equalTo: pillControl.bottomAnchor,
+                                                                  constant: margins.bottom)]
         if equalSegments {
             constraints.append(pillControl.centerXAnchor.constraint(equalTo: backgroundView.centerXAnchor))
+        }
+        if isFixedWidth {
+            constraints.append(contentsOf: [
+                backgroundView.leadingAnchor.constraint(lessThanOrEqualTo: pillControl.leadingAnchor),
+                backgroundView.trailingAnchor.constraint(greaterThanOrEqualTo: pillControl.trailingAnchor)
+            ])
+        } else {
+            constraints.append(contentsOf: [
+                backgroundView.leadingAnchor.constraint(equalTo: pillControl.leadingAnchor),
+                backgroundView.trailingAnchor.constraint(equalTo: pillControl.trailingAnchor)
+            ])
         }
 
         NSLayoutConstraint.activate(constraints)
@@ -90,5 +141,46 @@ class SegmentedControlDemoController: DemoController {
         if enabled {
             controlLabels[pillControl] = addDescription(text: "", textAlignment: .center)
         }
+    }
+
+    private var segmentedControls: [SegmentedControl] = []
+}
+
+extension SegmentedControlDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        fluentTheme.register(tokenSetType: SegmentedControlTokenSet.self,
+                             tokenSet: isOverrideEnabled ? themeWideOverrideSegmentedControlTokens : nil)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        self.segmentedControls.forEach({ segmentedControl in
+            segmentedControl.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideSegmentedControlTokens : nil)
+        })
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokens(for: SegmentedControlTokenSet.self) != nil
+    }
+
+    // MARK: - Custom tokens
+
+    private var themeWideOverrideSegmentedControlTokens: [SegmentedControlTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .font: .fontInfo {
+                return FontInfo(name: "Times", size: 20.0, weight: .regular)
+            }
+        ]
+    }
+
+    private var perControlOverrideSegmentedControlTokens: [SegmentedControlTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .font: .fontInfo {
+                return FontInfo(name: "Papyrus", size: 10.0, weight: .regular)
+            }
+        ]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -14,12 +14,15 @@ class TableViewHeaderFooterViewDemoController: DemoController {
     private let divider = MSFDivider()
 
     private lazy var segmentedControl: SegmentedControl = {
-        let tabTitles = TableViewHeaderFooterSampleData.tabTitles
-        let segmentedControl = SegmentedControl(items: tabTitles.map({ return SegmentItem(title: $0) }),
-                                                style: .primaryPill)
-        segmentedControl.addTarget(self,
-                                   action: #selector(updateActiveTabContent),
-                                   for: .valueChanged)
+        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
+        segmentedControl.onSelectAction = { [weak self] (_, _) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.updateActiveTabContent()
+        }
+
         return segmentedControl
     }()
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		C708B064260A87F7007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04EE25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
+		EC1C31732923022E00CF052C /* SegmentedControlTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1C31722923022E00CF052C /* SegmentedControlTokenSet.swift */; };
 		EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D727BF348700FD048D /* MSFAvatar.swift */; };
 		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
 		ECA9218627A3301C00B66117 /* MSFAvatarGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */; };
@@ -374,6 +375,7 @@
 		C77A04B625F03DD1001B3EB6 /* String+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		EC1C31722923022E00CF052C /* SegmentedControlTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlTokenSet.swift; sourceTree = "<group>"; };
 		EC5982D727BF348700FD048D /* MSFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatar.swift; sourceTree = "<group>"; };
 		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
 		ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatarGroup.swift; sourceTree = "<group>"; };
@@ -1052,6 +1054,7 @@
 				ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */,
 				C708B04B260A8696007190FA /* SegmentItem.swift */,
 				C708B055260A86FA007190FA /* SegmentPillButton.swift */,
+				EC1C31722923022E00CF052C /* SegmentedControlTokenSet.swift */,
 			);
 			path = SegmentedControl;
 			sourceTree = "<group>";
@@ -1574,6 +1577,7 @@
 				5328D97326FBA3D700F3723B /* IndeterminateProgressBarModifiers.swift in Sources */,
 				923DB9D7274CB66D00D8E58A /* ControlHostingView.swift in Sources */,
 				5314E03B25F00E3D0099271A /* BadgeStringExtractor.swift in Sources */,
+				EC1C31732923022E00CF052C /* SegmentedControlTokenSet.swift in Sources */,
 				5314E19825F019650099271A /* SideTabBar.swift in Sources */,
 				5314E10A25F014600099271A /* Obscurable.swift in Sources */,
 				5314E07D25F00F1A0099271A /* DateTimePickerViewComponentTableView.swift in Sources */,

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -232,12 +232,19 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func initSegmentedControl() {
-        let items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
-                     SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
-        segmentedControl = SegmentedControl(items: items,
-                                            style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
-    }
+            let items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
+                         SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
+            let segmentedControl = SegmentedControl(items: items,
+                                                style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
+            segmentedControl.onSelectAction = { [weak self] (_, index) in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                strongSelf.handleDidSelectStartEnd(index)
+            }
+            self.segmentedControl = segmentedControl
+        }
 
     private func updateNavigationBar() {
         let title = customTitle ?? String.dateString(from: focusDate, compactness: .shortDaynameShortMonthnameDay)
@@ -326,8 +333,8 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         dismiss()
     }
 
-    @objc private func handleDidSelectStartEnd(_ segmentedControl: SegmentedControl) {
-        selectionManager.selectionMode = segmentedControl.selectedSegmentIndex == 0 ? .start : .end
+    @objc private func handleDidSelectStartEnd(_ selectedIndex: Int) {
+        selectionManager.selectionMode = selectedIndex == 0 ? .start : .end
         updateNavigationBar()
         if let visibleDates = visibleDates, focusDate > visibleDates.endDate || focusDate < visibleDates.startDate {
             scrollToFocusDate(animated: false)

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -161,8 +161,15 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         }
-        segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
-        segmentedControl?.addTarget(self, action: #selector(handleDidSelectStartEnd(_:)), for: .valueChanged)
+        let segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
+        segmentedControl.onSelectAction = { [weak self] (_, index) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.handleDidSelectStartEnd(index)
+        }
+        self.segmentedControl = segmentedControl
     }
 
     private func initNavigationBar() {

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -17,8 +17,6 @@ class SegmentPillButton: UIButton {
         }
     }
 
-    var unreadDotColor: UIColor = Colors.gray100
-
     override var isSelected: Bool {
         didSet {
             if oldValue != isSelected && isSelected == true {
@@ -28,8 +26,37 @@ class SegmentPillButton: UIButton {
         }
     }
 
-    init(withItem item: SegmentItem) {
+    let tokenSet: SegmentedControlTokenSet
+
+    func updateTokenizedValues() {
+        titleLabel?.font = UIFont.fluent(tokenSet[.font].fontInfo, shouldScale: false)
+        let verticalInset = tokenSet[.verticalInset].float
+        let horizontalInset = tokenSet[.horizontalInset].float
+        if #available(iOS 15.0, *) {
+            var configuration = UIButton.Configuration.plain()
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: verticalInset,
+                                                                  leading: horizontalInset,
+                                                                  bottom: verticalInset,
+                                                                  trailing: horizontalInset)
+            configuration.background.backgroundColor = .clear
+            let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.fluent(self.tokenSet[.font].fontInfo, shouldScale: false)
+                return outgoing
+            }
+            configuration.titleTextAttributesTransformer = titleTransformer
+            self.configuration = configuration
+        } else {
+            self.contentEdgeInsets = UIEdgeInsets(top: verticalInset,
+                                                  left: horizontalInset,
+                                                  bottom: verticalInset,
+                                                  right: horizontalInset)
+        }
+    }
+
+    init(withItem item: SegmentItem, tokenSet: SegmentedControlTokenSet) {
         self.item = item
+        self.tokenSet = tokenSet
         super.init(frame: .zero)
 
         // TODO: Once iOS 14 support is dropped, set title, etc., in configuration
@@ -43,21 +70,12 @@ class SegmentPillButton: UIButton {
         }
         self.showsLargeContentViewer = true
 
-        var configuration = UIButton.Configuration.plain()
-        configuration.contentInsets = Constants.insets
-        configuration.background.backgroundColor = .clear
-        let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
-            var outgoing = incoming
-            outgoing.font = UIFont.systemFont(ofSize: Constants.fontSize)
-            return outgoing
-        }
-        configuration.titleTextAttributesTransformer = titleTransformer
-        self.configuration = configuration
-
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(isUnreadValueDidChange),
                                                name: SegmentItem.isUnreadValueDidChangeNotification,
                                                object: item)
+
+        updateTokenizedValues()
     }
 
     required init?(coder: NSCoder) {
@@ -67,14 +85,24 @@ class SegmentPillButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         updateUnreadDot()
+        guard let updateMaskedContentConstraints = updateMaskedContentConstraints else {
+            return
+        }
+        updateMaskedContentConstraints()
     }
+
+    /// UIButton.Configuration is doing something causing the layout of the label/icon
+    /// and masked content to render incorrectly, so we need to update the constraints
+    /// on the masked content when we layoutSubviews
+    var updateMaskedContentConstraints: (() -> Void)?
 
     private let item: SegmentItem
 
-    private let unreadDotLayer: CALayer = {
+    private lazy var unreadDotLayer: CALayer = {
         let unreadDotLayer = CALayer()
-        unreadDotLayer.bounds.size = CGSize(width: Constants.unreadDotSize, height: Constants.unreadDotSize)
-        unreadDotLayer.cornerRadius = Constants.unreadDotSize / 2
+        let unreadDotSize = tokenSet[.unreadDotSize].float
+        unreadDotLayer.bounds.size = CGSize(width: unreadDotSize, height: unreadDotSize)
+        unreadDotLayer.cornerRadius = unreadDotSize / 2
         return unreadDotLayer
     }()
 
@@ -89,19 +117,13 @@ class SegmentPillButton: UIButton {
             let anchor = self.titleLabel?.frame ?? .zero
             let xPos: CGFloat
             if effectiveUserInterfaceLayoutDirection == .leftToRight {
-                xPos = anchor.maxX + Constants.unreadDotOffset.x
+                xPos = anchor.maxX + tokenSet[.unreadDotOffsetX].float
             } else {
-                xPos = anchor.minX - Constants.unreadDotOffset.x - Constants.unreadDotSize
+                xPos = anchor.minX - tokenSet[.unreadDotOffsetX].float - tokenSet[.unreadDotSize].float
             }
-            unreadDotLayer.frame.origin = CGPoint(x: xPos, y: anchor.minY + Constants.unreadDotOffset.y)
-            unreadDotLayer.backgroundColor = unreadDotColor.cgColor
+            unreadDotLayer.frame.origin = CGPoint(x: xPos, y: anchor.minY + tokenSet[.unreadDotOffsetY].float)
+            let unreadDotColor = isEnabled ? tokenSet[.enabledUnreadDotColor].dynamicColor : tokenSet[.disabledUnreadDotColor].dynamicColor
+            unreadDotLayer.backgroundColor = UIColor(dynamicColor: unreadDotColor).cgColor
         }
-    }
-
-    private struct Constants {
-        static let fontSize: CGFloat = 16
-        static let unreadDotOffset = CGPoint(x: 6, y: 3)
-        static let unreadDotSize: CGFloat = 6
-        static let insets = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16)
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -3,124 +3,12 @@
 //  Licensed under the MIT License.
 //
 import UIKit
-
-// MARK: SegmentedControl Colors
-
-private extension Colors {
-    struct SegmentedControl {
-        struct PrimaryPill {
-            static let background = UIColor(light: surfaceTertiary, dark: gray950)
-            static let backgroundDisabled: UIColor = background
-            static let segmentText = UIColor(light: textSecondary, dark: textPrimary)
-            static let selectionDisabled: UIColor = surfaceQuaternary
-        }
-
-        struct OnBrandPill {
-            static let background: UIColor = PrimaryPill.background
-            static let backgroundDisabled: UIColor = PrimaryPill.backgroundDisabled
-            static let segmentText = UIColor(light: textOnAccent, dark: textPrimary)
-            static let selection = UIColor(light: surfacePrimary, dark: surfaceQuaternary)
-            static let selectionDisabled = UIColor(light: Colors.surfacePrimary, dark: Colors.surfaceQuaternary)
-        }
-    }
-}
+import Combine
 
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.
 @objc(MSFSegmentedControl)
-open class SegmentedControl: UIControl {
-    @objc(MSFSegmentedControlStyle)
-    public enum Style: Int {
-        /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
-        case primaryPill
-        /// Segments are shows as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
-        /// Selection is indicated by a thumb under the selected label.
-        case onBrandPill
-
-        var backgroundHasRoundedCorners: Bool { return self == .primaryPill || self == .onBrandPill }
-
-        func backgroundColor(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.background
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.background)
-            }
-        }
-        func backgroundColorDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.backgroundDisabled
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryShade10(for: window), dark: Colors.SegmentedControl.OnBrandPill.backgroundDisabled)
-            }
-        }
-        func selectionColor(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.primary(for: window)
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.selection
-            }
-        }
-        var selectionColorDisabled: UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.selectionDisabled
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.selectionDisabled
-            }
-        }
-        var segmentTextColor: UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.SegmentedControl.PrimaryPill.segmentText
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.segmentText
-            }
-        }
-        func segmentTextColorSelected(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.textOnAccent
-            case .onBrandPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
-            }
-        }
-        func segmentTextColorDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return Colors.textDisabled
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryTint10(for: window), dark: Colors.textDisabled)
-            }
-        }
-        func segmentTextColorSelectedAndDisabled(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return UIColor(light: Colors.surfacePrimary, dark: Colors.gray500)
-            case .onBrandPill:
-                return UIColor(light: Colors.primaryTint20(for: window), dark: Colors.gray500)
-            }
-        }
-
-        func segmentUnreadDotColor(for window: UIWindow) -> UIColor {
-            switch self {
-            case .primaryPill:
-                return UIColor(light: Colors.primary(for: window), dark: Colors.gray100)
-            case .onBrandPill:
-                return Colors.SegmentedControl.OnBrandPill.segmentText
-            }
-        }
-
-        var selectionChangeAnimationDuration: TimeInterval {
-            switch self {
-            case .primaryPill, .onBrandPill:
-                return 0.2
-            }
-        }
-    }
-
+open class SegmentedControl: UIView, TokenizedControlInternal {
     private struct Constants {
         static let selectionBarHeight: CGFloat = 1.5
         static let pillContainerHorizontalInset: CGFloat = 16
@@ -128,18 +16,32 @@ open class SegmentedControl: UIControl {
         static let iPadMinimumWidth: CGFloat = 375
     }
 
-    open override var isEnabled: Bool {
+    open var isEnabled: Bool = true {
         didSet {
             for button in buttons {
                 button.isEnabled = isEnabled
             }
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
 
     @objc public var isAnimated: Bool = true
     @objc public var numberOfSegments: Int { return items.count }
-    @objc public var shouldSetEqualWidthForSegments: Bool = true
+    /// Defines if the segments of the `SegmentedControl` are equal in width.
+    @objc public var shouldSetEqualWidthForSegments: Bool = true {
+        didSet {
+            updateStackDistribution()
+        }
+    }
+
+    /// Defines if the `SegmentedControl` will take up the full width of the screen on iPhone, or half on iPad.
+    /// Scrolling will only work if this is false.
+    @objc public var isFixedWidth: Bool = true {
+        didSet {
+            updateViewHierarchyForScrolling()
+            updatePillContainerConstraints()
+        }
+    }
 
     /// only used for pill style segment control. It is used to define the inset of the pillContainerView
     @objc public var contentInset: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 0, leading: Constants.pillContainerHorizontalInset, bottom: 0, trailing: Constants.pillContainerHorizontalInset) {
@@ -147,49 +49,51 @@ open class SegmentedControl: UIControl {
             guard oldValue != contentInset else {
                 return
             }
-            pillContainerViewTopConstraint?.constant = contentInset.top
-            pillContainerViewBottomConstraint?.constant = contentInset.bottom
-            pillContainerViewLeadingConstraint?.constant = contentInset.leading
-            pillContainerViewTrailingConstraint?.constant = contentInset.trailing
+            updatePillContainerConstraints()
 
             invalidateIntrinsicContentSize()
         }
     }
+    /// The closure for the action to be called when a segment is selected.
+    /// When called, the selected item and its index will be passed in to the closure.
+    @objc public var onSelectAction: ((SegmentItem, Int) -> Void)?
     @objc public var selectedSegmentIndex: Int {
         get { return _selectedSegmentIndex }
         set { selectSegment(at: newValue, animated: false) }
     }
 
     private var _selectedSegmentIndex: Int = -1
-    private var customSegmentedControlBackgroundColor: UIColor?
-    private var customSegmentedControlSelectedButtonBackgroundColor: UIColor?
-    private var customSegmentedControlButtonTextColor: UIColor?
-    private var customSelectedSegmentedControlButtonTextColor: UIColor?
 
     private var items = [SegmentItem]()
-    internal var style: Style {
+    internal var style: SegmentedControlStyle {
         didSet {
-            updateWindowSpecificColors()
+            updateColors()
         }
     }
 
-    // Hierarchy for pill styles:
+    // Hierarchy:
     //
+    // isFixedWidth = false (adds mask and scrollView):
+    // layer.mask -> gradientMaskLayer
+    // scrollView
+    // |--pillContainerView (used to create 16pt inset on either side)
+    // |  |--stackView (fill container view, uses restTabColor)
+    // |  |  |--buttons (uses restLabelColor)
+    // |  |--pillMaskedLabelsContainerView (fill container view, uses selectedTabColor)
+    // |  |  |.mask -> selectionView
+    // |  |  |--pillMaskedLabels (uses selectedLabelColor)
+    // |  |  |--pillMaskedImages (uses selectedLabelColor)
+    //
+    // isFixedWidth = true:
     // pillContainerView (used to create 16pt inset on either side)
-    // |--backgroundView (fill container view, uses customSegmentedControlBackgroundColor)
-    // |--buttons (uses customSegmentedControlButtonTextColor)
-    // |--pillMaskedContentContainerView (fill container view, uses customSegmentedControlSelectedButtonBackgroundColor)
+    // |--stackView (fill container view, uses restTabColor)
+    // |  |--buttons (uses restLabelColor)
+    // |--pillMaskedLabelsContainerView (fill container view, uses selectedTabColor)
     // |  |.mask -> selectionView
-    // |  |--pillMaskedLabels (uses customSelectedSegmentedControlButtonTextColor)
-    // |  |--pillMaskedImages (uses customSelectedSegmentedControlButtonTextColor)
+    // |  |--pillMaskedLabels (uses selectedLabelColor)
+    // |  |--pillMaskedImages (uses selectedLabelColor)
 
-    private let backgroundView: UIView = {
-        let view = UIView()
-        view.layer.cornerCurve = .continuous
-
-        return view
-    }()
-    private var buttons = [UIButton]()
+    private var buttons = [SegmentPillButton]()
     private let selectionView: UIView = {
         let view = UIView()
         view.layer.cornerCurve = .continuous
@@ -199,23 +103,63 @@ open class SegmentedControl: UIControl {
     private let pillContainerView: UIView = {
         let view = UIView()
         view.layer.cornerCurve = .continuous
+        view.translatesAutoresizingMaskIntoConstraints = false
 
         return view
     }()
     private let pillMaskedContentContainerView: UIView = {
         let view = UIView()
         view.layer.cornerCurve = .continuous
+        view.isUserInteractionEnabled = false
+        view.translatesAutoresizingMaskIntoConstraints = false
 
         return view
     }()
+    private let stackView: UIStackView = {
+       let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.layer.cornerCurve = .continuous
+
+        return stackView
+    }()
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+
+        return scrollView
+    }()
     private var pillMaskedLabels = [UILabel?]()
     private var pillMaskedImages = [UIImageView?]()
-    private var pillContainerViewTopConstraint: NSLayoutConstraint?
-    private var pillContainerViewBottomConstraint: NSLayoutConstraint?
-    private var pillContainerViewLeadingConstraint: NSLayoutConstraint?
-    private var pillContainerViewTrailingConstraint: NSLayoutConstraint?
+    private var pillContainerViewConstraints: [NSLayoutConstraint] = []
+
+    private lazy var scrollViewConstraints: [NSLayoutConstraint] = {
+        let safeArea = safeAreaLayoutGuide
+        return [scrollView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)]
+    }()
 
     private var isAnimating: Bool = false
+
+    private let gradientMaskLayer: CAGradientLayer = {
+        let gradient = CAGradientLayer()
+        gradient.startPoint = CGPoint(x: 0.0, y: 0.5)
+        gradient.endPoint = CGPoint(x: 1.0, y: 0.5)
+        return gradient
+    }()
+
+    private var gradientMaskColors: [CGColor] {
+        let contentOffsetX = scrollView.contentOffset.x
+        let leftColor = contentOffsetX <= 0 ? UIColor.black : UIColor.clear
+        let rightColor = contentOffsetX >= maximumContentOffset ? UIColor.black : UIColor.clear
+        // Divide the Segmented Control into 5 sections to control the length
+        // of the gradient
+        return [leftColor, UIColor.black, UIColor.black, UIColor.black, rightColor].map { $0.cgColor }
+    }
 
     public convenience init() {
         self.init(items: [])
@@ -225,87 +169,67 @@ open class SegmentedControl: UIControl {
     ///
     /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
-    @objc public convenience init(items: [SegmentItem], style: Style = .primaryPill) {
-        self.init(items: items,
-                  style: style,
-                  customSegmentedControlBackgroundColor: nil,
-                  customSegmentedControlSelectedButtonBackgroundColor: nil,
-                  customSegmentedControlButtonTextColor: nil,
-                  customSelectedSegmentedControlButtonTextColor: nil)
-    }
-
-    /// Initializes a segmented control with the specified titles, style, and colors (colors are for pill styles only).
-    ///
-    /// - Parameter items: An array of Segmented Items representing the segments for this control.
-    /// - Parameter style: A style used for rendering of the control.
-    /// - Parameter customSegmentedControlBackgroundColor: UIColor to use as the background color
-    /// - Parameter customSegmentedControlSelectedButtonBackgroundColor: UIColor to use as the selected button background color
-    /// - Parameter customSegmentedControlButtonTextColor: UIColor to use as the unselected button text color
-    /// - Parameter customSelectedSegmentedControlButtonTextColor: UIColor to use as the selected button text color
-    @objc public init(items: [SegmentItem],
-                      style: Style = .primaryPill,
-                      customSegmentedControlBackgroundColor: UIColor? = nil,
-                      customSegmentedControlSelectedButtonBackgroundColor: UIColor? = nil,
-                      customSegmentedControlButtonTextColor: UIColor? = nil,
-                      customSelectedSegmentedControlButtonTextColor: UIColor? = nil) {
+    @objc public init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
         self.style = style
-        self.customSegmentedControlBackgroundColor = customSegmentedControlBackgroundColor
-        self.customSegmentedControlSelectedButtonBackgroundColor = customSegmentedControlSelectedButtonBackgroundColor
-        self.customSegmentedControlButtonTextColor = customSegmentedControlButtonTextColor
-        self.customSelectedSegmentedControlButtonTextColor = customSelectedSegmentedControlButtonTextColor
 
         super.init(frame: .zero)
+        scrollView.delegate = self
 
-        backgroundView.layer.cornerRadius = Constants.pillButtonCornerRadius
-        pillContainerView.addSubview(backgroundView)
+        stackView.layer.cornerRadius = Constants.pillButtonCornerRadius
+        pillContainerView.addSubview(stackView)
         selectionView.backgroundColor = .black
         pillContainerView.addSubview(selectionView)
         pillMaskedContentContainerView.mask = selectionView
-        pillMaskedContentContainerView.isUserInteractionEnabled = false
         pillContainerView.addSubview(pillMaskedContentContainerView)
         addButtons(items: items)
-        // We need to add pillMaskedContentContainerView to the container view
-        // before the buttons in order to activate the label constraints, but
-        // we want pillMaskedContentContainerView to show above the buttons.
-        pillContainerView.bringSubviewToFront(pillMaskedContentContainerView)
         pillContainerView.addInteraction(UILargeContentViewerInteraction())
         addSubview(pillContainerView)
 
+        updateStackDistribution()
         setupLayoutConstraints()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
+        // Update appearance whenever overrideTokens changes.
+        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+            self?.updateColors()
+            self?.updateButtons()
+        }
     }
 
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    public func updateWindowSpecificColors() {
-        guard let window = window else {
-            return
+    public func updateColors() {
+        let tabColor: DynamicColor
+        let selectedTabColor: DynamicColor
+        let selectedContentColor: UIColor
+        if isEnabled {
+            tabColor = tokenSet[.restTabColor].dynamicColor
+            selectedTabColor = tokenSet[.selectedTabColor].dynamicColor
+            selectedContentColor = UIColor(dynamicColor: tokenSet[.selectedLabelColor].dynamicColor)
+        } else {
+            tabColor = tokenSet[.disabledTabColor].dynamicColor
+            selectedTabColor = tokenSet[.disabledSelectedTabColor].dynamicColor
+            selectedContentColor = UIColor(dynamicColor: tokenSet[.disabledSelectedLabelColor].dynamicColor)
         }
-
-        pillMaskedContentContainerView.backgroundColor = customSegmentedControlSelectedButtonBackgroundColor ?? (isEnabled ? style.selectionColor(for: window) : style.selectionColorDisabled)
-        backgroundView.backgroundColor = customSegmentedControlBackgroundColor ?? (isEnabled ? style.backgroundColor(for: window) : style.backgroundColorDisabled(for: window))
-        let maskedContentColor = isEnabled ? (customSelectedSegmentedControlButtonTextColor ?? style.segmentTextColorSelected(for: window)) : style.segmentTextColorSelectedAndDisabled(for: window)
+        stackView.backgroundColor = UIColor(dynamicColor: tabColor)
+        pillMaskedContentContainerView.backgroundColor = UIColor(dynamicColor: selectedTabColor)
         for maskedLabel in pillMaskedLabels {
             guard let maskedLabel = maskedLabel else {
                 continue
             }
-            maskedLabel.textColor = maskedContentColor
+            maskedLabel.textColor = selectedContentColor
         }
         for maskedImage in pillMaskedImages {
             guard let maskedImage = maskedImage else {
                 continue
             }
-            maskedImage.tintColor = maskedContentColor
-        }
-        let contentColor = isEnabled ? (customSegmentedControlButtonTextColor ?? style.segmentTextColor) : style.segmentTextColorDisabled(for: window)
-        for button in buttons {
-            button.setTitleColor(contentColor, for: .normal)
-            button.tintColor = contentColor
-
-            if let switchButton = button as? SegmentPillButton {
-                switchButton.unreadDotColor = isEnabled ? style.segmentUnreadDotColor(for: window) : style.segmentTextColorDisabled(for: window)
-            }
+            maskedImage.tintColor = selectedContentColor
         }
     }
 
@@ -318,7 +242,7 @@ open class SegmentedControl: UIControl {
         items.insert(item, at: index)
 
         let button = createPillButton(withItem: item)
-        pillContainerView.addSubview(button)
+        stackView.addArrangedSubview(button)
         addMaskedContent(over: button, at: index, hasImage: item.image != nil)
         buttons.insert(button, at: index)
         updateButton(at: index, isSelected: false)
@@ -374,7 +298,8 @@ open class SegmentedControl: UIControl {
     ///   - index: The index of the segment to set as selected
     ///   - animated: Whether or not to animate the change in selected segment
     @objc open func selectSegment(at index: Int, animated: Bool) {
-        precondition(index >= 0 && index < buttons.count, "SegmentedControl > try to selected segment index with invalid index: \(index)")
+        precondition(index >= 0 && index < buttons.count,
+                     "SegmentedControl > try to selected segment index with invalid index: \(index)")
 
         if index == _selectedSegmentIndex {
             return
@@ -391,7 +316,10 @@ open class SegmentedControl: UIControl {
 
         if animated {
             isAnimating = true
-            UIView.animate(withDuration: style.selectionChangeAnimationDuration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState], animations: {
+            UIView.animate(withDuration: selectionChangeAnimationDuration,
+                           delay: 0,
+                           options: [.curveEaseOut, .beginFromCurrentState],
+                           animations: {
                 self.layoutSelectionView()
             }, completion: { _ in
                 self.isAnimating = false
@@ -399,44 +327,34 @@ open class SegmentedControl: UIControl {
         } else {
             setNeedsLayout()
         }
+        if !isFixedWidth {
+            scrollView.scrollRectToVisible(buttons[_selectedSegmentIndex].frame, animated: animated)
+        }
     }
 
     open override func layoutSubviews() {
         super.layoutSubviews()
 
-        guard !isAnimating else {
-            return
-        }
+        stackView.layoutIfNeeded()
 
-        var rightOffset: CGFloat = 0
-        var leftOffset: CGFloat = 0
-        for (index, button) in buttons.enumerated() {
-            if shouldSetEqualWidthForSegments {
-                rightOffset = ceil(CGFloat(index + 1) / CGFloat(buttons.count) * pillContainerView.frame.width)
-            } else {
-                let maxSize = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-                rightOffset = leftOffset + ceil(button.sizeThatFits(maxSize).width)
-            }
-            button.frame = CGRect(x: leftOffset, y: 0, width: rightOffset - leftOffset, height: pillContainerView.frame.height)
-            leftOffset = rightOffset
-        }
-
-            // flipSubviewsForRTL only works on direct children subviews
-            pillContainerView.flipSubviewsForRTL()
+        // flipSubviewsForRTL only works on direct children subviews
+        pillContainerView.flipSubviewsForRTL()
 
         flipSubviewsForRTL()
         layoutSelectionView()
+
+        updateGradientMaskColors()
+        gradientMaskLayer.frame = layer.bounds
     }
 
     open override var intrinsicContentSize: CGSize {
-        return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
+        return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude,
+                                   height: CGFloat.greatestFiniteMagnitude))
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        if shouldSetEqualWidthForSegments {
-            invalidateIntrinsicContentSize()
-        }
+        invalidateIntrinsicContentSize()
         layoutSubviews()
     }
 
@@ -444,45 +362,43 @@ open class SegmentedControl: UIControl {
         guard let window = window else {
             return CGSize.zero
         }
-        var maxButtonHeight: CGFloat = 0.0
-        var maxButtonWidth: CGFloat = 0.0
-        var buttonsWidth: CGFloat = 0.0
+        var height: CGFloat = 0.0
+        var width: CGFloat = 0.0
 
         for button in buttons {
             let size = button.sizeThatFits(size)
-            maxButtonHeight = max(maxButtonHeight, ceil(size.height))
-            if shouldSetEqualWidthForSegments {
-                maxButtonWidth = max(maxButtonWidth, ceil(size.width))
-            } else {
-                buttonsWidth += ceil(size.width)
+            height = max(height, ceil(size.height))
+            if !isFixedWidth {
+                width += ceil(size.width)
             }
         }
 
-        if shouldSetEqualWidthForSegments {
-            maxButtonWidth *= CGFloat(buttons.count)
-        } else {
-            maxButtonWidth = buttonsWidth
-        }
-
-        if shouldSetEqualWidthForSegments {
-            let windowSafeAreaInsets = window.safeAreaInsets
-            let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
+        let windowSafeAreaInsets = window.safeAreaInsets
+        let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
+        if isFixedWidth {
             if traitCollection.userInterfaceIdiom == .pad {
-                maxButtonWidth = max(windowWidth / 2, Constants.iPadMinimumWidth)
+                width = max(windowWidth / 2, Constants.iPadMinimumWidth)
             } else {
-                maxButtonWidth = windowWidth
+                width = windowWidth
             }
         } else {
-            maxButtonWidth += (contentInset.leading + contentInset.trailing)
+            width += (contentInset.leading + contentInset.trailing)
         }
-        maxButtonHeight += (contentInset.top + contentInset.bottom)
+        height += (contentInset.top + contentInset.bottom)
 
-        return CGSize(width: min(maxButtonWidth, size.width), height: min(maxButtonHeight, size.height))
+        let finalWidth = min(min(width, windowWidth), size.width)
+        let finalHeight = min(height, size.height)
+        return CGSize(width: finalWidth,
+                      height: finalHeight)
     }
 
     open override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateWindowSpecificColors()
+
+        tokenSet.update(fluentTheme)
+        updateColors()
+        updateButtons()
+        updateGradientMaskColors()
     }
 
     func intrinsicContentSizeInvalidatedForChildView() {
@@ -498,6 +414,22 @@ open class SegmentedControl: UIControl {
         return buttons[index] as UIView
     }
 
+    public typealias TokenSetKeyType = SegmentedControlTokenSet.Tokens
+    lazy public var tokenSet: SegmentedControlTokenSet = .init(style: { self.style })
+    var tokenSetSink: AnyCancellable?
+
+    var selectionChangeAnimationDuration: TimeInterval { return 0.2 }
+
+    private func updateButtons() {
+        let contentColor = isEnabled ? UIColor(dynamicColor: tokenSet[.restLabelColor].dynamicColor) : UIColor(dynamicColor: tokenSet[.disabledLabelColor].dynamicColor)
+        for (index, button) in buttons.enumerated() {
+            button.updateTokenizedValues()
+            button.setTitleColor(contentColor, for: .normal)
+            button.tintColor = contentColor
+            pillMaskedLabels[index]?.font = button.titleLabel?.font
+        }
+    }
+
     private func addButtons(items: [SegmentItem]) {
         // Create buttons
         for (index, item) in items.enumerated() {
@@ -510,13 +442,13 @@ open class SegmentedControl: UIControl {
         }
     }
 
-    private func createPillButton(withItem item: SegmentItem) -> UIButton {
-        let button = SegmentPillButton(withItem: item)
+    private func createPillButton(withItem item: SegmentItem) -> SegmentPillButton {
+        let button = SegmentPillButton(withItem: item, tokenSet: tokenSet)
         button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
         return button
     }
 
-    private func addMaskedContent(over button: UIButton, at index: Int, hasImage: Bool) {
+    private func addMaskedContent(over button: SegmentPillButton, at index: Int, hasImage: Bool) {
         let unmaskedContent: UIView
         let maskedContent: UIView
         let maskedImageView: UIImageView?
@@ -547,53 +479,76 @@ open class SegmentedControl: UIControl {
         pillMaskedContentContainerView.addSubview(maskedContent)
         pillMaskedLabels.insert(maskedLabel, at: index)
         pillMaskedImages.insert(maskedImageView, at: index)
-
-        NSLayoutConstraint.activate([
+        let constraints = [
             unmaskedContent.leadingAnchor.constraint(equalTo: maskedContent.leadingAnchor),
             unmaskedContent.trailingAnchor.constraint(equalTo: maskedContent.trailingAnchor),
             unmaskedContent.topAnchor.constraint(equalTo: maskedContent.topAnchor),
             unmaskedContent.bottomAnchor.constraint(equalTo: maskedContent.bottomAnchor)
-        ])
-    }
+        ]
 
-    @objc private func handleButtonTap(_ sender: UIButton) {
-        if let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index {
-            selectSegment(at: index, animated: isAnimated)
-            sendActions(for: .valueChanged)
+        if #available(iOS 15.0, *) {
+            button.updateMaskedContentConstraints = {
+                unmaskedContent.removeConstraints(constraints)
+                NSLayoutConstraint.activate(constraints)
+            }
+        } else {
+            NSLayoutConstraint.activate(constraints)
         }
     }
 
+    @objc private func handleButtonTap(_ sender: SegmentPillButton) {
+        guard let index = buttons.firstIndex(of: sender), selectedSegmentIndex != index  else {
+            return
+        }
+
+        selectSegment(at: index, animated: isAnimated)
+        if let onSelectAction = onSelectAction {
+            onSelectAction(items[index], index)
+        }
+    }
+
+    private func updatePillContainerConstraints() {
+        NSLayoutConstraint.deactivate(pillContainerViewConstraints)
+        let topAnchor: NSLayoutYAxisAnchor
+        let leadingAnchor: NSLayoutXAxisAnchor
+        let trailingAnchor: NSLayoutXAxisAnchor
+        let bottomAnchor: NSLayoutYAxisAnchor
+        if isFixedWidth {
+            topAnchor = self.safeAreaLayoutGuide.topAnchor
+            leadingAnchor = self.safeAreaLayoutGuide.leadingAnchor
+            trailingAnchor = self.safeAreaLayoutGuide.trailingAnchor
+            bottomAnchor = self.safeAreaLayoutGuide.bottomAnchor
+        } else {
+            topAnchor = scrollView.topAnchor
+            leadingAnchor = scrollView.leadingAnchor
+            trailingAnchor = scrollView.trailingAnchor
+            bottomAnchor = scrollView.bottomAnchor
+        }
+        pillContainerViewConstraints = [
+            pillContainerView.topAnchor.constraint(equalTo: topAnchor,
+                                                   constant: contentInset.top),
+            pillContainerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: contentInset.leading),
+            pillContainerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -contentInset.trailing),
+            pillContainerView.bottomAnchor.constraint(equalTo: bottomAnchor,
+                                                   constant: -contentInset.bottom)
+        ]
+        NSLayoutConstraint.activate(pillContainerViewConstraints)
+    }
+
     private func setupLayoutConstraints () {
-        backgroundView.translatesAutoresizingMaskIntoConstraints = false
-        var constraints = [NSLayoutConstraint]()
-        pillContainerView.translatesAutoresizingMaskIntoConstraints = false
-        pillMaskedContentContainerView.translatesAutoresizingMaskIntoConstraints = false
+        updatePillContainerConstraints()
 
-        let pillContainerViewTopConstraint = pillContainerView.topAnchor.constraint(equalTo: topAnchor, constant: contentInset.top)
-        let pillContainerViewBottomConstraint = pillContainerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -contentInset.bottom)
-        let pillContainerViewLeadingConstraint = pillContainerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: contentInset.leading)
-        let pillContainerViewTrailingConstraint = pillContainerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -contentInset.trailing)
-        self.pillContainerViewTopConstraint = pillContainerViewTopConstraint
-        self.pillContainerViewBottomConstraint = pillContainerViewBottomConstraint
-        self.pillContainerViewLeadingConstraint = pillContainerViewLeadingConstraint
-        self.pillContainerViewTrailingConstraint = pillContainerViewTrailingConstraint
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: pillContainerView.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: pillContainerView.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: pillContainerView.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: pillContainerView.bottomAnchor),
 
-        constraints.append(contentsOf: [
-            pillContainerViewTopConstraint,
-            pillContainerViewBottomConstraint,
-            pillContainerViewLeadingConstraint,
-            pillContainerViewTrailingConstraint,
-            backgroundView.leadingAnchor.constraint(equalTo: pillContainerView.leadingAnchor),
-            backgroundView.trailingAnchor.constraint(equalTo: pillContainerView.trailingAnchor),
-            backgroundView.topAnchor.constraint(equalTo: pillContainerView.topAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: pillContainerView.bottomAnchor),
-
-            pillMaskedContentContainerView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
-            pillMaskedContentContainerView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
-            pillMaskedContentContainerView.topAnchor.constraint(equalTo: backgroundView.topAnchor),
-            pillMaskedContentContainerView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor)
+            pillMaskedContentContainerView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            pillMaskedContentContainerView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            pillMaskedContentContainerView.topAnchor.constraint(equalTo: stackView.topAnchor),
+            pillMaskedContentContainerView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
         ])
-        NSLayoutConstraint.activate(constraints)
     }
 
     private func updateButton(at index: Int, isSelected: Bool) {
@@ -603,6 +558,15 @@ open class SegmentedControl: UIControl {
 
         let button = buttons[index]
         button.isSelected = isSelected
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let window = window, window.isEqual(notification.object) else {
+            return
+        }
+        tokenSet.update(window.fluentTheme)
+        updateColors()
+        updateButtons()
     }
 
     private func layoutSelectionView() {
@@ -617,7 +581,45 @@ open class SegmentedControl: UIControl {
 
     private func updateAccessibilityHints() {
         for (index, button) in buttons.enumerated() {
-            button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
+            button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized,
+                                                                        index + 1, items.count)
         }
+    }
+
+    private func updateStackDistribution() {
+        stackView.distribution = shouldSetEqualWidthForSegments ? .fillEqually : .fillProportionally
+    }
+
+    private func updateGradientMaskColors() {
+        gradientMaskLayer.colors = gradientMaskColors
+    }
+
+    private func updateViewHierarchyForScrolling() {
+        if isFixedWidth {
+            scrollView.removeFromSuperview()
+            pillContainerView.removeFromSuperview()
+            addSubview(pillContainerView)
+            layer.mask = nil
+
+            NSLayoutConstraint.deactivate(scrollViewConstraints)
+        } else {
+            pillContainerView.removeFromSuperview()
+            scrollView.addSubview(pillContainerView)
+            addSubview(scrollView)
+            layer.mask = gradientMaskLayer
+
+            NSLayoutConstraint.activate(scrollViewConstraints)
+        }
+    }
+
+    private var maximumContentOffset: CGFloat {
+        return stackView.frame.size.width - scrollView.frame.size.width
+    }
+}
+
+// MARK: UIScrollViewDelegate
+extension SegmentedControl: UIScrollViewDelegate {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        updateGradientMaskColors()
     }
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -1,0 +1,202 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Design token set for the `SegmentedControl`.
+public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.Tokens> {
+    public enum Tokens: TokenSetKey {
+        /// Defines the background color of the unselected segments of the `SegmentedControl`.
+        case restTabColor
+
+        /// Defines the background color of the selected segments of the `SegmentedControl`.
+        case selectedTabColor
+
+        /// Defines the background color of the unselected segments of the `SegmentedControl` when disabled.
+        case disabledTabColor
+
+        /// Defines the background color of the selected segments of the `SegmentedControl` when disabled.
+        case disabledSelectedTabColor
+
+        /// Defines the label color of the unselected segments of the `SegmentedControl`.
+        case restLabelColor
+
+        /// Defines the label color of the selected segments of the `SegmentedControl`.
+        case selectedLabelColor
+
+        /// Defines the label color of the unselected segments of the `SegmentedControl` when disabled.
+        case disabledLabelColor
+
+        /// Defines the label color of the selected segments of the `SegmentedControl` when disabled.
+        case disabledSelectedLabelColor
+
+        /// The color of the unread dot when the `SegmentedControl` is enabled.
+        case enabledUnreadDotColor
+
+        /// The color of the unread dot when the `SegmentedControl` is disabled.
+        case disabledUnreadDotColor
+
+        /// The distance of the content from the top and bottom of the `SegmentedControl`.
+        case verticalInset
+
+        /// The distance of the content from the leading and trailing edges of the `SegmentedControl`.
+        case horizontalInset
+
+        /// The distance of the unread dot from the trailing edge of the content of the `SegmentedControl`.
+        case unreadDotOffsetX
+
+        /// The distance of the unread dot from the top of the content of the `SegmentedControl`.
+        case unreadDotOffsetY
+
+        /// The size of the unread dot of the `SegmentedControl`
+        case unreadDotSize
+
+        /// The font used for the label of the `SegmentedControl`.
+        case font
+    }
+
+    init(style: @escaping () -> SegmentedControlStyle) {
+        self.style = style
+        super.init { [style] token, theme in
+            switch token {
+            case .restTabColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral4].light,
+                                            dark: theme.aliasTokens.backgroundColors[.neutral3].dark)
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.brandHover].light,
+                                            dark: theme.aliasTokens.backgroundColors[.neutral3].dark)
+                    }
+                }
+
+            case .selectedTabColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return theme.aliasTokens.foregroundColors[.brandRest]
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
+                                            dark: GlobalTokens.neutralColors(.grey32))
+                    }
+                }
+
+            case .disabledTabColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                            dark: GlobalTokens.neutralColors(.grey8))
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
+                                            dark: GlobalTokens.neutralColors(.grey8))
+                    }
+                }
+
+            case .disabledSelectedTabColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey80),
+                                            dark: GlobalTokens.neutralColors(.grey30))
+                    case .onBrandPill:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                            dark: GlobalTokens.neutralColors(.grey30))
+                    }
+                }
+
+            case .restLabelColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutral3].light,
+                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
+                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                    }
+                }
+
+            case .selectedLabelColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
+                                            dark: theme.aliasTokens.foregroundColors[.neutralInverted].dark)
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.brandRest].light,
+                                            dark: theme.aliasTokens.foregroundColors[.neutral1].dark)
+                    }
+                }
+
+            case .disabledLabelColor, .disabledUnreadDotColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
+                                            dark: GlobalTokens.neutralColors(.grey26))
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
+                                            dark: GlobalTokens.neutralColors(.grey26))
+                    }
+                }
+
+            case .disabledSelectedLabelColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                            dark: GlobalTokens.neutralColors(.grey44))
+                    case .onBrandPill:
+                        return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
+                                            dark: GlobalTokens.neutralColors(.grey44))
+                    }
+                }
+
+            case .enabledUnreadDotColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return theme.aliasTokens.foregroundColors[.brandRest]
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
+                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                    }
+                }
+
+            case .verticalInset:
+                return .float { 6.0 }
+
+            case .horizontalInset:
+                return .float { GlobalTokens.spacing(.medium) }
+
+            case .unreadDotOffsetX:
+                return .float { 6.0 }
+
+            case .unreadDotOffsetY:
+                return .float { 3.0 }
+
+            case .unreadDotSize:
+                return .float { 6.0 }
+
+            case .font:
+                return .fontInfo { theme.aliasTokens.typography[.body2] }
+            }
+        }
+    }
+
+    /// Defines the style of the `SegmentedControl`.
+    var style: () -> SegmentedControlStyle
+}
+
+@objc(MSFSegmentedControlStyle)
+public enum SegmentedControlStyle: Int {
+    /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
+    case primaryPill
+    /// Segments are shows as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
+    /// Selection is indicated by a thumb under the selected label.
+    case onBrandPill
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Update main with the tokenized and scrollable Segmented Control from the fluent2-tokens branch

Includes changes from:
- #1354 
- #1276 
- #1006 
- #1127 (partial)
- #946 (partial)
- #940 

### Verification

(how the change was tested, including both manual and automated tests)

| main | fluent2-tokens | after |
|---|---|---|
| ![SegmentedControlMerge_Demo_Main](https://user-images.githubusercontent.com/67026548/201999134-c1038996-4ad8-4824-ba4d-cfc3aa510cff.png) | ![SegmentedControlMerge_Demo_Tokens](https://user-images.githubusercontent.com/67026548/201999143-3147080f-5e96-4a07-a06e-7d16e9506ed7.png) | ![SegmentedControlMerge_Demo_After](https://user-images.githubusercontent.com/67026548/201999156-a280319b-abf8-434d-81be-e2cde062d5b1.png) |
| ![SegmentedControlMerge_ColorDemo_Main](https://user-images.githubusercontent.com/67026548/201999172-0c4d49b7-fd0c-4a91-b76b-25b89a792104.png) | ![SegmentedControlMerge_ColorDemo_Tokens](https://user-images.githubusercontent.com/67026548/201999189-f0153002-0bb5-41da-b66c-344165f2fe1c.png) | ![SegmentedControlMerge_ColorDemo_After](https://user-images.githubusercontent.com/67026548/201999199-ea46a669-ad58-435f-b34b-4020e677ff9e.png) |
| ![SegmentedControlMerge_PillButtonBarDemo_Main](https://user-images.githubusercontent.com/67026548/201999206-49b59157-713e-4e29-b9ab-72836587abf3.gif) | ![SegmentedControlMerge_PillButtonBarDemo_Tokens](https://user-images.githubusercontent.com/67026548/201999215-2b215837-98ce-4295-8193-1e5455b31b28.gif) | ![SegmentedControlMerge_PillButtonBarDemo_After](https://user-images.githubusercontent.com/67026548/201999225-5c86c602-059e-4ddf-98ae-61c58f85a3c1.gif) |
| ![SegmentedControlMerge_TVHFVDemo_Main](https://user-images.githubusercontent.com/67026548/201999242-90838c2c-0637-488f-a38e-b2e27efa994a.png) | ![SegmentedControlMerge_TVHFVDemo_Tokens](https://user-images.githubusercontent.com/67026548/201999254-5b5efd29-4016-49a5-bc8a-a5b61acc5b4d.png) | ![SegmentedControlMerge_TVHFVDemo_After](https://user-images.githubusercontent.com/67026548/201999267-022626f5-8f01-4a7c-9d1d-431020baf484.png) |
| ![SegmentedControlMerge_DatePicker_Main](https://user-images.githubusercontent.com/67026548/201999279-1c426b5d-270d-46b4-a0f5-f4903e5789dc.png) | ![SegmentedControlMerge_DatePicker_Tokens](https://user-images.githubusercontent.com/67026548/201999291-7cc685e7-608e-4692-aa22-a8f3a4a09445.png) | ![SegmentedControlMerge_DatePickerDemo_After](https://user-images.githubusercontent.com/67026548/201999307-add289be-4d5d-46b5-83b0-2ae7bc154701.png) |
| ![SegmentedControlMerge_TimePicker_Main](https://user-images.githubusercontent.com/67026548/201999325-abef62ae-4ddf-4f07-932e-1e50b62d0ed1.png) | ![SegmentedControlMerge_TimePicker_Tokens](https://user-images.githubusercontent.com/67026548/201999336-3e3c53c8-548a-4351-a51b-a86ae47abb61.png) | ![SegmentedControlMerge_TimePicker_After](https://user-images.githubusercontent.com/67026548/201999343-abc211d3-81dc-4237-b2dd-b26a5a458670.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1363)