### PR TITLE
Fix Avatar crash on complicated unicode names

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -433,7 +433,7 @@ public struct Avatar: View, TokenizedControlView {
             var hash: Int32 = 0
             for len in (0..<text.length).reversed() {
                 let ch = text.character(at: len)
-                let shift = len % 8
+                let shift = Int32(len % 8)
                 hash ^= Int32((ch << shift) + (ch >> (8 - shift)))
               }
 

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -413,17 +413,7 @@ public struct Avatar: View, TokenizedControlView {
         }
 
         static func initialsHashCode(fromPrimaryText primaryText: String?, secondaryText: String?) -> Int {
-            var combined: String
-            if let secondaryText = secondaryText, let primaryText = primaryText, secondaryText.count > 0 {
-                combined = primaryText + secondaryText
-            } else if let primaryText = primaryText {
-                combined = primaryText
-            } else if let secondaryText = secondaryText {
-                combined = secondaryText
-            } else {
-                combined = ""
-            }
-
+            let combined = (primaryText ?? "") + (secondaryText ?? "")
             let combinedHashable = combined as NSString
             return Int(abs(hashCode(combinedHashable)))
         }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -418,6 +418,8 @@ public struct Avatar: View, TokenizedControlView {
                 combined = primaryText + secondaryText
             } else if let primaryText = primaryText {
                 combined = primaryText
+            } else if let secondaryText = secondaryText {
+                combined = secondaryText
             } else {
                 combined = ""
             }
@@ -432,8 +434,8 @@ public struct Avatar: View, TokenizedControlView {
         private static func hashCode(_ text: NSString) -> Int32 {
             var hash: Int32 = 0
             for len in (0..<text.length).reversed() {
-                let ch = text.character(at: len)
-                let shift = Int32(len % 8)
+                let ch = Int32(text.character(at: len))
+                let shift = len % 8
                 hash ^= Int32((ch << shift) + (ch >> (8 - shift)))
               }
 

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -360,7 +360,7 @@ open class AvatarView: NSView {
 		var updatedBackgroundColor = avatarBackgroundColor
 		var updatedInitialsColor = initialsFontColor
 		if !isCustomAvatarBackgroundColorConfigured || !isCustomAvatarInitialColorConfigured {
-			let defaultColorSet = AvatarView.getInitialsColorSet(fromPrimaryText: contactEmail, secondaryText: contactName)
+			let defaultColorSet = AvatarView.getInitialsColorSet(fromPrimaryText: contactName, secondaryText: contactEmail)
 
 			if !isCustomAvatarBackgroundColorConfigured {
 				updatedBackgroundColor = defaultColorSet.background.resolvedColor(appearance)
@@ -499,9 +499,13 @@ open class AvatarView: NSView {
 		if initials == nil,
 			let email = email?.trimmingCharacters(in: whitespaceNewlineAndZeroWidthSpace),
 			!email.isEmpty {
-			let initialCharacter = email[email.startIndex]
-			if initialCharacter.isValidInitialsCharacter {
-				initials = String(initialCharacter)
+			let emailComponentsWithUnicodeLetterFirstCharacters = email.filter {
+				$0.isValidInitialsCharacter
+			}
+
+			// Find the first valid unicode character in the email address and use that
+			if let initial = emailComponentsWithUnicodeLetterFirstCharacters.first {
+				initials = String(initial)
 			}
 		}
 
@@ -516,6 +520,8 @@ open class AvatarView: NSView {
 			combined = primaryText + secondaryText
 		} else if let primaryText = primaryText {
 			combined = primaryText
+		} else if let secondaryText = secondaryText {
+			combined = secondaryText
 		} else {
 			combined = ""
 		}
@@ -532,7 +538,7 @@ open class AvatarView: NSView {
 	private static func hashCode(_ text: NSString) -> Int32 {
 		var hash: Int32 = 0
 		for len in (0..<text.length).reversed() {
-			let ch = text.character(at: len)
+			let ch = Int32(text.character(at: len))
 			let shift = len % 8
 			hash ^= Int32((ch << shift) + (ch >> (8 - shift)))
 		}

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -515,20 +515,11 @@ open class AvatarView: NSView {
 	@objc(getInitialsColorSetFromPrimaryText:secondaryText:)
 	public static func getInitialsColorSet(fromPrimaryText primaryText: String?, secondaryText: String?) -> ColorSet {
 		// Set the color based on the primary text and secondary text
-		let combined: String
-		if let secondaryText = secondaryText, let primaryText = primaryText, secondaryText.count > 0 {
-			combined = primaryText + secondaryText
-		} else if let primaryText = primaryText {
-			combined = primaryText
-		} else if let secondaryText = secondaryText {
-			combined = secondaryText
-		} else {
-			combined = ""
-		}
-
-		let colors = AvatarView.avatarColors
+		let combined = (primaryText ?? "") + (secondaryText ?? "")
 		let combinedHashable = combined as NSString
 		let hashCode = Int(abs(hashCode(combinedHashable)))
+
+		let colors = AvatarView.avatarColors
 		return colors[hashCode % colors.count]
 	}
 

--- a/macos/FluentUITestViewControllers/TestAvatarViewController.swift
+++ b/macos/FluentUITestViewControllers/TestAvatarViewController.swift
@@ -19,6 +19,7 @@ private struct TestData {
 	static let maor = TestIdentity(name: "Maor Sharett", email: "Maor.Sharett@example.com", image: nil)
 	static let annieBoyl = TestIdentity(name: "Annie Boyl Lind", email: "annie.boyl@example.com", image: nil)
 	static let kat = TestIdentity(name: nil, email: "Kat.Larrson@example.com", image: nil)
+	static let turkey = TestIdentity(name: "🦃", email: "🦃🦃🦃🦃🦃🦃🦃🦃@example.com", image: nil)
 	static let anonymous = TestIdentity(name: nil, email: nil, image: nil)
 	private init() {}
 }
@@ -33,6 +34,7 @@ class TestAvatarViewController: NSViewController {
 															TestData.maor,
 															TestData.annieBoyl,
 															TestData.kat,
+															TestData.turkey,
 															TestData.anonymous
 		])
 

--- a/macos/FluentUIUnitTest/AvatarViewTests.swift
+++ b/macos/FluentUIUnitTest/AvatarViewTests.swift
@@ -40,11 +40,13 @@ class AvatarViewTests: XCTestCase {
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "😂", email: "happy@example.com"), "H")
 		XCTAssertNil(AvatarView.initials(name: "🧐", email: "😀@😬.😂"))
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "🧐", email: "😀@😬.😂"), "#")
+		XCTAssertEqual(AvatarView.initialsWithFallback(name: "🧐", email: "😀@😬.😂z"), "Z")
 		XCTAssertNil(AvatarView.initials(name: "☮︎", email: nil))
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "☮︎", email: nil), "#")
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "Maor Sharett 👑", email: "Maor.Sharett@example.com"), "MS")
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "Maor Sharett👑", email: "Maor.Sharett@example.com"), "MS")
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "Maor 👑 Sharett", email: "Maor.Sharett@example.com"), "MS")
+		XCTAssertEqual(AvatarView.initialsWithFallback(name: "👑 Maor Sharett", email: "Maor.Sharett@example.com"), "MS")
 
 		// Complex characters
 		XCTAssertEqual(AvatarView.initialsWithFallback(name: "王小博", email: "email@example.com"), "E")
