### PR TITLE
Rewrite `ShadowTokensDemoController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -36,7 +36,7 @@ class ShadowView: UIView, Shadowable {
     private struct Constants {
         static let borderWidth: CGFloat = 0.1
         static let cornerRadius: CGFloat = 8.0
-        static let width: CGFloat = 150
+        static let width: CGFloat = 200
         static let height: CGFloat = 70
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -7,45 +7,25 @@ import FluentUI
 import UIKit
 
 class ShadowTokensDemoController: DemoController {
-    var cards: [CardView] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        container.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stencil2])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stencil2])
 
         container.alignment = .center
-        container.spacing = Constants.spacing
-
+        container.spacing = 120
         initCards()
 
         container.addArrangedSubview(UIView())
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        updateShadows()
-    }
-
     private func initCards() {
-        let demoIcon = UIImage(named: "flag-24x24")
-
         for shadow in AliasTokens.ShadowTokens.allCases {
-            let card = CardView(size: .large, title: shadow.title, icon: demoIcon!, colorStyle: .neutral)
-            cards.append(card)
-            container.addArrangedSubview(card)
+            let view = ShadowView(shadowInfo: container.fluentTheme.aliasTokens.shadow[shadow],
+                                  title: shadow.title)
+            container.addArrangedSubview(view)
         }
-    }
-
-    private func updateShadows() {
-        for index in 0..<AliasTokens.ShadowTokens.allCases.count {
-            let shadowInfo = view.fluentTheme.aliasTokens.shadow[AliasTokens.ShadowTokens.allCases[index]]
-            shadowInfo.applyShadow(to: cards[index])
-        }
-    }
-
-    private struct Constants {
-        static let spacing: CGFloat = 120
     }
 }
 
@@ -67,5 +47,52 @@ private extension AliasTokens.ShadowTokens {
         case .shadow64:
             return "Shadow64"
         }
+    }
+}
+
+class ShadowView: UIView, Shadowable {
+    var shadow1: CALayer?
+    var shadow2: CALayer?
+
+    let shadowInfo: ShadowInfo
+    let label = Label()
+
+    init(shadowInfo: ShadowInfo, title: String) {
+        self.shadowInfo = shadowInfo
+
+        super.init(frame: .zero)
+
+        layer.borderWidth = 0.1
+        layer.cornerRadius = 8.0
+
+        label.text = title
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+        addSubview(label)
+
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        setupLayoutConstraints()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateShadows()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func updateShadows() {
+        shadowInfo.applyShadow(to: self)
+    }
+
+    private func setupLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: 150),
+            heightAnchor.constraint(equalToConstant: 70),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -30,6 +30,7 @@ class ShadowTokensDemoController: DemoController {
     }
 }
 
+// Custom View thats needs to conform to the Shadowable protocol to apply Fluent shadow tokens
 class ShadowView: UIView, Shadowable {
 
     private struct Constants {
@@ -65,6 +66,8 @@ class ShadowView: UIView, Shadowable {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+        // Make sure shadows are applied in the view's layoutSubviews function
         updateShadows()
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -31,7 +31,7 @@ class ShadowTokensDemoController: DemoController {
 }
 
 // Custom View thats needs to conform to the Shadowable protocol to apply Fluent shadow tokens
-class ShadowView: UIView, Shadowable {
+private class ShadowView: UIView, Shadowable {
 
     private struct Constants {
         static let borderWidth: CGFloat = 0.1

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -15,17 +15,74 @@ class ShadowTokensDemoController: DemoController {
 
         container.alignment = .center
         container.spacing = 120
-        initCards()
+
+        initializeShadowViews()
 
         container.addArrangedSubview(UIView())
     }
 
-    private func initCards() {
-        for shadow in AliasTokens.ShadowTokens.allCases {
-            let view = ShadowView(shadowInfo: container.fluentTheme.aliasTokens.shadow[shadow],
-                                  title: shadow.title)
-            container.addArrangedSubview(view)
+    private func initializeShadowViews() {
+        for shadowToken in AliasTokens.ShadowTokens.allCases {
+            let shadowView = ShadowView(shadowInfo: container.fluentTheme.aliasTokens.shadow[shadowToken],
+                                        title: shadowToken.title)
+            container.addArrangedSubview(shadowView)
         }
+    }
+}
+
+class ShadowView: UIView, Shadowable {
+
+    private struct Constants {
+        static let borderWidth: CGFloat = 0.1
+        static let cornerRadius: CGFloat = 8.0
+        static let width: CGFloat = 150
+        static let height: CGFloat = 70
+    }
+
+    var shadow1: CALayer?
+    var shadow2: CALayer?
+
+    let shadowInfo: ShadowInfo
+    let label = Label()
+
+    init(shadowInfo: ShadowInfo, title: String) {
+        self.shadowInfo = shadowInfo
+
+        super.init(frame: .zero)
+
+        layer.borderWidth = Constants.borderWidth
+        layer.cornerRadius = Constants.cornerRadius
+
+        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+
+        label.text = title
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+        addSubview(label)
+
+        setupLayoutConstraints()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateShadows()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func updateShadows() {
+        shadowInfo.applyShadow(to: self)
+    }
+
+    private func setupLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: Constants.width),
+            heightAnchor.constraint(equalToConstant: Constants.height),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
     }
 }
 
@@ -47,52 +104,5 @@ private extension AliasTokens.ShadowTokens {
         case .shadow64:
             return "Shadow64"
         }
-    }
-}
-
-class ShadowView: UIView, Shadowable {
-    var shadow1: CALayer?
-    var shadow2: CALayer?
-
-    let shadowInfo: ShadowInfo
-    let label = Label()
-
-    init(shadowInfo: ShadowInfo, title: String) {
-        self.shadowInfo = shadowInfo
-
-        super.init(frame: .zero)
-
-        layer.borderWidth = 0.1
-        layer.cornerRadius = 8.0
-
-        label.text = title
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-        addSubview(label)
-
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
-        setupLayoutConstraints()
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        updateShadows()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    private func updateShadows() {
-        shadowInfo.applyShadow(to: self)
-    }
-
-    private func setupLayoutConstraints() {
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: 150),
-            heightAnchor.constraint(equalToConstant: 70),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
-            label.centerXAnchor.constraint(equalTo: centerXAnchor)
-        ])
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`ShadowTokensDemoController` is rewritten to better show how to use our new shadow tokens API. The demo now shows a custom `ShadowView` that conforms to the `Shadowable` protocol instead of using `Cardview`s and changing their shadows.
This change also fixes a bug where switching between light and dark modes resets the `CardView`s to use Shadow02 instead of their respective new shadow set in  `ShadowTokensDemoController`. 

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,143,232 bytes | 29,143,232 bytes | 0 bytes |

### Verification

The change was tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_1_light" src="https://user-images.githubusercontent.com/106181067/208793990-03b518c0-4d11-48de-8f9e-d80b23410927.png"> | <img width="487" alt="after_1_light" src="https://user-images.githubusercontent.com/106181067/208793999-72758303-8f1f-4c0c-b1bf-5b20ec9cc2f1.png"> |
| <img width="487" alt="before_2_light" src="https://user-images.githubusercontent.com/106181067/208794029-de391bc4-95e2-41e9-ad28-4517b5c30f77.png"> | <img width="487" alt="after_2_light" src="https://user-images.githubusercontent.com/106181067/208794043-5c45fc47-27e1-4d4f-95f3-3ae1f6bc58a6.png"> |
| <img width="487" alt="before_1_dark" src="https://user-images.githubusercontent.com/106181067/208794076-3d9e347e-b706-45be-8207-99eafc3e9aea.png"> | <img width="487" alt="after_1_dark" src="https://user-images.githubusercontent.com/106181067/208794082-06bbe23a-e3a9-402a-9c71-ddc0d6e293f8.png"> |
| <img width="487" alt="before_2_dark" src="https://user-images.githubusercontent.com/106181067/208794120-4bd3417d-5e95-4046-a62c-a8d5177969e0.png"> | <img width="487" alt="after_2_dark" src="https://user-images.githubusercontent.com/106181067/208794131-f7fd3c92-7c93-4eb9-b7e9-1db50204a973.png"> |
| ![bug](https://user-images.githubusercontent.com/106181067/208794155-bca6da40-3bab-4946-bf1e-d360ae054202.gif) | ![bugfix](https://user-images.githubusercontent.com/106181067/208794167-9b396ab2-b05d-445c-9b93-750795811061.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1464)