### PR TITLE
Delegate ShyHeaderController's colors update to NavigationController

### DIFF
--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -138,6 +138,10 @@ open class NavigationController: UINavigationController {
     func updateNavigationBar(for viewController: UIViewController) {
         msfNavigationBar.update(with: viewController.navigationItem)
         viewController.navigationItem.accessorySearchBar?.navigationController = self
+        if let shyHeader = topViewController as? ShyHeaderController {
+            let theme = msfNavigationBar.tokenSet.fluentTheme
+            shyHeader.updateBackgroundColor(with: viewController.navigationItem, theme: theme)
+        }
         setNeedsStatusBarAppearanceUpdate()
         if let backgroundColor = msfNavigationBar.backgroundView.backgroundColor {
             transitionAnimator.tintColor = backgroundColor

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -126,7 +126,7 @@ open class NavigationController: UINavigationController {
         if !viewControllerNeedsWrapping(viewController) {
             return viewController
         }
-        return ShyHeaderController(contentViewController: viewController, containingView: self.parent?.view ?? view)
+        return ShyHeaderController(contentViewController: viewController, containingView: view)
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
@@ -147,6 +147,7 @@ open class NavigationController: UINavigationController {
 
     func updateNavigationBar(for viewController: UIViewController) {
         msfNavigationBar.update(with: viewController.navigationItem)
+        updateShyHeader()
         viewController.navigationItem.accessorySearchBar?.navigationController = self
         setNeedsStatusBarAppearanceUpdate()
         if let backgroundColor = msfNavigationBar.backgroundView.backgroundColor {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -67,8 +67,6 @@ open class NavigationController: UINavigationController {
         super.init(coder: aDecoder)
     }
 
-    private var navigationBarStyleObservation: NSKeyValueObservation?
-
     open override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -78,9 +76,11 @@ open class NavigationController: UINavigationController {
             popGesture.removeTarget(nil, action: nil)
             popGesture.addTarget(self, action: #selector(navigationPopScreenPanGestureRecognizerRecognized))
         }
+
         navigationBarStyleObservation = msfNavigationBar.observe(\.style) { [weak self] _, _ in
             self?.updateShyHeader()
         }
+
         super.delegate = self
 
         // Allow subviews to display a custom background view
@@ -212,6 +212,8 @@ open class NavigationController: UINavigationController {
             return
         }
     }
+
+    private var navigationBarStyleObservation: NSKeyValueObservation?
 }
 
 // MARK: - NavigationController: UINavigationControllerDelegate

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -81,6 +81,11 @@ open class NavigationController: UINavigationController {
             self?.updateShyHeader()
         }
 
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(themeDidChange),
+                                               name: .didChangeTheme,
+                                               object: nil)
+
         super.delegate = self
 
         // Allow subviews to display a custom background view
@@ -175,6 +180,13 @@ open class NavigationController: UINavigationController {
             }
         }
         super.setNavigationBarHidden(hidden, animated: animated)
+    }
+
+    @objc private func themeDidChange(_ notification: Notification) {
+        guard let themeView = notification.object as? UIView, self.view.isDescendant(of: themeView) else {
+            return
+        }
+        updateShyHeader()
     }
 
     private func searchIsActive(in viewController: UIViewController?) -> Bool {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -67,6 +67,8 @@ open class NavigationController: UINavigationController {
         super.init(coder: aDecoder)
     }
 
+    private var navigationBarStyleObservation: NSKeyValueObservation?
+
     open override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -76,7 +78,9 @@ open class NavigationController: UINavigationController {
             popGesture.removeTarget(nil, action: nil)
             popGesture.addTarget(self, action: #selector(navigationPopScreenPanGestureRecognizerRecognized))
         }
-
+        navigationBarStyleObservation = msfNavigationBar.observe(\.style) { [weak self] _,_ in
+            self?.updateShyHeader()
+        }
         super.delegate = self
 
         // Allow subviews to display a custom background view
@@ -122,7 +126,7 @@ open class NavigationController: UINavigationController {
         if !viewControllerNeedsWrapping(viewController) {
             return viewController
         }
-        return ShyHeaderController(contentViewController: viewController, containingView: self.parent?.view ?? view)
+        return ShyHeaderController(contentViewController: viewController, containingView: view)
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
@@ -135,13 +139,15 @@ open class NavigationController: UINavigationController {
         return false
     }
 
+    private func updateShyHeader() {
+        if let shyHeader = topViewController as? ShyHeaderController {
+            shyHeader.updateNavigationBarStyle(theme: view.fluentTheme)
+        }
+    }
+
     func updateNavigationBar(for viewController: UIViewController) {
         msfNavigationBar.update(with: viewController.navigationItem)
         viewController.navigationItem.accessorySearchBar?.navigationController = self
-        if let shyHeader = topViewController as? ShyHeaderController {
-            let theme = msfNavigationBar.tokenSet.fluentTheme
-            shyHeader.updateBackgroundColor(with: viewController.navigationItem, theme: theme)
-        }
         setNeedsStatusBarAppearanceUpdate()
         if let backgroundColor = msfNavigationBar.backgroundView.backgroundColor {
             transitionAnimator.tintColor = backgroundColor

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -78,7 +78,7 @@ open class NavigationController: UINavigationController {
             popGesture.removeTarget(nil, action: nil)
             popGesture.addTarget(self, action: #selector(navigationPopScreenPanGestureRecognizerRecognized))
         }
-        navigationBarStyleObservation = msfNavigationBar.observe(\.style) { [weak self] _,_ in
+        navigationBarStyleObservation = msfNavigationBar.observe(\.style) { [weak self] _, _ in
             self?.updateShyHeader()
         }
         super.delegate = self
@@ -126,7 +126,7 @@ open class NavigationController: UINavigationController {
         if !viewControllerNeedsWrapping(viewController) {
             return viewController
         }
-        return ShyHeaderController(contentViewController: viewController, containingView: view)
+        return ShyHeaderController(contentViewController: viewController, containingView: self.parent?.view ?? view)
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
@@ -141,7 +141,7 @@ open class NavigationController: UINavigationController {
 
     private func updateShyHeader() {
         if let shyHeader = topViewController as? ShyHeaderController {
-            shyHeader.updateNavigationBarStyle(theme: view.fluentTheme)
+            shyHeader.updateNavigationBarStyle(theme: msfNavigationBar.tokenSet.fluentTheme)
         }
     }
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -125,6 +125,10 @@ class ShyHeaderController: UIViewController {
 
         updatePadding()
         setupNotificationObservers()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         updateNavigationBarStyle(theme: containingView?.fluentTheme ?? view.fluentTheme)
     }
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -259,14 +259,14 @@ class ShyHeaderController: UIViewController {
         return true
     }
 
-    private func updateBackgroundColor(with item: UINavigationItem) {
-        let color = item.navigationBarColor(fluentTheme: containingView?.fluentTheme ?? view.fluentTheme)
+    public func updateBackgroundColor(with item: UINavigationItem, theme: FluentTheme) {
+        let color = item.navigationBarColor(fluentTheme: theme)
         shyHeaderView.backgroundColor = color
         view.backgroundColor = color
         paddingView.backgroundColor = color
 
         navigationBarColorObservation = item.observe(\.customNavigationBarColor) { [weak self] item, _ in
-            self?.updateBackgroundColor(with: item)
+            self?.updateBackgroundColor(with: item, theme: theme)
         }
     }
 
@@ -524,9 +524,9 @@ class ShyHeaderController: UIViewController {
 
     /// Updates based on the current navigation bar style.
     private func updateNavigationBarStyle() {
-        if let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
+        if let (actualStyle, _) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
             shyHeaderView.navigationBarStyle = actualStyle
-            updateBackgroundColor(with: actualItem)
+            //updateBackgroundColor(with: actualItem)
         }
     }
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -47,7 +47,6 @@ class ShyHeaderController: UIViewController {
     private var accessoryViewObservation: NSKeyValueObservation?
 
     private var navigationBarCenterObservation: NSKeyValueObservation?
-    private var navigationBarStyleObservation: NSKeyValueObservation?
     private var navigationBarHeightObservation: NSKeyValueObservation?
     private var navigationBarColorObservation: NSKeyValueObservation?
 
@@ -126,7 +125,7 @@ class ShyHeaderController: UIViewController {
 
         updatePadding()
         setupNotificationObservers()
-        updateNavigationBarStyle()
+        updateNavigationBarStyle(theme: containingView?.fluentTheme ?? view.fluentTheme)
     }
 
     // MARK: - Base Construction
@@ -214,9 +213,6 @@ class ShyHeaderController: UIViewController {
         // Observing `center` instead of `isHidden` allows us to do our changes along the system animation
         navigationBarCenterObservation = navigationController?.navigationBar.observe(\.center) { [weak self] navigationBar, _ in
             self?.shyHeaderView.navigationBarIsHidden = navigationBar.frame.maxY == 0
-        }
-        navigationBarStyleObservation = msfNavigationController?.msfNavigationBar.observe(\.style) { [weak self] _, _ in
-            self?.updateNavigationBarStyle()
         }
         navigationBarHeightObservation = msfNavigationController?.msfNavigationBar.observe(\.barHeight) { [weak self] _, _ in
             self?.updatePadding()
@@ -523,10 +519,10 @@ class ShyHeaderController: UIViewController {
     }
 
     /// Updates based on the current navigation bar style.
-    private func updateNavigationBarStyle() {
-        if let (actualStyle, _) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
+    public func updateNavigationBarStyle(theme: FluentTheme) {
+        if let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
             shyHeaderView.navigationBarStyle = actualStyle
-            //updateBackgroundColor(with: actualItem)
+            updateBackgroundColor(with: actualItem, theme: theme)
         }
     }
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -255,7 +255,7 @@ class ShyHeaderController: UIViewController {
         return true
     }
 
-    public func updateBackgroundColor(with item: UINavigationItem, theme: FluentTheme) {
+    private func updateBackgroundColor(with item: UINavigationItem, theme: FluentTheme) {
         let color = item.navigationBarColor(fluentTheme: theme)
         shyHeaderView.backgroundColor = color
         view.backgroundColor = color

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -523,7 +523,7 @@ class ShyHeaderController: UIViewController {
     }
 
     /// Updates based on the current navigation bar style.
-    public func updateNavigationBarStyle(theme: FluentTheme) {
+    func updateNavigationBarStyle(theme: FluentTheme) {
         if let (actualStyle, actualItem) = msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: navigationItem) {
             shyHeaderView.navigationBarStyle = actualStyle
             updateBackgroundColor(with: actualItem, theme: theme)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

There is a bug in partner repos where the shy header would have the wrong color when backing out of a file or switching from dark to light mode. This issue was irreproducible on the demo app, but seemed to be caused by the `ShyHeaderController` fetching the wrong theme when updating its colors.
To fix the bug, we delegate shy header color updates to `NavigationController` which updates `ShyHeaderController`'s colors by injecting the correct FluentTheme from the navigation bar's tokenSet. 

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

Total increase: 26,384 bytes
Total decrease: -1,592 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,425,960 bytes | 29,450,752 bytes | ⚠️ 24,792 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| NavigationController.o | 163,112 bytes | 185,120 bytes | ⚠️ 22,008 bytes |
| __.SYMDEF | 4,604,160 bytes | 4,607,632 bytes | ⚠️ 3,472 bytes |
| BadgeLabelButton.o | 852,160 bytes | 853,064 bytes | ⚠️ 904 bytes |
| ShyHeaderController.o | 251,216 bytes | 249,624 bytes | 🎉 -1,592 bytes |
</details>

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_brand](https://user-images.githubusercontent.com/106181067/220831400-c16f5f90-4b96-4716-b056-b940abfffc22.gif) | ![after_brand](https://user-images.githubusercontent.com/106181067/220831413-950bc4ac-3565-4ead-a938-ad51a38578d2.gif) |
| ![before_custom](https://user-images.githubusercontent.com/106181067/220831434-f026dea2-4cce-4970-8807-b72bb1504385.gif) | ![after_custom](https://user-images.githubusercontent.com/106181067/220831450-920aef1e-9620-4746-8805-d69ef934bbf2.gif) |
| <img width="487" alt="before_system" src="https://user-images.githubusercontent.com/106181067/220831478-62542998-aaa1-45f9-bc3c-3c394dd65e6c.png"> | <img width="487" alt="after_system" src="https://user-images.githubusercontent.com/106181067/220831487-b410d9d6-6771-42b2-8d5a-0581904a07ea.png"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1596)