### PR TITLE
[main_0.10 cherry pick] Change unavailable to unavailable

### DIFF
--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -213,7 +213,8 @@ open class Button: UIButton, TokenizedControlInternal {
         setTitleColor(UIColor(dynamicColor: tokenSet[.foregroundPressedColor].dynamicColor), for: .highlighted)
         setTitleColor(UIColor(dynamicColor: tokenSet[.foregroundDisabledColor].dynamicColor), for: .disabled)
 
-        if #unavailable(iOS 15.0) {
+        if #available(iOS 15.0, *) {
+        } else {
             titleLabel?.font = UIFont.fluent(tokenSet[.titleFont].fontInfo)
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

 - #1475 
Remove usage of `#unavailable` to make this version of Fluent buildable when using Swift 5.5.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1482)