### PR TITLE
[main_0.6 cherry pick] Fix scope of window check in Segmented Control  (#1429)

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -441,21 +441,17 @@ open class SegmentedControl: UIControl {
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        guard let window = window,
-              let screen = window.windowScene?.screen else {
-            return CGSize.zero
-        }
         var maxButtonHeight: CGFloat = 0.0
         var maxButtonWidth: CGFloat = 0.0
         var buttonsWidth: CGFloat = 0.0
 
         for button in buttons {
             let size = button.sizeThatFits(size)
-            maxButtonHeight = max(maxButtonHeight, screen.roundToDevicePixels(size.height))
+            maxButtonHeight = max(maxButtonHeight, ceil(size.height))
             if shouldSetEqualWidthForSegments {
-                maxButtonWidth = max(maxButtonWidth, screen.roundToDevicePixels(size.width))
+                maxButtonWidth = max(maxButtonWidth, ceil(size.width))
             } else {
-                buttonsWidth += screen.roundToDevicePixels(size.width)
+                buttonsWidth += ceil(size.width)
             }
         }
 
@@ -466,12 +462,14 @@ open class SegmentedControl: UIControl {
         }
 
         if shouldSetEqualWidthForSegments {
-            let windowSafeAreaInsets = window.safeAreaInsets
-            let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
-            if traitCollection.userInterfaceIdiom == .pad {
-                maxButtonWidth = max(windowWidth / 2, Constants.iPadMinimumWidth)
-            } else {
-                maxButtonWidth = windowWidth
+            if let window = window {
+                let windowSafeAreaInsets = window.safeAreaInsets
+                let windowWidth = window.bounds.width - windowSafeAreaInsets.left - windowSafeAreaInsets.right
+                if traitCollection.userInterfaceIdiom == .pad {
+                    maxButtonWidth = max(windowWidth / 2, Constants.iPadMinimumWidth)
+                } else {
+                    maxButtonWidth = windowWidth
+                }
             }
         } else {
             maxButtonWidth += (contentInset.leading + contentInset.trailing)
@@ -484,6 +482,9 @@ open class SegmentedControl: UIControl {
     open override func didMoveToWindow() {
         super.didMoveToWindow()
         updateWindowSpecificColors()
+        if shouldSetEqualWidthForSegments {
+            invalidateIntrinsicContentSize()
+        }
     }
 
     func intrinsicContentSizeInvalidatedForChildView() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

 - #1429 
Pulling from the main_0.7 cherry pick instead of main_0.9, since main_0.6 also requires the screen.roundToDevicePixels removals.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1433)