### PR TITLE
[XCUITests] Initial tests for Activity Indicator

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		114CF8B82423E10900D064AA /* ColorDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114CF8B72423E10900D064AA /* ColorDemoController.swift */; };
 		2F0A96FC25CA047100EF9736 /* SearchBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */; };
+		3AF555E1294CF4DD009211F4 /* ActivityIndicatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF555E0294CF4DD009211F4 /* ActivityIndicatorTest.swift */; };
+		3AF555E3294CF4DD009211F4 /* ActivityIndicatorTest_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF555E2294CF4DD009211F4 /* ActivityIndicatorTest_SwiftUI.swift */; };
 		43488C4A270FB7E800124C71 /* NotificationViewDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43488C49270FB7E800124C71 /* NotificationViewDemoController_SwiftUI.swift */; };
 		497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */; };
 		5303259326B3198A00611D05 /* AvatarDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5303259226B3198A00611D05 /* AvatarDemoController_SwiftUI.swift */; };
@@ -78,12 +80,25 @@
 		FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		3AF555E4294CF4DD009211F4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A5CEC20420E436F10016922A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A5CEC20B20E436F10016922A;
+			remoteInfo = FluentUI.Demo;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		0A0516BF2940A407006DE0A2 /* DividerDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		0A0516C02940A407006DE0A2 /* DividerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController.swift; sourceTree = "<group>"; };
 		11047D2522932DB1001F0F59 /* TabBarViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewDemoController.swift; sourceTree = "<group>"; };
 		114CF8B72423E10900D064AA /* ColorDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDemoController.swift; sourceTree = "<group>"; };
 		2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBarDemoController.swift; sourceTree = "<group>"; };
+		3AF555DE294CF4DD009211F4 /* FluentUIDemoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FluentUIDemoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AF555E0294CF4DD009211F4 /* ActivityIndicatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorTest.swift; sourceTree = "<group>"; };
+		3AF555E2294CF4DD009211F4 /* ActivityIndicatorTest_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorTest_SwiftUI.swift; sourceTree = "<group>"; };
 		43488C49270FB7E800124C71 /* NotificationViewDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationViewDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		497DC2DD24185896008D86F8 /* PillButtonBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBarDemoController.swift; sourceTree = "<group>"; };
 		5303259226B3198A00611D05 /* AvatarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
@@ -193,6 +208,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3AF555DB294CF4DD009211F4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A5CEC20920E436F10016922A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -207,6 +229,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3AF555DF294CF4DD009211F4 /* FluentUIDemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				3AF555E0294CF4DD009211F4 /* ActivityIndicatorTest.swift */,
+				3AF555E2294CF4DD009211F4 /* ActivityIndicatorTest_SwiftUI.swift */,
+			);
+			path = FluentUIDemoTests;
+			sourceTree = "<group>";
+		};
 		5303259626B31A6300611D05 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
