### PR TITLE
Fix BadgeLabel to use `tokenSet.fluentTheme`

### DIFF
--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -8,7 +8,11 @@ import UIKit
 // MARK: BadgeLabel
 
 class BadgeLabel: UILabel, TokenizedControlInternal {
-    var shouldUseWindowColor: Bool = false
+    var shouldUseWindowColor: Bool = false {
+        didSet {
+            updateColors()
+        }
+    }
 
     typealias TokenSetKeyType = EmptyTokenSet.Tokens
     var tokenSet: EmptyTokenSet = .init()

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -57,11 +57,11 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
 
     private func updateColors() {
         if shouldUseWindowColor {
-            textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light, dark: GlobalTokens.neutralColors(.white)))
-            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: fluentTheme.aliasTokens.colors[.brandBackground1].dark))
+            textColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.aliasTokens.colors[.brandForeground1].light, dark: GlobalTokens.neutralColors(.white)))
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground1].dark))
         } else {
             textColor = UIColor(colorValue: GlobalTokens.neutralColors(.white))
-            backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.dangerBackground2])
+            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerBackground2])
         }
     }
 

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -56,12 +56,15 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
     }
 
     private func updateColors() {
+        let colors = tokenSet.fluentTheme.aliasTokens.colors
         if shouldUseWindowColor {
-            textColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.aliasTokens.colors[.brandForeground1].light, dark: GlobalTokens.neutralColors(.white)))
-            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white), dark: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground1].dark))
+            textColor = UIColor(dynamicColor: DynamicColor(light: colors[.brandForeground1].light,
+                                                           dark: GlobalTokens.neutralColors(.white)))
+            backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white),
+                                                                 dark: colors[.brandBackground1].dark))
         } else {
             textColor = UIColor(colorValue: GlobalTokens.neutralColors(.white))
-            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerBackground2])
+            backgroundColor = UIColor(dynamicColor: colors[.dangerBackground2])
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updating `BadgeLabel` to fetch its `FluentTheme` from its `tokenSet` instead of directly off its `UIView.fluentTheme` property.

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 16 36 09](https://user-images.githubusercontent.com/4934719/220796012-7a784e9b-516b-49d1-af87-37b629a2de7e.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 16 35 43](https://user-images.githubusercontent.com/4934719/220796022-3351f0a7-0b00-4789-a5c5-311d473d39a2.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 16 36 07](https://user-images.githubusercontent.com/4934719/220795975-ece12172-739b-4c86-9e86-e7d1899756b7.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-22 at 16 35 41](https://user-images.githubusercontent.com/4934719/220795999-b60a8a3f-1ebd-4f1d-8bc1-c8b1e4869128.png) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1595)