### PR TITLE
[Fluent 2 iOS] Update Alias Color Tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -75,7 +75,6 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .stencil2,
              .foregroundDisabled2,
              .foregroundOnColor,
-             .brandForeground2,
              .brandForegroundDisabled2,
              .stroke1,
              .stroke2,
@@ -89,7 +88,6 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .foreground2,
              .foreground3,
              .foregroundInverted2,
-             .brandForegroundInverted,
              .strokeFocus2,
              .brandBackground1Pressed,
              .brandForeground1Pressed,
@@ -98,18 +96,15 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandForegroundTint,
              .brandStroke1Selected:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundOnColor])
-        case .brandBackground3Selected,
-             .brandBackgroundInverted,
+        case .brandBackgroundInverted,
              .brandBackgroundInvertedDisabled,
              .foregroundInverted1,
-             .foregroundLightStatic,
-             .brandForeground3:
+             .foregroundLightStatic:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundContrast])
         case .foregroundContrast,
              .brandForeground1,
              .brandForeground1Selected,
              .brandForeground4,
-             .brandForeground5,
              .brandForegroundDisabled1,
              .background5SelectedBrandFilled,
              .backgroundInverted,
@@ -195,7 +190,6 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .brandBackground2Selected,
                     .brandBackground3,
                     .brandBackground3Pressed,
-                    .brandBackground3Selected,
                     .brandBackground4,
                     .background5BrandTint,
                     .background5SelectedBrandFilled,
@@ -221,11 +215,7 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .brandForeground1,
                     .brandForeground1Pressed,
                     .brandForeground1Selected,
-                    .brandForeground2,
-                    .brandForeground3,
                     .brandForeground4,
-                    .brandForeground5,
-                    .brandForegroundInverted,
                     .brandForegroundDisabled1,
                     .brandForegroundDisabled2]
         case .neutralStrokes:
@@ -270,16 +260,8 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Foreground 1 Pressed"
         case .brandForeground1Selected:
             return "Brand Foreground 1 Selected"
-        case .brandForeground2:
-            return "Brand Foreground 2"
-        case .brandForeground3:
-            return "Brand Foreground 3"
         case .brandForeground4:
             return "Brand Foreground 4"
-        case .brandForeground5:
-            return "Brand Foreground 5"
-        case .brandForegroundInverted:
-            return "Brand Foreground Inverted"
         case .brandForegroundDisabled1:
             return "Brand Foreground Disabled 1"
         case .brandForegroundDisabled2:
@@ -344,8 +326,6 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Background 3"
         case .brandBackground3Pressed:
             return "Brand Background 3 Pressed"
-        case .brandBackground3Selected:
-            return "Brand Background 3 Selected"
         case .brandBackground4:
             return "Brand Background 4"
         case .background5BrandFilledSelected:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -67,7 +67,6 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .background6Pressed,
              .background6Selected,
              .backgroundDisabled,
-             .brandBackground4,
              .background5BrandTintSelected,
              .brandBackgroundDisabled,
              .canvasBackground,
@@ -96,15 +95,13 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandForegroundTint,
              .brandStroke1Selected:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundOnColor])
-        case .brandBackgroundInverted,
-             .brandBackgroundInvertedDisabled,
-             .foregroundInverted1,
-             .foregroundLightStatic:
-            return UIColor(dynamicColor: aliasTokens.colors[.foregroundContrast])
-        case .foregroundContrast,
-             .brandForeground1,
+        case .foregroundInverted1,
+             .foregroundLightStatic,
+             .backgroundLightStatic,
+             .backgroundLightStaticDisabled:
+            return UIColor(dynamicColor: aliasTokens.colors[.foregroundDarkStatic])
+        case .brandForeground1,
              .brandForeground1Selected,
-             .brandForeground4,
              .brandForegroundDisabled1,
              .background5SelectedBrandFilled,
              .backgroundInverted,
@@ -179,7 +176,9 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .canvasBackground,
                     .stencil1,
                     .stencil2,
