### PR TITLE
Fix bottom sheet demo safe area issue

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -37,6 +37,11 @@ class BottomSheetDemoController: DemoController {
         view.addSubview(bottomSheetViewController.view)
         bottomSheetViewController.didMove(toParent: self)
 
+        // If we're hosting a VC view in the bottom sheet, the VC itself needs to be a child of the bottom sheet VC
+        // This is important to ensure safe area changes propagate correctly.
+        bottomSheetViewController.addChild(contentNavigationController)
+        contentNavigationController.didMove(toParent: bottomSheetViewController)
+
         NSLayoutConstraint.activate([
             optionTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             optionTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change: N/A - demo only change.

We were seeing some strange behavior in the bottom sheet demo controller where in flexible mode, the content safe areas would be wrong just after expanding the sheet, but would jump to the correct value whenever the sheet was moved.

Turns out this is because the content VC wasn't a child of the sheet VC. Safe area propagation partially relies on the VC hierarchy to update layout guides etc.

In the future bottom sheet should offer a content VC init to encourage this pattern.

### Verification

Repro before, no repro after.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1565)