### PR TITLE
[Fluent 2 iOS] Alias token cleanup

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -78,25 +78,39 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .strokeDisabled,
              .strokeFocus1,
              .brandBackgroundTint,
-             .foregroundDisabled1:
+             .foregroundDisabled1,
+             .dangerBackground1,
+             .successBackground1,
+             .warningBackground1,
+             .severeBackground1:
             return UIColor(dynamicColor: aliasTokens.colors[.foreground1])
         case .brandBackground3Pressed,
              .foreground1,
              .foreground2,
              .foreground3,
-             .foregroundInverted2,
              .strokeFocus2,
              .brandBackground1Pressed,
              .brandForeground1Pressed,
              .brandStroke1Pressed,
              .brandStroke1,
              .brandForegroundTint,
-             .brandStroke1Selected:
+             .brandStroke1Selected,
+             .dangerBackground2,
+             .dangerForeground1,
+             .dangerForeground2,
+             .successBackground2,
+             .successForeground1,
+             .successForeground2,
+             .warningForeground1,
+             .warningForeground2,
+             .severeBackground2,
+             .severeForeground1,
+             .severeForeground2:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundOnColor])
-        case .foregroundInverted1,
-             .foregroundLightStatic,
+        case .foregroundLightStatic,
              .backgroundLightStatic,
-             .backgroundLightStaticDisabled:
+             .backgroundLightStaticDisabled,
+             .warningBackground2:
             return UIColor(dynamicColor: aliasTokens.colors[.foregroundDarkStatic])
         case .brandForeground1,
              .brandForeground1Selected,
@@ -110,8 +124,12 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .brandBackground3,
              .strokeAccessible,
              .backgroundDarkStatic,
-             .foregroundDarkStatic:
-            return UIColor(dynamicColor: aliasTokens.colors[.foregroundInverted1])
+             .foregroundDarkStatic,
+             .presenceAway,
+             .presenceDnd,
+             .presenceAvailable,
+             .presenceOof:
+            return UIColor(dynamicColor: aliasTokens.colors[.foregroundLightStatic])
         }
     }
 
@@ -128,6 +146,8 @@ private enum AliasColorTokensDemoSection: CaseIterable {
     case brandForegrounds
     case neutralStrokes
     case brandStrokes
+    case sharedErrorAndStatus
+    case sharedPresence
 
     var title: String {
         switch self {
@@ -143,6 +163,10 @@ private enum AliasColorTokensDemoSection: CaseIterable {
             return "Neutral Strokes"
         case .brandStrokes:
             return "Brand Strokes"
+        case .sharedErrorAndStatus:
+            return "Shared Error and Status"
+        case .sharedPresence:
+            return "Shared Presence"
         }
     }
 
@@ -193,8 +217,6 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .foregroundDisabled1,
                     .foregroundDisabled2,
                     .foregroundOnColor,
-                    .foregroundInverted1,
-                    .foregroundInverted2,
                     .foregroundLightStatic,
                     .foregroundDarkStatic]
         case .brandForegrounds:
@@ -215,6 +237,28 @@ private enum AliasColorTokensDemoSection: CaseIterable {
             return [.brandStroke1,
                     .brandStroke1Pressed,
                     .brandStroke1Selected]
+        case .sharedErrorAndStatus:
+            return [.dangerBackground1,
+                    .dangerBackground2,
+                    .dangerForeground1,
+                    .dangerForeground2,
+                    .successBackground1,
+                    .successBackground2,
+                    .successForeground1,
+                    .successForeground2,
+                    .warningBackground1,
+                    .warningBackground2,
+                    .warningForeground1,
+                    .warningForeground2,
+                    .severeBackground1,
+                    .severeBackground2,
+                    .severeForeground1,
+                    .severeForeground2]
+        case .sharedPresence:
+            return [.presenceAway,
+                    .presenceDnd,
+                    .presenceAvailable,
+                    .presenceOof]
         }
     }
 }
