### PR TITLE
Bumping FluentUI version (0.11.0)

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUI'
-  s.version          = '0.8.0'
+  s.version          = '0.11.0'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.11.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>130</string>
+	<string>137.11.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/FluentUI.Resources/Info.plist
+++ b/ios/FluentUI.Resources/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.0</string>
+	<string>0.11.0</string>
 </dict>
 </plist>

--- a/macos/FluentUI/FluentUI-Info.plist
+++ b/macos/FluentUI/FluentUI-Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.0</string>
+	<string>0.11.0</string>
 </dict>
 </plist>

--- a/macos/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/macos/FluentUITestApp/FluentUITestApp-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>55</string>
+	<string>62.11.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Summary of changes

**iOS:**
- **Badgefield:** Fixed spacing bug
- **TableViewCell:** Added new unread dot; fixed accessibility bug on larger text mode
- **Tooltip:** Introduced Tokenized Tooltip; fixed .png filenames

**General:**
- Updating GitHub workflows to v3
- Introduced a Readme section for all controls in the demo app
- Launched XCUITests for all controls
- Added documentation to controls

Commits introduced since main_0.10 branch:
- f7e917e8b8918d0aa8cc8bfab18a85866d8fd1f0
- 34719d4cb66e9d457f25ef04bde4ac24571bb1e6
- f1cd98b53307624614a77b8c9d39cf57f510ac2e
- 95e69eb37b7559510daf330cf35039195f996bf0
- fb0f794402752d797272fa41888ba4bd5a6ba788
- 01915e48c2afafd983b4c895e8e376f807a923ce
- b2d09e7d8c1e7417c91dbd680bb34918e9ba28bd
- 046951d4a32dab83f3663f771379c07dc94b6852
- e753536b6f76472bbf981941bfc24fc228f1e686
- d9527fe6cdc4913d4cb88fc458e5fefae513bf2d
- 7f0dd6bab0cb90538f77ae30148755002283e117
- dc08917b6ad8696c237149242afef3c0a9e060ad
- bfd213863aff750f317cc612f9f81e8203e8a1f0
- 2482a7323e5fd8286fcfc7092d3edf748e8e8c3c
- 749110974a03eaaec74942d889c21e58853c2f09
- 45131f675f118eec73ee7bf0da790039680528c0
- cfce4de23aa29c726846ac62fb0f57690b0a65e3
- 8872ab632d62c12e70fb5d69bfea1504be99c2e8
- 1339ed002be26f609cab63d1fbfc9927dd68c0d1
- 2ec7f3e859de5ec7ee3c5aaf7a91c6519bc63257

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1512)