### PR TITLE
Lighten all dark segmented controls

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -49,11 +49,9 @@ class ColoredPillBackgroundView: UIView {
     func updateBackgroundColor() {
         switch style {
         case .neutral:
-            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.grey98),
-                                                                 dark: GlobalTokens.neutralColors(.grey8)))
+            backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: fluentTheme)
         case .brand:
-            backgroundColor = UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]),
-                                      dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey8)))
+            backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: fluentTheme)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -24,7 +24,7 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: #selector(showLargeTitleWithSystemStyleAndNoShadow)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithSystemStyleAndShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithSystemStyleAndFixedAccessory)))
-		container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithSystemStyleAndPillSegment)))
+        container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithSystemStyleAndPillSegment)))
 
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showRegularTitleWithShyAccessory)))
@@ -234,7 +234,7 @@ extension NavigationControllerDemoController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         // Only show side drawer for the root view controller
         if let controller = presentedViewController as? UINavigationController,
-            gestureRecognizer is UIScreenEdgePanGestureRecognizer && gestureRecognizer.view == controller.view && controller.topViewController != controller.viewControllers.first {
+           gestureRecognizer is UIScreenEdgePanGestureRecognizer && gestureRecognizer.view == controller.view && controller.topViewController != controller.viewControllers.first {
             return false
         }
         return true

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -24,6 +24,7 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: #selector(showLargeTitleWithSystemStyleAndNoShadow)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithSystemStyleAndShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithSystemStyleAndFixedAccessory)))
+		container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithSystemStyleAndPillSegment)))
 
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showRegularTitleWithShyAccessory)))
@@ -70,6 +71,10 @@ class NavigationControllerDemoController: DemoController {
         presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
+    @objc func showLargeTitleWithSystemStyleAndPillSegment() {
+        presentController(withLargeTitle: true, style: .system, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
+    }
+
     @objc func showRegularTitleWithShyAccessory() {
         presentController(withLargeTitle: false, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
@@ -101,22 +106,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithPillSegment() {
-        let segmentItems: [SegmentItem] = [
-            SegmentItem(title: "First"),
-            SegmentItem(title: "Second")]
-        let pillControl = SegmentedControl(items: segmentItems, style: .onBrandPill)
-        pillControl.shouldSetEqualWidthForSegments = false
-        pillControl.isFixedWidth = false
-        pillControl.contentInset = .zero
-        let stackView = UIStackView()
-        stackView.addArrangedSubview(pillControl)
-        stackView.distribution = .equalCentering
-        stackView.alignment = .center
-        let button = UIButton(type: .system)
-        button.setImage(UIImage(named: "ic_fluent_filter_28"), for: .normal)
-        button.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
-        stackView.addArrangedSubview(button)
-        presentController(withLargeTitle: true, accessoryView: stackView, contractNavigationBarOnScroll: false)
+        presentController(withLargeTitle: true, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
     }
 
     @discardableResult
@@ -193,6 +183,25 @@ class NavigationControllerDemoController: DemoController {
         searchBar.style = style
         searchBar.placeholderText = "Search"
         return searchBar
+    }
+
+    private func createSegmentedControl() -> UIView {
+        let segmentItems: [SegmentItem] = [
+            SegmentItem(title: "First"),
+            SegmentItem(title: "Second")]
+        let pillControl = SegmentedControl(items: segmentItems, style: .onBrandPill)
+        pillControl.shouldSetEqualWidthForSegments = false
+        pillControl.isFixedWidth = false
+        pillControl.contentInset = .zero
+        let stackView = UIStackView()
+        stackView.addArrangedSubview(pillControl)
+        stackView.distribution = .equalCentering
+        stackView.alignment = .center
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(named: "ic_fluent_filter_28"), for: .normal)
+        button.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
+        stackView.addArrangedSubview(button)
+        return stackView
     }
 
     private func presentSideDrawer(presentingGesture: UIPanGestureRecognizer? = nil) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -28,7 +28,7 @@ class SegmentedControlDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1])
 
         readmeString = "A segmented control lets someone select one option from a set of two or more segments in a single, horizontal container.\n\nSegmented controls work well for changing states of elements or views within a single context, like filtering search results. It’s best not to use them to initiate actions or navigate to a new page. To let people navigate between the main sections of an app, use the tab bar."
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -66,12 +66,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                     switch style() {
                     case .primaryPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -82,8 +80,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
+                                            dark: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -92,12 +89,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                     switch style() {
                     case .primaryPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -108,8 +103,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
+                                            dark: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -120,8 +114,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.foreground2]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground2].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground2].dark)
+                                            dark: theme.aliasTokens.colors[.foreground2].dark)
                     }
                 }
 
@@ -132,8 +125,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.foregroundOnColor]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
+                                            dark: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 
@@ -144,8 +136,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.foregroundDisabled1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled1].light,
-                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled1].dark)
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark)
                     }
                 }
 
@@ -156,8 +147,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.brandForegroundDisabled1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled2].light,
-                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled2].dark)
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark)
                     }
                 }
 
@@ -166,12 +156,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                     switch style() {
                     case .primaryPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
+                                            dark: theme.aliasTokens.colors[.foreground1].dark)
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
+                                            dark: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

While we wait for a new set of designs for creating a new pivot for our segmented control (in navigation bar vs not in navigation bar), let's just default our dark appearance to always be what was previously elevated. This will improve accessibility of the bar in dark mode.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a |  |  |  |
|  |  |  |  |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
![before-seg](https://user-images.githubusercontent.com/4934719/219522081-18dc6663-e9fc-43b8-a46a-45fa89e5ea93.png) | ![after-seg-2](https://user-images.githubusercontent.com/4934719/219523417-8ac8ad1d-6cc3-4dfb-8099-5a59ace926ea.png) |
| ![before-nav](https://user-images.githubusercontent.com/4934719/219522084-0b298ccd-60b5-4768-8f74-5f764e42ec70.png) | ![after-nav](https://user-images.githubusercontent.com/4934719/219522071-7bbce81f-86cc-4108-ba4d-f3c95ba416e2.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1585)