### PR TITLE
Fix bottom sheet host height change detection

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -469,6 +469,18 @@ public class BottomSheetController: UIViewController {
     }
 
     public override func viewDidLayoutSubviews() {
+        let newHeight = view.bounds.height
+        if currentRootViewHeight != newHeight && currentExpansionState == .transitioning {
+            // The view height has changed and we can't guarantee the animation target frame is valid anymore.
+            // Let's complete animations and cancel ongoing gestures to guarantee we end up in a good state.
+            completeAnimationsIfNeeded(skipToEnd: true)
+
+            if panGestureRecognizer.state != .possible {
+                panGestureRecognizer.state = .cancelled
+            }
+        }
+        currentRootViewHeight = newHeight
+
         // In the transitioning state a pan gesture or an animator temporarily owns the sheet frame updates,
         // so to avoid interfering we won't update the frame here.
         if currentExpansionState != .transitioning {
@@ -484,20 +496,6 @@ public class BottomSheetController: UIViewController {
     public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         completeAnimationsIfNeeded(skipToEnd: true)
-    }
-
-    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
-
-        if size.height != view.frame.height && currentExpansionState == .transitioning {
-            // The view is resizing and we can't guarantee the animation target frame is valid anymore.
-            // Completing the animation ensures the sheet will be correctly positioned on the next layout pass
-            completeAnimationsIfNeeded(skipToEnd: true)
-
-            if panGestureRecognizer.state != .possible {
-                panGestureRecognizer.state = .cancelled
-            }
-        }
     }
 
     public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -971,6 +969,10 @@ public class BottomSheetController: UIViewController {
     private var currentSheetVerticalOffset: CGFloat {
         bottomSheetView.frame.minY
     }
+
+    // Only used for height change detection.
+    // For all other cases you should probably directly use self.view.bounds.height.
+    private var currentRootViewHeight: CGFloat = 0
 
     private let shouldShowDimmingView: Bool
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -491,6 +491,8 @@ public class BottomSheetController: UIViewController {
             updateDimmingViewAccessibility()
         }
         collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
+
+        super.viewDidLayoutSubviews()
     }
 
     public override func viewSafeAreaInsetsDidChange() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
|31,681,160 bytes|31,681,352 bytes|

#### Bug
In some cases when sheet was animating while the host view was resizing, we could end up with an outdated sheet position until the next layout pass.

#### Cause
In the bottom sheet, we detect trait collection, safe area, and root view height changes to auto-complete ongoing animations. This guarantees the animation won't target a frame that is now out of date.

We were missing a class of size changes not captured by `viewWillTransitionTo`. This becomes an issue on pre-iPhone X devices in some cases where the host height changes while we're hiding. On iPhone X and later in most cases this is luckily covered by the safe area change handler - that's also the reason why we didn't catch it for so long.

#### Fix
Switch to a catch-all method of height detection - manually doing it in `viewDidLayoutSubviews`. The logic of how it's handled stays the same - complete animations and cancel gestures.

### Verification

No visible change.

Validation:
- repro bug in test app, validate repro is gone after fix
- validate bug is fixed in client

Additional sanity:
- quickly toggle between isHidden true and false
- change screen orientation during animation
- change screen orientation during gesture
- repeat all above for bottom commanding

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1396)