### PR TITLE
[main_0.10 cherry pick] Update Date Picker test to start from `now` to fix test failure

### DIFF
--- a/ios/FluentUI.Tests/DatePickerControllerTests.swift
+++ b/ios/FluentUI.Tests/DatePickerControllerTests.swift
@@ -7,10 +7,8 @@ import XCTest
 @testable import FluentUI
 
 class DatePickerControllerTests: XCTestCase {
-    static let testDateInterval: TimeInterval = 1551903381
-
-    let startDate = Date(timeIntervalSince1970: DatePickerControllerTests.testDateInterval)
-    let endDate = Date(timeIntervalSince1970: DatePickerControllerTests.testDateInterval).adding(days: 1)
+    let startDate: Date = NSDate.now
+    let endDate: Date = NSDate.now.adding(days: 1)
 
     func testDateRangeInit() {
         let datePicker = DatePickerController(startDate: startDate, endDate: endDate, calendarConfiguration: CalendarConfiguration.default, mode: .dateRange, rangePresentation: .paged, titles: nil, leftBarButtonItem: nil, rightBarButtonItem: nil)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

 - #1477 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1481)