### PR TITLE
New `ControlTokenSet.registerOnUpdate(for:onUpdate:)` 

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -395,10 +395,13 @@ open class BadgeView: UIView, TokenizedControlInternal {
                                                name: UIContentSizeCategory.didChangeNotification,
                                                object: nil)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
+        tokenSet.onUpdate = { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.updateColors()
+            strongSelf.updateFonts()
+        }
 
         defer {
             self.dataSource = dataSource
@@ -409,15 +412,6 @@ open class BadgeView: UIView, TokenizedControlInternal {
 
     public required init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
-        updateColors()
-        updateFonts()
     }
 
     private func updateFonts() {

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -396,11 +396,8 @@ open class BadgeView: UIView, TokenizedControlInternal {
                                                object: nil)
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.updateColors()
-            strongSelf.updateFonts()
+            self?.updateColors()
+            self?.updateFonts()
         }
 
         defer {

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -395,7 +395,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
                                                name: UIContentSizeCategory.didChangeNotification,
                                                object: nil)
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 @objc(MSFBottomSheetControllerDelegate)
 public protocol BottomSheetControllerDelegate: AnyObject {

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -53,14 +53,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         self.expandedContentView = expandedContentView
         self.shouldShowDimmingView = shouldShowDimmingView
         super.init(nibName: nil, bundle: nil)
-
-        // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.updateAppearance()
-        }
     }
 
     @available(*, unavailable)
@@ -407,6 +399,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     // MARK: - Shadow Layers
     public var ambientShadow: CALayer?
     public var keyShadow: CALayer?
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Update appearance whenever `tokenSet` changes.
+        tokenSet.registerOnUpdate(for: view) { [weak self] in
+            self?.updateAppearance()
+        }
+    }
 
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -54,11 +54,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         self.shouldShowDimmingView = shouldShowDimmingView
         super.init(nibName: nil, bundle: nil)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
         // Update appearance whenever `tokenSet` changes.
         tokenSet.onUpdate = { [weak self] in
             guard let strongSelf = self else {
@@ -483,13 +478,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     private func updateCornerRadius() {
         bottomSheetView.subviews[0].layer.cornerRadius = tokenSet[.cornerRadius].float
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.view.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
     }
 
     private lazy var overflowView: UIView = UIView()

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -394,20 +394,16 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         constraints.append(contentsOf: makeLayoutGuideConstraints())
 
         NSLayoutConstraint.activate(constraints)
-    }
-
-    // MARK: - Shadow Layers
-    public var ambientShadow: CALayer?
-    public var keyShadow: CALayer?
-
-    public override func viewDidLoad() {
-        super.viewDidLoad()
 
         // Update appearance whenever `tokenSet` changes.
         tokenSet.registerOnUpdate(for: view) { [weak self] in
             self?.updateAppearance()
         }
     }
+
+    // MARK: - Shadow Layers
+    public var ambientShadow: CALayer?
+    public var keyShadow: CALayer?
 
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -60,7 +60,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             guard let strongSelf = self else {
                 return
             }
@@ -460,7 +460,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     public typealias TokenSetKeyType = BottomSheetTokenSet.Tokens
     public var tokenSet: BottomSheetTokenSet = .init()
 
-    var tokenSetSink: AnyCancellable?
     var fluentTheme: FluentTheme { return view.fluentTheme }
 
     private func updateAppearance() {

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -133,7 +133,7 @@ open class Button: UIButton, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever overrideTokens changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.update()
         }
     }
@@ -380,7 +380,6 @@ open class Button: UIButton, TokenizedControlInternal {
     private var normalImageTintColor: UIColor?
     private var highlightedImageTintColor: UIColor?
     private var disabledImageTintColor: UIColor?
-    private var tokenSetSink: AnyCancellable?
 
     private var isUsingCustomContentEdgeInsets: Bool = false
     private var isAdjustingCustomContentEdgeInsetsForImage: Bool = false

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -127,11 +127,6 @@ open class Button: UIButton, TokenizedControlInternal {
 
         update()
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
         // Update appearance whenever overrideTokens changes.
         tokenSet.onUpdate = { [weak self] in
             self?.update()
@@ -207,13 +202,6 @@ open class Button: UIButton, TokenizedControlInternal {
         if previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
             updateBorder()
         }
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
     }
 
     public typealias TokenSetKeyType = ButtonTokenSet.Tokens

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 // MARK: - Button
 

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -128,7 +128,7 @@ open class Button: UIButton, TokenizedControlInternal {
         update()
 
         // Update appearance whenever overrideTokens changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.update()
         }
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -113,16 +113,12 @@ class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
         contentView.addSubview(dateLabel)
         contentView.addSubview(dotView)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
+            self?.updateAppearance()
+        }
     }
 
-    @objc func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
+    func updateAppearance() {
         updateViews()
         dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
         dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -40,8 +40,8 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
         contentView.addSubview(monthLabel)
     }
 