@@ -234,10 +278,6 @@ private extension AliasTokens.ColorsTokens {
             return "Foreground Disabled 2"
         case .foregroundOnColor:
             return "Foreground On Color"
-        case .foregroundInverted1:
-            return "Foreground Inverted 1"
-        case .foregroundInverted2:
-            return "Foreground Inverted 2"
         case .brandForeground1:
             return "Brand Foreground 1"
         case .brandForeground1Pressed:
@@ -344,6 +384,46 @@ private extension AliasTokens.ColorsTokens {
             return "BackgroundLightStatic"
         case .backgroundLightStaticDisabled:
             return "BackgroundLightStaticDisabled"
+        case .dangerBackground1:
+            return "DangerBackground1"
+        case .dangerBackground2:
+            return "DangerBackground2"
+        case .dangerForeground1:
+            return "DangerForeground1"
+        case .dangerForeground2:
+            return "DangerForeground2"
+        case .successBackground1:
+            return "SuccessBackground1"
+        case .successBackground2:
+            return "SuccessBackground2"
+        case .successForeground1:
+            return "SuccessForeground1"
+        case .successForeground2:
+            return "SuccessForeground2"
+        case .warningBackground1:
+            return "WarningBackground1"
+        case .warningBackground2:
+            return "WarningBackground2"
+        case .warningForeground1:
+            return "WarningForeground1"
+        case .warningForeground2:
+            return "WarningForeground2"
+        case .severeBackground1:
+            return "SevereBackground1"
+        case .severeBackground2:
+            return "SevereBackground2"
+        case .severeForeground1:
+            return "SevereForeground1"
+        case .severeForeground2:
+            return "SevereForeground2"
+        case .presenceAway:
+            return "PresenceAway"
+        case .presenceDnd:
+            return "PresenceDnd"
+        case .presenceAvailable:
+            return "PresenceAvailable"
+        case .presenceOof:
+            return "PresenceOof"
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -664,7 +664,9 @@ class ModalViewController: UITableViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundInverted2])
+        let tintColor = DynamicColor(light: GlobalTokens.brandColors(.comm80),
+                                     dark: GlobalTokens.neutralColors(.white))
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: tintColor)
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI/Avatar/MSFAvatarPresence.swift
+++ b/ios/FluentUI/Avatar/MSFAvatarPresence.swift
@@ -23,13 +23,13 @@ import SwiftUI
         case .none:
             break
         case .available:
-            color = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceAvailable])
+            color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceAvailable])
         case .away:
-            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceAway])
+            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceAway])
         case .busy, .blocked, .doNotDisturb:
-            color = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceDnd])
+            color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceDnd])
         case .offline:
-            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         case .unknown:
             color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
         }

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -146,15 +146,15 @@ open class BadgeView: UIView {
             case .default:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundTint])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.warningForeground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.warningForeground1])
             case .error:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerForeground1])
             case .neutral:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
             case .severeWarning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.severeForeground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.severeForeground1])
             case .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.successForeground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.successForeground1])
             }
         }
         set {
@@ -220,15 +220,15 @@ open class BadgeView: UIView {
             case .default:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackgroundTint])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.warningBackground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.warningBackground1])
             case .error:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerBackground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerBackground1])
             case .neutral:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
             case .severeWarning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.severeBackground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.severeBackground1])
             case .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.successBackground1])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.successBackground1])
             }
         }
         set {
@@ -249,15 +249,15 @@ open class BadgeView: UIView {
             case .default:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.warningBackground2])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.warningBackground2])
             case .error:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerBackground2])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerBackground2])
             case .neutral:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5Selected])
             case .severeWarning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.severeBackground2])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.severeBackground2])
             case .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.successBackground2])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.successBackground2])
             }
         }
         set {

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -86,7 +86,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .danger:
-                        return theme.aliasTokens.sharedColors[.dangerBackground2]
+                        return theme.aliasTokens.colors[.dangerBackground2]
                     }
                 }
             case .backgroundFocusedColor:
@@ -97,7 +97,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .danger:
-                        return theme.aliasTokens.sharedColors[.dangerBackground2]
+                        return theme.aliasTokens.colors[.dangerBackground2]
                     }
                 }
             case .backgroundDisabledColor:
@@ -117,7 +117,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .danger:
-                        return theme.aliasTokens.sharedColors[.dangerBackground2]
+                        return theme.aliasTokens.colors[.dangerBackground2]
                     }
                 }
             case .borderColor:
@@ -128,7 +128,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .outline:
                         return theme.aliasTokens.colors[.brandStroke1]
                     case .dangerOutline:
-                        return theme.aliasTokens.sharedColors[.dangerForeground2]
+                        return theme.aliasTokens.colors[.dangerForeground2]
                     }
                 }
             case .borderFocusedColor:
@@ -139,7 +139,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .outline:
                         return theme.aliasTokens.colors[.strokeFocus2]
                     case .dangerOutline:
-                        return theme.aliasTokens.sharedColors[.dangerForeground2]
+                        return theme.aliasTokens.colors[.dangerForeground2]
                     }
                 }
             case .borderDisabledColor:
@@ -159,7 +159,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .outline:
                         return theme.aliasTokens.colors[.brandStroke1Pressed]
                     case .dangerOutline:
-                        return theme.aliasTokens.sharedColors[.dangerForeground2]
+                        return theme.aliasTokens.colors[.dangerForeground2]
                     }
                 }
             case .borderWidth:
