### PR TITLE
Add BadgeView with Avatar to PeoplePicker demo page

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -16,14 +16,16 @@ class PeoplePickerSampleData {
         let allowsPickedPersonasToAppearAsSuggested: Bool
         let showsSearchDirectoryButton: Bool
         let hidePersonaListViewWhenNoSuggestedPersonas: Bool
+        let showsAvatar: Bool
 
-        init(description: String, numberOfLines: Int = 0, pickedPersonas: [Persona] = [], allowsPickedPersonasToAppearAsSuggested: Bool = true, showsSearchDirectoryButton: Bool = true, hidePersonaListViewWhenNoSuggestedPersonas: Bool = false) {
+        init(description: String, numberOfLines: Int = 0, pickedPersonas: [Persona] = [], allowsPickedPersonasToAppearAsSuggested: Bool = true, showsSearchDirectoryButton: Bool = true, hidePersonaListViewWhenNoSuggestedPersonas: Bool = false, showsAvatar: Bool = false) {
             self.description = description
             self.numberOfLines = numberOfLines
             self.pickedPersonas = pickedPersonas
             self.allowsPickedPersonasToAppearAsSuggested = allowsPickedPersonasToAppearAsSuggested
             self.showsSearchDirectoryButton = showsSearchDirectoryButton
             self.hidePersonaListViewWhenNoSuggestedPersonas = hidePersonaListViewWhenNoSuggestedPersonas
+            self.showsAvatar = showsAvatar
         }
     }
 
@@ -31,7 +33,8 @@ class PeoplePickerSampleData {
         Variant(description: "Standard implementation with one line of picked personas", numberOfLines: 1, pickedPersonas: [samplePersonas[0], samplePersonas[4], samplePersonas[11], samplePersonas[14]]),
         Variant(description: "Doesn't allow picked personas to appear as suggested", pickedPersonas: [samplePersonas[0], samplePersonas[8]], allowsPickedPersonasToAppearAsSuggested: false),
         Variant(description: "Hides search directory button", pickedPersonas: [samplePersonas[13]], showsSearchDirectoryButton: false, hidePersonaListViewWhenNoSuggestedPersonas: true),
-        Variant(description: "Includes callback when picking a suggested persona")
+        Variant(description: "Includes callback when picking a suggested persona"),
+        Variant(description: "Showcases persona's avatar", pickedPersonas: [samplePersonas[0], samplePersonas[1]], allowsPickedPersonasToAppearAsSuggested: false, showsAvatar: true)
     ]
 }
 
