### PR TITLE
Add custom action support to NavigationBar

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -76,7 +76,7 @@ open class NavigationBarTitleAccessory: NSObject {
     public let location: Location
     /// The style of the accessory.
     public let style: Style
-    /// The action to perform when the view is tapped.
+    /// A delegate that handles title press actions.
     public weak var delegate: NavigationBarTitleAccessoryDelegate?
 
     public init(location: Location, style: Style, delegate: NavigationBarTitleAccessoryDelegate? = nil) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -47,6 +47,45 @@ open class NavigationBarTopSearchBarAttributes: NavigationBarTopAccessoryViewAtt
     }
 }
 
+// MARK: - NavigationBarTitleAccessory
+
+@objc(MSFNavigationBarTitleAccessoryDelegate)
+/// Handles user interactions with a `NavigationBar` with an accessory.
+public protocol NavigationBarTitleAccessoryDelegate {
+    @objc func navigationBarDidTapOnTitle(_ sender: NavigationBar)
+}
+
+/// The specifications for an accessory to show in the title or subtitle of the navigation bar.
+@objc(MSFNavigationBarTitleAccessory)
+open class NavigationBarTitleAccessory: NSObject {
+    /// Specifies a location where the title accessory should appear within the navigation bar.
+    @objc(MSFNavigationBarTitleAccessoryLocation)
+    public enum Location: Int {
+        case title
+        case subtitle
+    }
+
+    /// The style of title accessory to show.
+    @objc(MSFNavigationBarTitleAccessoryStyle)
+    public enum Style: Int {
+        case disclosure
+        case downArrow
+    }
+
+    /// The location of the accessory.
+    public let location: Location
+    /// The style of the accessory.
+    public let style: Style
+    /// The action to perform when the view is tapped.
+    public weak var delegate: NavigationBarTitleAccessoryDelegate?
+
+    public init(location: Location, style: Style, delegate: NavigationBarTitleAccessoryDelegate? = nil) {
+        self.location = location
+        self.style = style
+        self.delegate = delegate
+    }
+}
+
 // MARK: - NavigationBar
 
 /// UINavigationBar subclass, with a content view that contains various custom UIElements
@@ -732,15 +771,18 @@ open class NavigationBar: UINavigationBar, TwoLineTitleViewDelegate {
     }
 
     private func updateSubtitleView(for navigationItem: UINavigationItem?) {
-        guard let navigationItem = navigationItem, let subtitle = navigationItem.subtitle else {
+        guard let navigationItem = navigationItem else {
             // Use the default title view
             navigationItem?.titleView = nil
             return
         }
 
         let customTitleView = TwoLineTitleView(style: style == .primary ? .primary : .system)
-        customTitleView.setup(title: navigationItem.title ?? "", subtitle: subtitle, interactivePart: .title)
-        customTitleView.delegate = self
+        customTitleView.setup(navigationItem: navigationItem)
+        if navigationItem.titleAccessory == nil {
+            // Use default behavior of requesting an accessory expansion
+            customTitleView.delegate = self
+        }
         navigationItem.titleView = customTitleView
     }
 

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -8,6 +8,7 @@ import UIKit
 @objc public extension UINavigationItem {
     private struct AssociatedKeys {
         static var accessoryView: String = "accessoryView"
+        static var titleAccessory: String = "titleAccessory"
         static var topAccessoryView: String = "topAccessoryView"
         static var topAccessoryViewAttributes: String = "topAccessoryViewAttributes"
         static var contentScrollView: String = "contentScrollView"
@@ -24,6 +25,15 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.accessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    var titleAccessory: NavigationBarTitleAccessory? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.titleAccessory) as? NavigationBarTitleAccessory
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.titleAccessory, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -340,14 +340,10 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
         hasLeftBarButtonItems = !(navigationItem.leftBarButtonItems?.isEmpty ?? true)
         titleButton.setTitle(navigationItem.title, for: .normal)
         hasSubtitle = navigationItem.subtitle != nil
-        if let title = navigationItem.title {
-            twoLineTitleView.setup(
-                title: title,
-                subtitle: navigationItem.subtitle,
-                alignment: .leading,
-                interactivePart: .all,
-                animatesWhenPressed: false
-            )
+        twoLineTitleView.setup(navigationItem: navigationItem)
+        if navigationItem.titleAccessory == nil {
+            // Use default behavior of requesting an accessory expansion
+            twoLineTitleView.delegate = self
         }
     }
 

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -5,6 +5,40 @@
 
 import UIKit
 
+// MARK: NavigationBarTitleAccessory enum extensions
+
+extension NavigationBarTitleAccessory: TwoLineTitleViewDelegate {
+    public func twoLineTitleViewDidTapOnTitle(_ twoLineTitleView: TwoLineTitleView) {
+        guard let delegate = delegate,
+              let navigationBar = twoLineTitleView.findSuperview(of: NavigationBar.self) as? NavigationBar else {
+            return
+        }
+        delegate.navigationBarDidTapOnTitle(navigationBar)
+    }
+}
+
+fileprivate extension NavigationBarTitleAccessory.Location {
+    var twoLineTitleViewInteractivePart: TwoLineTitleView.InteractivePart {
+        switch self {
+        case .title:
+            return .title
+        case .subtitle:
+            return .subtitle
+        }
+    }
+}
+
+fileprivate extension NavigationBarTitleAccessory.Style {
+    var twoLineTitleViewAccessoryType: TwoLineTitleView.AccessoryType {
+        switch self {
+        case .downArrow:
+            return .downArrow
+        case .disclosure:
+            return .disclosure
+        }
+    }
+}
+
 // MARK: TwoLineTitleViewDelegate
 
 /// Handles user interactions with a `TwoLineTitleView`.
@@ -250,6 +284,29 @@ open class TwoLineTitleView: UIView {
 
         invalidateIntrinsicContentSize()
         setNeedsLayout()
+    }
+
+    @objc open func setup(navigationItem: UINavigationItem) {
+        let title = navigationItem.title ?? ""
+        let alignment: Alignment = navigationItem.usesLargeTitle ? .leading : .center
+
+        let interactivePart: InteractivePart
+        let accessoryType: AccessoryType
+        let animatesWhenPressed: Bool
+        if let titleAccessory = navigationItem.titleAccessory {
+            // Use the custom action provided by the title accessory specification
+            interactivePart = titleAccessory.location.twoLineTitleViewInteractivePart
+            accessoryType = titleAccessory.style.twoLineTitleViewAccessoryType
+            animatesWhenPressed = true
+            delegate = titleAccessory
+        } else {
+            // Use the default behavior of requesting expansion of the hosting navigation bar
+            interactivePart = .all
+            accessoryType = .none
+            animatesWhenPressed = false
+        }
+
+        setup(title: title, subtitle: navigationItem.subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType)
     }
 
     // MARK: Highlighting


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Previously, `TwoLineTitleView` had support for custom tap actions and disclosure arrows. We expose it to `UINavigationItem` via a new class called `NavigationBarTitleAccessory`.

In addition, we also enhance the test page to show how clients can play with `UINavigationItem` objects to enable navigation. More test cases can be added as feature work continues.

### Verification

See screenshots below.

| Test page | Child view |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-10 at 13 22 16](https://user-images.githubusercontent.com/717674/218200237-af593403-7a55-40b5-b24e-87e51e0d44a4.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-10 at 13 22 21](https://user-images.githubusercontent.com/717674/218200252-2cfa1dc1-15bf-4bbe-99d7-cd94fe995089.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1562)