### PR TITLE
Initial standalone implementation of colors2.swift functionality

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		C038992E2359307D00265026 /* TableViewCellShimmerDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */; };
 		C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */; };
 		CCC18C2F2501C75F00BE830E /* CardViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */; };
+		D6296DB1295B8E5E002E8EB6 /* ObjectiveCDemoColorProviding2.m in Sources */ = {isa = PBXBuildFile; fileRef = D6296DB0295B8E5E002E8EB6 /* ObjectiveCDemoColorProviding2.m */; };
 		E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842973247B672000A29C40 /* SceneDelegate.swift */; };
 		E6842996247C350700A29C40 /* DemoColorThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6842995247C350700A29C40 /* DemoColorThemes.swift */; };
 		EC1C31752923032000CF052C /* ColoredPillBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */; };
@@ -145,6 +146,8 @@
 		C038992D2359307D00265026 /* TableViewCellShimmerDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellShimmerDemoController.swift; sourceTree = "<group>"; };
 		C0938E49235F733100256251 /* ShimmerLinesViewDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShimmerLinesViewDemoController.swift; sourceTree = "<group>"; };
 		CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewDemoController.swift; sourceTree = "<group>"; };
+		D6296DAF295B8E1A002E8EB6 /* ObjectiveCDemoColorProviding2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjectiveCDemoColorProviding2.h; sourceTree = "<group>"; };
+		D6296DB0295B8E5E002E8EB6 /* ObjectiveCDemoColorProviding2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveCDemoColorProviding2.m; sourceTree = "<group>"; };
 		E6842973247B672000A29C40 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		E6842995247C350700A29C40 /* DemoColorThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoColorThemes.swift; sourceTree = "<group>"; };
 		EC1C31742923032000CF052C /* ColoredPillBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredPillBackgroundView.swift; sourceTree = "<group>"; };
@@ -327,7 +330,6 @@
 				B4D852DA225C010A004B1B29 /* ButtonDemoController.swift */,
 				92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */,
 				CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */,
-				6FEED93A28A6E5520099D178 /* ColorAliasTokensDemoController.swift */,
 				114CF8B72423E10900D064AA /* ColorDemoController.swift */,
 				9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */,
 				FC414E3625888BC300069E73 /* CommandBarDemoController.swift */,
@@ -342,6 +344,8 @@
 				A589F855211BA71000471C23 /* LabelDemoController.swift */,
 				FD41C8F322E28EEB0086F899 /* NavigationControllerDemoController.swift */,
 				A5B6617523A4227300E801DD /* NotificationViewDemoController.swift */,
+				D6296DAF295B8E1A002E8EB6 /* ObjectiveCDemoColorProviding2.h */,
+				D6296DB0295B8E5E002E8EB6 /* ObjectiveCDemoColorProviding2.m */,
 				FDDD73FC22C6D86B00A9D995 /* ObjectiveCDemoController.h */,
 				FDDD73FB22C6D86B00A9D995 /* ObjectiveCDemoController.m */,
 				B441478E228E02540040E88E /* OtherCellsDemoController.swift */,
@@ -365,7 +369,7 @@
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
 				92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */,
 				6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */,
-				6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */
+				6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -510,6 +514,7 @@
 				92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */,
 				5303259826B31A6300611D05 /* FluentUIDemoToggle.swift in Sources */,
 				9245E1F927BECDBB007616F3 /* GlobalColorTokensDemoController.swift in Sources */,
