### PR TITLE
make sure Accessibility.TabBarItemView.UnreadFormat are localized

### DIFF
--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "قيد التقدم";
 "Accessibility.ActivityIndicator.Stopped.label" = "تم إيقاف التقدم";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "تنبيه";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "تجاهل";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "اضغط ضغطاً مزدوجاً للتجاهل";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "تم";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "اضغط ضغطاً مزدوجاً برفق لتبديل التحديد";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@، %@ من العناصر";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ الساعة %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "البحث في الدليل";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ar.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@، %@ من العناصر";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, غير مقروء";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "En curs";
 "Accessibility.ActivityIndicator.Stopped.label" = "S'ha aturat el progrés";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alerta";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Descarta";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Toqueu dues vegades per descartar-ho.";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Fet";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Toca dues vegades per commutar la selecció";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elements";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "El %@ a les %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Cerca al directori";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ca.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elements";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, sense llegir";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Probíhá";
 "Accessibility.ActivityIndicator.Stopped.label" = "Průběh zastaven";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Upozornění";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Zavřít";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Poklepáním zavřete.";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Hotovo";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Výběr přepnete dvojitým poklepáním";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, počet položek: %@";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ v %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Prohledat adresář";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/cs.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, počet položek: %@";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, nepřečtené";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementer";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, ulæst";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/da.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Igangværende";
 "Accessibility.ActivityIndicator.Stopped.label" = "Status er standset";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Underretning";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Afvis";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dobbelttryk for at afvise";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Udført";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dobbelttryk for at skifte valg ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementer";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ kl. %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Søg i mappen";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "In Bearbeitung";
 "Accessibility.ActivityIndicator.Stopped.label" = "Bearbeitung angehalten";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Warnung";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Schließen";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Zum Schließen doppeltippen.";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Fertig";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Zum Umschalten der Auswahl doppelt tippen";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ Elemente";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ um %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Verzeichnis durchsuchen";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/de.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ Elemente";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, ungelesen";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ στοιχεία";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, μη αναγνωσμένο";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/el.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Σε εξέλιξη";
 "Accessibility.ActivityIndicator.Stopped.label" = "Η πρόοδος διεκόπη";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Ειδοποίηση";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Κλείσιμο";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Πατήστε δύο φορές για κλείσιμο";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Τέλος";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Πατήστε δύο φορές για εναλλαγή της επιλογής";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ στοιχεία";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ στις %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Αναζήτηση στον κατάλογο";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "In progress";
 "Accessibility.ActivityIndicator.Stopped.label" = "Progress halted";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alert";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Dismiss";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Double tap to dismiss";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Done";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Double tap to toggle selection";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ items";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ at %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Search Directory";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementos";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, no leído";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es-MX.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "En curso";
 "Accessibility.ActivityIndicator.Stopped.label" = "El progreso se detuvo";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alerta";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Descartar";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Pulsa dos veces para descartar";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Listo";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Pulsa dos veces para alternar la selección";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementos";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ a las %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Buscar en el directorio";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementos";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, no leído";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/es.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "En curso";
 "Accessibility.ActivityIndicator.Stopped.label" = "El progreso se detuvo";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alerta";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Descartar";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Pulsa dos veces para descartar";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Listo";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Pulse dos veces para alternar la selección";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementos";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ a las %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Buscar en el directorio";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Kesken";
 "Accessibility.ActivityIndicator.Stopped.label" = "Tilanne pysäytetty";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Hälytys";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Hylkää";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Hylkää kaksoisnapauttamalla";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Valmis";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Vaihda valintaa kaksoisnapauttamalla ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ kohdetta";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ klo %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Hae hakemistosta";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fi.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ kohdetta";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, lukematon";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ éléments";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, non lu(s)";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/fr.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "En cours";
 "Accessibility.ActivityIndicator.Stopped.label" = "Progrès stoppés";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alerte";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Ignorer";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Appuyez deux fois pour masquer";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Terminé";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Appuyez deux fois pour activer la sélection";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ éléments";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ à %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Rechercher dans l’annuaire";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, ‏%@ פריטים";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, לא נקרא";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/he.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "בביצוע";
 "Accessibility.ActivityIndicator.Stopped.label" = "ההתקדמות הופסקה";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "התראה";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "בטל";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "הקש פעמיים כדי לבטל";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "בוצע";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "הקש פעמיים כדי להחליף מצב בחירה";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, ‏%@ פריטים";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ ב- %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "חפש במדריך הכתובות";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ आइटम्स";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, नहीं पढ़ा गया";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hi.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "प्रगति पर है";
 "Accessibility.ActivityIndicator.Stopped.label" = "प्रगति रुक गई है";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "चेतावनी";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "ख़ारिज करें";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "ख़ारिज करने के लिए डबल-टैप करें";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "पूर्ण";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "चयन को टॉगल करने के लिए डबल टैप करें";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ आइटम्स";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ पर %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "डायरेक्टरी खोजें";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ stavke";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, nepročitano";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hr.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "U tijeku";
 "Accessibility.ActivityIndicator.Stopped.label" = "Zaustavljen napredak";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Upozorenje";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Odbaci";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dvaput dodirnite da biste odbacili";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Gotovo";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dvaput dodirnite za uključivanje/isključivanje odabira ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ stavke";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ u %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Pretraživanje direktorija";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Folyamatban";
 "Accessibility.ActivityIndicator.Stopped.label" = "Az előrehaladás leállt";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Értesítés";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Bezárás";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Koppintson duplán a bezáráshoz";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Kész";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Koppintson duplán a kijelölés váltásához";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elem";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ ekkor: %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Keresés a címtárban";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/hu.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elem";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, olvasatlan";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ item";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, belum dibaca";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/id.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Dalam proses";
 "Accessibility.ActivityIndicator.Stopped.label" = "Progres dihentikan";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Peringatan";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Tutup";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Ketuk dua kali untuk menutup";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Selesai";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Ketuk dua kali untuk mematikan/menghidupkan pilihan";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ item";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ pada %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Cari Direktori";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementi";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, da leggere";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/it.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "In corso";
 "Accessibility.ActivityIndicator.Stopped.label" = "Avanzamento interrotto";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Avviso";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Ignora";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Effettua un doppio tocco per ignorare l'elemento";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Fine";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Effettua un doppio tocco per attivare o disattivare la selezione";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementi";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ alle %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Cerca nella directory";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@、%@ 個の項目";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@、未読";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ja.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "進行中";
 "Accessibility.ActivityIndicator.Stopped.label" = "進行状況が停止しました";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "アラート";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "閉じる";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "ダブルタップして閉じます";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "完了";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "ダブルタップして、選択を切り替えます ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@、%@ 個の項目";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ の %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "ディレクトリの検索";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ 항목";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, 읽지 않음";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ko.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "진행 중";
 "Accessibility.ActivityIndicator.Stopped.label" = "진행이 중지되었습니다";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "알림";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "해제";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "해제하려면 두 번 탭하세요.";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "완료";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "두 번 탭하여 선택을 전환할 수 있습니다. ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ 항목";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "디렉터리 검색";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ item";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, tidak dibaca";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ms.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Sedang berjalan";
 "Accessibility.ActivityIndicator.Stopped.label" = "Kemajuan dihentikan";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Isyarat";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Tolak";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dwiketik untuk menolak";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Selesai";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dwiketik untuk togol pilihan";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ item";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ pada %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Cari dalam Direktori";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementer";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, ulest";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nb-NO.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Pågående";
 "Accessibility.ActivityIndicator.Stopped.label" = "Fremdrift stoppet";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Varsel";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Lukk";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dobbelttrykk for å lukke";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Fullført";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dobbelttrykk for å vise/skjule utvalg";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elementer";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ kl. %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Søk i katalogen";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ items";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, ongelezen";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/nl.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Wordt uitgevoerd";
 "Accessibility.ActivityIndicator.Stopped.label" = "Vooruitgang gestopt";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Waarschuwing";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Verwijderen";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dubbeltikken om te sluiten";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Gereed";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dubbeltikken om de selectie in of uit te schakelen";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ items";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ om %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Zoeken in adreslijst";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, liczba elementów: %@";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, nieprzeczytane";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pl.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "W toku";
 "Accessibility.ActivityIndicator.Stopped.label" = "Postęp wstrzymany";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alert";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Odrzuć";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Naciśnij dwukrotnie, aby odrzucić";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Gotowe";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dotknij dwukrotnie, aby przełączyć zaznaczenie";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, liczba elementów: %@";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ o %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Wyszukaj w katalogu";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ ítens";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, não lido(s)";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Em andamento";
 "Accessibility.ActivityIndicator.Stopped.label" = "Andamento interrompido";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alerta";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Ignorar";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dê um toque duplo para ignorar";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Concluída";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dê um toque duplo para alternar a seleção";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ ítens";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ às %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Diretório de Pesquisa";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ itens";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, não lido";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/pt-PT.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Em curso";
 "Accessibility.ActivityIndicator.Stopped.label" = "Progresso interrompido";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Alerta";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Dispensar";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Faça duplo toque para dispensar";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Concluído";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Toque duas vezes para ativar ou desativar a seleção";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ itens";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ na %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Procurar no Diretório";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "În desfășurare";
 "Accessibility.ActivityIndicator.Stopped.label" = "Progres oprit";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Avertizare";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Îndepărtare";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Atingeți de două ori pentru a îndepărta";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Gata";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Atingeți de două ori pentru a comuta selecția";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elemente";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ la %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Căutați în director";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ro.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ elemente";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, necitit";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Выполняется";
 "Accessibility.ActivityIndicator.Stopped.label" = "Ход выполнения остановлен";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Оповещение";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Закрыть";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Дважды коснитесь, чтобы закрыть";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Готово";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Дважды коснитесь, чтобы переключить выделение ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, элементов: %@";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ в %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Поиск в каталоге";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/ru.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, элементов: %@";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, непрочитано";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Prebieha";
 "Accessibility.ActivityIndicator.Stopped.label" = "Priebeh sa zastavil";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Upozornenie";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Zrušiť";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Zrušíte dvojitým ťuknutím";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Hotovo";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Výber prepnite dvojitým ťuknutím";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, položky: %@";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ o %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Prehľadať adresár";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sk.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, položky: %@";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, neprečítané";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ objekt";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, oläst";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/sv.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Pågående";
 "Accessibility.ActivityIndicator.Stopped.label" = "Förlopp har stoppats";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Varning";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Stäng";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Dubbeltryck för att stänga";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Klart";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Dubbelklicka för att växla markeringen";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ objekt";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ kl. %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Sök i katalog";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ รายการ";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@ ยังไม่ได้อ่าน";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/th.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "กำลังดำเนินการ";
 "Accessibility.ActivityIndicator.Stopped.label" = "หยุดความคืบหน้าแล้ว";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "การแจ้งเตือน";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "ยกเลิก";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "แตะสองครั้งเพื่อยกเลิก";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "เสร็จสิ้น";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "แตะสองครั้งเพื่อสลับการเลือก ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ รายการ";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ เวลา %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "ค้นหาในไดเรกทอรี";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Devam ediyor";
 "Accessibility.ActivityIndicator.Stopped.label" = "İlerleme durduruldu";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Uyarı";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Kapat";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Kapatmak için iki kez dokunun";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Bitti";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Seçimi değiştirmek için iki kez dokunun ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ öğe";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@, %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Dizinde Ara";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/tr.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ öğe";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, okunmadı";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Виконується";
 "Accessibility.ActivityIndicator.Stopped.label" = "Виконання припинено";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Оповіщення";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Закрити";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Торкніться двічі, щоб закрити";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Готово";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Торкніться двічі, щоб перемкнути виділення ";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, елементів: %@";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@, %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Пошук у каталозі";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/uk.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, елементів: %@";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, непрочитане";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "Đang tiến hành";
 "Accessibility.ActivityIndicator.Stopped.label" = "Tiến độ tạm dừng";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "Cảnh báo";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "Bỏ";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "Nhấn đúp để bỏ";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "Đã xong";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Nhấn đúp để chuyển đổi lựa chọn";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ mục";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ lúc %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "Tìm kiếm trong thư mục";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/vi.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@, %@ mục";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, chưa đọc";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@、%@ 个项目";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@，未读";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "正在进行";
 "Accessibility.ActivityIndicator.Stopped.label" = "已暂停进度";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "警报";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "关闭";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "双击以关闭";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "完成";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "双击以切换所选内容";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@、%@ 个项目";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "搜索目录";
 
 /* MSDateTimePicker label for the start time of a date range */

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 "Accessibility.TabBarItemView.LabelFormat" = "%@，%@ 個項目";
 
 /* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
-"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+"Accessibility.TabBarItemView.UnreadFormat" = "%@，未讀取";
 
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";

--- a/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -7,10 +7,15 @@
 "Accessibility.ActivityIndicator.Animating.label" = "進行中";
 "Accessibility.ActivityIndicator.Stopped.label" = "已暫停進度";
 
+/* Accessibility alert for common use */
 "Accessibility.Alert" = "通知";
