### PR TITLE
Get theme from parent to update ShyHeaderController colors

### DIFF
--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -122,7 +122,7 @@ open class NavigationController: UINavigationController {
         if !viewControllerNeedsWrapping(viewController) {
             return viewController
         }
-        return ShyHeaderController(contentViewController: viewController)
+        return ShyHeaderController(contentViewController: viewController, containingView: self.parent?.view ?? view)
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -25,40 +25,40 @@ public protocol SearchBarDelegate: AnyObject {
 open class SearchBar: UIView {
     @objc(MSFSearchBarStyle)
     public enum Style: Int {
-        case lightContent, darkContent, brandContent
+        case lightContent, darkContent
 
         func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2].light, dark: fluentTheme.aliasTokens.colors[.background5].dark))
             }
         }
 
         func cancelButtonColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
             }
         }
 
         func clearIconColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
             }
         }
 
         func placeholderColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
@@ -68,36 +68,36 @@ open class SearchBar: UIView {
             let idleBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
 
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return isSearching ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-            case .brandContent:
+            case .lightContent:
                 return isSearching ? searchBrandColor : idleBrandColor
             }
         }
 
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
             }
         }
 
         func tintColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }
 
         func progressSpinnerColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
-            case .lightContent, .darkContent:
+            case .darkContent:
                 return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-            case .brandContent:
+            case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }
         }

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -66,10 +66,15 @@ class ShyHeaderController: UIViewController {
     private var contentScrollViewObservation: NSKeyValueObservation?
     private var previousContentScrollViewTraits = ContentScrollViewTraits() //properties of the scroll view at the last scrollDidOccurIn: update. Used with current traits to understand user action
 
-    init(contentViewController: UIViewController) {
+    // The context of the parent controller used to pull the correct FluentTheme to update visuals
+    weak var containingView: UIView?
+
+    init(contentViewController: UIViewController, containingView: UIView?) {
         self.contentViewController = contentViewController
         shyHeaderView.accessoryView = contentViewController.navigationItem.accessoryView
         shyHeaderView.navigationBarShadow = contentViewController.navigationItem.navigationBarShadow
+
+        self.containingView = containingView
 
         super.init(nibName: nil, bundle: nil)
 
@@ -121,10 +126,6 @@ class ShyHeaderController: UIViewController {
 
         updatePadding()
         setupNotificationObservers()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         updateNavigationBarStyle()
     }
 
@@ -259,7 +260,7 @@ class ShyHeaderController: UIViewController {
     }
 
     private func updateBackgroundColor(with item: UINavigationItem) {
-        let color = item.navigationBarColor(fluentTheme: view.fluentTheme)
+        let color = item.navigationBarColor(fluentTheme: containingView?.fluentTheme ?? view.fluentTheme)
         shyHeaderView.backgroundColor = color
         view.backgroundColor = color
         paddingView.backgroundColor = color


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There's a bug where the `ShyHeaderController` wasn't using the correct theme to update colors. This PR fixes the bug by passing down a weak reference of the view context to make sure `ShyHeaderController` uses the correct theme to update its colors. Also, `viewDidAppear` has been removed and the color updates will be called in `viewWillAppear`.
This will be a short term fix, as we will be looking into ways to delegate `ShyHeaderController` color updates to `NavigationController` in the longer term.
This PR also fixes a bug introduced by #1050 where the `SearchBar` doesn't use the right branding colors. The `brandContent` style for the `SearchBar` has been removed to partially revert the change and fix the bug.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,075,768 bytes | 29,085,640 bytes | 9,872 bytes |

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://user-images.githubusercontent.com/106181067/218219118-0e82d58e-6cbe-46a3-b432-c02478f9c2e4.gif) | ![after](https://user-images.githubusercontent.com/106181067/218287413-cb6db38e-9f9c-4263-ae51-3daf2b6679e4.gif) |
| <img width="489" alt="before_blue" src="https://user-images.githubusercontent.com/106181067/218287586-63bc345f-f751-47ed-bebd-09c97dbd30f3.png"> | <img width="489" alt="after_blue" src="https://user-images.githubusercontent.com/106181067/218287589-d62ca4d1-6e50-42c9-9953-3a715a2554f0.png"> |
| <img width="489" alt="before_green" src="https://user-images.githubusercontent.com/106181067/218287592-1f302dee-a811-4e93-bd6a-7fa5a4ad163e.png"> | <img width="489" alt="after_green" src="https://user-images.githubusercontent.com/106181067/218287593-975f5175-bbc7-4454-afa2-5715563d123c.png"> |
| <img width="489" alt="before_light" src="https://user-images.githubusercontent.com/106181067/218287600-cc4e9f6a-714f-47d6-9935-c94ee7808488.png"> | <img width="489" alt="after_light" src="https://user-images.githubusercontent.com/106181067/218287602-a9e69423-12f4-4454-9138-d074f1550947.png"> |
| <img width="489" alt="before_dark" src="https://user-images.githubusercontent.com/106181067/218287608-018afefd-185d-4e92-abde-a29d203009bf.png"> | <img width="489" alt="after_dark" src="https://user-images.githubusercontent.com/106181067/218287613-8af3278b-6015-444d-adfd-6cf36233e92e.png"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1564)