### PR TITLE
Fix PersonaListViewDemoController navigation bar transparency bug

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -41,7 +41,7 @@ let searchDirectoryPersonas: [PersonaData] = [
     PersonaData(name: "Miguel Garcia", email: "miguel.garcia@contoso.com", subtitle: "Software Engineer", image: UIImage(named: "avatar_miguel_garcia"))
 ]
 
-class PersonaListViewDemoController: DemoController {
+class PersonaListViewDemoController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -41,7 +41,7 @@ let searchDirectoryPersonas: [PersonaData] = [
     PersonaData(name: "Miguel Garcia", email: "miguel.garcia@contoso.com", subtitle: "Software Engineer", image: UIImage(named: "avatar_miguel_garcia"))
 ]
 
-class PersonaListViewDemoController: UIViewController {
+class PersonaListViewDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -57,6 +57,7 @@ class PersonaListViewDemoController: DemoController {
             alert.addAction(action)
             self.present(alert, animated: true)
         }
+        scrollingContainer.removeFromSuperview()
         view.addSubview(personaListView)
         personaListView.frame = view.bounds
         personaListView.autoresizingMask = [.flexibleWidth, .flexibleHeight]


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a bug where the contents of the `PersonaListView` in the demo app would appear behind the navigation bar when scrolling. This bug is caused by `DemoController`'s `scrollingContainer` which is a `ScrollView`. Since `PersonaListView` also is a `ScrollView`, the navigation bar seems to get confused and doesn't properly detect scrolling to change from `StandardAppearance` to `ScrollEdgeAppearance`.

To fix the bug, `scrollingContainer` is removed as a subview in `PersonaListViewDemoController`'s `viewDidLoad`.

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 32,123,077 bytes | 32,123,077 bytes |

### Verification

The change was tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_light](https://user-images.githubusercontent.com/106181067/202304189-44d03152-4df8-4bf5-80d1-aa9100703cdd.gif) | ![after_light](https://user-images.githubusercontent.com/106181067/202303804-8646208f-8cab-4b92-9697-7f58c7d214cd.gif) |
| ![before_dark](https://user-images.githubusercontent.com/106181067/202303985-fab7b50e-bb9c-43c8-b56a-2f8660b03b3f.gif) | ![after_dark](https://user-images.githubusercontent.com/106181067/202304069-f433da91-a205-4dba-a5f8-6a62db8e5544.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1372)