-                    .backgroundDarkStatic]
+                    .backgroundDarkStatic,
+                    .backgroundLightStatic,
+                    .backgroundLightStaticDisabled]
         case .brandBackgrounds:
             return [.brandBackgroundTint,
                     .brandBackground1,
@@ -190,21 +189,17 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .brandBackground2Selected,
                     .brandBackground3,
                     .brandBackground3Pressed,
-                    .brandBackground4,
                     .background5BrandTint,
                     .background5SelectedBrandFilled,
                     .background5BrandFilledSelected,
                     .background5BrandTintSelected,
-                    .brandBackgroundInverted,
-                    .brandBackgroundDisabled,
-                    .brandBackgroundInvertedDisabled]
+                    .brandBackgroundDisabled]
         case .neutralForegrounds:
             return [.foreground1,
                     .foreground2,
                     .foreground3,
                     .foregroundDisabled1,
                     .foregroundDisabled2,
-                    .foregroundContrast,
                     .foregroundOnColor,
                     .foregroundInverted1,
                     .foregroundInverted2,
@@ -215,7 +210,6 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .brandForeground1,
                     .brandForeground1Pressed,
                     .brandForeground1Selected,
-                    .brandForeground4,
                     .brandForegroundDisabled1,
                     .brandForegroundDisabled2]
         case .neutralStrokes:
