### PR TITLE
Disabling testSelectionManagerEnd test in DatePicker

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/xcshareddata/xcschemes/Demo.Release.xcscheme
@@ -73,6 +73,11 @@
                BlueprintName = "FluentUITests"
                ReferencedContainer = "container:../FluentUI.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "DatePickerControllerTests/testSelectionManagerEnd()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO"

--- a/ios/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUI-iOS.xcscheme
+++ b/ios/FluentUI.xcodeproj/xcshareddata/xcschemes/FluentUI-iOS.xcscheme
@@ -39,6 +39,11 @@
                BlueprintName = "FluentUITests"
                ReferencedContainer = "container:FluentUI.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "DatePickerControllerTests/testSelectionManagerEnd()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->

DatePicker had been [failing again](https://github.com/microsoft/fluentui-apple/actions/runs/4030498005/jobs/6929199213#step:4:3623) in a PR with unrelated changes. It had already been disabled in #1495 , but only in the Development scheme. We should disable it in all schemes and address this with a follow-up fix once #1502 is merged.

### Verification

pod lib lint passes

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1526)