### PR TITLE
rename buttonSize to ButtonSizeCategory

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -14,14 +14,14 @@ class ButtonDemoController: DemoController {
         container.alignment = .leading
 
         for style in ButtonStyle.allCases {
-            for size in ButtonSize.allCases {
+            for size in ButtonSizeCategory.allCases {
                 addTitle(text: style.description + ", " + size.description)
 
                 let button = createButton(with: style,
-                                          size: size,
+                                          sizeCategory: size,
                                           title: "Text")
                 let disabledButton = createButton(with: style,
-                                                  size: size,
+                                                  sizeCategory: size,
                                                   title: "Text",
                                                   isEnabled: false)
                 let titleButtonStack = UIStackView(arrangedSubviews: [button, disabledButton])
@@ -31,11 +31,11 @@ class ButtonDemoController: DemoController {
 
                 if let image = size.image {
                     let iconButton = createButton(with: style,
-                                                  size: size,
+                                                  sizeCategory: size,
                                                   title: "Text",
                                                   image: image)
                     let disabledIconButton = createButton(with: style,
-                                                          size: size,
+                                                          sizeCategory: size,
                                                           title: "Text",
                                                           image: image,
                                                           isEnabled: false)
@@ -45,10 +45,10 @@ class ButtonDemoController: DemoController {
                     container.addArrangedSubview(titleImageButtonStack)
 
                     let iconOnlyButton = createButton(with: style,
-                                                      size: size,
+                                                      sizeCategory: size,
                                                       image: image)
                     let disabledIconOnlyButton = createButton(with: style,
-                                                              size: size,
+                                                              sizeCategory: size,
                                                               image: image,
                                                               isEnabled: false)
                     let imageButtonStack = UIStackView(arrangedSubviews: [iconOnlyButton, disabledIconOnlyButton])
@@ -64,16 +64,35 @@ class ButtonDemoController: DemoController {
                                   title: "Longer Text Button")
         let iconButton = createButton(with: .accent,
                                       title: "Longer Text Button",
-                                      image: ButtonSize.large.image)
+                                      image: ButtonSizeCategory.large.image)
         addRow(items: [button])
         addRow(items: [iconButton])
 
         container.addArrangedSubview(UIView())
+
+        let customButton = createButton(with: .accent, sizeCategory: .small, title: "ToolBar Test Button")
+        let buttonBarItem = UIBarButtonItem.init(customView: customButton)
+        customButton.sizeToFit()
+        toolbarItems = [
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            buttonBarItem,
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        ]
     }
 
-    private func createButton(with style: ButtonStyle, size: ButtonSize = .large, title: String? = nil, image: UIImage? = nil, isEnabled: Bool = true) -> Button {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        navigationController?.isToolbarHidden = false
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.isToolbarHidden = true
+    }
+
+    private func createButton(with style: ButtonStyle, sizeCategory: ButtonSizeCategory = .large, title: String? = nil, image: UIImage? = nil, isEnabled: Bool = true) -> Button {
         let button = Button(style: style)
-        button.size = size
+        button.sizeCategory = sizeCategory
         if let title = title {
             button.setTitle(title, for: .normal)
             button.titleLabel?.numberOfLines = 0
@@ -116,7 +135,7 @@ extension ButtonStyle {
     }
 }
 
-extension ButtonSize {
+extension ButtonSizeCategory {
     var description: String {
         switch self {
         case .large:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -195,37 +195,37 @@ class CommandBarDemoController: DemoController {
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
         let refreshButton = Button(style: .outline)
-        refreshButton.size = .small
+        refreshButton.sizeCategory = .small
         refreshButton.setTitle("Refresh 'Default' Bar", for: .normal)
         refreshButton.addTarget(self, action: #selector(refreshDefaultBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshButton)
 
         let removeTrailingItemButton = Button(style: .outline)
-        removeTrailingItemButton.size = .small
+        removeTrailingItemButton.sizeCategory = .small
         removeTrailingItemButton.setTitle("Remove Trailing Button", for: .normal)
         removeTrailingItemButton.addTarget(self, action: #selector(removeDefaultTrailingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(removeTrailingItemButton)
 
         let refreshTrailingItemButton = Button(style: .outline)
-        refreshTrailingItemButton.size = .small
+        refreshTrailingItemButton.sizeCategory = .small
         refreshTrailingItemButton.setTitle("Refresh Trailing Button", for: .normal)
         refreshTrailingItemButton.addTarget(self, action: #selector(refreshDefaultTrailingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshTrailingItemButton)
 
         let removeLeadingItemButton = Button(style: .outline)
-        removeLeadingItemButton.size = .small
+        removeLeadingItemButton.sizeCategory = .small
         removeLeadingItemButton.setTitle("Remove Leading Button", for: .normal)
         removeLeadingItemButton.addTarget(self, action: #selector(removeDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(removeLeadingItemButton)
 
         let refreshLeadingItemButton = Button(style: .outline)
-        refreshLeadingItemButton.size = .small
+        refreshLeadingItemButton.sizeCategory = .small
         refreshLeadingItemButton.setTitle("Refresh Leading Button", for: .normal)
         refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
         let resetScrollPositionButton = Button(style: .outline)
-        resetScrollPositionButton.size = .small
+        resetScrollPositionButton.sizeCategory = .small
         resetScrollPositionButton.setTitle("Reset Scroll Position", for: .normal)
         resetScrollPositionButton.addTarget(self, action: #selector(resetScrollPosition), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(resetScrollPositionButton)

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -20,9 +20,9 @@ open class Button: UIButton, TokenizedControlInternal {
         }
     }
 
-    @objc open var size: ButtonSize = .medium {
+    @objc open var sizeCategory: ButtonSizeCategory = .medium {
         didSet {
-            if size != oldValue {
+            if sizeCategory != oldValue {
                 update()
             }
         }
@@ -84,18 +84,22 @@ open class Button: UIButton, TokenizedControlInternal {
     }
 
     open override var intrinsicContentSize: CGSize {
-        var contentSize = titleLabel?.systemLayoutSizeFitting(CGSize(width: proposedTitleLabelWidth == 0 ? .greatestFiniteMagnitude : proposedTitleLabelWidth, height: .greatestFiniteMagnitude)) ?? .zero
+        return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
+    }
+
+    open override func sizeThatFits(_ size: CGSize) -> CGSize {
+        var contentSize = titleLabel?.systemLayoutSizeFitting(CGSize(width: proposedTitleLabelWidth == 0 ? size.width : proposedTitleLabelWidth, height: size.width)) ?? .zero
         contentSize.width = ceil(contentSize.width + edgeInsets.leading + edgeInsets.trailing)
-        contentSize.height = ceil(max(contentSize.height, ButtonTokenSet.minContainerHeight(size)) + edgeInsets.top + edgeInsets.bottom)
+        contentSize.height = ceil(max(contentSize.height, ButtonTokenSet.minContainerHeight(sizeCategory)) + edgeInsets.top + edgeInsets.bottom)
 
         if let image = image(for: .normal) {
             contentSize.width += image.size.width
             if #available(iOS 15.0, *) {
-                contentSize.width += ButtonTokenSet.titleImageSpacing(size)
+                contentSize.width += ButtonTokenSet.titleImageSpacing(sizeCategory)
             }
 
             if titleLabel?.text?.count ?? 0 == 0 {
-                contentSize.width -= ButtonTokenSet.titleImageSpacing(size)
+                contentSize.width -= ButtonTokenSet.titleImageSpacing(sizeCategory)
             }
         }
 
@@ -215,7 +219,7 @@ open class Button: UIButton, TokenizedControlInternal {
         return self?.style ?? .outline
     },
                                                      size: { [weak self] in
-        return self?.size ?? .medium
+        return self?.sizeCategory ?? .medium
     })
 
     private func updateTitle() {
@@ -308,7 +312,7 @@ open class Button: UIButton, TokenizedControlInternal {
     private func adjustCustomContentEdgeInsetsForImage() {
         isAdjustingCustomContentEdgeInsetsForImage = true
 
-        var spacing = ButtonTokenSet.titleImageSpacing(size)
+        var spacing = ButtonTokenSet.titleImageSpacing(sizeCategory)
 
         if image(for: .normal) == nil {
             spacing = -spacing
@@ -366,7 +370,7 @@ open class Button: UIButton, TokenizedControlInternal {
     }
 
     private func defaultEdgeInsets() -> NSDirectionalEdgeInsets {
-        let horizontalPadding = ButtonTokenSet.horizontalPadding(size)
+        let horizontalPadding = ButtonTokenSet.horizontalPadding(sizeCategory)
         return NSDirectionalEdgeInsets(top: 0, leading: horizontalPadding, bottom: 0, trailing: horizontalPadding)
     }
 

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -17,10 +17,10 @@ public enum ButtonStyle: Int, CaseIterable {
     case dangerSubtle
 }
 
-// MARK: ButtonSize
+// MARK: ButtonSizeCategory
 
 @objc(MSFButtonSize)
-public enum ButtonSize: Int, CaseIterable {
+public enum ButtonSizeCategory: Int, CaseIterable {
     case large
     case medium
     case small
@@ -73,7 +73,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
     }
 
     init(style: @escaping () -> ButtonStyle,
-         size: @escaping () -> ButtonSize) {
+         size: @escaping () -> ButtonSizeCategory) {
         self.style = style
         self.size = size
         super.init { [style, size] token, theme in
@@ -222,12 +222,12 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
     }
 
     var style: () -> ButtonStyle
-    var size: () -> ButtonSize
+    var size: () -> ButtonSizeCategory
 }
 
 extension ButtonTokenSet {
     /// The value for the horizontal padding between the content of the button and the frame.
-    static func horizontalPadding(_ size: ButtonSize) -> CGFloat {
+    static func horizontalPadding(_ size: ButtonSizeCategory) -> CGFloat {
         switch size {
         case .large:
             return GlobalTokens.spacing(.size200)
@@ -239,7 +239,7 @@ extension ButtonTokenSet {
     }
 
     /// The minimum value for the height of the content of the button.
-    static func minContainerHeight(_ size: ButtonSize) -> CGFloat {
+    static func minContainerHeight(_ size: ButtonSizeCategory) -> CGFloat {
         switch size {
         case .large:
             return 52
@@ -251,7 +251,7 @@ extension ButtonTokenSet {
     }
 
     /// The value for the spacing between the title and image.
-    static func titleImageSpacing(_ size: ButtonSize) -> CGFloat {
+    static func titleImageSpacing(_ size: ButtonSizeCategory) -> CGFloat {
         switch size {
         case .large, .medium:
             return GlobalTokens.spacing(.size80)

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -19,7 +19,7 @@ public enum ButtonStyle: Int, CaseIterable {
 
 // MARK: ButtonSizeCategory
 
-@objc(MSFButtonSize)
+@objc(MSFButtonSizeCategory)
 public enum ButtonSizeCategory: Int, CaseIterable {
     case large
     case medium


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Button's variable size seems confusing to the CGRect's size. Change the name to ButtonSizeCategory.
Add another case where we host Fluent button in toolbar.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a |  28.7 MB | 28.7 MB | 0 |
|  |  |  |  |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/218543885-7f2c29af-aa1a-4016-bb33-6951ff0eef06.png) | ![image](https://user-images.githubusercontent.com/20715435/218542221-56ed89dc-dd38-4785-ae09-76b2b932f3d8.png) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1567)