### PR TITLE
[Fluent2-Colors] Switch ColorProviding2 to use FluentThemeable

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
@@ -35,176 +35,176 @@ enum DemoColorTheme: CaseIterable {
 }
 
 class DemoColorDefaultTheme: NSObject, ColorProviding2 {
-    func brandBackground1(for theme: FluentTheme) -> UIColor? {
+    func brandBackground1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
-          dark: GlobalTokens.brandColors(.comm100)))
+                                                  dark: GlobalTokens.brandColors(.comm100)))
     }
 
-    func brandBackground1Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandBackground1Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm50),
-          dark: GlobalTokens.brandColors(.comm140)))
+                                                  dark: GlobalTokens.brandColors(.comm140)))
     }
 
-    func brandBackground1Selected(for theme: FluentTheme) -> UIColor? {
+    func brandBackground1Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
-         dark: GlobalTokens.brandColors(.comm120)))
+                                                  dark: GlobalTokens.brandColors(.comm120)))
     }
 
-    func brandBackground2(for theme: FluentTheme) -> UIColor? {
+    func brandBackground2(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm70)))
     }
 
-    func brandBackground2Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandBackground2Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandBackground2Selected(for theme: FluentTheme) -> UIColor? {
+    func brandBackground2Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80)))
     }
 
-    func brandBackground3(for theme: FluentTheme) -> UIColor? {
+    func brandBackground3(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
-         dark: GlobalTokens.brandColors(.comm120)))
+                                                  dark: GlobalTokens.brandColors(.comm120)))
     }
 
-    func brandBackgroundTint(for theme: FluentTheme) -> UIColor? {
+    func brandBackgroundTint(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm150),
-                                 dark: GlobalTokens.brandColors(.comm40)))
+                                                  dark: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandBackgroundDisabled(for theme: FluentTheme) -> UIColor? {
+    func brandBackgroundDisabled(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm140),
-          dark: GlobalTokens.brandColors(.comm40)))
+                                                  dark: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandForeground1(for theme: FluentTheme) -> UIColor? {
+    func brandForeground1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
-          dark: GlobalTokens.brandColors(.comm100)))
+                                                  dark: GlobalTokens.brandColors(.comm100)))
     }
 
-    func brandForeground1Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandForeground1Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm50),
-          dark: GlobalTokens.brandColors(.comm140)))
+                                                  dark: GlobalTokens.brandColors(.comm140)))
     }
 
-    func brandForeground1Selected(for theme: FluentTheme) -> UIColor? {
+    func brandForeground1Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
-          dark: GlobalTokens.brandColors(.comm120)))
+                                                  dark: GlobalTokens.brandColors(.comm120)))
     }
 
-    func brandForegroundTint(for theme: FluentTheme) -> UIColor? {
+    func brandForegroundTint(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
-          dark: GlobalTokens.brandColors(.comm130)))
+                                                  dark: GlobalTokens.brandColors(.comm130)))
     }
 
-    func brandForegroundDisabled1(for theme: FluentTheme) -> UIColor? {
+    func brandForegroundDisabled1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm90)))
     }
 
-    func brandForegroundDisabled2(for theme: FluentTheme) -> UIColor? {
+    func brandForegroundDisabled2(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm140),
-          dark: GlobalTokens.brandColors(.comm40)))
+                                                  dark: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandStroke1(for theme: FluentTheme) -> UIColor? {
+    func brandStroke1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
-                                 dark: GlobalTokens.brandColors(.comm100)))
+                                                  dark: GlobalTokens.brandColors(.comm100)))
     }
 
-    func brandStroke1Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandStroke1Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm50),
-                                 dark: GlobalTokens.brandColors(.comm140)))
+                                                  dark: GlobalTokens.brandColors(.comm140)))
     }
 
-    func brandStroke1Selected(for theme: FluentTheme) -> UIColor? {
+    func brandStroke1Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
-                                 dark: GlobalTokens.brandColors(.comm120)))
+                                                  dark: GlobalTokens.brandColors(.comm120)))
     }
 }
 
 class DemoColorGreenTheme: NSObject, ColorProviding2 {
-    func brandBackground1(for theme: FluentTheme) -> UIColor? {
+    func brandBackground1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x107C41),
                                                   dark: ColorValue(0x55B17E)))
     }
 