@@ -190,7 +190,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .danger:
                         return theme.aliasTokens.colors[.foregroundLightStatic]
                     case .dangerOutline, .dangerSubtle:
-                        return theme.aliasTokens.sharedColors[.dangerForeground2]
+                        return theme.aliasTokens.colors[.dangerForeground2]
                     }
                 }
             case .foregroundDisabledColor:
@@ -205,7 +205,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .danger:
                         return theme.aliasTokens.colors[.foregroundLightStatic]
                     case .dangerOutline, .dangerSubtle:
-                        return theme.aliasTokens.sharedColors[.dangerForeground2]
+                        return theme.aliasTokens.colors[.dangerForeground2]
                     }
                 }
             case .titleFont:

--- a/ios/FluentUI/Core/Colors.swift
+++ b/ios/FluentUI/Core/Colors.swift
@@ -27,35 +27,6 @@ public protocol ColorProviding {
     @objc func primaryShade30Color(for window: UIWindow) -> UIColor?
 }
 
-private func brandColorOverrides(provider: ColorProviding, for window: UIWindow) -> [AliasTokens.BrandColorsTokens: DynamicColor] {
-    var brandColors: [AliasTokens.BrandColorsTokens: DynamicColor] = [:]
-    if let primary = provider.primaryColor(for: window)?.dynamicColor {
-        brandColors[.primary] = primary
-    }
-    if let tint10 = provider.primaryTint10Color(for: window)?.dynamicColor {
-        brandColors[.tint10] = tint10
-    }
-    if let tint20 = provider.primaryTint20Color(for: window)?.dynamicColor {
-        brandColors[.tint20] = tint20
-    }
-    if let tint30 = provider.primaryTint30Color(for: window)?.dynamicColor {
-        brandColors[.tint30] = tint30
-    }
-    if let tint40 = provider.primaryTint40Color(for: window)?.dynamicColor {
-        brandColors[.tint40] = tint40
-    }
-    if let shade10 = provider.primaryShade10Color(for: window)?.dynamicColor {
-        brandColors[.shade10] = shade10
-    }
-    if let shade20 = provider.primaryShade20Color(for: window)?.dynamicColor {
-        brandColors[.shade20] = shade20
-    }
-    if let shade30 = provider.primaryShade30Color(for: window)?.dynamicColor {
-        brandColors[.shade30] = shade30
-    }
-    return brandColors
-}
-
 // MARK: Colors
 
 @objc(MSFColors)
@@ -477,32 +448,6 @@ public final class Colors: NSObject {
                 return "presenceUnknown"
             }
         }
-    }
-
-    /// Associates a `ColorProvider` with a given `UIWindow` instance.
-    ///
-    /// - Parameters:
-    ///   - provider: The `ColorProvider` whose colors should be used for controls in this window.
-    ///   - window: The window where these colors should be applied.
-    @objc public static func setProvider(provider: ColorProviding, for window: UIWindow) {
-        colorProvidersMap.setObject(provider, forKey: window)
-
-        // Create an updated fluent theme as well
-        let brandColors = brandColorOverrides(provider: provider, for: window)
-        let fluentTheme = FluentTheme()
-        brandColors.forEach { token, value in
-            fluentTheme.aliasTokens.brandColors[token] = value
-        }
-        window.fluentTheme = fluentTheme
-    }
-
-    /// Removes any associated `ColorProvider` from the given `UIWindow` instance.
-    ///
-    /// - Parameters:
-    ///   - window: The window that should have its `ColorProvider` removed.
-    @objc public static func removeProvider(for window: UIWindow) {
-        colorProvidersMap.removeObject(forKey: window)
-        window.fluentTheme = FluentThemeKey.defaultValue
     }
 
     // MARK: Primary

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -8,105 +8,6 @@ import SwiftUI
 @objc(MSFAliasTokens)
 public final class AliasTokens: NSObject {
 
-    // MARK: - BrandColors
-
-    @objc(MSFBrandColorsAliasTokens)
-    public enum BrandColorsTokens: Int, TokenSetKey {
-        case primary
-        case shade10
-        case shade20
-        case shade30
-        case tint10
-        case tint20
-        case tint30
-        case tint40
-    }
-
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `brandColors` property directly.")
-    @objc(brandColorForToken:)
-    public func brandColor(_ token: BrandColorsTokens) -> DynamicColor {
-        return brandColors[token]
-    }
-
-    public var brandColors: TokenSet<BrandColorsTokens, DynamicColor> = .init { token in
-        switch token {
-        case .primary:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
-                                dark: GlobalTokens.brandColors(.comm90))
-        case .shade10:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm70),
-                                dark: GlobalTokens.brandColors(.comm100))
-        case .shade20:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm60),
-                                dark: GlobalTokens.brandColors(.comm110))
-        case .shade30:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm50),
-                                dark: GlobalTokens.brandColors(.comm120))
-        case .tint10:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm90),
-                                dark: GlobalTokens.brandColors(.comm80))
-        case .tint20:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm100),
-                                dark: GlobalTokens.brandColors(.comm70))
-        case .tint30:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm110),
-                                dark: GlobalTokens.brandColors(.comm90))
-        case .tint40:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm140),
-                                dark: GlobalTokens.brandColors(.comm20))
-        }
-    }
-
-    // MARK: - ShadowColors
-
-    @objc(MSFShadowColorsAliasTokens)
-    public enum ShadowColorsTokens: Int, TokenSetKey {
-        case neutralAmbient
-        case neutralKey
-        case neutralAmbientLighter
-        case neutralKeyLighter
-        case neutralAmbientDarker
-        case neutralKeyDarker
-        case brandAmbient
-        case brandKey
-    }
-
-    @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `shadowColors` property directly.")
-    @objc(shadowColorForToken:)
-    public func shadowColor(_ token: ShadowColorsTokens) -> DynamicColor {
-        return shadowColors[token]
-    }
-
-    lazy public var shadowColors: TokenSet<ShadowColorsTokens, DynamicColor> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
-        switch token {
-        case .neutralAmbient:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20))
-        case .neutralKey:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28))
-        case .neutralAmbientLighter:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.06),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12))
-        case .neutralKeyLighter:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.07),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14))
-        case .neutralAmbientDarker:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40))
-        case .neutralKeyDarker:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48))
-        case .brandAmbient:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.30),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.30))
-        case .brandKey:
-            return DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.25),
-                                dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.25))
-        }
-    }
-
     // MARK: - Typography
 
     @objc(MSFTypographyAliasTokens)
