### PR TITLE
[main_0.9] Fix scope of window check in Segmented Control 

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -483,6 +483,9 @@ open class SegmentedControl: UIControl {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         updateWindowSpecificColors()
+        if shouldSetEqualWidthForSegments {
+            invalidateIntrinsicContentSize()
+        }
     }
 
     /// Used to retrieve the view from the segment at the specified index

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -442,9 +442,6 @@ open class SegmentedControl: UIControl {
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        guard let window = window else {
-            return CGSize.zero
-        }
         var maxButtonHeight: CGFloat = 0.0
         var maxButtonWidth: CGFloat = 0.0
         var buttonsWidth: CGFloat = 0.0
@@ -466,12 +463,14 @@ open class SegmentedControl: UIControl {
         }
 
         if shouldSetEqualWidthForSegments {
-            let windowSafeAreaInsets = window.safeAreaInsets
-            let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
-            if traitCollection.userInterfaceIdiom == .pad {
-                maxButtonWidth = max(windowWidth / 2, Constants.iPadMinimumWidth)
-            } else {
-                maxButtonWidth = windowWidth
+            if let window = window {
+                let windowSafeAreaInsets = window.safeAreaInsets
+                let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
+                if traitCollection.userInterfaceIdiom == .pad {
+                    maxButtonWidth = max(windowWidth / 2, Constants.iPadMinimumWidth)
+                } else {
+                    maxButtonWidth = windowWidth
+                }
             }
         } else {
             maxButtonWidth += (contentInset.leading + contentInset.trailing)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 31,263,518 bytes | 31,263,518 bytes |

Moved the check for if there is a window to be just around the logic for calculating the size of the Segmented Control, so that if UIKit decides to try and get the size of the SegmentedControl before adding it to a window we don't just return zero. Also updated the SegmentedControl to invalidate intrinsic content size if it moves to a new window and the size is based on the size of the window.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_WindowCheck_Before](https://user-images.githubusercontent.com/67026548/205371202-72b66797-1e64-45d1-b23d-0e562b091f21.png) | ![SegmentedControl_WindowCheck_After](https://user-images.githubusercontent.com/67026548/205371209-6dfec7bf-0ebf-4bdf-8965-55ef2d425865.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1423)