### PR TITLE
Change DemoListViewController cells to grouped style

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -98,6 +98,8 @@ class DemoListViewController: DemoTableViewController {
         let demo = DemoControllerSection.allCases[indexPath.section].rows[indexPath.row]
         cell.setup(title: demo.title, accessoryType: .disclosureIndicator)
         cell.titleNumberOfLinesForLargerDynamicType = 2
+        cell.backgroundStyleType = .grouped
+
         return cell
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The `DemoListViewController` cells are now using the grouped style to stay consistent with the `TableView` grouped background color.

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 59,567,962 bytes | 59,567,962 bytes |

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="489" alt="before_light" src="https://user-images.githubusercontent.com/106181067/203407399-588842d3-59fd-4586-87f5-16df2a97f445.png"> | <img width="489" alt="after_light" src="https://user-images.githubusercontent.com/106181067/203407418-9011b868-2e20-46f2-aae0-ae0f342ae9ea.png"> |
| <img width="489" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/203407441-e3caf86b-e2a3-4a00-be3a-b130c83a5343.png"> | <img width="489" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/203407447-589b0691-5637-43ce-a72c-2456a6b954c4.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1389)