### PR TITLE
Restore SegmentedControl init with custom colors

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -98,35 +98,30 @@ class SegmentedControlDemoController: DemoController {
     }
 
     func addPillControl(items: [SegmentItem], style: SegmentedControlStyle, equalSegments: Bool = true, enabled: Bool = true, isFixedWidth: Bool = true, customColors: Bool = false) {
-        let backgroundColor: UIColor?
-        let selectedBackgroundColor: UIColor?
-        let textColor: UIColor?
-        let selectedTextColor: UIColor?
-        let unreadDotColor: DynamicColor?
+        let pillControl: SegmentedControl
         if customColors {
-            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .shade30),
-                                                                 dark: GlobalTokens.sharedColors(.bronze, .tint40)))
-            selectedBackgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .tint40),
-                                                                         dark: GlobalTokens.sharedColors(.steel, .shade30)))
-            textColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .tint40),
-                                                                 dark: GlobalTokens.sharedColors(.bronze, .shade30)))
-            selectedTextColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .shade30),
-                                                                   dark: GlobalTokens.sharedColors(.steel, .tint40)))
-            unreadDotColor = DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint40),
-                                          dark: GlobalTokens.sharedColors(.charcoal, .shade30))
-        } else {
-            backgroundColor = nil
-            selectedBackgroundColor = nil
-            textColor = nil
-            selectedTextColor = nil
-            unreadDotColor = nil
-        }
-        let pillControl = SegmentedControl(items: items,
+            pillControl = SegmentedControl(items: items,
                                            style: style,
-                                           customSegmentedControlBackgroundColor: backgroundColor,
-                                           customSegmentedControlSelectedButtonBackgroundColor: selectedBackgroundColor,
-                                           customSegmentedControlButtonTextColor: textColor,
-                                           customSelectedSegmentedControlButtonTextColor: selectedTextColor)
+                                           customSegmentedControlBackgroundColor:
+                                            UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .shade30),
+                                                                               dark: GlobalTokens.sharedColors(.bronze, .tint40))),
+                                           customSegmentedControlSelectedButtonBackgroundColor:
+                                            UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .tint40),
+                                                                               dark: GlobalTokens.sharedColors(.steel, .shade30))),
+                                           customSegmentedControlButtonTextColor:
+                                            UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .tint40),
+                                                                               dark: GlobalTokens.sharedColors(.bronze, .shade30))),
+                                           customSelectedSegmentedControlButtonTextColor:
+                                            UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .shade30),
+                                                                               dark: GlobalTokens.sharedColors(.steel, .tint40))))
+            pillControl.tokenSet[.enabledUnreadDotColor] = .dynamicColor {
+                DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint40),
+                             dark: GlobalTokens.sharedColors(.charcoal, .shade30))
+            }
+        } else {
+            pillControl = SegmentedControl(items: items,
+                                           style: style)
+        }
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isFixedWidth = isFixedWidth
         pillControl.isEnabled = enabled
@@ -136,9 +131,6 @@ class SegmentedControlDemoController: DemoController {
             }
 
             strongSelf.updateLabel(forControl: pillControl)
-        }
-        if let unreadDotColor = unreadDotColor {
-            pillControl.tokenSet[.enabledUnreadDotColor] = .dynamicColor { unreadDotColor }
         }
 
         let backgroundStyle: ColoredPillBackgroundStyle = {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -198,7 +198,11 @@ extension SegmentedControlDemoController: DemoAppearanceDelegate {
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
         self.segmentedControls.forEach({ segmentedControl in
-            segmentedControl.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideSegmentedControlTokens : nil)
+            if isOverrideEnabled, let newFont = perControlOverrideSegmentedControlTokens[.font] {
+                segmentedControl.tokenSet[.font] = newFont
+            } else {
+                segmentedControl.tokenSet.removeOverride(.font)
+            }
         })
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -102,6 +102,7 @@ class SegmentedControlDemoController: DemoController {
         let selectedBackgroundColor: UIColor?
         let textColor: UIColor?
         let selectedTextColor: UIColor?
+        let unreadDotColor: DynamicColor?
         if customColors {
             backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .shade30),
                                                                  dark: GlobalTokens.sharedColors(.bronze, .tint40)))