@@ -268,6 +299,7 @@
 			isa = PBXGroup;
 			children = (
 				A5CEC20E20E436F10016922A /* FluentUI.Demo */,
+				3AF555DF294CF4DD009211F4 /* FluentUIDemoTests */,
 				A5CEC20D20E436F10016922A /* Products */,
 				A5CEC22920E44FBF0016922A /* Frameworks */,
 				5340828A26CFF298007716E1 /* Recovered References */,
@@ -278,6 +310,7 @@
 			isa = PBXGroup;
 			children = (
 				A5CEC20C20E436F10016922A /* FluentUI.Demo.app */,
+				3AF555DE294CF4DD009211F4 /* FluentUIDemoTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -379,6 +412,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3AF555DD294CF4DD009211F4 /* FluentUIDemoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AF555E9294CF4DD009211F4 /* Build configuration list for PBXNativeTarget "FluentUIDemoTests" */;
+			buildPhases = (
+				3AF555DA294CF4DD009211F4 /* Sources */,
+				3AF555DB294CF4DD009211F4 /* Frameworks */,
+				3AF555DC294CF4DD009211F4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3AF555E5294CF4DD009211F4 /* PBXTargetDependency */,
+			);
+			name = FluentUIDemoTests;
+			productName = FluentUIDemoTests;
+			productReference = 3AF555DE294CF4DD009211F4 /* FluentUIDemoTests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		A5CEC20B20E436F10016922A /* FluentUI.Demo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A5CEC22020E436F20016922A /* Build configuration list for PBXNativeTarget "FluentUI.Demo" */;
@@ -407,10 +458,14 @@
 		A5CEC20420E436F10016922A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0940;
+				LastSwiftUpdateCheck = 1410;
 				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = "Microsoft Corporation";
 				TargetAttributes = {
+					3AF555DD294CF4DD009211F4 = {
+						CreatedOnToolsVersion = 14.1;
+						TestTargetID = A5CEC20B20E436F10016922A;
+					};
 					A5CEC20B20E436F10016922A = {
 						CreatedOnToolsVersion = 9.4.1;
 						LastSwiftMigration = 1020;
@@ -474,11 +529,19 @@
 			projectRoot = "";
 			targets = (
 				A5CEC20B20E436F10016922A /* FluentUI.Demo */,
+				3AF555DD294CF4DD009211F4 /* FluentUIDemoTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3AF555DC294CF4DD009211F4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A5CEC20A20E436F10016922A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -492,6 +555,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3AF555DA294CF4DD009211F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3AF555E1294CF4DD009211F4 /* ActivityIndicatorTest.swift in Sources */,
+				3AF555E3294CF4DD009211F4 /* ActivityIndicatorTest_SwiftUI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A5CEC20820E436F10016922A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -563,6 +635,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		3AF555E5294CF4DD009211F4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A5CEC20B20E436F10016922A /* FluentUI.Demo */;
+			targetProxy = 3AF555E4294CF4DD009211F4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		A5CEC21A20E436F20016922A /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -611,6 +691,70 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		3AF555E6294CF4DD009211F4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.FluentUIDemoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "63d62159-2691-4b44-9553-b668cc1746c1";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = FluentUI.Demo;
+			};
+			name = Debug;
+		};
+		3AF555E7294CF4DD009211F4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.FluentUIDemoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "63d62159-2691-4b44-9553-b668cc1746c1";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = FluentUI.Demo;
+			};
+			name = Release;
+		};
+		3AF555E8294CF4DD009211F4 /* Dogfood */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UBF8T346G9;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.FluentUIDemoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "63d62159-2691-4b44-9553-b668cc1746c1";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = FluentUI.Demo;
+			};
+			name = Dogfood;
+		};
 		A52B636D21376228009F7ADF /* Dogfood */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -883,6 +1027,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3AF555E9294CF4DD009211F4 /* Build configuration list for PBXNativeTarget "FluentUIDemoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AF555E6294CF4DD009211F4 /* Debug */,
