### PR TITLE
[Cherry-Pick] Fixing initial theme setting for `willMove(toWindow:)` (#1581)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -34,6 +34,18 @@ class ColoredPillBackgroundView: UIView {
         updateBackgroundColor()
     }
 
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        // Note: We usually do updates during `willMove(toWindow:)` to ensure that there's no "flash" of the
+        // old color in cases whre the view is briefly visible before this API is called. However, the
+        // public APIs for easily hooking into theme changes have not yet been exposed, so this demo
+        // controller is not in a position to easily follow those rules. This will be sufficient for our
+        // current needs, but it's technically less correct than I'd like.
+        // TODO: update this to use proper theme updating hooks once they're built
+        updateBackgroundColor()
+    }
+
     func updateBackgroundColor() {
         switch style {
         case .neutral:

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		80AECC21263339E3005AF2F3 /* BottomSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECBD82629F18E005AF2F3 /* BottomSheetController.swift */; };
 		80AECC22263339E5005AF2F3 /* BottomSheetPassthroughView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AECBF1262FC34E005AF2F3 /* BottomSheetPassthroughView.swift */; };
 		8FA3CB5B246B19EA0049E431 /* ColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA3CB5A246B19EA0049E431 /* ColorTests.swift */; };
+		92016FF8299DF34A00660DB7 /* EmptyTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92016FF7299DF34A00660DB7 /* EmptyTokenSet.swift */; };
 		92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92088EF72666DB2C003F571A /* PersonaButton.swift */; };
 		920945492703DDA000B38E1A /* CardNudgeTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920945472703DDA000B38E1A /* CardNudgeTokenSet.swift */; };
 		922A34DF27BB87990062721F /* TokenizedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922A34DE27BB87990062721F /* TokenizedControlView.swift */; };
@@ -294,6 +295,7 @@
 		86AF4F7425AFC746005D4253 /* PillButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtonStyle.swift; sourceTree = "<group>"; };
 		8FA3CB5A246B19EA0049E431 /* ColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorTests.swift; sourceTree = "<group>"; };
 		8FD01166228A820600D25925 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		92016FF7299DF34A00660DB7 /* EmptyTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTokenSet.swift; sourceTree = "<group>"; };
 		92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeModifiers.swift; sourceTree = "<group>"; };
 		92088EF72666DB2C003F571A /* PersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButton.swift; sourceTree = "<group>"; };
 		920945472703DDA000B38E1A /* CardNudgeTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeTokenSet.swift; sourceTree = "<group>"; };
@@ -752,6 +754,7 @@
 				925D461E26FD18B200179583 /* AliasTokens.swift */,
 				92DEE2232723D34400E31ED0 /* ControlTokenSet.swift */,
 				92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */,
+				92016FF7299DF34A00660DB7 /* EmptyTokenSet.swift */,
 				925728F8276D6B5800EE1019 /* FontInfo.swift */,
 				925D461B26FD133600179583 /* GlobalTokens.swift */,
 				92D5FDFA28A713990087894B /* LinearGradientInfo.swift */,
@@ -1441,6 +1444,7 @@
 				5328D97726FBA3D700F3723B /* IndeterminateProgressBar.swift in Sources */,
 				5314E07625F00F160099271A /* DateTimePickerController.swift in Sources */,
 				922A34DF27BB87990062721F /* TokenizedControlView.swift in Sources */,
