### PR TITLE
Disable trigger for size comparison action

### DIFF
--- a/.github/workflows/sizeComparison.yml
+++ b/.github/workflows/sizeComparison.yml
@@ -1,11 +1,5 @@
 name: sizeComparison
 
-on:
-  pull_request:
-    branches:
-      - main*
-      - fluent2*
-
 jobs:
   archiveHeadBuild:
     runs-on: macos-12


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The size comparison action isn't currently giving us helpful data, so we're turning it off until it's updated.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1548)