### PR TITLE
[XCUITests] Indeterminate Progress Bar tests

### DIFF
--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest.swift
@@ -12,4 +12,20 @@ class IndeterminateProgressBarTest: BaseTest {
     func testLaunch() throws {
         XCTAssertTrue(app.navigationBars[controlName].exists)
     }
+
+    // tests start/stop functionality as well as hiding (indeterminate progress bar should disappear when stopped)
+    func testStartStopHide() throws {
+        let startStopButton: XCUIElement = app.buttons["Start / Stop activity"]
+        let inProgress: NSPredicate = NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")
+
+        XCTAssert(app.otherElements.element(matching: inProgress).exists)
+        startStopButton.tap()
+        XCTAssert(!app.otherElements.element(matching: inProgress).exists)
+
+        app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch.tap()
+        XCTAssert(app.otherElements.element(matching: NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is progress halted")).exists)
+
+        startStopButton.tap()
+        XCTAssert(app.otherElements.element(matching: inProgress).exists)
+    }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest.swift
@@ -26,13 +26,17 @@ class IndeterminateProgressBarTest: BaseTest {
         let hidesWhenStoppedButton: XCUIElement = app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch
 
         XCTAssert(indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(!indeterminateProgressBarExists(status: progressHalted))
         startStopButton.tap()
         XCTAssert(!indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(!indeterminateProgressBarExists(status: progressHalted))
 
         hidesWhenStoppedButton.tap()
+        XCTAssert(!indeterminateProgressBarExists(status: inProgress))
         XCTAssert(indeterminateProgressBarExists(status: progressHalted))
 
         startStopButton.tap()
         XCTAssert(indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(!indeterminateProgressBarExists(status: progressHalted))
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest.swift
@@ -8,6 +8,13 @@ import XCTest
 class IndeterminateProgressBarTest: BaseTest {
     override var controlName: String { "IndeterminateProgressBar" }
 
+    let inProgress: NSPredicate = NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")
+    let progressHalted: NSPredicate = NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is progress halted")
+
+    func indeterminateProgressBarExists(status: NSPredicate) -> Bool {
+         return app.otherElements.element(matching: status).exists
+     }
+
     // launch test that ensures the demo app does not crash and is on the correct control page
     func testLaunch() throws {
         XCTAssertTrue(app.navigationBars[controlName].exists)
@@ -16,16 +23,16 @@ class IndeterminateProgressBarTest: BaseTest {
     // tests start/stop functionality as well as hiding (indeterminate progress bar should disappear when stopped)
     func testStartStopHide() throws {
         let startStopButton: XCUIElement = app.buttons["Start / Stop activity"]
-        let inProgress: NSPredicate = NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")
+        let hidesWhenStoppedButton: XCUIElement = app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch
 
-        XCTAssert(app.otherElements.element(matching: inProgress).exists)
+        XCTAssert(indeterminateProgressBarExists(status: inProgress))
         startStopButton.tap()
-        XCTAssert(!app.otherElements.element(matching: inProgress).exists)
+        XCTAssert(!indeterminateProgressBarExists(status: inProgress))
 
-        app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch.tap()
-        XCTAssert(app.otherElements.element(matching: NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is progress halted")).exists)
+        hidesWhenStoppedButton.tap()
+        XCTAssert(indeterminateProgressBarExists(status: progressHalted))
 
         startStopButton.tap()
-        XCTAssert(app.otherElements.element(matching: inProgress).exists)
+        XCTAssert(indeterminateProgressBarExists(status: inProgress))
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
@@ -17,19 +17,23 @@ class IndeterminateProgressBarTestSwiftUI: IndeterminateProgressBarTest {
     }
 
     override func testStartStopHide() throws {
-         let animatingSwitch: XCUIElement = app.switches["Animating"]
-         let hidesWhenStoppedSwitch: XCUIElement = app.switches["Hides when stopped"]
+        let animatingSwitch: XCUIElement = app.switches["Animating"]
+        let hidesWhenStoppedSwitch: XCUIElement = app.switches["Hides when stopped"]
 
-         hidesWhenStoppedSwitch.tap()
-         XCTAssert(indeterminateProgressBarExists(status: inProgress))
+        hidesWhenStoppedSwitch.tap()
+        XCTAssert(indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(!indeterminateProgressBarExists(status: progressHalted))
 
-         animatingSwitch.tap()
-         XCTAssert(indeterminateProgressBarExists(status: progressHalted))
+        animatingSwitch.tap()
+        XCTAssert(!indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(indeterminateProgressBarExists(status: progressHalted))
 
-         hidesWhenStoppedSwitch.tap()
-         XCTAssert(!indeterminateProgressBarExists(status: inProgress))
+        hidesWhenStoppedSwitch.tap()
+        XCTAssert(!indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(!indeterminateProgressBarExists(status: progressHalted))
 
-         animatingSwitch.tap()
-         XCTAssert(indeterminateProgressBarExists(status: inProgress))
+        animatingSwitch.tap()
+        XCTAssert(indeterminateProgressBarExists(status: inProgress))
+        XCTAssert(!indeterminateProgressBarExists(status: progressHalted))
      }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
@@ -21,15 +21,15 @@ class IndeterminateProgressBarTestSwiftUI: IndeterminateProgressBarTest {
          let hidesWhenStoppedSwitch: XCUIElement = app.switches["Hides when stopped"]
 
          hidesWhenStoppedSwitch.tap()
-         XCTAssert(super.indeterminateProgressBarExists(status: super.inProgress))
+         XCTAssert(indeterminateProgressBarExists(status: inProgress))
 
          animatingSwitch.tap()
-         XCTAssert(super.indeterminateProgressBarExists(status: super.progressHalted))
+         XCTAssert(indeterminateProgressBarExists(status: progressHalted))
 
          hidesWhenStoppedSwitch.tap()
-         XCTAssert(!super.indeterminateProgressBarExists(status: super.inProgress))
+         XCTAssert(!indeterminateProgressBarExists(status: inProgress))
 
          animatingSwitch.tap()
-         XCTAssert(super.indeterminateProgressBarExists(status: super.inProgress))
+         XCTAssert(indeterminateProgressBarExists(status: inProgress))
      }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
@@ -17,4 +17,21 @@ class IndeterminateProgressBarTestSwiftUI: BaseTest {
     func testLaunch() throws {
         XCTAssertTrue(app.navigationBars.element(matching: NSPredicate(format: "identifier CONTAINS %@", controlName)).exists)
     }
+
+    // tests indeterminate progress bar's start/stop functionality
+     func testAnimating() throws {
+         app.switches["Hides when stopped"].tap()
+         XCTAssert(app.otherElements.element(matching: NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")).exists)
+
+         app.switches["Animating"].tap()
+         XCTAssert(app.otherElements.element(matching: NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is progress halted")).exists)
+     }
+
+     // ensures that indeterminate progress bar disappears when stopped
+     func testHidingWhenStoppedOn() throws {
+         let inProgress: NSPredicate = NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")
+         XCTAssert(app.otherElements.element(matching: inProgress).exists)
+         app.switches["Animating"].tap()
+         XCTAssert(!app.otherElements.element(matching: inProgress).exists)
+     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/IndeterminateProgressBarTest_SwiftUI.swift
@@ -5,33 +5,31 @@
 
 import XCTest
 
-class IndeterminateProgressBarTestSwiftUI: BaseTest {
-    override var controlName: String { "IndeterminateProgressBar" }
-
+class IndeterminateProgressBarTestSwiftUI: IndeterminateProgressBarTest {
     override func setUpWithError() throws {
         try super.setUpWithError()
         app.staticTexts["SwiftUI Demo"].tap()
     }
 
     // launch test that ensures the demo app does not crash and is on the correct control page
-    func testLaunch() throws {
+    override func testLaunch() throws {
         XCTAssertTrue(app.navigationBars.element(matching: NSPredicate(format: "identifier CONTAINS %@", controlName)).exists)
     }
 
-    // tests indeterminate progress bar's start/stop functionality
-     func testAnimating() throws {
-         app.switches["Hides when stopped"].tap()
-         XCTAssert(app.otherElements.element(matching: NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")).exists)
+    override func testStartStopHide() throws {
+         let animatingSwitch: XCUIElement = app.switches["Animating"]
+         let hidesWhenStoppedSwitch: XCUIElement = app.switches["Hides when stopped"]
 
-         app.switches["Animating"].tap()
-         XCTAssert(app.otherElements.element(matching: NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is progress halted")).exists)
-     }
+         hidesWhenStoppedSwitch.tap()
+         XCTAssert(super.indeterminateProgressBarExists(status: super.inProgress))
 
-     // ensures that indeterminate progress bar disappears when stopped
-     func testHidingWhenStoppedOn() throws {
-         let inProgress: NSPredicate = NSPredicate(format: "identifier CONTAINS %@", "Indeterminate Progress Bar that is in progress")
-         XCTAssert(app.otherElements.element(matching: inProgress).exists)
-         app.switches["Animating"].tap()
-         XCTAssert(!app.otherElements.element(matching: inProgress).exists)
+         animatingSwitch.tap()
+         XCTAssert(super.indeterminateProgressBarExists(status: super.progressHalted))
+
+         hidesWhenStoppedSwitch.tap()
+         XCTAssert(!super.indeterminateProgressBarExists(status: super.inProgress))
+
+         animatingSwitch.tap()
+         XCTAssert(super.indeterminateProgressBarExists(status: super.inProgress))
      }
 }

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -45,6 +45,11 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
                 :
                 "Accessibility.ActivityIndicator.Stopped.label".localized
         }()
+#if DEBUG
+        let accessibilityIdentifier: String = {
+            return "Indeterminate Progress Bar that is \(state.isAnimating ? "in progress" : "progress halted")"
+        }()
+#endif
 
         Rectangle()
             .fill(LinearGradient(gradient: Gradient(colors: [backgroundColor, gradientColor, backgroundColor]),
@@ -57,6 +62,9 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
                    alignment: .center)
             .background(backgroundColor)
             .accessibilityLabel(Text(accessibilityLabel))
+#if DEBUG
+            .accessibilityIdentifier(accessibilityIdentifier)
+#endif
             .accessibilityAddTraits(.updatesFrequently)
             .modifyIf(state.isAnimating, { view in
                 view

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBar.swift
@@ -46,9 +46,7 @@ public struct IndeterminateProgressBar: View, TokenizedControlView {
                 "Accessibility.ActivityIndicator.Stopped.label".localized
         }()
 #if DEBUG
-        let accessibilityIdentifier: String = {
-            return "Indeterminate Progress Bar that is \(state.isAnimating ? "in progress" : "progress halted")"
-        }()
+        let accessibilityIdentifier: String = "Indeterminate Progress Bar that is \(state.isAnimating ? "in progress" : "progress halted")"
 #endif
 
         Rectangle()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,875,336 bytes | 28,875,344 bytes | 8 bytes |

Added new UI test for Indeterminate Progress Bar (both UIKit and SwiftUI). An accessibility identifier was added to `IndeterminateProgressBar` in debug that tracks the state's status for tests. Specifically, `testStartStopHide` was added, which tests the start/stop functionality as well as hiding (indeterminate progress bar should disappear when stopped). The SwiftUI test was also updated to inherit from the UIKit test instead of `BaseTest` to cut down on code duplication.

### Verification

| UIKit                                       | SwiftUI                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-19 at 15 29 35](https://user-images.githubusercontent.com/55368679/213762479-70abd1cd-01c9-425f-a92f-867b5cfc73e3.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-19 at 15 30 23](https://user-images.githubusercontent.com/55368679/213762509-1e12b408-dc3c-4460-a7e8-216d27c92791.gif) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)