+				D6296DB1295B8E5E002E8EB6 /* ObjectiveCDemoColorProviding2.m in Sources */,
 				6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */,
 				6FEED93B28A6E5520099D178 /* AliasColorTokensDemoController.swift in Sources */,
 				A5DCA760211E3B4C005F4CB7 /* DemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoColorProviding2.h
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoColorProviding2.h
@@ -1,0 +1,16 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#import <UIKit/UIKit.h>
+#import <FluentUI/FluentUI-Swift.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ObjectiveCDemoColorProviding2 : NSObject<MSFColorProviding2>
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoColorProviding2.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoColorProviding2.m
@@ -1,0 +1,128 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#import "ObjectiveCDemoColorProviding2.h"
+#import <FluentUI/FluentUI-Swift.h>
+#import <FluentUI_Demo-Swift.h>
+
+@interface ObjectiveCDemoColorProviding2 () <MSFColorProviding2>
+
+@end
+
+@implementation ObjectiveCDemoColorProviding2
+
+- (UIColor * _Nullable)brandBackgroundColor:(MSFFluentTheme * _Nonnull)theme {
+    MSFColorValue *lightColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
+                                                                  token:MSFSharedColorsTokensTint40];
+    MSFColorValue *darkColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
+                                                                  token:MSFSharedColorsTokensShade30];
+
+    MSFDynamicColor *dynamicColor = [[MSFDynamicColor alloc] initWithLight:lightColor
+                                                             lightHighContrast:nil
+                                                             lightElevated:nil
+                                                 lightElevatedHighContrast:nil
+                                                                      dark:darkColor
+                                                          darkHighContrast:nil
+                                                              darkElevated:nil
+                                                  darkElevatedHighContrast:nil];
+
+    return [[UIColor alloc] initWithDynamicColor:dynamicColor];
+}
+
+- (UIColor * _Nullable)brandForegroundColor:(MSFFluentTheme * _Nonnull)theme {
+    MSFColorValue *lightColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
+                                                                  token:MSFSharedColorsTokensShade30];
+    MSFColorValue *darkColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
+                                                                token:MSFSharedColorsTokensTint40];
+
+    MSFDynamicColor *dynamicColor = [[MSFDynamicColor alloc] initWithLight:lightColor
+                                                             lightHighContrast:nil
+                                                             lightElevated:nil
+                                                 lightElevatedHighContrast:nil
+                                                                      dark:darkColor
+                                                          darkHighContrast:nil
+                                                              darkElevated:nil
+                                                  darkElevatedHighContrast:nil];
+
+    return [[UIColor alloc] initWithDynamicColor:dynamicColor];
+}
+
+- (UIColor * _Nullable)brandStrokeColor:(MSFFluentTheme * _Nonnull)theme {
+    return nil;
+}
+
+- (UIColor * _Nullable)brandBackground1For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackground1PressedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackground1SelectedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackground2For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackground2PressedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackground2SelectedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackground3For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackgroundDisabledFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandBackgroundTintFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandBackgroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandForeground1For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandForegroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandForeground1PressedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandForegroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandForeground1SelectedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandForegroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandForegroundDisabled1For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandForegroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandForegroundDisabled2For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandForegroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandForegroundTintFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandForegroundColor:theme];
+}
+
+- (UIColor * _Nullable)brandStroke1For:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandStrokeColor:theme];
+}
+
+- (UIColor * _Nullable)brandStroke1PressedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandStrokeColor:theme];
+}
+
+- (UIColor * _Nullable)brandStroke1SelectedFor:(MSFFluentTheme * _Nonnull)theme {
+    return [self brandStrokeColor:theme];
+}
+
+@end

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -98,7 +98,7 @@
 }
 
 - (void)overridesButtonPressed:(id)sender {
-    [MSFColors2 setProviderWithProvider:[ObjectiveCDemoColorProviding2 alloc] for:[self.view fluentTheme]];
+    [MSFFluentTheme setProviderWithProvider:[ObjectiveCDemoColorProviding2 alloc] for:[self.view fluentTheme]];
 
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
     MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
@@ -108,10 +108,10 @@
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     // Remove the overrides
-    [MSFColors2 removeProviderFor:([self.view fluentTheme])];
+    [MSFFluentTheme removeProviderFor:([self.view fluentTheme])];
     primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];
 
-    [self addLabelWithText:@"Test label with fixed brand color"
+    [self addLabelWithText:@"Test label with override color removed"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -103,7 +103,15 @@
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
     MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
     MSFDynamicColor *primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];
+
     [self addLabelWithText:@"Test label with override brand color"
+                 textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
+
+    // Remove the overrides
+    [MSFColors2 removeProviderFor:([self.view fluentTheme])];
+    primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];
+
+    [self addLabelWithText:@"Test label with fixed brand color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -4,6 +4,7 @@
 //
 
 #import "ObjectiveCDemoController.h"
+#import "ObjectiveCDemoColorProviding2.h"
 #import <FluentUI/FluentUI-Swift.h>
 #import <FluentUI_Demo-Swift.h>
 
@@ -17,6 +18,8 @@
 @property (nonatomic) UIViewController *appearanceController; // Type-erased to UIViewController because UIHostingController subclasses can't be represented directly in @objc
 
 @property (nonatomic) NSMutableSet<UILabel *> *addedLabels;
+
+@property (nonatomic) ObjectiveCDemoColorProviding2 *colorProvider;
 
 @end
 
@@ -44,8 +47,12 @@
         [[self.container widthAnchor] constraintEqualToAnchor:[self.scrollingContainer widthAnchor]],
     ]];
 
-    MSFButton *testButton = [self createButtonWithTitle:@"Test" action:@selector(buttonPressed:)];
-    [self.container addArrangedSubview:testButton];
+    MSFButton *testTokensButton = [self createButtonWithTitle:@"Test global and alias" action:@selector(tokensButtonPressed:)];
+    [self.container addArrangedSubview:testTokensButton];
+
+
+    MSFButton *testOverridesButton = [self createButtonWithTitle:@"Test overrides" action:@selector(overridesButtonPressed:)];
+    [self.container addArrangedSubview:testOverridesButton];
 
     [self setAddedLabels:[NSMutableSet set]];
 
@@ -56,6 +63,8 @@
                                              selector: @selector(themeDidChange:)
                                                  name: @"FluentUI.stylesheet.theme"
                                                object: nil];
+
+    [MSFColors2 setProviderWithProvider:[ObjectiveCDemoColorProviding2 alloc] for:[self.view fluentTheme]];
 }
 
 - (void)resetAddedLabels {
@@ -76,7 +85,7 @@
     [[self addedLabels] addObject:label];
 }
 
-- (void)buttonPressed:(id)sender {
+- (void)tokensButtonPressed:(id)sender {
     MSFColorValue *colorValue = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsPink
                                                                   token:MSFSharedColorsTokensPrimary];
     [self addLabelWithText:@"Test label with global color"
@@ -87,6 +96,14 @@
     MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
     MSFDynamicColor *primaryColor = [aliasTokens brandColorForToken:MSFBrandColorsAliasTokensPrimary];
     [self addLabelWithText:@"Test label with alias color"
+                 textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
+}
+
+- (void)overridesButtonPressed:(id)sender {
+    MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
+    MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
+    MSFDynamicColor *primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];
+    [self addLabelWithText:@"Test label with override brand color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -102,14 +102,14 @@
 
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
     MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];
+    MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandBackground1];
 
     [self addLabelWithText:@"Test label with override brand color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     // Remove the overrides
     [MSFFluentTheme removeProviderFor:([self.view fluentTheme])];
-    primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];
+    primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
 
     [self addLabelWithText:@"Test label with override color removed"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -63,8 +63,6 @@
                                              selector: @selector(themeDidChange:)
                                                  name: @"FluentUI.stylesheet.theme"
                                                object: nil];
-
-    [MSFColors2 setProviderWithProvider:[ObjectiveCDemoColorProviding2 alloc] for:[self.view fluentTheme]];
 }
 
 - (void)resetAddedLabels {
@@ -100,6 +98,8 @@
 }
 
 - (void)overridesButtonPressed:(id)sender {
+    [MSFColors2 setProviderWithProvider:[ObjectiveCDemoColorProviding2 alloc] for:[self.view fluentTheme]];
+
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
     MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
     MSFDynamicColor *primaryColor = [aliasTokens colorsForToken:MSFColorsAliasTokensBrandForeground1];

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		C708B064260A87F7007190FA /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708B04B260A8696007190FA /* SegmentItem.swift */; };
 		C77A04B825F03DD1001B3EB6 /* String+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04B625F03DD1001B3EB6 /* String+Date.swift */; };
 		C77A04EE25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */; };
