### PR TITLE
Rename icon size tokens

### DIFF
--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -224,11 +224,11 @@ extension AvatarTokenSet {
         case .size16:
             return 0
         case .size20, .size24, .size32:
-            return GlobalTokens.iconSize(.xxxSmall)
+            return GlobalTokens.icon(.size100)
         case .size40, .size56:
-            return GlobalTokens.iconSize(.xxSmall)
+            return GlobalTokens.icon(.size120)
         case .size72:
-            return GlobalTokens.iconSize(.small)
+            return GlobalTokens.icon(.size200)
         }
     }
 
@@ -248,9 +248,9 @@ extension AvatarTokenSet {
         case .size16, .size20, .size24, .size32, .size72:
             return 0
         case .size40:
-            return GlobalTokens.iconSize(.xSmall)
+            return GlobalTokens.icon(.size160)
         case .size56:
-            return GlobalTokens.iconSize(.medium)
+            return GlobalTokens.icon(.size240)
         }
     }
 
@@ -260,9 +260,9 @@ extension AvatarTokenSet {
         case .size16, .size20, .size24, .size32, .size72:
             return 0
         case .size40:
-            return GlobalTokens.iconSize(.small)
+            return GlobalTokens.icon(.size200)
         case .size56:
-            return GlobalTokens.iconSize(.large)
+            return GlobalTokens.icon(.size280)
         }
     }
 }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -142,9 +142,9 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 // MARK: - Constants
 
 extension CardNudgeTokenSet {
-    static let iconSize: CGFloat = GlobalTokens.iconSize(.medium)
-    static let circleSize: CGFloat = GlobalTokens.iconSize(.xxLarge)
-    static let accentIconSize: CGFloat = GlobalTokens.iconSize(.xxSmall)
+    static let iconSize: CGFloat = GlobalTokens.icon(.size240)
+    static let circleSize: CGFloat = GlobalTokens.icon(.size400)
+    static let accentIconSize: CGFloat = GlobalTokens.icon(.size120)
     static let accentPadding: CGFloat = GlobalTokens.spacing(.size40)
 
     static let horizontalPadding: CGFloat = GlobalTokens.spacing(.size160)

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -1693,35 +1693,35 @@ public class GlobalTokens: NSObject {
     // MARK: - IconSize
 
     public enum IconSizeToken: TokenSetKey {
-        case xxxSmall
-        case xxSmall
-        case xSmall
-        case small
-        case medium
-        case large
-        case xLarge
-        case xxLarge
-        case xxxLarge
+        case size100
+        case size120
+        case size160
+        case size200
+        case size240
+        case size280
+        case size360
+        case size400
+        case size480
     }
-    public static func iconSize(_ token: IconSizeToken) -> CGFloat {
+    public static func icon(_ token: IconSizeToken) -> CGFloat {
         switch token {
-        case .xxxSmall:
+        case .size100:
             return 10
-        case .xxSmall:
+        case .size120:
             return 12
-        case .xSmall:
+        case .size160:
             return 16
-        case .small:
+        case .size200:
             return 20
-        case .medium:
+        case .size240:
             return 24
-        case .large:
+        case .size280:
             return 28
-        case .xLarge:
+        case .size360:
             return 36
-        case .xxLarge:
+        case .size400:
             return 40
-        case .xxxLarge:
+        case .size480:
             return 48
         }
     }

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -101,9 +101,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                     case .zero:
                         return 0.0
                     case .small:
-                        return GlobalTokens.iconSize(.medium)
+                        return GlobalTokens.icon(.size240)
                     case .medium, .default:
-                        return GlobalTokens.iconSize(.xxLarge)
+                        return GlobalTokens.icon(.size400)
                     }
                 }
 
@@ -241,7 +241,7 @@ extension TableViewCellTokenSet {
     static let selectionImageMarginTrailing: CGFloat = GlobalTokens.spacing(.size160)
 
     /// The size for the selectionImage.
-    static let selectionImageSize: CGFloat = GlobalTokens.iconSize(.medium)
+    static let selectionImageSize: CGFloat = GlobalTokens.icon(.size240)
 
     /// The duration for the selectionModeAnimation.
     static let selectionModeAnimationDuration: CGFloat = 0.2


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR updates icon size tokens to align their names with other sizing tokens.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,107,752 bytes | 29,107,408 bytes | -344 bytes |

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="485" alt="before_tvc" src="https://user-images.githubusercontent.com/106181067/217073749-44c68ccd-0dbe-4342-8fad-dd8a8c64542d.png"> | <img width="485" alt="after_tvc" src="https://user-images.githubusercontent.com/106181067/217073772-ed3a139a-ef78-4107-931c-a10a96db47da.png"> |
| <img width="485" alt="before_card_nudge" src="https://user-images.githubusercontent.com/106181067/217073812-f1c01743-cd19-489b-9969-f7a110c2a8a1.png"> | <img width="485" alt="after_card_nudge" src="https://user-images.githubusercontent.com/106181067/217073831-f597b3d2-c9f6-4b68-825f-5b4f046ec27c.png"> |
| <img width="485" alt="before_avatar_group" src="https://user-images.githubusercontent.com/106181067/217073865-53e9b5d8-98ec-4ae0-83db-c9ca12f02b42.png"> | <img width="441" alt="after_avatar_group" src="https://user-images.githubusercontent.com/106181067/217073869-24d84009-4baa-4ec8-b1a7-b59d030292e7.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1545)