### PR TITLE
[Fluent 2 iOS] Fix SegmentedControl crash

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -417,8 +417,11 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     private let selectionChangeAnimationDuration: TimeInterval = 0.2
 
     private func updateButtons() {
+        let contentColor = isEnabled ? UIColor(dynamicColor: tokenSet[.restLabelColor].dynamicColor) : UIColor(dynamicColor: tokenSet[.disabledLabelColor].dynamicColor)
         for (index, button) in buttons.enumerated() {
             button.updateTokenizedValues()
+            button.setTitleColor(contentColor, for: .normal)
+            button.tintColor = contentColor
             pillMaskedLabels[index]?.font = button.titleLabel?.font
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,836,448 | 28,838,160  | +1,712 |

Previously, a change regressed behavior in SegmentedControl (#1496). This regression caused SegmentedControl to crash on layoutSubviews when updating masked constraints. This change re-introduces the correct behavior that was previously removed.

### Verification

Built and ran Simulator, verifying that SegmentedControl works again.

| Before                                       | After light | After dark | After green |
|-----------------------------|-----------------|-------------------|-------------------------|
| N/A - crashed while loading screen | ![segmentedControlAfterLight](https://user-images.githubusercontent.com/23249106/214721025-a7d6b43f-a44b-43f9-958e-2fde907fcd16.png) | ![segmentedControlAfterDark](https://user-images.githubusercontent.com/23249106/214721023-0b03c56c-f27a-4610-8349-7f24006f1aaf.png) | ![segmentedControlAfterGreen](https://user-images.githubusercontent.com/23249106/214721012-858e71e1-5b23-48b7-ad05-8982c41f4eaa.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)