@@ -192,8 +93,7 @@ public final class AliasTokens: NSObject {
         return shadow[token]
     }
 
-    lazy public var shadow: TokenSet<ShadowTokens, ShadowInfo> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
+    public var shadow: TokenSet<ShadowTokens, ShadowInfo> = .init { token in
         switch token {
         case .clear:
             return ShadowInfo(colorOne: DynamicColor(light: ColorValue.clear),
@@ -205,84 +105,79 @@ public final class AliasTokens: NSObject {
                               xTwo: 0.0,
                               yTwo: 0.0)
         case .shadow02:
-            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+            return ShadowInfo(colorOne: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
                               blurOne: 2,
                               xOne: 0,
                               yOne: 1,
-                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              colorTwo: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
                               blurTwo: 2,
                               xTwo: 0,
                               yTwo: 0)
         case .shadow04:
-            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+            return ShadowInfo(colorOne: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
                               blurOne: 4,
                               xOne: 0,
                               yOne: 2,
-                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              colorTwo: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
                               blurTwo: 2,
                               xTwo: 0,
                               yTwo: 0)
         case .shadow08:
-            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+            return ShadowInfo(colorOne: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
                               blurOne: 8,
                               xOne: 0,
                               yOne: 4,
-                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              colorTwo: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
                               blurTwo: 2,
                               xTwo: 0,
                               yTwo: 0)
         case .shadow16:
-            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKey],
+            return ShadowInfo(colorOne: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
                               blurOne: 16,
                               xOne: 0,
                               yOne: 8,
-                              colorTwo: strongSelf.shadowColors[.neutralAmbient],
+                              colorTwo: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
                               blurTwo: 2,
                               xTwo: 0,
                               yTwo: 0)
         case .shadow28:
-            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKeyDarker],
+            return ShadowInfo(colorOne: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48)),
                               blurOne: 28,
                               xOne: 0,
                               yOne: 14,
-                              colorTwo: strongSelf.shadowColors[.neutralAmbientDarker],
+                              colorTwo: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40)),
                               blurTwo: 8,
                               xTwo: 0,
                               yTwo: 0)
         case .shadow64:
-            return ShadowInfo(colorOne: strongSelf.shadowColors[.neutralKeyDarker],
+            return ShadowInfo(colorOne: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48)),
                               blurOne: 64,
                               xOne: 0,
                               yOne: 32,
-                              colorTwo: strongSelf.shadowColors[.neutralAmbientDarker],
+                              colorTwo: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40)),
                               blurTwo: 8,
                               xTwo: 0,
                               yTwo: 0)
         }
     }
 
