### PR TITLE
didmovetowindow to willMove:toWindow

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -464,8 +464,8 @@ open class BadgeView: UIView {
         return CGSize(width: max(minWidth, min(width, maxWidth)), height: min(height, maxHeight))
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -464,8 +464,8 @@ open class BadgeView: UIView {
         return CGSize(width: max(minWidth, min(width, maxWidth)), height: min(height, maxHeight))
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -143,7 +143,8 @@ open class Button: UIButton, TokenizedControlInternal {
         updateBackground()
     }
 
-    open override func didMoveToWindow() {
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         tokenSet.update(fluentTheme)
         update()
     }

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -143,8 +143,8 @@ open class Button: UIButton, TokenizedControlInternal {
         updateBackground()
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         tokenSet.update(fluentTheme)
         update()
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -285,8 +285,8 @@ private class SelectionOverlayView: UIView {
         flipSubviewsForRTL()
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
+	override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         setupActiveViews()
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -285,8 +285,8 @@ private class SelectionOverlayView: UIView {
         flipSubviewsForRTL()
     }
 
-	override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         setupActiveViews()
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -84,8 +84,8 @@ class CalendarViewWeekdayHeadingView: UIView {
         flipSubviewsForRTL()
     }
 
-	override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         super.didMoveToWindow()
         updateBackgroundColor()
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -84,7 +84,8 @@ class CalendarViewWeekdayHeadingView: UIView {
         flipSubviewsForRTL()
     }
 
-    override func didMoveToWindow() {
+	override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         super.didMoveToWindow()
         updateBackgroundColor()
     }

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -100,8 +100,8 @@ public class CommandBar: UIView, TokenizedControlInternal {
         }
     }
 
-	public override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    public override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
 
         tokenSet.update(fluentTheme)
         updateButtonTokens()

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -100,8 +100,8 @@ public class CommandBar: UIView, TokenizedControlInternal {
         }
     }
 
-    public override func didMoveToWindow() {
-        super.didMoveToWindow()
+	public override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
 
         tokenSet.update(fluentTheme)
         updateButtonTokens()

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -28,8 +28,8 @@ class CommandBarButton: UIButton {
         }
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateStyle()
     }
 

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -28,8 +28,8 @@ class CommandBarButton: UIButton {
         }
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateStyle()
     }
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -73,8 +73,8 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         // Override -> No highlight
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
+	override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateTextLabelColor()
     }
 

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -73,8 +73,8 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         // Override -> No highlight
     }
 
-	override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateTextLabelColor()
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -35,8 +35,8 @@ class BadgeLabel: UILabel {
         updateColors()
     }
 
-	override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -35,8 +35,8 @@ class BadgeLabel: UILabel {
         updateColors()
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
+	override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -80,8 +80,8 @@ open class Label: UILabel {
         initialize()
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateTextColor()
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -80,8 +80,8 @@ open class Label: UILabel {
         initialize()
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateTextColor()
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -436,8 +436,8 @@ open class NavigationBar: UINavigationBar {
         )
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateColors(for: topItem)
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -436,8 +436,8 @@ open class NavigationBar: UINavigationBar {
         )
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateColors(for: topItem)
     }
 

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -291,8 +291,8 @@ open class SearchBar: UIView {
         setupLayout()
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateColorsForStyle()
     }
 

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -291,8 +291,8 @@ open class SearchBar: UIView {
         setupLayout()
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateColorsForStyle()
     }
 

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -226,8 +226,8 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         )
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
 
         tokenSet.update(fluentTheme)
         updateAppearance()

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -226,8 +226,8 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         )
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
 
         tokenSet.update(fluentTheme)
         updateAppearance()

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -72,8 +72,8 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         activityIndicatorView.center = CGPoint(x: ceil(contentView.frame.width / 2), y: ceil(contentView.frame.height / 2))
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         tokenSet.update(fluentTheme)
         updateAppearance()
     }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -72,8 +72,8 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         activityIndicatorView.center = CGPoint(x: ceil(contentView.frame.width / 2), y: ceil(contentView.frame.height / 2))
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         tokenSet.update(fluentTheme)
         updateAppearance()
     }

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -87,8 +87,8 @@ open class BooleanCell: TableViewCell {
         onValueChanged?()
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         `switch`.onTintColor = UIColor(dynamicColor: tokenSet[.booleanCellBrandColor].dynamicColor)
     }
 

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -87,8 +87,8 @@ open class BooleanCell: TableViewCell {
         onValueChanged?()
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         `switch`.onTintColor = UIColor(dynamicColor: tokenSet[.booleanCellBrandColor].dynamicColor)
     }
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -100,8 +100,8 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         label.centerInSuperview()
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
 
         tokenSet.update(fluentTheme)
         updateAppearance()

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -100,8 +100,8 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         label.centerInSuperview()
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
 
         tokenSet.update(fluentTheme)
         updateAppearance()

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -46,8 +46,8 @@ open class PillButton: UIButton {
         }
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateAppearance()
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -46,8 +46,8 @@ open class PillButton: UIButton {
         }
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateAppearance()
     }
 

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -103,8 +103,8 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         }
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
+    override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -389,9 +389,8 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                       height: min(height, size.height))
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         tokenSet.update(fluentTheme)
         updateGradientMaskColors()
         if isFixedWidth {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -159,8 +159,8 @@ class TabBarItemView: UIControl {
         }
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
+	override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -159,8 +159,8 @@ class TabBarItemView: UIControl {
         }
     }
 
-	override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1852,9 +1852,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-
+	open override func willMove(toWindow newWindow: UIWindow?) {
+		super.willMove(toWindow: newWindow)
         tokenSet.update(fluentTheme)
         updateAppearance()
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
we shouldn't use didmovetowindow for updating colors. we should use willmove:towindow so we can handle animations better

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
no impact

### Verification
run though all the controls

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2023-02-10 at 14 56 35](https://user-images.githubusercontent.com/20715435/218217946-f83e1c48-7fec-4395-9b64-52b988ca1026.gif)|![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2023-02-10 at 14 49 50](https://user-images.githubusercontent.com/20715435/218216311-6b95d45c-585a-4f6d-836c-af9fe24e3644.gif)  |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1563)