### PR TITLE
[XCUITests] Table View Cell tests

### DIFF
--- a/ios/FluentUI.Demo/FluentUIDemoTests/TableViewCellTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/TableViewCellTest.swift
@@ -16,17 +16,21 @@ class TableViewCellTest: BaseTest {
     let longSubtitle: String = "\"This is a cell with a long text2 as an example of how this label will render\""
     let longFooter: String = "\"This is a cell with a long text3 as an example of how this label will render\""
 
+    func assertSingleLine() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 0).identifier, "Table View Cell with title \(title), with a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 1).identifier, "Table View Cell with title \(title), with a leading image and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading image and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading image and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading image and a title leading image")
+    }
+
     // launch test that ensures the demo app does not crash and is on the correct control page
     func testLaunch() throws {
         XCTAssertTrue(app.navigationBars[controlName].exists)
     }
 
     func testSingleLine() throws {
-        XCTAssertEqual(app.cells.element(boundBy: 0).identifier, "Table View Cell with title \(title), with a leading image")
-        XCTAssertEqual(app.cells.element(boundBy: 1).identifier, "Table View Cell with title \(title), with a leading image and a chevron")
-        XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading image and a details button")
-        XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading image and a checkmark")
-        XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading image and a title leading image")
+        try assertSingleLine()
     }
 
     func testDoubleLine() throws {
@@ -70,11 +74,7 @@ class TableViewCellTest: BaseTest {
     }
 
     func testSelection() throws {
-        XCTAssertEqual(app.cells.element(boundBy: 0).identifier, "Table View Cell with title \(title), with a leading image")
-        XCTAssertEqual(app.cells.element(boundBy: 1).identifier, "Table View Cell with title \(title), with a leading image and a chevron")
-        XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading image and a details button")
-        XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading image and a checkmark")
-        XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading image and a title leading image")
+        try assertSingleLine()
 
         app.buttons["Select"].tap()
         for i in 0...4 {
@@ -87,5 +87,13 @@ class TableViewCellTest: BaseTest {
         XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a details button")
         XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a checkmark")
         XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a title leading image")
+
+        app.buttons["Select"].tap()
+        for i in 0...4 {
+            app.images.element(boundBy: i).tap()
+        }
+        app.buttons["Done"].tap()
+
+        try assertSingleLine()
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/TableViewCellTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/TableViewCellTest.swift
@@ -8,8 +8,84 @@ import XCTest
 class TableViewCellTest: BaseTest {
     override var controlName: String { "TableViewCell" }
 
+    let title: String = "\"Contoso Survey\""
+    let subtitle: String = "\"Research Notes\""
+    let footer: String = "\"22 views\""
+    let customTitle: String = "\"Format\""
+    let longTitle: String = "\"This is a cell with a long text1 as an example of how this label will render\""
+    let longSubtitle: String = "\"This is a cell with a long text2 as an example of how this label will render\""
+    let longFooter: String = "\"This is a cell with a long text3 as an example of how this label will render\""
+
     // launch test that ensures the demo app does not crash and is on the correct control page
     func testLaunch() throws {
         XCTAssertTrue(app.navigationBars[controlName].exists)
+    }
+
+    func testSingleLine() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 0).identifier, "Table View Cell with title \(title), with a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 1).identifier, "Table View Cell with title \(title), with a leading image and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading image and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading image and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading image and a title leading image")
+    }
+
+    func testDoubleLine() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 5).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a leading unread dot and a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 6).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a leading unread dot, a leading image, and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 7).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a leading unread dot, a leading image, and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 8).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a leading unread dot, a leading image, and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 9).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a leading unread dot, a leading image, and a subtitle leading image")
+    }
+
+    func testInvertedDoubleLine() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 10).identifier, "Table View Cell with title \(title) and subtitle \(subtitle)")
+        XCTAssertEqual(app.cells.element(boundBy: 11).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 12).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 13).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 14).identifier, "Table View Cell with title \(title) and subtitle \(subtitle), with a subtitle leading image")
+    }
+
+    func testTripleLine() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 15).identifier, "Table View Cell with title \(title), subtitle \(subtitle), and footer \(footer), with a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 16).identifier, "Table View Cell with title \(title), subtitle \(subtitle), and footer \(footer), with a leading image and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 17).identifier, "Table View Cell with title \(title), subtitle \(subtitle), and footer \(footer), with a leading image and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 18).identifier, "Table View Cell with title \(title), subtitle \(subtitle), and footer \(footer), with a leading image and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 19).identifier, "Table View Cell with title \(title), subtitle \(subtitle), and footer, with a leading image, a subtitle trailing image, and a footer trailing image")
+    }
+
+    func testCustomView() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 25).identifier, "Table View Cell with title \(customTitle)")
+        XCTAssertEqual(app.cells.element(boundBy: 26).identifier, "Table View Cell with title \(customTitle), with a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 27).identifier, "Table View Cell with title \(customTitle), with a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 28).identifier, "Table View Cell with title \(customTitle), with a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 29).identifier, "Table View Cell with title \(customTitle)")
+    }
+
+    func testLongLabels() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 30).identifier, "Table View Cell with title \(longTitle), subtitle \(longSubtitle), and footer \(longFooter), with a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 31).identifier, "Table View Cell with title \(longTitle), subtitle \(longSubtitle), and footer \(longFooter), with a leading image and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 32).identifier, "Table View Cell with title \(longTitle), subtitle \(longSubtitle), and footer \(longFooter), with a leading image and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 33).identifier, "Table View Cell with title \(longTitle), subtitle \(longSubtitle), and footer \(longFooter), with a leading image and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 34).identifier, "Table View Cell with title \(longTitle), subtitle \(longSubtitle), and footer \(longFooter), with a leading image, a title trailing image, a subtitle trailing image, and a footer trailing image")
+    }
+
+    func testSelection() throws {
+        XCTAssertEqual(app.cells.element(boundBy: 0).identifier, "Table View Cell with title \(title), with a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 1).identifier, "Table View Cell with title \(title), with a leading image and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading image and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading image and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading image and a title leading image")
+
+        app.buttons["Select"].tap()
+        for i in 0...4 {
+            app.images.element(boundBy: i).tap()
+        }
+        app.buttons["Done"].tap()
+
+        XCTAssertEqual(app.cells.element(boundBy: 0).identifier, "Table View Cell with title \(title), with a leading unread dot and a leading image")
+        XCTAssertEqual(app.cells.element(boundBy: 1).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a chevron")
+        XCTAssertEqual(app.cells.element(boundBy: 2).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a details button")
+        XCTAssertEqual(app.cells.element(boundBy: 3).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a checkmark")
+        XCTAssertEqual(app.cells.element(boundBy: 4).identifier, "Table View Cell with title \(title), with a leading unread dot, a leading image, and a title leading image")
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/TableViewCellTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/TableViewCellTest.swift
@@ -73,6 +73,7 @@ class TableViewCellTest: BaseTest {
         XCTAssertEqual(app.cells.element(boundBy: 34).identifier, "Table View Cell with title \(longTitle), subtitle \(longSubtitle), and footer \(longFooter), with a leading image, a title trailing image, a subtitle trailing image, and a footer trailing image")
     }
 
+    // ensures that selection/deselection adds/removes unread dot
     func testSelection() throws {
         try assertSingleLine()
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1147,6 +1147,87 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         set { super.accessibilityValue = newValue }
     }
 
+#if DEBUG
+    open override var accessibilityIdentifier: String? {
+        get {
+            var identifier: String = "Table View Cell with"
+
+            switch layoutType {
+            case .oneLine:
+                identifier += " title \"\(title)\""
+            case .twoLines:
+                identifier += " title \"\(title)\" and subtitle \"\(subtitle)\""
+            case .threeLines:
+                identifier += " title \"\(title)\", subtitle \"\(subtitle)\", and footer"
+                if footer != "" {
+                    identifier += " \"\(footer)\""
+                }
+            }
+
+            var accessoryViews: [String] = []
+
+            if isUnreadDotVisible {
+                accessoryViews.append("leading unread dot")
+            }
+
+            if customView != nil {
+                accessoryViews.append("leading image")
+            }
+
+            if titleLeadingAccessoryView != nil {
+                accessoryViews.append("title leading image")
+            }
+
+            if subtitleLeadingAccessoryView != nil {
+                accessoryViews.append("subtitle leading image")
+            }
+
+            if footerLeadingAccessoryView != nil {
+                accessoryViews.append("footer leading image")
+            }
+
+            switch _accessoryType {
+            case .none:
+                break
+            case .disclosureIndicator:
+                accessoryViews.append("chevron")
+            case .detailButton:
+                accessoryViews.append("details button")
+            case .checkmark:
+                accessoryViews.append("checkmark")
+            }
+
+            if titleTrailingAccessoryView != nil {
+                accessoryViews.append("title trailing image")
+            }
+
+            if subtitleTrailingAccessoryView != nil {
+                accessoryViews.append("subtitle trailing image")
+            }
+
+            if footerTrailingAccessoryView != nil {
+                accessoryViews.append("footer trailing image")
+            }
+
+            if accessoryViews.count > 0 {
+                identifier += ", with a \(accessoryViews[0])"
+            }
+
+            if accessoryViews.count == 2 {
+                identifier += " and a \(accessoryViews[1])"
+            } else if accessoryViews.count > 2 {
+                for i in 1...accessoryViews.count - 2 {
+                    identifier += ", a \(accessoryViews[i])"
+                }
+                identifier += ", and a \(accessoryViews[accessoryViews.count - 1])"
+            }
+
+            return identifier
+        }
+        set { }
+    }
+#endif
+
     open override var accessibilityActivationPoint: CGPoint {
         get {
             if let customAccessoryView = customAccessoryView as? UISwitch {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,875,336 bytes | 28,875,336 bytes | 0 bytes |

Added targeted UI tests for Table View Cell. An accessibility identifier was added to `TableViewCell` in debug that tracks the title, subtitle (if applicable), footer (if applicable), and accessory views (unread dot, leading images, trailing images). `testSelection` tests that selecting the single line cells will add an unread dot and that deselecting them will remove the unread dot. All other tests ensure that each cell has the correct accessibility identifier (with emphasis on each cell's accessory views.)

### Verification

![Simulator Screen Recording - iPhone 14 Pro - 2023-01-23 at 14 27 09](https://user-images.githubusercontent.com/55368679/214164421-ca6c4f57-bfe9-4baf-8be2-ff2476ad6be7.gif)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)