-    // MARK: Colors
+    // MARK: - Colors
 
     @objc(MSFColorAliasTokens)
     public enum ColorsTokens: Int, TokenSetKey {
-        // Foreground colors
-        case foreground1
-        case foreground2
-        case foreground3
-        case foregroundDisabled1
-        case foregroundDisabled2
-        case foregroundOnColor
-        case foregroundInverted1
-        case foregroundInverted2
-        case brandForegroundTint
-        case brandForeground1
-        case brandForeground1Pressed
-        case brandForeground1Selected
-        case brandForegroundDisabled1
-        case brandForegroundDisabled2
-        case foregroundDarkStatic
-        case foregroundLightStatic
-        // Background colors
+        // Neutral colors - Background
         case background1
         case background1Pressed
         case background1Selected
@@ -301,8 +196,34 @@ public final class AliasTokens: NSObject {
         case background6
         case background6Pressed
         case background6Selected
+        case canvasBackground
+        case backgroundDarkStatic
+        case backgroundLightStatic
+        case backgroundLightStaticDisabled
+        case backgroundInverted
         case backgroundDisabled
-        case brandBackgroundTint
+        case stencil1
+        case stencil2
+
+        // Neutral colors - Foreground
+        case foreground1
+        case foreground2
+        case foreground3
+        case foregroundDisabled1
+        case foregroundDisabled2
+        case foregroundOnColor
+        case foregroundDarkStatic
+        case foregroundLightStatic
+
+        // Neutral colors - Stroke
+        case stroke1
+        case stroke2
+        case strokeAccessible
+        case strokeFocus1
+        case strokeFocus2
+        case strokeDisabled
+
+        // Brand colors - Brand background
         case brandBackground1
         case brandBackground1Pressed
         case brandBackground1Selected
@@ -311,24 +232,45 @@ public final class AliasTokens: NSObject {
         case brandBackground2Selected
         case brandBackground3
         case brandBackground3Pressed
+        case brandBackgroundTint
         case brandBackgroundDisabled
-        case stencil1
-        case stencil2
-        case canvasBackground
-        case backgroundDarkStatic
-        case backgroundInverted
-        case backgroundLightStatic
-        case backgroundLightStaticDisabled
-        // Stroke colors
-        case stroke1
-        case stroke2
-        case strokeDisabled
-        case strokeAccessible
-        case strokeFocus1
-        case strokeFocus2
+
+        // Brand colors - Brand foreground
+        case brandForeground1
+        case brandForeground1Pressed
+        case brandForeground1Selected
+        case brandForegroundTint
+        case brandForegroundDisabled1
+        case brandForegroundDisabled2
+
+        // Brand colors - Brand stroke
         case brandStroke1
         case brandStroke1Pressed
         case brandStroke1Selected
+
+        // Shared colors - Error & Status
+        case dangerBackground1
+        case dangerBackground2
+        case dangerForeground1
+        case dangerForeground2
+        case successBackground1
+        case successBackground2
+        case successForeground1
+        case successForeground2
+        case warningBackground1
+        case warningBackground2
+        case warningForeground1
+        case warningForeground2
+        case severeBackground1
+        case severeBackground2
+        case severeForeground1
+        case severeForeground2
+
+        // Shared colors - Presence
+        case presenceAway
+        case presenceDnd
+        case presenceAvailable
+        case presenceOof
     }
 
     @available(swift, obsoleted: 1.0, message: "This method exists for Objective-C backwards compatibility and should not be invoked from Swift. Please use the `colors` property directly.")
@@ -339,7 +281,6 @@ public final class AliasTokens: NSObject {
     public lazy var colors: TokenSet<ColorsTokens, DynamicColor> = .init { [weak self] token in
         guard let strongSelf = self else { preconditionFailure() }
         switch token {
-        // Foreground colors
         case .foreground1:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey14),
                                 dark: GlobalTokens.neutralColors(.white))
@@ -358,11 +299,6 @@ public final class AliasTokens: NSObject {
         case .foregroundOnColor:
             return DynamicColor(light: GlobalTokens.neutralColors(.white),
                                 dark: GlobalTokens.neutralColors(.black))
-        case .foregroundInverted1:
-            return DynamicColor(light: GlobalTokens.neutralColors(.white))
-        case .foregroundInverted2:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm80),
-                                dark: GlobalTokens.neutralColors(.white))
         case .brandForegroundTint:
             return DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                 dark: GlobalTokens.brandColors(.comm130))
@@ -386,83 +322,82 @@ public final class AliasTokens: NSObject {
         case .foregroundLightStatic:
             return DynamicColor(light: GlobalTokens.neutralColors(.white),
                                 dark: GlobalTokens.neutralColors(.white))
-        // Background colors
         case .background1:
-         return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                             dark: GlobalTokens.neutralColors(.black),
-                             darkElevated: GlobalTokens.neutralColors(.grey4))
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.black),
+                                darkElevated: GlobalTokens.neutralColors(.grey4))
         case .background1Pressed:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
