### PR TITLE
[Fluent 2 iOS] Re-do Segmented Control Colors

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -41,9 +41,6 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
         /// The color of the unread dot when the `SegmentedControl` is enabled.
         case enabledUnreadDotColor
 
-        /// The color of the unread dot when the `SegmentedControl` is enabled and active.
-        case enabledActiveUnreadDotColor
-
         /// The color of the unread dot when the `SegmentedControl` is disabled.
         case disabledUnreadDotColor
 
@@ -197,17 +194,6 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 }
 
             case .enabledUnreadDotColor:
-                return .dynamicColor {
-                    switch style() {
-                    case .primaryPill:
-                        return theme.aliasTokens.foregroundColors[.brandRest]
-                    case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
-                    }
-                }
-
-            case .enabledActiveUnreadDotColor:
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -11,6 +11,9 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
         /// Defines the background color of the unselected segments of the `SegmentedControl`.
         case restTabColor
 
+        /// Defines the background color of the pressed segments of the `SegmentedControl`.
+        case pressedTabColor
+
         /// Defines the background color of the selected segments of the `SegmentedControl`.
         case selectedTabColor
 
@@ -23,6 +26,9 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
         /// Defines the label color of the unselected segments of the `SegmentedControl`.
         case restLabelColor
 
+        /// Defines the label color of the pressed segments of the `SegmentedControl`.
+        case pressedLabelColor
+
         /// Defines the label color of the selected segments of the `SegmentedControl`.
         case selectedLabelColor
 
@@ -34,6 +40,9 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
 
         /// The color of the unread dot when the `SegmentedControl` is enabled.
         case enabledUnreadDotColor
+
+        /// The color of the unread dot when the `SegmentedControl` is enabled and active.
+        case enabledActiveUnreadDotColor
 
         /// The color of the unread dot when the `SegmentedControl` is disabled.
         case disabledUnreadDotColor
@@ -65,11 +74,27 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral4].light,
-                                            dark: theme.aliasTokens.backgroundColors[.neutral3].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.brandHover].light,
-                                            dark: theme.aliasTokens.backgroundColors[.neutral3].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                    }
+                }
+
+            case .pressedTabColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return DynamicColor(light: theme.aliasTokens.colors[.background5Pressed].light,
+                                            dark: theme.aliasTokens.colors[.background3Pressed].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5Pressed].dark)
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2Pressed].light,
+                                            dark: theme.aliasTokens.colors[.background3Pressed].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5Pressed].dark)
                     }
                 }
 
@@ -77,10 +102,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.foregroundColors[.brandRest]
+                        return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                            dark: GlobalTokens.neutralColors(.grey32))
+                        return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
+                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -88,11 +114,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
-                                            dark: GlobalTokens.neutralColors(.grey8))
+                        return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
-                                            dark: GlobalTokens.neutralColors(.grey8))
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -100,11 +128,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey80),
-                                            dark: GlobalTokens.neutralColors(.grey30))
+                        return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                                            dark: GlobalTokens.neutralColors(.grey30))
+                        return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
+                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -112,11 +140,23 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutral3].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                        return theme.aliasTokens.colors[.foreground2]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
+                                            dark: theme.aliasTokens.colors[.foreground2].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground2].dark)
+                    }
+                }
+
+            case .pressedLabelColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return theme.aliasTokens.colors[.foreground1]
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 
@@ -124,11 +164,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutralInverted].dark)
+                        return theme.aliasTokens.colors[.foregroundOnColor]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.brandRest].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral1].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 
@@ -136,11 +176,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
-                                            dark: GlobalTokens.neutralColors(.grey26))
+                        return theme.aliasTokens.colors[.foregroundDisabled1]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
-                                            dark: GlobalTokens.neutralColors(.grey26))
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled1].light,
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled1].dark)
                     }
                 }
 
@@ -148,15 +188,26 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
-                                            dark: GlobalTokens.neutralColors(.grey44))
+                        return theme.aliasTokens.colors[.brandForegroundDisabled1]
                     case .onBrandPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
-                                            dark: GlobalTokens.neutralColors(.grey44))
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled2].light,
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled2].dark)
                     }
                 }
 
             case .enabledUnreadDotColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .primaryPill:
+                        return theme.aliasTokens.foregroundColors[.brandRest]
+                    case .onBrandPill:
+                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
+                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                    }
+                }
+
+            case .enabledActiveUnreadDotColor:
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -23,9 +23,6 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
         /// Defines the label color of the unselected segments of the `SegmentedControl`.
         case restLabelColor
 
-        /// Defines the label color of the pressed segments of the `SegmentedControl`.
-        case pressedLabelColor
-
         /// Defines the label color of the selected segments of the `SegmentedControl`.
         case selectedLabelColor
 
@@ -125,18 +122,6 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
                                             dark: theme.aliasTokens.colors[.foreground2].dark,
                                             darkElevated: theme.aliasTokens.colors[.foreground2].dark)
-                    }
-                }
-
-            case .pressedLabelColor:
-                return .dynamicColor {
-                    switch style() {
-                    case .primaryPill:
-                        return theme.aliasTokens.colors[.foreground1]
-                    case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -197,10 +197,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.foregroundColors[.brandRest]
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -11,9 +11,6 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
         /// Defines the background color of the unselected segments of the `SegmentedControl`.
         case restTabColor
 
-        /// Defines the background color of the pressed segments of the `SegmentedControl`.
-        case pressedTabColor
-
         /// Defines the background color of the selected segments of the `SegmentedControl`.
         case selectedTabColor
 
@@ -78,20 +75,6 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
                                             dark: theme.aliasTokens.colors[.background3].dark,
                                             darkElevated: theme.aliasTokens.colors[.background5].dark)
-                    }
-                }
-
-            case .pressedTabColor:
-                return .dynamicColor {
-                    switch style() {
-                    case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.background5Pressed].light,
-                                            dark: theme.aliasTokens.colors[.background3Pressed].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5Pressed].dark)
-                    case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2Pressed].light,
-                                            dark: theme.aliasTokens.colors[.background3Pressed].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5Pressed].dark)
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 27,303,897 | 27,305,665 |

The previous merge of main into fluent2-colors (#1399) wasn't able to handle the merge between the fluent2-colors work and tokenizing Segmented Control. This change fixes this.

### Verification

Built and ran simulator, ensuring after colors match design.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-29 at 16 05 44](https://user-images.githubusercontent.com/23249106/204698944-784aac97-3b0a-4d6a-9567-245d7c60b028.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-29 at 16 03 20](https://user-images.githubusercontent.com/23249106/204698963-ca17a6f9-62c6-4eb8-8967-f5a222793cf0.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-29 at 16 05 50](https://user-images.githubusercontent.com/23249106/204698884-04d95db3-a651-42b0-a573-d2ae687f445f.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-29 at 16 04 08](https://user-images.githubusercontent.com/23249106/204698974-774f3917-6a3d-45d1-8bde-f645283530af.png) |






### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1410)