### PR TITLE
Tokenize BadgeView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
@@ -99,7 +99,7 @@ struct DemoAppearanceView: View {
                 // TODO: Still working through some issues with the theme-wide override tokens, so inform the user how to make it visible for now.
                 .alert(isPresented: $showingThemeWideAlert) {
                     Alert(title: Text("Theme-wide override"),
-                          message: Text("Changes to \"Theme-wide override\" tokens will only take effect when the control redraws for some othe reason.\n\nTry backing out of this view and re-entering it."))
+                          message: Text("Changes to \"Theme-wide override\" tokens will only take effect when the control redraws for some other reason.\n\nTry backing out of this view and re-entering it."))
                 }
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -22,6 +22,7 @@ struct Demos {
         DemoDescriptor("ActivityIndicator", ActivityIndicatorDemoController.self),
         DemoDescriptor("Avatar", AvatarDemoController.self),
         DemoDescriptor("AvatarGroup", AvatarGroupDemoController.self),
+        DemoDescriptor("BadgeView", BadgeViewDemoController.self),
         DemoDescriptor("BottomSheetController", BottomSheetDemoController.self),
         DemoDescriptor("Button", ButtonDemoController.self),
         DemoDescriptor("CardNudge", CardNudgeDemoController.self),
@@ -48,7 +49,6 @@ struct Demos {
 
     static let controls: [DemoDescriptor] = [
         DemoDescriptor("BadgeField", BadgeFieldDemoController.self),
-        DemoDescriptor("BadgeView", BadgeViewDemoController.self),
         DemoDescriptor("BottomCommandingController", BottomCommandingDemoController.self),
         DemoDescriptor("Card", CardViewDemoController.self),
         DemoDescriptor("DateTimePicker", DateTimePickerDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -99,8 +99,17 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         let dataSource = BadgeViewDataSource(text: text, customView: customView)
         let badge = BadgeView(dataSource: dataSource)
         badge.lineBreakMode = .byTruncatingTail
-        badge.disabledBackgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(.purple, .primary))
-        badge.disabledLabelTextColor = .white
+        var customTokens: [BadgeViewTokenSet.Tokens: ControlTokenValue] {
+            return [
+                .backgroundDisabledColor: .dynamicColor {
+                    return DynamicColor(light: GlobalTokens.sharedColors(.purple, .primary))
+                },
+                .foregroundDisabledColor: .dynamicColor {
+                    return DynamicColor(light: GlobalTokens.neutralColors(.white))
+                }
+            ]
+        }
+        badge.tokenSet.replaceAllOverrides(with: customTokens)
         badge.isActive = false
         badge.maxFontSize = Constants.badgeViewMaxFontSize
         return badge

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A8E61FB291DC11F009E412D /* CommandBarTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8E61FA291DC11F009E412D /* CommandBarTokenSet.swift */; };
 		2A9745DE281733D700E1A1FD /* TableViewCellTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9745DD281733D700E1A1FD /* TableViewCellTokenSet.swift */; };
+		3A7BAA0D29A586F4001D7908 /* BadgeViewTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7BAA0C29A586F4001D7908 /* BadgeViewTokenSet.swift */; };
 		43488C46270FAD1300124C71 /* FluentNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43488C44270FAD0200124C71 /* FluentNotification.swift */; };
 		4B2E373D2991CB53008929B4 /* BottomSheetTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2E373C2991CB53008929B4 /* BottomSheetTokenSet.swift */; };
 		4B4A2F2129A7E83100570CD4 /* LabelTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4A2F2029A7E83100570CD4 /* LabelTokenSet.swift */; };
@@ -243,6 +244,7 @@
 		1168630322E131CF0088B302 /* TabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		118D9847230BBA2300BC0B72 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		2A9745DD281733D700E1A1FD /* TableViewCellTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCellTokenSet.swift; sourceTree = "<group>"; };
+		3A7BAA0C29A586F4001D7908 /* BadgeViewTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeViewTokenSet.swift; sourceTree = "<group>"; };
 		43488C44270FAD0200124C71 /* FluentNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentNotification.swift; sourceTree = "<group>"; };
 		497DC2D724185885008D86F8 /* PillButtonBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButtonBar.swift; sourceTree = "<group>"; };
 		497DC2D824185885008D86F8 /* PillButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillButton.swift; sourceTree = "<group>"; };
@@ -868,13 +870,13 @@
 				5314DFEB25F002240099271A /* ActivityIndicator */,
 				C77A04F325F04CFB001B3EB6 /* Avatar */,
 				5306074E26A1E6A4002D49CF /* AvatarGroup */,
