### PR TITLE
[Fluent2 iOS] Cherry-Pick Separator

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -49,8 +49,8 @@ Pod::Spec.new do |s|
   s.subspec 'BottomCommanding_ios' do |bottomcommanding_ios|
     bottomcommanding_ios.platform = :ios
     bottomcommanding_ios.dependency 'MicrosoftFluentUI/BottomSheet_ios'
-    bottomcommanding_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     bottomcommanding_ios.dependency 'MicrosoftFluentUI/OtherCells_ios'
+    bottomcommanding_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     bottomcommanding_ios.dependency 'MicrosoftFluentUI/TabBar_ios'
     bottomcommanding_ios.dependency 'MicrosoftFluentUI/TableView_ios'
     bottomcommanding_ios.preserve_paths = ["ios/FluentUI/Bottom Commanding/BottomCommanding.resources.xcfilelist"]
@@ -73,11 +73,11 @@ Pod::Spec.new do |s|
   s.subspec 'Calendar_ios' do |calendar_ios|
     calendar_ios.platform = :ios
     calendar_ios.dependency 'MicrosoftFluentUI/BarButtonItems_ios'
-    calendar_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     calendar_ios.dependency 'MicrosoftFluentUI/DotView_ios'
     calendar_ios.dependency 'MicrosoftFluentUI/Label_ios'
     calendar_ios.dependency 'MicrosoftFluentUI/Presenters_ios'
     calendar_ios.dependency 'MicrosoftFluentUI/SegmentedControl_ios'
+    calendar_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     calendar_ios.dependency 'MicrosoftFluentUI/TwoLineTitleView_ios'
     calendar_ios.source_files = ["ios/FluentUI/Calendar/**/*.{swift,h}",
                                  "ios/FluentUI/Date Time Pickers/**/*.{swift,h}"]
@@ -149,9 +149,9 @@ fi', :execution_position => :before_compile }
 
   s.subspec 'Drawer_ios' do |drawer_ios|
     drawer_ios.platform = :ios
-    drawer_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     drawer_ios.dependency 'MicrosoftFluentUI/Obscurable_ios'
     drawer_ios.dependency 'MicrosoftFluentUI/ResizingHandleView_ios'
+    drawer_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     drawer_ios.dependency 'MicrosoftFluentUI/TouchForwardingView_ios'
     drawer_ios.source_files = ["ios/FluentUI/Drawer/**/*.{swift,h}"]
   end
@@ -187,7 +187,7 @@ fi', :execution_position => :before_compile }
     navigation_ios.platform = :ios
     navigation_ios.dependency 'MicrosoftFluentUI/ActivityIndicator_ios'
     navigation_ios.dependency 'MicrosoftFluentUI/Avatar_ios'
-    navigation_ios.dependency 'MicrosoftFluentUI/Divider_ios'
+    navigation_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     navigation_ios.dependency 'MicrosoftFluentUI/TwoLineTitleView_ios'
     navigation_ios.preserve_paths = ["ios/FluentUI/Navigation/Navigation.resources.xcfilelist"]
     navigation_ios.source_files = ["ios/FluentUI/Navigation/**/*.{swift,h}"]
@@ -195,7 +195,6 @@ fi', :execution_position => :before_compile }
 
   s.subspec 'Notification_ios' do |notification_ios|
     notification_ios.platform = :ios
-    notification_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     notification_ios.dependency 'MicrosoftFluentUI/Obscurable_ios'
     notification_ios.dependency 'MicrosoftFluentUI/Label_ios'
     notification_ios.preserve_paths = ["ios/FluentUI/Notification/Notification.resources.xcfilelist"]
@@ -220,7 +219,7 @@ fi', :execution_position => :before_compile }
     peoplepicker_ios.platform = :ios
     peoplepicker_ios.dependency 'MicrosoftFluentUI/Avatar_ios'
     peoplepicker_ios.dependency 'MicrosoftFluentUI/BadgeField_ios'
-    peoplepicker_ios.dependency 'MicrosoftFluentUI/Divider_ios'
+    peoplepicker_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     peoplepicker_ios.dependency 'MicrosoftFluentUI/OtherCells_ios'
     peoplepicker_ios.source_files = ["ios/FluentUI/People Picker/**/*.{swift,h}"]
   end
@@ -245,9 +244,9 @@ fi', :execution_position => :before_compile }
 
   s.subspec 'PopupMenu_ios' do |popupmenu_ios|
     popupmenu_ios.platform = :ios
-    popupmenu_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     popupmenu_ios.dependency 'MicrosoftFluentUI/Drawer_ios'
     popupmenu_ios.dependency 'MicrosoftFluentUI/Label_ios'
+    popupmenu_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     popupmenu_ios.dependency 'MicrosoftFluentUI/TableView_ios'
     popupmenu_ios.source_files = ["ios/FluentUI/Popup Menu/**/*.{swift,h}"]
   end
@@ -266,8 +265,14 @@ fi', :execution_position => :before_compile }
 
   s.subspec 'SegmentedControl_ios' do |segmentedcontrol_ios|
     segmentedcontrol_ios.platform = :ios
-    segmentedcontrol_ios.dependency 'MicrosoftFluentUI/Divider_ios'
+    segmentedcontrol_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     segmentedcontrol_ios.source_files = ["ios/FluentUI/SegmentedControl/**/*.{swift,h}"]
+  end
+
+  s.subspec 'Separator_ios' do |separator_ios|
+    separator_ios.platform = :ios
+    separator_ios.dependency 'MicrosoftFluentUI/Core_ios'
+    separator_ios.source_files = ["ios/FluentUI/Separator/**/*.{swift,h}"]
   end
 
   s.subspec 'Shimmer_ios' do |shimmer_ios|
@@ -280,15 +285,15 @@ fi', :execution_position => :before_compile }
   s.subspec 'TabBar_ios' do |tabbar_ios|
     tabbar_ios.platform = :ios
     tabbar_ios.dependency 'MicrosoftFluentUI/Avatar_ios'
-    tabbar_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     tabbar_ios.dependency 'MicrosoftFluentUI/Label_ios'
+    tabbar_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     tabbar_ios.source_files = ["ios/FluentUI/Tab Bar/**/*.{swift,h}"]
   end
 
   s.subspec 'TableView_ios' do |tableview_ios|
     tableview_ios.platform = :ios
-    tableview_ios.dependency 'MicrosoftFluentUI/Divider_ios'
     tableview_ios.dependency 'MicrosoftFluentUI/Label_ios'
+    tableview_ios.dependency 'MicrosoftFluentUI/Separator_ios'
     tableview_ios.preserve_paths = ["ios/FluentUI/Table View/TableView.resources.xcfilelist"]
     tableview_ios.source_files = ["ios/FluentUI/Table View/**/*.{swift,h}"]
   end

--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -74,15 +74,15 @@
 		CCC18C2F2501C75F00BE830E /* CardViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */; };
 		E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842973247B672000A29C40 /* SceneDelegate.swift */; };
 		E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemes.swift */; };
-		EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */; };
-		EC02A5F9274EED9200E81B3E /* DividerDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */; };
 		EC1C31752923032000CF052C /* ColoredPillBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */; };
-		EC6A71EC273DE6DF0076A586 /* DividerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */; };
+		EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
 		FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0A0516BF2940A407006DE0A2 /* DividerDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController_SwiftUI.swift; sourceTree = "<group>"; };
+		0A0516C02940A407006DE0A2 /* DividerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController.swift; sourceTree = "<group>"; };
 		11047D2522932DB1001F0F59 /* TabBarViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewDemoController.swift; sourceTree = "<group>"; };
 		114CF8B72423E10900D064AA /* ColorDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDemoController.swift; sourceTree = "<group>"; };
 		2F0A96FB25CA047100EF9736 /* SearchBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBarDemoController.swift; sourceTree = "<group>"; };
@@ -150,9 +150,6 @@
 		EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredPillBackgroundView.swift; sourceTree = "<group>"; };
 		EC24DBC428B97E950026EF92 /* PopupMenuObjCDemoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopupMenuObjCDemoController.h; sourceTree = "<group>"; };
 		EC24DBC528B97EB70026EF92 /* PopupMenuObjCDemoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PopupMenuObjCDemoController.m; sourceTree = "<group>"; };
-		EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividerDemoController_SwiftUI.swift; sourceTree = "<group>"; };
-		EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerDemoController.swift; sourceTree = "<group>"; };
-		EC8EA6AF2580D82A00F191CE /* ListDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDemoController.swift; sourceTree = "<group>"; };
 		FC414E3625888BC300069E73 /* CommandBarDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarDemoController.swift; sourceTree = "<group>"; };
 		FD41C8F322E28EEB0086F899 /* NavigationControllerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerDemoController.swift; sourceTree = "<group>"; };
 		FD6AE76C225679A4002CFDFE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -335,8 +332,8 @@
 				9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */,
 				FC414E3625888BC300069E73 /* CommandBarDemoController.swift */,
 				FD7254EC21471A3F002F4069 /* DateTimePickerDemoController.swift */,
