### PR TITLE
Re-add error style label

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -59,6 +59,8 @@ extension TextColorStyle {
             return "White"
         case .primary:
             return "Primary"
+        case .error:
+            return "Error"
         }
     }
 }

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -13,6 +13,7 @@ public enum TextColorStyle: Int, CaseIterable {
     case secondary
     case white
     case primary
+    case error
 
     func color(fluentTheme: FluentTheme) -> UIColor {
         switch self {
@@ -24,6 +25,8 @@ public enum TextColorStyle: Int, CaseIterable {
             return .white
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+        case .error:
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground2])
         }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Re-adding the error style label since it has a usage in devmain.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,106,328 bytes | 29,106,840 bytes | 514 bytes |

### Verification

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="Screenshot 2023-01-20 at 3 12 18 PM" src="https://user-images.githubusercontent.com/106181067/213821473-59d1bb1f-feed-47a7-85ab-c6b40fbae49c.png"> | <img width="487" alt="Screenshot 2023-01-20 at 3 12 22 PM" src="https://user-images.githubusercontent.com/106181067/213821489-04bef1c8-b694-4d87-ba66-02a5d3185f83.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1505)