### PR TITLE
bug fixes on colors around drawercontroller and bottomsheet

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift
@@ -47,6 +47,7 @@ class BadgeFieldDemoController: DemoController {
         badgeField.label = label
         badgeField.badgeFieldDelegate = self
         badgeField.addBadges(withDataSources: dataSources)
+        badgeField.isActive = true
         return badgeField
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -18,7 +18,8 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Neutral badge", style: .neutral)
         addBadgeSection(title: "Severe Warning badge", style: .severeWarning)
         addBadgeSection(title: "Success badge", style: .success)
-        addBadgeSection(title: "Disabled badge", style: .default, isEnabled: false)
+        addBadgeSection(title: "Disabled badge Default", style: .default, isEnabled: false)
+        addBadgeSection(title: "Disabled badge Neutral", style: .neutral, isEnabled: false)
         addBadgeSection(title: "Custom badge", style: .default, overrideColor: true)
         addBadgeSection(title: "Custom disabled badge", style: .default, isEnabled: false, overrideColor: true)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -146,7 +146,7 @@ class BottomSheetDemoController: DemoController {
     private lazy var personaListView: UIScrollView = {
         let personaListView = PersonaListView()
         personaListView.personaList = samplePersonas
-        personaListView.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        personaListView.backgroundColor = .clear
         personaListView.translatesAutoresizingMaskIntoConstraints = false
         return personaListView
     }()
@@ -157,7 +157,7 @@ class BottomSheetDemoController: DemoController {
         view.addSubview(personaListView)
 
         let bottomView = UIView()
-        bottomView.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.backgroundDisabled])
+        bottomView.backgroundColor = .clear
         bottomView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomView)
 
@@ -205,7 +205,7 @@ class BottomSheetDemoController: DemoController {
 
     private let headerView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.backgroundDisabled])
+        view.backgroundColor = .clear
 
         let label = Label()
         label.text = "Header view"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PeoplePickerDemoController.swift