-				EC6A71EB273DE6DF0076A586 /* DividerDemoController.swift */,
-				EC02A5F8274EED9200E81B3E /* DividerDemoController_SwiftUI.swift */,
+				0A0516BF2940A407006DE0A2 /* DividerDemoController_SwiftUI.swift */,
+				0A0516C02940A407006DE0A2 /* DividerDemoController.swift */,
 				A5DCA75D211E3A92005F4CB7 /* DrawerDemoController.swift */,
 				B4E8F65121CD9579008A1598 /* HUDDemoController.swift */,
 				5336B17B27F7817300B01E0D /* HUDDemoController_SwiftUI.swift */,
@@ -519,7 +516,6 @@
 				5328D97B26FBA3EA00F3723B /* IndeterminateProgressBarDemoController.swift in Sources */,
 				5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */,
 				7D0931C124AAA3D30072458A /* SideTabBarDemoController.swift in Sources */,
-				EC02A5F9274EED9200E81B3E /* DividerDemoController_SwiftUI.swift in Sources */,
 				80B1F7012628D8BB004DFEE5 /* BottomSheetDemoController.swift in Sources */,
 				FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */,
 				B45EB79221A4D047008646A2 /* BadgeFieldDemoController.swift in Sources */,
@@ -566,7 +562,6 @@
 				E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */,
 				A5CEC21020E436F10016922A /* AppDelegate.swift in Sources */,
 				53097D4227028AF000A6E4DC /* TabBarViewDemoController.swift in Sources */,
