### PR TITLE
Avatar accessory image changed to accommodate multiple rendering modes

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -208,7 +208,7 @@ class AvatarDemoController: DemoTableViewController {
                     isEven = index % 2 == 0
                     activityStyle = isEven ? .circle : .square
                     allDemoAvatarsCombined[index].state.activityStyle = isShowingActivity ? activityStyle : .none
-                    allDemoAvatarsCombined[index].state.activityImage = isEven ? UIImage(named: "thumbs_up_3d_default") : UIImage(named: "excelIcon")
+                    allDemoAvatarsCombined[index].state.activityImage = isEven ? UIImage(named: "Placeholder_20")?.withRenderingMode(.alwaysTemplate) : UIImage(named: "excelIcon")
                 }
             }
         }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -339,6 +339,9 @@ public struct Avatar: View, TokenizedControlView {
                                     .overlay(accessoryImage
                                         .interpolation(.high)
                                         .resizable()
+                                         // Rendering mode should be original for now to allow any image to show,
+                                         // but eventually should be changed to template when we add foreground tokens.
+                                        .renderingMode(.original)
                                         .frame(width: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                height: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                alignment: .center)

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -341,7 +341,7 @@ public struct Avatar: View, TokenizedControlView {
                                         .resizable()
                                          // Rendering mode should be original for now to allow any image to show,
                                          // but eventually should be changed to template when we add foreground tokens.
-                                        .renderingMode(.original)
+                                        .renderingMode(shouldDisplayPresence ? .template : .original)
                                         .frame(width: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                height: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                alignment: .center)

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -339,9 +339,7 @@ public struct Avatar: View, TokenizedControlView {
                                     .overlay(accessoryImage
                                         .interpolation(.high)
                                         .resizable()
-                                         // Rendering mode should be original for now to allow any image to show,
-                                         // but eventually should be changed to template when we add foreground tokens.
-                                        .renderingMode(shouldDisplayPresence ? .template : .original)
+                                        .foregroundColor(Color(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1]))
                                         .frame(width: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                height: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                alignment: .center)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In some scenarios, the activity image will not show even if the cutout is made within the Avatar if the image file is an SVG and the asset image is rendered as a Template Image. Added an SVG example in the demo controller and included hard-coded foreground color that will later be exposed as a token in a follow-up PR to unblock downstream dependencies.


### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/217138725-a1f616ec-e7bb-4710-8a26-993926b1c828.png) | ![image](https://user-images.githubusercontent.com/22566866/217150739-4e240bea-7a6d-44cb-858d-2a392c742ac1.png) |
| ![image](https://user-images.githubusercontent.com/22566866/217138785-fc5e89aa-8945-4809-a8c0-b300bace9ec9.png) | ![image](https://user-images.githubusercontent.com/22566866/217150710-ed278b8c-f3d4-4984-ab28-07c006ef12e8.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1554)