### PR TITLE
last cell of the section in insetgroup style shouldn't have separator

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -115,6 +115,10 @@ class DemoListViewController: DemoTableViewController {
         cell.titleNumberOfLinesForLargerDynamicType = 2
         cell.backgroundStyleType = .grouped
 
+        if indexPath.row == DemoControllerSection.allCases[indexPath.section].rows.count - 1 {
+            cell.bottomSeparatorType = .none
+        }
+
         return cell
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -210,8 +210,11 @@ extension TableViewCellDemoController {
 
         cell.backgroundStyleType = isGrouped ? .grouped : .plain
         cell.topSeparatorType = isGrouped && indexPath.row == 0 ? .full : .none
-        let isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
-        cell.bottomSeparatorType = isLastInSection ? .full : .inset
+        if indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1 {
+            cell.bottomSeparatorType = isGrouped ? .none : .full
+        } else {
+            cell.bottomSeparatorType = .inset
+        }
 
         cell.isInSelectionMode = section.allowsMultipleSelection ? isInSelectionMode : false
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Last cell of the insetGroup section shouldn't have a separator

Binary change:
n/a

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/218818693-d001f888-a621-41fe-bd48-d0df00b9aa54.png)| ![image](https://user-images.githubusercontent.com/20715435/218818462-33a0765d-16a8-4e13-b3ab-e24933c1ba31.png) |
| ![image](https://user-images.githubusercontent.com/20715435/218818920-ecca500c-aec3-4f6a-b0be-478fb1f61779.png)|  ![image](https://user-images.githubusercontent.com/20715435/218818523-bcf21e6d-adc8-4082-8f60-9531f89eee95.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1571)