### PR TITLE
Update tab bar item colors to fix bad disabled state visibility

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -215,7 +215,6 @@ class TabBarItemView: UIControl {
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFit
-        // imageView.tintColor = unselectedColor
 
         if canResizeImage {
             let sizeConstraints = (

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -268,7 +268,7 @@ class TabBarItemView: UIControl {
         let unselectedImageColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         let unselectedTextColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
         let disabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
-        
+
         titleLabel.textColor = isEnabled ? (isSelected ? selectedColor : unselectedTextColor) : disabledColor
         imageView.tintColor = isEnabled ? (isSelected ? selectedColor : unselectedImageColor) : disabledColor
     }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -234,7 +234,6 @@ class TabBarItemView: UIControl {
         let titleLabel = Label()
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.textAlignment = .center
-        titleLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
 
         return titleLabel
     }()

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -10,16 +10,13 @@ class TabBarItemView: UIControl {
 
     override var isEnabled: Bool {
         didSet {
-            titleLabel.isEnabled = isEnabled
-            imageView.tintAdjustmentMode = isEnabled ? .automatic : .dimmed
             isUserInteractionEnabled = isEnabled
+            updateColors()
         }
     }
 
     override var isSelected: Bool {
         didSet {
-            titleLabel.isHighlighted = isSelected
-            imageView.isHighlighted = isSelected
             updateImage()
             updateColors()
             if isSelected {
@@ -189,8 +186,6 @@ class TabBarItemView: UIControl {
         static let unreadDotSize: CGFloat = 8.0
     }
 
-    private lazy var unselectedColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-
     private var badgeValue: String? {
         didSet {
             if oldValue != badgeValue {
@@ -220,7 +215,7 @@ class TabBarItemView: UIControl {
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = unselectedColor
+        // imageView.tintColor = unselectedColor
 
         if canResizeImage {
             let sizeConstraints = (
@@ -271,16 +266,20 @@ class TabBarItemView: UIControl {
     }
 
     private func updateColors() {
-        let primaryColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
-        titleLabel.highlightedTextColor = primaryColor
-        imageView.tintColor = isSelected ? primaryColor : unselectedColor
+        let selectedColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+        let unselectedImageColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        let unselectedTextColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+        let disabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+        
+        titleLabel.textColor = isEnabled ? (isSelected ? selectedColor : unselectedTextColor) : disabledColor
+        imageView.tintColor = isEnabled ? (isSelected ? selectedColor : unselectedImageColor) : disabledColor
     }
 
     private func updateImage() {
         // Normally we'd set imageView.image and imageView.highlightedImage separately. However, there's a known issue with
         // UIImageView in iOS 16 where highlighted images lose their tint color in certain scenarios. While we wait for a fix,
         // this is a straightforward workaround that gets us the same effect without triggering the bug.
-        imageView.image = imageView.isHighlighted ?
+        imageView.image = isSelected ?
                             item.selectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden) :
                             item.unselectedImage(isInPortraitMode: isInPortraitMode, labelIsHidden: titleLabel.isHidden)
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a |28,685,560|28,682,608|-2,952|

Tab bar item view disabled state color differs from the spec. The view dims very slightly, and it's almost impossible to distinguish between disabled and enabled items.

Currently both the icon and the label use system dimming which is not customizable. In this PR I move away from the system behavior, and instead update the colors manually whenever the item's `isEnabled` or `isSelected` state changes.

The final colors are:
- Selected image + text -- brandFG 1
- Unselected image -- FG 3
- Unselected text -- FG 2
- Disabled image + text -- FG disabled 1

All of the colors were confirmed with Kori.

### Verification
(third row shows the bug)


| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 31 15](https://user-images.githubusercontent.com/3610850/214206755-c140192f-615e-4801-be33-9d73ca295fcd.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 32 38](https://user-images.githubusercontent.com/3610850/214206781-6a0fc663-14f8-406b-acc8-beb43358d52e.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 31 19](https://user-images.githubusercontent.com/3610850/214206825-46b966ed-0d92-4c1c-beec-b966262b307b.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 32 41](https://user-images.githubusercontent.com/3610850/214206844-22632afa-ce2d-4ab8-9df1-0487a85153c1.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 31 34](https://user-images.githubusercontent.com/3610850/214206917-5cdc74b6-9506-4c8f-98ab-ca5bb8e9a73a.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 32 59](https://user-images.githubusercontent.com/3610850/214206938-437cac6a-5ecd-460e-8c09-95d3493dac63.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 31 38](https://user-images.githubusercontent.com/3610850/214206973-aba20a30-a29a-4eaf-a380-034b3839fbe2.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 33 01](https://user-images.githubusercontent.com/3610850/214206990-744f751f-00c4-49f8-a712-d07c9c6cecb9.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 31 45](https://user-images.githubusercontent.com/3610850/214207017-0fbd551c-cd32-4b7a-9646-190cfbcc9c3d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 33 06](https://user-images.githubusercontent.com/3610850/214207031-b77b9d59-534f-4732-a0d3-f6e5b7c19361.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 31 48](https://user-images.githubusercontent.com/3610850/214207050-be4e2b77-b68b-4c40-9d08-3987f1effd1c.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 14 33 09](https://user-images.githubusercontent.com/3610850/214207060-87751fce-d945-444b-b433-0f63a14606ef.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)