-    @objc override func themeDidChange(_ notification: Notification) {
-        super.themeDidChange(notification)
+    override func updateAppearance() {
+        super.updateAppearance()
         updateMonthLabelColor()
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -35,8 +35,8 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
         contentView.addSubview(yearLabel)
     }
 
-    @objc override func themeDidChange(_ notification: Notification) {
-        super.themeDidChange(notification)
+    override func updateAppearance() {
+        super.updateAppearance()
         updateYearLabelColor(textStyle: textStyle)
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -36,12 +36,11 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
                     dateLabelText: dateLabelText,
                     indicatorLevel: indicatorLevel)
 
-        configureBackgroundColor()
-        configureFontColor()
+        updateAppearance()
     }
 
-    @objc override func themeDidChange(_ notification: Notification) {
-        super.themeDidChange(notification)
+    override func updateAppearance() {
+        super.updateAppearance()
         configureBackgroundColor()
         configureFontColor()
     }

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -316,10 +316,10 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
 
         super.init(frame: .zero)
         setupColors()
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
+
+        tokenSet.onUpdate = { [weak self] in
+            self?.setupColors()
+        }
 
         translatesAutoresizingMaskIntoConstraints = false
 
@@ -376,14 +376,6 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     @available(*, unavailable)
     @objc public required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
-        setupColors()
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -317,7 +317,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
         super.init(frame: .zero)
         setupColors()
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.setupColors()
         }
 

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -92,7 +92,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
         configureHierarchy()
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.objectWillChange.sink { [weak self] _ in
+        tokenSet.onUpdate = { [weak self] in
             // Values will be updated on the next run loop iteration.
             DispatchQueue.main.async {
                 self?.updateButtonTokens()
@@ -207,8 +207,6 @@ public class CommandBar: UIView, TokenizedControlInternal {
         }
         tokenSet.update(fluentTheme)
     }
-
-    private var tokenSetSink: AnyCancellable?
 
     /// Container UIStackView that holds the leading, main and trailing views
     private var commandBarContainerStackView: UIStackView

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -85,18 +85,11 @@ public class CommandBar: UIView, TokenizedControlInternal {
 
         super.init(frame: .zero)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
         configureHierarchy()
 
         // Update appearance whenever `tokenSet` changes.
         tokenSet.onUpdate = { [weak self] in
-            // Values will be updated on the next run loop iteration.
-            DispatchQueue.main.async {
-                self?.updateButtonTokens()
-            }
+            self?.updateButtonTokens()
         }
     }
 
@@ -200,13 +193,6 @@ public class CommandBar: UIView, TokenizedControlInternal {
     public weak var delegate: CommandBarDelegate?
 
     // MARK: - Private properties
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-    }
 
     /// Container UIStackView that holds the leading, main and trailing views
     private var commandBarContainerStackView: UIStackView

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 /// `CommandBarDelegate` is used to notify consumers of the `CommandBar` of certain events occurring within the `CommandBar`
 public protocol CommandBarDelegate: AnyObject {

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -88,7 +88,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
         configureHierarchy()
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateButtonTokens()
         }
     }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -75,11 +75,6 @@ class CommandBarButton: UIButton {
         }
 
         updateState()
-
-        tokenSet.registerOnUpdate(for: self) { [weak self] in
-            self?.updateStyle()
-            self?.isPointerInteractionEnabled = true
-        }
     }
 
     @available(*, unavailable)
@@ -159,7 +154,7 @@ class CommandBarButton: UIButton {
         accentImageView?.tintColor = tintColor
     }
 
-    private func updateStyle() {
+    func updateStyle() {
         // TODO: Once iOS 14 support is dropped, this should be converted to a constant (let) that will be initialized by the logic below.
         var resolvedBackgroundColor: UIColor = .clear
         let resolvedTintColor = UIColor(dynamicColor: isSelected ? tokenSet[.itemIconColorSelected].dynamicColor : tokenSet[.itemIconColorRest].dynamicColor)

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -76,7 +76,7 @@ class CommandBarButton: UIButton {
 
         updateState()
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateStyle()
             self?.isPointerInteractionEnabled = true
         }

--- a/ios/FluentUI/Command Bar/CommandBarButton.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButton.swift
@@ -76,18 +76,10 @@ class CommandBarButton: UIButton {
 
         updateState()
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
+        tokenSet.onUpdate = { [weak self] in
+            self?.updateStyle()
+            self?.isPointerInteractionEnabled = true
         }
-        updateStyle()
-        isPointerInteractionEnabled = true
     }
 
     @available(*, unavailable)

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -97,6 +97,13 @@ class CommandBarCommandGroupsView: UIView {
         }
     }
 
+    /// Refreshes the appearance of all buttons in the group.
+    func updateButtonsStyles() {
+        for button in itemsToButtonsMap.values {
+            button.updateStyle()
+        }
+    }
+
     // MARK: - Private properties
 
     private var buttonGroupsStackView: UIStackView

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -136,7 +136,7 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
     /// Holds the sink for any changes to the control token set.
     private var changeSink: AnyCancellable?
 
-    // Stores the notification handler for .didChangeTheme notifications.
+    /// Stores the notification handler for .didChangeTheme notifications.
     private var notificationObserver: NSObjectProtocol?
 
     /// A callback to be invoked after the token set has completed updating.

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -41,18 +41,9 @@ class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal
         textLabel?.showsLargeContentViewer = true
         textLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
+            self?.updateTextLabelColor()
         }
-        tokenSet.update(themeView.fluentTheme)
-        updateTextLabelColor()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -34,7 +34,7 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
         isHidden = true
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors()
         }
     }

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -34,12 +34,9 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
         font = UIFont.systemFont(ofSize: Constants.badgeFontSize, weight: .regular)
         isHidden = true
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
-        updateColors()
+        tokenSet.onUpdate = { [weak self] in
+            self?.updateColors()
+        }
     }
 
     override func willMove(toWindow newWindow: UIWindow?) {
@@ -48,14 +45,6 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
             return
         }
         tokenSet.update(newWindow.fluentTheme)
-        updateColors()
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
         updateColors()
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import Combine
 import UIKit
 
 // MARK: - Label

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -87,25 +87,12 @@ open class Label: UILabel, TokenizedControlInternal {
                                                selector: #selector(handleContentSizeCategoryDidChange),
                                                name: UIContentSizeCategory.didChangeNotification,
                                                object: nil)
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
 
         // Update appearance whenever overrideTokens changes.
         tokenSet.onUpdate = { [weak self] in
             self?.updateTextColor()
             self?.updateFont()
         }
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
-        updateTextColor()
-        updateFont()
     }
 
     private func updateFont() {

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -93,7 +93,7 @@ open class Label: UILabel, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever overrideTokens changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateTextColor()
             self?.updateFont()
         }