-                             dark: GlobalTokens.neutralColors(.grey18),
-                             darkElevated: GlobalTokens.neutralColors(.grey18))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey18),
+                                darkElevated: GlobalTokens.neutralColors(.grey18))
         case .background1Selected:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
-                             dark: GlobalTokens.neutralColors(.grey14),
-                             darkElevated: GlobalTokens.neutralColors(.grey14))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
+                                dark: GlobalTokens.neutralColors(.grey14),
+                                darkElevated: GlobalTokens.neutralColors(.grey14))
         case .background2:
-         return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                             dark: GlobalTokens.neutralColors(.grey12),
-                             darkElevated: GlobalTokens.neutralColors(.grey16))
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.grey12),
+                                darkElevated: GlobalTokens.neutralColors(.grey16))
         case .background2Pressed:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
-                             dark: GlobalTokens.neutralColors(.grey30),
-                             darkElevated: GlobalTokens.neutralColors(.grey30))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey30),
+                                darkElevated: GlobalTokens.neutralColors(.grey30))
         case .background2Selected:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
-                             dark: GlobalTokens.neutralColors(.grey26),
-                             darkElevated: GlobalTokens.neutralColors(.grey26))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
+                                dark: GlobalTokens.neutralColors(.grey26),
+                                darkElevated: GlobalTokens.neutralColors(.grey26))
         case .background3:
-         return DynamicColor(light: GlobalTokens.neutralColors(.white),
-                             dark: GlobalTokens.neutralColors(.grey16),
-                             darkElevated: GlobalTokens.neutralColors(.grey20))
+            return DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                dark: GlobalTokens.neutralColors(.grey16),
+                                darkElevated: GlobalTokens.neutralColors(.grey20))
         case .background3Pressed:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
-                             dark: GlobalTokens.neutralColors(.grey34),
-                             darkElevated: GlobalTokens.neutralColors(.grey34))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey34),
+                                darkElevated: GlobalTokens.neutralColors(.grey34))
         case .background3Selected:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
-                             dark: GlobalTokens.neutralColors(.grey30),
-                             darkElevated: GlobalTokens.neutralColors(.grey30))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey92),
+                                dark: GlobalTokens.neutralColors(.grey30),
+                                darkElevated: GlobalTokens.neutralColors(.grey30))
         case .background4:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
-                             dark: GlobalTokens.neutralColors(.grey20),
-                             darkElevated: GlobalTokens.neutralColors(.grey24))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
+                                dark: GlobalTokens.neutralColors(.grey20),
+                                darkElevated: GlobalTokens.neutralColors(.grey24))
         case .background4Pressed:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey86),
-                             dark: GlobalTokens.neutralColors(.grey38),
-                             darkElevated: GlobalTokens.neutralColors(.grey38))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey86),
+                                dark: GlobalTokens.neutralColors(.grey38),
+                                darkElevated: GlobalTokens.neutralColors(.grey38))
         case .background4Selected:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey90),
-                             dark: GlobalTokens.neutralColors(.grey34),
-                             darkElevated: GlobalTokens.neutralColors(.grey34))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey90),
+                                dark: GlobalTokens.neutralColors(.grey34),
+                                darkElevated: GlobalTokens.neutralColors(.grey34))
         case .background5:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
-                             dark: GlobalTokens.neutralColors(.grey24),
-                             darkElevated: GlobalTokens.neutralColors(.grey28))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey94),
+                                dark: GlobalTokens.neutralColors(.grey24),
+                                darkElevated: GlobalTokens.neutralColors(.grey28))
         case .background5Pressed:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
-                             dark: GlobalTokens.neutralColors(.grey42),
-                             darkElevated: GlobalTokens.neutralColors(.grey42))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
+                                dark: GlobalTokens.neutralColors(.grey42),
+                                darkElevated: GlobalTokens.neutralColors(.grey42))
         case .background5Selected:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey86),
-                             dark: GlobalTokens.neutralColors(.grey38),
-                             darkElevated: GlobalTokens.neutralColors(.grey38))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey86),
+                                dark: GlobalTokens.neutralColors(.grey38),
+                                darkElevated: GlobalTokens.neutralColors(.grey38))
         case .background6:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
-                             dark: GlobalTokens.neutralColors(.grey36),
-                             darkElevated: GlobalTokens.neutralColors(.grey40))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
+                                dark: GlobalTokens.neutralColors(.grey36),
+                                darkElevated: GlobalTokens.neutralColors(.grey40))
         case .background6Pressed:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
