### PR TITLE
[Fluent 2 iOS] Removing more deprecated alias tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -63,11 +63,9 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .background5Pressed,
              .background5Selected,
              .background6,
-             .background6Pressed,
-             .background6Selected,
              .backgroundDisabled,
              .brandBackgroundDisabled,
-             .canvasBackground,
+             .backgroundCanvas,
              .stencil1,
              .stencil2,
              .foregroundDisabled2,
@@ -84,8 +82,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .warningBackground1,
              .severeBackground1:
             return UIColor(dynamicColor: aliasTokens.colors[.foreground1])
-        case .brandBackground3Pressed,
-             .foreground1,
+        case .foreground1,
              .foreground2,
              .foreground3,
              .strokeFocus2,
@@ -189,11 +186,9 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .background5Pressed,
                     .background5Selected,
                     .background6,
-                    .background6Pressed,
-                    .background6Selected,
                     .backgroundInverted,
                     .backgroundDisabled,
-                    .canvasBackground,
+                    .backgroundCanvas,
                     .stencil1,
                     .stencil2,
                     .backgroundDarkStatic,
@@ -208,7 +203,6 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .brandBackground2Pressed,
                     .brandBackground2Selected,
                     .brandBackground3,
-                    .brandBackground3Pressed,
                     .brandBackgroundDisabled]
         case .neutralForegrounds:
             return [.foreground1,
@@ -320,10 +314,6 @@ private extension AliasTokens.ColorsTokens {
             return "Background 5 Selected"
         case .background6:
             return "Background 6"
-        case .background6Pressed:
-            return "Background 6 Pressed"
-        case .background6Selected:
-            return "Background 6 Selected"
         case .backgroundInverted:
             return "Background Inverted"
         case .backgroundDisabled:
@@ -342,8 +332,6 @@ private extension AliasTokens.ColorsTokens {
             return "Brand Background 2 Selected"
         case .brandBackground3:
             return "Brand Background 3"
-        case .brandBackground3Pressed:
-            return "Brand Background 3 Pressed"
         case .brandBackgroundDisabled:
             return "Brand Background Disabled"
         case .brandBackgroundTint:
@@ -354,8 +342,8 @@ private extension AliasTokens.ColorsTokens {
             return "Stencil 1"
         case .stencil2:
             return "Stencil 2"
-        case .canvasBackground:
-            return "Canvas Background"
+        case .backgroundCanvas:
+            return "Background Canvas"
         case .stroke1:
             return "Stroke 1"
         case .stroke2:

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -210,7 +210,7 @@ class CalendarViewDayCell: UICollectionViewCell {
         case .primary:
             contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
         case .secondary:
-            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.canvasBackground].light, dark: fluentTheme.aliasTokens.colors[.canvasBackground].dark))
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.backgroundCanvas].light, dark: fluentTheme.aliasTokens.colors[.backgroundCanvas].dark))
         }
 
         if isHighlighted || isSelected {

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -67,7 +67,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
                 switch style() {
                 case .standard:
                     return .dynamicColor {
-                        theme.aliasTokens.colors[.canvasBackground]
+                        theme.aliasTokens.colors[.backgroundCanvas]
                     }
                 case .outline:
                     return .dynamicColor {
@@ -99,7 +99,7 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
                 switch style() {
                 case .standard:
                     return .dynamicColor {
-                        theme.aliasTokens.colors[.canvasBackground]
+                        theme.aliasTokens.colors[.backgroundCanvas]
                     }
                 case .outline:
                     return .dynamicColor {

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -194,9 +194,7 @@ public final class AliasTokens: NSObject {
         case background5Pressed
         case background5Selected
         case background6
-        case background6Pressed
-        case background6Selected
-        case canvasBackground
+        case backgroundCanvas
         case backgroundDarkStatic
         case backgroundLightStatic
         case backgroundLightStaticDisabled
@@ -231,7 +229,6 @@ public final class AliasTokens: NSObject {
         case brandBackground2Pressed
         case brandBackground2Selected
         case brandBackground3
-        case brandBackground3Pressed
         case brandBackgroundTint
         case brandBackgroundDisabled
 
@@ -386,14 +383,6 @@ public final class AliasTokens: NSObject {
             return DynamicColor(light: GlobalTokens.neutralColors(.grey82),
                                 dark: GlobalTokens.neutralColors(.grey36),
                                 darkElevated: GlobalTokens.neutralColors(.grey40))
-        case .background6Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColors(.grey70),
-                                dark: GlobalTokens.neutralColors(.grey54),
-                                darkElevated: GlobalTokens.neutralColors(.grey54))
-        case .background6Selected:
-            return DynamicColor(light: GlobalTokens.neutralColors(.grey74),
-                                dark: GlobalTokens.neutralColors(.grey50),
-                                darkElevated: GlobalTokens.neutralColors(.grey50))
         case .backgroundDisabled:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey88),
                                 dark: GlobalTokens.neutralColors(.grey32),
@@ -419,9 +408,6 @@ public final class AliasTokens: NSObject {
         case .brandBackground3:
             return DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                 dark: GlobalTokens.brandColors(.comm120))
-        case .brandBackground3Pressed:
-            return DynamicColor(light: GlobalTokens.brandColors(.comm30),
-                                dark: GlobalTokens.brandColors(.comm160))
         case .brandBackgroundDisabled:
             return DynamicColor(light: GlobalTokens.brandColors(.comm140),
                                 dark: GlobalTokens.brandColors(.comm40))
@@ -431,7 +417,7 @@ public final class AliasTokens: NSObject {
         case .stencil2:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey98),
                                 dark: GlobalTokens.neutralColors(.grey20))
-        case .canvasBackground:
+        case .backgroundCanvas:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey96),
                                 dark: GlobalTokens.neutralColors(.grey8),
                                 darkElevated: GlobalTokens.neutralColors(.grey14))

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -81,7 +81,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 return .dynamicColor { theme.aliasTokens.colors[.background1] }
 
             case .backgroundGroupedColor:
-                return .dynamicColor { theme.aliasTokens.colors[.canvasBackground] }
+                return .dynamicColor { theme.aliasTokens.colors[.backgroundCanvas] }
 
             case .cellBackgroundColor:
                 return .dynamicColor { theme.aliasTokens.colors[.background1] }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Renamed `canvasBackground` to `backgroundCanvas`. Also removed more deprecated alias color tokens:
* `background6Pressed`
* `background6Selected`
* `brandBackground3Pressed`

### Verification

Still builds! No components were using the removed tokens other than the alias demo controller.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1522)