### PR TITLE
Cherry pick bottom sheet height fix and lint fix (#1396, #1393)

### DIFF
--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -242,7 +242,7 @@ open class SearchBar: UIView {
         clearButton.isHidden = true
 
         clearButton.isPointerInteractionEnabled = true
-        clearButton.pointerStyleProvider = { button, effect, _ in
+        clearButton.pointerStyleProvider = { button, _, _ in
             let preview = UITargetedPreview(view: button)
             return UIPointerStyle(effect: .lift(preview))
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry pick a bottom sheet fix from main:
#1396 

Also had to cherry pick a small lint fix bc of the new linter version:
#1393 

### Verification

Validation details in the other PR, also validated in client.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1397)