-                             dark: GlobalTokens.neutralColors(.grey54),
-                             darkElevated: GlobalTokens.neutralColors(.grey54))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
+                                dark: GlobalTokens.neutralColors(.grey54),
+                                darkElevated: GlobalTokens.neutralColors(.grey54))
         case .background6Selected:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
-                             dark: GlobalTokens.neutralColors(.grey50),
-                             darkElevated: GlobalTokens.neutralColors(.grey50))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
+                                dark: GlobalTokens.neutralColors(.grey50),
+                                darkElevated: GlobalTokens.neutralColors(.grey50))
         case .backgroundDisabled:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
-                             dark: GlobalTokens.neutralColors(.grey32),
-                             darkElevated: GlobalTokens.neutralColors(.grey32))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
+                                dark: GlobalTokens.neutralColors(.grey32),
+                                darkElevated: GlobalTokens.neutralColors(.grey32))
         case .brandBackgroundTint:
             return DynamicColor(light: GlobalTokens.brandColors(.comm150),
                                 dark: GlobalTokens.brandColors(.comm40))
@@ -491,11 +426,11 @@ public final class AliasTokens: NSObject {
             return DynamicColor(light: GlobalTokens.brandColors(.comm140),
                                 dark: GlobalTokens.brandColors(.comm40))
         case .stencil1:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey90),
-                             dark: GlobalTokens.neutralColors(.grey34))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey90),
+                                dark: GlobalTokens.neutralColors(.grey34))
         case .stencil2:
-         return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
-                             dark: GlobalTokens.neutralColors(.grey20))
+            return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
+                                dark: GlobalTokens.neutralColors(.grey20))
         case .canvasBackground:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey96),
                                 dark: GlobalTokens.neutralColors(.grey8),
@@ -516,7 +451,6 @@ public final class AliasTokens: NSObject {
             return DynamicColor(light: GlobalTokens.neutralColors(.white),
                                 dark: GlobalTokens.neutralColors(.grey68),
                                 darkElevated: GlobalTokens.neutralColors(.grey42))
-        // Stroke colors
         case .stroke1:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
                                 dark: GlobalTokens.neutralColors(.grey30),
@@ -545,42 +479,6 @@ public final class AliasTokens: NSObject {
         case .brandStroke1Selected:
             return DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                 dark: GlobalTokens.brandColors(.comm120))
-        }
-    }
-
-    // MARK: Shared Colors
-
-    public enum SharedColorsTokens: CaseIterable {
-        // Danger (Red)
-        case dangerBackground1
-        case dangerBackground2
-        case dangerForeground1
-        case dangerForeground2
-        // Severe (Dark Orange)
-        case severeBackground1
-        case severeBackground2
-        case severeForeground1
-        case severeForeground2
-        // Warning (Yellow)
-        case warningBackground1
-        case warningBackground2
-        case warningForeground1
-        case warningForeground2
-        // Success (Green)
-        case successBackground1
-        case successBackground2
-        case successForeground1
-        case successForeground2
-        // Presence
-        case presenceAway
-        case presenceDnd
-        case presenceAvailable
-        case presenceOof
-    }
-    public lazy var sharedColors: TokenSet<SharedColorsTokens, DynamicColor> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
-        switch token {
-        // Danger
         case .dangerBackground1:
             return DynamicColor(light: GlobalTokens.sharedColors(.red, .tint60),
                                 dark: GlobalTokens.sharedColors(.red, .shade40))
@@ -593,7 +491,6 @@ public final class AliasTokens: NSObject {
         case .dangerForeground2:
             return DynamicColor(light: GlobalTokens.sharedColors(.red, .primary),
                                 dark: GlobalTokens.sharedColors(.red, .tint30))
-        // Success
         case .successBackground1:
             return DynamicColor(light: GlobalTokens.sharedColors(.green, .tint60),
                                 dark: GlobalTokens.sharedColors(.green, .shade40))
@@ -606,7 +503,6 @@ public final class AliasTokens: NSObject {
         case .successForeground2:
             return DynamicColor(light: GlobalTokens.sharedColors(.green, .primary),
                                 dark: GlobalTokens.sharedColors(.green, .tint30))
-        // Severe
         case .severeBackground1:
             return DynamicColor(light: GlobalTokens.sharedColors(.darkOrange, .tint60),
                                 dark: GlobalTokens.sharedColors(.darkOrange, .shade40))
@@ -619,7 +515,6 @@ public final class AliasTokens: NSObject {
         case .severeForeground2:
             return DynamicColor(light: GlobalTokens.sharedColors(.darkOrange, .shade20),
                                 dark: GlobalTokens.sharedColors(.darkOrange, .tint30))
-        // Warning
         case .warningBackground1:
             return DynamicColor(light: GlobalTokens.sharedColors(.yellow, .tint60),
                                 dark: GlobalTokens.sharedColors(.yellow, .shade40))
@@ -632,7 +527,6 @@ public final class AliasTokens: NSObject {
         case .warningForeground2:
             return DynamicColor(light: GlobalTokens.sharedColors(.yellow, .shade30),
                                 dark: GlobalTokens.sharedColors(.yellow, .tint30))
-        // Presence
         case .presenceAway:
             return DynamicColor(light: GlobalTokens.sharedColors(.marigold, .primary))
         case .presenceDnd:

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -53,7 +53,7 @@ class BadgeLabel: UILabel {
             backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: fluentTheme.aliasTokens.colors[.brandBackground1].dark))
         } else {
             textColor = UIColor(colorValue: GlobalTokens.neutralColors(.white))
-            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerBackground2])
+            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerBackground2])
         }
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -26,7 +26,7 @@ public enum TextColorStyle: Int, CaseIterable {
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
         case .error:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.sharedColors[.dangerForeground2])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerForeground2])
         }
     }
 }

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -120,9 +120,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case .neutralBar:
                         return theme.aliasTokens.colors[.background5]
                     case .dangerToast:
