### PR TITLE
[fluent2-tokens] Merging main -> fluent2-tokens

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenizedControlView.swift
@@ -52,7 +52,9 @@ extension View {
     /// - Returns: The rendered view after applying updates.
     func fluentTokens<TokenSetType: Hashable>(_ tokenSet: ControlTokenSet<TokenSetType>,
                                               _ fluentTheme: FluentTheme) -> some View {
-        tokenSet.update(fluentTheme)
         return self
+            .onChange(of: fluentTheme) { newTheme in
+                tokenSet.update(newTheme)
+            }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Merging changes from main -> fluent2-tokens branch. Small merge, with only one commit (#1450)

### Verification

Test app still runs. No visual changes.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1454)