### PR TITLE
Update GlobalTokens to include new ramps

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -295,7 +295,7 @@ extension HUDDemoController: DemoAppearanceDelegate {
     private var perControlOverrideHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
         let aliasTokens = self.view.fluentTheme.aliasTokens
         return [
-            .cornerRadius: .float { GlobalTokens.borderRadius(.cornerRadius120) },
+            .cornerRadius: .float { GlobalTokens.cornerRadius(.cornerRadius120) },
             .labelColor: .dynamicColor { aliasTokens.brandColors[.primary] }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -295,7 +295,7 @@ extension HUDDemoController: DemoAppearanceDelegate {
     private var perControlOverrideHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
         let aliasTokens = self.view.fluentTheme.aliasTokens
         return [
-            .cornerRadius: .float { GlobalTokens.cornerRadius(.cornerRadius120) },
+            .cornerRadius: .float { GlobalTokens.corner(.cornerRadius120) },
             .labelColor: .dynamicColor { aliasTokens.brandColors[.primary] }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -295,7 +295,7 @@ extension HUDDemoController: DemoAppearanceDelegate {
     private var perControlOverrideHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
         let aliasTokens = self.view.fluentTheme.aliasTokens
         return [
-            .cornerRadius: .float { GlobalTokens.borderRadius(.xLarge) },
+            .cornerRadius: .float { GlobalTokens.borderRadius(.cornerRadius120) },
             .labelColor: .dynamicColor { aliasTokens.brandColors[.primary] }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -295,7 +295,7 @@ extension HUDDemoController: DemoAppearanceDelegate {
     private var perControlOverrideHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
         let aliasTokens = self.view.fluentTheme.aliasTokens
         return [
-            .cornerRadius: .float { GlobalTokens.corner(.cornerRadius120) },
+            .cornerRadius: .float { GlobalTokens.corner(.radius120) },
             .labelColor: .dynamicColor { aliasTokens.brandColors[.primary] }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -514,8 +514,8 @@ class TableViewCellFileAccessoryViewDemoController: DemoTableViewController {
 
         for accessoryView in topAccessoryViews + bottomAccessoryViews {
             if let cell = accessoryView.tableViewCell {
-                cell.paddingLeading = GlobalTokens.spacing(.medium) + extraPadding
-                cell.paddingTrailing = GlobalTokens.spacing(.medium) + extraPadding
+                cell.paddingLeading = GlobalTokens.spacing(.size160) + extraPadding
+                cell.paddingTrailing = GlobalTokens.spacing(.size160) + extraPadding
             }
         }
     }

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -53,17 +53,17 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch style() {
                     case .default, .accent, .outlined, .outlinedPrimary, .overflow:
-                        return GlobalTokens.corner(.cornerRadiusNone)
+                        return GlobalTokens.corner(.radiusNone)
                     case .group:
                         switch size() {
                         case .size16, .size20:
-                            return GlobalTokens.corner(.cornerRadius20)
+                            return GlobalTokens.corner(.radius20)
                         case .size24, .size32:
-                            return GlobalTokens.corner(.cornerRadius40)
+                            return GlobalTokens.corner(.radius40)
                         case .size40, .size56:
-                            return GlobalTokens.corner(.cornerRadius80)
+                            return GlobalTokens.corner(.radius80)
                         case .size72:
-                            return GlobalTokens.corner(.cornerRadius120)
+                            return GlobalTokens.corner(.radius120)
                         }
                     }
                 })
@@ -105,11 +105,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24:
-                        return GlobalTokens.stroke(.strokeWidth10)
+                        return GlobalTokens.stroke(.width10)
                     case .size32, .size40, .size56:
-                        return GlobalTokens.stroke(.strokeWidth20)
+                        return GlobalTokens.stroke(.width20)
                     case .size72:
-                        return GlobalTokens.stroke(.strokeWidth40)
+                        return GlobalTokens.stroke(.width40)
                     }
                 })
 
@@ -117,9 +117,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.stroke(.strokeWidth20)
+                        return GlobalTokens.stroke(.width20)
                     case .size72:
-                        return GlobalTokens.stroke(.strokeWidth40)
+                        return GlobalTokens.stroke(.width40)
                     }
                 })
 
@@ -127,9 +127,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.stroke(.strokeWidth20)
+                        return GlobalTokens.stroke(.width20)
                     case .size72:
-                        return GlobalTokens.stroke(.strokeWidth40)
+                        return GlobalTokens.stroke(.width40)
                     }
                 })
 
@@ -137,9 +137,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16:
-                        return GlobalTokens.stroke(.strokeWidthNone)
+                        return GlobalTokens.stroke(.widthNone)
                     case .size20, .size24, .size32, .size40, .size56, .size72:
-                        return GlobalTokens.stroke(.strokeWidth20)
+                        return GlobalTokens.stroke(.width20)
                     }
                 })
 

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -53,17 +53,17 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch style() {
                     case .default, .accent, .outlined, .outlinedPrimary, .overflow:
-                        return GlobalTokens.borderRadius(.none)
+                        return GlobalTokens.borderRadius(.cornerRadiusNone)
                     case .group:
                         switch size() {
                         case .size16, .size20:
-                            return GlobalTokens.borderRadius(.small)
+                            return GlobalTokens.borderRadius(.cornerRadius20)
                         case .size24, .size32:
-                            return GlobalTokens.borderRadius(.medium)
+                            return GlobalTokens.borderRadius(.cornerRadius40)
                         case .size40, .size56:
-                            return GlobalTokens.borderRadius(.large)
+                            return GlobalTokens.borderRadius(.cornerRadius80)
                         case .size72:
-                            return GlobalTokens.borderRadius(.xLarge)
+                            return GlobalTokens.borderRadius(.cornerRadius120)
                         }
                     }
                 })

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -53,17 +53,17 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch style() {
                     case .default, .accent, .outlined, .outlinedPrimary, .overflow:
-                        return GlobalTokens.borderRadius(.cornerRadiusNone)
+                        return GlobalTokens.cornerRadius(.cornerRadiusNone)
                     case .group:
                         switch size() {
                         case .size16, .size20:
-                            return GlobalTokens.borderRadius(.cornerRadius20)
+                            return GlobalTokens.cornerRadius(.cornerRadius20)
                         case .size24, .size32:
-                            return GlobalTokens.borderRadius(.cornerRadius40)
+                            return GlobalTokens.cornerRadius(.cornerRadius40)
                         case .size40, .size56:
-                            return GlobalTokens.borderRadius(.cornerRadius80)
+                            return GlobalTokens.cornerRadius(.cornerRadius80)
                         case .size72:
-                            return GlobalTokens.borderRadius(.cornerRadius120)
+                            return GlobalTokens.cornerRadius(.cornerRadius120)
                         }
                     }
                 })
