### PR TITLE
Add unread to accessibility labels of PillButton and SegmentPillButton

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -163,8 +163,10 @@ open class PillButton: UIButton {
             if oldValue != isUnreadDotVisible {
                 if isUnreadDotVisible {
                     layer.addSublayer(unreadDotLayer)
+                    accessibilityLabel = String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, pillBarItem.title)
                 } else {
                     unreadDotLayer.removeFromSuperlayer()
+                    accessibilityLabel = pillBarItem.title
                 }
             }
         }

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -10,8 +10,10 @@ class SegmentPillButton: UIButton {
             if oldValue != isUnreadDotVisible {
                 if isUnreadDotVisible {
                     self.layer.addSublayer(unreadDotLayer)
+                    accessibilityLabel = String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, item.title)
                 } else {
                     unreadDotLayer.removeFromSuperlayer()
+                    accessibilityLabel = item.title
                 }
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 31,640,170 bytes | 31,640,330 bytes |

Updated the PillButton and SegmentPillButton to update their accessibility labels to reflect if the unread dot is visible.

### Verification

Note: The screenshots look a bit odd because they're screenshots of QuickPlayer, but the Segmented Control isn't actually having those color issues. The important bit is the text at the bottom.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![UnreadLabel_PillButton_Before](https://user-images.githubusercontent.com/67026548/205173555-61e659bb-fc31-4fe1-b74b-5563e4e16bc4.png) | ![UnreadLabel_PillButton_After](https://user-images.githubusercontent.com/67026548/205173558-ac7e5cb8-b34e-44a9-9077-8f7dc50d67f5.png) |
| ![UnreadLabel_SegmentedControl_Before](https://user-images.githubusercontent.com/67026548/205173565-a4b2a29d-15ba-4fb7-9d9a-9eccf1b20184.png) | ![UnreadLabel_SegmentedControl_After](https://user-images.githubusercontent.com/67026548/205173575-51bff2ac-f2af-434f-9955-540ce121cf37.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1418)