### PR TITLE
[main_0.12] Cherry-picking: Avatar accessory image changed to be original rendering mode (#1554)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -208,7 +208,7 @@ class AvatarDemoController: DemoTableViewController {
                     isEven = index % 2 == 0
                     activityStyle = isEven ? .circle : .square
                     allDemoAvatarsCombined[index].state.activityStyle = isShowingActivity ? activityStyle : .none
-                    allDemoAvatarsCombined[index].state.activityImage = isEven ? UIImage(named: "thumbs_up_3d_default") : UIImage(named: "excelIcon")
+                    allDemoAvatarsCombined[index].state.activityImage = isEven ? UIImage(named: "Placeholder_20")?.withRenderingMode(.alwaysTemplate) : UIImage(named: "excelIcon")
                 }
             }
         }

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -312,11 +312,10 @@ public struct Avatar: View, TokenizedControlView {
                                     .overlay(accessoryImage
                                         .interpolation(.high)
                                         .resizable()
-                                        .foregroundColor(Color(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1]))
                                         .frame(width: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                height: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                alignment: .center)
-                                            .foregroundColor(shouldDisplayActivity ? Color.clear : presence.color(isOutOfOffice: isOutOfOffice)))
+                                            .foregroundColor(shouldDisplayActivity ? Color(dynamicColor: tokenSet.fluentTheme.aliasTokens.foregroundColors[.neutral1]) : presence.color(isOutOfOffice: isOutOfOffice)))
                                         .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
                                         .frame(width: shouldDisplayActivity ? activityBackgroundFrameSideRelativeToOuterRing : accessoryBorderFrameSideRelativeToOuterRing,
                                                height: shouldDisplayActivity ? activityBackgroundFrameSideRelativeToOuterRing : accessoryBorderFrameSideRelativeToOuterRing,

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -312,6 +312,7 @@ public struct Avatar: View, TokenizedControlView {
                                     .overlay(accessoryImage
                                         .interpolation(.high)
                                         .resizable()
+                                        .foregroundColor(Color(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1]))
                                         .frame(width: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                height: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                alignment: .center)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picked:
- 1d1aacf0dfab7576b69cd5e695bdb94ce1522186 (#1554)

Made a slight edit to accommodate for presence + fluent1 colors.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/22566866/217155425-bb4dbd4f-a692-43b2-a855-f2ab9db4122c.png) | ![image](https://user-images.githubusercontent.com/22566866/217155214-7f96ae0a-02d4-4a19-98b7-38648aa22280.png) |
| ![image](https://user-images.githubusercontent.com/22566866/217155473-ec7f56ff-cbd8-4529-9f8c-b2b3f07eb056.png) | ![image](https://user-images.githubusercontent.com/22566866/217155257-cc6943b2-375d-4fd2-a146-e34bbbd4df26.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1556)