### PR TITLE
[main_0.13] [cherry-pick] Tokenize ShyHeaderView (#1603)

### DIFF
--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -78,6 +78,7 @@ class ShyHeaderController: UIViewController {
 
         super.init(nibName: nil, bundle: nil)
 
+        shyHeaderView.parentController = self
         shyHeaderView.maxHeightChanged = { [weak self] in
             self?.updatePadding()
         }

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -11,7 +11,10 @@ import UIKit
 /// Used to contain an accessory provided by the VC contained by the NavigatableShyContainerVC
 /// This class in itself is fairly straightforward, defining a height and a containment layout
 /// The animation around showing/hiding this view progressively is handled by its superview/superVC, an instance of ShyHeaderController
-class ShyHeaderView: UIView {
+class ShyHeaderView: UIView, TokenizedControlInternal {
+    typealias TokenSetKeyType = EmptyTokenSet.Tokens
+    public var tokenSet: EmptyTokenSet = .init()
+
     /// Defines all possible states of the header view's appearance
     ///
     /// - exposed: Fully showing header
@@ -62,6 +65,15 @@ class ShyHeaderView: UIView {
         static let maxHeightNoAccessory: CGFloat = 56 - 44  // navigation bar - design: 56, system: 44
         static let maxHeightNoAccessoryCompact: CGFloat = 44 - 32   // navigation bar - design: 44, system: 32
         static let maxHeightNoAccessoryCompactForLargePhone: CGFloat = 44 - 44   // navigation bar - design: 44, system: 44
+    }
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
+        updateColors()
     }
 
     private var contentInsets: UIEdgeInsets {
@@ -132,6 +144,7 @@ class ShyHeaderView: UIView {
     var maxHeightChanged: (() -> Void)?
 
     var lockedInContractedState: Bool = false
+    weak var parentController: ShyHeaderController?
 
     var navigationBarIsHidden: Bool = false {
         didSet {
@@ -149,6 +162,14 @@ class ShyHeaderView: UIView {
         didSet {
             updateShadowVisibility()
         }
+    }
+
+    private func updateColors() {
+        guard let parentController = parentController, let (_, actualItem) = parentController.msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: parentController.navigationItem) else {
+            return
+        }
+        let color = actualItem.navigationBarColor(fluentTheme: tokenSet.fluentTheme)
+        backgroundColor = color
     }
 
     private let contentStackView = UIStackView()


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

This PR cherry picks 542e11ea4f5ccb5f53039d743d65a38992895769 to main_0.13.

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)