### PR TITLE
fix dark mode of fluent demo cell

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TableViewCell/ic_fluent_lock_closed_20_regular.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TableViewCell/ic_fluent_lock_closed_20_regular.imageset/Contents.json
@@ -2,11 +2,14 @@
   "images" : [
     {
       "filename" : "ic_fluent_lock_closed_20_regular.pdf",
-      "idiom" : "universal",
+      "idiom" : "universal"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TableViewCell/ic_fluent_share_20_regular.imageset/Contents.json
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Resources/Assets.xcassets/TableViewCell/ic_fluent_share_20_regular.imageset/Contents.json
@@ -2,11 +2,14 @@
   "images" : [
     {
       "filename" : "ic_fluent_share_20_regular.pdf",
-      "idiom" : "universal",
+      "idiom" : "universal"
     }
   ],
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
When example icons were added to the cell demo page, it wasn't marked as templated. so the icon doesn't appear in dark mode.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| n/a| n/a | n/a  | n/a  |

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/217112976-cc8c02e7-295b-4f0f-97e5-6246dfea8c87.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-06 at 15 49 23](https://user-images.githubusercontent.com/20715435/217112938-233d9301-a472-4dd5-bdec-3558b3fa2004.png)|

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1551)