### PR TITLE
[cherry-pick] Add observer to CommandBarItem menu (#1623)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -246,6 +246,14 @@ class CommandBarDemoController: DemoController {
         itemEnabledStackView.addArrangedSubview(itemEnabledSwitch)
         itemCustomizationContainer.addArrangedSubview(itemEnabledStackView)
 
+        let disableMenuItemsStackView = createHorizontalStackView()
+        disableMenuItemsStackView.addArrangedSubview(createLabelWithText("Disable Undo Menu Items"))
+        let disableMenuItemsSwitch: UISwitch = UISwitch()
+        disableMenuItemsSwitch.isOn = false
+        disableMenuItemsSwitch.addTarget(self, action: #selector(disableMenuItemValueChanged), for: .valueChanged)
+        disableMenuItemsStackView.addArrangedSubview(disableMenuItemsSwitch)
+        itemCustomizationContainer.addArrangedSubview(disableMenuItemsStackView)
+
         let itemHiddenStackView = createHorizontalStackView()
         itemHiddenStackView.addArrangedSubview(createLabelWithText("'Delete' Hidden"))
         let itemHiddenSwitch: UISwitch = UISwitch()
@@ -418,6 +426,22 @@ class CommandBarDemoController: DemoController {
         }
 
         item.isEnabled = sender.isOn
+    }
+
+    @objc func disableMenuItemValueChanged(sender: UISwitch!) {
+        guard let item: CommandBarItem = defaultCommandBar?.itemGroups[4][0] else {
+            return
+        }
+
+        if sender.isOn {
+            let disabledMenu = UIMenu(children: [UIAction(title: "Copy Image", image: UIImage(named: "copy24Regular"), attributes: .disabled, handler: { _ in }),
+                                            UIAction(title: "Copy Text", image: UIImage(named: "text24Regular"), attributes: .disabled, handler: { _ in })])
+            item.menu = disabledMenu
+        } else {
+            let enabledMenu = UIMenu(children: [UIAction(title: "Copy Image", image: UIImage(named: "copy24Regular"), handler: { _ in }),
+                                            UIAction(title: "Copy Text", image: UIImage(named: "text24Regular"), handler: { _ in })])
+            item.menu = enabledMenu
+        }
     }
 
     @objc func itemHiddenValueChanged(sender: UISwitch!) {

--- a/ios/FluentUI.Demo/FluentUIDemoTests/CommandBarTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/CommandBarTest.swift
@@ -70,7 +70,7 @@ class CommandBarTest: BaseTest {
 
     func testRemoveDeleteButton() throws {
         let numButtons: Int = app.buttons.count
-        let removeDeleteButtonSwitch: XCUIElement = app.switches.element(boundBy: 2)
+        let removeDeleteButtonSwitch: XCUIElement = app.switches.element(boundBy: 3)
 
         removeDeleteButtonSwitch.tap()
         XCTAssert(app.buttons.count == numButtons - 1)

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -133,6 +133,7 @@ class CommandBarButton: UIButton {
         accessibilityHint = item.accessibilityHint
         accessibilityValue = item.accessibilityValue
         accessibilityIdentifier = item.accessibilityIdentifier
+        menu = item.menu
     }
 
     private let isPersistSelection: Bool

--- a/ios/FluentUI/Command Bar/CommandBarItem.swift
+++ b/ios/FluentUI/Command Bar/CommandBarItem.swift
@@ -148,7 +148,13 @@ open class CommandBarItem: NSObject {
 	/// property will disable the `itemTappedHandler`. The customControlView must manually handle gesutres.
     @objc public var customControlView: (() -> UIView)?
 
-    @objc public lazy var menu: UIMenu? = nil // Only lazy property can be used with @available
+    @objc public lazy var menu: UIMenu? = nil { // Only lazy property can be used with @available
+        didSet {
+            if menu != oldValue {
+                propertyChangedUpdateBlock?(self, /* shouldUpdateGroupState */ false)
+            }
+        }
+    }
 
     @objc public lazy var showsMenuAsPrimaryAction: Bool = false
 


### PR DESCRIPTION
Changes on CommandBarItem objects should automatically trigger updates to their corresponding CommandBarButtons. Currently, this is not the case for menu so updates are not propagated. This PR adds an observer to menu and updates it in the updateState function.

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

git cherry-pick 3a2675fad6d6ccedd7bcde6dc05d3183fdc1b38a

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1624)