### PR TITLE
[Fluent 2 iOS] PageCardPresenter update

### DIFF
--- a/ios/FluentUI/Presenters/PageCardPresenterController.swift
+++ b/ios/FluentUI/Presenters/PageCardPresenterController.swift
@@ -5,16 +5,6 @@
 
 import UIKit
 
-// MARK: PageCardPresenter Colors
-
-private extension Colors {
-    struct PageCardPresenter {
-        // Should use physical color because page indicators are shown on physical blurred dark background
-        static var currentPageIndicator: UIColor = .white
-        static var pageIndicator = UIColor.white.withAlphaComponent(0.5)
-    }
-}
-
 // MARK: - CardPresentable
 
 protocol CardPresentable: AnyObject {
@@ -52,11 +42,8 @@ open class PageCardPresenterController: UIViewController {
 
     private let pageControl: UIPageControl = {
         let pageControl = UIPageControl()
-        let color = UIColor(colorValue: GlobalTokens.neutralColors(.white))
         pageControl.hidesForSinglePage = true
         pageControl.isUserInteractionEnabled = false
-        pageControl.pageIndicatorTintColor = color.withAlphaComponent(0.5)
-        pageControl.currentPageIndicatorTintColor = color
         return pageControl
     }()
 
@@ -79,6 +66,27 @@ open class PageCardPresenterController: UIViewController {
         self.currentlyVisibleIndex = startingIndex
 
         super.init(nibName: nil, bundle: nil)
+
+        updatePageControlColors()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, view.isDescendant(of: themeView) else {
+            return
+        }
+        updatePageControlColors()
+    }
+
+    private func updatePageControlColors() {
+        let color = UIColor(colorValue: GlobalTokens.neutralColors(.white))
+
+        pageControl.pageIndicatorTintColor = color.withAlphaComponent(0.5)
+        pageControl.currentPageIndicatorTintColor = color
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Presenters/PageCardPresenterController.swift
+++ b/ios/FluentUI/Presenters/PageCardPresenterController.swift
@@ -52,10 +52,11 @@ open class PageCardPresenterController: UIViewController {
 
     private let pageControl: UIPageControl = {
         let pageControl = UIPageControl()
+        let color = UIColor(colorValue: GlobalTokens.neutralColors(.white))
         pageControl.hidesForSinglePage = true
         pageControl.isUserInteractionEnabled = false
-        pageControl.pageIndicatorTintColor = Colors.PageCardPresenter.pageIndicator
-        pageControl.currentPageIndicatorTintColor = Colors.PageCardPresenter.currentPageIndicator
+        pageControl.pageIndicatorTintColor = color.withAlphaComponent(0.5)
+        pageControl.currentPageIndicatorTintColor = color
         return pageControl
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The only color changes needed were on the `UIPageControl`. Since there aren't design specs for this, I kept the colors consistent with fluent 1. I just changed the color references from `Colors.swift` to `GlobalTokens`.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,923,624 bytes | 29,929,264 bytes | 5640 bytes |

### Verification

The changes were tested the on `DateTimePicker` demo.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_light" src="https://user-images.githubusercontent.com/106181067/206551760-02cc3247-baf5-4ae4-bf47-6e2bfad33c55.png"> | <img width="487" alt="after_light" src="https://user-images.githubusercontent.com/106181067/206551775-e4b7c2d1-de8c-4036-8bc1-a3ef6636ae8e.png"> |
| <img width="487" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/206551838-71ad3410-0a0f-4ee3-be24-8dbe9ca0754e.png"> | <img width="487" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/206551856-b106a062-f810-42c8-8251-e8267c6ce14a.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1447)