### PR TITLE
Resolving label height clipping in larger text mode for TableViewCell

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -581,25 +581,26 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                                                               text: text, labelAccessoryViewMarginLeading: labelAccessoryViewMarginLeading)
 
         let availableWidth = textAreaWidth - (leadingAccessoryAreaWidth + trailingAccessoryAreaWidth + labelAccessoryViewMarginTrailing)
+        let labelSize = text.preferredSize(for: font, width: availableWidth, numberOfLines: numberOfLines)
         if isAttributedTextSet, let attributedText = attributedText {
-            return preferredLabelSize(with: attributedText, availableTextWidth: availableWidth)
+            let attributedSize = preferredLabelSize(with: attributedText, availableTextWidth: availableWidth)
+            // The boundingRect method for NSAttributedString does not consider system font size,
+            // which is the default in the case where there is not .font attribute, resulting in an inaccurate
+            // height value. Taking the max of labelSize and attributedSize resolves this.
+            return CGSize(width: attributedSize.width, height: max(labelSize.height, attributedSize.height))
         }
-        return text.preferredSize(for: font, width: availableWidth, numberOfLines: numberOfLines)
+
+        return labelSize
     }
 
     private static func preferredLabelSize(with attributedText: NSAttributedString,
                                            availableTextWidth: CGFloat = .greatestFiniteMagnitude) -> CGSize {
-        // We need to have .usesDeviceMetrics to ensure that there is no trailing clipping in our label.
-        // However, it causes the bottom portion of the label to be clipped instead. Creating a calculated CGRect
-        // for width and height accommodates for both scenarios so that there is no clipping.
         let estimatedBoundsHeight = attributedText.boundingRect(
             with: CGSize(width: availableTextWidth, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading],
             context: nil)
 
-        // We want the larger width value so that the label does not undergo any trucation.
         return CGSize(width: ceil(availableTextWidth), height: ceil(estimatedBoundsHeight.height))
-
     }
 
     private static func labelPreferredWidth(text: String,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 40,446,736 bytes | 40,447,720 bytes | +984 bytes |
| TableViewCell.o | 1,433,712 bytes | 1,434,696 bytes | +984 bytes |

When an `NSAttributedString` (or even a normal `String`) has no specified font, the system font is used as default. There was a specific scenario where an `NSAttributedString` without a `.font` attribute would cause the cell's label to be clipped in larger text mode. It seems that the boundingRect does not redraw when the system font adjusts to the larger text. This change will take the max height of our `.preferredSize()` (used for strings) and `.preferredLabelSize` (used for attributed strings) methods to accommodate for this scenario.

Also removed some outdated comments in `.preferredLabelSize()`.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/211432892-252ba531-ff33-4e3d-8dd6-de6249d8ccbb.png) | ![image](https://user-images.githubusercontent.com/22566866/211432794-93d28b05-c719-41da-9425-cd1084dee0d2.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1485)