### PR TITLE
Fix BadgeField space bug

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -742,7 +742,8 @@ open class BadgeField: UIView {
     }
 
     private func updateLabelsVisibility(textFieldContent: String? = nil) {
-        let textFieldContent = textFieldContent ?? self.textFieldContent
+        var textFieldContent = textFieldContent ?? self.textFieldContent
+        textFieldContent = textFieldContent.trimmingCharacters(in: .whitespaces) == "" ? textFieldContent : textFieldContent.trimmed()
         labelView.isHidden = label.isEmpty
         placeholderView.isHidden = !labelView.isHidden || !badges.isEmpty || !textFieldContent.isEmpty
         setNeedsLayout()
@@ -1185,13 +1186,13 @@ extension BadgeField: UITextFieldDelegate {
                 let didBadge = badgeText(newString, force: false)
                 if !didBadge {
                     // Placeholder
-                    updateLabelsVisibility(textFieldContent: newString.trimmed())
+                    updateLabelsVisibility(textFieldContent: newString)
                     badgeFieldDelegate?.badgeField?(self, willChangeTextFieldContentWithText: newString.trimmed())
                 }
                 return !didBadge
             }
 
-            updateLabelsVisibility(textFieldContent: newString.trimmed())
+            updateLabelsVisibility(textFieldContent: newString)
 
             // Handle delete key
             if string.isEmpty {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,872,320 bytes | 28,873,688 bytes | 1,368 bytes |

Fixed bug where `BadgeField`'s placeholder does not disappear after entering whitespace (spaces/tabs). This was because calls to `updateLabelsVisibility` used trimmed strings (strings with just whitespace became empty strings). This fix updates `updateLabelsVisibility` to take in non-trimmed strings. To preserve the existing behavior where badges that contain characters and whitespace are still trimmed properly, `updateLabelsVisibility` first checks if the parameter `textFieldContent` only contains whitespace. If that is the case, it will not trim it. That way, when `placeholderView.isHidden` is checked, `!textFieldContent.isEmpty` will evaluate to true.

### Verification

The videos below copy paste a tab and then enter spaces.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-18 at 09 43 01](https://user-images.githubusercontent.com/55368679/213255386-db83b414-d593-41eb-8a05-a7c9ee2b082e.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-18 at 09 45 42](https://user-images.githubusercontent.com/55368679/213255943-174c6501-ae40-4503-9f02-584b1dc37242.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)