### PR TITLE
Defensive fixes for a UIViewPropertyAnimator crash

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -789,7 +789,7 @@ public class BottomSheetController: UIViewController {
 
             // It's important we drop the reference to the animator as early as possible.
             // Otherwise we could accidentally try modifying the animator while it's calling out to its completion handler, which can lead to a crash.
-            if let animator = strongSelf.currentStateChangeAnimator,animator == translationAnimator {
+            if let animator = strongSelf.currentStateChangeAnimator, animator == translationAnimator {
                 strongSelf.currentStateChangeAnimator = nil
             }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
|31,642,171 bytes |31,639,099 bytes |


### Problem 
Clients can crash if they make certain bottom sheet modifications during `UIViewPropertyAnimator` completion callbacks.

### Cause
`UIViewPropertyAnimator` has a bug / undocumented behavior - when it's calling out to its completion handlers, the animator reports `isRunning==true` and it's in a private `UIViewAnimatingState` (value 5). When it's in this state, calling `finishAnimation` will cause it to throw an exception.

We have a `completeAnimationsIfNeeded` helper function that frequently gets called on bottom sheet environment changes, like the host view size / safe area. This helper checks the `isRunning` prop to make sure it's only trying to force complete animators that are running. But if an animator is in the process of completing, and the client reacts to that completion in a way that triggers `completeAnimationsIfNeeded` synchronously, we can end up triggering the exception.

### Fix
Two fixes to be safe, but either would work to mitigate the problem:
1. Remove our reference to the current animator as soon as possible. This eliminates most / all possibilities for this bug, because we'll bail early in our `completeAnimationsIfNeeded` helper as it no longer has an animator to act on.
2. Add an additional check to `completeAnimationsIfNeeded` - in addition to checking `isRunning`, let's also make sure `state == .active`. Documentation says this is always true, but it's clearly not.

### Verification

Force crash condition by modifying safe area in animator completion. Verify crash doesn't occur anymore with the fixes.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1385)