@@ -138,5 +138,4 @@ open class Label: UILabel, TokenizedControlInternal {
 
     private var _textColor: UIColor?
     private var isUsingCustomAttributedText: Bool = false
-    private var tokenSetSink: AnyCancellable?
 }

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -89,7 +89,7 @@ open class Label: UILabel, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever overrideTokens changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTextColor()
             self?.updateFont()
         }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -300,23 +300,11 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         super.init(frame: frame)
         initBase()
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
     }
 
     @objc public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         initBase()
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
-        updateColors(for: topItem)
     }
 
     /// Custom base initializer, used regardless of entry point
@@ -366,6 +354,13 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         updateColors(for: topItem)
         updateViewsForLargeTitlePresentation(for: topItem)
         updateAccessibilityElements()
+
+        tokenSet.onUpdate = { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.updateColors(for: strongSelf.topItem)
+        }
     }
 
     private func updateTopAccessoryView(for navigationItem: UINavigationItem?) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -356,10 +356,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         updateAccessibilityElements()
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.updateColors(for: strongSelf.topItem)
+            self?.updateColors(for: self?.topItem)
         }
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -355,7 +355,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         updateViewsForLargeTitlePresentation(for: topItem)
         updateAccessibilityElements()
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -282,7 +282,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
     private func initialize() {
         setupLayout()
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColorsForStyle()
         }
     }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -271,19 +271,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
     @objc public override init(frame: CGRect) {
         super.init(frame: frame)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
         initialize()
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
-        updateColorsForStyle()
     }
 
     @objc public required init?(coder aDecoder: NSCoder) {
@@ -293,6 +281,10 @@ open class SearchBar: UIView, TokenizedControlInternal {
 
     private func initialize() {
         setupLayout()
+
+        tokenSet.onUpdate = { [weak self] in
+            self?.updateColorsForStyle()
+        }
     }
 
     open override func willMove(toWindow newWindow: UIWindow?) {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -67,6 +67,13 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         static let maxHeightNoAccessoryCompactForLargePhone: CGFloat = 44 - 44   // navigation bar - design: 44, system: 44
     }
 
+    convenience init() {
+        self.init(frame: .zero)
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
+            self?.updateColors()
+        }
+    }
+
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         guard let newWindow else {

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -50,7 +50,6 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
     public var tokenSet: TableViewCellTokenSet
-    var tokenSetSink: AnyCancellable?
 
     @objc private func themeDidChange(_ notification: Notification) {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
@@ -151,7 +150,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 // MARK: ActionsCell
 

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -49,15 +49,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     public static let identifier: String = "ActionsCell"
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
-    public var tokenSet: TableViewCellTokenSet
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-        updateAppearance()
-    }
+    public let tokenSet: TableViewCellTokenSet = .init(customViewSize: { .default })
 
     private func updateAppearance() {
         setupBackgroundColors()
@@ -126,7 +118,6 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
     private let verticalSeparator = Separator(orientation: .vertical)
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.tokenSet = TableViewCellTokenSet(customViewSize: { .default })
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         contentView.addSubview(action1Button)
@@ -143,11 +134,6 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
 
         setupAction(action1Button)
         setupAction(action2Button)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
 
         // Update appearance whenever `tokenSet` changes.
         tokenSet.registerOnUpdate(for: self) { [weak self] in

--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -150,7 +150,7 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -23,7 +23,6 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
     public var tokenSet: TableViewCellTokenSet
-    var tokenSetSink: AnyCancellable?
 
     @objc private func themeDidChange(_ notification: Notification) {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
@@ -56,7 +55,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         setupBackgroundColors()
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 // MARK: ActivityIndicatorCell
 

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -55,7 +55,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
         setupBackgroundColors()
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
+++ b/ios/FluentUI/Other Cells/ActivityIndicatorCell.swift
@@ -22,15 +22,7 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
     }
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
-    public var tokenSet: TableViewCellTokenSet
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-        updateAppearance()
-    }
+    public let tokenSet: TableViewCellTokenSet = .init(customViewSize: { .default })
 
     private func updateAppearance() {
         setupBackgroundColors()
@@ -43,14 +35,8 @@ open class ActivityIndicatorCell: UITableViewCell, TokenizedControlInternal {
     }()
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        self.tokenSet = TableViewCellTokenSet(customViewSize: { .default })
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.addSubview(activityIndicator)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
 
         setupBackgroundColors()
 

--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -87,12 +87,8 @@ open class BooleanCell: TableViewCell {
         onValueChanged?()
     }
 
-    open override func willMove(toWindow newWindow: UIWindow?) {
-        super.willMove(toWindow: newWindow)
-        guard let newWindow else {
-            return
-        }
-        tokenSet.update(newWindow.fluentTheme)
+    override func updateAppearance() {
+        super.updateAppearance()
         `switch`.onTintColor = UIColor(dynamicColor: tokenSet[.booleanCellBrandColor].dynamicColor)
     }
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 // MARK: CenteredLabelCell
 

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -59,7 +59,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         setupBackgroundColors()
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -14,7 +14,6 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
     public var tokenSet: TableViewCellTokenSet
-    var tokenSetSink: AnyCancellable?
 
     @objc private func themeDidChange(_ notification: Notification) {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
@@ -60,7 +59,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
         setupBackgroundColors()
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Other Cells/CenteredLabelCell.swift
+++ b/ios/FluentUI/Other Cells/CenteredLabelCell.swift
@@ -13,15 +13,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     public static let identifier: String = "CenteredLabelCell"
 
     public typealias TokenSetKeyType = TableViewCellTokenSet.Tokens
-    public var tokenSet: TableViewCellTokenSet
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-        updateAppearance()
-    }
+    public var tokenSet: TableViewCellTokenSet = .init(customViewSize: { .default })
 
     private func updateAppearance() {
         setupBackgroundColors()
@@ -47,13 +39,7 @@ open class CenteredLabelCell: UITableViewCell, TokenizedControlInternal {
     }
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        tokenSet = TableViewCellTokenSet(customViewSize: { .default })
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
 
         contentView.addSubview(label)
         setupBackgroundColors()

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -68,22 +68,13 @@ open class PillButton: UIButton, TokenizedControlInternal {
                                                object: pillBarItem)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
-        NotificationCenter.default.addObserver(self,
                                                selector: #selector(titleValueDidChange),
                                                name: PillButtonBarItem.titleValueDidChangeNotification,
                                                object: pillBarItem)
-    }
 
-    @objc func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
+        tokenSet.onUpdate = { [weak self] in
+            self?.updateAppearance()
         }
-        tokenSet.update(themeView.fluentTheme)
-        updateAppearance()
     }
 
     public typealias TokenSetKeyType = EmptyTokenSet.Tokens

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -72,7 +72,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
                                                name: PillButtonBarItem.titleValueDidChangeNotification,
                                                object: pillBarItem)
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -94,7 +94,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
                                                name: .didChangeTheme,
                                                object: nil)
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -88,32 +88,12 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         contentView.addSubview(accessoryImageView)
 
         isAccessibilityElement = true
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
-        tokenSet.registerOnUpdate(for: self) { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.updateAppearance()
-            strongSelf.updateColors()        // until popupmenuitemcell actually supports token system, clients will override colors via cell's backgroundColor property
-        }
     }
 
-    override func willMove(toWindow newWindow: UIWindow?) {
-        super.willMove(toWindow: newWindow)
-        updateColors()
-    }
-
-    @objc override func themeDidChange(_ notification: Notification) {
-        super.themeDidChange(notification)
-        guard let window = window, window.isEqual(notification.object) else {
-            return
-        }
+    override func updateAppearance() {
+        super.updateAppearance()
         backgroundStyleType = .custom
+        updateColors()
     }
 
     func setup(item: PopupMenuTemplateItem) {

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -94,7 +94,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
                                                name: .didChangeTheme,
                                                object: nil)
 
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -194,7 +194,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever overrideTokens changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateTokenizedValues()
         }
         updateTokenizedValues()
@@ -421,7 +421,6 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     lazy public var tokenSet: SegmentedControlTokenSet = .init(style: { [weak self] in
         return self?.style ?? .primaryPill
     })
-    private var tokenSetSink: AnyCancellable?
 
     private let selectionChangeAnimationDuration: TimeInterval = 0.2
 

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -189,7 +189,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         setupLayoutConstraints()
 
         // Update appearance whenever overrideTokens changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTokenizedValues()
         }
         updateTokenizedValues()

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License.
 //
 import UIKit
