### PR TITLE
Fix memory leak by removing retain cycles

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -415,7 +415,9 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     }
 
     public typealias TokenSetKeyType = SegmentedControlTokenSet.Tokens
-    lazy public var tokenSet: SegmentedControlTokenSet = .init(style: { self.style })
+    lazy public var tokenSet: SegmentedControlTokenSet = .init(style: { [weak self] in
+        return self?.style ?? .primaryPill
+    })
     var tokenSetSink: AnyCancellable?
 
     var selectionChangeAnimationDuration: TimeInterval { return 0.2 }

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -75,7 +75,9 @@ open class ShimmerView: UIView, TokenizedControlInternal {
 
     // MARK: - TokenizedControl
     public typealias TokenSetKeyType = ShimmerTokenSet.Tokens
-    public lazy var tokenSet: ShimmerTokenSet = .init(style: { self.style })
+    public lazy var tokenSet: ShimmerTokenSet = .init(style: { [weak self] in
+        return self?.style ?? .concealing
+    })
 
     var tokenSetSink: AnyCancellable?
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -182,7 +182,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     class var labelVerticalMarginForOneAndThreeLines: CGFloat { return TableViewCellTokenSet.defaultLabelVerticalMarginForOneAndThreeLines }
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
-    public lazy var tokenSet: TableViewCellTokenSet = .init(customViewSize: { self.customViewSize })
+    public lazy var tokenSet: TableViewCellTokenSet = .init(customViewSize: { [weak self] in
+        return self?.customViewSize ?? .default
+    })
 
     var tokenSetSink: AnyCancellable?
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Resolves issue reported by consumer:
* #1365 

A few of our views were accidentally retaining themselves in an `@escaping` closure passed into their token set. This ensures that the `self` reference is weak, which avoids the retain cycle.

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
|    31,723,088    |    31,725,872   |

### Verification

Verified no change to the three controls in question (`SegmentedControl`, `Shimmer`, and `TableViewCell`), including theme changing.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)