+				B4F118EA21C8270F00855942 /* Badge Field */,
 				5314DFF625F0079B0099271A /* BarButtonItems */,
 				80B52538264CA5BC00E3FD32 /* Bottom Commanding */,
 				80B1F6F52628CDEB004DFEE5 /* Bottom Sheet */,
 				5314DFEC25F0029C0099271A /* Button */,
-				CCC18C2A2501B1A900BE830E /* Card */,
-				B4F118EA21C8270F00855942 /* Badge Field */,
 				FDFB8AE921361C860046850A /* Calendar */,
+				CCC18C2A2501B1A900BE830E /* Card */,
 				92D5597C26A0FC9700328FD3 /* Card Nudge */,
 				FC414E1D258876D400069E73 /* Command Bar */,
 				A5CEC16B20D98EBF0016922A /* Core */,
@@ -1016,6 +1018,7 @@
 				B45EB78F219E310F008646A2 /* BadgeField.swift */,
 				B4A8BBCC21BF6D6900D5E3ED /* BadgeStringExtractor.swift */,
 				B444D6B52183A9740002B4D4 /* BadgeView.swift */,
+				3A7BAA0C29A586F4001D7908 /* BadgeViewTokenSet.swift */,
 			);
 			path = "Badge Field";
 			sourceTree = "<group>";
@@ -1446,6 +1449,7 @@
 				6ED5E55126D3D39400D8BE81 /* BadgeLabelButton.swift in Sources */,
 				6ED5E55226D3D39400D8BE81 /* UIBarButtonItem+BadgeValue.swift in Sources */,
 				5314E0ED25F012C40099271A /* ContentScrollViewTraits.swift in Sources */,
+				3A7BAA0D29A586F4001D7908 /* BadgeViewTokenSet.swift in Sources */,
 				EC5982DA27C703EE00FD048D /* ShapeCutout.swift in Sources */,
 				5314E03A25F00E3D0099271A /* BadgeView.swift in Sources */,
 				5314E1A325F01A7C0099271A /* TableViewHeaderFooterView.swift in Sources */,