+				3AF555E7294CF4DD009211F4 /* Release */,
+				3AF555E8294CF4DD009211F4 /* Dogfood */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A5CEC20720E436F10016922A /* Build configuration list for PBXProject "FluentUI.Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Development.xcscheme
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Development.xcscheme
@@ -74,6 +74,17 @@
                ReferencedContainer = "container:../FluentUI.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AF555DD294CF4DD009211F4"
+               BuildableName = "FluentUIDemoTests.xctest"
+               BlueprintName = "FluentUIDemoTests"
+               ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Dogfood.xcscheme
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Dogfood.xcscheme
@@ -51,6 +51,17 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AF555DD294CF4DD009211F4"
+               BuildableName = "FluentUIDemoTests.xctest"
+               BlueprintName = "FluentUIDemoTests"
+               ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
@@ -74,6 +74,17 @@
                ReferencedContainer = "container:../FluentUI.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AF555DD294CF4DD009211F4"
+               BuildableName = "FluentUIDemoTests.xctest"
+               BlueprintName = "FluentUIDemoTests"
+               ReferencedContainer = "container:FluentUI.Demo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -13,11 +13,16 @@ class ActivityIndicatorTest: XCTestCase {
         continueAfterFailure = false
         app.launch()
 
-        if app.staticTexts["FluentUI DEV"].exists {
-            app.staticTexts["ActivityIndicator"].tap()
-        } else if !app.staticTexts["ActivityIndicator"].exists {
-            app.buttons["FluentUI DEV"].tap()
-            app.staticTexts["ActivityIndicator"].tap()
+        let onHomePage = app.staticTexts["FluentUI DEV"].exists
+        let onDifferentControlPage = !onHomePage && !app.staticTexts["ActivityIndicator"].exists
+        let activityIndicatorCell = app.staticTexts["ActivityIndicator"]
+        let backButton = app.buttons["FluentUI DEV"]
+
+        if onHomePage {
+            activityIndicatorCell.tap()
+        } else if onDifferentControlPage {
+            backButton.tap()
+            activityIndicatorCell.tap()
         }
     }
 
@@ -38,14 +43,16 @@ class ActivityIndicatorTest: XCTestCase {
     }
 
     func testStartStopHide() throws {
+        let startStopButton = app.buttons["Start / Stop activity"]
+
         XCTAssert(app.images["In progress"].exists)
-        app.buttons["Start / Stop activity"].tap()
+        startStopButton.tap()
         XCTAssert(!app.images["In progress"].exists)
 
         app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch.tap()
         XCTAssert(app.images["Progress halted"].exists)
 
-        app.buttons["Start / Stop activity"].tap()
+        startStopButton.tap()
         XCTAssert(app.images["In progress"].exists)
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -10,42 +10,42 @@ class ActivityIndicatorTest: XCTestCase {
     let app = XCUIApplication()
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
         app.launch()
-        
+
         if app.staticTexts["FluentUI DEV"].exists {
             app.staticTexts["ActivityIndicator"].tap()
-        }
-        else if !app.staticTexts["ActivityIndicator"].exists {
+        } else if !app.staticTexts["ActivityIndicator"].exists {
             app.buttons["FluentUI DEV"].tap()
             app.staticTexts["ActivityIndicator"].tap()
         }
     }
 
     func testSizes() throws {
-        XCTAssertEqual(app.images.element(boundBy: 0).identifier, "Activity Indicator that is In progress of size xLarge")
-        XCTAssertEqual(app.images.element(boundBy: 1).identifier, "Activity Indicator that is In progress of size large")
-        XCTAssertEqual(app.images.element(boundBy: 2).identifier, "Activity Indicator that is In progress of size medium")
-        XCTAssertEqual(app.images.element(boundBy: 3).identifier, "Activity Indicator that is In progress of size small")
-        XCTAssertEqual(app.images.element(boundBy: 4).identifier, "Activity Indicator that is In progress of size xSmall")
+        XCTAssertEqual(app.images.element(boundBy: 0).identifier, "Activity Indicator that is In progress of size 4")
+        XCTAssertEqual(app.images.element(boundBy: 1).identifier, "Activity Indicator that is In progress of size 3")
+        XCTAssertEqual(app.images.element(boundBy: 2).identifier, "Activity Indicator that is In progress of size 2")
+        XCTAssertEqual(app.images.element(boundBy: 3).identifier, "Activity Indicator that is In progress of size 1")
+        XCTAssertEqual(app.images.element(boundBy: 4).identifier, "Activity Indicator that is In progress of size 0")
     }
-    
+
     func testColor() throws {
-        XCTAssertEqual(app.images.element(boundBy: 5).identifier, "Activity Indicator that is In progress of size xLarge and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 6).identifier, "Activity Indicator that is In progress of size large and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 7).identifier, "Activity Indicator that is In progress of size medium and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 8).identifier, "Activity Indicator that is In progress of size small and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 9).identifier, "Activity Indicator that is In progress of size xSmall and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 5).identifier, "Activity Indicator that is In progress of size 4 and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 6).identifier, "Activity Indicator that is In progress of size 3 and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 7).identifier, "Activity Indicator that is In progress of size 2 and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 8).identifier, "Activity Indicator that is In progress of size 1 and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 9).identifier, "Activity Indicator that is In progress of size 0 and color cyan blue")
     }
-    
+
     func testStartStopHide() throws {
         XCTAssert(app.images["In progress"].exists)
         app.buttons["Start / Stop activity"].tap()
         XCTAssert(!app.images["In progress"].exists)
-        
+
         app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch.tap()
         XCTAssert(app.images["Progress halted"].exists)
-        
+
         app.buttons["Start / Stop activity"].tap()
         XCTAssert(app.images["In progress"].exists)
     }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -4,7 +4,6 @@
 //
 
 import XCTest
-import FluentUI
 
 class ActivityIndicatorTest: XCTestCase {
     let app = XCUIApplication()

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -27,19 +27,21 @@ class ActivityIndicatorTest: XCTestCase {
     }
 
     func testSizes() throws {
-        XCTAssertEqual(app.images.element(boundBy: 0).identifier, "Activity Indicator that is In progress of size 4")
-        XCTAssertEqual(app.images.element(boundBy: 1).identifier, "Activity Indicator that is In progress of size 3")
-        XCTAssertEqual(app.images.element(boundBy: 2).identifier, "Activity Indicator that is In progress of size 2")
-        XCTAssertEqual(app.images.element(boundBy: 3).identifier, "Activity Indicator that is In progress of size 1")
-        XCTAssertEqual(app.images.element(boundBy: 4).identifier, "Activity Indicator that is In progress of size 0")
+        XCTAssertEqual(app.images.element(boundBy: 0).identifier, "Activity Indicator that is in progress of size 4")
+        XCTAssertEqual(app.images.element(boundBy: 1).identifier, "Activity Indicator that is in progress of size 3")
+        XCTAssertEqual(app.images.element(boundBy: 2).identifier, "Activity Indicator that is in progress of size 2")
+        XCTAssertEqual(app.images.element(boundBy: 3).identifier, "Activity Indicator that is in progress of size 1")
+        XCTAssertEqual(app.images.element(boundBy: 4).identifier, "Activity Indicator that is in progress of size 0")
     }
 
     func testColor() throws {
-        XCTAssertEqual(app.images.element(boundBy: 5).identifier, "Activity Indicator that is In progress of size 4 and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 6).identifier, "Activity Indicator that is In progress of size 3 and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 7).identifier, "Activity Indicator that is In progress of size 2 and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 8).identifier, "Activity Indicator that is In progress of size 1 and color cyan blue")
-        XCTAssertEqual(app.images.element(boundBy: 9).identifier, "Activity Indicator that is In progress of size 0 and color cyan blue")
+        let cyanBlueRGBAValues = "[0.0, 0.47058823529411764, 0.8313725490196079, 1.0]"
+
+        XCTAssertEqual(app.images.element(boundBy: 5).identifier, "Activity Indicator that is in progress of size 4 and rgba values \(cyanBlueRGBAValues)")
+        XCTAssertEqual(app.images.element(boundBy: 6).identifier, "Activity Indicator that is in progress of size 3 and rgba values \(cyanBlueRGBAValues)")
+        XCTAssertEqual(app.images.element(boundBy: 7).identifier, "Activity Indicator that is in progress of size 2 and rgba values \(cyanBlueRGBAValues)")
+        XCTAssertEqual(app.images.element(boundBy: 8).identifier, "Activity Indicator that is in progress of size 1 and rgba values \(cyanBlueRGBAValues)")
+        XCTAssertEqual(app.images.element(boundBy: 9).identifier, "Activity Indicator that is in progress of size 0 and rgba values \(cyanBlueRGBAValues)")
     }
 
     func testStartStopHide() throws {

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+import FluentUI
+
+class ActivityIndicatorTest: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+        
+        if app.staticTexts["FluentUI DEV"].exists {
+            app.staticTexts["ActivityIndicator"].tap()
+        }
+        else if !app.staticTexts["ActivityIndicator"].exists {
+            app.buttons["FluentUI DEV"].tap()
+            app.staticTexts["ActivityIndicator"].tap()
+        }
+    }
+
+    func testSizes() throws {
+        XCTAssertEqual(app.images.element(boundBy: 0).identifier, "Activity Indicator that is In progress of size xLarge")
+        XCTAssertEqual(app.images.element(boundBy: 1).identifier, "Activity Indicator that is In progress of size large")
+        XCTAssertEqual(app.images.element(boundBy: 2).identifier, "Activity Indicator that is In progress of size medium")
+        XCTAssertEqual(app.images.element(boundBy: 3).identifier, "Activity Indicator that is In progress of size small")
+        XCTAssertEqual(app.images.element(boundBy: 4).identifier, "Activity Indicator that is In progress of size xSmall")
+    }
+    
+    func testColor() throws {
+        XCTAssertEqual(app.images.element(boundBy: 5).identifier, "Activity Indicator that is In progress of size xLarge and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 6).identifier, "Activity Indicator that is In progress of size large and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 7).identifier, "Activity Indicator that is In progress of size medium and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 8).identifier, "Activity Indicator that is In progress of size small and color cyan blue")
+        XCTAssertEqual(app.images.element(boundBy: 9).identifier, "Activity Indicator that is In progress of size xSmall and color cyan blue")
+    }
+    
+    func testStartStopHide() throws {
+        XCTAssert(app.images["In progress"].exists)
+        app.buttons["Start / Stop activity"].tap()
+        XCTAssert(!app.images["In progress"].exists)
+        
+        app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch.tap()
+        XCTAssert(app.images["Progress halted"].exists)
+        
+        app.buttons["Start / Stop activity"].tap()
+        XCTAssert(app.images["In progress"].exists)
+    }
+}

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
@@ -10,68 +10,68 @@ class ActivityIndicatorSwiftUITest: XCTestCase {
     let app = XCUIApplication()
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
         app.launch()
-        
+
         if app.staticTexts["FluentUI DEV"].exists {
             app.staticTexts["ActivityIndicator"].tap()
-        }
-        else if !app.staticTexts["ActivityIndicator"].exists {
+        } else if !app.staticTexts["ActivityIndicator"].exists {
             app.buttons["FluentUI DEV"].tap()
             app.staticTexts["ActivityIndicator"].tap()
         }
         app.staticTexts["SwiftUI Demo"].tap()
     }
-    
+
     func testHidingWhenStoppedOn() throws {
-        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
         app.switches["Animating"].tap()
-        XCTAssert(!app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        XCTAssert(!app.images["Activity Indicator that is In progress of size 4"].exists)
     }
-    
+
     func testHidingWhenStoppedOff() throws {
         app.switches["Hides when stopped"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
         app.switches["Animating"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size xLarge"].exists)
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size 4"].exists)
     }
-    
+
     func testCustomColor() throws {
-        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
         app.switches["Uses custom color"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge and color cyan blue"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 4 and color cyan blue"].exists)
     }
 
     func testSizeChanges() throws {
-        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
         app.buttons[".xLarge"].tap()
         app.buttons[".large"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size large"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 3"].exists)
         app.buttons[".large"].tap()
         app.buttons[".medium"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size medium"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 2"].exists)
         app.buttons[".medium"].tap()
         app.buttons[".small"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size small"].exists)
+        XCTAssert(app.images["Activity Indicator that is In progress of size 1"].exists)
         app.buttons[".small"].tap()
         app.buttons[".xSmall"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size xSmall"].exists)
-        
+        XCTAssert(app.images["Activity Indicator that is In progress of size 0"].exists)
+
         app.switches["Hides when stopped"].tap()
         app.switches["Animating"].tap()
-        
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size xSmall"].exists)
+
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size 0"].exists)
         app.buttons[".xSmall"].tap()
         app.buttons[".small"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size small"].exists)
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size 1"].exists)
         app.buttons[".small"].tap()
         app.buttons[".medium"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size medium"].exists)
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size 2"].exists)
         app.buttons[".medium"].tap()
         app.buttons[".large"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size large"].exists)
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size 3"].exists)
         app.buttons[".large"].tap()
         app.buttons[".xLarge"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size xLarge"].exists)
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size 4"].exists)
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+@testable import FluentUI
+
+class ActivityIndicatorSwiftUITest: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app.launch()
+        
+        if app.staticTexts["FluentUI DEV"].exists {
+            app.staticTexts["ActivityIndicator"].tap()
+        }
+        else if !app.staticTexts["ActivityIndicator"].exists {
+            app.buttons["FluentUI DEV"].tap()
+            app.staticTexts["ActivityIndicator"].tap()
+        }
+        app.staticTexts["SwiftUI Demo"].tap()
+    }
+    
+    func testHidingWhenStoppedOn() throws {
+        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        app.switches["Animating"].tap()
+        XCTAssert(!app.images["Activity Indicator that is In progress of size xLarge"].exists)
+    }
+    
+    func testHidingWhenStoppedOff() throws {
+        app.switches["Hides when stopped"].tap()
+        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        app.switches["Animating"].tap()
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size xLarge"].exists)
+    }
+    
+    func testCustomColor() throws {
+        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        app.switches["Uses custom color"].tap()
+        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge and color cyan blue"].exists)
+    }
+
+    func testSizeChanges() throws {
+        XCTAssert(app.images["Activity Indicator that is In progress of size xLarge"].exists)
+        app.buttons[".xLarge"].tap()
+        app.buttons[".large"].tap()
+        XCTAssert(app.images["Activity Indicator that is In progress of size large"].exists)
+        app.buttons[".large"].tap()
+        app.buttons[".medium"].tap()
+        XCTAssert(app.images["Activity Indicator that is In progress of size medium"].exists)
+        app.buttons[".medium"].tap()
+        app.buttons[".small"].tap()
+        XCTAssert(app.images["Activity Indicator that is In progress of size small"].exists)
+        app.buttons[".small"].tap()
+        app.buttons[".xSmall"].tap()
+        XCTAssert(app.images["Activity Indicator that is In progress of size xSmall"].exists)
+        
+        app.switches["Hides when stopped"].tap()
+        app.switches["Animating"].tap()
+        
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size xSmall"].exists)
+        app.buttons[".xSmall"].tap()
+        app.buttons[".small"].tap()
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size small"].exists)
+        app.buttons[".small"].tap()
+        app.buttons[".medium"].tap()
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size medium"].exists)
+        app.buttons[".medium"].tap()
+        app.buttons[".large"].tap()
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size large"].exists)
+        app.buttons[".large"].tap()
+        app.buttons[".xLarge"].tap()
+        XCTAssert(app.images["Activity Indicator that is Progress halted of size xLarge"].exists)
+    }
+}

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
@@ -29,54 +29,54 @@ class ActivityIndicatorSwiftUITest: XCTestCase {
     }
 
     func testHidingWhenStoppedOn() throws {
-        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 4"].exists)
         app.switches["Animating"].tap()
-        XCTAssert(!app.images["Activity Indicator that is In progress of size 4"].exists)
+        XCTAssert(!app.images["Activity Indicator that is in progress of size 4"].exists)
     }
 
     func testHidingWhenStoppedOff() throws {
         app.switches["Hides when stopped"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 4"].exists)
         app.switches["Animating"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size 4"].exists)
+        XCTAssert(app.images["Activity Indicator that is progress halted of size 4"].exists)
     }
 
     func testCustomColor() throws {
-        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 4"].exists)
         app.switches["Uses custom color"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size 4 and color cyan blue"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 4 and rgba values [0.0, 0.47058823529411764, 0.8313725490196079, 1.0]"].exists)
     }
 
     func testSizeChanges() throws {
-        XCTAssert(app.images["Activity Indicator that is In progress of size 4"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 4"].exists)
         app.buttons[".xLarge"].tap()
         app.buttons[".large"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size 3"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 3"].exists)
         app.buttons[".large"].tap()
         app.buttons[".medium"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size 2"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 2"].exists)
         app.buttons[".medium"].tap()
         app.buttons[".small"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size 1"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 1"].exists)
         app.buttons[".small"].tap()
         app.buttons[".xSmall"].tap()
-        XCTAssert(app.images["Activity Indicator that is In progress of size 0"].exists)
+        XCTAssert(app.images["Activity Indicator that is in progress of size 0"].exists)
 
         app.switches["Hides when stopped"].tap()
         app.switches["Animating"].tap()
 
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size 0"].exists)
+        XCTAssert(app.images["Activity Indicator that is progress halted of size 0"].exists)
         app.buttons[".xSmall"].tap()
         app.buttons[".small"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size 1"].exists)
+        XCTAssert(app.images["Activity Indicator that is progress halted of size 1"].exists)
         app.buttons[".small"].tap()
         app.buttons[".medium"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size 2"].exists)
+        XCTAssert(app.images["Activity Indicator that is progress halted of size 2"].exists)
         app.buttons[".medium"].tap()
         app.buttons[".large"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size 3"].exists)
+        XCTAssert(app.images["Activity Indicator that is progress halted of size 3"].exists)
         app.buttons[".large"].tap()
         app.buttons[".xLarge"].tap()
-        XCTAssert(app.images["Activity Indicator that is Progress halted of size 4"].exists)
+        XCTAssert(app.images["Activity Indicator that is progress halted of size 4"].exists)
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
@@ -4,7 +4,6 @@
 //
 
 import XCTest
-@testable import FluentUI
 
 class ActivityIndicatorSwiftUITest: XCTestCase {
     let app = XCUIApplication()

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest_SwiftUI.swift
@@ -13,13 +13,19 @@ class ActivityIndicatorSwiftUITest: XCTestCase {
         continueAfterFailure = false
         app.launch()
 
-        if app.staticTexts["FluentUI DEV"].exists {
-            app.staticTexts["ActivityIndicator"].tap()
-        } else if !app.staticTexts["ActivityIndicator"].exists {
-            app.buttons["FluentUI DEV"].tap()
-            app.staticTexts["ActivityIndicator"].tap()
+        let onHomePage = app.staticTexts["FluentUI DEV"].exists
+        let onDifferentControlPage = !onHomePage && !app.staticTexts["ActivityIndicator"].exists
+        let activityIndicatorCell = app.staticTexts["ActivityIndicator"]
+        let backButton = app.buttons["FluentUI DEV"]
+        let swiftUIDemoButton = app.staticTexts["SwiftUI Demo"]
+
+        if onHomePage {
+            activityIndicatorCell.tap()
+        } else if onDifferentControlPage {
+            backButton.tap()
+            activityIndicatorCell.tap()
         }
-        app.staticTexts["SwiftUI Demo"].tap()
+        swiftUIDemoButton.tap()
     }
 
     func testHidingWhenStoppedOn() throws {

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
@@ -60,10 +60,10 @@ public struct ActivityIndicator: View, TokenizedControlView {
         }()
         let accessibilityIdentifier: String = {
             if let color = state.color {
-                return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.description) and color \(color.accessibilityName)"
+                return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.rawValue) and color \(color.accessibilityName)"
             }
 
-            return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.description)"
+            return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.rawValue)"
         }()
 
         SemiRing(color: color,

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
@@ -58,10 +58,18 @@ public struct ActivityIndicator: View, TokenizedControlView {
                 :
                 "Accessibility.ActivityIndicator.Stopped.label".localized
         }()
+        let accessibilityIdentifier: String = {
+            if let color = state.color {
+                return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.description) and color \(color.accessibilityName)"
+            }
+
+            return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.description)"
+        }()
 
         SemiRing(color: color,
                  thickness: tokenSet[.thickness].float,
-                 accessibilityLabel: accessibilityLabel)
+                 accessibilityLabel: accessibilityLabel,
+                 accessibilityIdentifier: accessibilityIdentifier)
             .modifyIf(state.isAnimating, { animatedView in
                 animatedView
                     .rotationEffect(.degrees(rotationAngle), anchor: .center)
@@ -92,6 +100,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
         var color: Color
         var thickness: CGFloat
         var accessibilityLabel: String
+        var accessibilityIdentifier: String
 
         public var body: some View {
             Circle()
@@ -103,6 +112,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
                 .accessibilityElement(children: .ignore)
                 .accessibility(addTraits: .isImage)
                 .accessibility(label: Text(accessibilityLabel))
+                .accessibility(identifier: accessibilityIdentifier)
         }
 
         private let semiRingStartFraction: CGFloat = 0.0

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
@@ -59,11 +59,13 @@ public struct ActivityIndicator: View, TokenizedControlView {
                 "Accessibility.ActivityIndicator.Stopped.label".localized
         }()
         let accessibilityIdentifier: String = {
-            if let color = state.color {
-                return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.rawValue) and color \(color.accessibilityName)"
+            let status = state.isAnimating ? "in progress" : "progress halted"
+
+            if let rgba = state.color?.cgColor.components {
+                return "Activity Indicator that is \(status) of size \(state.size.rawValue) and rgba values \(rgba)"
             }
 
-            return "Activity Indicator that is \(accessibilityLabel) of size \(state.size.rawValue)"
+            return "Activity Indicator that is \(status) of size \(state.size.rawValue)"
         }()
 
         SemiRing(color: color,

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokenSet.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokenSet.swift
@@ -15,6 +15,23 @@ import UIKit
     case xLarge
 }
 
+extension MSFActivityIndicatorSize : CustomStringConvertible {
+     public var description: String {
+         switch self {
+         case .xSmall:
+             return "xSmall"
+         case .small:
+             return "small"
+         case .medium:
+             return "medium"
+         case .large:
+             return "large"
+         case .xLarge:
+             return "xLarge"
+         }
+     }
+ }
+
 /// Design token set for the `ActivityIndicator` control.
 public class ActivityIndicatorTokenSet: ControlTokenSet<ActivityIndicatorTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {

--- a/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokenSet.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicatorTokenSet.swift
@@ -15,23 +15,6 @@ import UIKit
     case xLarge
 }
 
-extension MSFActivityIndicatorSize : CustomStringConvertible {
-     public var description: String {
-         switch self {
-         case .xSmall:
-             return "xSmall"
-         case .small:
-             return "small"
-         case .medium:
-             return "medium"
-         case .large:
-             return "large"
-         case .xLarge:
-             return "xLarge"
-         }
-     }
- }
-
 /// Design token set for the `ActivityIndicator` control.
 public class ActivityIndicatorTokenSet: ControlTokenSet<ActivityIndicatorTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 54,943,520 bytes | 54,965,576 bytes | 22,056 bytes |

Added initial tests for activity indicator. These include tests for size, color, and starting/stopping activity (both when hidden when stopped is turned on and off).

### Verification

| UIKit                                       | SwiftUI                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Recording - Clone 2 of iPhone 14 Pro - 2022-12-16 at 11 36 21](https://user-images.githubusercontent.com/55368679/208176016-9948f768-3145-4151-bdc7-c92c5ac67d43.gif) | ![Simulator Screen Recording - Clone 2 of iPhone 14 Pro - 2022-12-16 at 11 39 11](https://user-images.githubusercontent.com/55368679/208175948-32e0b8c8-59e8-4d71-98b9-b6be62cbd32a.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1458)