### PR TITLE
make sure headerfooterview isn't clear background color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -123,7 +123,7 @@ class DemoListViewController: DemoTableViewController {
         let demoController: UIViewController
         if demo.title.compare("TableViewCell", options: .caseInsensitive) == .orderedSame {
             // .grouped is used for plain type so that the headerfooterview will scroll with the rest of the plain style cells
-            demoController = TableViewCellDemoController.init(style: showGroupedTableViewCellStyle ? .insetGrouped : .grouped)
+            demoController = TableViewCellDemoController.init(style: showGroupedTableViewCellStyle ? .insetGrouped : .plain)
         } else {
             demoController = demo.controllerClass.init(nibName: nil, bundle: nil)
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -17,7 +17,7 @@ class TableViewCellDemoController: DemoTableViewController {
 
     override init(style: UITableView.Style) {
         super.init(style: style)
-        self.isGrouped = (style == .insetGrouped)
+        self.isGrouped = (style == .insetGrouped || style == .grouped)
     }
 
     required init?(coder: NSCoder) {
@@ -228,6 +228,7 @@ extension TableViewCellDemoController {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let section = sections[section]
         header?.setup(style: section.headerStyle, title: section.title)
+        header?.tableViewStyle = tableView.style
         return header
     }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -44,13 +44,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
         case footer
         case headerPrimary
 
-        func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
-            switch self {
-            case .header, .footer, .headerPrimary:
-                return .clear
-            }
-        }
-
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .header, .footer:
@@ -169,6 +162,15 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     /// `onAccessoryButtonTapped` is called when `accessoryButton` is tapped
     @objc open var onAccessoryButtonTapped: (() -> Void)?
     @objc open var onHeaderViewTapped: (() -> Void)?
+
+    /// configure this variable to change the appropriate background color based on what type of UITableView style it is in hosted
+    @objc public var tableViewStyle: UITableView.Style = .insetGrouped {
+        didSet {
+            if tableViewStyle != oldValue {
+                updateTitleAndBackgroundColors()
+            }
+        }
+    }
 
     @objc public weak var delegate: TableViewHeaderFooterViewDelegate?
 
@@ -473,7 +475,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
 
     private func updateTitleAndBackgroundColors() {
         titleView.textColor = style.textColor(fluentTheme: fluentTheme)
-        backgroundView?.backgroundColor = style.backgroundColor(fluentTheme: fluentTheme)
+
+        if tableViewStyle == .insetGrouped || tableViewStyle == .grouped {
+            backgroundView?.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundCanvas])
+        } else {
+            backgroundView?.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+        }
+
         titleView.font = style.textFont()
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
If the tableviewStyle is .plain, because the headerfooterview by default is .clear color, when the cell scrolls, it draws in the background. Even though TableViewHeaderFooterView isn't fluent2 tokenize yet, lets use the alias token to update the background color, if the client configures what TableViewStyle this headerfooter view is hosted in.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a |  |  28.8 MB|  |
|  |  |  |  |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

|| Before                                       | After                                      |
|--|----------------------------------------------|--------------------------------------------|
|.plain| Screenshot or description before this change | ![Simulator Screen Recording - iPhone 14 Pro - 2023-02-14 at 09 19 07](https://user-images.githubusercontent.com/20715435/218810450-2986866a-103c-480b-8a44-d9e45ff88f74.gif) |
|.insetGrouped| Screenshot or description before this change | ![image](https://user-images.githubusercontent.com/20715435/218810314-f481847a-8c1f-470c-929d-982eed04a100.png) |
### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)