@@ -87,8 +90,8 @@ class PeoplePickerDemoController: DemoController {
         peoplePicker.showsSearchDirectoryButton = variant.showsSearchDirectoryButton
         peoplePicker.numberOfLines = variant.numberOfLines
         peoplePicker.allowsPickedPersonasToAppearAsSuggested = variant.allowsPickedPersonasToAppearAsSuggested
-        peoplePicker.showsSearchDirectoryButton = variant.showsSearchDirectoryButton
         peoplePicker.hidePersonaListViewWhenNoSuggestedPersonas = variant.hidePersonaListViewWhenNoSuggestedPersonas
+        peoplePicker.showsAvatar = variant.showsAvatar
         peoplePicker.delegate = self
         peoplePickers.append(peoplePicker)
         container.addArrangedSubview(peoplePicker)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -32,9 +32,9 @@ class PeoplePickerSampleData {
     static let variants: [Variant] = [
         Variant(description: "Standard implementation with one line of picked personas", numberOfLines: 1, pickedPersonas: [samplePersonas[0], samplePersonas[4], samplePersonas[11], samplePersonas[14]]),
         Variant(description: "Doesn't allow picked personas to appear as suggested", pickedPersonas: [samplePersonas[0], samplePersonas[8]], allowsPickedPersonasToAppearAsSuggested: false),
+        Variant(description: "Showcases persona's avatar", pickedPersonas: [samplePersonas[0], samplePersonas[1]], allowsPickedPersonasToAppearAsSuggested: false, showsAvatar: true),
         Variant(description: "Hides search directory button", pickedPersonas: [samplePersonas[13]], showsSearchDirectoryButton: false, hidePersonaListViewWhenNoSuggestedPersonas: true),
-        Variant(description: "Includes callback when picking a suggested persona"),
-        Variant(description: "Showcases persona's avatar", pickedPersonas: [samplePersonas[0], samplePersonas[1]], allowsPickedPersonasToAppearAsSuggested: false, showsAvatar: true)
+        Variant(description: "Includes callback when picking a suggested persona")
     ]
 }
 

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -91,6 +91,33 @@ open class PeoplePicker: BadgeField {
 	 */
 	@objc open var hidePersonaListViewWhenNoSuggestedPersonas: Bool = false
 
+    /**
+     Set `showsAvatar` to true to show the persona's Avatar.
+     */
+    @objc open var showsAvatar: Bool = false {
+        didSet {
+            if showsAvatar {
+                deleteAllBadges()
+                for persona in pickedPersonas {
+                    let avatar = MSFAvatar(style: .default, size: .size16)
+                    avatar.state.image = persona.image
+
+                    let dataSource = BadgeViewDataSource(
+                        text: persona.name,
+                        style: BadgeView.Style.default,
+                        size: BadgeView.Size.medium,
+                        customView: avatar
+                    )
+
+                    let badge = BadgeView(dataSource: dataSource)
+                    badge.delegate = self
+                    badge.isActive = true
+                    super.addBadge(badge)
+                }
+            }
+        }
+    }
+
     @objc open weak var delegate: PeoplePickerDelegate? {
         didSet {
             badgeFieldDelegate = delegate

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -98,21 +98,10 @@ open class PeoplePicker: BadgeField {
         didSet {
             if showsAvatar {
                 deleteAllBadges()
-                for persona in pickedPersonas {
+                pickedPersonas.forEach {
                     let avatar = MSFAvatar(style: .default, size: .size16)
-                    avatar.state.image = persona.image
-
-                    let dataSource = BadgeViewDataSource(
-                        text: persona.name,
-                        style: BadgeView.Style.default,
-                        size: BadgeView.Size.medium,
-                        customView: avatar
-                    )
-
-                    let badge = BadgeView(dataSource: dataSource)
-                    badge.delegate = self
-                    badge.isActive = true
-                    super.addBadge(badge)
+                    avatar.state.image = $0.image
+                    addBadge(withDataSource: PersonaBadgeViewDataSource(persona: $0, customView: avatar))
                 }
             }
         }
@@ -314,7 +303,13 @@ open class PeoplePicker: BadgeField {
     private func updatePickedPersonaBadges() {
         deleteAllBadges()
         pickedPersonas.forEach {
-            addBadge(withDataSource: PersonaBadgeViewDataSource(persona: $0))
+            if showsAvatar {
+                let avatar = MSFAvatar(style: .default, size: .size16)
+                avatar.state.image = $0.image
+                addBadge(withDataSource: PersonaBadgeViewDataSource(persona: $0, customView: avatar))
+            } else {
+                addBadge(withDataSource: PersonaBadgeViewDataSource(persona: $0))
+            }
         }
     }
 

--- a/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
+++ b/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
@@ -11,9 +11,13 @@ import UIKit
 open class PersonaBadgeViewDataSource: BadgeViewDataSource {
     @objc open var persona: Persona
 
-    @objc public init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium, customView: UIView? = nil) {
+    @objc public init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium) {
         self.persona = persona
         super.init(text: persona.name, style: style, size: size)
+    }
+
+    @objc public convenience init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium, customView: UIView? = nil) {
+        self.init(persona: persona, style: style, size: size)
         super.customView = customView
     }
 }

--- a/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
+++ b/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
@@ -11,8 +11,9 @@ import UIKit
 open class PersonaBadgeViewDataSource: BadgeViewDataSource {
     @objc open var persona: Persona
 
-    @objc public init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium) {
+    @objc public init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium, customView: UIView? = nil) {
         self.persona = persona
         super.init(text: persona.name, style: style, size: size)
+        super.customView = customView
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,869,912 bytes | 28,908,928 bytes | 39,016 bytes |

Added a new variant to the `PeoplePicker` demo page that displays badges with an `Avatar`. To do so, a new bool, `showsAvatar` was added that controls whether or not the avatar is shown. When `showsAvatar` is true, `addBadge` will be called with a `PersonaBadgeViewDataSource` that includes a `customView` (the avatar). When set to false, the existing `addBadge` call will be used. `PersonaBadgeViewDataSource`'s init function now takes in an optional `customView` parameter that defaults to nil if no value is provided.

### Verification

| Before                                       | Light                                      | Dark                                      |
|----------------------------------------------|--------------------------------------------|--------------------------------------------|
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-27 at 13 07 18](https://user-images.githubusercontent.com/55368679/215199223-6faa220f-ab60-4911-881d-17472423be68.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-27 at 13 00 27](https://user-images.githubusercontent.com/55368679/215198907-97430395-08ba-45c1-89cd-f2aea58cc122.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-01-27 at 13 08 55](https://user-images.githubusercontent.com/55368679/215200297-5c7bb538-5401-456e-a0b0-9c1557c93018.gif) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1524)