### PR TITLE
[Fluent 2 iOS] TwoLineTitleView + LargeTitleView update

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -64,7 +64,7 @@
 }
 
 - (void)setupTitleView {
-    self.titleView = [[MSFTwoLineTitleView alloc] initWithStyle:MSFTwoLineTitleViewStyleDark];
+    self.titleView = [[MSFTwoLineTitleView alloc] initWithStyle:MSFTwoLineTitleViewStyleSystem];
     [self.titleView setupWithTitle:self.title subtitle:nil interactivePart:MSFTwoLineTitleViewInteractivePartTitle accessoryType:MSFTwoLineTitleViewAccessoryTypeNone];
     self.titleView.delegate = self;
     self.navigationItem.titleView = self.titleView;

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
@@ -9,7 +9,7 @@ import UIKit
 // MARK: TooltipDemoController
 
 class TooltipDemoController: DemoController {
-    let titleView = TwoLineTitleView(style: .dark)
+    let titleView = TwoLineTitleView(style: .system)
     var edgeCaseStackView: UIStackView!
 
     override func viewDidLoad() {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -507,9 +507,9 @@ open class NavigationBar: UINavigationBar {
 
         switch style {
         case .primary, .default, .custom:
-            titleView.style = .light
+            titleView.style = .primary
         case .system:
-            titleView.style = .dark
+            titleView.style = .system
         }
 
         standardAppearance.backgroundColor = color

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -22,7 +22,6 @@ class LargeTitleView: UIView {
 
         // Once we are iOS 14 minimum, we can use Fonts.largeTitle.withSize() function instead
         static let compactTitleFont = UIFont.systemFont(ofSize: 26, weight: .bold)
-        static let titleFont = UIFont.systemFont(ofSize: 30, weight: .bold)
     }
 
     var personaData: Persona? {
@@ -93,7 +92,7 @@ class LargeTitleView: UIView {
             case .contracted:
                 titleButton.titleLabel?.font = Constants.compactTitleFont
             case .expanded:
-                titleButton.titleLabel?.font = Constants.titleFont
+                titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
             }
         }
     }
@@ -201,7 +200,7 @@ class LargeTitleView: UIView {
         // title button setup
         contentStackView.addArrangedSubview(titleButton)
         titleButton.setTitle(nil, for: .normal)
-        titleButton.titleLabel?.font = Constants.titleFont
+        titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
         titleButton.setTitleColor(colorForStyle, for: .normal)
         titleButton.titleLabel?.textAlignment = .left
         titleButton.contentHorizontalAlignment = .left
@@ -221,7 +220,7 @@ class LargeTitleView: UIView {
 
     private func expansionAnimation() {
         if titleSize == .automatic {
-            titleButton.titleLabel?.font = Constants.titleFont
+            titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
         }
 
         if avatarSize == .automatic {

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -159,6 +159,18 @@ class LargeTitleView: UIView {
     private func initBase() {
         setupLayout()
         setupAccessibility()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
+        titleButton.setTitleColor(colorForStyle, for: .normal)
     }
 
     // MARK: - Base Construction Methods

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -10,7 +10,8 @@ import UIKit
 /// Large Header and custom profile button container
 class LargeTitleView: UIView {
     enum Style: Int {
-        case light, dark
+        case primary
+        case system
     }
 
     private struct Constants {
@@ -77,10 +78,10 @@ class LargeTitleView: UIView {
         }
     }
 
-    var style: Style = .light {
+    var style: Style = .primary {
         didSet {
             titleButton.setTitleColor(colorForStyle, for: .normal)
-            avatar?.state.style = style == .light ? .default : .accent
+            avatar?.state.style = style == .primary ? .default : .accent
         }
     }
 
@@ -114,10 +115,11 @@ class LargeTitleView: UIView {
 
     private var colorForStyle: UIColor {
         switch style {
-        case .light:
-            return Colors.Navigation.Primary.title
-        case .dark:
-            return Colors.Navigation.System.title
+        case .primary:
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+        case .system:
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
         }
     }
 
@@ -174,7 +176,7 @@ class LargeTitleView: UIView {
                                                                  bottom: 0,
                                                                  right: 8))
         // Avatar setup
-        let preferredFallbackImageStyle: MSFAvatarStyle = style == .light ? .default : .accent
+        let preferredFallbackImageStyle: MSFAvatarStyle = style == .primary ? .default : .accent
         let avatar = MSFAvatar(style: preferredFallbackImageStyle,
                                size: Constants.avatarSize)
         let avatarState = avatar.state

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -26,7 +26,7 @@ open class TwoLineTitleView: UIView {
 
     @objc(MSFTwoLineTitleViewStyle)
     public enum Style: Int {
-        case brand
+        case primary
         case system
     }
 
@@ -130,7 +130,7 @@ open class TwoLineTitleView: UIView {
 
     private var subtitleButtonImageView = UIImageView()
 
-    @objc public convenience init(style: Style = .brand) {
+    @objc public convenience init(style: Style = .primary) {
         self.init(frame: .zero)
         self.currentStyle = style
 
@@ -219,11 +219,13 @@ open class TwoLineTitleView: UIView {
             titleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             subtitleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             titleButtonImageView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-        case .brand:
-            let color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
-            titleButtonLabel.textColor = color
-            subtitleButtonLabel.textColor = color
-            titleButtonImageView.tintColor = color
+        case .primary:
+            titleButtonLabel.textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                                            dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+            subtitleButtonLabel.textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                                               dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
+            titleButtonImageView.tintColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                                                dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
         }
 
         // unlike title accessory image view, subtitle accessory image view should be the same color as subtitle label

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -193,6 +193,8 @@ open class TwoLineTitleView: UIView {
         addInteraction(UILargeContentViewerInteraction())
         titleButtonLabel.showsLargeContentViewer = true
         subtitleButtonLabel.showsLargeContentViewer = true
+
+        updateFonts()
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -284,6 +286,11 @@ open class TwoLineTitleView: UIView {
         subtitleSize.width += subtitleAccessoryType.areaWidth
 
         return CGSize(width: max(titleSize.width, subtitleSize.width), height: titleSize.height + subtitleSize.height)
+    }
+
+    private func updateFonts() {
+        titleButtonLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1Strong])
+        subtitleButtonLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption1])
     }
 
     open override func layoutSubviews() {

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -129,6 +129,8 @@ open class TwoLineTitleView: UIView {
         return interactivePart == .title ? accessoryType : .none
     }
 
+    private var currentStyle: Style
+
     private lazy var titleButtonLabel: Label = {
         let label = Label()
         label.lineBreakMode = .byTruncatingTail
@@ -157,13 +159,17 @@ open class TwoLineTitleView: UIView {
 
     @objc public convenience init(style: Style = .brand) {
         self.init(frame: .zero)
-        applyStyle(style: style)
+        self.currentStyle = style
+
+        applyStyle()
     }
 
     public override init(frame: CGRect) {
+        self.currentStyle = .system
+
         super.init(frame: frame)
 
-        applyStyle(style: .system)
+        applyStyle()
 
         titleButton.addTarget(self, action: #selector(onTitleButtonHighlighted), for: [.touchDown, .touchDragInside, .touchDragEnter])
         titleButton.addTarget(self, action: #selector(onTitleButtonUnhighlighted), for: [.touchUpInside, .touchDragOutside, .touchDragExit])
@@ -195,6 +201,18 @@ open class TwoLineTitleView: UIView {
         subtitleButtonLabel.showsLargeContentViewer = true
 
         updateFonts()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
+        applyStyle()
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -222,8 +240,8 @@ open class TwoLineTitleView: UIView {
 
     // MARK: Highlighting
 
-    private func applyStyle(style: Style) {
-        switch style {
+    private func applyStyle() {
+        switch currentStyle {
         case .system:
             titleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
             subtitleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -223,13 +223,14 @@ open class TwoLineTitleView: UIView {
     private func applyStyle(style: Style) {
         switch style {
         case .system:
-            titleButtonLabel.textColor = .red
-            subtitleButtonLabel.textColor = .red
-            titleButtonImageView.tintColor = .red
+            titleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            subtitleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            titleButtonImageView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
         case .brand:
-            titleButtonLabel.textColor = .green
-            subtitleButtonLabel.textColor = .green
-            titleButtonImageView.tintColor = .green
+            let color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            titleButtonLabel.textColor = color
+            subtitleButtonLabel.textColor = color
+            titleButtonImageView.tintColor = color
         }
 
         // unlike title accessory image view, subtitle accessory image view should be the same color as subtitle label

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -53,8 +53,8 @@ open class TwoLineTitleView: UIView {
 
     @objc(MSFTwoLineTitleViewStyle)
     public enum Style: Int {
-        case light
-        case dark
+        case brand
+        case system
     }
 
     @objc(MSFTwoLineTitleViewInteractivePart)
@@ -155,7 +155,7 @@ open class TwoLineTitleView: UIView {
 
     private var subtitleButtonImageView = UIImageView()
 
-    @objc public convenience init(style: Style = .light) {
+    @objc public convenience init(style: Style = .brand) {
         self.init(frame: .zero)
         applyStyle(style: style)
     }
@@ -163,7 +163,7 @@ open class TwoLineTitleView: UIView {
     public override init(frame: CGRect) {
         super.init(frame: frame)
 
-        applyStyle(style: .dark)
+        applyStyle(style: .system)
 
         titleButton.addTarget(self, action: #selector(onTitleButtonHighlighted), for: [.touchDown, .touchDragInside, .touchDragEnter])
         titleButton.addTarget(self, action: #selector(onTitleButtonUnhighlighted), for: [.touchUpInside, .touchDragOutside, .touchDragExit])
@@ -222,14 +222,14 @@ open class TwoLineTitleView: UIView {
 
     private func applyStyle(style: Style) {
         switch style {
-        case .dark:
-            titleButtonLabel.textColor = Colors.TwoLineTitle.titleDark
-            subtitleButtonLabel.textColor = Colors.TwoLineTitle.subtitleDark
-            titleButtonImageView.tintColor = Colors.TwoLineTitle.titleAccessoryDark
-        case .light:
-            titleButtonLabel.textColor = Colors.TwoLineTitle.titleLight
-            subtitleButtonLabel.textColor = Colors.TwoLineTitle.subtitleLight
-            titleButtonImageView.tintColor = Colors.TwoLineTitle.titleAccessoryLight
+        case .system:
+            titleButtonLabel.textColor = .red
+            subtitleButtonLabel.textColor = .red
+            titleButtonImageView.tintColor = .red
+        case .brand:
+            titleButtonLabel.textColor = .green
+            subtitleButtonLabel.textColor = .green
+            titleButtonImageView.tintColor = .green
         }
 
         // unlike title accessory image view, subtitle accessory image view should be the same color as subtitle label

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -12,33 +12,6 @@ public protocol TwoLineTitleViewDelegate: AnyObject {
     func twoLineTitleViewDidTapOnTitle(_ twoLineTitleView: TwoLineTitleView)
 }
 
-extension Colors {
-
-    // MARK: Navigation Colors
-    struct Navigation {
-        public struct System {
-            public static var background: UIColor = NavigationBar.background
-            public static var tint: UIColor = NavigationBar.tint
-            public static var title: UIColor = NavigationBar.title
-        }
-        public struct Primary {
-            public static var tint = UIColor(light: textOnAccent, dark: System.tint)
-            public static var title = UIColor(light: textOnAccent, dark: System.title)
-        }
-    }
-
-    // MARK: - TwoLineTitle Colors
-    struct TwoLineTitle {
-        // light style is used Navigation.Primary.background. Dark style is used for Navigation.System.background
-        static var titleDark: UIColor = Navigation.System.title
-        static var titleLight: UIColor = Navigation.Primary.title
-        static var subtitleDark = UIColor(light: textSecondary, dark: textDominant)
-        static var subtitleLight: UIColor = titleLight
-        static var titleAccessoryLight = UIColor(light: iconOnAccent, dark: iconPrimary)
-        static var titleAccessoryDark = UIColor(light: iconSecondary, dark: iconPrimary)
-    }
-}
-
 // MARK: - TwoLineTitleView
 
 @objc(MSFTwoLineTitleView)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`TwoLineTitleView` and `LargeTitleView` are updated to fluent 2. 
Update includes changes to colors and fonts. 

Binary change:
<!---
Please fill in the below table using the size of the Demo app, as found in Finder, from 
the latest state of the branch you are merging in to and the latest state of your changes.
In order to get an accurate measurement for iOS, please build the Demo app using the
Demo.Release scheme for "Any iOS Device (arm64)"
--->
| Before | After |
|--------|-------|
| 32,548,900 bytes | 32,550,308 bytes |

### Verification

The `TwoLineTitleView` is tested on the `DateTimePicker` demo and the `LargeTitleView` is tested on the `Navigation` demo. 

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_two_title_light" src="https://user-images.githubusercontent.com/106181067/206051389-47b960a0-5f56-4bbc-baec-5dbebb1a355b.png"> | <img width="487" alt="after_two_title_light" src="https://user-images.githubusercontent.com/106181067/206051407-ec01a546-99c9-4f6e-9344-9a7498a6bdd2.png"> |
| <img width="487" alt="before_two_title_dark" src="https://user-images.githubusercontent.com/106181067/206051445-f069dfb5-ee2b-44e1-aa0a-86fc41ccad56.png"> | <img width="487" alt="after_two_title_dark" src="https://user-images.githubusercontent.com/106181067/206051461-2339bd07-f750-4fce-8a84-71b9bead3fc6.png"> |
| <img width="487" alt="before_system_light" src="https://user-images.githubusercontent.com/106181067/206051572-4a510d24-5758-4764-9eb7-431b2ed2a502.png"> | <img width="487" alt="after_system_light" src="https://user-images.githubusercontent.com/106181067/206051578-1553039b-9d13-43e8-8246-1f6e04d1161a.png"> |
| <img width="487" alt="before_system_dark" src="https://user-images.githubusercontent.com/106181067/206051603-ac595101-998a-4803-89ba-2a36c2ede8a9.png"> | <img width="487" alt="after_system_dark" src="https://user-images.githubusercontent.com/106181067/206051631-35f73398-513e-42d4-bc92-7a41c0b4f1b8.png"> |
| <img width="487" alt="before_primary_light" src="https://user-images.githubusercontent.com/106181067/206051708-1000c88a-cd80-49f2-a403-f08db6fed8f0.png"> | <img width="487" alt="after_primary_light" src="https://user-images.githubusercontent.com/106181067/206051725-67c088f8-3de8-4882-a37e-957057dafae2.png"> |
| <img width="487" alt="before_primary_dark" src="https://user-images.githubusercontent.com/106181067/206051753-5b5844b3-eddb-4527-a030-03c17bdf27c5.png"> | <img width="487" alt="after_primary_dark" src="https://user-images.githubusercontent.com/106181067/206051767-c22aa38c-0299-4968-ae4d-d15092e7f429.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1436)