### PR TITLE
Fix Segmented Control unread dot for icons

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -9,7 +9,7 @@ import UIKit
 class SegmentedControlDemoController: DemoController {
     let segmentItems: [SegmentItem] = [
         SegmentItem(title: "First"),
-        SegmentItem(title: "Second", image: UIImage(named: "Placeholder_20")),
+        SegmentItem(title: "Second", image: UIImage(named: "Placeholder_20"), isUnread: true),
         SegmentItem(title: "Third", isUnread: true),
         SegmentItem(title: "Fourth"),
         SegmentItem(title: "Fifth"),

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -114,7 +114,13 @@ class SegmentPillButton: UIButton {
     private func updateUnreadDot() {
         isUnreadDotVisible = item.isUnread
         if isUnreadDotVisible {
-            let anchor = self.titleLabel?.frame ?? .zero
+            let anchorView: UIView?
+            if item.image != nil {
+                anchorView = self.imageView
+            } else {
+                anchorView = self.titleLabel
+            }
+            let anchor = anchorView?.frame ?? .zero
             let xPos: CGFloat
             if effectiveUserInterfaceLayoutDirection == .leftToRight {
                 xPos = anchor.maxX + tokenSet[.unreadDotOffsetX].float


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 31,666,729 bytes | 31,666,729 bytes |

The (lack of) size difference is a bit suspicious, but I did clean the build between, so, it should be accurate.

When I added support for icons in the Segmented Control, I didn't update the unread dot layout logic correctly. Now we'll check to see if the item has an image, and if it does base the location of the unread dot off of the image rather than the title or zero.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_UnreadAnchor_Before](https://user-images.githubusercontent.com/67026548/204686980-3e9eb7bb-7baa-49ea-95b1-ddf998778299.png) | ![SegmentedControl_UnreadAnchor_After](https://user-images.githubusercontent.com/67026548/204686997-7c53df67-c320-4d49-a17f-c2415ac592bd.png) |
| ![SegmentedControl_UnreadAnchor_Landscape_Before](https://user-images.githubusercontent.com/67026548/204701833-3a569fee-166d-4cf2-a9c5-8d0fd93b21c7.png) | ![SegmentedControl_UnreadAnchor_Landcape_After](https://user-images.githubusercontent.com/67026548/204701849-b34527f9-1982-4bb5-8c68-7ca448212629.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1408)