### PR TITLE
Adding new foreground token for Avatar activity

### DIFF
--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -292,6 +292,7 @@ public struct Avatar: View, TokenizedControlView {
                 let accessoryIconSize: CGFloat = shouldDisplayActivity ? AvatarTokenSet.activityIconBackgroundSize(size) : AvatarTokenSet.presenceIconSize(size)
                 let accessoryBorderSize: CGFloat = accessoryIconSize + (accessoryBorderThicknessToken * 2)
                 let accessoryBackgroundColor: DynamicColor = shouldDisplayActivity ? tokenSet[.activityBackgroundColor].dynamicColor : accessoryBorderColorToken
+                let accessoryForegroundColor: Color = shouldDisplayActivity ? Color(dynamicColor: tokenSet[.activityForegroundColor].dynamicColor) : presence.color(isOutOfOffice: isOutOfOffice, fluentTheme: fluentTheme)
                 let accessoryIconOffset: CGFloat = shouldDisplayActivity ? accessoryBorderThicknessToken * 3 : accessoryBorderThicknessToken
                 let accessoryCutoutCoordinates: CGPoint = accessoryCoordinates(iconOffset: accessoryIconOffset,
                                                                                iconSize: accessoryBorderSize,
@@ -339,11 +340,10 @@ public struct Avatar: View, TokenizedControlView {
                                     .overlay(accessoryImage
                                         .interpolation(.high)
                                         .resizable()
-                                        .foregroundColor(Color(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1]))
                                         .frame(width: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                height: shouldDisplayActivity ? activityImageSize : accessoryIconSize,
                                                alignment: .center)
-                                            .foregroundColor(shouldDisplayActivity ? Color.clear : presence.color(isOutOfOffice: isOutOfOffice, fluentTheme: fluentTheme)))
+                                            .foregroundColor(accessoryForegroundColor))
                                         .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
                                         .frame(width: shouldDisplayActivity ? activityBackgroundFrameSideRelativeToOuterRing : accessoryBorderFrameSideRelativeToOuterRing,
                                                height: shouldDisplayActivity ? activityBackgroundFrameSideRelativeToOuterRing : accessoryBorderFrameSideRelativeToOuterRing,

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -36,6 +36,9 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
         /// The color of the border around the presence/activity.
         case borderColor
 
+        /// The foreground color of the activity.
+        case activityForegroundColor
+
         /// The background color of the activity.
         case activityBackgroundColor
 
@@ -149,6 +152,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
             case .borderColor:
                 return .dynamicColor({
                     theme.aliasTokens.colors[.background1]
+                })
+
+            case .activityForegroundColor:
+                return .dynamicColor({
+                    theme.aliasTokens.colors[.foreground1]
                 })
 
             case .activityBackgroundColor:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A follow-up of #1554. Adding new foreground token and getting rid of hardcoded value. Also simplifying foreground color calling so that it doesn't affect presence.

### Verification


| After                                       | Before                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/217157254-932d3a84-165d-4039-92f3-bebdfcf5d290.png) | ![image](https://user-images.githubusercontent.com/22566866/217157447-2e02384b-0ab5-4407-a5d9-55a4579cdc38.png) |
| ![image](https://user-images.githubusercontent.com/22566866/217157285-b697f396-529a-4cc9-afb0-e6988f0b018f.png) | ![image](https://user-images.githubusercontent.com/22566866/217157486-92039c42-f0b8-4edd-a4c3-fb944fb9b924.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/fluentui-apple/pulls/1557)