### PR TITLE
Update avatar ring color for outlined and overflow styles

### DIFF
--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -92,7 +92,7 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                     case .default, .group, .accent, .outlinedPrimary:
                         return theme.aliasTokens.colors[.brandStroke1]
                     case .outlined, .overflow:
-                        return theme.aliasTokens.colors[.stroke1]
+                        return theme.aliasTokens.colors[.strokeAccessible]
                     }
                 })
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The overflow and outlined avatar rings now use strokeAccessible to fix contrast ratio issues.

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="445" alt="before_light" src="https://user-images.githubusercontent.com/106181067/202049558-a37be363-c72f-4158-b8e5-31caf7eccc9d.png"> | <img width="489" alt="after_light" src="https://user-images.githubusercontent.com/106181067/202049572-36cbc72f-1093-4bf0-a17d-93901a787b1c.png"> |
| <img width="489" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/202049613-ee7652a9-c718-423d-bd4c-787875c2a993.png"> | <img width="489" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/202049629-7ee6d286-4206-4d93-a2d2-76a47a2861a3.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1366)