### PR TITLE
Check isViewLoaded before setting Drawer background color

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -126,7 +126,9 @@ open class DrawerController: UIViewController {
     @objc open var backgroundColor: UIColor = Colors.Drawer.background {
         didSet {
             useCustomBackgroundColor = true
-            view.backgroundColor = backgroundColor
+            if isViewLoaded {
+                view.backgroundColor = backgroundColor
+            }
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Setting the background color in `DrawerController` forces a call to `loadView` if the root view isn't initialized yet. This PR adds a `isViewLoaded` check before setting the view's background color. 
* #1338 

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 32,126,133 bytes | 32,126,133 bytes |

(a summary of the changes made, often organized by file)

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="489" alt="before" src="https://user-images.githubusercontent.com/106181067/202562980-2836ede9-420b-4ca6-b3d0-d0abc7673983.png"> | <img width="489" alt="after" src="https://user-images.githubusercontent.com/106181067/202562997-c299d23e-8fd3-45a2-8b07-cf19b59db586.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1379)