### PR TITLE
Removing nil assignment to textColor in TableViewCell

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -44,7 +44,6 @@ public enum TextColorStyle: Int, CaseIterable {
 open class Label: UILabel {
     @objc open var colorStyle: TextColorStyle = .regular {
         didSet {
-            _textColor = nil
             updateTextColor()
         }
     }
@@ -98,9 +97,6 @@ open class Label: UILabel {
     }
 
     private func initialize() {
-        // textColor is assigned in super.init to a default value and so we need to reset our cache afterwards
-        _textColor = nil
-
         updateFont()
         updateTextColor()
         adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
| Before | After |
|--------|-------|
|    28,475,600    |   28,475,600    |

There was an EXC_BAD_ACCESS error when trying to set the textColor of a TableViewCell label. It could be that the error was caused because the textColor was set to `nil` in multiple places. This change removes that since textColor already has a default assigned to it if not set.

### Verification

Opened TableViewCellDemoController, tested text color changes. No crashes observed.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/203458066-58acc44d-e60d-4e2c-82ba-d64dfe868dcf.png) | ![image](https://user-images.githubusercontent.com/22566866/203456840-2499b0af-a10b-47b3-b667-8212ba5bab9e.png) |
| ![image](https://user-images.githubusercontent.com/22566866/203458098-63554011-6825-4c8d-89d0-05a68d833510.png) | ![image](https://user-images.githubusercontent.com/22566866/203456903-6c90d893-4413-4935-bb83-db678149dcaa.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)