### PR TITLE
[Fluent 2 iOS] Update CCB spacing to match spec

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
+++ b/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
@@ -95,7 +95,7 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarTokenSet.Tokens> {
 
 extension CommandBarTokenSet {
     /// The spacing between each Command Bar Group.
-    static let groupInterspace: CGFloat = GlobalTokens.spacing(.size40)
+    static let groupInterspace: CGFloat = GlobalTokens.spacing(.size80)
 
     /// The spacing between each Command Bar Group for iPad.
     static let groupInterspaceWide: CGFloat = GlobalTokens.spacing(.size160)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,598,568 | 29,598,568 | 0 |

Updated the spacing to match the current figma spec file for CCB buttons and groups. There is no delta in binary size due to only changing a single token value, no other code.

### Verification

Built and ran simulator, visually inspected and compare screenshots to ensure updated spacing matches figma.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ccbBeforeSpacing](https://user-images.githubusercontent.com/23249106/206577785-15841930-a51a-4208-9cc2-8679dfa28b9d.png) | ![ccbAfterSpacing](https://user-images.githubusercontent.com/23249106/206577777-899880b8-99bf-4ad0-85bd-94257683f119.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)