-				EC6A71EC273DE6DF0076A586 /* DividerDemoController.swift in Sources */,
 				B4414794228F6FDF0040E88E /* OtherCellsSampleData.swift in Sources */,
 				53097D4327028AF400A6E4DC /* TableViewCellFileAccessoryViewDemoController.swift in Sources */,
 				B444D6B82183BA4B0002B4D4 /* BadgeViewDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -25,7 +25,6 @@ struct Demos {
         DemoDescriptor("Button", ButtonDemoController.self),
         DemoDescriptor("CardNudge", CardNudgeDemoController.self),
         DemoDescriptor("CommandBar", CommandBarDemoController.self),
-        DemoDescriptor("Divider", DividerDemoController.self),
         DemoDescriptor("HUD", HUDDemoController.self),
         DemoDescriptor("IndeterminateProgressBar", IndeterminateProgressBarDemoController.self),
         DemoDescriptor("NotificationView", NotificationViewDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController_SwiftUI.swift
@@ -45,7 +45,7 @@ struct ActivityIndicatorDemoView: View {
                             Text("Settings")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         FluentUIDemoToggle(titleKey: "Animating", isOn: $isAnimating)
@@ -58,7 +58,7 @@ struct ActivityIndicatorDemoView: View {
                             Text("Size")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         Picker(selection: $size, label: EmptyView()) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -63,7 +63,7 @@ struct AvatarDemoView: View {
                             Text("Content")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         TextField("Primary Text", text: $primaryText)
@@ -88,7 +88,7 @@ struct AvatarDemoView: View {
                             Text("Ring")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
                         FluentUIDemoToggle(titleKey: "Ring visible", isOn: $isRingVisible)
                         FluentUIDemoToggle(titleKey: "Ring inner gap", isOn: $hasRingInnerGap)
@@ -100,7 +100,7 @@ struct AvatarDemoView: View {
                             Text("Presence")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         Picker(selection: $presence, label: EmptyView()) {
@@ -124,7 +124,7 @@ struct AvatarDemoView: View {
                             Text("Style")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         Picker(selection: $style, label: EmptyView()) {
@@ -144,7 +144,7 @@ struct AvatarDemoView: View {
                             Text("Size")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         Picker(selection: $size, label: EmptyView()) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
@@ -33,11 +33,11 @@ class BadgeFieldDemoController: DemoController {
 
         addDescription(text: "Badge field with limited number of lines")
         container.addArrangedSubview(badgeField1)
-        container.addArrangedSubview(MSFDivider())
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(UIView())
         addDescription(text: "Badge field with unlimited number of lines")
         container.addArrangedSubview(badgeField2)
-        container.addArrangedSubview(MSFDivider())
+        container.addArrangedSubview(Separator())
     }
 
     private func setupBadgeField(label: String, dataSources: [BadgeViewDataSource]) -> BadgeField {
@@ -49,7 +49,6 @@ class BadgeFieldDemoController: DemoController {
         badgeField.addBadges(withDataSources: dataSources)
         return badgeField
     }
-
 }
 
 extension BadgeFieldDemoController: BadgeFieldDelegate {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -107,7 +107,7 @@ class ColorDemoController: UIViewController {
         tableView.allowsSelection = false
         tableView.backgroundColor = TableViewCell.tableBackgroundColor
 
-        let separator = Separator(style: .shadow, orientation: .horizontal)
+        let separator = Separator(orientation: .horizontal)
         let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])
         stackView.setCustomSpacing(8, after: segmentedControl)
         stackView.axis = .vertical

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ColorDemoController.swift
@@ -107,7 +107,8 @@ class ColorDemoController: UIViewController {
         tableView.allowsSelection = false
         tableView.backgroundColor = TableViewCell.tableBackgroundColor
 
-        let stackView = UIStackView(arrangedSubviews: [segmentedControl, divider, tableView])
+        let separator = Separator(style: .shadow, orientation: .horizontal)
+        let stackView = UIStackView(arrangedSubviews: [segmentedControl, separator, tableView])
         stackView.setCustomSpacing(8, after: segmentedControl)
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -171,7 +172,6 @@ class ColorDemoController: UIViewController {
     }
 
     private let tableView = UITableView(frame: .zero, style: .grouped)
-    private let divider = MSFDivider()
 }
 
 // MARK: - ColorDemoController: UITableViewDelegate

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController_SwiftUI.swift
@@ -42,7 +42,7 @@ struct IndeterminateProgressBarDemoView: View {
                             Text("Settings")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         FluentUIDemoToggle(titleKey: "Animating", isOn: $isAnimating)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -100,7 +100,7 @@ struct NotificationDemoView: View {
                             Text("Content")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         TextField("Title", text: $title)
@@ -129,7 +129,7 @@ struct NotificationDemoView: View {
                             Text("Action")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
                         FluentUIDemoToggle(titleKey: "Has Action Button Action", isOn: $hasActionButtonAction)
                         FluentUIDemoToggle(titleKey: "Show Default Dismiss Button", isOn: $showDefaultDismissActionButton)
@@ -141,7 +141,7 @@ struct NotificationDemoView: View {
                             Text("Style")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.title)
-                            FluentDivider()
+                            Divider()
                         }
 
                         Picker(selection: $style, label: EmptyView()) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -27,16 +27,8 @@ class OtherCellsDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-<<<<<<< HEAD
         tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
         tableView.separatorColor = Colors.dividerOnPrimary
-||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
-        tableView.backgroundColor = Colors.tableBackgroundGrouped
-        tableView.separatorColor = Colors.dividerOnPrimary
-=======
-        tableView.backgroundColor = Colors.tableBackgroundGrouped
-        tableView.separatorColor = Colors.Separator.default
->>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -27,8 +27,16 @@ class OtherCellsDemoController: DemoController {
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
         tableView.dataSource = self
         tableView.delegate = self
+<<<<<<< HEAD
         tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
         tableView.separatorColor = Colors.dividerOnPrimary
+||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
+        tableView.backgroundColor = Colors.tableBackgroundGrouped
+        tableView.separatorColor = Colors.dividerOnPrimary
+=======
+        tableView.backgroundColor = Colors.tableBackgroundGrouped
+        tableView.separatorColor = Colors.Separator.default
+>>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -68,14 +68,13 @@ class PeoplePickerDemoController: DemoController {
 
     private func setupView() {
         container.addArrangedSubview(createAsyncImageToggle())
-        container.addArrangedSubview(MSFDivider())
+        container.addArrangedSubview(Separator())
 
         for (index, variant) in PeoplePickerSampleData.variants.enumerated() {
             addDescription(text: variant.description)
             addPeoplePicker(for: variant)
             if index != PeoplePickerSampleData.variants.count - 1 {
-                let divider = MSFDivider()
-                container.addArrangedSubview(divider)
+                container.addArrangedSubview(Separator())
             }
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -65,38 +65,36 @@ class ShimmerViewDemoController: DemoController {
         }
 
         container.addArrangedSubview(shimmerViewLabel("A ShimmerLinesView needs no containerview or subviews"))
-        container.addArrangedSubview(dividers[0])
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(ShimmerLinesView())
-        container.addArrangedSubview(dividers[1])
+        container.addArrangedSubview(Separator())
 
         container.addArrangedSubview(shimmerViewLabel("The middle lines of ShimmerLinesView are always at 100% width"))
-        container.addArrangedSubview(dividers[0])
+        container.addArrangedSubview(Separator())
         let shimmerLinesView = ShimmerLinesView(containerView: nil,
                                                 excludedViews: [],
                                                 animationSynchronizer: nil)
         shimmerLinesView.lineCount = 6
         container.addArrangedSubview(shimmerLinesView)
-        container.addArrangedSubview(dividers[1])
+        container.addArrangedSubview(Separator())
 
         container.addArrangedSubview(shimmerViewLabel("ShimmerView shimmers all the top level subviews of its container view"))
-        container.addArrangedSubview(dividers[2])
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmeringContentView(false))
-        container.addArrangedSubview(dividers[3])
+        container.addArrangedSubview(Separator())
 
         container.addArrangedSubview(shimmerViewLabel("With shimmersLeafViews set, the ShimmerView will shimmer the labels inside the stackview"))
-        container.addArrangedSubview(dividers[4])
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmeringContentView(true))
-        container.addArrangedSubview(dividers[5])
+        container.addArrangedSubview(Separator())
 
         container.addArrangedSubview(shimmerViewLabel("Revealing style shimmer on an image: the gradient reveals its container view as it moves"))
-        container.addArrangedSubview(dividers[6])
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmeringImageView(.revealing))
 
-        container.addArrangedSubview(dividers[7])
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmerViewLabel("Concealing style shimmer on an image: the gradient conceals its container view as it moves"))
-        container.addArrangedSubview(dividers[8])
+        container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmeringImageView(.concealing))
     }
-
-    private let dividers: [MSFDivider] = (0..<9).map { _ in MSFDivider() }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -10,97 +10,16 @@ import UIKit
 
 class TableViewHeaderFooterViewDemoController: DemoController {
     private let groupedSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.groupedSections
-<<<<<<< HEAD
-||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
-    private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
-    private let divider = MSFDivider()
-
-    private lazy var segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
-        segmentedControl.onSelectAction = { [weak self] (_, _) in
-            guard let strongSelf = self else {
-                return
-            }
-
-            strongSelf.updateActiveTabContent()
-        }
-
-        return segmentedControl
-    }()
-=======
-    private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
-
-    private lazy var segmentedControl: SegmentedControl = {
-        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
-        segmentedControl.onSelectAction = { [weak self] (_, _) in
-            guard let strongSelf = self else {
-                return
-            }
-
-            strongSelf.updateActiveTabContent()
-        }
-
-        return segmentedControl
-    }()
->>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)
     private var collapsedSections: [Bool] = [Bool](repeating: false, count: TableViewHeaderFooterSampleData.groupedSections.count)
-    private let divider = MSFDivider()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-<<<<<<< HEAD
         view.addSubview(groupedTableView)
         groupedTableView.frame = view.bounds
         groupedTableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         scrollingContainer.removeFromSuperview()
-||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
-        container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
-        container.layoutMargins = .zero
-        container.spacing = 0
-
-        navigationController?.navigationBar.shadowImage = UIImage()
-        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
-        container.addArrangedSubview(segmentedControl)
-        container.setCustomSpacing(8, after: segmentedControl)
-        container.backgroundColor = Colors.navigationBarBackground
-
-        container.addArrangedSubview(divider)
-
-        container.addArrangedSubview(groupedTableView)
-        container.addArrangedSubview(plainTableView)
-
-        updateActiveTabContent()
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        navigationController?.navigationBar.shadowImage = nil
-=======
-        container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
-        container.layoutMargins = .zero
-        container.spacing = 0
-
-        navigationController?.navigationBar.shadowImage = UIImage()
-        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
-        container.addArrangedSubview(segmentedControl)
-        container.setCustomSpacing(8, after: segmentedControl)
-        container.backgroundColor = Colors.navigationBarBackground
-
-        let separator = Separator(style: .shadow, orientation: .horizontal)
-        container.addArrangedSubview(separator)
-
-        container.addArrangedSubview(groupedTableView)
-        container.addArrangedSubview(plainTableView)
-
-        updateActiveTabContent()
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        navigationController?.navigationBar.shadowImage = nil
->>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
     }
 
     func createTableView(style: UITableView.Style) -> UITableView {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -10,6 +10,39 @@ import UIKit
 
 class TableViewHeaderFooterViewDemoController: DemoController {
     private let groupedSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.groupedSections
+<<<<<<< HEAD
+||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
+    private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
+    private let divider = MSFDivider()
+
+    private lazy var segmentedControl: SegmentedControl = {
+        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
+        segmentedControl.onSelectAction = { [weak self] (_, _) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.updateActiveTabContent()
+        }
+
+        return segmentedControl
+    }()
+=======
+    private let plainSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.plainSections
+
+    private lazy var segmentedControl: SegmentedControl = {
+        let segmentedControl = SegmentedControl(items: TableViewHeaderFooterSampleData.tabTitles.map({return SegmentItem(title: $0)}), style: .primaryPill)
+        segmentedControl.onSelectAction = { [weak self] (_, _) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.updateActiveTabContent()
+        }
+
+        return segmentedControl
+    }()
+>>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
     private lazy var groupedTableView: UITableView = createTableView(style: .grouped)
     private var collapsedSections: [Bool] = [Bool](repeating: false, count: TableViewHeaderFooterSampleData.groupedSections.count)
     private let divider = MSFDivider()
@@ -17,10 +50,57 @@ class TableViewHeaderFooterViewDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+<<<<<<< HEAD
         view.addSubview(groupedTableView)
         groupedTableView.frame = view.bounds
         groupedTableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         scrollingContainer.removeFromSuperview()
+||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
+        container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
+        container.layoutMargins = .zero
+        container.spacing = 0
+
+        navigationController?.navigationBar.shadowImage = UIImage()
+        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(segmentedControl)
+        container.setCustomSpacing(8, after: segmentedControl)
+        container.backgroundColor = Colors.navigationBarBackground
+
+        container.addArrangedSubview(divider)
+
+        container.addArrangedSubview(groupedTableView)
+        container.addArrangedSubview(plainTableView)
+
+        updateActiveTabContent()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        navigationController?.navigationBar.shadowImage = nil
+=======
+        container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
+        container.layoutMargins = .zero
+        container.spacing = 0
+
+        navigationController?.navigationBar.shadowImage = UIImage()
+        navigationController?.navigationBar.backgroundColor = Colors.navigationBarBackground
+        container.addArrangedSubview(segmentedControl)
+        container.setCustomSpacing(8, after: segmentedControl)
+        container.backgroundColor = Colors.navigationBarBackground
+
+        let separator = Separator(style: .shadow, orientation: .horizontal)
+        container.addArrangedSubview(separator)
+
+        container.addArrangedSubview(groupedTableView)
+        container.addArrangedSubview(plainTableView)
+
+        updateActiveTabContent()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        navigationController?.navigationBar.shadowImage = nil
+>>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
     }
 
     func createTableView(style: UITableView.Style) -> UITableView {

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -7,9 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0ADBD5872915B9C100C8BC06 /* DividerTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADBD5832915B9C100C8BC06 /* DividerTokenSet.swift */; };
-		0ADBD5882915B9C100C8BC06 /* MSFDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADBD5842915B9C100C8BC06 /* MSFDivider.swift */; };
-		0ADBD58A2915B9C100C8BC06 /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADBD5862915B9C100C8BC06 /* Divider.swift */; };
 		0A8E61FB291DC11F009E412D /* CommandBarTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8E61FA291DC11F009E412D /* CommandBarTokenSet.swift */; };
 		2A9745DE281733D700E1A1FD /* TableViewCellTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9745DD281733D700E1A1FD /* TableViewCellTokenSet.swift */; };
 		43488C46270FAD1300124C71 /* FluentNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43488C44270FAD0200124C71 /* FluentNotification.swift */; };
