### PR TITLE
[Cherry-Pick] Remove retain cycles (#1374)

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -182,7 +182,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     class var labelVerticalMarginForOneAndThreeLines: CGFloat { return TableViewCellTokenSet.defaultLabelVerticalMarginForOneAndThreeLines }
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
-    public lazy var tokenSet: TableViewCellTokenSet = .init(customViewSize: { self.customViewSize })
+    public lazy var tokenSet: TableViewCellTokenSet = .init(customViewSize: { [weak self] in
+        return self?.customViewSize ?? .default
+    })
 
     var tokenSetSink: AnyCancellable?
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-pick of 4d8816cd81e92fb6a8f422e4c70a320265932879. Note that while the original commit touches three controls, only `TableViewCell` has been tokenized in the `main_0.8` branch 

### Verification

Ensured no change to `TableViewCell` behavior.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1375)