@@ -246,8 +240,6 @@ private extension AliasTokens.ColorsTokens {
             return "Foreground Disabled 1"
         case .foregroundDisabled2:
             return "Foreground Disabled 2"
-        case .foregroundContrast:
-            return "Foreground Contrast"
         case .foregroundOnColor:
             return "Foreground On Color"
         case .foregroundInverted1:
@@ -260,8 +252,6 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Foreground 1 Pressed"
         case .brandForeground1Selected:
             return "Brand Foreground 1 Selected"
-        case .brandForeground4:
-            return "Brand Foreground 4"
         case .brandForegroundDisabled1:
             return "Brand Foreground Disabled 1"
         case .brandForegroundDisabled2:
@@ -326,18 +316,12 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Background 3"
         case .brandBackground3Pressed:
             return "Brand Background 3 Pressed"
-        case .brandBackground4:
-            return "Brand Background 4"
         case .background5BrandFilledSelected:
             return "Background 5 Brand Filled Selected"
         case .background5BrandTintSelected:
             return "Background 5 Brand Tint Selected"
-        case .brandBackgroundInverted:
-            return "Brand Background Inverted"
         case .brandBackgroundDisabled:
             return "Brand Background Disabled"
-        case .brandBackgroundInvertedDisabled:
-            return "Brand Background Inverted Disabled"
         case .brandBackgroundTint:
             return "Brand Background Tint"
         case .brandForegroundTint:
@@ -372,6 +356,10 @@ private extension AliasTokens.ColorsTokens {
             return "Foreground Light Static"
         case .backgroundDarkStatic:
             return "Background Dark Static"
+        case .backgroundLightStatic:
+            return "BackgroundLightStatic"
+        case .backgroundLightStaticDisabled:
+            return "BackgroundLightStaticDisabled"
         }
     }
 }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -138,12 +138,12 @@ class CommandBarButton: UIButton {
     }
 
     private var selectedTintColor: UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground4].light,
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundTint].light,
                                                   dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
     }
 
     private var selectedBackgroundColor: UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground4].light,
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundTint].light,
                                                  dark: fluentTheme.aliasTokens.colors[.background5Selected].dark))
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -451,7 +451,6 @@ public final class AliasTokens {
         case foreground3
         case foregroundDisabled1
         case foregroundDisabled2
-        case foregroundContrast
         case foregroundOnColor
         case foregroundInverted1
         case foregroundInverted2
@@ -459,7 +458,6 @@ public final class AliasTokens {
         case brandForeground1
         case brandForeground1Pressed
         case brandForeground1Selected
-        case brandForeground4
         case brandForegroundDisabled1
         case brandForegroundDisabled2
         case foregroundDarkStatic
@@ -485,7 +483,6 @@ public final class AliasTokens {
         case background6
         case background6Pressed
         case background6Selected
-        case backgroundInverted
         case backgroundDisabled
         case brandBackgroundTint
         case brandBackground1
@@ -496,16 +493,16 @@ public final class AliasTokens {
         case brandBackground2Selected
         case brandBackground3
         case brandBackground3Pressed
-        case brandBackground4
         case background5BrandFilledSelected
         case background5BrandTintSelected
-        case brandBackgroundInverted
         case brandBackgroundDisabled
-        case brandBackgroundInvertedDisabled
         case stencil1
         case stencil2
         case canvasBackground
         case backgroundDarkStatic
+        case backgroundInverted
+        case backgroundLightStatic
+        case backgroundLightStaticDisabled
         // Stroke colors
         case stroke1
         case stroke2
@@ -536,9 +533,6 @@ public final class AliasTokens {
         case .foregroundDisabled2:
             return DynamicColor(light: GlobalTokens.neutralColors(.white),
                                 dark: GlobalTokens.neutralColors(.grey18))
-        case .foregroundContrast:
-            return DynamicColor(light: GlobalTokens.neutralColors(.black),
-                                dark: GlobalTokens.neutralColors(.black))
         case .foregroundOnColor:
             return DynamicColor(light: GlobalTokens.neutralColors(.white),
                                 dark: GlobalTokens.neutralColors(.black))
@@ -558,9 +552,6 @@ public final class AliasTokens {
                                 dark: strongSelf.brandColors[.comm140].light)
         case .brandForeground1Selected:
             return DynamicColor(light: strongSelf.brandColors[.comm60].light,
-                                dark: strongSelf.brandColors[.comm120].light)
-        case .brandForeground4:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
                                 dark: strongSelf.brandColors[.comm120].light)
         case .brandForegroundDisabled1:
             return DynamicColor(light: strongSelf.brandColors[.comm90].light)
@@ -654,10 +645,6 @@ public final class AliasTokens {
          return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
                              dark: GlobalTokens.neutralColors(.grey50),
                              darkElevated: GlobalTokens.neutralColors(.grey50))
-        case .backgroundInverted:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey46),
-                             dark: GlobalTokens.neutralColors(.grey72),
-                             darkElevated: GlobalTokens.neutralColors(.grey78))
         case .backgroundDisabled:
          return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
                              dark: GlobalTokens.neutralColors(.grey32),
@@ -686,24 +673,15 @@ public final class AliasTokens {
         case .brandBackground3Pressed:
             return DynamicColor(light: strongSelf.brandColors[.comm30].light,
                                 dark: strongSelf.brandColors[.comm160].light)
-        case .brandBackground4:
-            return DynamicColor(light: strongSelf.brandColors[.comm160].light,
-                                dark: strongSelf.brandColors[.comm20].light)
         case .background5BrandFilledSelected:
             return DynamicColor(light: strongSelf.brandColors[.comm80].light,
                                 dark: GlobalTokens.neutralColors(.grey38))
         case .background5BrandTintSelected:
             return DynamicColor(light: strongSelf.brandColors[.comm160].light,
                                 dark: GlobalTokens.neutralColors(.grey38))
-        case .brandBackgroundInverted:
-            return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                                dark: GlobalTokens.neutralColors(.white))
         case .brandBackgroundDisabled:
             return DynamicColor(light: strongSelf.brandColors[.comm140].light,
                                 dark: strongSelf.brandColors[.comm40].light)
-        case .brandBackgroundInvertedDisabled:
-            return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                                dark: GlobalTokens.neutralColors(.grey86))
         case .stencil1:
          return DynamicColor(light: GlobalTokens.neutralColors(.grey90),
                              dark: GlobalTokens.neutralColors(.grey34))
@@ -718,10 +696,23 @@ public final class AliasTokens {
             return DynamicColor(light: GlobalTokens.neutralColors(.grey14),
                                 dark: GlobalTokens.neutralColors(.grey24),
                                 darkElevated: GlobalTokens.neutralColors(.grey30))
+        case .backgroundInverted:
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey46),
+                                dark: GlobalTokens.neutralColors(.grey72),
+                                darkElevated: GlobalTokens.neutralColors(.grey78))
+        case .backgroundLightStatic:
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.white),
+                                darkElevated: GlobalTokens.neutralColors(.white))
+        case .backgroundLightStaticDisabled:
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.grey68),
+                                darkElevated: GlobalTokens.neutralColors(.grey42))
         // Stroke colors
         case .stroke1:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
