### PR TITLE
Fix scope of window check in Segmented Control

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -104,6 +104,7 @@ class NavigationControllerDemoController: DemoController {
             SegmentItem(title: "Second")]
         let pillControl = SegmentedControl(items: segmentItems, style: .onBrandPill)
         pillControl.shouldSetEqualWidthForSegments = false
+        pillControl.isFixedWidth = false
         pillControl.contentInset = .zero
         let stackView = UIStackView()
         stackView.addArrangedSubview(pillControl)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -359,9 +359,6 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        guard let window = window else {
-            return CGSize.zero
-        }
         var height: CGFloat = 0.0
         var width: CGFloat = 0.0
 
@@ -373,23 +370,23 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
             }
         }
 
-        let windowSafeAreaInsets = window.safeAreaInsets
-        let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
         if isFixedWidth {
-            if traitCollection.userInterfaceIdiom == .pad {
-                width = max(windowWidth / 2, Constants.iPadMinimumWidth)
-            } else {
-                width = windowWidth
+            if let window = window {
+                let windowSafeAreaInsets = window.safeAreaInsets
+                let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
+                if traitCollection.userInterfaceIdiom == .pad {
+                    width = max(windowWidth / 2, Constants.iPadMinimumWidth)
+                } else {
+                    width = windowWidth
+                }
             }
         } else {
             width += (contentInset.leading + contentInset.trailing)
         }
         height += (contentInset.top + contentInset.bottom)
 
-        let finalWidth = min(min(width, windowWidth), size.width)
-        let finalHeight = min(height, size.height)
-        return CGSize(width: finalWidth,
-                      height: finalHeight)
+        return CGSize(width: min(width, size.width),
+                      height: min(height, size.height))
     }
 
     open override func didMoveToWindow() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -394,6 +394,9 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
 
         tokenSet.update(fluentTheme)
         updateGradientMaskColors()
+        if isFixedWidth {
+            invalidateIntrinsicContentSize()
+        }
     }
 
     func intrinsicContentSizeInvalidatedForChildView() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -393,8 +393,6 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         super.didMoveToWindow()
 
         tokenSet.update(fluentTheme)
-        updateColors()
-        updateButtons()
         updateGradientMaskColors()
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 31,640,362 bytes | 31,640,362 bytes |

Mirror of #1423 in main, since it's a bit more involved than a cherry pick.
The updated SegmentedControl wasn't having the issue, but, the logic is still bad.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_WindowCheck_Main_Before](https://user-images.githubusercontent.com/67026548/205375611-930f7f36-9eb2-44aa-8200-e7a864f5491a.png) | ![SegmentedControl_WindowCheck_Main_After](https://user-images.githubusercontent.com/67026548/205375615-58a3dd4d-f479-432b-a9b4-966206518d7c.png) |
| ![SegmentedControl_WindowCheck_Main_iPhone_Before](https://user-images.githubusercontent.com/67026548/205375621-3599731c-2cf8-4d65-8b0e-e9a6b9f7fd4c.png) | ![SegmentedControl_WindowCheck_iPhone_Before](https://user-images.githubusercontent.com/67026548/205375626-3aecb404-69d2-4cd7-9aca-b5f78413880c.png) |
| ![SegmentedControl_WindowCheck_iPad_Before](https://user-images.githubusercontent.com/67026548/205375632-8bcf167a-4084-4473-87d2-897d9e034cb3.png) | ![SegmentedControl_WindowCheck_iPad_After](https://user-images.githubusercontent.com/67026548/205375649-9f769ba5-d5b6-44f0-aca6-007bbfeeaea7.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1425)