### PR TITLE
[Draft] Add functionality to enable the usage of group style avatars in PersonaButtonCarousel

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaButtonCarouselDemoController.swift
@@ -33,11 +33,14 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
         var actionButtons: Bool = false
         var size: MSFPersonaButtonSize = .large
         var carousel: Bool = false
+        var isGroupStyle: Bool = false
     }
     let tableInfo: [TableSectionInfo] = [
         TableSectionInfo(actionButtons: true),
         TableSectionInfo(size: .large, carousel: true),
         TableSectionInfo(size: .small, carousel: true),
+        TableSectionInfo(size: .large, carousel: true, isGroupStyle: true),
+        TableSectionInfo(size: .small, carousel: true, isGroupStyle: true),
         TableSectionInfo(size: .large, carousel: false),
         TableSectionInfo(size: .small, carousel: false)
     ]
@@ -116,15 +119,20 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     }
 
     @objc private func handleAppendPersona() {
-        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        for carousel in carousels {
+            let personas = getResolvedPersonas(isGroupStyle: carousel.state.isGroupStyle)
             let random = Int.random(in: 0...personas.count - 1)
             let persona = personas[random]
             add(persona, to: carousel)
         }
     }
 
+    private func getResolvedPersonas(isGroupStyle: Bool) -> [PersonaData] {
+        return isGroupStyle ? groupPersonas : defaultPersonas
+    }
+
     @objc private func handleRemovePersona() {
-        carousels.forEach { (_: MSFPersonaButtonSize, carousel: MSFPersonaButtonCarousel) in
+        for carousel in carousels {
             let state = carousel.state
             let count = state.count
             if count > 0 {
@@ -166,11 +174,14 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
             cell = tableView.dequeueReusableCell(withIdentifier: PersonaButtonCarouselDemoController.smallCarouselReuseIdentifier, for: indexPath)
         }
 
-        let carousel = MSFPersonaButtonCarousel(size: size)
+        let isGroupStyle = tableInfo[indexPath.section].isGroupStyle
+        let carousel = MSFPersonaButtonCarousel(size: size, isGroupStyle: isGroupStyle)
+        let personas = getResolvedPersonas(isGroupStyle: isGroupStyle)
+
         personas.forEach { persona in
             add(persona, to: carousel)
         }
-        carousels[size] = carousel
+        carousels.append(carousel)
         carousel.state.onTapAction = { [weak self] (personaButtonState: MSFPersonaCarouselButtonState, index: Int) in
             self?.didTap(on: personaButtonState, at: index)
         }
@@ -206,7 +217,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
         // Create the PersonaButton to be displayed
         let personaButton = MSFPersonaButton(size: size)
         let personaButtonState = personaButton.state
-        let persona = personas[indexPath.item]
+        let persona = defaultPersonas[indexPath.item]
         personaButtonState.image = persona.image
         personaButtonState.primaryText = persona.name
         personaButtonState.secondaryText = persona.email
@@ -233,7 +244,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
         return cell
     }
 
-    private var carousels: [MSFPersonaButtonSize: MSFPersonaButtonCarousel] = [:]
+    private var carousels: [MSFPersonaButtonCarousel] = []
 
     private static let controlReuseIdentifier: String = "controlReuseIdentifier"
     private static let largeCarouselReuseIdentifier: String = "largeCarouselReuseIdentifier"
@@ -241,7 +252,7 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
     private static let largeButtonReuseIdentifier: String = "largeButtonReuseIdentifier"
     private static let smallButtonReuseIdentifier: String = "smallButtonReuseIdentifier"
 
-    private let personas: [PersonaData] = [
+    private let defaultPersonas: [PersonaData] = [
         PersonaData(firstName: "Kat", lastName: "Larsson", image: UIImage(named: "avatar_kat_larsson")),
         PersonaData(firstName: "Ashley", lastName: "McCarthy", image: UIImage(named: "avatar_ashley_mccarthy")),
         PersonaData(firstName: "Allan", lastName: "Munger", image: UIImage(named: "avatar_allan_munger")),
@@ -266,6 +277,18 @@ class PersonaButtonCarouselDemoController: DemoTableViewController {
         PersonaData(name: "Colin Ballinger", email: "colin.ballinger@contoso.com", image: UIImage(named: "avatar_colin_ballinger")),
         PersonaData(email: "wanda.howard@contoso.com"),
         PersonaData(email: "carlos.slattery@contoso.com", subtitle: "Software Engineer")
+    ]
+
+    private let groupPersonas: [PersonaData] = [
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365"),
+        PersonaData(name: "M365")
     ]
 
 }

--- a/ios/FluentUI/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButton.swift
@@ -140,7 +140,7 @@ class MSFPersonaButtonStateImpl: ControlState, MSFPersonaButtonState {
     /// Creates and initializes a `MSFPersonaButtonStateImpl`
     /// - Parameters:
     ///   - size: The size of the persona button
-    init(size: MSFPersonaButtonSize, isGroupStyle: Bool) {
+    init(size: MSFPersonaButtonSize, isGroupStyle: Bool = false) {
         self.buttonSize = size
         self.avatarState = MSFAvatarStateImpl(style: isGroupStyle ? .group : .default,
                                               size: size.avatarSize)

--- a/ios/FluentUI/PersonaButton/PersonaButton.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButton.swift
@@ -61,8 +61,8 @@ public struct PersonaButton: View, TokenizedControlView {
     /// Creates a new `PersonaButton` instance.
     /// - Parameters:
     ///   - size: The` MSFPersonaButtonSize` value used by the `PersonaButton`.
-    public init(size: MSFPersonaButtonSize) {
-        let state = MSFPersonaButtonStateImpl(size: size)
+    public init(size: MSFPersonaButtonSize, isGroupStyle: Bool = false) {
+        let state = MSFPersonaButtonStateImpl(size: size, isGroupStyle: isGroupStyle)
         self.state = state
         self.tokenSet = PersonaButtonTokenSet(size: { state.buttonSize })
     }
@@ -140,9 +140,10 @@ class MSFPersonaButtonStateImpl: ControlState, MSFPersonaButtonState {
     /// Creates and initializes a `MSFPersonaButtonStateImpl`
     /// - Parameters:
     ///   - size: The size of the persona button
-    init(size: MSFPersonaButtonSize) {
+    init(size: MSFPersonaButtonSize, isGroupStyle: Bool) {
         self.buttonSize = size
-        self.avatarState = MSFAvatarStateImpl(style: .default, size: size.avatarSize)
+        self.avatarState = MSFAvatarStateImpl(style: isGroupStyle ? .group : .default,
+                                              size: size.avatarSize)
 
         super.init()
     }

--- a/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -12,7 +12,7 @@ import UIKit
     /// Creates a new MSFPersonaButtonCarousel instance.
     /// - Parameters:
     ///   - size: The MSFPersonaButtonSize value used by the PersonaButtonCarousel.
-    @objc public init(size: MSFPersonaButtonSize = .large, isGroupStyle: Bool) {
+    @objc public init(size: MSFPersonaButtonSize = .large, isGroupStyle: Bool = false) {
         let personaButtonCarousel = PersonaButtonCarousel(size: size, isGroupStyle: isGroupStyle)
         state = personaButtonCarousel.state
         super.init(AnyView(personaButtonCarousel))

--- a/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/MSFPersonaButtonCarousel.swift
@@ -12,8 +12,8 @@ import UIKit
     /// Creates a new MSFPersonaButtonCarousel instance.
     /// - Parameters:
     ///   - size: The MSFPersonaButtonSize value used by the PersonaButtonCarousel.
-    @objc public init(size: MSFPersonaButtonSize = .large) {
-        let personaButtonCarousel = PersonaButtonCarousel(size: size)
+    @objc public init(size: MSFPersonaButtonSize = .large, isGroupStyle: Bool) {
+        let personaButtonCarousel = PersonaButtonCarousel(size: size, isGroupStyle: isGroupStyle)
         state = personaButtonCarousel.state
         super.init(AnyView(personaButtonCarousel))
     }

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -91,7 +91,7 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
     /// Creates a new `PersonaButtonCarousel` instance.
     /// - Parameters:
     ///   - size: The MSFPersonaButtonSize value used by the `PersonaButtonCarousel`.
-    public init(size: MSFPersonaButtonSize, isGroupStyle: Bool) {
+    public init(size: MSFPersonaButtonSize, isGroupStyle: Bool = false) {
         let state = MSFPersonaButtonCarouselStateImpl(size: size, isGroupStyle: isGroupStyle)
         self.state = state
         self.tokenSet = PersonaButtonCarouselTokenSet()
@@ -127,7 +127,7 @@ class MSFPersonaButtonCarouselStateImpl: ControlState, MSFPersonaButtonCarouselS
     @Published var onTapAction: ((_ personaButtonState: MSFPersonaCarouselButtonState, _ index: Int) -> Void)?
     @Published var buttons: [MSFPersonaCarouselButtonStateImpl] = []
 
-    init(size: MSFPersonaButtonSize, isGroupStyle: Bool) {
+    init(size: MSFPersonaButtonSize, isGroupStyle: Bool = false) {
         self.isGroupStyle = isGroupStyle
         self.buttonSize = size
 

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -10,6 +10,9 @@ import SwiftUI
     /// Determines whether the carousel will display small or large avatars.
     var buttonSize: MSFPersonaButtonSize { get }
 
+    /// Determines whether the carousel has group style avatars or regular avatars
+    var isGroupStyle: Bool { get set }
+
     /// Handles the event of tapping one of the `PersonaButton` items in a `PersonaButtonCarousel`.
     var onTapAction: ((_ personaButtonState: MSFPersonaCarouselButtonState, _ index: Int) -> Void)? { get set }
 
@@ -88,8 +91,8 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
     /// Creates a new `PersonaButtonCarousel` instance.
     /// - Parameters:
     ///   - size: The MSFPersonaButtonSize value used by the `PersonaButtonCarousel`.
-    public init(size: MSFPersonaButtonSize) {
-        let state = MSFPersonaButtonCarouselStateImpl(size: size)
+    public init(size: MSFPersonaButtonSize, isGroupStyle: Bool) {
+        let state = MSFPersonaButtonCarouselStateImpl(size: size, isGroupStyle: isGroupStyle)
         self.state = state
         self.tokenSet = PersonaButtonCarouselTokenSet()
     }
@@ -118,12 +121,14 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
 
 /// Properties that make up PersonaButtonCarousel content
 class MSFPersonaButtonCarouselStateImpl: ControlState, MSFPersonaButtonCarouselState {
+    var isGroupStyle: Bool
     let buttonSize: MSFPersonaButtonSize
 
     @Published var onTapAction: ((_ personaButtonState: MSFPersonaCarouselButtonState, _ index: Int) -> Void)?
     @Published var buttons: [MSFPersonaCarouselButtonStateImpl] = []
 
-    init(size: MSFPersonaButtonSize) {
+    init(size: MSFPersonaButtonSize, isGroupStyle: Bool) {
+        self.isGroupStyle = isGroupStyle
         self.buttonSize = size
 
         super.init()
@@ -136,7 +141,7 @@ class MSFPersonaButtonCarouselStateImpl: ControlState, MSFPersonaButtonCarouselS
     }
 
     @discardableResult func add(primaryText: String?, secondaryText: String?, image: UIImage?) -> MSFPersonaCarouselButtonState {
-        let persona = MSFPersonaCarouselButtonStateImpl(size: self.buttonSize)
+        let persona = MSFPersonaCarouselButtonStateImpl(size: self.buttonSize, isGroupStyle: isGroupStyle)
 
         // Set passed-in properties
         persona.primaryText = primaryText


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a partner request to enable the usage of group style avatars in `PersonaButtonCarousel`. I added a boolean variable `isGroupStyle` in the `MSFPersonaButtonCarouselState` protocol. As the name suggests, this boolean is used to determine whether the carousel contains regular avatars or group avatars. 
I confirmed with design that there are no changes to the paddings (or any other values) for the group style carousel. 

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,864,736 bytes | 28,880,512 bytes | 15,776 bytes |

### Verification

The changes were tested on the demo app.

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="Screenshot 2022-12-15 at 6 27 28 PM" src="https://user-images.githubusercontent.com/106181067/207991136-a2b1fb6c-c71f-48cd-abec-8777593f5582.png"> | <img width="487" alt="Screenshot 2022-12-15 at 6 27 33 PM" src="https://user-images.githubusercontent.com/106181067/207991149-4cc7d3c1-3758-41d3-a267-700503e15000.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1456)