-import Combine
 
 // MARK: SegmentedControl
 /// A styled segmented control that should be used instead of UISegmentedControl. It is designed to flex the button width proportionally to the control's width.

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -188,11 +188,6 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         updateStackDistribution()
         setupLayoutConstraints()
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
         // Update appearance whenever overrideTokens changes.
         tokenSet.onUpdate = { [weak self] in
             self?.updateTokenizedValues()
@@ -562,13 +557,6 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
 
         let button = buttons[index]
         button.isSelected = isSelected
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
     }
 
     private func layoutSelectionView() {

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -59,7 +59,7 @@ open class ShimmerView: UIView, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateShimmeringAnimation()
         }
     }

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 /// View that converts the subviews of a container view into a loading state with the "shimmering" effect.
 @objc(MSFShimmerView)

--- a/ios/FluentUI/Shimmer/ShimmerView.swift
+++ b/ios/FluentUI/Shimmer/ShimmerView.swift
@@ -59,7 +59,7 @@ open class ShimmerView: UIView, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateShimmeringAnimation()
         }
     }
@@ -78,8 +78,6 @@ open class ShimmerView: UIView, TokenizedControlInternal {
     public lazy var tokenSet: ShimmerTokenSet = .init(style: { [weak self] in
         return self?.style ?? .concealing
     })
-
-    var tokenSetSink: AnyCancellable?
 
     /// Style to draw the control.
     public let style: MSFShimmerStyle

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -120,7 +120,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
 
         badgeValue = item.badgeValue
         updateLayout()
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors()
         }
     }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -114,25 +114,15 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
                                                object: item)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
-        NotificationCenter.default.addObserver(self,
                                                selector: #selector(isUnreadValueDidChange),
                                                name: TabBarItem.isUnreadValueDidChangeNotification,
                                                object: item)
 
         badgeValue = item.badgeValue
         updateLayout()
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
+        tokenSet.onUpdate = { [weak self] in
+            self?.updateColors()
         }
-        tokenSet.update(themeView.fluentTheme)
-        updateColors()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1314,7 +1314,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -173,14 +173,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         return self?.customViewSize ?? .default
     })
 
-    @objc func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-        updateAppearance()
-    }
-
     /// The height of the cell based on the height of its content.
     ///
     /// - Parameters:
@@ -1304,11 +1296,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         updateAccessibility()
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
-        NotificationCenter.default.addObserver(self,
                                                selector: #selector(handleContentSizeCategoryDidChange),
                                                name: UIContentSizeCategory.didChangeNotification,
                                                object: nil)
@@ -1862,7 +1849,11 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         updateAppearance()
     }
 
-    internal func updateAppearance() {
+    /// Updates appearance for the given TableViewCell class.
+    ///
+    /// Subclasses should override this function, call `super.updateAppearance()`, and then
+    /// perform any custom appearance updates necessary.
+    func updateAppearance() {
         updateFonts()
         updateTextColors()
         updateSelectionImageColor()

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -173,8 +173,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         return self?.customViewSize ?? .default
     })
 