+				92016FF8299DF34A00660DB7 /* EmptyTokenSet.swift in Sources */,
 				5314E14525F016860099271A /* CardPresentationController.swift in Sources */,
 				5314E0A925F010070099271A /* DrawerTransitionAnimator.swift in Sources */,
 				5314E06525F00EFD0099271A /* CalendarViewDayMonthCell.swift in Sources */,

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -56,7 +56,7 @@ public protocol BadgeViewDelegate {
  `BadgeView` can be selected with a tap gesture and tapped again after entering a selected state for the purpose of displaying more details about the entity represented by the selected badge.
  */
 @objc(MSFBadgeView)
-open class BadgeView: UIView {
+open class BadgeView: UIView, TokenizedControlInternal {
     @objc(MSFBadgeViewStyle)
     public enum Style: Int {
         case `default`
@@ -144,17 +144,17 @@ open class BadgeView: UIView {
             }
             switch style {
             case .default:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundTint])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForegroundTint])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.warningForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.warningForeground1])
             case .error:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerForeground1])
             case .neutral:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
             case .severeWarning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.severeForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.severeForeground1])
             case .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.successForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.successForeground1])
             }
         }
         set {
@@ -174,15 +174,15 @@ open class BadgeView: UIView {
 
             switch style {
             case .default:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundOnColor])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDarkStatic])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundDarkStatic])
             case .error,
                  .severeWarning,
                  .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundLightStatic])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
             case .neutral:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
             }
         }
         set {
@@ -200,9 +200,9 @@ open class BadgeView: UIView {
                 return customDisabledLabelTextColor
             }
 
-            let textDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+            let textDisabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundDisabled1])
             if style == .default {
-                return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]), dark: textDisabledColor)
+                return UIColor(light: UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]), dark: textDisabledColor)
             } else {
                 return textDisabledColor
             }
@@ -223,17 +223,17 @@ open class BadgeView: UIView {
             }
             switch style {
             case .default:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackgroundTint])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackgroundTint])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.warningBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.warningBackground1])
             case .error:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerBackground1])
             case .neutral:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background5])
             case .severeWarning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.severeBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.severeBackground1])
             case .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.successBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.successBackground1])
             }
         }
         set {
@@ -252,17 +252,17 @@ open class BadgeView: UIView {
             }
             switch style {
             case .default:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground1])
             case .warning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.warningBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.warningBackground2])
             case .error:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerBackground2])
             case .neutral:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5Selected])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background5Selected])
             case .severeWarning:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.severeBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.severeBackground2])
             case .success:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.successBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.successBackground2])
             }
         }
         set {
@@ -289,9 +289,9 @@ open class BadgeView: UIView {
                 return customDisabledBackgroundColor
             }
 
-            let backgroundDisabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+            let backgroundDisabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background5])
             if style == .default {
-                return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground3]), dark: backgroundDisabledColor)
+                return UIColor(light: UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground3]), dark: backgroundDisabledColor)
             } else {
                 return backgroundDisabledColor
             }
@@ -325,6 +325,9 @@ open class BadgeView: UIView {
     open override var intrinsicContentSize: CGSize {
         return sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
     }
+
+    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    public var tokenSet: EmptyTokenSet = .init()
 
     private var style: Style = .default {
         didSet {
@@ -412,15 +415,17 @@ open class BadgeView: UIView {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateColors()
+        updateFonts()
     }
 
     private func updateFonts() {
         switch size {
         case .small:
-            label.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption1])
+            label.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.caption1])
         case .medium:
-            label.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body2])
+            label.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.body2])
         }
     }
 
@@ -476,7 +481,12 @@ open class BadgeView: UIView {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateColors()
+        updateFonts()
     }
 
     private func customViewSize(for size: CGSize) -> CGSize? {

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -149,7 +149,10 @@ open class Button: UIButton, TokenizedControlInternal {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
-        tokenSet.update(fluentTheme)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         update()
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -50,7 +50,7 @@ let calendarViewDayCellVisualStateTransitionDuration: TimeInterval = 0.3
 
 // MARK: - CalendarViewDayCell
 
-class CalendarViewDayCell: UICollectionViewCell {
+class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
     struct Constants {
         static let borderWidth: CGFloat = 0.5
         static let dotDiameter: CGFloat = 6.0
@@ -82,6 +82,9 @@ class CalendarViewDayCell: UICollectionViewCell {
     let dateLabel: UILabel
     let dotView: DotView
 
+    typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    let tokenSet: EmptyTokenSet = .init()
+
     override init(frame: CGRect) {
         // Initialize subviews
         //
@@ -103,8 +106,8 @@ class CalendarViewDayCell: UICollectionViewCell {
         super.init(frame: frame)
 
         dateLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
-        dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-        dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
+        dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
 
         contentView.addSubview(selectionOverlayView)
         contentView.addSubview(dateLabel)
@@ -121,8 +124,8 @@ class CalendarViewDayCell: UICollectionViewCell {
             return
         }
         updateViews()
-        dotView.color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-        dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
+        dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -198,27 +201,38 @@ class CalendarViewDayCell: UICollectionViewCell {
         )
     }
 
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
+        updateViews()
+    }
+
     private func updateViews() {
         switch textStyle {
         case .primary:
-            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
         case .secondary:
-            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
         }
 
         switch backgroundStyle {
         case .primary:
-            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.aliasTokens.colors[.background2].light, dark: tokenSet.fluentTheme.aliasTokens.colors[.background2].dark))
         case .secondary:
-            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.backgroundCanvas].light, dark: fluentTheme.aliasTokens.colors[.backgroundCanvas].dark))
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.aliasTokens.colors[.backgroundCanvas].light, dark: tokenSet.fluentTheme.aliasTokens.colors[.backgroundCanvas].dark))
         }
 
         if isHighlighted || isSelected {
             dotView.isHidden = true
-            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundOnColor])
         } else {
             dotView.isHidden = false
         }
