### PR TITLE
Move communication blue colors from AliasTokens to GlobalTokens

### DIFF
--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -31,21 +31,29 @@ public final class AliasTokens: NSObject {
     public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
         switch token {
         case .primary:
-            return DynamicColor(light: ColorValue(0x0F6CBD) /*comm80*/, dark: ColorValue(0x2886DE) /*comm90*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                dark: GlobalTokens.brandColors(.comm90))
         case .shade10:
-            return DynamicColor(light: ColorValue(0x115EA3) /*comm70*/, dark: ColorValue(0x292929) /*comm100*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm70),
+                                dark: GlobalTokens.brandColors(.comm100))
         case .shade20:
-            return DynamicColor(light: ColorValue(0x0F548C) /*comm60*/, dark: ColorValue(0x479EF5) /*comm110*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
+                                dark: GlobalTokens.brandColors(.comm110))
         case .shade30:
-            return DynamicColor(light: ColorValue(0x0E4775) /*comm50*/, dark: ColorValue(0x77B7F7) /*comm120*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm50),
+                                dark: GlobalTokens.brandColors(.comm120))
         case .tint10:
-            return DynamicColor(light: ColorValue(0x2886DE) /*comm90*/, dark: ColorValue(0x0F6CBD) /*comm80*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm90),
+                                dark: GlobalTokens.brandColors(.comm80))
         case .tint20:
-            return DynamicColor(light: ColorValue(0x292929) /*comm100*/, dark: ColorValue(0x115EA3) /*comm70*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm100),
+                                dark: GlobalTokens.brandColors(.comm70))
         case .tint30:
-            return DynamicColor(light: ColorValue(0x479EF5) /*comm110*/, dark: ColorValue(0x0C3B5E) /*comm90*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm110),
+                                dark: GlobalTokens.brandColors(.comm90))
         case .tint40:
-            return DynamicColor(light: ColorValue(0xB4D6FA) /*comm140*/, dark: ColorValue(0x082338) /*comm20*/)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm140),
+                                dark: GlobalTokens.brandColors(.comm20))
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -20,22 +20,6 @@ public final class AliasTokens: NSObject {
         case tint20
         case tint30
         case tint40
-        case comm10
-        case comm20
-        case comm30
-        case comm40
-        case comm50
-        case comm60
-        case comm70
-        case comm80
-        case comm90
-        case comm100
-        case comm110
-        case comm120
-        case comm130
-        case comm140
-        case comm150
-        case comm160
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `brandColors` property directly.")
@@ -62,38 +46,6 @@ public final class AliasTokens: NSObject {
             return DynamicColor(light: ColorValue(0x479EF5) /*comm110*/, dark: ColorValue(0x0C3B5E) /*comm90*/)
         case .tint40:
             return DynamicColor(light: ColorValue(0xB4D6FA) /*comm140*/, dark: ColorValue(0x082338) /*comm20*/)
-        case .comm10:
-            return DynamicColor(light: ColorValue(0x061724))
-        case .comm20:
-            return DynamicColor(light: ColorValue(0x082338))
-        case .comm30:
-            return DynamicColor(light: ColorValue(0x0A2E4A))
-        case .comm40:
-            return DynamicColor(light: ColorValue(0x0C3B5E))
-        case .comm50:
-            return DynamicColor(light: ColorValue(0x0E4775))
-        case .comm60:
-            return DynamicColor(light: ColorValue(0x0F548C))
-        case .comm70:
-            return DynamicColor(light: ColorValue(0x115EA3))
-        case .comm80:
-            return DynamicColor(light: ColorValue(0x0F6CBD))
-        case .comm90:
-            return DynamicColor(light: ColorValue(0x2886DE))
-        case .comm100:
-            return DynamicColor(light: ColorValue(0x479EF5))
-        case .comm110:
-            return DynamicColor(light: ColorValue(0x62ABF5))
-        case .comm120:
-            return DynamicColor(light: ColorValue(0x77B7F7))
-        case .comm130:
-            return DynamicColor(light: ColorValue(0x96C6FA))
-        case .comm140:
-            return DynamicColor(light: ColorValue(0xB4D6FA))
-        case .comm150:
-            return DynamicColor(light: ColorValue(0xCFE4FA))
-        case .comm160:
-            return DynamicColor(light: ColorValue(0xEBF3FC))
         }
     }
 