-    var tokenSetSink: AnyCancellable?
-
     @objc func themeDidChange(_ notification: Notification) {
         guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
             return
@@ -1316,7 +1314,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 // MARK: TableViewCellAccessoryType
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -269,11 +269,8 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-            strongSelf.updateTitleAndBackgroundColors()
-            strongSelf.updateAccessoryButtonTitleColor()
+            self?.updateTitleAndBackgroundColors()
+            self?.updateAccessoryButtonTitleColor()
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -268,7 +268,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             guard let strongSelf = self else {
                 return
             }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -268,19 +268,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
+        tokenSet.onUpdate = { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.updateTitleAndBackgroundColors()
+            strongSelf.updateAccessoryButtonTitleColor()
         }
-        tokenSet.update(themeView.fluentTheme)
-        updateTitleAndBackgroundColors()
-        updateAccessoryButtonTitleColor()
     }
 
     // MARK: Setup

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -147,10 +147,6 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
             leadingImageView.centerYAnchor.constraint(equalTo: textfield.centerYAnchor)
         ])
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
         updateTokenizedValues()
 
         tokenSet.onUpdate = { [weak self] in
@@ -238,14 +234,6 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
         label.numberOfLines = 0
         return label
     }()
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-        updateTokenizedValues()
-    }
 
     @objc private func editingChanged() {
         guard let onEditingChanged else {

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import Combine
 import UIKit
 
 @objc(MSFTextField)

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -153,7 +153,7 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
                                                object: nil)
         updateTokenizedValues()
 
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateTokenizedValues()
         }
     }
@@ -299,5 +299,4 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
             updateTokenizedValues()
         }
     }
-    private var tokenSetSink: AnyCancellable?
 }

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -149,7 +149,7 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
 
         updateTokenizedValues()
 
-        tokenSet.onUpdate = { [weak self] in
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTokenizedValues()
         }
     }

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -4,7 +4,6 @@
 //
 
 import UIKit
