### PR TITLE
Add brand style to SearchBar demo

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -11,6 +11,7 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         static let badgeViewCornerRadius: CGFloat = 10
         static let badgeViewSideLength: CGFloat = 20
         static let badgeViewMaxFontSize: CGFloat = 40
+        static let searchBarStackviewMargin: CGFloat = 16
     }
 
     private lazy var searchBarWithBadgeView: SearchBar =
@@ -34,19 +35,15 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         let segmentedControl = SegmentedControl(items: [SegmentItem(title: "System"), SegmentItem(title: "Brand")],
                                                 style: .primaryPill)
 
-        // Override the selected tab's background color otherwise it will blend into the container's background
-        segmentedControl.tokenSet.replaceAllOverrides(with: [.selectedTabColor: .dynamicColor({
-            segmentedControl.fluentTheme.aliasTokens.colors[.brandForeground1Selected]
-        })])
         return segmentedControl
     }()
 
     @objc private func updateSearchbars() {
         if segmentedControl.selectedSegmentIndex == 1 {
-            container.backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: view.fluentTheme)
+            searchBarsStackView.backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: view.fluentTheme)
             updateSearchBarsStyles(to: .lightContent)
         } else {
-            container.backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: view.fluentTheme)
+            searchBarsStackView.backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: view.fluentTheme)
             updateSearchBarsStyles(to: .darkContent)
         }
     }
@@ -56,6 +53,19 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
             searchBar.style = style
         }
     }
+
+    // Used to change the SearchBars' background color between brand and system styles
+    private let searchBarsStackView: UIStackView = {
+        let stackView = UIStackView(frame: .zero)
+        stackView.layoutMargins = UIEdgeInsets(top: Constants.searchBarStackviewMargin,
+                                               left: Constants.searchBarStackviewMargin,
+                                               bottom: Constants.searchBarStackviewMargin,
+                                               right: Constants.searchBarStackviewMargin)
+        stackView.axis = .vertical
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.spacing = Constants.searchBarStackviewMargin
+        return stackView
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -69,8 +79,10 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         container.addArrangedSubview(UIView())
 
         for searchBar in searchBars {
-            container.addArrangedSubview(searchBar)
+            searchBarsStackView.addArrangedSubview(searchBar)
         }
+
+        container.addArrangedSubview(searchBarsStackView)
 
         segmentedControl.onSelectAction = { [weak self] (_, _) in
             guard let strongSelf = self else {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -28,16 +28,59 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         return buildBadgeView(text: "Kat Larsson", customView: imageView)
     }()
 
+    private var searchBars: [SearchBar] = []
+
+    let segmentedControl: SegmentedControl = {
+        let segmentedControl = SegmentedControl(items: [SegmentItem(title: "System"), SegmentItem(title: "Brand")],
+                                                style: .primaryPill)
+
+        // Override the selected tab's background color otherwise it will blend into the container's background
+        segmentedControl.tokenSet.replaceAllOverrides(with: [.selectedTabColor: .dynamicColor({
+            segmentedControl.fluentTheme.aliasTokens.colors[.brandForeground1Selected]
+        })])
+        return segmentedControl
+    }()
+
+    @objc private func updateSearchbars() {
+        if segmentedControl.selectedSegmentIndex == 1 {
+            container.backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: view.fluentTheme)
+            updateSearchBarsStyles(to: .lightContent)
+        } else {
+            container.backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: view.fluentTheme)
+            updateSearchBarsStyles(to: .darkContent)
+        }
+    }
+
+    private func updateSearchBarsStyles(to style: SearchBar.Style) {
+        for searchBar in searchBars {
+            searchBar.style = style
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let searchBarNoAutocorrect = buildSearchBar(autocorrectionType: .no, placeholderText: "no autocorrect")
         let searchBarAutocorrect = buildSearchBar(autocorrectionType: .yes, placeholderText: "autocorrect")
 
-        container.addArrangedSubview(searchBarNoAutocorrect)
-        container.addArrangedSubview(searchBarAutocorrect)
-        container.addArrangedSubview(searchBarWithBadgeView)
-        container.addArrangedSubview(searchBarWithAvatarBadgeView)
+        searchBars = [searchBarNoAutocorrect, searchBarAutocorrect, searchBarWithBadgeView, searchBarWithAvatarBadgeView]
+
+        container.addArrangedSubview(segmentedControl)
+        container.addArrangedSubview(UIView())
+
+        for searchBar in searchBars {
+            container.addArrangedSubview(searchBar)
+        }
+
+        segmentedControl.onSelectAction = { [weak self] (_, _) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            strongSelf.updateSearchbars()
+        }
+
+        updateSearchbars()
     }
 
     func buildBadgeView(text: String, customView: UIView? = nil) -> UIView {

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -57,7 +57,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
         func placeholderColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
             case .lightContent:
                 return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`SearchBarDemoController` doesn't allow us to test brand colors. A segmented control has been added to switch between brand and system styles on the demo page. 
This PR also fixes a bug where the SearchBar's text was using the wrong token in system style's dark mode.

Binary change:
<!---
Please fill in the table below with the binary size of files changed from the latest 
state of the branch you are merging into and the latest state of your changes. In 
order to get an accurate measurement of our framework, follow these instructions:
  1. Change scheme to Demo.Release for Any iOS Device (arm64).
  2. Build, then navigate to left panel: FluentUI -> Products -> libFluentUI.a
  3. Show file in Finder, Get Info, & record libFluentUI.a binary size.

For individual files:
  1. Prepare a new folder anywhere outside of the FluentUI git repo. The following 
     .o files will be generated here. Open terminal & navigate to your new folder.
  2. Type "ar x <path of libFluentUI.a>" (no quotes or brackets).
  3. Find your modified .o files in your folder, Get Info, & record binary size.

NOTE: These generated files should not be a part of the PR.
--->
| File | Before | After | Delta |
|------|--------|-------|-------|
| libFluentUI.a | 29,435,536 bytes | 29,435,536 bytes | 0 bytes |

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

| System                                       | Brand                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="488" alt="after_system" src="https://user-images.githubusercontent.com/106181067/220454578-642ff3d2-be4c-4c89-9509-c16f79351840.png"> | <img width="488" alt="after_brand" src="https://user-images.githubusercontent.com/106181067/220454591-df97a70f-422d-4e5e-b5b9-03becb66414d.png"> |
| <img width="488" alt="after_system_dark" src="https://user-images.githubusercontent.com/106181067/220454618-8610137e-1b82-4b01-99dd-1922b11f9b77.png"> | <img width="488" alt="after_brand_dark" src="https://user-images.githubusercontent.com/106181067/220454639-e26231f7-80ef-45a4-9071-bf6521d13ca1.png"> |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1591)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1591)