### PR TITLE
Move `tokenSet.update(_:)` to `.onChange(of:)`

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
@@ -52,7 +52,9 @@ extension View {
     /// - Returns: The rendered view after applying updates.
     func fluentTokens<TokenSetType: Hashable>(_ tokenSet: ControlTokenSet<TokenSetType>,
                                               _ fluentTheme: FluentTheme) -> some View {
-        tokenSet.update(fluentTheme)
         return self
+            .onChange(of: fluentTheme) { newTheme in
+                tokenSet.update(newTheme)
+            }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This resolves issue #1427 by moving Fluent token set updates away from a mid-render update and into a `.onChange` block for the environment variable. This ensures that the view state cannot be interrupted mid-render, silencing a new warning introduced in Xcode 14.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,689,720 | 28,838,304 | 148,584 |
| FluentUITestApp | 31,734,955 | 31,798,411 | 63,456 |

### Verification

Verified that modified controls update as expected. See `CardNudge` demo below:

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2022-12-09 at 11 30 34](https://user-images.githubusercontent.com/4934719/206782513-0aaa9c2f-221c-406f-97a1-8bc0bfc8eb5c.gif)


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1450)