### PR TITLE
fix rotation bug on segmented control

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -419,6 +419,7 @@ open class SegmentedControl: UIControl {
             }
             button.frame = CGRect(x: leftOffset, y: 0, width: rightOffset - leftOffset, height: pillContainerView.frame.height)
             leftOffset = rightOffset
+            button.setNeedsLayout()
         }
 
             // flipSubviewsForRTL only works on direct children subviews
@@ -437,7 +438,7 @@ open class SegmentedControl: UIControl {
         if shouldSetEqualWidthForSegments {
             invalidateIntrinsicContentSize()
         }
-        layoutSubviews()
+        setNeedsLayout()
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
@@ -483,10 +484,6 @@ open class SegmentedControl: UIControl {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         updateWindowSpecificColors()
-    }
-
-    func intrinsicContentSizeInvalidatedForChildView() {
-        invalidateIntrinsicContentSize()
     }
 
     /// Used to retrieve the view from the segment at the specified index


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
fix 1)
In main branch, segmentedcontrol is re-written with UIStackView so the layout happens correctly.
However, in previous versions, segmentedcontrol buttons were layed out by frame calculation. There is a bug which when segmented control rotates it doesn't layout the pillbutton's title and the mask title correctly.
Workaround for now is to call SetNeedLayout on each button when we set the frame of the buttons during layoutSubviews.

Fix 2)
we should never call layoutsubview() directly. According to apple documentation, if you want to force a layout update, call the [setNeedsLayout](https://developer.apple.com/documentation/uikit/uiview/1622601-setneedslayout?language=objc) method instead to do so prior to the next drawing update. If you want to update the layout of your views immediately, call the [layoutIfNeeded](https://developer.apple.com/documentation/uikit/uiview/1622507-layoutifneeded?language=objc) method.

Fix 3)
remove unused code "intrinsicContentSizeInvalidatedForChildView"

### Verification

|--------| Before | After |
|--------|--------|-------|
|screenshots|   ![image](https://user-images.githubusercontent.com/20715435/204714085-c89486d1-4799-4ac7-92df-87349b580e9d.png)     |    ![image](https://user-images.githubusercontent.com/20715435/204713276-247569e5-3ead-4c9b-a9ce-d7d0ab5ade1d.png)   |
|size|      28,135,992 bytes   |    28,135,576 bytes   |





### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1411)