@@ -111,11 +112,14 @@ class SegmentedControlDemoController: DemoController {
                                                                  dark: GlobalTokens.sharedColors(.bronze, .shade30)))
             selectedTextColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .shade30),
                                                                    dark: GlobalTokens.sharedColors(.steel, .tint40)))
+            unreadDotColor = DynamicColor(light: GlobalTokens.sharedColors(.charcoal, .tint40),
+                                          dark: GlobalTokens.sharedColors(.charcoal, .shade30))
         } else {
             backgroundColor = nil
             selectedBackgroundColor = nil
             textColor = nil
             selectedTextColor = nil
+            unreadDotColor = nil
         }
         let pillControl = SegmentedControl(items: items,
                                            style: style,
@@ -132,6 +136,9 @@ class SegmentedControlDemoController: DemoController {
             }
 
             strongSelf.updateLabel(forControl: pillControl)
+        }
+        if let unreadDotColor = unreadDotColor {
+            pillControl.tokenSet[.enabledUnreadDotColor] = .dynamicColor { unreadDotColor }
         }
 
         let backgroundStyle: ColoredPillBackgroundStyle = {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -82,14 +82,47 @@ class SegmentedControlDemoController: DemoController {
         addPillControl(items: Array(segmentItems.prefix(2)),
                        style: .onBrandPill,
                        enabled: false)
+        container.addArrangedSubview(UIView())
+
+        addTitle(text: "Custom Colors")
+        addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(4)),
+                       style: .onBrandPill,
+                       equalSegments: false,
+                       isFixedWidth: false,
+                       customColors: true)
     }
 
     @objc func updateLabel(forControl control: SegmentedControl) {
         controlLabels[control]?.text = "\"\(segmentItems[control.selectedSegmentIndex].title)\" segment is selected"
     }
 
-    func addPillControl(items: [SegmentItem], style: SegmentedControlStyle, equalSegments: Bool = true, enabled: Bool = true, isFixedWidth: Bool = true) {
-        let pillControl = SegmentedControl(items: items, style: style)
+    func addPillControl(items: [SegmentItem], style: SegmentedControlStyle, equalSegments: Bool = true, enabled: Bool = true, isFixedWidth: Bool = true, customColors: Bool = false) {
+        let backgroundColor: UIColor?
+        let selectedBackgroundColor: UIColor?
+        let textColor: UIColor?
+        let selectedTextColor: UIColor?
+        if customColors {
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .shade30),
+                                                                 dark: GlobalTokens.sharedColors(.bronze, .tint40)))
+            selectedBackgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .tint40),
+                                                                         dark: GlobalTokens.sharedColors(.steel, .shade30)))
+            textColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.bronze, .tint40),
+                                                                 dark: GlobalTokens.sharedColors(.bronze, .shade30)))
+            selectedTextColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.sharedColors(.steel, .shade30),
+                                                                   dark: GlobalTokens.sharedColors(.steel, .tint40)))
+        } else {
+            backgroundColor = nil
+            selectedBackgroundColor = nil
+            textColor = nil
+            selectedTextColor = nil
+        }
+        let pillControl = SegmentedControl(items: items,
+                                           style: style,
+                                           customSegmentedControlBackgroundColor: backgroundColor,
+                                           customSegmentedControlSelectedButtonBackgroundColor: selectedBackgroundColor,
+                                           customSegmentedControlButtonTextColor: textColor,
+                                           customSelectedSegmentedControlButtonTextColor: selectedTextColor)
         pillControl.shouldSetEqualWidthForSegments = equalSegments
         pillControl.isFixedWidth = isFixedWidth
         pillControl.isEnabled = enabled
@@ -102,10 +135,9 @@ class SegmentedControlDemoController: DemoController {
         }
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
-            switch style {
-            case .primaryPill:
+            if customColors == true || style == .primaryPill {
                 return .neutral
-            case .onBrandPill:
+            } else {
                 return .brand
             }
         }()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -87,7 +87,7 @@ class SegmentedControlDemoController: DemoController {
         addTitle(text: "Custom Colors")
         addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(4)),
-                       style: .onBrandPill,
+                       style: .primaryPill,
                        equalSegments: false,
                        isFixedWidth: false,
                        customColors: true)