@@ -105,11 +105,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24:
-                        return GlobalTokens.borderSize(.strokeWidth10)
+                        return GlobalTokens.strokeWidth(.strokeWidth10)
                     case .size32, .size40, .size56:
-                        return GlobalTokens.borderSize(.strokeWidth20)
+                        return GlobalTokens.strokeWidth(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.borderSize(.strokeWidth40)
+                        return GlobalTokens.strokeWidth(.strokeWidth40)
                     }
                 })
 
@@ -117,9 +117,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.borderSize(.strokeWidth20)
+                        return GlobalTokens.strokeWidth(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.borderSize(.strokeWidth40)
+                        return GlobalTokens.strokeWidth(.strokeWidth40)
                     }
                 })
 
@@ -127,9 +127,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.borderSize(.strokeWidth20)
+                        return GlobalTokens.strokeWidth(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.borderSize(.strokeWidth40)
+                        return GlobalTokens.strokeWidth(.strokeWidth40)
                     }
                 })
 
@@ -137,9 +137,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16:
-                        return GlobalTokens.borderSize(.strokeWidthNone)
+                        return GlobalTokens.strokeWidth(.strokeWidthNone)
                     case .size20, .size24, .size32, .size40, .size56, .size72:
-                        return GlobalTokens.borderSize(.strokeWidth20)
+                        return GlobalTokens.strokeWidth(.strokeWidth20)
                     }
                 })
 

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -216,11 +216,11 @@ extension AvatarTokenSet {
         case .size16:
             return 0
         case .size20, .size24, .size32:
-            return GlobalTokens.iconSize(.size100)
+            return GlobalTokens.iconSize(.xxxSmall)
         case .size40, .size56:
-            return GlobalTokens.iconSize(.size120)
+            return GlobalTokens.iconSize(.xxSmall)
         case .size72:
-            return GlobalTokens.iconSize(.size200)
+            return GlobalTokens.iconSize(.small)
         }
     }
 }

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -105,11 +105,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24:
-                        return GlobalTokens.borderSize(.thinner)
+                        return GlobalTokens.borderSize(.strokeWidth10)
                     case .size32, .size40, .size56:
-                        return GlobalTokens.borderSize(.thick)
+                        return GlobalTokens.borderSize(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.borderSize(.thicker)
+                        return GlobalTokens.borderSize(.strokeWidth40)
                     }
                 })
 
@@ -117,9 +117,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.borderSize(.thick)
+                        return GlobalTokens.borderSize(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.borderSize(.thicker)
+                        return GlobalTokens.borderSize(.strokeWidth40)
                     }
                 })
 
@@ -127,9 +127,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.borderSize(.thick)
+                        return GlobalTokens.borderSize(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.borderSize(.thicker)
+                        return GlobalTokens.borderSize(.strokeWidth40)
                     }
                 })
 
@@ -137,9 +137,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16:
-                        return GlobalTokens.borderSize(.none)
+                        return GlobalTokens.borderSize(.strokeWidthNone)
                     case .size20, .size24, .size32, .size40, .size56, .size72:
-                        return GlobalTokens.borderSize(.thick)
+                        return GlobalTokens.borderSize(.strokeWidth20)
                     }
                 })
 

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -53,17 +53,17 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch style() {
                     case .default, .accent, .outlined, .outlinedPrimary, .overflow:
-                        return GlobalTokens.cornerRadius(.cornerRadiusNone)
+                        return GlobalTokens.corner(.cornerRadiusNone)
                     case .group:
                         switch size() {
                         case .size16, .size20:
-                            return GlobalTokens.cornerRadius(.cornerRadius20)
+                            return GlobalTokens.corner(.cornerRadius20)
                         case .size24, .size32:
-                            return GlobalTokens.cornerRadius(.cornerRadius40)
+                            return GlobalTokens.corner(.cornerRadius40)
                         case .size40, .size56:
-                            return GlobalTokens.cornerRadius(.cornerRadius80)
+                            return GlobalTokens.corner(.cornerRadius80)
                         case .size72:
-                            return GlobalTokens.cornerRadius(.cornerRadius120)
+                            return GlobalTokens.corner(.cornerRadius120)
                         }
                     }
                 })
@@ -105,11 +105,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24:
-                        return GlobalTokens.strokeWidth(.strokeWidth10)
+                        return GlobalTokens.stroke(.strokeWidth10)
                     case .size32, .size40, .size56:
-                        return GlobalTokens.strokeWidth(.strokeWidth20)
+                        return GlobalTokens.stroke(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.strokeWidth(.strokeWidth40)
+                        return GlobalTokens.stroke(.strokeWidth40)
                     }
                 })
 
@@ -117,9 +117,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.strokeWidth(.strokeWidth20)
+                        return GlobalTokens.stroke(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.strokeWidth(.strokeWidth40)
+                        return GlobalTokens.stroke(.strokeWidth40)
                     }
                 })
 
@@ -127,9 +127,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16, .size20, .size24, .size32, .size40, .size56:
-                        return GlobalTokens.strokeWidth(.strokeWidth20)
+                        return GlobalTokens.stroke(.strokeWidth20)
                     case .size72:
-                        return GlobalTokens.strokeWidth(.strokeWidth40)
+                        return GlobalTokens.stroke(.strokeWidth40)
                     }
                 })
 
@@ -137,9 +137,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .float({
                     switch size() {
                     case .size16:
-                        return GlobalTokens.strokeWidth(.strokeWidthNone)
+                        return GlobalTokens.stroke(.strokeWidthNone)
                     case .size20, .size24, .size32, .size40, .size56, .size72:
-                        return GlobalTokens.strokeWidth(.strokeWidth20)
+                        return GlobalTokens.stroke(.strokeWidth20)
                     }
                 })
 

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -216,11 +216,11 @@ extension AvatarTokenSet {
         case .size16:
             return 0
         case .size20, .size24, .size32:
-            return GlobalTokens.iconSize(.xxxSmall)
+            return GlobalTokens.iconSize(.size100)
         case .size40, .size56:
-            return GlobalTokens.iconSize(.xxSmall)
+            return GlobalTokens.iconSize(.size120)
         case .size72:
-            return GlobalTokens.iconSize(.small)
+            return GlobalTokens.iconSize(.size200)
         }
     }
 }

