### PR TITLE
Add demo to show notification bar from top

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -20,6 +20,7 @@ class NotificationViewDemoController: DemoController {
         case persistentBarWithCancel
         case primaryToastWithStrikethroughAttribute
         case neutralBarWithFontAttribute
+        case neutralBarFromTop
         case neutralToastWithOverriddenTokens
         case neutralToastWithGradientBackground
         case warningToastWithFlexibleWidth
@@ -50,6 +51,8 @@ class NotificationViewDemoController: DemoController {
                 return "Primary Toast with Strikethrough Attribute"
             case .neutralBarWithFontAttribute:
                 return "Neutral Bar with Font Attribute"
+            case .neutralBarFromTop:
+                return "Neutral Bar Presented from Top"
             case .neutralToastWithOverriddenTokens:
                 return "Neutral Toast With Overridden Tokens"
             case .neutralToastWithGradientBackground:
@@ -180,6 +183,15 @@ class NotificationViewDemoController: DemoController {
                                                                       attributes: [.font: UIFont.init(name: "Papyrus",
                                                                                                       size: 30.0)!,
                                                                                    .foregroundColor: UIColor.red])
+            notification.state.actionButtonAction = { [weak self] in
+                self?.showMessage("`Dismiss` tapped")
+                notification.hide()
+            }
+            return notification
+        case .neutralBarFromTop:
+            let notification = MSFNotification(style: .neutralBar)
+            notification.state.message = "This is a bar presented from the top."
+            notification.state.showFromBottom = false
             notification.state.actionButtonAction = { [weak self] in
                 self?.showMessage("`Dismiss` tapped")
                 notification.hide()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add a demo to showcase presenting a notification bar from the top of the screen.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/31874971/202006323-f2893f22-3a08-437d-bf00-994e8df5016e.png) | ![image](https://user-images.githubusercontent.com/31874971/202005692-05b0bc0c-b628-419b-b7eb-d14d97b32d33.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1364)