-import Combine
 
 // MARK: Tooltip
 // Tooltip Hierarchy:

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -238,7 +238,6 @@ open class Tooltip: NSObject, TokenizedControlInternal {
     // MARK: - TokenizedControl
     public typealias TokenSetKeyType = TooltipTokenSet.Tokens
     public var tokenSet: TooltipTokenSet = .init()
-    var tokenSetSink: AnyCancellable?
     var fluentTheme: FluentTheme {
         // Use anchor view to get theme since tooltip view will most likely be nil
         guard let anchorView = anchorView else {
@@ -264,7 +263,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
                                                object: nil)
 
         // Update appearance whenever `tokenSet` changes.
-        tokenSetSink = tokenSet.sinkChanges { [weak self] in
+        tokenSet.onUpdate = { [weak self] in
             self?.updateAppearance()
         }
     }

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -57,6 +57,11 @@ open class Tooltip: NSObject, TokenizedControlInternal {
             return
         }
 
+        // Connect tokenSet
+        tokenSet.registerOnUpdate(for: tooltipView) { [weak self] in
+            self?.tooltipViewController?.updateAppearance()
+        }
+
         let rootViewController = window.rootViewController
         let rootView = rootViewController?.view
         rootViewController?.addChild(tooltipViewController)
@@ -180,6 +185,8 @@ open class Tooltip: NSObject, TokenizedControlInternal {
 
         tooltipViewController?.removeFromParent()
         tooltipViewController = nil
+
+        tokenSet.deregisterOnUpdate()
 
         onTap = nil
 

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -246,21 +246,8 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         return anchorView.fluentTheme
     }
 
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, let anchorView = anchorView, anchorView.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(fluentTheme)
-        updateAppearance()
-    }
-
     private override init() {
         super.init()
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
 
         // Update appearance whenever `tokenSet` changes.
         tokenSet.onUpdate = { [weak self] in

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -248,11 +248,6 @@ open class Tooltip: NSObject, TokenizedControlInternal {
 
     private override init() {
         super.init()
-
-        // Update appearance whenever `tokenSet` changes.
-        tokenSet.onUpdate = { [weak self] in
-            self?.updateAppearance()
-        }
     }
 
     @objc private func handleTapGesture() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This consolidates updates for tokenized controls into a single method on `ControlTokenSet` called `registerOnUpdate(for:onUpdate:)`.

This method takes a (weak) reference to the calling component as a view, which is used to verify that app-wide theme changes actually apply to the component in question, reducing unnecessary redraws and ensuring that multiple themes stay cleanly separate from each other.

The second argument is simple: a callback provided by the component that will perform any necessary updates when a theme changes.

The biggest bonus: by consolidating this logic in `ControlTokenSet`, we can use the same `onUpdate` block for changes to the token set itself (client-specified overrides to control-level tokens). Previously these two blocks/callbacks were fully separate, and required per-component `Combine` integration as well as `NSNotification` observation. This is no longer necessary, simplifying control writing.

Some components required additional refactoring to support this approach, particularly to keep multiple components from registering for callbacks on the same `ControlTokenSet`. In particular, components related to `CommandBar` and `TableViewCell` were most heavily affected (and thus heavily verified).

Note: this change has no effect on SwiftUI-based components. None of the new notification logic is executed until `registerOnUpdate(for:onUpdate:)` is invoked, which will not happen in SwiftUI. Their update system, based on property observation, will continue unchanged.

Binary change:

Total increase: 130,200 bytes
Total decrease: -226,784 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,896,152 bytes | 29,799,568 bytes | 🎉 -96,584 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BadgeView.o | 338,896 bytes | 440,304 bytes | 🛑 101,408 bytes |
| TextFieldTokenSet.o | 88,168 bytes | 97,152 bytes | ⚠️ 8,984 bytes |
| ShyHeaderView.o | 120,440 bytes | 125,016 bytes | ⚠️ 4,576 bytes |
| HeadsUpDisplayTokenSet.o | 56,848 bytes | 57,776 bytes | ⚠️ 928 bytes |
| BottomSheetTokenSet.o | 48,616 bytes | 49,536 bytes | ⚠️ 920 bytes |
| IndeterminateProgressBarTokenSet.o | 44,888 bytes | 45,792 bytes | ⚠️ 904 bytes |
| EmptyTokenSet.o | 38,272 bytes | 39,176 bytes | ⚠️ 904 bytes |
| TooltipTokenSet.o | 59,504 bytes | 60,408 bytes | ⚠️ 904 bytes |
| CommandBarTokenSet.o | 67,872 bytes | 68,776 bytes | ⚠️ 904 bytes |
| PersonaButtonCarouselTokenSet.o | 42,952 bytes | 43,840 bytes | ⚠️ 888 bytes |
| TableViewCellTokenSet.o | 115,200 bytes | 116,048 bytes | ⚠️ 848 bytes |
| SegmentedControlTokenSet.o | 92,488 bytes | 93,328 bytes | ⚠️ 840 bytes |
| ShimmerTokenSet.o | 78,696 bytes | 79,528 bytes | ⚠️ 832 bytes |
| ActivityIndicatorTokenSet.o | 66,576 bytes | 67,400 bytes | ⚠️ 824 bytes |
| NotificationTokenSet.o | 97,992 bytes | 98,816 bytes | ⚠️ 824 bytes |
| PersonaButtonTokenSet.o | 68,624 bytes | 69,448 bytes | ⚠️ 824 bytes |
| CardNudgeTokenSet.o | 87,336 bytes | 88,144 bytes | ⚠️ 808 bytes |
| BadgeLabelButton.o | 865,376 bytes | 866,184 bytes | ⚠️ 808 bytes |
| CalendarViewDataSource.o | 152,592 bytes | 153,200 bytes | ⚠️ 608 bytes |
| BooleanCell.o | 93,768 bytes | 94,296 bytes | ⚠️ 528 bytes |
| AvatarGroup.o | 363,416 bytes | 363,728 bytes | ⚠️ 312 bytes |
| BottomCommandingController.o | 737,032 bytes | 737,328 bytes | ⚠️ 296 bytes |
| MSFCardNudge.o | 41,176 bytes | 41,320 bytes | ⚠️ 144 bytes |
| CommandBarCommandGroupsView.o | 146,680 bytes | 146,784 bytes | ⚠️ 104 bytes |
| FluentNotification.o | 797,008 bytes | 797,104 bytes | ⚠️ 96 bytes |
| ActivityIndicator.o | 198,344 bytes | 198,432 bytes | ⚠️ 88 bytes |
| CardNudge.o | 452,320 bytes | 452,400 bytes | ⚠️ 80 bytes |
| Avatar.o | 593,376 bytes | 593,392 bytes | ⚠️ 16 bytes |
| SwiftUI+ViewPresentation.o | 60,616 bytes | 60,608 bytes | 🎉 -8 bytes |
| MSFPersonaButtonCarousel.o | 36,008 bytes | 36,000 bytes | 🎉 -8 bytes |
| NavigationController.o | 163,032 bytes | 163,024 bytes | 🎉 -8 bytes |
| AvatarGroupModifiers.o | 10,368 bytes | 10,360 bytes | 🎉 -8 bytes |
| TabBarItem.o | 64,072 bytes | 64,064 bytes | 🎉 -8 bytes |
| AccessibleViewDelegate.o | 14,808 bytes | 14,800 bytes | 🎉 -8 bytes |
| FluentTextInputError.o | 23,832 bytes | 23,824 bytes | 🎉 -8 bytes |
| DateTimePickerViewComponentTableView.o | 72,232 bytes | 72,224 bytes | 🎉 -8 bytes |
| AnimationSynchronizer.o | 32,664 bytes | 32,656 bytes | 🎉 -8 bytes |
| SwiftUI+ViewAnimation.o | 50,624 bytes | 50,616 bytes | 🎉 -8 bytes |
| Persona.o | 79,400 bytes | 79,392 bytes | 🎉 -8 bytes |
| TokenizedControl.o | 13,056 bytes | 13,048 bytes | 🎉 -8 bytes |
| CommandingItem.o | 91,464 bytes | 91,456 bytes | 🎉 -8 bytes |
| PersonaButtonCarouselModifiers.o | 10,416 bytes | 10,408 bytes | 🎉 -8 bytes |
| CalendarConfiguration.o | 46,960 bytes | 46,952 bytes | 🎉 -8 bytes |
| AliasTokens.o | 201,296 bytes | 201,288 bytes | 🎉 -8 bytes |
| BottomSheetPassthroughView.o | 21,272 bytes | 21,264 bytes | 🎉 -8 bytes |
| DateTimePickerController.o | 165,920 bytes | 165,912 bytes | 🎉 -8 bytes |
| UIKit+SwiftUI_interoperability.o | 55,640 bytes | 55,632 bytes | 🎉 -8 bytes |
| GenericDateTimePicker.o | 12,008 bytes | 12,000 bytes | 🎉 -8 bytes |
| PopupMenuItem.o | 115,584 bytes | 115,576 bytes | 🎉 -8 bytes |
| TabBarView.o | 112,288 bytes | 112,280 bytes | 🎉 -8 bytes |
| Obscurable.o | 24,104 bytes | 24,096 bytes | 🎉 -8 bytes |
| DynamicColor.o | 51,720 bytes | 51,712 bytes | 🎉 -8 bytes |
| HeadsUpDisplay.o | 289,016 bytes | 289,008 bytes | 🎉 -8 bytes |
| ResizingHandleView.o | 52,104 bytes | 52,096 bytes | 🎉 -8 bytes |
| NotificationModifiers.o | 75,680 bytes | 75,672 bytes | 🎉 -8 bytes |
| NavigationAnimator.o | 122,560 bytes | 122,552 bytes | 🎉 -8 bytes |
| EasyTapButton.o | 26,464 bytes | 26,456 bytes | 🎉 -8 bytes |
| MSFActivityIndicator.o | 32,048 bytes | 32,040 bytes | 🎉 -8 bytes |
| Date+Extensions.o | 52,000 bytes | 51,992 bytes | 🎉 -8 bytes |
| AccessibilityContainerView.o | 37,600 bytes | 37,592 bytes | 🎉 -8 bytes |
| BarButtonItems.o | 28,568 bytes | 28,560 bytes | 🎉 -8 bytes |
| TooltipViewController.o | 47,720 bytes | 47,712 bytes | 🎉 -8 bytes |
| UIImage+Extensions.o | 10,360 bytes | 10,352 bytes | 🎉 -8 bytes |
| DrawerTransitionAnimator.o | 73,000 bytes | 72,992 bytes | 🎉 -8 bytes |
| TokenizedControlView.o | 182,464 bytes | 182,456 bytes | 🎉 -8 bytes |
| UIColor+Extensions.o | 58,264 bytes | 58,256 bytes | 🎉 -8 bytes |
| MSFNotification.o | 144,560 bytes | 144,552 bytes | 🎉 -8 bytes |
| UIBarButtonItem+BadgeValue.o | 32,160 bytes | 32,152 bytes | 🎉 -8 bytes |
| PageCardPresenterController.o | 159,152 bytes | 159,144 bytes | 🎉 -8 bytes |
| PopupMenuSection.o | 30,768 bytes | 30,760 bytes | 🎉 -8 bytes |
| CardPresentationController.o | 48,536 bytes | 48,528 bytes | 🎉 -8 bytes |
| LargeTitleView.o | 163,216 bytes | 163,208 bytes | 🎉 -8 bytes |
| CalendarViewMonthBannerView.o | 27,016 bytes | 27,008 bytes | 🎉 -8 bytes |
| GlobalTokens.o | 478,728 bytes | 478,720 bytes | 🎉 -8 bytes |
| HUDModifiers.o | 70,376 bytes | 70,368 bytes | 🎉 -8 bytes |
| CardTransitionAnimator.o | 63,688 bytes | 63,680 bytes | 🎉 -8 bytes |
| UIView+Extensions.o | 74,368 bytes | 74,360 bytes | 🎉 -8 bytes |
| ActivityIndicatorModifiers.o | 28,600 bytes | 28,592 bytes | 🎉 -8 bytes |
| Date+CellFileAccessoryView.o | 52,992 bytes | 52,984 bytes | 🎉 -8 bytes |
| Calendar+Extensions.o | 108,936 bytes | 108,928 bytes | 🎉 -8 bytes |
| FluentUIHostingController.o | 32,864 bytes | 32,856 bytes | 🎉 -8 bytes |
| SideTabBar.o | 217,632 bytes | 217,624 bytes | 🎉 -8 bytes |
| DrawerShadowView.o | 62,264 bytes | 62,256 bytes | 🎉 -8 bytes |
| TooltipView.o | 212,784 bytes | 212,776 bytes | 🎉 -8 bytes |
| NSLayoutConstraint+Extensions.o | 24,368 bytes | 24,360 bytes | 🎉 -8 bytes |
| CommandBarItem.o | 115,976 bytes | 115,968 bytes | 🎉 -8 bytes |
| MSFAvatarPresence.o | 45,520 bytes | 45,512 bytes | 🎉 -8 bytes |
| CommandingSection.o | 29,944 bytes | 29,936 bytes | 🎉 -8 bytes |
| IndeterminateProgressBarModifiers.o | 17,352 bytes | 17,344 bytes | 🎉 -8 bytes |
| BadgeStringExtractor.o | 63,288 bytes | 63,280 bytes | 🎉 -8 bytes |
| SegmentItem.o | 35,024 bytes | 35,016 bytes | 🎉 -8 bytes |
| DatePickerController.o | 355,160 bytes | 355,152 bytes | 🎉 -8 bytes |
| CardNudgeModifiers.o | 43,000 bytes | 42,992 bytes | 🎉 -8 bytes |
| DotView.o | 33,040 bytes | 33,032 bytes | 🎉 -8 bytes |
| DateTimePicker.o | 177,496 bytes | 177,488 bytes | 🎉 -8 bytes |
| PillButtonBar.o | 294,256 bytes | 294,248 bytes | 🎉 -8 bytes |
| SwiftUI+ViewModifiers.o | 203,720 bytes | 203,712 bytes | 🎉 -8 bytes |
| PersonaButtonModifiers.o | 10,376 bytes | 10,368 bytes | 🎉 -8 bytes |
| MSFAvatar.o | 29,416 bytes | 29,408 bytes | 🎉 -8 bytes |
| PersonaListView.o | 187,160 bytes | 187,152 bytes | 🎉 -8 bytes |
| MSFIndeterminateProgressBar.o | 30,112 bytes | 30,104 bytes | 🎉 -8 bytes |
| UIViewController+Navigation.o | 15,552 bytes | 15,544 bytes | 🎉 -8 bytes |
| PersonaButtonCarousel.o | 198,152 bytes | 198,144 bytes | 🎉 -8 bytes |
| LinearGradientInfo.o | 87,512 bytes | 87,504 bytes | 🎉 -8 bytes |
| DateTimePickerViewLayout.o | 42,936 bytes | 42,928 bytes | 🎉 -8 bytes |
| CommandBarButtonGroupView.o | 64,432 bytes | 64,424 bytes | 🎉 -8 bytes |
| BlurringView.o | 35,504 bytes | 35,496 bytes | 🎉 -8 bytes |
| CALayer+Extensions.o | 10,352 bytes | 10,344 bytes | 🎉 -8 bytes |
| UIApplication+Extensions.o | 10,376 bytes | 10,368 bytes | 🎉 -8 bytes |
| TwoLineTitleView.o | 212,448 bytes | 212,424 bytes | 🎉 -24 bytes |
| BadgeField.o | 540,344 bytes | 540,320 bytes | 🎉 -24 bytes |
| PeoplePicker.o | 294,576 bytes | 294,544 bytes | 🎉 -32 bytes |
| DateTimePickerViewDataSource.o | 286,064 bytes | 286,032 bytes | 🎉 -32 bytes |
| HUD.o | 229,368 bytes | 229,336 bytes | 🎉 -32 bytes |
| DrawerPresentationController.o | 259,152 bytes | 259,120 bytes | 🎉 -32 bytes |
| IndeterminateProgressBar.o | 280,208 bytes | 280,176 bytes | 🎉 -32 bytes |
| TableViewCellFileAccessoryView.o | 333,360 bytes | 333,296 bytes | 🎉 -64 bytes |
| AvatarTokenSet.o | 128,920 bytes | 128,856 bytes | 🎉 -64 bytes |
| LabelTokenSet.o | 66,080 bytes | 65,992 bytes | 🎉 -88 bytes |
| DrawerController.o | 492,384 bytes | 492,296 bytes | 🎉 -88 bytes |
| ShimmerLinesView.o | 242,336 bytes | 242,248 bytes | 🎉 -88 bytes |
| FluentUIFramework.o | 80,648 bytes | 80,560 bytes | 🎉 -88 bytes |
| ShadowInfo.o | 54,704 bytes | 54,600 bytes | 🎉 -104 bytes |
| DateTimePickerViewComponent.o | 148,592 bytes | 148,480 bytes | 🎉 -112 bytes |
| DateTimePickerView.o | 276,968 bytes | 276,856 bytes | 🎉 -112 bytes |
| PersonaCell.o | 64,048 bytes | 63,936 bytes | 🎉 -112 bytes |
| AvatarGroupTokenSet.o | 49,072 bytes | 48,960 bytes | 🎉 -112 bytes |
| FontInfo.o | 64,056 bytes | 63,944 bytes | 🎉 -112 bytes |
| FluentTheme.o | 60,024 bytes | 59,912 bytes | 🎉 -112 bytes |
| String+Extension.o | 58,160 bytes | 58,048 bytes | 🎉 -112 bytes |
| ButtonTokenSet.o | 120,856 bytes | 120,736 bytes | 🎉 -120 bytes |
| ShyHeaderController.o | 251,240 bytes | 251,080 bytes | 🎉 -160 bytes |
| PopupMenuSectionHeaderView.o | 27,352 bytes | 27,184 bytes | 🎉 -168 bytes |
| MSFHeadsUpDisplay.o | 35,312 bytes | 34,744 bytes | 🎉 -568 bytes |
| PersonaButton.o | 278,776 bytes | 278,056 bytes | 🎉 -720 bytes |
| CalendarViewDayTodayCell.o | 39,480 bytes | 38,480 bytes | 🎉 -1,000 bytes |
| CalendarViewDayMonthYearCell.o | 51,560 bytes | 50,528 bytes | 🎉 -1,032 bytes |
| CalendarViewDayMonthCell.o | 43,856 bytes | 42,784 bytes | 🎉 -1,072 bytes |
| NavigationBar.o | 556,536 bytes | 554,384 bytes | 🎉 -2,152 bytes |
| SearchBar.o | 449,040 bytes | 446,608 bytes | 🎉 -2,432 bytes |
| TableViewHeaderFooterView.o | 290,176 bytes | 287,592 bytes | 🎉 -2,584 bytes |
| CalendarViewDayCell.o | 152,152 bytes | 149,384 bytes | 🎉 -2,768 bytes |
| TabBarItemView.o | 214,560 bytes | 211,752 bytes | 🎉 -2,808 bytes |
| CardView.o | 283,200 bytes | 280,064 bytes | 🎉 -3,136 bytes |
| ControlTokenSet.o | 88,640 bytes | 85,368 bytes | 🎉 -3,272 bytes |
| BadgeLabel.o | 56,944 bytes | 53,448 bytes | 🎉 -3,496 bytes |
| PillButton.o | 201,528 bytes | 197,720 bytes | 🎉 -3,808 bytes |
| DateTimePickerViewComponentCell.o | 58,112 bytes | 54,296 bytes | 🎉 -3,816 bytes |
| ShimmerView.o | 175,576 bytes | 169,736 bytes | 🎉 -5,840 bytes |
| CommandBarButton.o | 114,504 bytes | 108,376 bytes | 🎉 -6,128 bytes |
| TableViewCell.o | 835,264 bytes | 825,632 bytes | 🎉 -9,632 bytes |
| CenteredLabelCell.o | 99,480 bytes | 89,016 bytes | 🎉 -10,464 bytes |
| FluentTextField.o | 217,040 bytes | 206,024 bytes | 🎉 -11,016 bytes |
| SegmentedControl.o | 336,688 bytes | 325,528 bytes | 🎉 -11,160 bytes |
| MSFPersonaButton.o | 41,392 bytes | 29,720 bytes | 🎉 -11,672 bytes |
| Button.o | 199,736 bytes | 187,968 bytes | 🎉 -11,768 bytes |
| ActivityIndicatorCell.o | 92,864 bytes | 80,912 bytes | 🎉 -11,952 bytes |
| Label.o | 109,920 bytes | 97,928 bytes | 🎉 -11,992 bytes |
| BottomSheetController.o | 518,896 bytes | 506,696 bytes | 🎉 -12,200 bytes |
| CommandBar.o | 222,256 bytes | 208,392 bytes | 🎉 -13,864 bytes |
| ActionsCell.o | 221,744 bytes | 207,504 bytes | 🎉 -14,240 bytes |
| PopupMenuItemCell.o | 182,272 bytes | 167,480 bytes | 🎉 -14,792 bytes |
| Tooltip.o | 141,664 bytes | 126,192 bytes | 🎉 -15,472 bytes |
| __.SYMDEF | 4,592,024 bytes | 4,574,768 bytes | 🎉 -17,256 bytes |
</details>

<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

(a summary of the changes made, often organized by file)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

Videos still incoming, but here are a few examples of components that required the most changes.

#### CommandBar

https://user-images.githubusercontent.com/4934719/223467194-8868893c-ea76-4e82-a229-57a73c7e908b.mp4

#### TableViewCell

https://user-images.githubusercontent.com/4934719/223468526-3c648c0a-e3d9-4640-997a-705d262792e5.mp4

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1628)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1628)