### PR TITLE
Fix PillButton colors

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -37,10 +37,11 @@ class ColoredPillBackgroundView: UIView {
     func updateBackgroundColor() {
         switch style {
         case .neutral:
-            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light:  GlobalTokens.neutralColors(.grey98),
+                                                                 dark: GlobalTokens.neutralColors(.grey8)))
         case .brand:
             backgroundColor = UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]),
-                                      dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3]))
+                                      dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey8)))
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -37,7 +37,7 @@ class ColoredPillBackgroundView: UIView {
     func updateBackgroundColor() {
         switch style {
         case .neutral:
-            backgroundColor = UIColor(dynamicColor: DynamicColor(light:  GlobalTokens.neutralColors(.grey98),
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.grey98),
                                                                  dark: GlobalTokens.neutralColors(.grey8)))
         case .brand:
             backgroundColor = UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -77,13 +77,6 @@ class PillButtonBarDemoController: DemoController {
         container.addArrangedSubview(UIView())
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        let backgroundColorLight = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandBackground1])
-        onBrandBar?.backgroundColor = UIColor(light: backgroundColorLight, dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey16)))
-        customBar?.backgroundColor = UIColor(light: backgroundColorLight, dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey16)))
-    }
-
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .primary, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsColors: Bool = false) -> UIView {
         let accentColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundOnColor])
         let textColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -255,9 +255,6 @@ open class PillButton: UIButton {
                     setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: fluentTheme, for: style),
                                   for: .highlighted)
                 }
-
-                setTitleColor(customSelectedTextColor ?? PillButton.selectedTitleColor(for: fluentTheme, for: style), for: .normal)
-                setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: fluentTheme, for: style), for: .highlighted)
             } else {
                 resolvedBackgroundColor = PillButton.selectedDisabledBackgroundColor(for: fluentTheme, for: style)
                 if #available(iOS 15.0, *) {

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -88,7 +88,9 @@ public extension PillButton {
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foregroundDisabled1].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.foregroundDisabled1].darkElevated))
         }
     }
 
@@ -96,18 +98,23 @@ public extension PillButton {
     static func selectedDisabledBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundDisabled])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
+
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundDisabled]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3Selected].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Selected].darkElevated))
         }
     }
 
     static func selectedDisabledTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled2])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1])
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled2]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled2]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundDisabled2].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foregroundDisabled2].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.foregroundDisabled2].darkElevated))
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -59,18 +59,21 @@ public extension PillButton {
         case .primary:
             return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3Selected].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Selected].darkElevated))
         }
     }
 
     static func selectedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]),
-                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic]))
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]),
-                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground1].darkElevated))
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -106,12 +106,27 @@ public extension PillButton {
     // MARK: highlighted state
 
     static func highlightedBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
-        return disabledBackgroundColor(for: fluentTheme, for: style)
+        switch style {
+        case .primary:
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background5Pressed].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3Pressed].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Pressed].darkElevated))
+        case .onBrand:
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2Pressed].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3Pressed].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Pressed].darkElevated))
+        }
     }
 
     static func highlightedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
-        return UIColor(light: disabledTitleColor(for: fluentTheme, for: style),
-                       dark: UIColor(colorValue: GlobalTokens.sharedColors(.lime, .primary)))
+        switch style {
+        case .primary:
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+        case .onBrand:
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground1].darkElevated))
+        }
     }
 
     // MARK: selected highlighted state
@@ -119,19 +134,22 @@ public extension PillButton {
     static func selectedHighlightedBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1Pressed])
         case .onBrand:
-            return UIColor(light: UIColor(colorValue: GlobalTokens.neutralColors(.white)),
-                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3Pressed].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background3Pressed].darkElevated))
         }
     }
 
     static func selectedHighlightedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return selectedTitleColor(for: fluentTheme, for: style)
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
         case .onBrand:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1Pressed].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground1].darkElevated))
         }
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -25,21 +25,26 @@ public extension PillButton {
 
     @objc(normalBackgroundColorForWindow:ForStyle:)
     static func normalBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
-        let defaultColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
         switch style {
         case .primary:
-            return defaultColor
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background5].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5].darkElevated))
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground2]), dark: defaultColor)
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.background3].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5].darkElevated))
         }
     }
 
     static func titleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]), dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
+                                                      dark: fluentTheme.aliasTokens.colors[.foreground2].dark,
+                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground2].darkElevated))
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`PillButton` colors seem to have been updated by design and this PR fixes them.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,965,104 bytes | 29,013,856 bytes | 48,752 bytes |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_light](https://user-images.githubusercontent.com/106181067/217627662-356a3712-d0c1-48e6-8fee-277da0598c49.gif) | ![after_light](https://user-images.githubusercontent.com/106181067/217627712-81a3cf2d-fa8b-47cf-bafe-605044f05c59.gif) |
| ![before_dark](https://user-images.githubusercontent.com/106181067/217627767-6748ccf1-d9dd-4455-872e-4fc63fd9b052.gif) | ![after_dark](https://user-images.githubusercontent.com/106181067/217627790-cf71513f-d5c6-42da-9f0b-bfe9532db933.gif) |
| <img width="489" alt="before_green" src="https://user-images.githubusercontent.com/106181067/217633151-f346aa6a-4129-49d5-8b84-b47581102b84.png"> | <img width="489" alt="after_green" src="https://user-images.githubusercontent.com/106181067/217633163-499701e2-8d1d-4467-9847-dfe023aed979.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1560)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1560)