### PR TITLE
bug fix: unreaddot interfering tableviewcell accessibilityLabel

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -190,7 +190,7 @@ extension TableViewCellDemoController {
 
         let showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
 
-        cell.isUnreadDotVisible = section.isUnreadDotVisible
+//        cell.isUnreadDotVisible = section.isUnreadDotVisible
         cell.titleLeadingAccessoryView = showsLabelAccessoryView ? item.text1LeadingAccessoryView() : nil
         cell.titleTrailingAccessoryView = showsLabelAccessoryView ? item.text1TrailingAccessoryView() : nil
         cell.subtitleLeadingAccessoryView = showsLabelAccessoryView ? item.text2LeadingAccessoryView() : nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -190,7 +190,7 @@ extension TableViewCellDemoController {
 
         let showsLabelAccessoryView = TableViewCellSampleData.hasLabelAccessoryViews(at: indexPath)
 
-//        cell.isUnreadDotVisible = section.isUnreadDotVisible
+        cell.isUnreadDotVisible = section.isUnreadDotVisible
         cell.titleLeadingAccessoryView = showsLabelAccessoryView ? item.text1LeadingAccessoryView() : nil
         cell.titleTrailingAccessoryView = showsLabelAccessoryView ? item.text1TrailingAccessoryView() : nil
         cell.subtitleLeadingAccessoryView = showsLabelAccessoryView ? item.text2LeadingAccessoryView() : nil

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -886,10 +886,8 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             if oldValue != isUnreadDotVisible {
                 if isUnreadDotVisible {
                     self.contentView.layer.addSublayer(unreadDotLayer)
-                    accessibilityLabel = String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, title)
                 } else {
                     unreadDotLayer.removeFromSuperlayer()
-                    accessibilityLabel = title
                 }
             }
         }
@@ -1103,23 +1101,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
-    open override var accessibilityLabel: String? {
-        get {
-            if isInSelectionMode && isEnabled {
-                return "Accessibility.MultiSelect.Hint".localized
-            }
-            if let customSwitch = customAccessoryView as? UISwitch {
-                if isEnabled && customSwitch.isEnabled {
-                    return "Accessibility.TableViewCell.Switch.Hint".localized
-                } else {
-                    return nil
-                }
-            }
-            return super.accessibilityLabel
-        }
-        set { super.accessibilityLabel = newValue }
-    }
-
     open override var accessibilityHint: String? {
         get {
             if isInSelectionMode && isEnabled {
@@ -1141,6 +1122,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         get {
             if let customAccessoryView = customAccessoryView as? UISwitch {
                 return (customAccessoryView.isOn ? "Accessibility.TableViewCell.Switch.On" : "Accessibility.TableViewCell.Switch.Off").localized
+            }
+            if isUnreadDotVisible {
+                return String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, "")
             }
             return super.accessibilityValue
         }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -883,12 +883,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     /// Boolean determining if the unread dot is visible.
     @objc open var isUnreadDotVisible: Bool = false {
         didSet {
-            if isUnreadDotVisible {
-                self.contentView.layer.addSublayer(unreadDotLayer)
-                accessibilityLabel = String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, title)
-            } else {
-                unreadDotLayer.removeFromSuperlayer()
-                accessibilityLabel = title
+            if oldValue != isUnreadDotVisible {
+                if isUnreadDotVisible {
+                    self.contentView.layer.addSublayer(unreadDotLayer)
+                    accessibilityLabel = String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, title)
+                } else {
+                    unreadDotLayer.removeFromSuperlayer()
+                    accessibilityLabel = title
+                }
             }
         }
     }
@@ -1099,6 +1101,23 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                 invalidateIntrinsicContentSize()
             }
         }
+    }
+
+    open override var accessibilityLabel: String? {
+        get {
+            if isInSelectionMode && isEnabled {
+                return "Accessibility.MultiSelect.Hint".localized
+            }
+            if let customSwitch = customAccessoryView as? UISwitch {
+                if isEnabled && customSwitch.isEnabled {
+                    return "Accessibility.TableViewCell.Switch.Hint".localized
+                } else {
+                    return nil
+                }
+            }
+            return super.accessibilityLabel
+        }
+        set { super.accessibilityLabel = newValue }
     }
 
     open override var accessibilityHint: String? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When https://github.com/microsoft/fluentui-apple/pull/1446 introduced unread dot to tableviewcell, it started to customize accessibilityLabel of the cell. Couple of issues observed
(1) when tableview scrolls, and it dequeues an existing cell identifier, it will still contain the old accessibilityLabel value and not grab the latest title of the cell. We assume Apple behind the scene groups all the UILabel inside the cell and aggregate the cell's accessibilitylabel correctly. But, once you custom call accessibilityLabel and set it yourself, this hidden feature no longer works.

(2) unread dot assumes that the titleLabel.title is the right string. When in fact, it could be titleLabel.attributedString that has the right value for the cell.

We want to fix this bug quickly with minimal impact of loc and code changes. For now, similar to how we handle boolean cell (which is cell with uiswitch) move the "unread" string to AccessibilityValue instead. Currently our loc string is "%@, unread" which isn't ideal, but VoiceOver seems to just read out fine. We will need to refactor a bit later to get this corrected. 

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

Total increase: 0 bytes
Total decrease: -1,448 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,710,328 bytes | 29,708,880 bytes | 🎉 -1,448 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 4,506,904 bytes | 4,506,848 bytes | 🎉 -56 bytes |
| TableViewCell.o | 832,152 bytes | 830,760 bytes | 🎉 -1,392 bytes |
</details>

### Verification
Turn on voice over

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![IMG_6958](https://user-images.githubusercontent.com/20715435/222537399-672ae9f2-64be-4c64-a2c3-942cea86788e.PNG)|![IMG_0055](https://user-images.githubusercontent.com/20715435/222536714-d5dd545c-a892-4fd7-8c58-e57cc03c8b1c.PNG)|

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1618)