### PR TITLE
[cherry-pick] Add accessibilityIdentifier property to CommandBarItem

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -121,6 +121,7 @@ class CommandBarButton: UIButton {
         accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
         accessibilityHint = item.accessibilityHint
         accessibilityValue = item.accessibilityValue
+        accessibilityIdentifier = item.accessibilityIdentifier
     }
 
     private let isPersistSelection: Bool


### PR DESCRIPTION
Add accessibilityIdentifier property to CommandBarItem.

Co-authored-by: Des Marks <johnmarks@microsoft.com>

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-pick of 1b5f7f5dee1dfda3e9e4ca3c6d2f3014a78b1c21 to restore CommandBarButton accessibility.

### Verification

Cherry-picking known good change into main_0.12 branch

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1561)