### PR TITLE
Enabling ObjC support for AliasTokens, plus expanded demo verification

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 /// Callbacks for changes to a `DemoAppearanceView` via the `DemoAppearanceController`. This delegate should
 /// ensure that the appropriate token overrides are set when these callbacks are received.
+@objc(MSFDemoAppearanceDelegate)
 protocol DemoAppearanceDelegate: NSObjectProtocol {
     /// Notifies the delegate that the control's "theme-wide override" value has changed.
     ///
@@ -16,7 +17,7 @@ protocol DemoAppearanceDelegate: NSObjectProtocol {
     /// using the `register(controlType:tokens:)` API.
     ///
     /// - Parameter isOverrideEnabled: Represents the new value for the "theme-wide override" toggle.
-    func themeWideOverrideDidChange(isOverrideEnabled: Bool)
+    @objc func themeWideOverrideDidChange(isOverrideEnabled: Bool)
 
     /// Notifies the delegate that the control's "per-control override" value has changed
     ///
@@ -24,13 +25,29 @@ protocol DemoAppearanceDelegate: NSObjectProtocol {
     /// a custom token set onto each using its `overrideTokens` property.
     ///
     /// - Parameter isOverrideEnabled: Represents the new value for the "theme-wide override" toggle.
-    func perControlOverrideDidChange(isOverrideEnabled: Bool)
+    @objc func perControlOverrideDidChange(isOverrideEnabled: Bool)
 
     /// Returns whether "theme-wide override" tokens are currently registered for the given control.
     ///
     /// This method, when implemented, should query the current `FluentTheme` using its
     /// `tokens(for:)` API, and return whether a token creation function is returned.
-    func isThemeWideOverrideApplied() -> Bool
+    @objc func isThemeWideOverrideApplied() -> Bool
+}
+
+@objc(MSFDemoAppearanceControllerWrapper)
+class DemoAppearanceControllerWrapper: NSObject {
+    /// Convenience wrapper to allow creation of a `DemoAppearanceController` from Objective-C.
+    ///
+    /// The class itself cannot be represented via `@objc` because it inherits from `UIHostingController`, which is a Swift-only class.
+    /// This workaround allows us to create one anyway, though it will be type-erased to `UIViewController` in the process.
+    ///
+    /// - Parameter delegate: An optional `DemoAppearanceDelegate` for the created `DemoAppearanceController`.
+    ///
+    /// - Returns: A new `DemoAppearanceController`, type-erased to `UIViewController`.
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please create a `DemoAppearanceController` instance directly.")
+    @objc static func createDemoAppearanceController(delegate: DemoAppearanceDelegate?) -> UIViewController {
+        return DemoAppearanceController(delegate: delegate)
+    }
 }
 
 /// Wrapper class to allow presenting of `DemoAppearanceView` from a UIKit host.

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -42,6 +42,17 @@
     [self.container addArrangedSubview:testButton];
 }
 
+- (void)viewDidAppear:(BOOL)animated {
+    MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
+    MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
+    MSFDynamicColor *primaryColor = [aliasTokens brandColorFromToken:MSFBrandColorsAliasTokensPrimary];
+
+    UIColorWell *colorWell = [[UIColorWell alloc] init];
+    [colorWell setSelectedColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
+
+    [[self container] addArrangedSubview:colorWell];
+}
+
 - (void)buttonPressed:(id)sender {
     MSFLabel *label = [[MSFLabel alloc] initWithStyle:MSFTextStyleHeadline colorStyle:MSFTextColorStyleRegular];
     [label setTextAlignment:NSTextAlignmentCenter];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -49,7 +49,7 @@
 
     [self setAddedLabels:[NSMutableSet set]];
 
-    self.appearanceController = [MSFDemoAppearanceControllerWrapper createDemoAppearanceControllerWithDelegate:nil];
+    [self setAppearanceController:[MSFDemoAppearanceControllerWrapper createDemoAppearanceControllerWithDelegate:nil]];
     [self configureAppearancePopover];
 
     [[NSNotificationCenter defaultCenter] addObserver:self

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -85,7 +85,7 @@
     // Add alias-colored label too
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
     MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens brandColorFromToken:MSFBrandColorsAliasTokensPrimary];
+    MSFDynamicColor *primaryColor = [aliasTokens brandColorForToken:MSFBrandColorsAliasTokensPrimary];
     [self addLabelWithText:@"Test label with alias color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -5,12 +5,18 @@
 
 #import "ObjectiveCDemoController.h"
 #import <FluentUI/FluentUI-Swift.h>
+#import <FluentUI_Demo-Swift.h>
 
-@interface ObjectiveCDemoController () <MSFTwoLineTitleViewDelegate>
+@interface ObjectiveCDemoController () <MSFTwoLineTitleViewDelegate,
+                                        UIPopoverPresentationControllerDelegate>
 
 @property (nonatomic) MSFTwoLineTitleView *titleView;
 @property (nonatomic) UIStackView *container;
 @property (nonatomic) UIScrollView *scrollingContainer;
+
+@property (nonatomic) UIViewController *appearanceController; // Type-erased to UIViewController because UIHostingController subclasses can't be represented directly in @objc
+
+@property (nonatomic) NSMutableSet<UILabel *> *addedLabels;
 
 @end
 
@@ -40,29 +46,48 @@
 
     MSFButton *testButton = [self createButtonWithTitle:@"Test" action:@selector(buttonPressed:)];
     [self.container addArrangedSubview:testButton];
+
+    [self setAddedLabels:[NSMutableSet set]];
+
+    self.appearanceController = [MSFDemoAppearanceControllerWrapper createDemoAppearanceControllerWithDelegate:nil];
+    [self configureAppearancePopover];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector: @selector(themeDidChange:)
+                                                 name: @"FluentUI.stylesheet.theme"
+                                               object: nil];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
-    MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens brandColorFromToken:MSFBrandColorsAliasTokensPrimary];
+- (void)resetAddedLabels {
+    for (UILabel *label in [self addedLabels]) {
+        [label removeFromSuperview];
+    }
+    [[self addedLabels] removeAllObjects];
+}
 
-    UIColorWell *colorWell = [[UIColorWell alloc] init];
-    [colorWell setSelectedColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
+- (void)addLabelWithText:(NSString *)text
+               textColor:(UIColor *)textColor {
+    MSFLabel *label = [[MSFLabel alloc] initWithStyle:MSFTextStyleHeadline colorStyle:MSFTextColorStyleRegular];
+    [label setTextAlignment:NSTextAlignmentCenter];
+    [label setText:text];
+    [label setTextColor:textColor];
 
-    [[self container] addArrangedSubview:colorWell];
+    [[self container] addArrangedSubview:label];
+    [[self addedLabels] addObject:label];
 }
 
 - (void)buttonPressed:(id)sender {
-    MSFLabel *label = [[MSFLabel alloc] initWithStyle:MSFTextStyleHeadline colorStyle:MSFTextColorStyleRegular];
-    [label setTextAlignment:NSTextAlignmentCenter];
-    [label setText:@"Test label with color"];
-
     MSFColorValue *colorValue = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsPink
                                                                   token:MSFSharedColorsTokensPrimary];
-    [label setTextColor:[[UIColor alloc] initWithColorValue:colorValue]];
+    [self addLabelWithText:@"Test label with global color"
+                 textColor:[[UIColor alloc] initWithColorValue:colorValue]];
 
-    [[self container] addArrangedSubview:label];
+    // Add alias-colored label too
+    MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
+    MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
+    MSFDynamicColor *primaryColor = [aliasTokens brandColorFromToken:MSFBrandColorsAliasTokensPrimary];
+    [self addLabelWithText:@"Test label with alias color"
+                 textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }
 
 - (UIStackView *)createVerticalContainer {
@@ -96,12 +121,42 @@
     [self.container addArrangedSubview:titleLabel];
 }
 
+#pragma mark Demo Appearance Controller
+
+- (void)configureAppearancePopover {
+    // Display the DemoAppearancePopover button
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"ic_fluent_settings_24_regular"]
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:self
+                                                            action:@selector(showAppearancePopover:)];
+    [[self navigationItem] setRightBarButtonItem:item];
+}
+
+- (void)showAppearancePopover:(UIBarButtonItem *)sender {
+    [[[self appearanceController] popoverPresentationController] setBarButtonItem:sender];
+    [[[self appearanceController] popoverPresentationController] setDelegate:self];
+    [self presentViewController:[self appearanceController]
+                       animated:YES
+                     completion:nil];
+}
+
+- (void)themeDidChange:(NSNotification *)n {
+    [self resetAddedLabels];
+}
+
 #pragma mark MSFTwoLineTitleViewDelegate
 
 - (void)twoLineTitleViewDidTapOnTitle:(MSFTwoLineTitleView *)twoLineTitleView {
     UIAlertController* alert = [UIAlertController alertControllerWithTitle:nil message:@"The title button was pressed" preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
     [self presentViewController:alert animated:true completion:nil];
+}
+
+#pragma mark UIPopoverPresentationControllerDelegate
+
+/// Overridden to allow for popover-style modal presentation on compact (e.g. iPhone) devices.
+- (UIModalPresentationStyle)adaptivePresentationStyleForPresentationController:(UIPresentationController *)controller {
+    return UIModalPresentationNone;
 }
 
 @end

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -6,7 +6,8 @@
 import SwiftUI
 
 /// Base class that allows for customization of global, alias, and control tokens.
-@objc public class FluentTheme: NSObject, ObservableObject {
+@objc(MSFFluentTheme)
+public class FluentTheme: NSObject, ObservableObject {
     /// Initializes and returns a new `FluentTheme`.
     ///
     /// Once created, a `FluentTheme` can have its `AliasTokens` customized by setting custom values on the
@@ -35,7 +36,7 @@ import SwiftUI
     }
 
     /// The associated `AliasTokens` for this theme.
-    public let aliasTokens: AliasTokens = .init()
+    @objc public let aliasTokens: AliasTokens = .init()
 
     static var shared: FluentTheme = .init()
 
@@ -64,7 +65,7 @@ public extension Notification.Name {
     }
 
     /// The custom `FluentTheme` to apply to this view.
-    public var fluentTheme: FluentTheme {
+    @objc public var fluentTheme: FluentTheme {
         get {
             var optionalView: UIView? = self
             while let view = optionalView {

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -23,7 +23,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `brandColors` property directly.")
-    @objc(brandColorFromToken:)
+    @objc(brandColorForToken:)
     public func brandColor(_ token: BrandColorsTokens) -> DynamicColor {
         return brandColors[token]
     }
@@ -51,7 +51,7 @@ public final class AliasTokens: NSObject {
 
     // MARK: ForegroundColors
 
-    @objc(MSFForegroundColorsTokens)
+    @objc(MSFForegroundColorsAliasTokens)
     public enum ForegroundColorsTokens: Int, TokenSetKey {
         case neutral1
         case neutral2
@@ -67,7 +67,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `foregroundColors` property directly.")
-    @objc(foregroundColorFromToken:)
+    @objc(foregroundColorForToken:)
     public func foregroundColor(_ token: ForegroundColorsTokens) -> DynamicColor {
         return foregroundColors[token]
     }
@@ -124,7 +124,7 @@ public final class AliasTokens: NSObject {
 
     // MARK: BackgroundColors
 
-    @objc(MSFBackgroundColorsTokens)
+    @objc(MSFBackgroundColorsAliasTokens)
     public enum BackgroundColorsTokens: Int, TokenSetKey {
         case neutral1
         case neutral2
@@ -141,7 +141,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `backgroundColors` property directly.")
-    @objc(backgroundColorFromToken:)
+    @objc(backgroundColorForToken:)
     public func backgroundColor(_ token: BackgroundColorsTokens) -> DynamicColor {
         return backgroundColors[token]
     }
@@ -192,14 +192,14 @@ public final class AliasTokens: NSObject {
 
     // MARK: StrokeColors
 
-    @objc(MSFStrokeColorsTokens)
+    @objc(MSFStrokeColorsAliasTokens)
     public enum StrokeColorsTokens: Int, TokenSetKey {
         case neutral1
         case neutral2
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `strokeColors` property directly.")
-    @objc(strokeColorFromToken:)
+    @objc(strokeColorForToken:)
     public func strokeColor(_ token: StrokeColorsTokens) -> DynamicColor {
         return strokeColors[token]
     }
@@ -224,7 +224,7 @@ public final class AliasTokens: NSObject {
 
     // MARK: - ShadowColors
 
-    @objc(MSFShadowColorsTokens)
+    @objc(MSFShadowColorsAliasTokens)
     public enum ShadowColorsTokens: Int, TokenSetKey {
         case neutralAmbient
         case neutralKey
@@ -237,7 +237,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `shadowColors` property directly.")
-    @objc(shadowColorFromToken:)
+    @objc(shadowColorForToken:)
     public func shadowColor(_ token: ShadowColorsTokens) -> DynamicColor {
         return shadowColors[token]
     }
@@ -274,7 +274,7 @@ public final class AliasTokens: NSObject {
 
     // MARK: - Typography
 
-    @objc(MSFTypographyTokens)
+    @objc(MSFTypographyAliasTokens)
     public enum TypographyTokens: Int, TokenSetKey {
         case display
         case largeTitle
@@ -291,7 +291,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `typography` property directly.")
-    @objc(typographyFromToken:)
+    @objc(typographyForToken:)
     public func typography(_ token: TypographyTokens) -> FontInfo {
         return typography[token]
     }
@@ -340,7 +340,7 @@ public final class AliasTokens: NSObject {
 
     // MARK: - Shadow
 
-    @objc(MSFShadowTokens)
+    @objc(MSFShadowAliasTokens)
     public enum ShadowTokens: Int, TokenSetKey {
         case clear
         case shadow02
@@ -352,7 +352,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `shadow` property directly.")
-    @objc(shadowFromToken:)
+    @objc(shadowForToken:)
     public func shadow(_ token: ShadowTokens) -> ShadowInfo {
         return shadow[token]
     }
@@ -428,7 +428,7 @@ public final class AliasTokens: NSObject {
 
     // MARK: Elevation
 
-    @objc(MSFElevationTokens)
+    @objc(MSFElevationAliasTokens)
     public enum ElevationTokens: Int, TokenSetKey {
         case interactiveElevation1Rest
         case interactiveElevation1Hover
@@ -438,7 +438,7 @@ public final class AliasTokens: NSObject {
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `elevation` property directly.")
-    @objc(elevationFromToken:)
+    @objc(elevationForToken:)
     public func elevation(_ token: ElevationTokens) -> ShadowInfo {
         return elevation[token]
     }

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -22,8 +22,9 @@ public final class AliasTokens: NSObject {
         case tint40
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `brandColors` property directly.")
-    @objc public func brandColorFrom(token: BrandColorsTokens) -> DynamicColor {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `brandColors` property directly.")
+    @objc(brandColorFromToken:)
+    public func brandColor(_ token: BrandColorsTokens) -> DynamicColor {
         return brandColors[token]
     }
 
@@ -65,8 +66,9 @@ public final class AliasTokens: NSObject {
         case brandDisabled
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `foregroundColors` property directly.")
-    @objc public func foregroundColorsFrom(token: ForegroundColorsTokens) -> DynamicColor {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `foregroundColors` property directly.")
+    @objc(foregroundColorFromToken:)
+    public func foregroundColor(_ token: ForegroundColorsTokens) -> DynamicColor {
         return foregroundColors[token]
     }
 
@@ -138,8 +140,9 @@ public final class AliasTokens: NSObject {
         case surfaceQuaternary
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `backgroundColors` property directly.")
-    @objc public func backgroundColorsFrom(token: BackgroundColorsTokens) -> DynamicColor {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `backgroundColors` property directly.")
+    @objc(backgroundColorFromToken:)
+    public func backgroundColor(_ token: BackgroundColorsTokens) -> DynamicColor {
         return backgroundColors[token]
     }
 
@@ -195,8 +198,9 @@ public final class AliasTokens: NSObject {
         case neutral2
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `strokeColors` property directly.")
-    @objc public func strokeColorsFrom(token: StrokeColorsTokens) -> DynamicColor {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `strokeColors` property directly.")
+    @objc(strokeColorFromToken:)
+    public func strokeColor(_ token: StrokeColorsTokens) -> DynamicColor {
         return strokeColors[token]
     }
 
@@ -232,8 +236,9 @@ public final class AliasTokens: NSObject {
         case brandKey
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `shadowColors` property directly.")
-    @objc public func shadowColorsFrom(token: ShadowColorsTokens) -> DynamicColor {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `shadowColors` property directly.")
+    @objc(shadowColorFromToken:)
+    public func shadowColor(_ token: ShadowColorsTokens) -> DynamicColor {
         return shadowColors[token]
     }
 
@@ -285,8 +290,9 @@ public final class AliasTokens: NSObject {
         case caption2
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `typography` property directly.")
-    @objc public func typographyFrom(token: TypographyTokens) -> FontInfo {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `typography` property directly.")
+    @objc(typographyFromToken:)
+    public func typography(_ token: TypographyTokens) -> FontInfo {
         return typography[token]
     }
 
@@ -345,8 +351,9 @@ public final class AliasTokens: NSObject {
         case shadow64
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `shadow` property directly.")
-    @objc public func shadowFrom(token: ShadowTokens) -> ShadowInfo {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `shadow` property directly.")
+    @objc(shadowFromToken:)
+    public func shadow(_ token: ShadowTokens) -> ShadowInfo {
         return shadow[token]
     }
 
@@ -430,8 +437,9 @@ public final class AliasTokens: NSObject {
         case interactiveElevation1Disabled
     }
 
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `elevation` property directly.")
-    @objc public func elevationFrom(token: ElevationTokens) -> ShadowInfo {
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `elevation` property directly.")
+    @objc(elevationFromToken:)
+    public func elevation(_ token: ElevationTokens) -> ShadowInfo {
         return elevation[token]
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -5,11 +5,13 @@
 
 import SwiftUI
 
-public final class AliasTokens {
+@objc(MSFAliasTokens)
+public final class AliasTokens: NSObject {
 
     // MARK: - BrandColors
 
-    public enum BrandColorsTokens: TokenSetKey {
+    @objc(MSFBrandColorsAliasTokens)
+    public enum BrandColorsTokens: Int, TokenSetKey {
         case primary
         case shade10
         case shade20
@@ -19,6 +21,12 @@ public final class AliasTokens {
         case tint30
         case tint40
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `brandColors` property directly.")
+    @objc public func brandColorFrom(token: BrandColorsTokens) -> DynamicColor {
+        return brandColors[token]
+    }
+
     public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
         switch token {
         case .primary:
@@ -42,7 +50,8 @@ public final class AliasTokens {
 
     // MARK: ForegroundColors
 
-    public enum ForegroundColorsTokens: TokenSetKey {
+    @objc(MSFForegroundColorsTokens)
+    public enum ForegroundColorsTokens: Int, TokenSetKey {
         case neutral1
         case neutral2
         case neutral3
@@ -55,6 +64,12 @@ public final class AliasTokens {
         case brandSelected
         case brandDisabled
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `foregroundColors` property directly.")
+    @objc public func foregroundColorsFrom(token: ForegroundColorsTokens) -> DynamicColor {
+        return foregroundColors[token]
+    }
+
     public lazy var foregroundColors: TokenSet<ForegroundColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -107,7 +122,8 @@ public final class AliasTokens {
 
     // MARK: BackgroundColors
 
-    public enum BackgroundColorsTokens: TokenSetKey {
+    @objc(MSFBackgroundColorsTokens)
+    public enum BackgroundColorsTokens: Int, TokenSetKey {
         case neutral1
         case neutral2
         case neutral3
@@ -121,6 +137,12 @@ public final class AliasTokens {
         case brandDisabled
         case surfaceQuaternary
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `backgroundColors` property directly.")
+    @objc public func backgroundColorsFrom(token: BackgroundColorsTokens) -> DynamicColor {
+        return backgroundColors[token]
+    }
+
     public lazy var backgroundColors: TokenSet<BackgroundColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -167,10 +189,17 @@ public final class AliasTokens {
 
     // MARK: StrokeColors
 
-    public enum StrokeColorsTokens: TokenSetKey {
+    @objc(MSFStrokeColorsTokens)
+    public enum StrokeColorsTokens: Int, TokenSetKey {
         case neutral1
         case neutral2
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `strokeColors` property directly.")
+    @objc public func strokeColorsFrom(token: StrokeColorsTokens) -> DynamicColor {
+        return strokeColors[token]
+    }
+
     public lazy var strokeColors: TokenSet<StrokeColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -191,7 +220,8 @@ public final class AliasTokens {
 
     // MARK: - ShadowColors
 
-    public enum ShadowColorsTokens: TokenSetKey {
+    @objc(MSFShadowColorsTokens)
+    public enum ShadowColorsTokens: Int, TokenSetKey {
         case neutralAmbient
         case neutralKey
         case neutralAmbientLighter
@@ -201,6 +231,12 @@ public final class AliasTokens {
         case brandAmbient
         case brandKey
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `shadowColors` property directly.")
+    @objc public func shadowColorsFrom(token: ShadowColorsTokens) -> DynamicColor {
+        return shadowColors[token]
+    }
+
     lazy public var shadowColors: TokenSet<ShadowColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -233,7 +269,8 @@ public final class AliasTokens {
 
     // MARK: - Typography
 
-    public enum TypographyTokens: TokenSetKey {
+    @objc(MSFTypographyTokens)
+    public enum TypographyTokens: Int, TokenSetKey {
         case display
         case largeTitle
         case title1
@@ -247,6 +284,12 @@ public final class AliasTokens {
         case caption1
         case caption2
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `typography` property directly.")
+    @objc public func typographyFrom(token: TypographyTokens) -> FontInfo {
+        return typography[token]
+    }
+
     lazy public var typography: TokenSet<TypographyTokens, FontInfo> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -291,7 +334,8 @@ public final class AliasTokens {
 
     // MARK: - Shadow
 
-    public enum ShadowTokens: TokenSetKey {
+    @objc(MSFShadowTokens)
+    public enum ShadowTokens: Int, TokenSetKey {
         case clear
         case shadow02
         case shadow04
@@ -300,6 +344,12 @@ public final class AliasTokens {
         case shadow28
         case shadow64
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `shadow` property directly.")
+    @objc public func shadowFrom(token: ShadowTokens) -> ShadowInfo {
+        return shadow[token]
+    }
+
     lazy public var shadow: TokenSet<ShadowTokens, ShadowInfo> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -371,13 +421,20 @@ public final class AliasTokens {
 
     // MARK: Elevation
 
-    public enum ElevationTokens: TokenSetKey {
+    @objc(MSFElevationTokens)
+    public enum ElevationTokens: Int, TokenSetKey {
         case interactiveElevation1Rest
         case interactiveElevation1Hover
         case interactiveElevation1Pressed
         case interactiveElevation1Selected
         case interactiveElevation1Disabled
     }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and is not meant to be invoked from Swift. Please use the `elevation` property directly.")
+    @objc public func elevationFrom(token: ElevationTokens) -> ShadowInfo {
+        return elevation[token]
+    }
+
     lazy public var elevation: TokenSet<ElevationTokens, ShadowInfo> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
@@ -396,5 +453,5 @@ public final class AliasTokens {
 
     // MARK: Initialization
 
-    init() {}
+    override init() {}
 }

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -86,28 +86,28 @@ public class DynamicColor: NSObject {
     }
 
     /// The default color for a light context. Required.
-    var light: ColorValue
+    let light: ColorValue
 
     /// The override color for a light, high contrast context. Optional.
-    var lightHighContrast: ColorValue?
+    let lightHighContrast: ColorValue?
 
     /// The override color for a light, elevated context. Optional.
-    var lightElevated: ColorValue?
+    let lightElevated: ColorValue?
 
     /// The override color for a light, elevated, high contrast context. Optional.
-    var lightElevatedHighContrast: ColorValue?
+    let lightElevatedHighContrast: ColorValue?
 
     /// The override color for a dark context. Optional.
-    var dark: ColorValue?
+    let dark: ColorValue?
 
     /// The override color for a dark, high contrast context. Optional.
-    var darkHighContrast: ColorValue?
+    let darkHighContrast: ColorValue?
 
     /// The override color for a dark, elevated context. Optional.
-    var darkElevated: ColorValue?
+    let darkElevated: ColorValue?
 
     /// The override color for a dark, elevated, high contrast context. Optional.
-    var darkElevatedHighContrast: ColorValue?
+    let darkElevatedHighContrast: ColorValue?
 
     // MARK: - Internal functions
 

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -54,7 +54,8 @@ public class ColorValue: NSObject {
 }
 
 /// Represents a set of color values to be used in different contexts.
-public struct DynamicColor: Equatable {
+@objc(MSFDynamicColor)
+public class DynamicColor: NSObject {
 
     /// Creates a dynamic color object that wraps a set of color values for various rendering contexts.
     ///
@@ -66,14 +67,14 @@ public struct DynamicColor: Equatable {
     /// - Parameter darkHighContrast: The override color for a dark, high contrast context. Optional.
     /// - Parameter darkElevated: The override color for a dark, elevated context. Optional.
     /// - Parameter darkElevatedHighContrast: The override color for a dark, elevated, high contrast context. Optional.
-    public init(light: ColorValue,
-                lightHighContrast: ColorValue? = nil,
-                lightElevated: ColorValue? = nil,
-                lightElevatedHighContrast: ColorValue? = nil,
-                dark: ColorValue? = nil,
-                darkHighContrast: ColorValue? = nil,
-                darkElevated: ColorValue? = nil,
-                darkElevatedHighContrast: ColorValue? = nil) {
+    @objc public init(light: ColorValue,
+                      lightHighContrast: ColorValue? = nil,
+                      lightElevated: ColorValue? = nil,
+                      lightElevatedHighContrast: ColorValue? = nil,
+                      dark: ColorValue? = nil,
+                      darkHighContrast: ColorValue? = nil,
+                      darkElevated: ColorValue? = nil,
+                      darkElevatedHighContrast: ColorValue? = nil) {
         self.light = light
         self.lightHighContrast = lightHighContrast
         self.lightElevated = lightElevated

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -6,7 +6,8 @@
 import SwiftUI
 
 /// Represents the description of a font used by FluentUI components.
-public struct FontInfo: Equatable {
+@objc(MSFFontInfo)
+public class FontInfo: NSObject {
 
     /// Creates a `FontInfo` instance using the specified information.
     ///
@@ -74,7 +75,7 @@ public extension Font {
 }
 
 extension UIFont {
-    public static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
+    @objc public static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
         let unscaledFont: UIFont
 
         if let name = fontInfo.name,

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -3,10 +3,11 @@
 //  Licensed under the MIT License.
 //
 
-import CoreGraphics
+import Foundation
 
 /// Represents a two-part shadow as used by FluentUI.
-public struct ShadowInfo: Equatable {
+@objc(MSFShadowInfo)
+public class ShadowInfo: NSObject {
     /// Initializes a shadow struct to be used in Fluent.
     ///
     /// - Parameters:
@@ -37,26 +38,26 @@ public struct ShadowInfo: Equatable {
     }
 
     /// The color of the shadow for shadow 1.
-    public let colorOne: DynamicColor
+    @objc public let colorOne: DynamicColor
 
     /// The blur of the shadow for shadow 1.
-    public let blurOne: CGFloat
+    @objc public let blurOne: CGFloat
 
     /// The horizontal offset of the shadow for shadow 1.
-    public let xOne: CGFloat
+    @objc public let xOne: CGFloat
 
     /// The vertical offset of the shadow for shadow 1.
-    public let yOne: CGFloat
+    @objc public let yOne: CGFloat
 
     /// The color of the shadow for shadow 2.
-    public let colorTwo: DynamicColor
+    @objc public let colorTwo: DynamicColor
 
     /// The blur of the shadow for shadow 2.
-    public let blurTwo: CGFloat
+    @objc public let blurTwo: CGFloat
 
     /// The horizontal offset of the shadow for shadow 2.
-    public let xTwo: CGFloat
+    @objc public let xTwo: CGFloat
 
     /// The vertical offset of the shadow for shadow 2.
-    public let yTwo: CGFloat
+    @objc public let yTwo: CGFloat
 }

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -102,7 +102,7 @@ extension UIColor {
     /// rendering context.
     ///
     /// - Parameter dynamicColor: The set of color values that may be applied based on the current context.
-    public convenience init(dynamicColor: DynamicColor) {
+    @objc public convenience init(dynamicColor: DynamicColor) {
         self.init { traits -> UIColor in
             let colorValue = dynamicColor.value(colorScheme: (traits.userInterfaceStyle == .dark ? .dark : .light),
                                             contrast: traits.accessibilityContrast == .high ? .increased : .standard,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Exposed read-only access of `AliasTokens` to Objective-C clients.

Each `AliasTokens` property now has an equivalent Objective-C getter method. These methods are marked `obsoleted` for Swift clients, who should continue using the properties directly.

```swift
@available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `brandColors` property directly.")
@objc(brandColorFromToken:)
public func brandColor(_ token: BrandColorsTokens) -> DynamicColor {
    return brandColors[token]
}
```

This also required converting a number of Swift structs (`DynamicColors`, `ShadowInfo`, and `FontInfo`) to NSObject subclasses in order to be accessible from Objective-C. This change resulted in a pretty substantial binary size reduction, which is pretty cool!

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta
| -- | -- | -- | -- |
| libFluentUI.a | 28,689,720 | 28,414,304 | -275,416 |
| FluentUITestApp | 31,734,955 | 31,691,301 | --43,654 |

### Verification

Expanded `ObjectiveCDemoController` to expose this code and test theme swapping.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-12 at 15 02 27](https://user-images.githubusercontent.com/4934719/207176135-0a72a2b2-70fd-4851-8695-ebd2b0ea6add.png) | ![Simulator Screen Recording - iPhone 14 Pro - 2022-12-12 at 15 01 37](https://user-images.githubusercontent.com/4934719/207175406-b937aa1b-2e5c-4c7f-9e38-962c5be464a6.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1452)