### PR TITLE
Fix png filenames in tooltip documentation 

### DIFF
--- a/ios/docs/Controls/Tooltip.md
+++ b/ios/docs/Controls/Tooltip.md
@@ -7,12 +7,12 @@ Variations: The tooltip can have an optional title and the tip of the tooltip ca
 #### Text
 | Message Only | Message and Title |
 | - | - |
-| ![MessageOnly.png](.attachments/MessageOnly.png) | ![MessageAndTitle.png](.attachments/MessageAndTitle.png) |
+| ![Tooltip-MessageOnly.png](.attachments/Tooltip-MessageOnly.png) | ![Tooltip-MessageAndTitle.png](.attachments/Tooltip-MessageAndTitle.png) |
 
 #### Tooltip Direction
 | Up | Down | Left | Right |
 | - | - | - | - |
-| ![TooltipUp.png](.attachments/TooltipUp.png) | ![TooltipDown.png](.attachments/TooltipDown.png) | ![TooltipLeft.png](.attachments/TooltipLeft.png) | ![TooltipRight.png](.attachments/TooltipRight.png) |
+| ![Tooltip-Up.png](.attachments/Tooltip-Up.png) | ![Tooltip-Down.png](.attachments/Tooltip-Down.png) | ![Tooltip-Left.png](.attachments/Tooltip-Left.png) | ![Tooltip-Right.png](.attachments/Tooltip-Right.png) |
 
 ## Usage
 Displays a tooltip based on the current settings, pointing to the supplied anchorView. If another tooltip view is already showing, it will be dismissed and the new tooltip will be shown.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixed `tooltip` documentation to use correct filenames. Images in `Tooltip.md` were missing the Tooltip- prefix.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="599" alt="Screenshot 2022-12-30 at 3 07 43 PM" src="https://user-images.githubusercontent.com/55368679/210108364-b98d7016-5573-4e9f-8717-8af243296f04.png"> | <img width="1025" alt="Screenshot 2022-12-30 at 3 08 14 PM" src="https://user-images.githubusercontent.com/55368679/210108370-c75bfd47-6eac-489b-82ce-f2ddddaafa2e.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1473)