-                                dark: GlobalTokens.neutralColors(.grey32))
+                                dark: GlobalTokens.neutralColors(.grey30),
+                                darkElevated: GlobalTokens.neutralColors(.grey36))
         case .stroke2:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
                                 dark: GlobalTokens.neutralColors(.grey24))

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -459,11 +459,7 @@ public final class AliasTokens {
         case brandForeground1
         case brandForeground1Pressed
         case brandForeground1Selected
-        case brandForeground2
-        case brandForeground3
         case brandForeground4
-        case brandForeground5
-        case brandForegroundInverted
         case brandForegroundDisabled1
         case brandForegroundDisabled2
         case foregroundDarkStatic
@@ -500,7 +496,6 @@ public final class AliasTokens {
         case brandBackground2Selected
         case brandBackground3
         case brandBackground3Pressed
-        case brandBackground3Selected
         case brandBackground4
         case background5BrandFilledSelected
         case background5BrandTintSelected
@@ -564,19 +559,9 @@ public final class AliasTokens {
         case .brandForeground1Selected:
             return DynamicColor(light: strongSelf.brandColors[.comm60].light,
                                 dark: strongSelf.brandColors[.comm120].light)
-        case .brandForeground2:
-            return DynamicColor(light: strongSelf.brandColors[.comm160].light,
-                                dark: strongSelf.brandColors[.comm20].light)
-        case .brandForeground3:
-            return DynamicColor(light: strongSelf.brandColors[.comm150].light)
         case .brandForeground4:
             return DynamicColor(light: strongSelf.brandColors[.comm80].light,
                                 dark: strongSelf.brandColors[.comm120].light)
-        case .brandForeground5:
-            return DynamicColor(light: strongSelf.brandColors[.comm70].light)
-        case .brandForegroundInverted:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
-                                dark: GlobalTokens.neutralColors(.white))
         case .brandForegroundDisabled1:
             return DynamicColor(light: strongSelf.brandColors[.comm90].light)
         case .brandForegroundDisabled2:
@@ -701,8 +686,6 @@ public final class AliasTokens {
         case .brandBackground3Pressed:
             return DynamicColor(light: strongSelf.brandColors[.comm30].light,
                                 dark: strongSelf.brandColors[.comm160].light)
-        case .brandBackground3Selected:
-            return DynamicColor(light: strongSelf.brandColors[.comm150].light)
         case .brandBackground4:
             return DynamicColor(light: strongSelf.brandColors[.comm160].light,
                                 dark: strongSelf.brandColors[.comm20].light)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -65,7 +65,7 @@ open class NavigationBar: UINavigationBar {
         func tintColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primary, .default, .custom:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground2].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             case .system:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -50,7 +50,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .brandContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground2].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             }
         }
 
@@ -59,13 +59,13 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .brandContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
 
         func searchIconColor(fluentTheme: FluentTheme, isSearching: Bool = false) -> UIColor {
             let searchBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
-            let idleBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+            let idleBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
 
             switch self {
             case .lightContent, .darkContent:
@@ -89,7 +89,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .brandContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground2].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
 
@@ -98,7 +98,7 @@ open class SearchBar: UIView {
             case .lightContent, .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .brandContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground3].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
     }

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -112,7 +112,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.aliasTokens.colors[.brandBackground4]
+                        return theme.aliasTokens.colors[.brandBackgroundTint]
                     case .neutralToast:
                         return theme.aliasTokens.colors[.background4]
                     case .primaryOutlineBar:
@@ -131,7 +131,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.aliasTokens.colors[.brandForeground4]
+                        return theme.aliasTokens.colors[.brandForegroundTint]
                     case .neutralToast,
                             .neutralBar:
                         return theme.aliasTokens.colors[.foreground2]
@@ -149,7 +149,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.aliasTokens.colors[.brandForeground4]
+                        return theme.aliasTokens.colors[.brandForegroundTint]
                     case .neutralToast,
                             .neutralBar:
                         return theme.aliasTokens.colors[.foreground2]

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -138,9 +138,10 @@ public extension PillButton {
     static func enabledUnreadDotColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundInverted])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
         case .onBrand:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]),
+                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]))
         }
     }
 
@@ -149,7 +150,8 @@ public extension PillButton {
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
         case .onBrand:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1])
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]),
+                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1]))
         }
     }
 }

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -54,7 +54,7 @@ public extension PillButton {
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackgroundInverted]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]))
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]))
         }
     }
 
@@ -140,7 +140,7 @@ public extension PillButton {
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]),
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]),
                            dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]))
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -138,7 +138,8 @@ public extension PillButton {
     static func enabledUnreadDotColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]),
