### PR TITLE
[Fluent2 iOS] Fluent2 BadgeLabel

### DIFF
--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -23,7 +23,7 @@ class BadgeLabel: UILabel {
     /// Base function for initialization
     private func initBase() {
         layer.masksToBounds = true
-        backgroundColor = Colors.Palette.dangerPrimary.color
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerBackground1])
         textColor = .white
         textAlignment = .center
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
@@ -33,11 +33,11 @@ class BadgeLabel: UILabel {
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
-        guard shouldUseWindowColor, let window = window else {
+        guard shouldUseWindowColor else {
             return
         }
-        textColor = UIColor(light: Colors.primary(for: window), dark: .white)
-        backgroundColor = UIColor(light: .white, dark: Colors.primary(for: window))
+        textColor = UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground1].light), dark: .white)
+        backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: fluentTheme.aliasTokens.colors[.brandBackground1].dark))
     }
 
     private struct Constants {

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -23,21 +23,26 @@ class BadgeLabel: UILabel {
     /// Base function for initialization
     private func initBase() {
         layer.masksToBounds = true
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerBackground1])
-        textColor = .white
         textAlignment = .center
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
         isHidden = true
+
+        updateColors()
     }
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
+        updateColors()
+    }
 
-        guard shouldUseWindowColor else {
-            return
+    private func updateColors() {
+        if shouldUseWindowColor {
+            textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light, dark: GlobalTokens.neutralColors(.white)))
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: fluentTheme.aliasTokens.colors[.brandBackground1].dark))
+        } else {
+            textColor = UIColor(colorValue: GlobalTokens.neutralColors(.white))
+            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerBackground2])
         }
-        textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light, dark: GlobalTokens.neutralColors(.white)))
-        backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: fluentTheme.aliasTokens.colors[.brandBackground1].dark))
     }
 
     private struct Constants {

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -27,11 +27,23 @@ class BadgeLabel: UILabel {
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
         isHidden = true
 
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
         updateColors()
     }
 
     override func didMoveToWindow() {
         super.didMoveToWindow()
+        updateColors()
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateColors()
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -36,7 +36,7 @@ class BadgeLabel: UILabel {
         guard shouldUseWindowColor else {
             return
         }
-        textColor = UIColor(light: UIColor(colorValue: fluentTheme.aliasTokens.colors[.brandForeground1].light), dark: .white)
+        textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light, dark: GlobalTokens.neutralColors(.white)))
         backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: fluentTheme.aliasTokens.colors[.brandBackground1].dark))
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -65,11 +65,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral4].light,
-                                            dark: theme.aliasTokens.backgroundColors[.neutral3].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.brandHover].light,
-                                            dark: theme.aliasTokens.backgroundColors[.neutral3].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -77,10 +79,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.foregroundColors[.brandRest]
+                        return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                            dark: GlobalTokens.neutralColors(.grey32))
+                        return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
+                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -88,11 +91,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
-                                            dark: GlobalTokens.neutralColors(.grey8))
+                        return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade20].light,
-                                            dark: GlobalTokens.neutralColors(.grey8))
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
+                                            dark: theme.aliasTokens.colors[.background3].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -100,11 +105,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey80),
-                                            dark: GlobalTokens.neutralColors(.grey30))
+                        return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                                            dark: GlobalTokens.neutralColors(.grey30))
+                        return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
+                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
+                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -112,11 +117,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutral3].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                        return theme.aliasTokens.colors[.foreground2]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
+                                            dark: theme.aliasTokens.colors[.foreground2].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground2].dark)
                     }
                 }
 
@@ -124,11 +129,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.backgroundColors[.neutral1].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutralInverted].dark)
+                        return theme.aliasTokens.colors[.foregroundOnColor]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.brandRest].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral1].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 
@@ -136,11 +141,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
-                                            dark: GlobalTokens.neutralColors(.grey26))
+                        return theme.aliasTokens.colors[.foregroundDisabled1]
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.brandColors[.shade10].light,
-                                            dark: GlobalTokens.neutralColors(.grey26))
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled1].light,
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled1].dark)
                     }
                 }
 
@@ -148,11 +153,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
-                                            dark: GlobalTokens.neutralColors(.grey44))
+                        return theme.aliasTokens.colors[.brandForegroundDisabled1]
                     case .onBrandPill:
-                        return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
-                                            dark: GlobalTokens.neutralColors(.grey44))
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled2].light,
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled2].dark)
                     }
                 }
 
@@ -160,10 +165,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.foregroundColors[.brandRest]
+                        return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.foregroundColors[.neutralInverted].light,
-                                            dark: theme.aliasTokens.foregroundColors[.neutral2].dark)
+                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
+                                            dark: theme.aliasTokens.colors[.foreground1].dark,
+                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 27,427,169 | 27,429,089 |

Updating BadgeLabel to be Fluent2 compliant. This indirectly affects NavigationBar and TabBar.

### Verification

Built and ran simulator, used Colour Contrast Analyser to ensure colors were as expected and also screen shots looked correct.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 14 54 52](https://user-images.githubusercontent.com/23249106/205409671-459032b6-02f1-406e-96cb-2b6be0143a26.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 15 34 05](https://user-images.githubusercontent.com/23249106/205409739-7ae6f3eb-5bb4-4893-99b2-7e435dbbc7f4.png)
vbar light |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 14 40 14](https://user-images.githubusercontent.com/23249106/205409665-3e4bdc07-1ca6-4279-9b40-a777be155676.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 15 34 13](https://user-images.githubusercontent.com/23249106/205409729-5441e277-a11f-4f32-b500-c1c3defa0cc2.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 15 44 33](https://user-images.githubusercontent.com/23249106/205409972-777d8739-634e-49f3-97ec-78a9a26d880a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 15 33 47](https://user-images.githubusercontent.com/23249106/205409770-695e95e7-783e-4e12-9ff0-d24d03eb332b.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 15 44 37](https://user-images.githubusercontent.com/23249106/205409976-f43177df-26ca-4239-8a3e-ab25e535b651.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-02 at 15 33 52](https://user-images.githubusercontent.com/23249106/205409763-63bd2ddb-f743-4c1d-9c53-b6c3785a5198.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1426)