### PR TITLE
Remove TableViewHeaderFooterView divider styles + references

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -10,46 +10,17 @@ import UIKit
 
 class TableViewHeaderFooterViewDemoController: DemoController {
     private let groupedSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.groupedSections
-    private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
-    private let divider = MSFDivider()
 
-    private lazy var segmentedControl: SegmentedControl = {
-        let tabTitles = TableViewHeaderFooterSampleData.tabTitles
-        let segmentedControl = SegmentedControl(items: tabTitles.map({ return SegmentItem(title: $0) }),
-                                                style: .primaryPill)
-        segmentedControl.addTarget(self,
-                                   action: #selector(updateActiveTabContent),
-                                   for: .valueChanged)
-        return segmentedControl
-    }()
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)
-    private lazy var plainTableView: UITableView = createTableView(style: .plain)
     private var collapsedSections: [Bool] = [Bool](repeating: false, count: TableViewHeaderFooterSampleData.groupedSections.count)
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
-        container.layoutMargins = .zero
-        container.spacing = 0
-
-        navigationController?.navigationBar.shadowImage = UIImage()
-        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
-        container.addArrangedSubview(segmentedControl)
-        container.setCustomSpacing(8, after: segmentedControl)
-        container.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1])
-
-        container.addArrangedSubview(divider)
-
-        container.addArrangedSubview(groupedTableView)
-        container.addArrangedSubview(plainTableView)
-
-        updateActiveTabContent()
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        navigationController?.navigationBar.shadowImage = nil
+        view.addSubview(groupedTableView)
+        groupedTableView.frame = view.bounds
+        groupedTableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        scrollingContainer.removeFromSuperview()
     }
 
     func createTableView(style: UITableView.Style) -> UITableView {
@@ -62,18 +33,13 @@ class TableViewHeaderFooterViewDemoController: DemoController {
         tableView.separatorStyle = .none
         return tableView
     }
-
-    @objc private func updateActiveTabContent() {
-        groupedTableView.isHidden = segmentedControl.selectedSegmentIndex == 1
-        plainTableView.isHidden = !groupedTableView.isHidden
-    }
 }
 
 // MARK: - TableViewHeaderFooterViewDemoController: UITableViewDataSource
 
 extension TableViewHeaderFooterViewDemoController: UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        return tableView.style == .grouped ? groupedSections.count : plainSections.count
+        return  groupedSections.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -104,14 +70,14 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDataSource {
 
 extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let section = tableView.style == .grouped ? groupedSections[section] : plainSections[section]
+        let section = groupedSections[section]
         return section.hasFooter ? UITableView.automaticDimension : 0
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let index = section
-        let section = tableView.style == .grouped ? groupedSections[section] : plainSections[section]
+        let section = groupedSections[section]
         if let header = header, section.hasHandler {
             header.onHeaderViewTapped = { [weak self] in self?.forHeaderTapped(header: header, section: index) }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewHeaderFooterSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewHeaderFooterSampleData.swift
@@ -22,7 +22,6 @@ class TableViewHeaderFooterSampleData: TableViewSampleData {
     ]
 
     static let plainSections: [Section] = [
-        Section(title: "Divider Highlighted • Label", headerStyle: .dividerHighlighted),
         Section(title: "Divider • Label", headerStyle: .divider),
         Section(title: "Divider • Label", headerStyle: .divider),
         Section(title: "Divider • Label", headerStyle: .divider)

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewHeaderFooterSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewHeaderFooterSampleData.swift
@@ -20,12 +20,4 @@ class TableViewHeaderFooterSampleData: TableViewSampleData {
         Section(title: "Default with multi-line truncated text - A description that starts at the bottom and provides three to two lines of info. Also maybe used for providing detailed documentation for a specific feature.", numberOfLines: 3, hasFooter: true, footerText: "Footer - A description that starts at the top and provides three to two lines of info. Custom Learn More", footerLinkText: "Custom Learn More", hasCustomLinkHandler: true),
         Section(title: "Default with custom accessory view", numberOfLines: 0, hasCustomAccessoryView: true)
     ]
-
-    static let plainSections: [Section] = [
-        Section(title: "Divider • Label", headerStyle: .divider),
-        Section(title: "Divider • Label", headerStyle: .divider),
-        Section(title: "Divider • Label", headerStyle: .divider)
-    ]
-
-    static let tabTitles: [String] = ["Default styles", "Divider styles"]
 }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -41,7 +41,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     @objc(MSFTableViewHeaderFooterViewStyle)
     public enum Style: Int {
         case header
-        case divider
         case footer
         case headerPrimary
 
@@ -49,16 +48,12 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             switch self {
             case .header, .footer, .headerPrimary:
                 return .clear
-            case .divider:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
             }
         }
 
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .header, .footer:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            case .divider:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .headerPrimary:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
@@ -69,7 +64,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             switch self {
             case .headerPrimary:
                 return Constants.primaryTitleTextStyle.font
-            case .header, .footer, .divider:
+            case .header, .footer:
                 return Constants.titleTextStyle.font
             }
         }
@@ -108,8 +103,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             verticalMargin = Constants.titleDefaultTopMargin + Constants.titleDefaultBottomMargin
         case .headerPrimary:
             verticalMargin = Constants.titleDefaultTopMargin + Constants.titleDefaultBottomMargin
-        case .divider:
-            verticalMargin = Constants.titleDividerVerticalMargin * 2
         }
 
         if let accessoryView = accessoryView {
@@ -374,7 +367,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     private func setup(style: Style, accessoryButtonTitle: String, leadingView: UIView? = nil) {
         updateTitleViewFont()
         switch style {
-        case .header, .divider, .headerPrimary:
+        case .header, .headerPrimary:
             titleView.accessibilityTraits.insert(.header)
         case .footer:
             titleView.accessibilityTraits.remove(.header)
@@ -402,9 +395,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         case .header, .footer, .headerPrimary:
             titleYOffset = style == .footer ? Constants.titleDefaultBottomMargin : Constants.titleDefaultTopMargin
             titleHeight = contentView.frame.height - titleYOffset - Constants.titleDefaultBottomMargin
-        case .divider:
-            titleYOffset = Constants.titleDividerVerticalMargin
-            titleHeight = contentView.frame.height - (Constants.titleDividerVerticalMargin * 2)
         }
 
         if let leadingView = leadingView {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -17,7 +17,7 @@ public protocol TableViewHeaderFooterViewDelegate: AnyObject {
 
 /// `TableViewHeaderFooterView` is used to present a section header or footer with a `title` and an optional accessory button.
 /// Set the `TableViewHeaderFooterView.Style` of the view to specify its visual style. The `default` and `headerPrimary` style may be used for headers.
-/// The `footer` style, which lays out the `title` near the top of the view, may be used for footers in grouped lists. Use `divider` and `dividerHighlighted` as headers for plain lists.
+/// The `footer` style, which lays out the `title` near the top of the view, may be used for footers in grouped lists. Use `divider` as header for plain lists.
 /// The optional accessory button should only be used with `default` style headers with the `title` as a single line of text.
 /// Use `titleNumberOfLines` to configure the number of lines for the `title`. Headers generally use the default number of lines of 1 while footers may use a multiple number of lines.
 @objc(MSFTableViewHeaderFooterView)
@@ -42,7 +42,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     public enum Style: Int {
         case header
         case divider
-        case dividerHighlighted
         case footer
         case headerPrimary
 
@@ -52,8 +51,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 return .clear
             case .divider:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
-            case .dividerHighlighted:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground4])
             }
         }
 
@@ -63,8 +60,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .divider:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            case .dividerHighlighted:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground4])
             case .headerPrimary:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             }
