### PR TITLE
ReadmeViewController improvements

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
@@ -9,7 +9,6 @@ import UIKit
 class BadgeFieldDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         let badgeDataSources1 = [
             BadgeViewDataSource(text: "Kat Larsson", style: .default),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardViewDemoController.swift
@@ -10,7 +10,6 @@ class CardViewDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        readmeString = "< Documentation will be added soon >"
         container.alignment = .leading
 
         let demoIcon = UIImage(named: "flag-24x24")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/IndeterminateProgressBarDemoController.swift
@@ -17,7 +17,6 @@ class IndeterminateProgressBarDemoController: DemoTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
         tableView.register(ActionsCell.self, forCellReuseIdentifier: ActionsCell.identifier)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -11,7 +11,6 @@ class LabelDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         addLabel(text: "Text Styles", style: .headline, colorStyle: .regular).textAlignment = .center
         for style in TextStyle.allCases {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -17,7 +17,6 @@ class OtherCellsDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         tableView = UITableView(frame: view.bounds, style: .grouped)
         tableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -61,7 +61,6 @@ class PeoplePickerDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         asyncImageSwitch.addTarget(self, action: #selector(onAsyncImageSwitchValueChanged), for: .valueChanged)
         setupView()

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift
@@ -45,7 +45,6 @@ let searchDirectoryPersonas: [PersonaData] = [
 class PersonaListViewDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         let personaListView = PersonaListView()
         personaListView.personaList = samplePersonas

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonDemoController.swift
@@ -9,7 +9,6 @@ import UIKit
 class PillButtonDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         for style in buttonStyles {
             addTitle(text: "\(style.0) style")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -30,7 +30,6 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         let searchBarNoAutocorrect = buildSearchBar(autocorrectionType: .no, placeholderText: "no autocorrect")
         let searchBarAutocorrect = buildSearchBar(autocorrectionType: .yes, placeholderText: "autocorrect")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -10,7 +10,7 @@ class ShimmerViewDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        readmeString = "A shimmer let’s people know that information is loading and gives them an idea of the structure of the information.\n\nUse shimmers for loading states that take longer than one second but avoid them for long loading processes. They are indeterminate indicators, so they don’t communicate how much time is left before the process is done. Seeing a shimmer for too long could make people think something’s gone wrong."
+        readmeString = "A shimmer lets people know that information is loading and gives them an idea of the structure of the information.\n\nUse shimmers for loading states that take longer than one second but avoid them for long loading processes. They are indeterminate indicators, so they don’t communicate how much time is left before the process is done. Seeing a shimmer for too long could make people think something’s gone wrong."
         let contentView = { () -> UIStackView in
             let label1 = UILabel()
             label1.text = "Label 1"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -58,7 +58,6 @@ class TableViewCellDemoController: DemoTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellFileAccessoryViewDemoController.swift
@@ -17,7 +17,6 @@ class TableViewCellFileAccessoryViewDemoController: DemoTableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         dateTimePicker.delegate = self
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -30,7 +30,6 @@ class TableViewHeaderFooterViewDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        readmeString = "< Documentation will be added soon >"
 
         container.heightAnchor.constraint(equalTo: scrollingContainer.heightAnchor).isActive = true
         container.layoutMargins = .zero

--- a/ios/FluentUI.Demo/FluentUI.Demo/ReadmeViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ReadmeViewController.swift
@@ -11,9 +11,7 @@ class ReadmeViewController: UIViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if let readmeString = readmeString {
-            readmeLabel.text = readmeString
-        }
+        readmeLabel.text = readmeString ?? "< Documentation will be added soon >"
 
         let popoverHeight = readmeLabel.frame.height + Constants.topPadding
         preferredContentSize = CGSize(width: Constants.popoverWidth, height: popoverHeight)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The earlier readme PR wasn't on the latest main branch, so tokenized `Tooltip` demo was missing a documentation string. This PR is setting `"< Documentation will be added soon >"` in `ReadmeViewController` instead of setting it in the `DemoController` files.
This PR also fixes a typo in the `Shimmer` documentation.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,154,832 bytes | 29,154,832 bytes | 0 bytes |

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_tooltip" src="https://user-images.githubusercontent.com/106181067/210620010-2978ccc9-5a42-4f21-aefa-92c6aa025490.png"> | <img width="487" alt="after_tooltip" src="https://user-images.githubusercontent.com/106181067/210620018-1216c221-46f6-40ee-bf34-9e9239b052d5.png"> |
| <img width="487" alt="before_shimmer" src="https://user-images.githubusercontent.com/106181067/210620052-82a92a8e-d457-43bb-8472-37eed35f41db.png"> | <img width="487" alt="after_shimmer" src="https://user-images.githubusercontent.com/106181067/210620064-98076fee-a76a-4d63-a378-c8defb078941.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1479)