### PR TITLE
PillButton text should not scale with DynamicType.

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -151,7 +151,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
             }
         } else {
             setTitle(pillBarItem.title, for: .normal)
-            titleLabel?.font = UIFont.fluent(titleFont)
+            titleLabel?.font = UIFont.fluent(titleFont, shouldScale: false)
 
             contentEdgeInsets = UIEdgeInsets(top: Constants.topInset,
                                              left: Constants.horizontalInset,
@@ -219,12 +219,12 @@ open class PillButton: UIButton, TokenizedControlInternal {
     private func updateAttributedTitle() {
         let itemTitle = pillBarItem.title
         var attributedTitle = AttributedString(itemTitle)
-        attributedTitle.font = UIFont.fluent(titleFont)
+        attributedTitle.font = UIFont.fluent(titleFont, shouldScale: false)
         configuration?.attributedTitle = attributedTitle
 
         let attributedTitleTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
-            outgoing.font = UIFont.fluent(self.titleFont)
+            outgoing.font = UIFont.fluent(self.titleFont, shouldScale: false)
             return outgoing
         }
         configuration?.titleTextAttributesTransformer = attributedTitleTransformer


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

The titleLabel text within the `PillButton` was scaling with Dynamic Type. This is not support behavior of the PillButton. Before Fluent2, the PillButton used a fixed size font. We should match that here.

To fix this, set the `shouldScale` property to `false`. This will prevent the text from scaling.

### Verification

- Verified in the PillButton and PillButtonBar demo controllers
- Verified in the devmain applications

Before:
<img width="515" alt="before2" src="https://user-images.githubusercontent.com/10938746/221077152-1543198d-83f2-42f7-8453-527468718751.png">

After:
<img width="509" alt="after3" src="https://user-images.githubusercontent.com/10938746/221078502-21911c7b-893b-4d4a-b462-35b6ab86d036.png">

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1601)