@@ -74,7 +69,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             switch self {
             case .headerPrimary:
                 return Constants.primaryTitleTextStyle.font
-            case .header, .footer, .divider, .dividerHighlighted:
+            case .header, .footer, .divider:
                 return Constants.titleTextStyle.font
             }
         }
@@ -113,7 +108,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
             verticalMargin = Constants.titleDefaultTopMargin + Constants.titleDefaultBottomMargin
         case .headerPrimary:
             verticalMargin = Constants.titleDefaultTopMargin + Constants.titleDefaultBottomMargin
-        case .divider, .dividerHighlighted:
+        case .divider:
             verticalMargin = Constants.titleDividerVerticalMargin * 2
         }
 
@@ -379,7 +374,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     private func setup(style: Style, accessoryButtonTitle: String, leadingView: UIView? = nil) {
         updateTitleViewFont()
         switch style {
-        case .header, .divider, .dividerHighlighted, .headerPrimary:
+        case .header, .divider, .headerPrimary:
             titleView.accessibilityTraits.insert(.header)
         case .footer:
             titleView.accessibilityTraits.remove(.header)
@@ -407,7 +402,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         case .header, .footer, .headerPrimary:
             titleYOffset = style == .footer ? Constants.titleDefaultBottomMargin : Constants.titleDefaultTopMargin
             titleHeight = contentView.frame.height - titleYOffset - Constants.titleDefaultBottomMargin
-        case .divider, .dividerHighlighted:
+        case .divider:
             titleYOffset = Constants.titleDividerVerticalMargin
             titleHeight = contentView.frame.height - (Constants.titleDividerVerticalMargin * 2)
         }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -17,7 +17,7 @@ public protocol TableViewHeaderFooterViewDelegate: AnyObject {
 
 /// `TableViewHeaderFooterView` is used to present a section header or footer with a `title` and an optional accessory button.
 /// Set the `TableViewHeaderFooterView.Style` of the view to specify its visual style. The `default` and `headerPrimary` style may be used for headers.
-/// The `footer` style, which lays out the `title` near the top of the view, may be used for footers in grouped lists. Use `divider` as header for plain lists.
+/// The `footer` style, which lays out the `title` near the top of the view, may be used for footers in grouped lists.
 /// The optional accessory button should only be used with `default` style headers with the `title` as a single line of text.
 /// Use `titleNumberOfLines` to configure the number of lines for the `title`. Headers generally use the default number of lines of 1 while footers may use a multiple number of lines.
 @objc(MSFTableViewHeaderFooterView)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`dividerHighlighted` and `divider` styles are removed as they are not part of fluent 2. 
The segmented control in the demo has been removed. 

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 32,408,341 bytes | 32,373,701 bytes |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="489" alt="before_light" src="https://user-images.githubusercontent.com/106181067/202557404-00b38339-4cee-4d8a-a33d-68f8077835a4.png"> | ![after_light](https://user-images.githubusercontent.com/106181067/202557420-c565bdd2-431b-49cd-8f36-7b3d1a43bfaf.gif) |
| <img width="489" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/202557459-068e93ef-3eb0-4948-88a5-b56322f21a31.png"> | ![after_dark](https://user-images.githubusercontent.com/106181067/202557600-3060b087-95a3-4b19-9ce9-ea135ea0956b.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1373)