### PR TITLE
[Fluent 2 iOS] ColoredPillBackgroundView update

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -27,38 +27,21 @@ class ColoredPillBackgroundView: UIView {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        updateBackgroundColor()
-    }
-
-    @objc func themeDidChange() {
+    @objc func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+            return
+        }
         updateBackgroundColor()
     }
 
     func updateBackgroundColor() {
-        let lightColor: UIColor
-        let darkColor: UIColor
         switch style {
         case .neutral:
-            if let fluentTheme = window?.fluentTheme {
-                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral1])
-                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
-            } else {
-                lightColor = Colors.navigationBarBackground
-                darkColor = Colors.navigationBarBackground
-            }
+            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
         case .brand:
-            if let fluentTheme = window?.fluentTheme {
-                lightColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.brandRest])
-                darkColor = UIColor(dynamicColor: fluentTheme.aliasTokens.backgroundColors[.neutral4])
-            } else {
-                lightColor = Colors.communicationBlue
-                darkColor = Colors.navigationBarBackground
-            }
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                                                 dark: GlobalTokens.neutralColors(.grey12)))
         }
-
-        backgroundColor = UIColor(light: lightColor, dark: darkColor)
     }
 
     let style: ColoredPillBackgroundStyle


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`ColoredPillBackgroundView` is updated to match fluent 2 specs. 

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,163,248 bytes | 29,163,248 bytes | 0 bytes |

### Verification

The changes to both styles of the `ColoredPillBackgroundView` were tested on the `PillButtonBarDemoController` and the `SegmentedControlDemoController`.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_pbb_light" src="https://user-images.githubusercontent.com/106181067/210094547-33ffb94d-8d2c-4bcb-9c4d-69872ceffa30.png"> | <img width="487" alt="after_pbb_light" src="https://user-images.githubusercontent.com/106181067/210094569-599d2578-3969-4b97-b096-bf9fc49581c8.png"> |
| <img width="487" alt="before_pbb_dark" src="https://user-images.githubusercontent.com/106181067/210094584-be8ee2fb-36b2-43fd-92c0-fac3b03253e7.png"> | <img width="487" alt="after_pbb_dark" src="https://user-images.githubusercontent.com/106181067/210094591-c538ef39-e7a2-42d6-b604-f3d7cc2f9094.png"> |
| <img width="487" alt="before_segmented_1_light" src="https://user-images.githubusercontent.com/106181067/210094605-7553af7a-22c0-4edd-8a3c-936b778c9c09.png"> | <img width="487" alt="after_segmented_1_light" src="https://user-images.githubusercontent.com/106181067/210094614-4e877556-e2d0-4a04-bbfd-d5a3b4f614b7.png"> |
| <img width="487" alt="before_segmented_1_dark" src="https://user-images.githubusercontent.com/106181067/210094631-6cb88fb6-540f-4c01-8599-e8a3a81f7f8a.png"> | <img width="487" alt="after_segmented_1_dark" src="https://user-images.githubusercontent.com/106181067/210094638-a53261f1-6be1-41f3-b839-4251a896093b.png"> |
| <img width="487" alt="before_segmented_2_light" src="https://user-images.githubusercontent.com/106181067/210094655-0b852d27-e12a-4589-8535-12dc083a140f.png"> | <img width="487" alt="after_segmented_2_light" src="https://user-images.githubusercontent.com/106181067/210094665-800cf2f8-255c-4f97-8927-aaab14c118ad.png"> |
| <img width="487" alt="before_segmented_2_dark" src="https://user-images.githubusercontent.com/106181067/210094684-8b860967-9659-45e6-84c8-816e2cde4277.png"> | <img width="487" alt="after_segmented_2_dark" src="https://user-images.githubusercontent.com/106181067/210094694-1b740c12-4be1-43dc-b751-c5c896a5d7c0.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1470)