### PR TITLE
Update PR Template to include binary change table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,17 @@
 
 ### Description of changes
 
+Binary change:
+<!---
+Please fill in the below table using the size of the Demo app, as found in Finder, from 
+the latest state of the branch you are merging in to and the latest state of your changes.
+In order to get an accurate measurement for iOS, please build the Demo app using the
+Demo.Release scheme for "Any iOS Device (arm64)"
+--->
+| Before | After |
+|--------|-------|
+|        |       |
+
 (a summary of the changes made, often organized by file)
 
 ### Verification


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Update the PR Template to have a new table for binary size changes. Included instructions via a comment so that they'd show up while filling out the template, but not in every PR (unless, of course, you hit edit).

### Verification

Looked at the .md file in my fork/branch, saw the new table and not the instructions. This PR doesn't include the table, since it hasn't merged yet. Otherwise it would include one under "Description of changes" that looks just like:

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
|        |       |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1368)