-                        return theme.aliasTokens.sharedColors[.dangerBackground1]
+                        return theme.aliasTokens.colors[.dangerBackground1]
                     case .warningToast:
-                        return theme.aliasTokens.sharedColors[.warningBackground1]
+                        return theme.aliasTokens.colors[.warningBackground1]
                     }
                 }
 
@@ -138,9 +138,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case .primaryOutlineBar:
                         return theme.aliasTokens.colors[.brandForeground1]
                     case .dangerToast:
-                        return theme.aliasTokens.sharedColors[.dangerForeground1]
+                        return theme.aliasTokens.colors[.dangerForeground1]
                     case .warningToast:
-                        return theme.aliasTokens.sharedColors[.warningForeground1]
+                        return theme.aliasTokens.colors[.warningForeground1]
                     }
                 }
 
@@ -156,9 +156,9 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case .primaryOutlineBar:
                         return theme.aliasTokens.colors[.brandForeground1]
                     case .dangerToast:
-                        return theme.aliasTokens.sharedColors[.dangerForeground1]
+                        return theme.aliasTokens.colors[.dangerForeground1]
                     case .warningToast:
-                        return theme.aliasTokens.sharedColors[.warningForeground1]
+                        return theme.aliasTokens.colors[.warningForeground1]
                     }
                 }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -61,9 +61,11 @@ public extension PillButton {
     static func selectedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundInverted1]))
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]),
+                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic]))
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundInverted1]))
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]),
+                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic]))
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -153,7 +153,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
 
             case .dangerTextColor:
-                return .dynamicColor { theme.aliasTokens.sharedColors[.dangerForeground2] }
+                return .dynamicColor { theme.aliasTokens.colors[.dangerForeground2] }
 
             case .brandTextColor:
                 return .dynamicColor { theme.aliasTokens.colors[.brandForeground1] }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,889,408 | 28,753,048 | -136,360 |
|  |  |  |  |

* Organizing alias token colors to better match designs
  * Moving `sharedColors` into `colors`
  * Removing `brandColors`
  * Reorganizing enums to align with newest groupings
* Removing stale alias tokens `foregroundInverted1` and `foregroundInverted2` and replace usages with modern matching alternatives
* Add more color tokens to `AliasColorTokensDemoController`

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
| ![alias-old-l](https://user-images.githubusercontent.com/4934719/214367757-c59816fa-6a25-42b0-b17a-72d55c223400.png) | ![alias-after-l](https://user-images.githubusercontent.com/4934719/214367747-e3cd90e5-b0af-40b7-9f63-c9d89b7688e7.png) |
| ![alias-old-d](https://user-images.githubusercontent.com/4934719/214367763-d835fe4f-e520-4237-9e71-db478c27b088.png) | ![alias-after-d](https://user-images.githubusercontent.com/4934719/214367744-65e2c836-796c-49a9-b10b-bcaff3a06f56.png) |
| ![pill-old-l](https://user-images.githubusercontent.com/4934719/214367755-7e352785-acf8-4ddf-8cf5-95b6b608a6cf.png) | ![pill-after-l](https://user-images.githubusercontent.com/4934719/214367751-d58abce3-8b07-482b-b888-a71605e5e4d1.png) |
| ![pill-old-d](https://user-images.githubusercontent.com/4934719/214367760-74fd1f7d-1709-4168-913e-ed7eca0f422e.png) | ![pill-after-d](https://user-images.githubusercontent.com/4934719/214367738-83c3e505-90ec-4418-b613-39738a8b52e9.png) |


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1510)