@@ -93,6 +93,7 @@ class PeoplePickerDemoController: DemoController {
         peoplePicker.hidePersonaListViewWhenNoSuggestedPersonas = variant.hidePersonaListViewWhenNoSuggestedPersonas
         peoplePicker.showsAvatar = variant.showsAvatar
         peoplePicker.delegate = self
+        peoplePicker.isActive = true
         peoplePickers.append(peoplePicker)
         container.addArrangedSubview(peoplePicker)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -231,7 +231,7 @@ extension TableViewCellDemoController {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let section = sections[section]
         header?.setup(style: section.headerStyle, title: section.title)
-        header?.tableViewStyle = tableView.style
+        header?.tableViewCellStyle = tableView.style == .plain ? .plain : .grouped
         return header
     }
 

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -199,8 +199,8 @@ open class BadgeView: UIView {
             if let customDisabledLabelTextColor = _disabledLabelTextColor {
                 return customDisabledLabelTextColor
             }
-            let textDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
-            return style == .default ? textDisabledColor : (isSelected ? self.selectedLabelTextColor : self.labelTextColor)
+            let textDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1])
+            return style == .default ? textDisabledColor : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled2])
         }
         set {
             if disabledBackgroundColor != newValue {
@@ -283,8 +283,8 @@ open class BadgeView: UIView {
             if let customDisabledBackgroundColor = _disabledBackgroundColor {
                 return customDisabledBackgroundColor
             }
-            let backgroundDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
-            return style == .default ? backgroundDisabledColor : (isSelected ? self.selectedBackgroundColor : self.backgroundColor)
+            let backgroundDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3])
+            return style == .default ? backgroundDisabledColor : self.backgroundColor
         }
         set {
             if disabledBackgroundColor != newValue {

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -199,8 +199,13 @@ open class BadgeView: UIView {
             if let customDisabledLabelTextColor = _disabledLabelTextColor {
                 return customDisabledLabelTextColor
             }
-            let textDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1])
-            return style == .default ? textDisabledColor : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled2])
+
+            let textDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+            if style == .default {
+                return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]), dark: textDisabledColor)
+            } else {
+                return textDisabledColor
+            }
         }
         set {
             if disabledBackgroundColor != newValue {
@@ -283,8 +288,13 @@ open class BadgeView: UIView {
             if let customDisabledBackgroundColor = _disabledBackgroundColor {
                 return customDisabledBackgroundColor
             }
-            let backgroundDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3])
-            return style == .default ? backgroundDisabledColor : self.backgroundColor
+
+            let backgroundDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+            if style == .default {
+                return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3]), dark: backgroundDisabledColor)
+            } else {
+                return backgroundDisabledColor
+            }
         }
         set {
             if disabledBackgroundColor != newValue {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -960,6 +960,7 @@ extension BottomCommandingController: UITableViewDelegate {
         var configuredHeader: UIView?
         if let sectionTitle = section.title {
             header.setup(style: .header, title: sectionTitle)
+            header.tableViewCellStyle = .clear
             configuredHeader = header
         }
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetTokenSet.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetTokenSet.swift
@@ -16,7 +16,8 @@ public class BottomSheetTokenSet: ControlTokenSet<BottomSheetTokenSet.Tokens> {
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background2]
+                return .dynamicColor { DynamicColor(light: theme.aliasTokens.colors[.background2].light,
+                                                    dark: theme.aliasTokens.colors[.background2].dark)
                 }
             case .cornerRadius:
                 return .float { GlobalTokens.corner(.radius120) }

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -102,7 +102,7 @@ public class FluentUIFramework: NSObject {
             navigationBar.standardAppearance.backgroundColor = UIColor(dynamicColor: aliasTokens.colors[.background3])
         }
 
-        navigationBar.tintColor = UIColor(dynamicColor: aliasTokens.colors[.foreground3])
+        navigationBar.tintColor = UIColor(dynamicColor: aliasTokens.colors[.foreground2])
 
         let traits = traits ?? navigationBar.traitCollection
         // Removing built-in shadow for Dark Mode

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -164,6 +164,8 @@ open class PeoplePicker: BadgeField {
             self.pickPersona(persona: persona)
         }
         personaListView.searchDirectoryDelegate = self
+        personaListView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light,
+                                                                             dark: fluentTheme.aliasTokens.colors[.background2].dark))
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -163,10 +163,10 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     @objc open var onAccessoryButtonTapped: (() -> Void)?
     @objc open var onHeaderViewTapped: (() -> Void)?
 
-    /// configure this variable to change the appropriate background color based on what type of UITableView style it is in hosted
-    @objc public var tableViewStyle: UITableView.Style = .insetGrouped {
+    /// configure this variable to change the appropriate background color based on what type of TableViewCell style it is associated with
+    @objc public var tableViewCellStyle: TableViewCellBackgroundStyleType = .grouped {
         didSet {
-            if tableViewStyle != oldValue {
+            if tableViewCellStyle != oldValue {
                 updateTitleAndBackgroundColors()
             }
         }
@@ -476,10 +476,12 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView {
     private func updateTitleAndBackgroundColors() {
         titleView.textColor = style.textColor(fluentTheme: fluentTheme)
 
-        if tableViewStyle == .insetGrouped || tableViewStyle == .grouped {
+        if tableViewCellStyle == .grouped {
             backgroundView?.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.backgroundCanvas])
-        } else {
+        } else if tableViewCellStyle == .plain {
             backgroundView?.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+        } else {
+            backgroundView?.backgroundColor = .clear
         }
 
         titleView.font = style.textFont()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
- BottomSheet in darkmode uses darkelevated. so using just alias background 2 isn't goodenough
- Badgefield and people picker rest state on darkmode seems to be not correct
- bottomsheet demo color on darkmode should be more consistent
- light mode default style badgeview(branding color) should have its own disabled color that is branding color
- bottomcommandingbar headerfooterview color in darkmode didn't seem right.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 28,800,128 bytes  |28,806,720 bytes  | 6592 bytes |


(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

|| Before                                       | After                                      |
|--|----------------------------------------------|--------------------------------------------|
|BottomSheet | ![image](https://user-images.githubusercontent.com/20715435/218878920-08a2d1aa-08e3-4dcf-a0d8-b1d297f423ab.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 13 59 15](https://user-images.githubusercontent.com/20715435/218877930-632d5297-db84-4db4-b017-fce5743f0e70.png) |
| bottomcommanding| ![image](https://user-images.githubusercontent.com/20715435/218878863-34ddd677-96b1-4869-b587-469851add286.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 13 59 31](https://user-images.githubusercontent.com/20715435/218878025-8af5e080-98c4-408d-a4ac-15104e3e5f19.png) |
| people picker |![image](https://user-images.githubusercontent.com/20715435/218878787-cb018662-6457-4816-a8aa-6229fb0b464f.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 13 59 47](https://user-images.githubusercontent.com/20715435/218878111-cb329276-e6bd-41d4-afcb-6114f7f28d06.png)|
|badgeField| ![image](https://user-images.githubusercontent.com/20715435/218878722-eb78e76a-ba5f-4770-b961-695c256f7abb.png)| ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 14 00 24](https://user-images.githubusercontent.com/20715435/218878164-2c62763d-d41f-4cf1-904f-bc7fe04dd562.png)|
|badgeview| ![image](https://user-images.githubusercontent.com/20715435/218878677-bdc8cb56-8925-4084-9db2-11066fb92577.png)| ![image](https://user-images.githubusercontent.com/20715435/218878247-83d56596-1365-4586-bc79-e86140bf1ad2.png)|

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1573)