--- a/ios/FluentUI/Badge Field/BadgeViewTokenSet.swift
+++ b/ios/FluentUI/Badge Field/BadgeViewTokenSet.swift
@@ -1,0 +1,199 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Pre-defined styles of the Badge.
+@objc public enum MSFBadgeViewStyle: Int, CaseIterable {
+    case `default`
+    case danger
+    case severeWarning
+    case warning
+    case success
+    case neutral
+}
+
+/// Pre-defined sizes of the Badge.
+@objc public enum MSFBadgeViewSize: Int, CaseIterable {
+    case small
+    case medium
+
+    var labelTextStyle: AliasTokens.TypographyTokens {
+        switch self {
+        case .small:
+            return .caption1
+        case .medium:
+            return .body2
+        }
+    }
+}
+
+/// Design token set for the `BadgeView` control.
+public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
+    public enum Tokens: TokenSetKey {
+        /// The background tint color of the Badge.
+        case backgroundTintColor
+
+        /// The background filled color of the Badge.
+        case backgroundFilledColor
+
+        /// The background color of the Badge when disabled.
+        case backgroundDisabledColor
+
+        /// The foreground tint color of the Badge.
+        case foregroundTintColor
+
+        /// The foreground filled color of the Badge.
+        case foregroundFilledColor
+
+        /// The foreground color of the Badge when disabled.
+        case foregroundDisabledColor
+
+        /// The border radius of the Badge.
+        case borderRadius
+
+        /// The font used for text in the Badge.
+        case textFont
+    }
+
+    init(style: @escaping () -> MSFBadgeViewStyle,
+         size: @escaping () -> MSFBadgeViewSize) {
+        self.style = style
+        self.size = size
+        super.init { [style] token, theme in
+            switch token {
+            case .backgroundTintColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .default:
+                        return theme.aliasTokens.colors[.brandBackgroundTint]
+                    case .danger:
+                        return theme.aliasTokens.colors[.dangerBackground1]
+                    case .severeWarning:
+                        return theme.aliasTokens.colors[.severeBackground1]
+                    case .warning:
+                        return theme.aliasTokens.colors[.warningBackground1]
+                    case .success:
+                        return theme.aliasTokens.colors[.successBackground1]
+                    case .neutral:
+                        return theme.aliasTokens.colors[.background5]
+                    }
+                }
+            case .backgroundFilledColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .default:
+                        return theme.aliasTokens.colors[.brandBackground1]
+                    case .danger:
+                        return theme.aliasTokens.colors[.dangerBackground2]
+                    case .severeWarning:
+                        return theme.aliasTokens.colors[.severeBackground2]
+                    case .warning:
+                        return theme.aliasTokens.colors[.warningBackground2]
+                    case .success:
+                        return theme.aliasTokens.colors[.successBackground2]
+                    case .neutral:
+                        return theme.aliasTokens.colors[.background5Selected]
+                    }
+                }
+            case .backgroundDisabledColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .default:
+                        return theme.aliasTokens.colors[.brandBackground3]
+                    case .danger, .severeWarning, .warning, .success, .neutral:
+                        return theme.aliasTokens.colors[.background5]
+                    }
+                }
+            case .foregroundTintColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .default:
+                        return theme.aliasTokens.colors[.brandForegroundTint]
+                    case .danger:
+                        return theme.aliasTokens.colors[.dangerForeground1]
+                    case .severeWarning:
+                        return theme.aliasTokens.colors[.severeForeground1]
+                    case .warning:
+                        return theme.aliasTokens.colors[.warningForeground1]
+                    case .success:
+                        return theme.aliasTokens.colors[.successForeground1]
+                    case .neutral:
+                        return theme.aliasTokens.colors[.foreground2]
+                    }
+                }
+            case .foregroundFilledColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .default:
+                        return theme.aliasTokens.colors[.foregroundOnColor]
+                    case .danger, .severeWarning, .success:
+                        return theme.aliasTokens.colors[.foregroundLightStatic]
+                    case .warning:
+                        return theme.aliasTokens.colors[.foregroundDarkStatic]
+                    case .neutral:
+                        return theme.aliasTokens.colors[.foreground1]
+                    }
+                }
+            case .foregroundDisabledColor:
+                return .dynamicColor {
+                    switch style() {
+                    case .default:
+                        return theme.aliasTokens.colors[.brandForegroundDisabled1]
+                    case .danger, .severeWarning, .warning, .success, .neutral:
+                        return theme.aliasTokens.colors[.foregroundDisabled1]
+                    }
+                }
+            case .borderRadius:
+                return .float({
+                    switch size() {
+                    case .small:
+                        return GlobalTokens.corner(.radius20)
+                    case .medium:
+                        return GlobalTokens.corner(.radius40)
+                    }
+                })
+            case .textFont:
+                return .fontInfo({
+                    switch size() {
+                    case .small:
+                        return theme.aliasTokens.typography[.caption1]
+                    case .medium:
+                        return theme.aliasTokens.typography[.body2]
+                    }
+                })
+            }
+        }
+    }
+
+    /// Defines the style of the Badge.
+    var style: () -> MSFBadgeViewStyle
+
+    /// Defines the size of the Badge.
+    var size: () -> MSFBadgeViewSize
+}
+
+// MARK: Constants
+extension BadgeViewTokenSet {
+    static func horizontalPadding(_ size: MSFBadgeViewSize) -> CGFloat {
+        switch size {
+        case .small:
+            return GlobalTokens.spacing(.size40)
+        case .medium:
+            return GlobalTokens.spacing(.size80)
+        }
+    }
+
+    static func verticalPadding(_ size: MSFBadgeViewSize) -> CGFloat {
+        switch size {
+        case .small:
+            return 1.5
+        case .medium:
+            return GlobalTokens.spacing(.size40)
+        }
+    }
+
+    static let defaultMinWidth: CGFloat = 25
+}

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -346,7 +346,7 @@ open class PeoplePicker: BadgeField {
             return
         }
         let isValid = delegate?.peoplePicker?(self, personaIsValid: personaBadgeDataSource.persona) ?? true