+                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]))
         case .onBrand:
             return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]),
                            dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 27,303,897 | 27,139,460  |

Updating the alias tokens to match two refreshes of the token definitions. This resulted in a significant reduction of redundant and unused tokens.

From internal notification channels:

Removed:

Brand Foreground 2 and Brand Foreground 3
Brand Foreground Inverted
Brand Background 3 Selected and Brand Foreground 5
Removed only DM values for Brand Background 3 (Comm 130) and Brand Background 3 Pressed (Comm 160)
Global token reassigned (we have a formula for calculating states, and this is done to align to it)
Brand Background 1 Pressed changed from Comm 140 to Comm 130 in Dark mode
Brand Foreground 1 Pressed changed from Comm 140 to Comm 130 in Dark mode
Brand Stroke 1 Pressed changed from Comm 140 to Comm 130 in Dark mode
Canvas Background changed from Grey 12 to Grey 8 in Dark mode
therefore Elevated Canvas Background in dark theme has changed from Grey 18 to Grey 14 (same formula as before)
Brand Background Tint changed from L: Comm 160, D: Comm 20 to L: Comm 150, D: Comm 40
Brand Foreground Tint changed from L: Comm 80, D: Comm 120 to L: Comm 60, D: Comm 130

Renamed:

Foreground Contrast name to Foreground Dark Static
Foreground Inverted name to Foreground Light Static
Background Inverted to Background Dark Static
Brand Foreground 4 to Brand Foreground Tint
Brand Background 4 to Brand Background Tint

Added:

Background Inverted (not the same as previous BG inverted)


Second round of changes:

Changes

- Removed Brand Background Inverted token.

- Removed Brand Background Inverted disabled.

- Added BG Light Static design token.

- Added BG Light Static Disabled design token.

- Changed Stroke 1 value in dark theme from Grey 32 to Grey 30.

- Changed Stroke 1 value in dark elevated theme from Grey 38 to Grey 36.

### Verification

Built and ran simulator, comparing before and after screenshots as well as comparing against figma definitions.


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 51 09](https://user-images.githubusercontent.com/23249106/204405110-d913fb71-2f09-4cac-aa2c-57c37a98cfb9.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 56 05](https://user-images.githubusercontent.com/23249106/204405418-240b7ccf-b9a4-4430-97a6-51b9b6745ff0.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 51 13](https://user-images.githubusercontent.com/23249106/204405120-641f79a8-23a1-4af5-865f-eaa72011e859.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 56 10](https://user-images.githubusercontent.com/23249106/204405408-242082ad-262f-4780-9fd5-b3d2219189ed.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 48 23](https://user-images.githubusercontent.com/23249106/204405026-90d994d2-cf2f-4c68-ad75-5b681c3af0d9.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 55 18](https://user-images.githubusercontent.com/23249106/204405487-7a4a3bc1-60a8-4a8b-a142-7c418d38ada9.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 48 35](https://user-images.githubusercontent.com/23249106/204405037-666c398e-1d06-4b09-84df-2f17a96e1070.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 55 24](https://user-images.githubusercontent.com/23249106/204405479-b8188316-d2e9-4bf2-9d90-8182def2045c.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 48 51](https://user-images.githubusercontent.com/23249106/204405055-5d8a9dd1-cf09-43b4-b1ec-522efa5f7c90.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 55 35](https://user-images.githubusercontent.com/23249106/204405465-0c2222ab-8f48-466b-89ca-bf3d26109e5d.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 48 57](https://user-images.githubusercontent.com/23249106/204405072-c5cabd4f-a444-4c76-a7bf-5880162c4a73.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 55 40](https://user-images.githubusercontent.com/23249106/204405455-b71492d2-7971-425e-af6a-329409a86fb3.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 49 12](https://user-images.githubusercontent.com/23249106/204405089-5ab33fec-657c-4c9a-9301-8c347e34623a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 55 47](https://user-images.githubusercontent.com/23249106/204405440-7ab2a9fa-14fc-4081-b679-98d54aa3356d.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 15 49 17](https://user-images.githubusercontent.com/23249106/204405097-dc021335-e8e3-4097-8a59-5d2f50e2efba.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-28 at 16 03 37](https://user-images.githubusercontent.com/23249106/204406174-0cb5a754-1651-4041-962d-a47c795b77d8.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1406)