+/* Accessibility dismiss label for common use */
 "Accessibility.Dismiss.Label" = "關閉";
+/* Accessibility dismiss hint for common use */
 "Accessibility.Dismiss.Hint" = "點兩下以關閉";
+/* Accessibility done label for common use */
 "Accessibility.Done.Label" = "完成";
+/* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "點兩下以切換選取項目";
 
 /* Accessibility label for the upper calendar date picker view. */
@@ -117,6 +122,9 @@
 /* Format string for tab bar item accessbility labels. Format: "<Title>, <BadgeValue> items". Example: "Home, 5 items" */
 "Accessibility.TabBarItemView.LabelFormat" = "%@，%@ 個項目";
 
+/* Accessibility hint for TabBarItem in TabBarItemView. Indicates whether the item is unread or not. Format: "<Title>, unread". Example: "Files, unread" */
+"Accessibility.TabBarItemView.UnreadFormat" = "%@, unread";
+
 /* Format string for badge label button accessibility label. Format: "<Item Accessibility>, <Badge Label Accessibility>". Example: "Notifications, 5 new notifications" */
 "Accessibility.BadgeLabelButton.LabelFormat" = "%@, %@";
 
@@ -150,7 +158,7 @@
 /* Day and time format string. Example: "Fri at 11:00 AM" */
 "Date.FormatDayTime" = "%@ 於 %@";
 
-// MSPersonaListView
+/* MSPersonaListView cell title: search(action) the directory */
 "MSPersonaListView.SearchDirectory" = "搜尋目錄";
 
 /* MSDateTimePicker label for the start time of a date range */


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

git cherry-pick c710b953320d4ce31591087a97b525bf89199de5
git cherry-pick f4e343568183ba3ac5c28d3043411ad91bc0d685
git cherry-pick 6dac60b9c2ec2797f9e41187f44e5b1b7ec974da
git cherry-pick ae56f02d5631a8d2617b93dd5ac07132876d4b2f

### Verification

"Accessibility.TabBarItemView.UnreadFormat" are all localized

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1407)