### PR TITLE
[main_0.11] Cherry-picking: Removing unreadDot from height and width methods (#1514)

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -220,7 +220,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public class func height(title: String,
                                    subtitle: String = "",
                                    footer: String = "",
-                                   hasunreadDot: Bool = false,
                                    titleLeadingAccessoryView: UIView? = nil,
                                    titleTrailingAccessoryView: UIView? = nil,
                                    subtitleLeadingAccessoryView: UIView? = nil,
@@ -276,7 +275,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - titleFont: The title font; If not set, it will default to the font definition in tokens
     ///   - subtitleFont: The subtitle font; If not set, it will default to the font definition in tokens
     ///   - footerFont: The footer font; If not set, it will default to the font definition in tokens
-    ///   - hasunreadDot: Boolean determining whether to show or hide the `unreadDotLayer`, on the leading edge of the `customView`.
     ///   - titleLeadingAccessoryView: The accessory view on the leading edge of the title
     ///   - titleTrailingAccessoryView: The accessory view on the trailing edge of the title
     ///   - subtitleLeadingAccessoryView: The accessory view on the leading edge of the subtitle
@@ -306,7 +304,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                              titleFont: UIFont? = nil,
                              subtitleFont: UIFont? = nil,
                              footerFont: UIFont? = nil,
-                             hasunreadDot: Bool = false,
                              titleLeadingAccessoryView: UIView? = nil,
                              titleTrailingAccessoryView: UIView? = nil,
                              subtitleLeadingAccessoryView: UIView? = nil,
@@ -411,7 +408,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - title: The title string
     ///   - subtitle: The subtitle string
     ///   - footer: The footer string
-    ///   - hasunreadDot: Boolean determining whether to show or hide the `unreadDotLayer`, on the leading edge of the `customView`.
     ///   - titleLeadingAccessoryView: The accessory view on the leading edge of the title
     ///   - titleTrailingAccessoryView: The accessory view on the trailing edge of the title
     ///   - subtitleLeadingAccessoryView: The accessory view on the leading edge of the subtitle
@@ -427,7 +423,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     @objc public class func preferredWidth(title: String,
                                            subtitle: String = "",
                                            footer: String = "",
-                                           hasunreadDot: Bool = false,
                                            titleLeadingAccessoryView: UIView? = nil,
                                            titleTrailingAccessoryView: UIView? = nil,
                                            subtitleLeadingAccessoryView: UIView? = nil,
@@ -475,7 +470,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     ///   - titleFont: The title font; If not set, it will default to the font definition in tokens
     ///   - subtitleFont: The subtitle font; If not set, it will default to the font definition in tokens
     ///   - footerFont: The footer font; If not set, it will default to the font definition in tokens
-    ///   - hasunreadDot: Boolean determining whether to show or hide the `unreadDotLayer`, on the leading edge of the `customView`.
     ///   - titleLeadingAccessoryView: The accessory view on the leading edge of the title
     ///   - titleTrailingAccessoryView: The accessory view on the trailing edge of the title
     ///   - subtitleLeadingAccessoryView: The accessory view on the leading edge of the subtitle
@@ -501,7 +495,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                      titleFont: UIFont? = nil,
                                      subtitleFont: UIFont? = nil,
                                      footerFont: UIFont? = nil,
-                                     hasunreadDot: Bool = false,
                                      titleLeadingAccessoryView: UIView? = nil,
                                      titleTrailingAccessoryView: UIView? = nil,
                                      subtitleLeadingAccessoryView: UIView? = nil,


### PR DESCRIPTION

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

cherry picked from commit d1b93f83aa33ff1d94fdd097d828b619e9e7390d

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/214698520-fb6f0686-472e-4128-817f-c6eb8cb16ea6.png) | ![image](https://user-images.githubusercontent.com/22566866/214697638-9bdea270-dcfc-4e88-9dbc-8f3349b39130.png) |
| ![image](https://user-images.githubusercontent.com/22566866/214699128-93b07f1c-fd3f-44f8-acba-2003a6f80939.png) | ![image](https://user-images.githubusercontent.com/22566866/214697714-1369c352-4f17-4df2-a709-5c95626b758d.png) |
| ![image](https://user-images.githubusercontent.com/22566866/214699529-8bdc362c-40a1-48a0-93ab-fdb5a2e85194.png) | ![image](https://user-images.githubusercontent.com/22566866/214697877-118ceb61-5712-478a-ac65-997e8a71a24f.png) |
| ![image](https://user-images.githubusercontent.com/22566866/214699571-a8a67718-95b4-42ec-be1d-4fb269692ba7.png) | ![image](https://user-images.githubusercontent.com/22566866/214697926-d43d5d48-1daf-4816-a692-9924c76a70fa.png) |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1516)