@@ -142,9 +142,10 @@ class SegmentedControlDemoController: DemoController {
         }
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
-            if customColors == true || style == .primaryPill {
+            switch style {
+            case .primaryPill:
                 return .neutral
-            } else {
+            case .onBrandPill:
                 return .brand
             }
         }()

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -215,6 +215,26 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                                                name: .didChangeTheme,
                                                object: nil)
 
+        if let customSegmentedControlBackgroundColor = customSegmentedControlBackgroundColor,
+           let restTabColor = customSegmentedControlBackgroundColor.dynamicColor {
+            tokenSet[.restTabColor] = .dynamicColor { restTabColor }
+        }
+
+        if let customSegmentedControlSelectedButtonBackgroundColor = customSegmentedControlSelectedButtonBackgroundColor,
+           let selectedTabColor = customSegmentedControlSelectedButtonBackgroundColor.dynamicColor {
+            tokenSet[.selectedTabColor] = .dynamicColor { selectedTabColor }
+        }
+
+        if let customSegmentedControlButtonTextColor = customSegmentedControlButtonTextColor,
+           let restLabelColor = customSegmentedControlButtonTextColor.dynamicColor {
+            tokenSet[.restLabelColor] = .dynamicColor { restLabelColor }
+        }
+
+        if let customSelectedSegmentedControlButtonTextColor = customSelectedSegmentedControlButtonTextColor,
+           let selectedLabelColor = customSelectedSegmentedControlButtonTextColor.dynamicColor {
+            tokenSet[.selectedLabelColor] = .dynamicColor { selectedLabelColor }
+        }
+
         // Update appearance whenever overrideTokens changes.
         tokenSetSink = tokenSet.sinkChanges { [weak self] in
             self?.updateColors()

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -169,7 +169,29 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     ///
     /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
-    @objc public init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
+    @objc public convenience init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
+        self.init(items: items,
+                          style: style,
+                          customSegmentedControlBackgroundColor: nil,
+                          customSegmentedControlSelectedButtonBackgroundColor: nil,
+                          customSegmentedControlButtonTextColor: nil,
+                          customSelectedSegmentedControlButtonTextColor: nil)
+    }
+
+    /// Initializes a segmented control with the specified titles, style, and colors (colors are for pill styles only).
+    ///
+    /// - Parameter items: An array of Segmented Items representing the segments for this control.
+    /// - Parameter style: A style used for rendering of the control.
+    /// - Parameter customSegmentedControlBackgroundColor: UIColor to use as the background color, will override the .restTabColor token
+    /// - Parameter customSegmentedControlSelectedButtonBackgroundColor: UIColor to use as the selected button background color, will override the .selectedTabColor token
+    /// - Parameter customSegmentedControlButtonTextColor: UIColor to use as the unselected button text color, will override the .restLabelColor token
+    /// - Parameter customSelectedSegmentedControlButtonTextColor: UIColor to use as the selected button text color, will override the .selectedLabelColor token
+    @objc public init(items: [SegmentItem],
+                      style: SegmentedControlStyle = .primaryPill,
+                      customSegmentedControlBackgroundColor: UIColor? = nil,
+                      customSegmentedControlSelectedButtonBackgroundColor: UIColor? = nil,
+                      customSegmentedControlButtonTextColor: UIColor? = nil,
+                      customSelectedSegmentedControlButtonTextColor: UIColor? = nil) {
         self.style = style
 
         super.init(frame: .zero)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,510,136 bytes | 28,560,792 bytes  | 50,656 bytes |
| SegmentedControl.o | 350,208 bytes | 378,456 bytes | 28,248 bytes |

I removed this init in #940 when our guidance was "All color customization must be through tokens always", but we've relaxed on that point. So I'm adding it back (and redirecting the custom colors through tokens) to align a bit more with the SegmentedControl from before it was tokenized.

### Verification

(how the change was tested, including both manual and automated tests)

| Light | Dark | Theme Overrides |
|---|---|---|
| ![SegmentedControl_CustomColors_Light](https://user-images.githubusercontent.com/67026548/206575879-e6bf4856-546b-4992-a8b5-46d6d1b8b70b.png) | ![SegmentedControl_CustomColors_Dark](https://user-images.githubusercontent.com/67026548/206575889-c71db24d-8f66-4e52-935d-e447fa35d111.png) | ![SegmentedControl_CustomColors_Overrides](https://user-images.githubusercontent.com/67026548/206575895-b6a8d864-2a01-4a82-bd41-ce21f540111d.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1449)