+
+        selectionOverlayView.activeColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground1])
 
         setNeedsLayout()
     }
@@ -250,8 +264,10 @@ private class SelectionOverlayView: UIView {
         }
     }
 
-    private var activeColor: UIColor {
-        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
+    var activeColor: UIColor = .clear {
+        didSet {
+            setupActiveViews()
+        }
     }
 
     // Lazy load views as every additional subview impacts the "Calendar"
@@ -283,11 +299,6 @@ private class SelectionOverlayView: UIView {
         }
 
         flipSubviewsForRTL()
-    }
-
-    override func willMove(toWindow newWindow: UIWindow?) {
-        super.willMove(toWindow: newWindow)
-        setupActiveViews()
     }
 
     private func setupActiveViews() {

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -151,7 +151,7 @@ public enum CardSize: Int, CaseIterable {
  Conform to the `CardDelegate` in order to provide a handler for the card tap event
  */
 @objc(MSFCardView)
-open class CardView: UIView, Shadowable {
+open class CardView: UIView, Shadowable, TokenizedControlInternal {
 
     /// Delegate to handle user interaction with the CardView
     @objc public weak var delegate: CardDelegate?
@@ -209,7 +209,7 @@ open class CardView: UIView, Shadowable {
     }
 
     /// Set `customBackgroundColor` in order to set the background color when using the custom color style
-    @objc open lazy var customBackgroundColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2]) {
+    @objc open lazy var customBackgroundColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background2]) {
         didSet {
             if customBackgroundColor != oldValue {
                 setupColors()
@@ -218,7 +218,7 @@ open class CardView: UIView, Shadowable {
     }
 
     /// Set `customTitleColor` in order to set the title's text color when using the custom color style
-    @objc open lazy var customTitleColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]) {
+    @objc open lazy var customTitleColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1]) {
         didSet {
             if customTitleColor != oldValue {
                 setupColors()
@@ -227,7 +227,7 @@ open class CardView: UIView, Shadowable {
     }
 
     /// Set `customSubtitleColor` in order to set the subtitle's text color when using the custom color style
-    @objc open lazy var customSubtitleColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]) {
+    @objc open lazy var customSubtitleColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2]) {
         didSet {
             if customSubtitleColor != oldValue {
                 setupColors()
@@ -236,7 +236,7 @@ open class CardView: UIView, Shadowable {
     }
 
     /// Set `customIconTintColor` in order to set the icon's tint color when using the custom color style
-    @objc open lazy var customIconTintColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]) {
+    @objc open lazy var customIconTintColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2]) {
         didSet {
             if customIconTintColor != oldValue {
                 setupColors()
@@ -245,7 +245,7 @@ open class CardView: UIView, Shadowable {
     }
 
     /// Set `customBorderColor` in order to set the border's color when using the custom color style
-    @objc open lazy var customBorderColor: UIColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]) {
+    @objc open lazy var customBorderColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]) {
         didSet {
             if customBorderColor != oldValue {
                 setupColors()
@@ -261,6 +261,9 @@ open class CardView: UIView, Shadowable {
             }
         }
     }
+
+    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    public var tokenSet: EmptyTokenSet = .init()
 
     /// The size of the card.
     private var size: CardSize = .small
@@ -366,7 +369,7 @@ open class CardView: UIView, Shadowable {
     public var keyShadow: CALayer?
 
     private func updateShadow() {
-        let shadowInfo = fluentTheme.aliasTokens.shadow[.shadow02]
+        let shadowInfo = tokenSet.fluentTheme.aliasTokens.shadow[.shadow02]
         shadowInfo.applyShadow(to: self)
     }
 
@@ -379,6 +382,7 @@ open class CardView: UIView, Shadowable {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         setupColors()
     }
 
@@ -395,9 +399,9 @@ open class CardView: UIView, Shadowable {
                 // Update border color
                 switch colorStyle {
                 case .appColor:
-                    layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+                    layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
                 case .neutral:
-                    layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+                    layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
                 case .custom:
                     layer.borderColor = customBorderColor.cgColor
                 }
@@ -405,21 +409,30 @@ open class CardView: UIView, Shadowable {
         }
     }
 
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
+        setupColors()
+    }
+
     /// Set up the background color of the card and update the icon and text color if necessary
     private func setupColors() {
         switch colorStyle {
         case .appColor:
-            primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-            secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            iconView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
-            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
-            layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+            primaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
+            secondaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
+            iconView.tintColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForeground1])
+            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background2])
+            layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
         case .neutral:
-            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
-            primaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-            secondaryLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            iconView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            layer.borderColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background2])
+            primaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
+            secondaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
+            iconView.tintColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
+            layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
         case .custom:
             backgroundColor = customBackgroundColor
             primaryLabel.textColor = customTitleColor

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -102,8 +102,10 @@ public class CommandBar: UIView, TokenizedControlInternal {
 
     public override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
-
-        tokenSet.update(fluentTheme)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateButtonTokens()
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/EmptyTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/EmptyTokenSet.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+/// An empty `ControlTokenSet` for components that want to use some of the perks
+/// of being tokenized, but are not fully at that stage yet.
+public class EmptyTokenSet: ControlTokenSet<EmptyTokenSet.Tokens> {
+
+    /// The set of tokens associated with this `EmptyTokenSet`.
+    public enum Tokens: TokenSetKey {
+        /// A default token, which only exists because Swift requires at least one value in this enum.
+        case none
+    }
+    init() {
+        super.init { _, _ in
+            preconditionFailure("Should not fetch values")
+        }
+    }
+}

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: - DateTimePickerViewComponentCell
 
 /// TableViewCell representing the cell of component view (should be used only by DateTimePickerViewComponent and not instantiated on its own)
-class DateTimePickerViewComponentCell: UITableViewCell {
+class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal {
     private struct Constants {
         static let baseHeight: CGFloat = 45
         static let verticalPadding: CGFloat = 12
@@ -26,6 +26,9 @@ class DateTimePickerViewComponentCell: UITableViewCell {
             updateTextLabelColor()
         }
     }
+
+    typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    var tokenSet: EmptyTokenSet = .init()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
@@ -48,6 +51,7 @@ class DateTimePickerViewComponentCell: UITableViewCell {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateTextLabelColor()
     }
 
@@ -75,6 +79,10 @@ class DateTimePickerViewComponentCell: UITableViewCell {
 
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateTextLabelColor()
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -7,8 +7,11 @@ import UIKit
 
 // MARK: BadgeLabel
 
-class BadgeLabel: UILabel {
+class BadgeLabel: UILabel, TokenizedControlInternal {
     var shouldUseWindowColor: Bool = false
+
+    typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    var tokenSet: EmptyTokenSet = .init()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -37,6 +40,10 @@ class BadgeLabel: UILabel {
 
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateColors()
     }
 
@@ -44,6 +51,7 @@ class BadgeLabel: UILabel {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateColors()
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -35,7 +35,7 @@ public enum TextColorStyle: Int, CaseIterable {
 
 /// By default, `adjustsFontForContentSizeCategory` is set to true to automatically update its font when device's content size category changes
 @objc(MSFLabel)
-open class Label: UILabel {
+open class Label: UILabel, TokenizedControlInternal {
     @objc open var colorStyle: TextColorStyle = .regular {
         didSet {
             _textColor = nil
@@ -66,6 +66,9 @@ open class Label: UILabel {
     }
     private var _textColor: UIColor?
 
+    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    public var tokenSet: EmptyTokenSet = .init()
+
     private var isUsingCustomAttributedText: Bool = false
 
     @objc public init(style: AliasTokens.TypographyTokens = .body1, colorStyle: TextColorStyle = .regular) {
@@ -82,6 +85,10 @@ open class Label: UILabel {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateTextColor()
     }
 
@@ -113,6 +120,7 @@ open class Label: UILabel {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateTextColor()
     }
 
@@ -135,7 +143,7 @@ open class Label: UILabel {
         guard !isUsingCustomAttributedText else {
             return
         }
-        super.textColor = _textColor ?? colorStyle.color(fluentTheme: fluentTheme)
+        super.textColor = _textColor ?? colorStyle.color(fluentTheme: tokenSet.fluentTheme)
     }
 
     @objc private func handleContentSizeCategoryDidChange() {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -53,7 +53,7 @@ open class NavigationBarTopSearchBarAttributes: NavigationBarTopAccessoryViewAtt
 /// Contains the MSNavigationTitleView class and handles passing animatable progress through
 /// Custom UI can be hidden if desired
 @objc(MSFNavigationBar)
-open class NavigationBar: UINavigationBar {
+open class NavigationBar: UINavigationBar, TokenizedControlInternal {
     /// If the style is `.custom`, UINavigationItem's `navigationBarColor` is used for all the subviews' backgroundColor
     @objc(MSFNavigationBarStyle)
     public enum Style: Int {
@@ -108,6 +108,9 @@ open class NavigationBar: UINavigationBar {
         case automatic
         case alwaysHidden
     }
+
+    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    public var tokenSet: EmptyTokenSet = .init()
 
     static let expansionContractionAnimationDuration: TimeInterval = 0.1 // the interval over which the expansion/contraction animations occur
 
@@ -312,6 +315,7 @@ open class NavigationBar: UINavigationBar {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateColors(for: topItem)
     }
 
@@ -438,6 +442,10 @@ open class NavigationBar: UINavigationBar {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateColors(for: topItem)
     }
 
@@ -512,7 +520,7 @@ open class NavigationBar: UINavigationBar {
     // MARK: UINavigationItem & UIBarButtonItem handling
 
     func updateColors(for navigationItem: UINavigationItem?) {
-        let color = navigationItem?.navigationBarColor(fluentTheme: fluentTheme)
+        let color = navigationItem?.navigationBarColor(fluentTheme: tokenSet.fluentTheme)
 
         switch style {
         case .primary, .default, .custom:
@@ -523,9 +531,9 @@ open class NavigationBar: UINavigationBar {
 
         standardAppearance.backgroundColor = color
         backgroundView.backgroundColor = color
-        tintColor = style.tintColor(fluentTheme: fluentTheme)
-        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: fluentTheme)
-        standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: fluentTheme)
+        tintColor = style.tintColor(fluentTheme: tokenSet.fluentTheme)
+        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: tokenSet.fluentTheme)
+        standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: tokenSet.fluentTheme)
 
         // Update the scroll edge appearance to match the new standard appearance
         scrollEdgeAppearance = standardAppearance

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -228,8 +228,10 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
-
-        tokenSet.update(fluentTheme)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateAppearance()
     }
 

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -74,7 +74,10 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
-        tokenSet.update(fluentTheme)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateAppearance()
     }
 

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -89,6 +89,10 @@ open class BooleanCell: TableViewCell {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         `switch`.onTintColor = UIColor(dynamicColor: tokenSet[.booleanCellBrandColor].dynamicColor)
     }
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -102,8 +102,10 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
-
-        tokenSet.update(fluentTheme)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateAppearance()
     }
 

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// An `PillButton` is a button in the shape of a pill that can have two states: on (Selected) and off (not selected)
 @objc(MSFPillButton)
-open class PillButton: UIButton {
+open class PillButton: UIButton, TokenizedControlInternal {
 
     /// Set `backgroundColor` to customize background color of the pill button
     @objc open var customBackgroundColor: UIColor? {
@@ -48,6 +48,10 @@ open class PillButton: UIButton {
 
     open override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateAppearance()
     }
 
@@ -78,12 +82,16 @@ open class PillButton: UIButton {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateAppearance()
     }
 
-    lazy var unreadDotColor: UIColor = customUnreadDotColor ?? PillButton.enabledUnreadDotColor(for: fluentTheme, for: style)
+    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    public var tokenSet: EmptyTokenSet = .init()
 
-    lazy var titleFont: FontInfo = PillButton.titleFont(for: fluentTheme)
+    lazy var unreadDotColor: UIColor = customUnreadDotColor ?? PillButton.enabledUnreadDotColor(for: tokenSet.fluentTheme, for: style)
+
+    lazy var titleFont: FontInfo = PillButton.titleFont(for: tokenSet.fluentTheme)
 
     @objc public static let cornerRadius: CGFloat = 16.0
 
@@ -244,55 +252,55 @@ open class PillButton: UIButton {
         if isSelected {
             if isEnabled {
                 resolvedBackgroundColor = customSelectedBackgroundColor ?? (isHighlighted
-                                                                            ? PillButton.selectedHighlightedBackgroundColor(for: fluentTheme, for: style)
-                                                                            : PillButton.selectedBackgroundColor(for: fluentTheme, for: style))
+                                                                            ? PillButton.selectedHighlightedBackgroundColor(for: tokenSet.fluentTheme, for: style)
+                                                                            : PillButton.selectedBackgroundColor(for: tokenSet.fluentTheme, for: style))
                 if #available(iOS 15.0, *) {
-                    resolvedTitleColor = customSelectedTextColor ?? (isHighlighted ? PillButton.selectedHighlightedTitleColor(for: fluentTheme, for: style)
-                                                                     : PillButton.selectedTitleColor(for: fluentTheme, for: style))
+                    resolvedTitleColor = customSelectedTextColor ?? (isHighlighted ? PillButton.selectedHighlightedTitleColor(for: tokenSet.fluentTheme, for: style)
+                                                                     : PillButton.selectedTitleColor(for: tokenSet.fluentTheme, for: style))
                 } else {
-                    setTitleColor(customSelectedTextColor ?? PillButton.selectedTitleColor(for: fluentTheme, for: style),
+                    setTitleColor(customSelectedTextColor ?? PillButton.selectedTitleColor(for: tokenSet.fluentTheme, for: style),
                                   for: .normal)
-                    setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: fluentTheme, for: style),
+                    setTitleColor(customSelectedTextColor ?? PillButton.selectedHighlightedTitleColor(for: tokenSet.fluentTheme, for: style),
                                   for: .highlighted)
                 }
             } else {
-                resolvedBackgroundColor = PillButton.selectedDisabledBackgroundColor(for: fluentTheme, for: style)
+                resolvedBackgroundColor = PillButton.selectedDisabledBackgroundColor(for: tokenSet.fluentTheme, for: style)
                 if #available(iOS 15.0, *) {
-                    resolvedTitleColor = PillButton.selectedDisabledTitleColor(for: fluentTheme, for: style)
+                    resolvedTitleColor = PillButton.selectedDisabledTitleColor(for: tokenSet.fluentTheme, for: style)
                 } else {
-                    setTitleColor(PillButton.selectedDisabledTitleColor(for: fluentTheme, for: style),
+                    setTitleColor(PillButton.selectedDisabledTitleColor(for: tokenSet.fluentTheme, for: style),
                                   for: .normal)
                 }
             }
         } else {
             if isEnabled {
-                unreadDotColor = customUnreadDotColor ?? PillButton.enabledUnreadDotColor(for: fluentTheme, for: style)
+                unreadDotColor = customUnreadDotColor ?? PillButton.enabledUnreadDotColor(for: tokenSet.fluentTheme, for: style)
                 resolvedBackgroundColor = customBackgroundColor ?? (isHighlighted
-                                                                    ? PillButton.highlightedBackgroundColor(for: fluentTheme, for: style)
-                                                                    : PillButton.normalBackgroundColor(for: fluentTheme, for: style))
+                                                                    ? PillButton.highlightedBackgroundColor(for: tokenSet.fluentTheme, for: style)
+                                                                    : PillButton.normalBackgroundColor(for: tokenSet.fluentTheme, for: style))
                 if #available(iOS 15.0, *) {
                     resolvedTitleColor = {
                         guard let customTextColor = customTextColor else {
                             if isHighlighted {
-                                return PillButton.highlightedTitleColor(for: fluentTheme, for: style)
+                                return PillButton.highlightedTitleColor(for: tokenSet.fluentTheme, for: style)
                             }
 
-                            return PillButton.titleColor(for: fluentTheme, for: style)
+                            return PillButton.titleColor(for: tokenSet.fluentTheme, for: style)
                         }
 
                         return customTextColor
                     }()
                 } else {
-                    setTitleColor(customTextColor ?? PillButton.titleColor(for: fluentTheme, for: style), for: .normal)
-                    setTitleColor(customTextColor ?? PillButton.highlightedTitleColor(for: fluentTheme, for: style), for: .highlighted)
+                    setTitleColor(customTextColor ?? PillButton.titleColor(for: tokenSet.fluentTheme, for: style), for: .normal)
+                    setTitleColor(customTextColor ?? PillButton.highlightedTitleColor(for: tokenSet.fluentTheme, for: style), for: .highlighted)
                 }
             } else {
-                unreadDotColor = customUnreadDotColor ?? PillButton.disabledUnreadDotColor(for: fluentTheme, for: style)
-                resolvedBackgroundColor = customBackgroundColor ?? PillButton.disabledBackgroundColor(for: fluentTheme, for: style)
+                unreadDotColor = customUnreadDotColor ?? PillButton.disabledUnreadDotColor(for: tokenSet.fluentTheme, for: style)
+                resolvedBackgroundColor = customBackgroundColor ?? PillButton.disabledBackgroundColor(for: tokenSet.fluentTheme, for: style)
                 if #available(iOS 15.0, *) {
-                    resolvedTitleColor = PillButton.disabledTitleColor(for: fluentTheme, for: style)
+                    resolvedTitleColor = PillButton.disabledTitleColor(for: tokenSet.fluentTheme, for: style)
                 } else {
-                    setTitleColor(PillButton.disabledTitleColor(for: fluentTheme, for: style), for: .disabled)
+                    setTitleColor(PillButton.disabledTitleColor(for: tokenSet.fluentTheme, for: style), for: .disabled)
                 }
             }
         }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -104,7 +104,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
 
     override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
+        super.willMove(toWindow: newWindow)
         updateColors()
     }
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -389,9 +389,12 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                       height: min(height, size.height))
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
-        tokenSet.update(fluentTheme)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateGradientMaskColors()
         if isFixedWidth {
             invalidateIntrinsicContentSize()

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class TabBarItemView: UIControl {
+class TabBarItemView: UIControl, TokenizedControlInternal {
     let item: TabBarItem
 
     override var isEnabled: Bool {
@@ -48,7 +48,7 @@ class TabBarItemView: UIControl {
                 updateLayout()
             }
         }
-	}
+    }
 
     /// The number of lines for the item's title label.
     var numberOfTitleLines: Int = 1 {
@@ -68,6 +68,9 @@ class TabBarItemView: UIControl {
             titleLabel.preferredMaxLayoutWidth = newValue
         }
     }
+
+    typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    var tokenSet: EmptyTokenSet = .init()
 
     init(item: TabBarItem, showsTitle: Bool, canResizeImage: Bool = true) {
         self.canResizeImage = canResizeImage
@@ -128,6 +131,7 @@ class TabBarItemView: UIControl {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
         }
+        tokenSet.update(themeView.fluentTheme)
         updateColors()
     }
 
@@ -161,6 +165,10 @@ class TabBarItemView: UIControl {
 
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateColors()
     }
 
@@ -264,10 +272,10 @@ class TabBarItemView: UIControl {
     }
 
     private func updateColors() {
-        let selectedColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
-        let unselectedImageColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
-        let unselectedTextColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-        let disabledColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+        let selectedColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForeground1])
+        let unselectedImageColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
+        let unselectedTextColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
+        let disabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundDisabled1])
 
         titleLabel.textColor = isEnabled ? (isSelected ? selectedColor : unselectedTextColor) : disabledColor
         imageView.tintColor = isEnabled ? (isSelected ? selectedColor : unselectedImageColor) : disabledColor

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1852,9 +1852,12 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
-	open override func willMove(toWindow newWindow: UIWindow?) {
-		super.willMove(toWindow: newWindow)
-        tokenSet.update(fluentTheme)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
         updateAppearance()
     }
 


### PR DESCRIPTION
Cherry-pick of fb8b2f41 into main_0.13 branch

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a |  |  |  |
|  |  |  |  |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1583)