### PR TITLE
Change TableViewCellDemoController's table view style to insetGroup

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -11,14 +11,6 @@ import UIKit
 class TableViewCellDemoController: DemoTableViewController {
     let sections: [TableViewSampleData.Section] = TableViewCellSampleData.sections
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(style: .grouped)
-    }
-
-    required init?(coder: NSCoder) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
-
     private var isGrouped: Bool = false {
         didSet {
             updateTableView()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The table view style in `TableViewCellDemoController` is set to `grouped` but it needs to be set to `insetGrouped` in order to display `TableViewCell`s with rounded corners. 
The overridden inits have been removed so that the table view's style defaults to its `insetGrouped` value set in `DemoTableViewController`'s init.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,940,864 bytes | 28,940,864 bytes | 0 bytes |

### Verification

The changes were tested on the demo app.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="487" alt="before_plain_light" src="https://user-images.githubusercontent.com/106181067/215866573-de1a9064-097f-4276-aa80-3f90bb7a18fc.png"> | <img width="487" alt="after_plain_light" src="https://user-images.githubusercontent.com/106181067/215866592-a910eecb-1e73-4aa1-9469-b23c297bceae.png"> |
| <img width="487" alt="before_grouped_light" src="https://user-images.githubusercontent.com/106181067/215866643-fafc6601-6bfa-4363-ad20-fb1c1bce3759.png"> | <img width="487" alt="after_grouped_light" src="https://user-images.githubusercontent.com/106181067/215866664-dd0ef837-1958-4833-890f-3caceec623e4.png"> |
| <img width="487" alt="before_plain_dark" src="https://user-images.githubusercontent.com/106181067/215866736-03e080fe-1a1c-4d1e-9bb7-0a4394965a10.png"> | <img width="487" alt="after_plain_dark" src="https://user-images.githubusercontent.com/106181067/215866750-341b4595-c4c9-4e43-aad1-8046cdb96348.png"> |
| <img width="487" alt="before_grouped_dark" src="https://user-images.githubusercontent.com/106181067/215866777-46e29a81-c443-494a-966c-2eac994b0bb5.png"> | <img width="487" alt="after_grouped_dark" src="https://user-images.githubusercontent.com/106181067/215866791-4682d5a0-bf37-4bef-b45e-e240ab0ced52.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1535)