### PR TITLE
[main_0.13] [cherry-pick] Lighten all dark segmented controls (#1585)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -49,11 +49,9 @@ class ColoredPillBackgroundView: UIView {
     func updateBackgroundColor() {
         switch style {
         case .neutral:
-            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.grey98),
-                                                                 dark: GlobalTokens.neutralColors(.grey8)))
+            backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: fluentTheme)
         case .brand:
-            backgroundColor = UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1]),
-                                      dark: UIColor(colorValue: GlobalTokens.neutralColors(.grey8)))
+            backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: fluentTheme)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -24,6 +24,7 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: #selector(showLargeTitleWithSystemStyleAndNoShadow)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithSystemStyleAndShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithSystemStyleAndFixedAccessory)))
+        container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithSystemStyleAndPillSegment)))
 
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showRegularTitleWithShyAccessory)))
@@ -70,6 +71,10 @@ class NavigationControllerDemoController: DemoController {
         presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
+    @objc func showLargeTitleWithSystemStyleAndPillSegment() {
+        presentController(withLargeTitle: true, style: .system, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
+    }
+
     @objc func showRegularTitleWithShyAccessory() {
         presentController(withLargeTitle: false, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
@@ -101,22 +106,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithPillSegment() {
-        let segmentItems: [SegmentItem] = [
-            SegmentItem(title: "First"),
-            SegmentItem(title: "Second")]
-        let pillControl = SegmentedControl(items: segmentItems, style: .onBrandPill)
-        pillControl.shouldSetEqualWidthForSegments = false
-        pillControl.isFixedWidth = false
-        pillControl.contentInset = .zero
-        let stackView = UIStackView()
-        stackView.addArrangedSubview(pillControl)
-        stackView.distribution = .equalCentering
-        stackView.alignment = .center
-        let button = UIButton(type: .system)
-        button.setImage(UIImage(named: "ic_fluent_filter_28"), for: .normal)
-        button.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
-        stackView.addArrangedSubview(button)
-        presentController(withLargeTitle: true, accessoryView: stackView, contractNavigationBarOnScroll: false)
+        presentController(withLargeTitle: true, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
     }
 
     @discardableResult
@@ -195,6 +185,25 @@ class NavigationControllerDemoController: DemoController {
         return searchBar
     }
 
+    private func createSegmentedControl() -> UIView {
+        let segmentItems: [SegmentItem] = [
+            SegmentItem(title: "First"),
+            SegmentItem(title: "Second")]
+        let pillControl = SegmentedControl(items: segmentItems, style: .onBrandPill)
+        pillControl.shouldSetEqualWidthForSegments = false
+        pillControl.isFixedWidth = false
+        pillControl.contentInset = .zero
+        let stackView = UIStackView()
+        stackView.addArrangedSubview(pillControl)
+        stackView.distribution = .equalCentering
+        stackView.alignment = .center
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(named: "ic_fluent_filter_28"), for: .normal)
+        button.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
+        stackView.addArrangedSubview(button)
+        return stackView
+    }
+
     private func presentSideDrawer(presentingGesture: UIPanGestureRecognizer? = nil) {
         let meControl = Label(style: .title2, colorStyle: .regular)
         meControl.text = "Me Control goes here"
@@ -225,7 +234,7 @@ extension NavigationControllerDemoController: UIGestureRecognizerDelegate {
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         // Only show side drawer for the root view controller
         if let controller = presentedViewController as? UINavigationController,
-            gestureRecognizer is UIScreenEdgePanGestureRecognizer && gestureRecognizer.view == controller.view && controller.topViewController != controller.viewControllers.first {
+           gestureRecognizer is UIScreenEdgePanGestureRecognizer && gestureRecognizer.view == controller.view && controller.topViewController != controller.viewControllers.first {
             return false
         }
         return true

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -28,7 +28,7 @@ class SegmentedControlDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1])
 
         readmeString = "A segmented control lets someone select one option from a set of two or more segments in a single, horizontal container.\n\nSegmented controls work well for changing states of elements or views within a single context, like filtering search results. It’s best not to use them to initiate actions or navigate to a new page. To let people navigate between the main sections of an app, use the tab bar."
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -66,12 +66,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                     switch style() {
                     case .primaryPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -82,8 +80,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
+                                            dark: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -92,12 +89,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                     switch style() {
                     case .primaryPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
-                                            dark: theme.aliasTokens.colors[.background3].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5].dark)
+                                            dark: theme.aliasTokens.colors[.background5].dark)
                     }
                 }
 
@@ -108,8 +103,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.brandBackground1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                            dark: theme.aliasTokens.colors[.background3Selected].dark,
-                                            darkElevated: theme.aliasTokens.colors[.background5Selected].dark)
+                                            dark: theme.aliasTokens.colors[.background5Selected].dark)
                     }
                 }
 
@@ -120,8 +114,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.foreground2]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground2].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground2].dark)
+                                            dark: theme.aliasTokens.colors[.foreground2].dark)
                     }
                 }
 
@@ -132,8 +125,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.foregroundOnColor]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
+                                            dark: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 
@@ -144,8 +136,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.foregroundDisabled1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled1].light,
-                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled1].dark)
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark)
                     }
                 }
 
@@ -156,8 +147,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                         return theme.aliasTokens.colors[.brandForegroundDisabled1]
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled2].light,
-                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foregroundDisabled2].dark)
+                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark)
                     }
                 }
 
@@ -166,12 +156,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                     switch style() {
                     case .primaryPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
+                                            dark: theme.aliasTokens.colors[.foreground1].dark)
                     case .onBrandPill:
                         return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark,
-                                            darkElevated: theme.aliasTokens.colors[.foreground1].dark)
+                                            dark: theme.aliasTokens.colors[.foreground1].dark)
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Cherry-pick of the following commit: ec36ca3

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1586)