@@ -604,25 +556,25 @@ public final class AliasTokens: NSObject {
         case .foregroundInverted1:
             return DynamicColor(light: GlobalTokens.neutralColors(.white))
         case .foregroundInverted2:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
                                 dark: GlobalTokens.neutralColors(.white))
         case .brandForegroundTint:
-            return DynamicColor(light: strongSelf.brandColors[.comm60].light,
-                                dark: strongSelf.brandColors[.comm130].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
+                                dark: GlobalTokens.brandColors(.comm130))
         case .brandForeground1:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
-                                dark: strongSelf.brandColors[.comm100].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                dark: GlobalTokens.brandColors(.comm100))
         case .brandForeground1Pressed:
-            return DynamicColor(light: strongSelf.brandColors[.comm50].light,
-                                dark: strongSelf.brandColors[.comm140].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm50),
+                                dark: GlobalTokens.brandColors(.comm140))
         case .brandForeground1Selected:
-            return DynamicColor(light: strongSelf.brandColors[.comm60].light,
-                                dark: strongSelf.brandColors[.comm120].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
+                                dark: GlobalTokens.brandColors(.comm120))
         case .brandForegroundDisabled1:
-            return DynamicColor(light: strongSelf.brandColors[.comm90].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm90))
         case .brandForegroundDisabled2:
-            return DynamicColor(light: strongSelf.brandColors[.comm140].light,
-                                dark: strongSelf.brandColors[.comm40].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm140),
+                                dark: GlobalTokens.brandColors(.comm40))
         case .foregroundDarkStatic:
             return DynamicColor(light: GlobalTokens.neutralColors(.black),
                                 dark: GlobalTokens.neutralColors(.black))
@@ -691,12 +643,12 @@ public final class AliasTokens: NSObject {
                              dark: GlobalTokens.neutralColors(.grey38),
                              darkElevated: GlobalTokens.neutralColors(.grey38))
         case .background5SelectedBrandFilled:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
-                             dark: GlobalTokens.neutralColors(.grey38),
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                dark: GlobalTokens.neutralColors(.grey38),
                                 darkElevated: GlobalTokens.neutralColors(.grey38))
         case .background5BrandTint:
-            return DynamicColor(light: strongSelf.brandColors[.comm160].light,
-                             dark: GlobalTokens.neutralColors(.grey38),
+            return DynamicColor(light: GlobalTokens.brandColors(.comm160),
+                                dark: GlobalTokens.neutralColors(.grey38),
                                 darkElevated: GlobalTokens.neutralColors(.grey38))
         case .background6:
          return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
@@ -715,38 +667,38 @@ public final class AliasTokens: NSObject {
                              dark: GlobalTokens.neutralColors(.grey32),
                              darkElevated: GlobalTokens.neutralColors(.grey32))
         case .brandBackgroundTint:
-            return DynamicColor(light: strongSelf.brandColors[.comm150].light,
-                                dark: strongSelf.brandColors[.comm40].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm150),
+                                dark: GlobalTokens.brandColors(.comm40))
         case .brandBackground1:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
-                                dark: strongSelf.brandColors[.comm100].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                dark: GlobalTokens.brandColors(.comm100))
         case .brandBackground1Pressed:
-            return DynamicColor(light: strongSelf.brandColors[.comm50].light,
-                                dark: strongSelf.brandColors[.comm140].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm50),
+                                dark: GlobalTokens.brandColors(.comm140))
         case .brandBackground1Selected:
-            return DynamicColor(light: strongSelf.brandColors[.comm60].light,
-                                dark: strongSelf.brandColors[.comm120].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
+                                dark: GlobalTokens.brandColors(.comm120))
         case .brandBackground2:
-            return DynamicColor(light: strongSelf.brandColors[.comm70].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm70))
         case .brandBackground2Pressed:
-            return DynamicColor(light: strongSelf.brandColors[.comm40].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm40))
         case .brandBackground2Selected:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80))
         case .brandBackground3:
-            return DynamicColor(light: strongSelf.brandColors[.comm60].light,
-                                dark: strongSelf.brandColors[.comm120].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
+                                dark: GlobalTokens.brandColors(.comm120))
         case .brandBackground3Pressed:
-            return DynamicColor(light: strongSelf.brandColors[.comm30].light,
-                                dark: strongSelf.brandColors[.comm160].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm30),
+                                dark: GlobalTokens.brandColors(.comm160))
         case .background5BrandFilledSelected:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
                                 dark: GlobalTokens.neutralColors(.grey38))
         case .background5BrandTintSelected:
-            return DynamicColor(light: strongSelf.brandColors[.comm160].light,
+            return DynamicColor(light: GlobalTokens.brandColors(.comm160),
                                 dark: GlobalTokens.neutralColors(.grey38))
         case .brandBackgroundDisabled:
-            return DynamicColor(light: strongSelf.brandColors[.comm140].light,
-                                dark: strongSelf.brandColors[.comm40].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm140),
+                                dark: GlobalTokens.brandColors(.comm40))
         case .stencil1:
          return DynamicColor(light: GlobalTokens.neutralColors(.grey90),
                              dark: GlobalTokens.neutralColors(.grey34))
@@ -794,14 +746,14 @@ public final class AliasTokens: NSObject {
             return DynamicColor(light: GlobalTokens.neutralColors(.black),
                                 dark: GlobalTokens.neutralColors(.white))
         case .brandStroke1:
-            return DynamicColor(light: strongSelf.brandColors[.comm80].light,
-                                dark: strongSelf.brandColors[.comm100].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                dark: GlobalTokens.brandColors(.comm100))
         case .brandStroke1Pressed:
-            return DynamicColor(light: strongSelf.brandColors[.comm50].light,
-                                dark: strongSelf.brandColors[.comm140].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm50),
+                                dark: GlobalTokens.brandColors(.comm140))
         case .brandStroke1Selected:
-            return DynamicColor(light: strongSelf.brandColors[.comm60].light,
-                                dark: strongSelf.brandColors[.comm120].light)
+            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
+                                dark: GlobalTokens.brandColors(.comm120))
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -9,6 +9,66 @@ import SwiftUI
 @objc(MSFGlobalTokens)
 public class GlobalTokens: NSObject {
 
+    // MARK: - BrandColors
+
+    @objc(MSFBrandColorsGlobalTokens)
+    public enum BrandColorsTokens: Int, TokenSetKey {
+        case comm10
+        case comm20
+        case comm30
+        case comm40
+        case comm50
+        case comm60
+        case comm70
+        case comm80
+        case comm90
+        case comm100
+        case comm110
+        case comm120
+        case comm130
+        case comm140
+        case comm150
+        case comm160
+    }
+
+    @objc(brandColorForGlobalToken:)
+    public static func brandColors(_ token: BrandColorsTokens) -> ColorValue {
+        switch token {
+        case .comm10:
+            return ColorValue(0x061724)
+        case .comm20:
+            return ColorValue(0x082338)
+        case .comm30:
+            return ColorValue(0x0A2E4A)
+        case .comm40:
+            return ColorValue(0x0C3B5E)
+        case .comm50:
+            return ColorValue(0x0E4775)
+        case .comm60:
+            return ColorValue(0x0F548C)
+        case .comm70:
+            return ColorValue(0x115EA3)
+        case .comm80:
+            return ColorValue(0x0F6CBD)
+        case .comm90:
+            return ColorValue(0x2886DE)
+        case .comm100:
+            return ColorValue(0x479EF5)
+        case .comm110:
+            return ColorValue(0x62ABF5)
+        case .comm120:
+            return ColorValue(0x77B7F7)
+        case .comm130:
+            return ColorValue(0x96C6FA)
+        case .comm140:
+            return ColorValue(0xB4D6FA)
+        case .comm150:
+            return ColorValue(0xCFE4FA)
+        case .comm160:
+            return ColorValue(0xEBF3FC)
+        }
+    }
+
     // MARK: - NeutralColors
 
     @objc(MSFNeutralColorsToken)

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -162,10 +162,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .dynamicColor { theme.aliasTokens.colors[.brandBackground1] }
 
             case .communicationTextColor:
-                return .dynamicColor {
-                    DynamicColor(light: theme.aliasTokens.brandColors[.comm80].light,
-                                 dark: theme.aliasTokens.brandColors[.comm100].light)
-                }
+                return .dynamicColor { theme.aliasTokens.colors[.brandStroke1] }
 
             case .paddingLeading:
                 return .float { GlobalTokens.spacing(.size160) }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Comm blue colors are moved from `AliasTokens` to `GlobalTokens` and all the references are updated to match the change.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,143,232 bytes | 29,163,248 bytes | 20,016 bytes |
| AliasTokens | 379,632 bytes | 379,472 bytes | -160 bytes |
| GlobalTokens | 458,976 bytes | 478,672 bytes | 19,696 bytes |
| TvcTokenSet | 114,576 bytes | 112,096 bytes | -2,480 bytes |

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_bb_light" src="https://user-images.githubusercontent.com/106181067/209218742-143369c9-494e-4b58-87cc-7de8e0092266.png"> | <img width="487" alt="after_bb_light" src="https://user-images.githubusercontent.com/106181067/209218755-1516d661-8256-44d9-8eaa-63d3fa49c141.png"> |
| <img width="487" alt="before_bb_dark" src="https://user-images.githubusercontent.com/106181067/209218789-be0ce29c-8042-47ca-83e3-118502da3fb9.png"> | <img width="487" alt="after_bb_dark" src="https://user-images.githubusercontent.com/106181067/209218796-e10bee2e-2376-46cf-9274-56a0ce674570.png"> |
| <img width="487" alt="before_bf_light" src="https://user-images.githubusercontent.com/106181067/209218823-490a519b-b0c4-4118-9a95-87d31670bd39.png"> | <img width="487" alt="after_bf_light" src="https://user-images.githubusercontent.com/106181067/209218840-d554dbb7-8f7f-4fb3-a777-bd639579c88d.png"> |
| <img width="487" alt="before_bf_dark" src="https://user-images.githubusercontent.com/106181067/209218863-8512d39a-1c4d-4033-a90b-463b91806599.png"> | <img width="487" alt="after_bf_dark" src="https://user-images.githubusercontent.com/106181067/209218868-f0998726-235a-4e99-aee0-76da51b37d94.png"> |
| <img width="487" alt="before_bs_light" src="https://user-images.githubusercontent.com/106181067/209218893-48536bec-37a8-47e1-be73-e4a41a3b741e.png"> | <img width="487" alt="after_bs_light" src="https://user-images.githubusercontent.com/106181067/209218906-812ce96d-6ecb-48e1-89a3-8ce05ee4fb70.png"> |
| <img width="487" alt="before_bs_dark" src="https://user-images.githubusercontent.com/106181067/209218953-1aece1e1-d91e-4f50-ad2c-912e85bebed8.png"> | <img width="487" alt="after_bs_dark" src="https://user-images.githubusercontent.com/106181067/209218980-b2f9af20-4a5d-4f13-801f-26f22f534a12.png"> |
| <img width="487" alt="before_tvc_light" src="https://user-images.githubusercontent.com/106181067/209219013-13266058-9278-4b80-8f73-e9d71e6064d4.png"> | <img width="487" alt="after_tvc_light" src="https://user-images.githubusercontent.com/106181067/209219028-6f8be3d9-1722-46c2-9720-2961dd339ec7.png"> |
| <img width="487" alt="before_tvc_dark" src="https://user-images.githubusercontent.com/106181067/209219087-b0376c9c-9187-4c4b-8e19-24d470a8e8e8.png"> | <img width="487" alt="after_tvc_dark" src="https://user-images.githubusercontent.com/106181067/209219112-2f72d553-2f31-4d8a-ad0e-96703f8387ff.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)