@@ -163,5 +165,8 @@ class AvatarViewTests: XCTestCase {
 		colorSet = AvatarView.getInitialsColorSet(fromPrimaryText: "", secondaryText: "")
 		XCTAssertEqual(colorSet.background, DynamicColor(light: Colors.Palette.darkRedTint40.color, dark: Colors.Palette.darkRedShade30.color))
 		XCTAssertEqual(colorSet.foreground, DynamicColor(light: Colors.Palette.darkRedShade30.color, dark: Colors.Palette.darkRedTint40.color))
+		colorSet = AvatarView.getInitialsColorSet(fromPrimaryText: "🦃", secondaryText: "🦃🦃🦃🦃🦃🦃🦃🦃@example.com")
+		XCTAssertEqual(colorSet.background, DynamicColor(light: Colors.Palette.anchorTint40.color, dark: Colors.Palette.anchorShade30.color))
+		XCTAssertEqual(colorSet.foreground, DynamicColor(light: Colors.Palette.anchorShade30.color, dark: Colors.Palette.anchorTint40.color))
 	}
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Fixing Avatar hashing in iOS and macOS by preemptively upscaling our unicode point value from a `unichar` (aka an `unsigned short`) to an `Int32`. This ensures that, when bit-shifted by up to 8 bits, all possible UTF-16 values will still fit within the given space without overflowing.

In JavaScript (where this algorithm was first written) this isn't a problem, since all values are automatically upsized to have enough bits. Swift is pickier and will crash if an arithmetic operation results in overflow. No overflow means no crash!

While here, I discovered a couple of other minor issues with how we derive hash codes on both iOS and macOS:
* Both platforms ignore a possible scenario where a `secondaryText` value is provided with no `primaryText` value. Instead of falling back to nothing, let's use whatever we have (aligns with web). Logic is thus greatly simplified.
* On macOS there's a bug where primary and secondary flip during certain layout passes. This resolves that, again to match both iOS and web.

### Verification

Verified with a known set of crashing unicode emoji (though it is also possible to crash with many other sets of UTF-16 characters). Added unit tests to ensure this code stays working and matches what FluentUI web does (note the gray `E` avatar).

| Before | After | FluentUI web |
|-------------------|--------------------|--------------------|
| <img width="720" alt="Screenshot 2022-12-02 at 11 27 56 AM" src="https://user-images.githubusercontent.com/4934719/205371953-e29a788c-9768-4ab5-a3c9-c8475947381a.png"> | <img width="912" alt="Screenshot 2022-12-02 at 11 27 17 AM" src="https://user-images.githubusercontent.com/4934719/205371917-cf885d7c-2016-42ae-a1df-8512ab7cb238.png"> | <img width="47" alt="Screenshot 2022-12-02 at 11 34 24 AM" src="https://user-images.githubusercontent.com/4934719/205372059-a3aa4059-2657-4f38-9ba0-bcce5263b12a.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)