### PR TITLE
PillButton attributedTitle is showing the wrong font size

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -221,6 +221,13 @@ open class PillButton: UIButton, TokenizedControlInternal {
         var attributedTitle = AttributedString(itemTitle)
         attributedTitle.font = UIFont.fluent(titleFont)
         configuration?.attributedTitle = attributedTitle
+        
+        let attributedTitleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = UIFont.fluent(self.titleFont)
+            return outgoing
+        }
+        configuration?.titleTextAttributesTransformer = attributedTitleTransformer
 
         // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically
         accessibilityLabel = itemTitle

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -151,7 +151,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
             }
         } else {
             setTitle(pillBarItem.title, for: .normal)
-            titleLabel?.font = .fluent(titleFont)
+            titleLabel?.font = UIFont.fluent(titleFont)
 
             contentEdgeInsets = UIEdgeInsets(top: Constants.topInset,
                                              left: Constants.horizontalInset,
@@ -219,7 +219,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
     private func updateAttributedTitle() {
         let itemTitle = pillBarItem.title
         var attributedTitle = AttributedString(itemTitle)
-        attributedTitle.font = .fluent(titleFont)
+        attributedTitle.font = UIFont.fluent(titleFont)
         configuration?.attributedTitle = attributedTitle
 
         // Workaround for Apple bug: when UIButton.Configuration is used with UIControl's isSelected = true, accessibilityLabel doesn't get set automatically

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -221,7 +221,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
         var attributedTitle = AttributedString(itemTitle)
         attributedTitle.font = UIFont.fluent(titleFont)
         configuration?.attributedTitle = attributedTitle
-        
+
         let attributedTitleTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
             outgoing.font = UIFont.fluent(self.titleFont)


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes
The wrong font size was being used for the PillButton despite it declaring `body2` as its font style.

The use of `.fluent(fontInfo:)` inside PillButton was resolving to `Font.fluent(fontInfo:)` (SwiftUI) and not `UIFont.fluent(fontInfo:)` (UIKit).

To fix this, we can add `UIFont.` class prefix to ensure the correct method is called.

Binary change:

### Verification

- Validated font size as `15.0` (`body2`) in PillButton demo and PillButtonBar demo
- Validated font size in devmain applications

Before:
<img width="376" alt="before" src="https://user-images.githubusercontent.com/10938746/221008652-37c2f658-3946-4494-9144-024598299118.png">

After:
<img width="377" alt="actually_after" src="https://user-images.githubusercontent.com/10938746/221008639-0961ba67-65e1-4b64-9e2f-fe4e92fd7be0.png">

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1597)