--- a/ios/FluentUI/AvatarGroup/AvatarGroupTokenSet.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroupTokenSet.swift
@@ -25,21 +25,21 @@ public class AvatarGroupTokenSet: ControlTokenSet<AvatarGroupTokenSet.Tokens> {
                     case .stack:
                         switch size() {
                         case .size16, .size20, .size24:
-                            return -GlobalTokens.spacing(.xxxSmall)
+                            return -GlobalTokens.spacing(.size20)
                         case .size32:
-                            return -GlobalTokens.spacing(.xxSmall)
+                            return -GlobalTokens.spacing(.size40)
                         case .size40:
-                            return -GlobalTokens.spacing(.xSmall)
+                            return -GlobalTokens.spacing(.size80)
                         case .size56, .size72:
-                            return -GlobalTokens.spacing(.small)
+                            return -GlobalTokens.spacing(.size120)
                         }
 
                     case .pile:
                         switch size() {
                         case .size16, .size20, .size24:
-                            return GlobalTokens.spacing(.xxSmall)
+                            return GlobalTokens.spacing(.size40)
                         case .size32, .size40, .size56, .size72:
-                            return GlobalTokens.spacing(.xSmall)
+                            return GlobalTokens.spacing(.size80)
                         }
                     }
                 }

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -383,7 +383,7 @@ open class Button: UIButton {
     private lazy var dangerTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground2])
     private lazy var dangerFilledTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic])
 
-    private lazy var borderWidth = GlobalTokens.stroke(.strokeWidth10)
+    private lazy var borderWidth = GlobalTokens.stroke(.width10)
 
     private var normalImageTintColor: UIColor?
     private var highlightedImageTintColor: UIColor?

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -383,7 +383,7 @@ open class Button: UIButton {
     private lazy var dangerTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground2])
     private lazy var dangerFilledTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic])
 
-    private lazy var borderWidth = GlobalTokens.borderSize(.strokeWidth10)
+    private lazy var borderWidth = GlobalTokens.strokeWidth(.strokeWidth10)
 
     private var normalImageTintColor: UIColor?
     private var highlightedImageTintColor: UIColor?

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -383,7 +383,7 @@ open class Button: UIButton {
     private lazy var dangerTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground2])
     private lazy var dangerFilledTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic])
 
-    private lazy var borderWidth = GlobalTokens.strokeWidth(.strokeWidth10)
+    private lazy var borderWidth = GlobalTokens.stroke(.strokeWidth10)
 
     private var normalImageTintColor: UIColor?
     private var highlightedImageTintColor: UIColor?

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -383,7 +383,7 @@ open class Button: UIButton {
     private lazy var dangerTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground2])
     private lazy var dangerFilledTitleAndImageColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic])
 
-    private lazy var borderWidth = GlobalTokens.borderSize(.thinner)
+    private lazy var borderWidth = GlobalTokens.borderSize(.strokeWidth10)
 
     private var normalImageTintColor: UIColor?
     private var highlightedImageTintColor: UIColor?

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -87,12 +87,12 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .circleRadius:
                 return .float {
-                    GlobalTokens.corner(.cornerRadiusCircular)
+                    GlobalTokens.corner(.radiusCircular)
                 }
 
             case .cornerRadius:
                 return .float {
-                    GlobalTokens.corner(.cornerRadius120)
+                    GlobalTokens.corner(.radius120)
                 }
 
             case .outlineColor:
@@ -109,7 +109,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .outlineWidth:
                 return .float {
-                    GlobalTokens.stroke(.strokeWidth10)
+                    GlobalTokens.stroke(.width10)
                 }
 
             case .subtitleTextColor:

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -142,9 +142,9 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 // MARK: - Constants
 
 extension CardNudgeTokenSet {
-    static let iconSize: CGFloat = GlobalTokens.iconSize(.medium)
-    static let circleSize: CGFloat = GlobalTokens.iconSize(.xxLarge)
-    static let accentIconSize: CGFloat = GlobalTokens.iconSize(.xxSmall)
+    static let iconSize: CGFloat = GlobalTokens.iconSize(.size240)
+    static let circleSize: CGFloat = GlobalTokens.iconSize(.size400)
+    static let accentIconSize: CGFloat = GlobalTokens.iconSize(.size120)
     static let accentPadding: CGFloat = GlobalTokens.spacing(.xxSmall)
 
     static let horizontalPadding: CGFloat = GlobalTokens.spacing(.medium)

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -87,12 +87,12 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .circleRadius:
                 return .float {
-                    GlobalTokens.borderRadius(.circle)
+                    GlobalTokens.borderRadius(.cornerRadiusCircular)
                 }
 
             case .cornerRadius:
                 return .float {
-                    GlobalTokens.borderRadius(.xLarge)
+                    GlobalTokens.borderRadius(.cornerRadius120)
                 }
 
             case .outlineColor:

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -109,7 +109,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .outlineWidth:
                 return .float {
-                    GlobalTokens.borderSize(.thinner)
+                    GlobalTokens.borderSize(.strokeWidth10)
                 }
 
             case .subtitleTextColor:

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -87,12 +87,12 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .circleRadius:
                 return .float {
-                    GlobalTokens.borderRadius(.cornerRadiusCircular)
+                    GlobalTokens.cornerRadius(.cornerRadiusCircular)
                 }
 
             case .cornerRadius:
                 return .float {
-                    GlobalTokens.borderRadius(.cornerRadius120)
+                    GlobalTokens.cornerRadius(.cornerRadius120)
                 }
 
             case .outlineColor:
@@ -109,7 +109,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .outlineWidth:
                 return .float {
-                    GlobalTokens.borderSize(.strokeWidth10)
+                    GlobalTokens.strokeWidth(.strokeWidth10)
                 }
 
             case .subtitleTextColor:

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -145,13 +145,13 @@ extension CardNudgeTokenSet {
     static let iconSize: CGFloat = GlobalTokens.iconSize(.medium)
     static let circleSize: CGFloat = GlobalTokens.iconSize(.xxLarge)
     static let accentIconSize: CGFloat = GlobalTokens.iconSize(.xxSmall)
-    static let accentPadding: CGFloat = GlobalTokens.spacing(.xxSmall)
+    static let accentPadding: CGFloat = GlobalTokens.spacing(.size40)
 
-    static let horizontalPadding: CGFloat = GlobalTokens.spacing(.medium)
-    static let verticalPadding: CGFloat = GlobalTokens.spacing(.xSmall)
-    static let buttonInnerPaddingHorizontal: CGFloat = GlobalTokens.spacing(.small)
-    static let interTextVerticalPadding: CGFloat = GlobalTokens.spacing(.xxxSmall)
-    static let mainContentVerticalPadding: CGFloat = GlobalTokens.spacing(.small)
+    static let horizontalPadding: CGFloat = GlobalTokens.spacing(.size160)
+    static let verticalPadding: CGFloat = GlobalTokens.spacing(.size80)
+    static let buttonInnerPaddingHorizontal: CGFloat = GlobalTokens.spacing(.size120)
+    static let interTextVerticalPadding: CGFloat = GlobalTokens.spacing(.size20)
+    static let mainContentVerticalPadding: CGFloat = GlobalTokens.spacing(.size120)
 
     static let minimumHeight: CGFloat = 56.0
 }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -142,9 +142,9 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 // MARK: - Constants
 
 extension CardNudgeTokenSet {
-    static let iconSize: CGFloat = GlobalTokens.iconSize(.size240)
-    static let circleSize: CGFloat = GlobalTokens.iconSize(.size400)
-    static let accentIconSize: CGFloat = GlobalTokens.iconSize(.size120)
+    static let iconSize: CGFloat = GlobalTokens.iconSize(.medium)
+    static let circleSize: CGFloat = GlobalTokens.iconSize(.xxLarge)
+    static let accentIconSize: CGFloat = GlobalTokens.iconSize(.xxSmall)
     static let accentPadding: CGFloat = GlobalTokens.spacing(.xxSmall)
 
     static let horizontalPadding: CGFloat = GlobalTokens.spacing(.medium)

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -87,12 +87,12 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .circleRadius:
                 return .float {
-                    GlobalTokens.cornerRadius(.cornerRadiusCircular)
+                    GlobalTokens.corner(.cornerRadiusCircular)
                 }
 
             case .cornerRadius:
                 return .float {
-                    GlobalTokens.cornerRadius(.cornerRadius120)
+                    GlobalTokens.corner(.cornerRadius120)
                 }
 
             case .outlineColor:
@@ -109,7 +109,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .outlineWidth:
                 return .float {
-                    GlobalTokens.strokeWidth(.strokeWidth10)
+                    GlobalTokens.stroke(.strokeWidth10)
                 }
 
             case .subtitleTextColor:

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1762,29 +1762,32 @@ public class GlobalTokens: NSObject {
     // MARK: - BorderSize
 
     public enum BorderSizeToken: TokenSetKey {
-        case none
-        case thinnest
-        case thinner
-        case thin
-        case thick
-        case thicker
-        case thickest
+        case strokeWidthNone
+        case strokeWidth05
+        case strokeWidth10
+        case strokeWidth15
+        case strokeWidth20
+        case strokeWidth30
+        case strokeWidth40
+        case strokeWidth60
     }
     public static func borderSize(_ token: BorderSizeToken) -> CGFloat {
         switch token {
-        case .none:
+        case .strokeWidthNone:
             return 0
-        case .thinnest:
+        case .strokeWidth05:
             return 0.5
-        case .thinner:
+        case .strokeWidth10:
             return 1
-        case .thin:
+        case .strokeWidth15:
             return 1.5
-        case .thick:
+        case .strokeWidth20:
             return 2
-        case .thicker:
+        case .strokeWidth30:
+            return 3
+        case .strokeWidth40:
             return 4
-        case .thickest:
+        case .strokeWidth60:
             return 6
         }
     }

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1633,60 +1633,36 @@ public class GlobalTokens: NSObject {
     // MARK: - IconSize
 
     public enum IconSizeToken: TokenSetKey {
-        case sizeNone
-        case size20
-        case size40
-        case size60
-        case size80
-        case size100
-        case size120
-        case size160
-        case size200
-        case size240
-        case size280
-        case size320
-        case size360
-        case size400
-        case size480
-        case size520
-        case size560
+        case xxxSmall
+        case xxSmall
+        case xSmall
+        case small
+        case medium
+        case large
+        case xLarge
+        case xxLarge
+        case xxxLarge
     }
     public static func iconSize(_ token: IconSizeToken) -> CGFloat {
         switch token {
-        case .sizeNone:
-            return 0
-        case .size20:
-            return 2
-        case .size40:
-            return 4
-        case .size60:
-            return 6
-        case .size80:
-            return 8
-        case .size100:
+        case .xxxSmall:
             return 10
-        case .size120:
+        case .xxSmall:
             return 12
-        case .size160:
+        case .xSmall:
             return 16
-        case .size200:
+        case .small:
             return 20
-        case .size240:
+        case .medium:
             return 24
-        case .size280:
+        case .large:
             return 28
-        case .size320:
-            return 32
-        case .size360:
+        case .xLarge:
             return 36
-        case .size400:
+        case .xxLarge:
             return 40
-        case .size480:
+        case .xxxLarge:
             return 48
-        case .size520:
-            return 52
-        case .size560:
-            return 56
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1734,7 +1734,7 @@ public class GlobalTokens: NSObject {
 
     // MARK: - BorderRadius
 
-    public enum BorderRadiusToken: TokenSetKey {
+    public enum CornerRadiusToken: TokenSetKey {
         case cornerRadiusNone
         case cornerRadius20
         case cornerRadius40
@@ -1743,7 +1743,7 @@ public class GlobalTokens: NSObject {
         case cornerRadius120
         case cornerRadiusCircular
     }
-    public static func borderRadius(_ token: BorderRadiusToken) -> CGFloat {
+    public static func cornerRadius(_ token: CornerRadiusToken) -> CGFloat {
         switch token {
         case .cornerRadiusNone:
             return 0
@@ -1764,7 +1764,7 @@ public class GlobalTokens: NSObject {
 
     // MARK: - BorderSize
 
-    public enum BorderSizeToken: TokenSetKey {
+    public enum StrokeWidthToken: TokenSetKey {
         case strokeWidthNone
         case strokeWidth05
         case strokeWidth10
@@ -1774,7 +1774,7 @@ public class GlobalTokens: NSObject {
         case strokeWidth40
         case strokeWidth60
     }
-    public static func borderSize(_ token: BorderSizeToken) -> CGFloat {
+    public static func strokeWidth(_ token: StrokeWidthToken) -> CGFloat {
         switch token {
         case .strokeWidthNone:
             return 0

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1669,42 +1669,60 @@ public class GlobalTokens: NSObject {
     // MARK: - Spacing
 
     public enum SpacingToken: TokenSetKey {
-        case none
-        case xxxSmall
-        case xxSmall
-        case xSmall
-        case small
-        case medium
-        case large
-        case xLarge
-        case xxLarge
-        case xxxLarge
-        case xxxxLarge
+        case sizeNone
+        case size20
+        case size40
+        case size60
+        case size80
+        case size100
+        case size120
+        case size160
+        case size200
+        case size240
+        case size280
+        case size320
+        case size360
+        case size400
+        case size480
+        case size520
+        case size560
     }
     public static func spacing(_ token: SpacingToken) -> CGFloat {
         switch token {
-        case .none:
+        case .sizeNone:
             return 0
-        case .xxxSmall:
+        case .size20:
             return 2
-        case .xxSmall:
+        case .size40:
             return 4
-        case .xSmall:
+        case .size60:
+            return 6
+        case .size80:
             return 8
-        case .small:
+        case .size100:
+            return 10
+        case .size120:
             return 12
-        case .medium:
+        case .size160:
             return 16
-        case .large:
+        case .size200:
             return 20
-        case .xLarge:
+        case .size240:
             return 24
-        case .xxLarge:
+        case .size280:
+            return 28
+        case .size320:
+            return 32
+        case .size360:
             return 36
-        case .xxxLarge:
+        case .size400:
+            return 40
+        case .size480:
             return 48
-        case .xxxxLarge:
-            return 72
+        case .size520:
+            return 52
+        case .size560:
+            return 56
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1743,7 +1743,7 @@ public class GlobalTokens: NSObject {
         case cornerRadius120
         case cornerRadiusCircular
     }
-    public static func cornerRadius(_ token: CornerRadiusToken) -> CGFloat {
+    public static func corner(_ token: CornerRadiusToken) -> CGFloat {
         switch token {
         case .cornerRadiusNone:
             return 0
@@ -1774,7 +1774,7 @@ public class GlobalTokens: NSObject {
         case strokeWidth40
         case strokeWidth60
     }
-    public static func strokeWidth(_ token: StrokeWidthToken) -> CGFloat {
+    public static func stroke(_ token: StrokeWidthToken) -> CGFloat {
         switch token {
         case .strokeWidthNone:
             return 0

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1735,26 +1735,29 @@ public class GlobalTokens: NSObject {
     // MARK: - BorderRadius
 
     public enum BorderRadiusToken: TokenSetKey {
-        case none
-        case small
-        case medium
-        case large
-        case xLarge
-        case circle
+        case cornerRadiusNone
+        case cornerRadius20
+        case cornerRadius40
+        case cornerRadius60
+        case cornerRadius80
+        case cornerRadius120
+        case cornerRadiusCircular
     }
     public static func borderRadius(_ token: BorderRadiusToken) -> CGFloat {
         switch token {
-        case .none:
+        case .cornerRadiusNone:
             return 0
-        case .small:
+        case .cornerRadius20:
             return 2
-        case .medium:
+        case .cornerRadius40:
             return 4
-        case .large:
+        case .cornerRadius60:
+            return 6
+        case .cornerRadius80:
             return 8
-        case .xLarge:
+        case .cornerRadius120:
             return 12
-        case .circle:
+        case .cornerRadiusCircular:
             return 9999
         }
     }

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1633,36 +1633,60 @@ public class GlobalTokens: NSObject {
     // MARK: - IconSize
 
     public enum IconSizeToken: TokenSetKey {
-        case xxxSmall
-        case xxSmall
-        case xSmall
-        case small
-        case medium
-        case large
-        case xLarge
-        case xxLarge
-        case xxxLarge
+        case sizeNone
+        case size20
+        case size40
+        case size60
+        case size80
+        case size100
+        case size120
+        case size160
+        case size200
+        case size240
+        case size280
+        case size320
+        case size360
+        case size400
+        case size480
+        case size520
+        case size560
     }
     public static func iconSize(_ token: IconSizeToken) -> CGFloat {
         switch token {
-        case .xxxSmall:
+        case .sizeNone:
+            return 0
+        case .size20:
+            return 2
+        case .size40:
+            return 4
+        case .size60:
+            return 6
+        case .size80:
+            return 8
+        case .size100:
             return 10
-        case .xxSmall:
+        case .size120:
             return 12
-        case .xSmall:
+        case .size160:
             return 16
-        case .small:
+        case .size200:
             return 20
-        case .medium:
+        case .size240:
             return 24
-        case .large:
+        case .size280:
             return 28
-        case .xLarge:
+        case .size320:
+            return 32
+        case .size360:
             return 36
-        case .xxLarge:
+        case .size400:
             return 40
-        case .xxxLarge:
+        case .size480:
             return 48
+        case .size520:
+            return 52
+        case .size560:
+            return 56
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1735,29 +1735,29 @@ public class GlobalTokens: NSObject {
     // MARK: - BorderRadius
 
     public enum CornerRadiusToken: TokenSetKey {
-        case cornerRadiusNone
-        case cornerRadius20
-        case cornerRadius40
-        case cornerRadius60
-        case cornerRadius80
-        case cornerRadius120
-        case cornerRadiusCircular
+        case radiusNone
+        case radius20
+        case radius40
+        case radius60
+        case radius80
+        case radius120
+        case radiusCircular
     }
     public static func corner(_ token: CornerRadiusToken) -> CGFloat {
         switch token {
-        case .cornerRadiusNone:
+        case .radiusNone:
             return 0
-        case .cornerRadius20:
+        case .radius20:
             return 2
-        case .cornerRadius40:
+        case .radius40:
             return 4
-        case .cornerRadius60:
+        case .radius60:
             return 6
-        case .cornerRadius80:
+        case .radius80:
             return 8
-        case .cornerRadius120:
+        case .radius120:
             return 12
-        case .cornerRadiusCircular:
+        case .radiusCircular:
             return 9999
         }
     }
@@ -1765,32 +1765,32 @@ public class GlobalTokens: NSObject {
     // MARK: - BorderSize
 
     public enum StrokeWidthToken: TokenSetKey {
-        case strokeWidthNone
-        case strokeWidth05
-        case strokeWidth10
-        case strokeWidth15
-        case strokeWidth20
-        case strokeWidth30
-        case strokeWidth40
-        case strokeWidth60
+        case widthNone
+        case width05
+        case width10
+        case width15
+        case width20
+        case width30
+        case width40
+        case width60
     }
     public static func stroke(_ token: StrokeWidthToken) -> CGFloat {
         switch token {
-        case .strokeWidthNone:
+        case .widthNone:
             return 0
-        case .strokeWidth05:
+        case .width05:
             return 0.5
-        case .strokeWidth10:
+        case .width10:
             return 1
-        case .strokeWidth15:
+        case .width15:
             return 1.5
-        case .strokeWidth20:
+        case .width20:
             return 2
-        case .strokeWidth30:
+        case .width30:
             return 3
-        case .strokeWidth40:
+        case .width40:
             return 4
-        case .strokeWidth60:
+        case .width60:
             return 6
         }
     }

--- a/ios/FluentUI/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Divider/DividerTokenSet.swift
@@ -46,5 +46,5 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
     let spacing: () -> MSFDividerSpacing
 
     /// The default thickness for the divider: half pt.
-    static var thickness: CGFloat { return GlobalTokens.strokeWidth(.strokeWidth05) }
+    static var thickness: CGFloat { return GlobalTokens.stroke(.strokeWidth05) }
 }

--- a/ios/FluentUI/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Divider/DividerTokenSet.swift
@@ -46,5 +46,5 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
     let spacing: () -> MSFDividerSpacing
 
     /// The default thickness for the divider: half pt.
-    static var thickness: CGFloat { return GlobalTokens.stroke(.strokeWidth05) }
+    static var thickness: CGFloat { return GlobalTokens.stroke(.width05) }
 }

--- a/ios/FluentUI/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Divider/DividerTokenSet.swift
@@ -30,9 +30,9 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
                 return .float {
                     switch spacing() {
                     case .none:
-                        return GlobalTokens.spacing(.none)
+                        return GlobalTokens.spacing(.sizeNone)
                     case .medium:
-                        return GlobalTokens.spacing(.medium)
+                        return GlobalTokens.spacing(.size160)
                     }
                 }
 

--- a/ios/FluentUI/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Divider/DividerTokenSet.swift
@@ -46,5 +46,5 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
     let spacing: () -> MSFDividerSpacing
 
     /// The default thickness for the divider: half pt.
-    static var thickness: CGFloat { return GlobalTokens.borderSize(.thinnest) }
+    static var thickness: CGFloat { return GlobalTokens.borderSize(.strokeWidth05) }
 }

--- a/ios/FluentUI/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Divider/DividerTokenSet.swift
@@ -46,5 +46,5 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
     let spacing: () -> MSFDividerSpacing
 
     /// The default thickness for the divider: half pt.
-    static var thickness: CGFloat { return GlobalTokens.borderSize(.strokeWidth05) }
+    static var thickness: CGFloat { return GlobalTokens.strokeWidth(.strokeWidth05) }
 }

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -32,7 +32,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
 
             case .cornerRadius:
                 return .float {
-                    return GlobalTokens.corner(.cornerRadius40)
+                    return GlobalTokens.corner(.radius40)
                 }
 
             case .activityIndicatorColor:

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -59,16 +59,16 @@ extension HeadsUpDisplayTokenSet {
     static let opacityDismissed: Double = 0.0
 
     /// The distance between the label and image contents from the left and right edges of the squared background of the Heads-up display.
-    static let horizontalPadding: CGFloat = GlobalTokens.spacing(.small)
+    static let horizontalPadding: CGFloat = GlobalTokens.spacing(.size120)
 
     /// The distance between the label and image contents from the top and bottom edges of the squared background of the Heads-up display.
-    static let verticalPadding: CGFloat = GlobalTokens.spacing(.large)
+    static let verticalPadding: CGFloat = GlobalTokens.spacing(.size200)
 
     /// The distance between the top of the hud panel and the activity indicator
-    static let topPadding: CGFloat = GlobalTokens.spacing(.large)
+    static let topPadding: CGFloat = GlobalTokens.spacing(.size200)
 
     /// The distance between the bottom of the hud panel and the label
-    static let bottomPadding: CGFloat = GlobalTokens.spacing(.medium)
+    static let bottomPadding: CGFloat = GlobalTokens.spacing(.size160)
 
     /// The minimum value for the side of the squared background of the Heads-up display.
     static let minSize: CGFloat = 100

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -32,7 +32,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
 
             case .cornerRadius:
                 return .float {
-                    return GlobalTokens.cornerRadius(.cornerRadius40)
+                    return GlobalTokens.corner(.cornerRadius40)
                 }
 
             case .activityIndicatorColor:

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -32,7 +32,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
 
             case .cornerRadius:
                 return .float {
-                    return GlobalTokens.borderRadius(.medium)
+                    return GlobalTokens.borderRadius(.cornerRadius40)
                 }
 
             case .activityIndicatorColor:

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -32,7 +32,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
 
             case .cornerRadius:
                 return .float {
-                    return GlobalTokens.borderRadius(.cornerRadius40)
+                    return GlobalTokens.cornerRadius(.cornerRadius40)
                 }
 
             case .activityIndicatorColor:

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -166,9 +166,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return GlobalTokens.borderRadius(.cornerRadius120)
+                        return GlobalTokens.cornerRadius(.cornerRadius120)
                     case false:
-                        return GlobalTokens.borderRadius(.cornerRadiusNone)
+                        return GlobalTokens.cornerRadius(.cornerRadiusNone)
                     }
                 }
 
@@ -202,7 +202,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .outlineWidth:
-                return .float { GlobalTokens.borderSize(.strokeWidth05) }
+                return .float { GlobalTokens.strokeWidth(.strokeWidth05) }
 
             case .shadow:
                 return .shadowInfo {

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -166,9 +166,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return GlobalTokens.corner(.cornerRadius120)
+                        return GlobalTokens.corner(.radius120)
                     case false:
-                        return GlobalTokens.corner(.cornerRadiusNone)
+                        return GlobalTokens.corner(.radiusNone)
                     }
                 }
 
@@ -202,7 +202,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .outlineWidth:
-                return .float { GlobalTokens.stroke(.strokeWidth05) }
+                return .float { GlobalTokens.stroke(.width05) }
 
             case .shadow:
                 return .shadowInfo {

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -166,7 +166,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return GlobalTokens.borderRadius(.xLarge)
+                        return GlobalTokens.borderRadius(.cornerRadius120)
                     case false:
                         return GlobalTokens.borderSize(.strokeWidthNone)
                     }

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -166,9 +166,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return GlobalTokens.cornerRadius(.cornerRadius120)
+                        return GlobalTokens.corner(.cornerRadius120)
                     case false:
-                        return GlobalTokens.cornerRadius(.cornerRadiusNone)
+                        return GlobalTokens.corner(.cornerRadiusNone)
                     }
                 }
 
@@ -202,7 +202,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .outlineWidth:
-                return .float { GlobalTokens.strokeWidth(.strokeWidth05) }
+                return .float { GlobalTokens.stroke(.strokeWidth05) }
 
             case .shadow:
                 return .shadowInfo {

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -168,7 +168,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case true:
                         return GlobalTokens.borderRadius(.cornerRadius120)
                     case false:
-                        return GlobalTokens.borderSize(.strokeWidthNone)
+                        return GlobalTokens.borderRadius(.cornerRadiusNone)
                     }
                 }
 

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -168,7 +168,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case true:
                         return GlobalTokens.borderRadius(.xLarge)
                     case false:
-                        return GlobalTokens.borderSize(.none)
+                        return GlobalTokens.borderSize(.strokeWidthNone)
                     }
                 }
 
@@ -202,7 +202,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .outlineWidth:
-                return .float { GlobalTokens.borderSize(.thinnest) }
+                return .float { GlobalTokens.borderSize(.strokeWidth05) }
 
             case .shadow:
                 return .shadowInfo {

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -176,17 +176,17 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float {
                     switch style().isToast {
                     case true:
-                        return GlobalTokens.spacing(.medium)
+                        return GlobalTokens.spacing(.size160)
                     case false:
-                        return GlobalTokens.spacing(.none)
+                        return GlobalTokens.spacing(.sizeNone)
                     }
                 }
 
             case .bottomPresentationPadding:
-                return .float { GlobalTokens.spacing(.medium) }
+                return .float { GlobalTokens.spacing(.size160) }
 
             case .horizontalSpacing:
-                return .float { GlobalTokens.spacing(.medium) }
+                return .float { GlobalTokens.spacing(.size160) }
 
             case .minimumHeight:
                 return .float { 52.0 }
@@ -229,8 +229,8 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
 // MARK: Constants
 extension NotificationTokenSet {
     /// The value for the horizontal padding between the elements within a notification and its frame
-    static let horizontalPadding: CGFloat = GlobalTokens.spacing(.medium)
+    static let horizontalPadding: CGFloat = GlobalTokens.spacing(.size160)
 
     /// The value for the vertical padding between the elements within a multi-line notification and its frame
-    static let verticalPadding: CGFloat = GlobalTokens.spacing(.small)
+    static let verticalPadding: CGFloat = GlobalTokens.spacing(.size120)
 }

--- a/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
@@ -88,9 +88,9 @@ extension PersonaButtonTokenSet {
     static func horizontalAvatarPadding(_ size: MSFPersonaButtonSize) -> CGFloat {
         switch size {
         case .small:
-            return GlobalTokens.spacing(.medium)
+            return GlobalTokens.spacing(.size160)
         case .large:
-            return GlobalTokens.spacing(.xSmall)
+            return GlobalTokens.spacing(.size80)
         }
     }
 
@@ -98,15 +98,15 @@ extension PersonaButtonTokenSet {
     static func avatarInterspace(_ size: MSFPersonaButtonSize) -> CGFloat {
         switch size {
         case .small:
-            return GlobalTokens.spacing(.xSmall)
+            return GlobalTokens.spacing(.size80)
         case .large:
-            return GlobalTokens.spacing(.small)
+            return GlobalTokens.spacing(.size120)
         }
     }
 
     /// How much space should be reserved to the left and right of the control's labels.
-    static let horizontalTextPadding: CGFloat = GlobalTokens.spacing(.xxxSmall)
+    static let horizontalTextPadding: CGFloat = GlobalTokens.spacing(.size20)
 
     /// How much padding to add above the `Avatar` and below the lowest text label.
-    static let verticalPadding: CGFloat = GlobalTokens.spacing(.xSmall)
+    static let verticalPadding: CGFloat = GlobalTokens.spacing(.size80)
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -154,8 +154,8 @@ open class PopupMenuController: DrawerController {
         view.isHidden = true
 
         view.addSubview(descriptionLabel)
-        let verticalMargin = GlobalTokens.spacing(.small)
-        let horizontalMargin = GlobalTokens.spacing(.medium)
+        let verticalMargin = GlobalTokens.spacing(.size120)
+        let horizontalMargin = GlobalTokens.spacing(.size160)
         descriptionLabel.fitIntoSuperview(
             usingConstraints: true,
             margins: UIEdgeInsets(

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -171,7 +171,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .float { 6.0 }
 
             case .horizontalInset:
-                return .float { GlobalTokens.spacing(.medium) }
+                return .float { GlobalTokens.spacing(.size160) }
 
             case .unreadDotOffsetX:
                 return .float { 6.0 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -96,10 +96,10 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .float { 0.4 }
 
             case .cornerRadius:
-                return .float { GlobalTokens.borderRadius(.cornerRadius40) }
+                return .float { GlobalTokens.cornerRadius(.cornerRadius40) }
 
             case .labelCornerRadius:
-                return .float { GlobalTokens.borderRadius(.cornerRadius20) }
+                return .float { GlobalTokens.cornerRadius(.cornerRadius20) }
 
             case .labelHeight:
                 return .float { 11.0 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -96,10 +96,10 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .float { 0.4 }
 
             case .cornerRadius:
-                return .float { GlobalTokens.corner(.cornerRadius40) }
+                return .float { GlobalTokens.corner(.radius40) }
 
             case .labelCornerRadius:
-                return .float { GlobalTokens.corner(.cornerRadius20) }
+                return .float { GlobalTokens.corner(.radius20) }
 
             case .labelHeight:
                 return .float { 11.0 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -96,10 +96,10 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .float { 0.4 }
 
             case .cornerRadius:
-                return .float { GlobalTokens.cornerRadius(.cornerRadius40) }
+                return .float { GlobalTokens.corner(.cornerRadius40) }
 
             case .labelCornerRadius:
-                return .float { GlobalTokens.cornerRadius(.cornerRadius20) }
+                return .float { GlobalTokens.corner(.cornerRadius20) }
 
             case .labelHeight:
                 return .float { 11.0 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -96,10 +96,10 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .float { 0.4 }
 
             case .cornerRadius:
-                return .float { GlobalTokens.borderRadius(.medium) }
+                return .float { GlobalTokens.borderRadius(.cornerRadius40) }
 
             case .labelCornerRadius:
-                return .float { GlobalTokens.borderRadius(.small) }
+                return .float { GlobalTokens.borderRadius(.cornerRadius20) }
 
             case .labelHeight:
                 return .float { 11.0 }

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -105,7 +105,7 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .float { 11.0 }
 
             case .labelSpacing:
-                return .float { GlobalTokens.spacing(.small) }
+                return .float { GlobalTokens.spacing(.size120) }
             }
         }
     }

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -114,11 +114,11 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .float {
                     switch customViewSize() {
                     case .zero:
-                        return GlobalTokens.spacing(.none)
+                        return GlobalTokens.spacing(.sizeNone)
                     case .small:
-                        return GlobalTokens.spacing(.medium)
+                        return GlobalTokens.spacing(.size160)
                     case .medium, .default:
-                        return GlobalTokens.spacing(.small)
+                        return GlobalTokens.spacing(.size120)
                     }
                 }
 
@@ -168,7 +168,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 }
 
             case .paddingLeading:
-                return .float { GlobalTokens.spacing(.medium) }
+                return .float { GlobalTokens.spacing(.size160) }
             }
         }
     }
@@ -181,7 +181,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
 
 extension TableViewCellTokenSet {
     /// The minimum TableViewCell height; the height of a TableViewCell with one line of text.
-    static let oneLineMinHeight: CGFloat = GlobalTokens.spacing(.xxxLarge)
+    static let oneLineMinHeight: CGFloat = GlobalTokens.spacing(.size480)
 
     /// The height of a TableViewCell with two lines of text.
     static let twoLineMinHeight: CGFloat = 64.0
@@ -190,13 +190,13 @@ extension TableViewCellTokenSet {
     static let threeLineMinHeight: CGFloat = 84.0
 
     /// The default horizontal spacing in the cell.
-    static let horizontalSpacing: CGFloat = GlobalTokens.spacing(.medium)
+    static let horizontalSpacing: CGFloat = GlobalTokens.spacing(.size160)
 
     /// The vertical padding in the cell.
     static let paddingVertical: CGFloat = 11.0
 
     /// The trailing padding in the cell.
-    static let paddingTrailing: CGFloat = GlobalTokens.spacing(.medium)
+    static let paddingTrailing: CGFloat = GlobalTokens.spacing(.size160)
 
     static let selectionImageOff = UIImage.staticImageNamed("selection-off")
     static let selectionImageOn = UIImage.staticImageNamed("selection-on")
@@ -214,13 +214,13 @@ extension TableViewCellTokenSet {
     static let footerHeight: CGFloat = 18.0
 
     /// The leading margin for the labelAccessoryView.
-    static let labelAccessoryViewMarginLeading: CGFloat = GlobalTokens.spacing(.xSmall)
+    static let labelAccessoryViewMarginLeading: CGFloat = GlobalTokens.spacing(.size80)
 
     /// The trailing margin for the labelAccessoryView.
-    static let labelAccessoryViewMarginTrailing: CGFloat = GlobalTokens.spacing(.xSmall)
+    static let labelAccessoryViewMarginTrailing: CGFloat = GlobalTokens.spacing(.size80)
 
     /// The leading margin for the customAccessoryView.
-    static let customAccessoryViewMarginLeading: CGFloat = GlobalTokens.spacing(.xSmall)
+    static let customAccessoryViewMarginLeading: CGFloat = GlobalTokens.spacing(.size80)
 
     /// The minimum vertical margin for the customAccessoryView.
     static let customAccessoryViewMinVerticalMargin: CGFloat = 6.0
@@ -229,13 +229,13 @@ extension TableViewCellTokenSet {
     static let defaultLabelVerticalMarginForOneAndThreeLines: CGFloat = 11.0
 
     /// The vertical margin for the label when it has two lines.
-    static let labelVerticalMarginForTwoLines: CGFloat = GlobalTokens.spacing(.small)
+    static let labelVerticalMarginForTwoLines: CGFloat = GlobalTokens.spacing(.size120)
 
     /// The vertical spacing for the label.
-    static let labelVerticalSpacing: CGFloat = GlobalTokens.spacing(.none)
+    static let labelVerticalSpacing: CGFloat = GlobalTokens.spacing(.sizeNone)
 
     /// The trailing margin for the selectionImage.
-    static let selectionImageMarginTrailing: CGFloat = GlobalTokens.spacing(.medium)
+    static let selectionImageMarginTrailing: CGFloat = GlobalTokens.spacing(.size160)
 
     /// The size for the selectionImage.
     static let selectionImageSize: CGFloat = GlobalTokens.iconSize(.medium)

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -104,9 +104,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                     case .zero:
                         return 0.0
                     case .small:
-                        return GlobalTokens.iconSize(.medium)
+                        return GlobalTokens.iconSize(.size240)
                     case .medium, .default:
-                        return GlobalTokens.iconSize(.xxLarge)
+                        return GlobalTokens.iconSize(.size400)
                     }
                 }
 
@@ -238,7 +238,7 @@ extension TableViewCellTokenSet {
     static let selectionImageMarginTrailing: CGFloat = GlobalTokens.spacing(.medium)
 
     /// The size for the selectionImage.
-    static let selectionImageSize: CGFloat = GlobalTokens.iconSize(.medium)
+    static let selectionImageSize: CGFloat = GlobalTokens.iconSize(.size240)
 
     /// The duration for the selectionModeAnimation.
     static let selectionModeAnimationDuration: CGFloat = 0.2

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -104,9 +104,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                     case .zero:
                         return 0.0
                     case .small:
-                        return GlobalTokens.iconSize(.size240)
+                        return GlobalTokens.iconSize(.medium)
                     case .medium, .default:
-                        return GlobalTokens.iconSize(.size400)
+                        return GlobalTokens.iconSize(.xxLarge)
                     }
                 }
 
@@ -238,7 +238,7 @@ extension TableViewCellTokenSet {
     static let selectionImageMarginTrailing: CGFloat = GlobalTokens.spacing(.medium)
 
     /// The size for the selectionImage.
-    static let selectionImageSize: CGFloat = GlobalTokens.iconSize(.size240)
+    static let selectionImageSize: CGFloat = GlobalTokens.iconSize(.medium)
 
     /// The duration for the selectionModeAnimation.
     static let selectionModeAnimationDuration: CGFloat = 0.2


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`IconSizeToken`, `BorderSizeToken`, and `BorderRadiusToken` enums have been updated to their new defined names to align fluent sizing tokens across platforms. 
Our existing sizing tokens were simply renamed, and a few new tokens have been added.

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 32,543,810 bytes | 32,560,546 bytes |

### Verification

The controls affected by this change were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="489" alt="before_avatar" src="https://user-images.githubusercontent.com/106181067/204387714-6e9baaad-d893-47fa-9d88-a28352598918.png"> | <img width="489" alt="after_avatar" src="https://user-images.githubusercontent.com/106181067/204387729-3d2962b6-79b0-4bad-b4d0-d63b67179b2f.png"> |
| <img width="489" alt="before_button" src="https://user-images.githubusercontent.com/106181067/204387767-26be6283-1fea-460a-9681-1b1854266281.png"> | <img width="489" alt="after_button" src="https://user-images.githubusercontent.com/106181067/204387777-8a58db4d-0226-451c-9ea7-264fa935f7bc.png"> |
| <img width="489" alt="before_card_nudge" src="https://user-images.githubusercontent.com/106181067/204387806-7edc7056-5a45-44b4-bc15-f699c6bab150.png"> | <img width="489" alt="after_card_nudge" src="https://user-images.githubusercontent.com/106181067/204387823-6d32e26d-7673-46c1-8c1b-67ea085f77b6.png"> |
| <img width="489" alt="before_hud" src="https://user-images.githubusercontent.com/106181067/204387870-1e591d08-6759-44d5-b5c1-d8345e44410b.png"> | <img width="489" alt="after_hud" src="https://user-images.githubusercontent.com/106181067/204387887-b8e750e2-305a-4aad-a50b-282a087744ed.png"> |
| <img width="489" alt="before_notification" src="https://user-images.githubusercontent.com/106181067/204387913-349b7987-54ed-43f2-b7c4-c1d6fdd3a2da.png"> | <img width="489" alt="after_notification" src="https://user-images.githubusercontent.com/106181067/204387925-7e0f8ee1-b742-4f4d-be06-6d0edde633b5.png"> |
| <img width="489" alt="before_shimmer" src="https://user-images.githubusercontent.com/106181067/204387960-ef5bfd61-ef75-42ba-ae04-d06f681aeb0a.png"> | <img width="489" alt="after_shimmer" src="https://user-images.githubusercontent.com/106181067/204387975-cae716de-3d4d-4876-b29b-36fcabf15355.png"> |
| <img width="489" alt="before_tvc" src="https://user-images.githubusercontent.com/106181067/204388018-f092c11b-140e-4a3e-83ee-c7b552d5d543.png"> | <img width="489" alt="after_tvc" src="https://user-images.githubusercontent.com/106181067/204388030-f6a664c8-8af6-42ef-9b96-b8dedce28cc7.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1405)