+		D6296DAE295B7CA0002E8EB6 /* Colors2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6296DAD295B7C9F002E8EB6 /* Colors2.swift */; };
 		EC1C31732923022E00CF052C /* SegmentedControlTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1C31722923022E00CF052C /* SegmentedControlTokenSet.swift */; };
 		EC5982D827BF348700FD048D /* MSFAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D727BF348700FD048D /* MSFAvatar.swift */; };
 		EC5982DA27C703EE00FD048D /* CircleCutout.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5982D927C703ED00FD048D /* CircleCutout.swift */; };
@@ -377,6 +378,7 @@
 		C77A04B625F03DD1001B3EB6 /* String+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Date.swift"; sourceTree = "<group>"; };
 		C77A04EC25F046EB001B3EB6 /* Date+CellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+CellFileAccessoryView.swift"; sourceTree = "<group>"; };
 		CCC18C2B2501B22F00BE830E /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		D6296DAD295B7C9F002E8EB6 /* Colors2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Colors2.swift; sourceTree = "<group>"; };
 		EC1C31722923022E00CF052C /* SegmentedControlTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedControlTokenSet.swift; sourceTree = "<group>"; };
 		EC5982D727BF348700FD048D /* MSFAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatar.swift; sourceTree = "<group>"; };
 		EC5982D927C703ED00FD048D /* CircleCutout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleCutout.swift; sourceTree = "<group>"; };
@@ -919,6 +921,7 @@
 			children = (
 				925D461926FD124B00179583 /* Theme */,
 				A5CEC16C20D98EE70016922A /* Colors.swift */,
+				D6296DAD295B7C9F002E8EB6 /* Colors2.swift */,
 				923DB9D6274CB66D00D8E58A /* ControlHostingView.swift */,
 				A559BB82212B7D870055E107 /* FluentUIFramework.swift */,
 				535559E22711411E0094A871 /* FluentUIHostingController.swift */,
@@ -1489,6 +1492,7 @@
 				5314E1B125F01A980099271A /* TooltipView.swift in Sources */,
 				5314E19525F019650099271A /* TabBarItemView.swift in Sources */,
 				5314E03C25F00E3D0099271A /* BadgeField.swift in Sources */,
+				D6296DAE295B7CA0002E8EB6 /* Colors2.swift in Sources */,
 				5314E05B25F00EF50099271A /* CalendarView.swift in Sources */,
 				92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */,
 				5314E28125F0240D0099271A /* DateComponents+Extensions.swift in Sources */,

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -219,7 +219,7 @@ public final class Colors2: NSObject {
 
         static var brandForeground1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1])
 
-        static var brandForeground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Selected])
+        static var brandForeground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Pressed])
 
         static var brandForeground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Selected])
 

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -58,6 +58,9 @@ private func brandColorOverrides(provider: ColorProviding2, for theme: FluentThe
     if let brandBackgroundTint = provider.brandBackgroundTint(for: theme)?.dynamicColor {
         brandColors[.brandBackgroundTint] = brandBackgroundTint
     }
+    if let brandBackgroundDisabled = provider.brandBackgroundDisabled(for: theme)?.dynamicColor {
+        brandColors[.brandBackgroundDisabled] = brandBackgroundDisabled
+    }
     if let brandForeground1 = provider.brandForeground1(for: theme)?.dynamicColor {
         brandColors[.brandForeground1] = brandForeground1
     }
@@ -152,6 +155,10 @@ public final class Colors2: NSObject {
         return colorProvidersMap.object(forKey: theme)?.brandBackgroundTint(for: theme) ?? FallbackThemeColor.brandBackgroundTint
     }
 
+    @objc public static func brandBackgroundDisabled(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackgroundDisabled(for: theme) ?? FallbackThemeColor.brandBackgroundDisabled
+    }
+
     @objc public static func brandForeground1(for theme: FluentTheme) -> UIColor {
         return colorProvidersMap.object(forKey: theme)?.brandForeground1(for: theme) ?? FallbackThemeColor.brandForeground1
     }
@@ -207,6 +214,8 @@ public final class Colors2: NSObject {
         static var brandBackground3: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground3])
 
         static var brandBackgroundTint: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackgroundTint])