-    func brandBackground1Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandBackground1Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325),
                                                   dark: ColorValue(0xCAEAD8)))
     }
 
-    func brandBackground1Selected(for theme: FluentTheme) -> UIColor? {
+    func brandBackground1Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B),
                                                   dark: ColorValue(0x60BD82)))
     }
 
-    func brandBackground2(for theme: FluentTheme) -> UIColor? {
+    func brandBackground2(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B)))
     }
 
-    func brandBackground2Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandBackground2Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x052912)))
     }
 
-    func brandBackground2Selected(for theme: FluentTheme) -> UIColor? {
+    func brandBackground2Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325)))
     }
 
-    func brandBackground3(for theme: FluentTheme) -> UIColor? {
+    func brandBackground3(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325)))
     }
 
-    func brandBackgroundTint(for theme: FluentTheme) -> UIColor? {
+    func brandBackgroundTint(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0xCAEAD8),
                                                   dark: ColorValue(0x094624)))
     }
 
-    func brandBackgroundDisabled(for theme: FluentTheme) -> UIColor? {
+    func brandBackgroundDisabled(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0xA0D8B9),
                                                   dark: ColorValue(0x0A5325)))
     }
 
-    func brandForeground1(for theme: FluentTheme) -> UIColor? {
+    func brandForeground1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x107C41),
                                                   dark: ColorValue(0x55B17E)))
     }
 
-    func brandForeground1Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandForeground1Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325),
                                                   dark: ColorValue(0xCAEAD8)))
     }
 
-    func brandForeground1Selected(for theme: FluentTheme) -> UIColor? {
+    func brandForeground1Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B),
                                                   dark: ColorValue(0x60BD82)))
     }
 
-    func brandForegroundTint(for theme: FluentTheme) -> UIColor? {
+    func brandForegroundTint(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0C5F32),
                                                   dark: ColorValue(0x60BD82)))
     }
 
-    func brandForegroundDisabled1(for theme: FluentTheme) -> UIColor? {
+    func brandForegroundDisabled1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x37A660),
                                                   dark: ColorValue(0x218D51)))
     }
 
-    func brandForegroundDisabled2(for theme: FluentTheme) -> UIColor? {
+    func brandForegroundDisabled2(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0xCAEAD8),
                                                   dark: ColorValue(0x0F703B)))
     }
 
-    func brandStroke1(for theme: FluentTheme) -> UIColor? {
+    func brandStroke1(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x107C41),
                                                   dark: ColorValue(0x55B17E)))
     }
 
-    func brandStroke1Pressed(for theme: FluentTheme) -> UIColor? {
+    func brandStroke1Pressed(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325),
                                                   dark: ColorValue(0xCAEAD8)))
     }
 