-        personaBadgeDataSource.style = isValid ? .default : .error
+        personaBadgeDataSource.style = isValid ? .default : .danger
         badge.reload()
         super.addBadge(badge)
     }

--- a/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
+++ b/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
@@ -11,12 +11,12 @@ import UIKit
 open class PersonaBadgeViewDataSource: BadgeViewDataSource {
     @objc open var persona: Persona
 
-    @objc public init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium) {
+    @objc public init(persona: Persona, style: MSFBadgeViewStyle = .default, size: MSFBadgeViewSize = .medium) {
         self.persona = persona
         super.init(text: persona.name, style: style, size: size)
     }
 
-    @objc public convenience init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium, customView: UIView? = nil) {
+    @objc public convenience init(persona: Persona, style: MSFBadgeViewStyle = .default, size: MSFBadgeViewSize = .medium, customView: UIView? = nil) {
         self.init(persona: persona, style: style, size: size)
         super.customView = customView
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

Total increase: 119,536 bytes
Total decrease: -113,440 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,797,072 bytes | 29,803,168 bytes | ⚠️ 6,096 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BadgeViewTokenSet.o | 0 bytes | 108,312 bytes | 🛑 108,312 bytes |
| __.SYMDEF | 4,556,624 bytes | 4,561,632 bytes | ⚠️ 5,008 bytes |
| ShimmerLinesView.o | 242,024 bytes | 246,832 bytes | ⚠️ 4,808 bytes |
| ControlTokenSet.o | 88,432 bytes | 89,352 bytes | ⚠️ 920 bytes |
| PersonaBadgeViewDataSource.o | 37,152 bytes | 37,440 bytes | ⚠️ 288 bytes |
| PeoplePicker.o | 293,936 bytes | 294,088 bytes | ⚠️ 152 bytes |
| BadgeField.o | 539,280 bytes | 539,328 bytes | ⚠️ 48 bytes |
| Label.o | 109,600 bytes | 109,576 bytes | 🎉 -24 bytes |
| FluentTextField.o | 216,592 bytes | 216,472 bytes | 🎉 -120 bytes |
| TableViewHeaderFooterView.o | 289,640 bytes | 289,376 bytes | 🎉 -264 bytes |
| UIColor+Extensions.o | 58,048 bytes | 55,968 bytes | 🎉 -2,080 bytes |
| BadgeLabelButton.o | 863,080 bytes | 841,232 bytes | 🎉 -21,848 bytes |
| ActionsCell.o | 221,328 bytes | 181,144 bytes | 🎉 -40,184 bytes |
| BadgeView.o | 338,424 bytes | 289,504 bytes | 🎉 -48,920 bytes |
</details>

Tokenized `BadgeView`. This PR also fixes two small mistakes I noticed while working on the tokenization (spelling mistake, Card was out of alphabetical order).

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![badge before 1](https://user-images.githubusercontent.com/55368679/222013364-3bf6a188-ba94-433c-9279-7d3ac6f047e9.png) | ![badge after 1](https://user-images.githubusercontent.com/55368679/222013477-d60d59e5-82f3-45f8-8d59-d9f5e8712007.png)|
| ![badge before 2](https://user-images.githubusercontent.com/55368679/222013386-b74e4bf7-8804-42b7-bf85-8453399476cb.png) | ![badge after 2](https://user-images.githubusercontent.com/55368679/222013518-1a6b7ed6-15ac-4684-8b68-e8d750270b3c.png) |
| ![people picker before](https://user-images.githubusercontent.com/55368679/222013393-41c07286-114b-4869-8982-ec1584ec2311.png) | ![people picker after](https://user-images.githubusercontent.com/55368679/222013550-7345473b-923f-4ba1-a013-b2758a6dec47.png) |
| ![dark badge before 1](https://user-images.githubusercontent.com/55368679/222013409-df7e9ae7-32ad-47df-9238-24ced4e825d6.png) | ![dark badge after 1](https://user-images.githubusercontent.com/55368679/222013591-9a275846-b8e3-473e-a4cf-785a9802f75b.png) |
| ![dark badge before 2](https://user-images.githubusercontent.com/55368679/222013422-d71cd69d-3533-4379-a683-b146a245c67d.png) | ![dark badge after 2](https://user-images.githubusercontent.com/55368679/222013624-38ecd96b-f6fd-495c-9770-41af5dd657be.png) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1615)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1615)