+
+        static var brandBackgroundDisabled: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackgroundDisabled])
 
         static var brandForeground1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1])
 

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -115,126 +115,20 @@ public final class Colors2: NSObject {
     /// - Parameters:
     ///   - window: The window that should have its `ColorProvider2` removed.
     @objc public static func removeProvider(for theme: FluentTheme) {
+        let removedProvider = colorProvidersMap.object(forKey: theme)
         colorProvidersMap.removeObject(forKey: theme)
-        // TODO: what is the equivalent function here?
-        // window.fluentTheme = FluentThemeKey.defaultValue
-    }
 
-    // MARK: Primary
-
-    /// Use these funcs to grab a color customized by a ColorProvidingobject for a specific window. If no colorProvider2 exists for the window, falls back to deprecated singleton theme color
-    @objc public static func brandBackground1(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground1(for: theme) ?? FallbackThemeColor.brandBackground1
-    }
-
-    @objc public static func brandBackground1Pressed(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground1Pressed(for: theme) ?? FallbackThemeColor.brandBackground1Pressed
-    }
-
-    @objc public static func brandBackground1Selected(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground1Selected(for: theme) ?? FallbackThemeColor.brandBackground1Selected
-    }
-
-    @objc public static func brandBackground2(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground2(for: theme) ?? FallbackThemeColor.brandBackground2
-    }
-
-    @objc public static func brandBackground2Pressed(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground2Pressed(for: theme) ?? FallbackThemeColor.brandBackground2Pressed
-    }
-
-    @objc public static func brandBackground2Selected(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground2Selected(for: theme) ?? FallbackThemeColor.brandBackground2Selected
-    }
-
-    @objc public static func brandBackground3(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackground3(for: theme) ?? FallbackThemeColor.brandBackground3
-    }
-
-    @objc public static func brandBackgroundTint(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackgroundTint(for: theme) ?? FallbackThemeColor.brandBackgroundTint
-    }
-
-    @objc public static func brandBackgroundDisabled(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandBackgroundDisabled(for: theme) ?? FallbackThemeColor.brandBackgroundDisabled
-    }
-
-    @objc public static func brandForeground1(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandForeground1(for: theme) ?? FallbackThemeColor.brandForeground1
-    }
-
-    @objc public static func brandForeground1Pressed(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandForeground1Pressed(for: theme) ?? FallbackThemeColor.brandForeground1Pressed
-    }
-
-    @objc public static func brandForeground1Selected(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandForeground1Selected(for: theme) ?? FallbackThemeColor.brandForeground1Selected
-    }
-
-    @objc public static func brandForegroundTint(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandForegroundTint(for: theme) ?? FallbackThemeColor.brandForegroundTint
-    }
-
-    @objc public static func brandForegroundDisabled1(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandForegroundDisabled1(for: theme) ?? FallbackThemeColor.brandForegroundDisabled1
-    }
-
-    @objc public static func brandForegroundDisabled2(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandForegroundDisabled2(for: theme) ?? FallbackThemeColor.brandForegroundDisabled2
-    }
-
-    @objc public static func brandStroke1(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandStroke1(for: theme) ?? FallbackThemeColor.brandStroke1
-    }
-
-    @objc public static func brandStroke1Pressed(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandStroke1Pressed(for: theme) ?? FallbackThemeColor.brandStroke1Pressed
-    }
-
-    @objc public static func brandStroke1Selected(for theme: FluentTheme) -> UIColor {
-        return colorProvidersMap.object(forKey: theme)?.brandStroke1Selected(for: theme) ?? FallbackThemeColor.brandStroke1Selected
+        guard let removedProvider = removedProvider else {
+            return
+        }
+        let defaultTokens = FluentTheme.shared.aliasTokens
+        let brandColors = brandColorOverrides(provider: removedProvider, for: theme)
+        brandColors.forEach { token, _ in
+            theme.aliasTokens.colors[token] = defaultTokens.colors[token]
+        }
     }
 
     private static var colorProvidersMap = NSMapTable<FluentTheme, ColorProviding2>(keyOptions: .weakMemory, valueOptions: .weakMemory)
-
-    /// A namespace for holding fallback theme colors (empty enum is an uninhabited type)
-    private enum FallbackThemeColor {
-        static var brandBackground1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground1])
-
-        static var brandBackground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground1Pressed])
-
-        static var brandBackground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground1Selected])
-
-        static var brandBackground2: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground2])
-
-        static var brandBackground2Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground2Pressed])
-
-        static var brandBackground2Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground2Selected])
-
-        static var brandBackground3: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground3])
-
-        static var brandBackgroundTint: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackgroundTint])
-
-        static var brandBackgroundDisabled: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackgroundDisabled])
-
-        static var brandForeground1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1])
-
-        static var brandForeground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Pressed])
-
-        static var brandForeground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Selected])
-
-        static var brandForegroundTint: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundTint])
-
-        static var brandForegroundDisabled1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundDisabled1])
-
-        static var brandForegroundDisabled2: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundDisabled2])
-
-        static var brandStroke1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1])
-
-        static var brandStroke1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1Pressed])
-
-        static var brandStroke1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1Selected])
-    }
 
     @available(*, unavailable)
     override init() {

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: ColorProviding2 - temporary stand-in for ColorProviding so we can replace side by side
 
 /// Protocol through which consumers can provide colors to "theme" their experiences
-/// The window in which the color will be shown is sent to allow apps to provide different experiences per each window
+/// The view associated with the passed in theme will display the set colors to alllow apps to provide different experiences per each view
 @objc(MSFColorProviding2)
 public protocol ColorProviding2 {
     /// If this protocol is not conformed to, communicationBlue variants will be used
@@ -156,10 +156,10 @@ public enum BrandColorsForOverriding: CaseIterable {
 }
 
 public extension FluentTheme {
-    /// Associates a `ColorProvider2` with a given `UIWindow` instance.
+    /// Associates a `ColorProvider2` with a given `FluentTheme` instance.
     ///
     /// - Parameters:
-    ///   - provider: The `ColorProvider2` whose colors should be used for controls in this window.
+    ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
     ///   - window: The window where these colors should be applied.
     @objc static func setProvider(provider: ColorProviding2, for theme: FluentTheme) {
         // Create an updated fluent theme as well
@@ -169,7 +169,7 @@ public extension FluentTheme {
         }
     }
 
-    /// Removes any associated `ColorProvider2` from the given `UIWindow` instance.
+    /// Removes any associated `ColorProvider2` from the given `FluentTheme` instance.
     ///
     /// - Parameters:
     ///   - window: The window that should have its `ColorProvider2` removed.

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -1,0 +1,234 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+// MARK: ColorProviding2 - temporary stand-in for ColorProviding so we can replace side by side
+
+/// Protocol through which consumers can provide colors to "theme" their experiences
+/// The window in which the color will be shown is sent to allow apps to provide different experiences per each window
+@objc(MSFColorProviding2)
+public protocol ColorProviding2 {
+    /// If this protocol is not conformed to, communicationBlue variants will be used
+    @objc func brandBackground1(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground1Pressed(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground1Selected(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground2(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground2Pressed(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground2Selected(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground3(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackgroundTint(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackgroundDisabled(for theme: FluentTheme) -> UIColor?
+    @objc func brandForeground1(for theme: FluentTheme) -> UIColor?
+    @objc func brandForeground1Pressed(for theme: FluentTheme) -> UIColor?
+    @objc func brandForeground1Selected(for theme: FluentTheme) -> UIColor?
+    @objc func brandForegroundTint(for theme: FluentTheme) -> UIColor?
+    @objc func brandForegroundDisabled1(for theme: FluentTheme) -> UIColor?
+    @objc func brandForegroundDisabled2(for theme: FluentTheme) -> UIColor?
+    @objc func brandStroke1(for theme: FluentTheme) -> UIColor?
+    @objc func brandStroke1Pressed(for theme: FluentTheme) -> UIColor?
+    @objc func brandStroke1Selected(for theme: FluentTheme) -> UIColor?
+}
+
+private func brandColorOverrides(provider: ColorProviding2, for theme: FluentTheme) -> [AliasTokens.ColorsTokens: DynamicColor] {
+    var brandColors: [AliasTokens.ColorsTokens: DynamicColor] = [:]
+    if let brandBackground1 = provider.brandBackground1(for: theme)?.dynamicColor {
+        brandColors[.brandBackground1] = brandBackground1
+    }
+    if let brandBackground1Pressed = provider.brandBackground1Pressed(for: theme)?.dynamicColor {
+        brandColors[.brandBackground1Pressed] = brandBackground1Pressed
+    }
+    if let brandBackground1Selected = provider.brandBackground1Selected(for: theme)?.dynamicColor {
+        brandColors[.brandBackground1Selected] = brandBackground1Selected
+    }
+    if let brandBackground2 = provider.brandBackground2(for: theme)?.dynamicColor {
+        brandColors[.brandBackground2] = brandBackground2
+    }
+    if let brandBackground2Pressed = provider.brandBackground2Pressed(for: theme)?.dynamicColor {
+        brandColors[.brandBackground2Pressed] = brandBackground2Pressed
+    }
+    if let brandBackground2Selected = provider.brandBackground2Selected(for: theme)?.dynamicColor {
+        brandColors[.brandBackground2Selected] = brandBackground2Selected
+    }
+    if let brandBackground3 = provider.brandBackground3(for: theme)?.dynamicColor {
+        brandColors[.brandBackground3] = brandBackground3
+    }
+    if let brandBackgroundTint = provider.brandBackgroundTint(for: theme)?.dynamicColor {
+        brandColors[.brandBackgroundTint] = brandBackgroundTint
+    }
+    if let brandForeground1 = provider.brandForeground1(for: theme)?.dynamicColor {
+        brandColors[.brandForeground1] = brandForeground1
+    }
+    if let brandForeground1Pressed = provider.brandForeground1Pressed(for: theme)?.dynamicColor {
+        brandColors[.brandForeground1Pressed] = brandForeground1Pressed
+    }
+    if let brandForeground1Selected = provider.brandForeground1Selected(for: theme)?.dynamicColor {
+        brandColors[.brandForeground1Selected] = brandForeground1Selected
+    }
+    if let brandForegroundTint = provider.brandForegroundTint(for: theme)?.dynamicColor {
+        brandColors[.brandForegroundTint] = brandForegroundTint
+    }
+    if let brandForegroundDisabled1 = provider.brandForegroundDisabled1(for: theme)?.dynamicColor {
+        brandColors[.brandForegroundDisabled1] = brandForegroundDisabled1
+    }
+    if let brandForegroundDisabled2 = provider.brandForegroundDisabled2(for: theme)?.dynamicColor {
+        brandColors[.brandForegroundDisabled2] = brandForegroundDisabled2
+    }
+    if let brandStroke1 = provider.brandStroke1(for: theme)?.dynamicColor {
+        brandColors[.brandStroke1] = brandStroke1
+    }
+    if let brandStroke1Pressed = provider.brandStroke1Pressed(for: theme)?.dynamicColor {
+        brandColors[.brandStroke1Pressed] = brandStroke1Pressed
+    }
+    if let brandStroke1Selected = provider.brandStroke1Selected(for: theme)?.dynamicColor {
+        brandColors[.brandStroke1Selected] = brandStroke1Selected
+    }
+    return brandColors
+}
+
+// MARK: Colors
+
+@objc(MSFColors2)
+public final class Colors2: NSObject {
+    /// Associates a `ColorProvider2` with a given `UIWindow` instance.
+    ///
+    /// - Parameters:
+    ///   - provider: The `ColorProvider2` whose colors should be used for controls in this window.
+    ///   - window: The window where these colors should be applied.
+    @objc public static func setProvider(provider: ColorProviding2, for theme: FluentTheme) {
+        colorProvidersMap.setObject(provider, forKey: theme)
+
+        // Create an updated fluent theme as well
+        let brandColors = brandColorOverrides(provider: provider, for: theme)
+        brandColors.forEach { token, value in
+            theme.aliasTokens.colors[token] = value
+        }
+    }
+
+    /// Removes any associated `ColorProvider` from the given `UIWindow` instance.
+    ///
+    /// - Parameters:
+    ///   - window: The window that should have its `ColorProvider` removed.
+    @objc public static func removeProvider(for theme: FluentTheme) {
+        colorProvidersMap.removeObject(forKey: theme)
+        // TODO: what is the equivalent function here?
+        // window.fluentTheme = FluentThemeKey.defaultValue
+    }
+
+    // MARK: Primary
+
+    /// Use these funcs to grab a color customized by a ColorProviding object for a specific window. If no colorProvider exists for the window, falls back to deprecated singleton theme color
+    @objc public static func brandBackground1(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground1(for: theme) ?? FallbackThemeColor.brandBackground1
+    }
+
+    @objc public static func brandBackground1Pressed(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground1Pressed(for: theme) ?? FallbackThemeColor.brandBackground1Pressed
+    }
+
+    @objc public static func brandBackground1Selected(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground1Selected(for: theme) ?? FallbackThemeColor.brandBackground1Selected
+    }
+
+    @objc public static func brandBackground2(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground2(for: theme) ?? FallbackThemeColor.brandBackground2
+    }
+
+    @objc public static func brandBackground2Pressed(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground2Pressed(for: theme) ?? FallbackThemeColor.brandBackground2Pressed
+    }
+
+    @objc public static func brandBackground2Selected(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground2Selected(for: theme) ?? FallbackThemeColor.brandBackground2Selected
+    }
+
+    @objc public static func brandBackground3(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackground3(for: theme) ?? FallbackThemeColor.brandBackground3
+    }
+
+    @objc public static func brandBackgroundTint(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandBackgroundTint(for: theme) ?? FallbackThemeColor.brandBackgroundTint
+    }
+
+    @objc public static func brandForeground1(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandForeground1(for: theme) ?? FallbackThemeColor.brandForeground1
+    }
+
+    @objc public static func brandForeground1Pressed(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandForeground1Pressed(for: theme) ?? FallbackThemeColor.brandForeground1Pressed
+    }
+
+    @objc public static func brandForeground1Selected(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandForeground1Selected(for: theme) ?? FallbackThemeColor.brandForeground1Selected
+    }
+
+    @objc public static func brandForegroundTint(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandForegroundTint(for: theme) ?? FallbackThemeColor.brandForegroundTint
+    }
+
+    @objc public static func brandForegroundDisabled1(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandForegroundDisabled1(for: theme) ?? FallbackThemeColor.brandForegroundDisabled1
+    }
+
+    @objc public static func brandForegroundDisabled2(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandForegroundDisabled2(for: theme) ?? FallbackThemeColor.brandForegroundDisabled2
+    }
+
+    @objc public static func brandStroke1(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandStroke1(for: theme) ?? FallbackThemeColor.brandStroke1
+    }
+
+    @objc public static func brandStroke1Pressed(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandStroke1Pressed(for: theme) ?? FallbackThemeColor.brandStroke1Pressed
+    }
+
+    @objc public static func brandStroke1Selected(for theme: FluentTheme) -> UIColor {
+        return colorProvidersMap.object(forKey: theme)?.brandStroke1Selected(for: theme) ?? FallbackThemeColor.brandStroke1Selected
+    }
+
+    private static var colorProvidersMap = NSMapTable<FluentTheme, ColorProviding2>(keyOptions: .weakMemory, valueOptions: .weakMemory)
+
+    /// A namespace for holding fallback theme colors (empty enum is an uninhabited type)
+    private enum FallbackThemeColor {
+        static var brandBackground1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground1])
+
+        static var brandBackground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground1Pressed])
+
+        static var brandBackground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground1Selected])
+
+        static var brandBackground2: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground2])
+
+        static var brandBackground2Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground2Pressed])
+
+        static var brandBackground2Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground2Selected])
+
+        static var brandBackground3: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackground3])
+
+        static var brandBackgroundTint: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandBackgroundTint])
+
+        static var brandForeground1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1])
+
+        static var brandForeground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Selected])
+
+        static var brandForeground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1Selected])
+
+        static var brandForegroundTint: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundTint])
+
+        static var brandForegroundDisabled1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundDisabled1])
+
+        static var brandForegroundDisabled2: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundDisabled2])
+
+        static var brandStroke1: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1])
+
+        static var brandStroke1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1Pressed])
+
+        static var brandStroke1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1Selected])
+    }
+
+    @available(*, unavailable)
+    override init() {
+        super.init()
+    }
+}

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -93,16 +93,75 @@ private func brandColorOverrides(provider: ColorProviding2, for theme: FluentThe
 
 // MARK: Colors
 
-@objc(MSFColors2)
-public final class Colors2: NSObject {
+public enum BrandColorsForOverriding: CaseIterable {
+    case brandBackground1
+    case brandBackground1Pressed
+    case brandBackground1Selected
+    case brandBackground2
+    case brandBackground2Pressed
+    case brandBackground2Selected
+    case brandBackground3
+    case brandBackgroundTint
+    case brandBackgroundDisabled
+    case brandForeground1
+    case brandForeground1Pressed
+    case brandForeground1Selected
+    case brandForegroundTint
+    case brandForegroundDisabled1
+    case brandForegroundDisabled2
+    case brandStroke1
+    case brandStroke1Pressed
+    case brandStroke1Selected
+
+    var equivalentAliasToken: AliasTokens.ColorsTokens {
+        switch self {
+        case .brandBackground1:
+            return .brandBackground1
+        case .brandBackground1Pressed:
+            return .brandBackground1Pressed
+        case .brandBackground1Selected:
+            return .brandBackground1Selected
+        case .brandBackground2:
+            return .brandBackground2
+        case .brandBackground2Pressed:
+            return .brandBackground2Pressed
+        case .brandBackground2Selected:
+            return .brandBackground2Selected
+        case .brandBackground3:
+            return .brandBackground3
+        case .brandBackgroundTint:
+            return .brandBackgroundTint
+        case .brandBackgroundDisabled:
+            return .brandBackgroundDisabled
+        case .brandForeground1:
+            return .brandForeground1
+        case .brandForeground1Pressed:
+            return .brandForeground1Pressed
+        case .brandForeground1Selected:
+            return .brandForeground1Selected
+        case .brandForegroundTint:
+            return .brandForegroundTint
+        case .brandForegroundDisabled1:
+            return .brandForegroundDisabled1
+        case .brandForegroundDisabled2:
+            return .brandForegroundDisabled2
+        case .brandStroke1:
+            return .brandStroke1
+        case .brandStroke1Pressed:
+            return .brandStroke1Pressed
+        case .brandStroke1Selected:
+            return .brandStroke1Selected
+        }
+    }
+}
+
+public extension FluentTheme {
     /// Associates a `ColorProvider2` with a given `UIWindow` instance.
     ///
     /// - Parameters:
     ///   - provider: The `ColorProvider2` whose colors should be used for controls in this window.
     ///   - window: The window where these colors should be applied.
-    @objc public static func setProvider(provider: ColorProviding2, for theme: FluentTheme) {
-        colorProvidersMap.setObject(provider, forKey: theme)
-
+    @objc static func setProvider(provider: ColorProviding2, for theme: FluentTheme) {
         // Create an updated fluent theme as well
         let brandColors = brandColorOverrides(provider: provider, for: theme)
         brandColors.forEach { token, value in
@@ -114,24 +173,9 @@ public final class Colors2: NSObject {
     ///
     /// - Parameters:
     ///   - window: The window that should have its `ColorProvider2` removed.
-    @objc public static func removeProvider(for theme: FluentTheme) {
-        let removedProvider = colorProvidersMap.object(forKey: theme)
-        colorProvidersMap.removeObject(forKey: theme)
-
-        guard let removedProvider = removedProvider else {
-            return
+    @objc static func removeProvider(for theme: FluentTheme) {
+        for brandColor in BrandColorsForOverriding.allCases {
+            theme.aliasTokens.colors.removeOverride(brandColor.equivalentAliasToken)
         }
-        let defaultTokens = FluentTheme.shared.aliasTokens
-        let brandColors = brandColorOverrides(provider: removedProvider, for: theme)
-        brandColors.forEach { token, _ in
-            theme.aliasTokens.colors[token] = defaultTokens.colors[token]
-        }
-    }
-
-    private static var colorProvidersMap = NSMapTable<FluentTheme, ColorProviding2>(keyOptions: .weakMemory, valueOptions: .weakMemory)
-
-    @available(*, unavailable)
-    override init() {
-        super.init()
     }
 }

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -110,10 +110,10 @@ public final class Colors2: NSObject {
         }
     }
 
-    /// Removes any associated `ColorProvider` from the given `UIWindow` instance.
+    /// Removes any associated `ColorProvider2` from the given `UIWindow` instance.
     ///
     /// - Parameters:
-    ///   - window: The window that should have its `ColorProvider` removed.
+    ///   - window: The window that should have its `ColorProvider2` removed.
     @objc public static func removeProvider(for theme: FluentTheme) {
         colorProvidersMap.removeObject(forKey: theme)
         // TODO: what is the equivalent function here?
@@ -122,7 +122,7 @@ public final class Colors2: NSObject {
 
     // MARK: Primary
 
-    /// Use these funcs to grab a color customized by a ColorProviding object for a specific window. If no colorProvider exists for the window, falls back to deprecated singleton theme color
+    /// Use these funcs to grab a color customized by a ColorProvidingobject for a specific window. If no colorProvider2 exists for the window, falls back to deprecated singleton theme color
     @objc public static func brandBackground1(for theme: FluentTheme) -> UIColor {
         return colorProvidersMap.object(forKey: theme)?.brandBackground1(for: theme) ?? FallbackThemeColor.brandBackground1
     }
@@ -221,7 +221,7 @@ public final class Colors2: NSObject {
 
         static var brandForeground1Pressed: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Selected])
 
-        static var brandForeground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandStroke1Selected])
+        static var brandForeground1Selected: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForeground1Selected])
 
         static var brandForegroundTint: UIColor = UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.brandForegroundTint])
 

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -160,7 +160,7 @@ public extension FluentTheme {
     ///
     /// - Parameters:
     ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
-    ///   - window: The window where these colors should be applied.
+    ///   - theme: The theme where these colors should be applied.
     @objc static func setProvider(provider: ColorProviding2, for theme: FluentTheme) {
         // Create an updated fluent theme as well
         let brandColors = brandColorOverrides(provider: provider, for: theme)
@@ -172,7 +172,7 @@ public extension FluentTheme {
     /// Removes any associated `ColorProvider2` from the given `FluentTheme` instance.
     ///
     /// - Parameters:
-    ///   - window: The window that should have its `ColorProvider2` removed.
+    ///   - theme: The theme that should have its `ColorProvider2` removed.
     @objc static func removeProvider(for theme: FluentTheme) {
         for brandColor in BrandColorsForOverriding.allCases {
             theme.aliasTokens.colors.removeOverride(brandColor.equivalentAliasToken)

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -469,7 +469,8 @@ public final class AliasTokens: NSObject {
 
     // MARK: Colors
 
-    public enum ColorsTokens: CaseIterable {
+    @objc(MSFColorsAliasTokens)
+    public enum ColorsTokens: Int, TokenSetKey {
         // Foreground colors
         case foreground1
         case foreground2
@@ -538,6 +539,12 @@ public final class AliasTokens: NSObject {
         case brandStroke1
         case brandStroke1Pressed
         case brandStroke1Selected
+    }
+
+    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `colors` property directly.")
+    @objc(colorsForToken:)
+    public func colors(_ token: ColorsTokens) -> DynamicColor {
+        return colors[token]
     }
     public lazy var colors: TokenSet<ColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }

--- a/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
@@ -33,6 +33,13 @@ public final class TokenSet<T: TokenSetKey, V> {
         }
     }
 
+    /// Removes a stored override for a given token value.
+    ///
+    /// - Parameter token: The token value whose override should be removed.
+    public func removeOverride(_ token: T) {
+        valueOverrides?[token] = nil
+    }
+
     /// Initializes this token set with a callback to fetch its default values as needed.
     ///
     /// The `defaultValues` closure being passed in is expected to take the form of a static switch statement, like so:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This is a draft pull request to review the new colors2.swift implementation, which will stand in side-by-side with the current colors.swift functionality until we have everything replaced in devmain and all dependencies, and then we will remove colors.swift and do a large rename. This will allow us to maintain a building state while doing a massive find and replace effort.

### Verification

Added ColorProviding2 implementation to the objective C demo controller.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![objCBeforeLight](https://user-images.githubusercontent.com/23249106/209731505-a8f9ff8b-13cf-4131-9257-b98d1881ecfd.png) | ![objcAfterLight](https://user-images.githubusercontent.com/23249106/210018292-a0136b63-d6a7-4ddf-b8b1-87ed0d3362a7.png) |
| ![objCBeforeDark](https://user-images.githubusercontent.com/23249106/209731504-2b150f0f-c3fd-4f05-8a94-e3f0793d86ad.png) | ![objcAfterDark](https://user-images.githubusercontent.com/23249106/210018279-d029d9d6-5dae-41d4-865f-b28056dae5f0.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1468)