### PR TITLE
Fix Popup Menu Colors

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -93,6 +93,14 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
                                                selector: #selector(themeDidChange),
                                                name: .didChangeTheme,
                                                object: nil)
+
+        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.updateAppearance()
+            strongSelf.updateColors()        // until popupmenuitemcell actually supports token system, clients will override colors via cell's backgroundColor property
+        }
     }
 
     override func didMoveToWindow() {
@@ -106,13 +114,6 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             return
         }
         backgroundStyleType = .custom
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.updateAppearance()
-            strongSelf.updateColors()        // until popupmenuitemcell actually supports token system, clients will override colors via cell's backgroundColor property
-        }
     }
 
     func setup(item: PopupMenuTemplateItem) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,831,032 | 28,827,832 | -3200 |

A bad merge means the popup menu controller's tokensetsink was merged into the wrong location. This change fixes that.

### Verification

Built and ran the simulator, ensuring the colors are now correct.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![popupLightBefore](https://user-images.githubusercontent.com/23249106/212232881-ca681487-387c-4266-9ff5-7a41dfa10d93.png) | ![popupLightAfter](https://user-images.githubusercontent.com/23249106/212232877-2f2624c7-3243-4732-b985-35086a6a73bd.png) |
| ![popupDarkBefore](https://user-images.githubusercontent.com/23249106/212232878-a3460556-cbaf-4d5e-8b2c-6904aa5d7204.png) | ![popupDarkAfter](https://user-images.githubusercontent.com/23249106/212232873-079fa063-e27d-47b6-8732-0fa1967bb62d.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1492)