-    func brandStroke1Selected(for theme: FluentTheme) -> UIColor? {
+    func brandStroke1Selected(for themeable: FluentThemeable) -> UIColor? {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B),
                                                   dark: ColorValue(0x60BD82)))
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -32,7 +32,7 @@ class DemoListViewController: DemoTableViewController {
     func updateColorProviderFor(window: UIWindow, theme: DemoColorTheme) {
         self.theme = theme
         if let provider2 = self.provider {
-            self.view.fluentTheme.setProvider(provider: provider2)
+            FluentTheme.setProvider(provider2, for: window)
             let aliasTokens = self.view.fluentTheme.aliasTokens
             let primaryColor = UIColor(dynamicColor: aliasTokens.colors[.brandBackground1])
             FluentUIFramework.initializeAppearance(with: primaryColor, whenContainedInInstancesOf: [type(of: window)])

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -32,7 +32,7 @@ class DemoListViewController: DemoTableViewController {
     func updateColorProviderFor(window: UIWindow, theme: DemoColorTheme) {
         self.theme = theme
         if let provider2 = self.provider {
-            FluentTheme.setProvider(provider2, for: window)
+            window.setColorProvider(provider2)
             let aliasTokens = self.view.fluentTheme.aliasTokens
             let primaryColor = UIColor(dynamicColor: aliasTokens.colors[.brandBackground1])
             FluentUIFramework.initializeAppearance(with: primaryColor, whenContainedInInstancesOf: [type(of: window)])

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -98,17 +98,18 @@
 }
 
 - (void)overridesButtonPressed:(id)sender {
-    MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
-    [fluentTheme setProviderWithProvider:[ObjectiveCDemoColorProviding2 alloc]];
+    [MSFFluentTheme setProvider:[ObjectiveCDemoColorProviding2 alloc]
+                   forThemeable:[self view]];
 
-    MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
+    MSFAliasTokens *aliasTokens = [[[self view] fluentTheme] aliasTokens];
     MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
 
     [self addLabelWithText:@"Test label with override brand color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     // Remove the overrides
-    [fluentTheme removeProvider];
+    [MSFFluentTheme removeProviderForThemeable:[self view]];
+    aliasTokens = [[[self view] fluentTheme] aliasTokens];
     primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
 
     [self addLabelWithText:@"Test label with override color removed"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -98,8 +98,7 @@
 }
 
 - (void)overridesButtonPressed:(id)sender {
-    [MSFFluentTheme setProvider:[ObjectiveCDemoColorProviding2 alloc]
-                   forThemeable:[self view]];
+    [[self view] setColorProvider:[[ObjectiveCDemoColorProviding2 alloc] init]];
 
     MSFAliasTokens *aliasTokens = [[[self view] fluentTheme] aliasTokens];
     MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
@@ -108,7 +107,7 @@
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     // Remove the overrides
-    [MSFFluentTheme removeProviderForThemeable:[self view]];
+    [[self view] resetFluentTheme];
     aliasTokens = [[[self view] fluentTheme] aliasTokens];
     primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
 

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -12,80 +12,81 @@ import UIKit
 @objc(MSFColorProviding2)
 public protocol ColorProviding2 {
     /// If this protocol is not conformed to, communicationBlue variants will be used
-    @objc func brandBackground1(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackground1Pressed(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackground1Selected(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackground2(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackground2Pressed(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackground2Selected(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackground3(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackgroundTint(for theme: FluentTheme) -> UIColor?
-    @objc func brandBackgroundDisabled(for theme: FluentTheme) -> UIColor?
-    @objc func brandForeground1(for theme: FluentTheme) -> UIColor?
-    @objc func brandForeground1Pressed(for theme: FluentTheme) -> UIColor?
-    @objc func brandForeground1Selected(for theme: FluentTheme) -> UIColor?
-    @objc func brandForegroundTint(for theme: FluentTheme) -> UIColor?
-    @objc func brandForegroundDisabled1(for theme: FluentTheme) -> UIColor?
-    @objc func brandForegroundDisabled2(for theme: FluentTheme) -> UIColor?
-    @objc func brandStroke1(for theme: FluentTheme) -> UIColor?
-    @objc func brandStroke1Pressed(for theme: FluentTheme) -> UIColor?
-    @objc func brandStroke1Selected(for theme: FluentTheme) -> UIColor?
+    @objc func brandBackground1(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackground1Pressed(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackground1Selected(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackground2(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackground2Pressed(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackground2Selected(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackground3(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackgroundTint(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandBackgroundDisabled(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandForeground1(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandForeground1Pressed(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandForeground1Selected(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandForegroundTint(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandForegroundDisabled1(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandForegroundDisabled2(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandStroke1(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandStroke1Pressed(for themeable: FluentThemeable) -> UIColor?
+    @objc func brandStroke1Selected(for themeable: FluentThemeable) -> UIColor?
 }
 
-private func brandColorOverrides(provider: ColorProviding2, for theme: FluentTheme) -> [AliasTokens.ColorsTokens: DynamicColor] {
+private func brandColorOverrides(provider: ColorProviding2,
+                                 for themeable: FluentThemeable) -> [AliasTokens.ColorsTokens: DynamicColor] {
     var brandColors: [AliasTokens.ColorsTokens: DynamicColor] = [:]
-    if let brandBackground1 = provider.brandBackground1(for: theme)?.dynamicColor {
+    if let brandBackground1 = provider.brandBackground1(for: themeable)?.dynamicColor {
         brandColors[.brandBackground1] = brandBackground1
     }
-    if let brandBackground1Pressed = provider.brandBackground1Pressed(for: theme)?.dynamicColor {
+    if let brandBackground1Pressed = provider.brandBackground1Pressed(for: themeable)?.dynamicColor {
         brandColors[.brandBackground1Pressed] = brandBackground1Pressed
     }
-    if let brandBackground1Selected = provider.brandBackground1Selected(for: theme)?.dynamicColor {
+    if let brandBackground1Selected = provider.brandBackground1Selected(for: themeable)?.dynamicColor {
         brandColors[.brandBackground1Selected] = brandBackground1Selected
     }
-    if let brandBackground2 = provider.brandBackground2(for: theme)?.dynamicColor {
+    if let brandBackground2 = provider.brandBackground2(for: themeable)?.dynamicColor {
         brandColors[.brandBackground2] = brandBackground2
     }
-    if let brandBackground2Pressed = provider.brandBackground2Pressed(for: theme)?.dynamicColor {
+    if let brandBackground2Pressed = provider.brandBackground2Pressed(for: themeable)?.dynamicColor {
         brandColors[.brandBackground2Pressed] = brandBackground2Pressed
     }
-    if let brandBackground2Selected = provider.brandBackground2Selected(for: theme)?.dynamicColor {
+    if let brandBackground2Selected = provider.brandBackground2Selected(for: themeable)?.dynamicColor {
         brandColors[.brandBackground2Selected] = brandBackground2Selected
     }
-    if let brandBackground3 = provider.brandBackground3(for: theme)?.dynamicColor {
+    if let brandBackground3 = provider.brandBackground3(for: themeable)?.dynamicColor {
         brandColors[.brandBackground3] = brandBackground3
     }
-    if let brandBackgroundTint = provider.brandBackgroundTint(for: theme)?.dynamicColor {
+    if let brandBackgroundTint = provider.brandBackgroundTint(for: themeable)?.dynamicColor {
         brandColors[.brandBackgroundTint] = brandBackgroundTint
     }
-    if let brandBackgroundDisabled = provider.brandBackgroundDisabled(for: theme)?.dynamicColor {
+    if let brandBackgroundDisabled = provider.brandBackgroundDisabled(for: themeable)?.dynamicColor {
         brandColors[.brandBackgroundDisabled] = brandBackgroundDisabled
     }
-    if let brandForeground1 = provider.brandForeground1(for: theme)?.dynamicColor {
+    if let brandForeground1 = provider.brandForeground1(for: themeable)?.dynamicColor {
         brandColors[.brandForeground1] = brandForeground1
     }
-    if let brandForeground1Pressed = provider.brandForeground1Pressed(for: theme)?.dynamicColor {
+    if let brandForeground1Pressed = provider.brandForeground1Pressed(for: themeable)?.dynamicColor {
         brandColors[.brandForeground1Pressed] = brandForeground1Pressed
     }
-    if let brandForeground1Selected = provider.brandForeground1Selected(for: theme)?.dynamicColor {
+    if let brandForeground1Selected = provider.brandForeground1Selected(for: themeable)?.dynamicColor {
         brandColors[.brandForeground1Selected] = brandForeground1Selected
     }
-    if let brandForegroundTint = provider.brandForegroundTint(for: theme)?.dynamicColor {
+    if let brandForegroundTint = provider.brandForegroundTint(for: themeable)?.dynamicColor {
         brandColors[.brandForegroundTint] = brandForegroundTint
     }
-    if let brandForegroundDisabled1 = provider.brandForegroundDisabled1(for: theme)?.dynamicColor {
+    if let brandForegroundDisabled1 = provider.brandForegroundDisabled1(for: themeable)?.dynamicColor {
         brandColors[.brandForegroundDisabled1] = brandForegroundDisabled1
     }
-    if let brandForegroundDisabled2 = provider.brandForegroundDisabled2(for: theme)?.dynamicColor {
+    if let brandForegroundDisabled2 = provider.brandForegroundDisabled2(for: themeable)?.dynamicColor {
         brandColors[.brandForegroundDisabled2] = brandForegroundDisabled2
     }
-    if let brandStroke1 = provider.brandStroke1(for: theme)?.dynamicColor {
+    if let brandStroke1 = provider.brandStroke1(for: themeable)?.dynamicColor {
         brandColors[.brandStroke1] = brandStroke1
     }
-    if let brandStroke1Pressed = provider.brandStroke1Pressed(for: theme)?.dynamicColor {
+    if let brandStroke1Pressed = provider.brandStroke1Pressed(for: themeable)?.dynamicColor {
         brandColors[.brandStroke1Pressed] = brandStroke1Pressed
     }
-    if let brandStroke1Selected = provider.brandStroke1Selected(for: theme)?.dynamicColor {
+    if let brandStroke1Selected = provider.brandStroke1Selected(for: themeable)?.dynamicColor {
         brandColors[.brandStroke1Selected] = brandStroke1Selected
     }
     return brandColors
@@ -93,85 +94,28 @@ private func brandColorOverrides(provider: ColorProviding2, for theme: FluentThe
 
 // MARK: Colors
 
-private enum BrandColorsForOverriding: CaseIterable {
-    case brandBackground1
-    case brandBackground1Pressed
-    case brandBackground1Selected
-    case brandBackground2
-    case brandBackground2Pressed
-    case brandBackground2Selected
-    case brandBackground3
-    case brandBackgroundTint
-    case brandBackgroundDisabled
-    case brandForeground1
-    case brandForeground1Pressed
-    case brandForeground1Selected
-    case brandForegroundTint
-    case brandForegroundDisabled1
-    case brandForegroundDisabled2
-    case brandStroke1
-    case brandStroke1Pressed
-    case brandStroke1Selected
-
-    var equivalentAliasToken: AliasTokens.ColorsTokens {
-        switch self {
-        case .brandBackground1:
-            return .brandBackground1
-        case .brandBackground1Pressed:
-            return .brandBackground1Pressed
-        case .brandBackground1Selected:
-            return .brandBackground1Selected
-        case .brandBackground2:
-            return .brandBackground2
-        case .brandBackground2Pressed:
-            return .brandBackground2Pressed
-        case .brandBackground2Selected:
-            return .brandBackground2Selected
-        case .brandBackground3:
-            return .brandBackground3
-        case .brandBackgroundTint:
-            return .brandBackgroundTint
-        case .brandBackgroundDisabled:
-            return .brandBackgroundDisabled
-        case .brandForeground1:
-            return .brandForeground1
-        case .brandForeground1Pressed:
-            return .brandForeground1Pressed
-        case .brandForeground1Selected:
-            return .brandForeground1Selected
-        case .brandForegroundTint:
-            return .brandForegroundTint
-        case .brandForegroundDisabled1:
-            return .brandForegroundDisabled1
-        case .brandForegroundDisabled2:
-            return .brandForegroundDisabled2
-        case .brandStroke1:
-            return .brandStroke1
-        case .brandStroke1Pressed:
-            return .brandStroke1Pressed
-        case .brandStroke1Selected:
-            return .brandStroke1Selected
-        }
-    }
-}
-
 public extension FluentTheme {
-    /// Associates a `ColorProvider2` with a given `FluentTheme` instance.
+    /// Associates a `ColorProvider2` with a given `FluentThemeable` instance.
     ///
     /// - Parameters:
     ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
-    @objc func setProvider(provider: ColorProviding2) {
+    @objc(setProvider:forThemeable:)
+    static func setProvider(_ provider: ColorProviding2, for themeable: FluentThemeable) {
         // Create an updated fluent theme as well
-        let brandColors = brandColorOverrides(provider: provider, for: self)
+        let brandColors = brandColorOverrides(provider: provider, for: themeable)
+        let fluentTheme = FluentTheme()
         brandColors.forEach { token, value in
-            self.aliasTokens.colors[token] = value
+            fluentTheme.aliasTokens.colors[token] = value
         }
+        themeable.fluentTheme = fluentTheme
     }
 
-    /// Removes any associated `ColorProvider2` from the given `FluentTheme` instance.
-    @objc func removeProvider() {
-        for brandColor in BrandColorsForOverriding.allCases {
-            self.aliasTokens.colors.removeOverride(brandColor.equivalentAliasToken)
-        }
+    /// Removes any associated `ColorProvider` from the given `FluentThemeable` instance.
+    ///
+    /// - Parameters:
+    ///   - window: The `FluentThemeable` that should have its `ColorProvider2` removed.
+    @objc(removeProviderForThemeable:)
+    static func removeProvider(for themeable: FluentThemeable) {
+        themeable.fluentTheme = FluentThemeKey.defaultValue
     }
 }

--- a/ios/FluentUI/Core/Colors2.swift
+++ b/ios/FluentUI/Core/Colors2.swift
@@ -94,28 +94,25 @@ private func brandColorOverrides(provider: ColorProviding2,
 
 // MARK: Colors
 
-public extension FluentTheme {
-    /// Associates a `ColorProvider2` with a given `FluentThemeable` instance.
+@objc public extension UIView {
+    /// Associates a `ColorProvider2` with a given `UIView`.
     ///
     /// - Parameters:
     ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
-    @objc(setProvider:forThemeable:)
-    static func setProvider(_ provider: ColorProviding2, for themeable: FluentThemeable) {
+    @objc(setColorProvider:)
+    func setColorProvider(_ provider: ColorProviding2) {
         // Create an updated fluent theme as well
-        let brandColors = brandColorOverrides(provider: provider, for: themeable)
+        let brandColors = brandColorOverrides(provider: provider, for: self)
         let fluentTheme = FluentTheme()
         brandColors.forEach { token, value in
             fluentTheme.aliasTokens.colors[token] = value
         }
-        themeable.fluentTheme = fluentTheme
+        self.fluentTheme = fluentTheme
     }
 
-    /// Removes any associated `ColorProvider` from the given `FluentThemeable` instance.
-    ///
-    /// - Parameters:
-    ///   - window: The `FluentThemeable` that should have its `ColorProvider2` removed.
-    @objc(removeProviderForThemeable:)
-    static func removeProvider(for themeable: FluentThemeable) {
-        themeable.fluentTheme = FluentThemeKey.defaultValue
+    /// Removes any associated `ColorProvider` from the given `UIView`.
+    @objc(resetFluentTheme)
+    func resetFluentTheme() {
+        self.fluentTheme = FluentThemeKey.defaultValue
     }
 }

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -50,7 +50,7 @@ public class FluentTheme: NSObject, ObservableObject {
 // MARK: - FluentThemeable
 
 /// Public protocol that, when implemented, allows any container to store and yield a `FluentTheme`.
-public protocol FluentThemeable {
+@objc public protocol FluentThemeable {
     var fluentTheme: FluentTheme { get set }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,918,928 | 28,883,920 | -35,008 |
|  |  |  |  |

Moving the `ColorProviding2` API to align more closely with the existing `ColorProviding` API. In particular, the primary change is to move from changing `AliasTokens` _on_ the current `FluentTheme`, back to creating an entirely new `FluentTheme`. Among other things, this restores dynamic component re-rendering when calling the `ColorProviding2` API.

I also took the liberty to clean up the Objective-C API a bit, since it needs to change anyway.

Before (`ColorProviding1`):
```objc
@selector(setProviderWithProvider:for:)
```

After (`ColorProviding2`):
```objc
@selector(setProvider:forThemeable:)
```

### Verification

Works in UIKit, SwiftUI, and via the Objective-C APIs.

https://user-images.githubusercontent.com/4934719/213594220-7fd03b94-14a8-4950-b1a7-2a903dd0e433.mp4

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1501)