@@ -91,6 +88,7 @@
 		5314E14525F016860099271A /* CardPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDA1AF9221487225001AE720 /* CardPresentationController.swift */; };
 		5314E14E25F016CD0099271A /* ResizingHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */; };
 		5314E16925F017940099271A /* SegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */; };
+		5314E17225F0191C0099271A /* Separator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DCA76321224026005F4CB7 /* Separator.swift */; };
 		5314E18D25F0195C0099271A /* ShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0EAAEAC2347E1DF00C7244E /* ShimmerView.swift */; };
 		5314E18E25F0195C0099271A /* ShimmerLinesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A0D76B233AEF6C00F432FD /* ShimmerLinesView.swift */; };
 		5314E19525F019650099271A /* TabBarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168630222E131CF0088B302 /* TabBarItemView.swift */; };
@@ -229,9 +227,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0ADBD5832915B9C100C8BC06 /* DividerTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DividerTokenSet.swift; sourceTree = "<group>"; };
-		0ADBD5842915B9C100C8BC06 /* MSFDivider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFDivider.swift; sourceTree = "<group>"; };
-		0ADBD5862915B9C100C8BC06 /* Divider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
+		0A0516BC2940A3CE006DE0A2 /* DividerTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerTokenSet.swift; sourceTree = "<group>"; };
+		0A0516BD2940A3CE006DE0A2 /* MSFDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFDivider.swift; sourceTree = "<group>"; };
+		0A0516BE2940A3CE006DE0A2 /* Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
 		0A8E61FA291DC11F009E412D /* CommandBarTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandBarTokenSet.swift; sourceTree = "<group>"; };
 		0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuProtocols.swift; sourceTree = "<group>"; };
 		1168630222E131CF0088B302 /* TabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemView.swift; sourceTree = "<group>"; };
@@ -350,6 +348,7 @@
 		A5CEC23020E451D00016922A /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		A5DA88FC226FAA01000A8EA8 /* FluentUIResources-ios.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FluentUIResources-ios.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5DA88FE226FAA01000A8EA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A5DCA76321224026005F4CB7 /* Separator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Separator.swift; sourceTree = "<group>"; };
 		A5DF1EAC2213B26900CC741A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		B441478C228CDA130040E88E /* BooleanCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanCell.swift; sourceTree = "<group>"; };
 		B444D6B52183A9740002B4D4 /* BadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeView.swift; sourceTree = "<group>"; };
@@ -524,15 +523,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0ADBD5822915B9C100C8BC06 /* Divider */ = {
+		0A0516BB2940A3CE006DE0A2 /* Divider */ = {
 			isa = PBXGroup;
 			children = (
-				0ADBD5862915B9C100C8BC06 /* Divider.swift */,
-				0ADBD5832915B9C100C8BC06 /* DividerTokenSet.swift */,
-				0ADBD5842915B9C100C8BC06 /* MSFDivider.swift */,
+				0A0516BC2940A3CE006DE0A2 /* DividerTokenSet.swift */,
+				0A0516BD2940A3CE006DE0A2 /* MSFDivider.swift */,
+				0A0516BE2940A3CE006DE0A2 /* Divider.swift */,
 			);
-			path = Divider;
-			sourceTree = "<group>";
+			name = Divider;
+			path = FluentUI/Divider;
+			sourceTree = SOURCE_ROOT;
 		};
 		1168630122E131A20088B302 /* Tab Bar */ = {
 			isa = PBXGroup;
@@ -575,6 +575,14 @@
 				5306074F26A1E6A4002D49CF /* AvatarGroupTokenSet.swift */,
 			);
 			path = AvatarGroup;
+			sourceTree = "<group>";
+		};
+		5314DFE625F000740099271A /* Separator */ = {
+			isa = PBXGroup;
+			children = (
+				A5DCA76321224026005F4CB7 /* Separator.swift */,
+			);
+			path = Separator;
 			sourceTree = "<group>";
 		};
 		5314DFEB25F002240099271A /* ActivityIndicator */ = {
@@ -858,7 +866,7 @@
 				FC414E1D258876D400069E73 /* Command Bar */,
 				A5CEC16B20D98EBF0016922A /* Core */,
 				FD599D0021347FA0008845EE /* Date Time Pickers */,
-				0ADBD5822915B9C100C8BC06 /* Divider */,
+				0A0516BB2940A3CE006DE0A2 /* Divider */,
 				5314DFEF25F003C60099271A /* DotView */,
 				A5B87AF2211E13D00038C37C /* Drawer */,
 				5314DFF525F007020099271A /* EasyTapButton */,
@@ -878,6 +886,7 @@
 				FD7254EE2147382D002F4069 /* Presenters */,
 				5314DFF725F007FF0099271A /* ResizingHandleView */,
 				ECEBA8F625EDEFF70048EE24 /* SegmentedControl */,
+				5314DFE625F000740099271A /* Separator */,
 				C0A0D75D233AEA9900F432FD /* Shimmer */,
 				1168630122E131A20088B302 /* Tab Bar */,
 				B444D6B421825B510002B4D4 /* Table View */,
@@ -1425,7 +1434,6 @@
 				532FE3D426EA6D74007539C0 /* ActivityIndicatorTokenSet.swift in Sources */,
 				92D5FDFB28A713990087894B /* LinearGradientInfo.swift in Sources */,
 				53E2EE07278799B30086D30D /* MSFIndeterminateProgressBar.swift in Sources */,
-				0ADBD5872915B9C100C8BC06 /* DividerTokenSet.swift in Sources */,
 				532FE3D626EA6D74007539C0 /* ActivityIndicatorModifiers.swift in Sources */,
 				5314E2F525F025C60099271A /* CalendarConfiguration.swift in Sources */,
 				923DB9D4274CB65700D8E58A /* TokenizedControl.swift in Sources */,
@@ -1512,7 +1520,6 @@
 				5314E0F225F012C80099271A /* ShyHeaderView.swift in Sources */,
 				5314E02825F00DA80099271A /* BlurringView.swift in Sources */,
 				5314E13625F016370099271A /* PopupMenuSectionHeaderView.swift in Sources */,
-				0ADBD5882915B9C100C8BC06 /* MSFDivider.swift in Sources */,
 				5314E05925F00EF50099271A /* CalendarViewDataSource.swift in Sources */,
 				5314E01625F00CF70099271A /* BarButtonItems.swift in Sources */,
 				5314E25425F023650099271A /* UIImage+Extensions.swift in Sources */,
@@ -1524,7 +1531,6 @@
 				5314E12925F016230099271A /* PillButtonStyle.swift in Sources */,
 				530D9C5327EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift in Sources */,
 				5306075726A1E6A4002D49CF /* AvatarGroup.swift in Sources */,
-				0ADBD58A2915B9C100C8BC06 /* Divider.swift in Sources */,
 				92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */,
 				5314E1C425F01B4E0099271A /* TwoLineTitleView.swift in Sources */,
 				5314E0CF25F011F10099271A /* Label.swift in Sources */,
@@ -1545,6 +1551,7 @@
 				5314E2E325F025500099271A /* FluentUIFramework.swift in Sources */,
 				ECA9218627A3301C00B66117 /* MSFAvatarGroup.swift in Sources */,
 				5314E0EC25F012C40099271A /* NavigationAnimator.swift in Sources */,
+				5314E17225F0191C0099271A /* Separator.swift in Sources */,
 				5314E14225F016860099271A /* CardPresenterNavigationController.swift in Sources */,
 				5314E11725F015EA0099271A /* PersonaCell.swift in Sources */,
 				5314E23025F022C80099271A /* UIScrollView+Extensions.swift in Sources */,

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -457,21 +457,21 @@ open class BottomCommandingController: UIViewController {
 
     private func makeSheetExpandedContent(with tableView: UITableView) -> UIView {
         let view = UIView()
-        let dividerView = divider
-        dividerView.translatesAutoresizingMaskIntoConstraints = false
+        let separator = Separator()
+        separator.translatesAutoresizingMaskIntoConstraints = false
         tableView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(tableView)
-        view.addSubview(dividerView)
+        view.addSubview(separator)
 
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            dividerView.topAnchor.constraint(equalTo: tableView.topAnchor),
-            dividerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dividerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            separator.topAnchor.constraint(equalTo: tableView.topAnchor),
+            separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         return view
     }
@@ -500,8 +500,6 @@ open class BottomCommandingController: UIViewController {
         heroCommandStack.removeAllSubviews()
         heroViews.forEach { heroCommandStack.addArrangedSubview($0) }
     }
-
-    private lazy var divider: MSFDivider = .init()
 
     private lazy var moreHeroItem: CommandingItem = CommandingItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage(), action: handleMoreCommandTap)
 

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -23,13 +23,13 @@ class CalendarView: UIView {
 
     weak var accessibleViewDelegate: AccessibleViewDelegate?
 
-    private let headingViewDivider: MSFDivider
-    private let collectionViewDivider: MSFDivider
+    private let headingViewSeparator: Separator
+    private let collectionViewSeparator: Separator
 
     init(headerStyle: DatePickerHeaderStyle = .light) {
         weekdayHeadingView = CalendarViewWeekdayHeadingView(headerStyle: headerStyle)
 
-        headingViewDivider = MSFDivider()
+        headingViewSeparator = Separator(style: .shadow)
 
         collectionViewLayout = CalendarViewLayout()
 
@@ -39,7 +39,7 @@ class CalendarView: UIView {
         // Enable multiple selection to allow for one cell to be selected and another cell to be highlighted simultaneously
         collectionView.allowsMultipleSelection = true
 
-        collectionViewDivider = MSFDivider()
+        collectionViewSeparator = Separator(style: .default)
 
         super.init(frame: .zero)
 
@@ -47,11 +47,11 @@ class CalendarView: UIView {
 
         addSubview(weekdayHeadingView)
         addSubview(collectionView)
-        addSubview(collectionViewDivider)
+        addSubview(collectionViewSeparator)
         addInteraction(UILargeContentViewerInteraction())
 
         if headerStyle == .light {
-            addSubview(headingViewDivider)
+            addSubview(headingViewSeparator)
         }
 
         NotificationCenter.default.addObserver(self,
@@ -87,11 +87,11 @@ class CalendarView: UIView {
             height: weekdayHeadingViewSize.height
         )
 
-        headingViewDivider.frame = CGRect(
+        headingViewSeparator.frame = CGRect(
             x: 0.0,
             y: weekdayHeadingView.frame.height,
             width: bounds.size.width,
-            height: headingViewDivider.frame.height
+            height: headingViewSeparator.frame.height
         )
 
         // Collection view
@@ -108,11 +108,11 @@ class CalendarView: UIView {
         )
         collectionView.contentOffset = originalContentOffset
 
-        collectionViewDivider.frame = CGRect(
+        collectionViewSeparator.frame = CGRect(
             x: 0.0,
-            y: collectionView.frame.maxY - collectionViewDivider.frame.height,
+            y: collectionView.frame.maxY - collectionViewSeparator.frame.height,
             width: bounds.size.width,
-            height: collectionViewDivider.frame.height
+            height: collectionViewSeparator.frame.height
         )
     }
 
@@ -125,8 +125,8 @@ class CalendarView: UIView {
         // Day cells
         height += CalendarViewLayout.preferredItemHeight * rows(for: style)
 
-        // Do not include last divider
-        height -= MSFDivider.thickness
+        // Do not include last separator
+        height -= Separator.thickness
 
         return height
     }

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -29,7 +29,7 @@ class CalendarView: UIView {
     init(headerStyle: DatePickerHeaderStyle = .light) {
         weekdayHeadingView = CalendarViewWeekdayHeadingView(headerStyle: headerStyle)
 
-        headingViewSeparator = Separator(style: .shadow)
+        headingViewSeparator = Separator()
 
         collectionViewLayout = CalendarViewLayout()
 
@@ -39,7 +39,7 @@ class CalendarView: UIView {
         // Enable multiple selection to allow for one cell to be selected and another cell to be highlighted simultaneously
         collectionView.allowsMultipleSelection = true
 
-        collectionViewSeparator = Separator(style: .default)
+        collectionViewSeparator = Separator()
 
         super.init(frame: .zero)
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -72,19 +72,9 @@ class DateTimePickerView: UIControl {
 
         super.init(frame: .zero)
 
-<<<<<<< HEAD
         gradientLayer = createGradientLayer()
-        addSubview(selectionTopDivider)
-        addSubview(selectionBottomDivider)
-||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
-        layer.addSublayer(gradientLayer)
-        addSubview(selectionTopDivider)
-        addSubview(selectionBottomDivider)
-=======
-        layer.addSublayer(gradientLayer)
         addSubview(selectionTopSeparator)
         addSubview(selectionBottomSeparator)
->>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
         addInteraction(UILargeContentViewerInteraction())
 
         updateBackgroundColor()

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -45,8 +45,8 @@ class DateTimePickerView: UIControl {
     private let componentTypes: [DateTimePickerViewComponentType]!
     private let componentsByType: [DateTimePickerViewComponentType: DateTimePickerViewComponent]!
 
-    private let selectionTopDivider = MSFDivider()
-    private let selectionBottomDivider = MSFDivider()
+    private let selectionTopSeparator = Separator()
+    private let selectionBottomSeparator = Separator()
 
     private var gradientLayer = CAGradientLayer()
 
@@ -72,9 +72,19 @@ class DateTimePickerView: UIControl {
 
         super.init(frame: .zero)
 
+<<<<<<< HEAD
         gradientLayer = createGradientLayer()
         addSubview(selectionTopDivider)
         addSubview(selectionBottomDivider)
+||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
+        layer.addSublayer(gradientLayer)
+        addSubview(selectionTopDivider)
+        addSubview(selectionBottomDivider)
+=======
+        layer.addSublayer(gradientLayer)
+        addSubview(selectionTopSeparator)
+        addSubview(selectionBottomSeparator)
+>>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
         addInteraction(UILargeContentViewerInteraction())
 
         updateBackgroundColor()
@@ -180,26 +190,15 @@ class DateTimePickerView: UIControl {
             x += viewWidth
         }
 
-        let selectionTopDividerView = selectionTopDivider
-        let selectionTopDividerHeight = selectionTopDividerView.frame.height
-        let selectionBottomDividerView = selectionBottomDivider
-        let selectionBottomDividerHeight = selectionTopDividerView.frame.height
-        let frameWidth = frame.width
-        let frameHeight = frame.height
-        let lineOffset = round((frameHeight - DateTimePickerViewComponentCell.idealHeight - 2 * selectionTopDividerHeight) / 2)
+        let lineOffset = round((frame.height - DateTimePickerViewComponentCell.idealHeight - 2 * selectionTopSeparator.frame.height) / 2)
 
-        selectionTopDividerView.frame = CGRect(
-            x: 0,
-            y: lineOffset,
-            width: frameWidth,
-            height: selectionTopDividerHeight
-        )
+        selectionTopSeparator.frame = CGRect(x: 0, y: lineOffset, width: frame.width, height: selectionTopSeparator.frame.height)
 
-        selectionBottomDividerView.frame = CGRect(
+        selectionBottomSeparator.frame = CGRect(
             x: 0,
-            y: frameHeight - lineOffset - selectionBottomDividerHeight,
-            width: frameWidth,
-            height: selectionBottomDividerHeight
+            y: frame.height - lineOffset - selectionBottomSeparator.frame.height,
+            width: frame.width,
+            height: selectionBottomSeparator.frame.height
         )
 
         let gradientOffset = lineOffset - DateTimePickerViewComponentCell.idealHeight

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -90,7 +90,7 @@ class DrawerPresentationController: UIPresentationController {
         return DrawerShadowView(shadowDirection: actualPresentationOffset == 0 ? presentationDirection : nil)
     }()
     // Imitates the bottom shadow of navigation bar or top shadow of toolbar because original ones are hidden by presented view
-    private lazy var separator = MSFDivider()
+    private lazy var separator = Separator(style: .shadow)
 
     // MARK: Presentation
 

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -90,7 +90,7 @@ class DrawerPresentationController: UIPresentationController {
         return DrawerShadowView(shadowDirection: actualPresentationOffset == 0 ? presentationDirection : nil)
     }()
     // Imitates the bottom shadow of navigation bar or top shadow of toolbar because original ones are hidden by presented view
-    private lazy var separator = Separator(style: .shadow)
+    private lazy var separator = Separator()
 
     // MARK: Presentation
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -152,7 +152,7 @@ class ShyHeaderView: UIView {
     }
 
     private let contentStackView = UIStackView()
-    private let shadow = MSFDivider()
+    private let shadow = Separator(style: .shadow)
 
     private var needsShadow: Bool {
         switch navigationBarShadow {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -152,7 +152,7 @@ class ShyHeaderView: UIView {
     }
 
     private let contentStackView = UIStackView()
-    private let shadow = Separator(style: .shadow)
+    private let shadow = Separator()
 
     private var needsShadow: Bool {
         switch navigationBarShadow {

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -122,9 +122,9 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     private var action1Type: ActionType = .regular
     private var action2Type: ActionType = .regular
 
-    private let topSeparator = MSFDivider()
-    private let bottomSeparator = MSFDivider()
-    private let verticalSeparator = MSFDivider(orientation: .vertical)
+    private let topSeparator = Separator(style: .default, orientation: .horizontal)
+    private let bottomSeparator = Separator(style: .default, orientation: .horizontal)
+    private let verticalSeparator = Separator(style: .default, orientation: .vertical)
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         self.tokenSet = TableViewCellTokenSet(customViewSize: { .default })
@@ -250,7 +250,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         button.titleLabel?.textAlignment = .center
     }
 
-    private func layoutHorizontalSeparator(_ separator: MSFDivider, with type: TableViewCell.SeparatorType, at verticalOffset: CGFloat) {
+    private func layoutHorizontalSeparator(_ separator: Separator, with type: TableViewCell.SeparatorType, at verticalOffset: CGFloat) {
         let horizontalOffset = type == .inset ? safeAreaInsets.left + TableViewCellTokenSet.horizontalSpacing : 0
 
         separator.frame = CGRect(
@@ -262,7 +262,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         separator.flipForRTL()
     }
 
-    private func updateHorizontalSeparator(_ separator: MSFDivider, with type: TableViewCell.SeparatorType) {
+    private func updateHorizontalSeparator(_ separator: Separator, with type: TableViewCell.SeparatorType) {
         separator.isHidden = type == .none
         setNeedsLayout()
     }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -122,9 +122,9 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     private var action1Type: ActionType = .regular
     private var action2Type: ActionType = .regular
 
-    private let topSeparator = Separator(style: .default, orientation: .horizontal)
-    private let bottomSeparator = Separator(style: .default, orientation: .horizontal)
-    private let verticalSeparator = Separator(style: .default, orientation: .vertical)
+    private let topSeparator = Separator(orientation: .horizontal)
+    private let bottomSeparator = Separator(orientation: .horizontal)
+    private let verticalSeparator = Separator(orientation: .vertical)
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         self.tokenSet = TableViewCellTokenSet(customViewSize: { .default })

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -128,7 +128,7 @@ open class PeoplePicker: BadgeField {
 
     private var containingViewBoundsObservation: NSKeyValueObservation?
 
-    private let divider = MSFDivider()
+    private let separator = Separator()
 
     @objc public override init() {
         super.init()
@@ -142,7 +142,7 @@ open class PeoplePicker: BadgeField {
 
     func initialize() {
         personaSuggestionsView.addSubview(personaListView)
-        personaSuggestionsView.addSubview(divider)
+        personaSuggestionsView.addSubview(separator)
 
         personaListView.onPersonaSelected = { [unowned self] persona in
             self.pickPersona(persona: persona)
@@ -241,7 +241,7 @@ open class PeoplePicker: BadgeField {
 
         personaListView.frame = personaSuggestionsView.bounds
 
-        divider.frame = CGRect(x: 0, y: separatorY, width: personaSuggestionsView.frame.width, height: divider.frame.height)
+        separator.frame = CGRect(x: 0, y: separatorY, width: personaSuggestionsView.frame.width, height: separator.frame.height)
     }
 
     // MARK: Personas

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -116,16 +116,12 @@ open class PopupMenuController: DrawerController {
         }
     }
 
-    /// set `separatorColor` to customize separator colors of PopupMenuItem cells and the drawer
-    @objc open var separatorColor: UIColor = Colors.dividerOnPrimary {
-            didSet {
-                guard let dynamicColor = separatorColor.dynamicColor else {
-                    assertionFailure("Unable to create dynamic color from separator color: \(separatorColor)")
-                    return
-                }
-                divider.tokenSet[.color] = .dynamicColor({ dynamicColor })
-            }
+    /// set `separatorColor` to customize separator colors of  PopupMenuItem cells and the drawer
+    @objc open var separatorColor: UIColor = Colors.Separator.default {
+        didSet {
+            separator?.backgroundColor = separatorColor
         }
+    }
 
     private var sections: [PopupMenuSection] = []
     private var itemForExecutionAfterPopupMenuDismissal: PopupMenuTemplateItem?
@@ -146,7 +142,7 @@ open class PopupMenuController: DrawerController {
         return view
     }()
 
-    private lazy var divider: MSFDivider = .init()
+    private var separator: Separator?
     private lazy var descriptionView: UIView = {
         let view = UIView()
         view.isAccessibilityElement = true
@@ -154,29 +150,35 @@ open class PopupMenuController: DrawerController {
         view.isHidden = true
 
         view.addSubview(descriptionLabel)
+<<<<<<< HEAD
         let verticalMargin = GlobalTokens.spacing(.size120)
         let horizontalMargin = GlobalTokens.spacing(.size160)
+||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
+        let verticalMargin = GlobalTokens.spacing(.small)
+        let horizontalMargin = GlobalTokens.spacing(.medium)
+=======
+>>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
         descriptionLabel.fitIntoSuperview(
             usingConstraints: true,
             margins: UIEdgeInsets(
-                top: verticalMargin,
-                left: horizontalMargin,
-                bottom: verticalMargin,
-                right: horizontalMargin
+                top: Constants.descriptionVerticalMargin,
+                left: Constants.descriptionHorizontalMargin,
+                bottom: Constants.descriptionVerticalMargin,
+                right: Constants.descriptionHorizontalMargin
             )
         )
 
-        if let dynamicColor = separatorColor.dynamicColor {
-            divider.tokenSet[.color] = .dynamicColor({ dynamicColor })
+        separator = Separator()
+        if let separator = separator {
+            separator.backgroundColor = separatorColor
+            view.addSubview(separator)
+            separator.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                separator.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                separator.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                separator.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
         }
-        view.addSubview(divider)
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            divider.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            divider.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-
         return view
     }()
     private let descriptionLabel: Label = {

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -117,11 +117,14 @@ open class PopupMenuController: DrawerController {
     }
 
     /// set `separatorColor` to customize separator colors of  PopupMenuItem cells and the drawer
-    @objc open var separatorColor: UIColor = Colors.Separator.default {
-        didSet {
-            separator?.backgroundColor = separatorColor
+    @objc open var separatorColor: UIColor = Colors.dividerOnPrimary {
+            didSet {
+                guard let separator = separator else {
+                    return
+                }
+                separator.backgroundColor = UIColor(cgColor: separatorColor.cgColor)
+            }
         }
-    }
 
     private var sections: [PopupMenuSection] = []
     private var itemForExecutionAfterPopupMenuDismissal: PopupMenuTemplateItem?
@@ -150,14 +153,8 @@ open class PopupMenuController: DrawerController {
         view.isHidden = true
 
         view.addSubview(descriptionLabel)
-<<<<<<< HEAD
         let verticalMargin = GlobalTokens.spacing(.size120)
         let horizontalMargin = GlobalTokens.spacing(.size160)
-||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
-        let verticalMargin = GlobalTokens.spacing(.small)
-        let horizontalMargin = GlobalTokens.spacing(.medium)
-=======
->>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
         descriptionLabel.fitIntoSuperview(
             usingConstraints: true,
             margins: UIEdgeInsets(

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -9,11 +9,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
 
     var customSeparatorColor: UIColor? {
         didSet {
-            if let color = customSeparatorColor?.dynamicColor {
-                bottomSeparator.tokenSet[.color] = .dynamicColor({ color })
-            } else {
-                bottomSeparator.tokenSet.removeOverride(.color)
-            }
+            bottomSeparator.backgroundColor = customSeparatorColor
         }
     }
 

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 //
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //  Licensed under the MIT License.
@@ -87,3 +88,107 @@ open class Separator: UIView {
         }
     }
 }
+||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
+=======
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+// MARK: Separator Colors
+
+public extension Colors {
+    struct Separator {
+        public static var `default`: UIColor = dividerOnPrimary
+        public static var shadow: UIColor = dividerOnSecondary
+    }
+    // Objective-C support
+    @objc static var separatorDefault: UIColor { return Separator.default }
+}
+
+// MARK: - SeparatorStyle
+
+@objc(MSFSeparatorStyle)
+public enum SeparatorStyle: Int {
+    case `default`
+    case shadow
+
+    fileprivate var color: UIColor {
+        switch self {
+        case .default:
+            return Colors.Separator.default
+        case .shadow:
+            return Colors.Separator.shadow
+        }
+    }
+}
+
+// MARK: - SeparatorOrientation
+
+@objc(MSFSeparatorOrientation)
+public enum SeparatorOrientation: Int {
+    case horizontal
+    case vertical
+}
+
+// MARK: - Separator
+
+@objc(MSFSeparator)
+open class Separator: UIView {
+    private var orientation: SeparatorOrientation = .horizontal
+
+    @objc public override init(frame: CGRect) {
+        super.init(frame: frame)
+        initialize(style: .default, orientation: .horizontal)
+    }
+
+    @objc public init(style: SeparatorStyle = .default, orientation: SeparatorOrientation = .horizontal) {
+        super.init(frame: .zero)
+        initialize(style: style, orientation: orientation)
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    /**
+     The default thickness for the separator: half pt.
+    */
+    @objc public static var thickness: CGFloat { return 0.5 }
+
+    private func initialize(style: SeparatorStyle, orientation: SeparatorOrientation) {
+        super.backgroundColor = style.color
+        self.orientation = orientation
+        switch orientation {
+        case .horizontal:
+            frame.size.height = Separator.thickness
+            autoresizingMask = .flexibleWidth
+        case .vertical:
+            frame.size.width = Separator.thickness
+            autoresizingMask = .flexibleHeight
+        }
+        isAccessibilityElement = false
+        isUserInteractionEnabled = false
+    }
+
+    open override var intrinsicContentSize: CGSize {
+        switch orientation {
+        case .horizontal:
+            return CGSize(width: UIView.noIntrinsicMetric, height: frame.height)
+        case .vertical:
+            return CGSize(width: frame.width, height: UIView.noIntrinsicMetric)
+        }
+    }
+
+    open override func sizeThatFits(_ size: CGSize) -> CGSize {
+        switch orientation {
+        case .horizontal:
+            return CGSize(width: size.width, height: frame.height)
+        case .vertical:
+            return CGSize(width: frame.width, height: size.height)
+        }
+    }
+}
+>>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 //
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //  Licensed under the MIT License.
@@ -37,7 +36,7 @@ open class Separator: UIView {
     /**
      The default thickness for the separator: half pt.
     */
-    @objc public static var thickness: CGFloat { return GlobalTokens.borderSize(.thinnest) }
+    @objc public static var thickness: CGFloat { return GlobalTokens.stroke(.width05) }
 
     @objc public static func separatorDefaultColor(fluentTheme: FluentTheme) -> UIColor {
         return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
@@ -88,107 +87,3 @@ open class Separator: UIView {
         }
     }
 }
-||||||| parent of 022e3eed (Partially reverting Divider + bringing back Separator (#1441))
-=======
-//
-//  Copyright (c) Microsoft Corporation. All rights reserved.
-//  Licensed under the MIT License.
-//
-
-import UIKit
-
-// MARK: Separator Colors
-
-public extension Colors {
-    struct Separator {
-        public static var `default`: UIColor = dividerOnPrimary
-        public static var shadow: UIColor = dividerOnSecondary
-    }
-    // Objective-C support
-    @objc static var separatorDefault: UIColor { return Separator.default }
-}
-
-// MARK: - SeparatorStyle
-
-@objc(MSFSeparatorStyle)
-public enum SeparatorStyle: Int {
-    case `default`
-    case shadow
-
-    fileprivate var color: UIColor {
-        switch self {
-        case .default:
-            return Colors.Separator.default
-        case .shadow:
-            return Colors.Separator.shadow
-        }
-    }
-}
-
-// MARK: - SeparatorOrientation
-
-@objc(MSFSeparatorOrientation)
-public enum SeparatorOrientation: Int {
-    case horizontal
-    case vertical
-}
-
-// MARK: - Separator
-
-@objc(MSFSeparator)
-open class Separator: UIView {
-    private var orientation: SeparatorOrientation = .horizontal
-
-    @objc public override init(frame: CGRect) {
-        super.init(frame: frame)
-        initialize(style: .default, orientation: .horizontal)
-    }
-
-    @objc public init(style: SeparatorStyle = .default, orientation: SeparatorOrientation = .horizontal) {
-        super.init(frame: .zero)
-        initialize(style: style, orientation: orientation)
-    }
-
-    public required init?(coder aDecoder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    /**
-     The default thickness for the separator: half pt.
-    */
-    @objc public static var thickness: CGFloat { return 0.5 }
-
-    private func initialize(style: SeparatorStyle, orientation: SeparatorOrientation) {
-        super.backgroundColor = style.color
-        self.orientation = orientation
-        switch orientation {
-        case .horizontal:
-            frame.size.height = Separator.thickness
-            autoresizingMask = .flexibleWidth
-        case .vertical:
-            frame.size.width = Separator.thickness
-            autoresizingMask = .flexibleHeight
-        }
-        isAccessibilityElement = false
-        isUserInteractionEnabled = false
-    }
-
-    open override var intrinsicContentSize: CGSize {
-        switch orientation {
-        case .horizontal:
-            return CGSize(width: UIView.noIntrinsicMetric, height: frame.height)
-        case .vertical:
-            return CGSize(width: frame.width, height: UIView.noIntrinsicMetric)
-        }
-    }
-
-    open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        switch orientation {
-        case .horizontal:
-            return CGSize(width: size.width, height: frame.height)
-        case .vertical:
-            return CGSize(width: frame.width, height: size.height)
-        }
-    }
-}
->>>>>>> 022e3eed (Partially reverting Divider + bringing back Separator (#1441))

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -162,7 +162,7 @@ open class SideTabBar: UIView {
     }
 
     private var layoutConstraints: [NSLayoutConstraint] = []
-    private let borderLine = MSFDivider(orientation: .vertical)
+    private let borderLine = Separator(style: .shadow, orientation: .vertical)
 
     private let backgroundView: UIVisualEffectView = {
         var style = UIBlurEffect.Style.regular

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -162,7 +162,7 @@ open class SideTabBar: UIView {
     }
 
     private var layoutConstraints: [NSLayoutConstraint] = []
-    private let borderLine = Separator(style: .shadow, orientation: .vertical)
+    private let borderLine = Separator(orientation: .vertical)
 
     private let backgroundView: UIVisualEffectView = {
         var style = UIBlurEffect.Style.regular

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -155,7 +155,7 @@ open class TabBarView: UIView {
         return stackView
     }()
 
-    private let topBorderLine = MSFDivider()
+    private let topBorderLine = Separator(style: .shadow, orientation: .horizontal)
 
     private func updateHeight() {
         if traitCollection.userInterfaceIdiom == .phone {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -155,7 +155,7 @@ open class TabBarView: UIView {
         return stackView
     }()
 
-    private let topBorderLine = Separator(style: .shadow, orientation: .horizontal)
+    private let topBorderLine = Separator(orientation: .horizontal)
 
     private func updateHeight() {
         if traitCollection.userInterfaceIdiom == .phone {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1239,8 +1239,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         return imageView
     }()
 
-    internal let topSeparator = MSFDivider()
-    internal let bottomSeparator = MSFDivider()
+    internal let topSeparator = Separator(style: .default, orientation: .horizontal)
+    internal let bottomSeparator = Separator(style: .default, orientation: .horizontal)
 
     private var superTableView: UITableView? {
         return findSuperview(of: UITableView.self) as? UITableView
@@ -1479,6 +1479,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         layoutContentSubviews()
         contentView.flipSubviewsForRTL()
+
+        layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
+        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)
     }
 
     open func layoutContentSubviews() {
@@ -1572,9 +1575,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             let yOffset = ceil((contentView.frame.height - _accessoryType.size.height) / 2)
             accessoryTypeView.frame = CGRect(origin: CGPoint(x: xOffset, y: yOffset), size: _accessoryType.size)
         }
-
-        layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
-        layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - MSFDivider.thickness)
     }
 
     private func layoutLabelViews(label: UILabel,
@@ -1650,13 +1650,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         trailingAccessoryView?.frame.origin.y += offset
     }
 
-    private func layoutSeparator(_ separator: MSFDivider, with type: SeparatorType, at verticalOffset: CGFloat) {
+    private func layoutSeparator(_ separator: Separator, with type: SeparatorType, at verticalOffset: CGFloat) {
         separator.frame = CGRect(
             x: separatorLeadingInset(for: type),
             y: verticalOffset,
             width: frame.width - separatorLeadingInset(for: type),
-            height: MSFDivider.thickness
+            height: separator.frame.height
         )
+        separator.flipForRTL()
     }
 
     func separatorLeadingInset(for type: SeparatorType) -> CGFloat {
@@ -1931,7 +1932,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         selectionImageView.tintColor = UIColor(dynamicColor: isSelected ? tokenSet[.brandTextColor].dynamicColor : tokenSet[.selectionIndicatorOffColor].dynamicColor)
     }
 
-    private func updateSeparator(_ separator: MSFDivider, with type: SeparatorType) {
+    private func updateSeparator(_ separator: Separator, with type: SeparatorType) {
         separator.isHidden = type == .none
         setNeedsLayout()
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1239,8 +1239,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         return imageView
     }()
 
-    internal let topSeparator = Separator(style: .default, orientation: .horizontal)
-    internal let bottomSeparator = Separator(style: .default, orientation: .horizontal)
+    internal let topSeparator = Separator(orientation: .horizontal)
+    internal let bottomSeparator = Separator(orientation: .horizontal)
 
     private var superTableView: UITableView? {
         return findSuperview(of: UITableView.self) as? UITableView

--- a/ios/README.md
+++ b/ios/README.md
@@ -32,7 +32,6 @@ Some of the controls available include:
 - CardNudge
 - Color
 - DateTimePicker
-- Divider
 - DrawerController
 - HUD
 - IndeterminateProgressBar
@@ -46,6 +45,7 @@ Some of the controls available include:
 - PopupMenuController
 - SearchBar
 - SegmentedControl
+- Separator
 - ShimmerView
 - SideTabBar
 - TabBarView


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,676,864 | 29,437,928 | -238,936 |

Cherry-picking the Separator/Divider partial revert (#1441).

### Verification

Built and ran the simulator, confirmed the affected demos run as expected.

| Main | Fluent2-Colors | After |
|----------------|----------------|----------------|
| ![otherCellsMainLight](https://user-images.githubusercontent.com/23249106/208531751-7e8b357d-aa07-4c98-8da3-199d7f819d41.png) | ![otherCellsColorsLight](https://user-images.githubusercontent.com/23249106/208531767-e7867cb9-00d1-4737-a730-6ac65b159d79.png) | ![otherCellsLightAfter](https://user-images.githubusercontent.com/23249106/208531782-04191355-2366-44ea-88c2-b7f1e62ce3a9.png) |
| ![otherCellsMainDark](https://user-images.githubusercontent.com/23249106/208531749-edb2aa9f-695a-49ec-901f-05a7db2edfab.png) | ![otherCellsColorsDark](https://user-images.githubusercontent.com/23249106/208531765-144327be-61e5-4418-8d97-85274862cc82.png) | ![otherCellsDarkAfter](https://user-images.githubusercontent.com/23249106/208531781-76631172-2791-48ee-bdd9-30d260bfc86a.png) |
| ![tableViewMainLight](https://user-images.githubusercontent.com/23249106/208531744-7ef2e00e-0cb9-4210-9cea-80b2ea9a0f56.png) | ![tableViewColorsLight](https://user-images.githubusercontent.com/23249106/208531761-8bf0932d-17b9-42b7-a39d-7ba121449389.png) | ![tableViewLightAfter](https://user-images.githubusercontent.com/23249106/208531779-836359ae-f99b-4b7d-801d-49a342a85cf1.png) |
| ![tableViewMainDark](https://user-images.githubusercontent.com/23249106/208531741-2100a2e5-7702-430d-90a1-3d2bf60e55b9.png) | ![tableViewColorsDark](https://user-images.githubusercontent.com/23249106/208531759-80d9ce00-b476-4db9-9ff9-520057bae547.png) | ![tableViewDarkAfter](https://user-images.githubusercontent.com/23249106/208531778-d5127a33-6412-4ed6-bf4c-60c45529d9a4.png) |
| ![dateTimeMainLight](https://user-images.githubusercontent.com/23249106/208531735-02942b44-5157-4413-9ed5-3c7b20bf7315.png) | ![dateTimeColorsLight](https://user-images.githubusercontent.com/23249106/208531758-a4585a3f-0e1f-40e2-b974-54d938bf86bc.png) | ![dateTimeLightAfter](https://user-images.githubusercontent.com/23249106/208531775-e6d484a6-2af8-4654-b82c-38b5aa0fe2d0.png) |
| ![dateTimeMainDark](https://user-images.githubusercontent.com/23249106/208531728-1b2531ae-d510-4a21-a869-238b1ba37e6a.png) | ![dateTimeColorsDark](https://user-images.githubusercontent.com/23249106/208531756-d96de2ad-bf8f-4b11-bd6b-3110dcd380a7.png) | ![dateTimeDarkAfter](https://user-images.githubusercontent.com/23249106/208531774-d7173217-b0b5-4e6a-b190-7ba01a1caa80.png) |
| ![popupMainLight](https://user-images.githubusercontent.com/23249106/208531722-2736f7a1-9791-4dbb-aa23-f5458b2f7869.png) | ![popupColorsLight](https://user-images.githubusercontent.com/23249106/208531754-8e43c0d8-fa9b-426a-80c8-f6244bb64f82.png) | ![popupLightAfter](https://user-images.githubusercontent.com/23249106/208531773-8cb12032-caf7-4396-94de-06e1cb8878b9.png) |
| ![popupMainDark](https://user-images.githubusercontent.com/23249106/208531714-ff57f5cf-cd74-40f5-8f5d-e1d97d152065.png) | ![popupColorsDark](https://user-images.githubusercontent.com/23249106/208531752-86c3968b-5104-459a-a286-d8481aa25088.png) | ![popupDarkAfter](https://user-images.githubusercontent.com/23249106/208531772-d6017723-3e0d-4f80-b833-9e82bd984266.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1460)