### PR TITLE
Make Label font overridable

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -19,6 +19,7 @@ open class Label: UILabel, TokenizedControlInternal {
     }
     @objc open var style: AliasTokens.TypographyTokens = .body1 {
         didSet {
+            _font = nil
             updateFont()
         }
     }
@@ -37,6 +38,13 @@ open class Label: UILabel, TokenizedControlInternal {
         didSet {
             _textColor = textColor
             updateTextColor()
+        }
+    }
+
+    open override var font: UIFont! {
+        didSet {
+            _font = font
+            updateFont()
         }
     }
 
@@ -76,8 +84,9 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     private func initialize() {
-        // textColor is assigned in super.init to a default value and so we need to reset our cache afterwards
+        // textColor and font are assigned in super.init to a default value and so we need to reset our cache afterwards
         _textColor = nil
+        _font = nil
 
         updateFont()
         updateTextColor()
@@ -114,11 +123,11 @@ open class Label: UILabel, TokenizedControlInternal {
             return
         }
 
-        let defaultFont = UIFont.fluent(tokenSet[.font].fontInfo)
-        if maxFontSize > 0 && defaultFont.pointSize > maxFontSize {
-            font = defaultFont.withSize(maxFontSize)
+        let labelFont = _font ?? UIFont.fluent(tokenSet[.font].fontInfo)
+        if maxFontSize > 0 && labelFont.pointSize > maxFontSize {
+            super.font = labelFont.withSize(maxFontSize)
         } else {
-            font = defaultFont
+            super.font = labelFont
         }
     }
 
@@ -137,6 +146,7 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     private var _textColor: UIColor?
+    private var _font: UIFont?
     private var isUsingCustomAttributedText: Bool = false
     private var tokenSetSink: AnyCancellable?
 }

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -13,13 +13,13 @@ import UIKit
 open class Label: UILabel, TokenizedControlInternal {
     @objc open var colorStyle: TextColorStyle = .regular {
         didSet {
-            _textColor = nil
+            labelTextColor = nil
             updateTextColor()
         }
     }
     @objc open var style: AliasTokens.TypographyTokens = .body1 {
         didSet {
-            _font = nil
+            labelFont = nil
             updateFont()
         }
     }
@@ -36,14 +36,14 @@ open class Label: UILabel, TokenizedControlInternal {
 
     open override var textColor: UIColor! {
         didSet {
-            _textColor = textColor
+            labelTextColor = textColor
             updateTextColor()
         }
     }
 
     open override var font: UIFont! {
         didSet {
-            _font = font
+            labelFont = font
             updateFont()
         }
     }
@@ -85,8 +85,8 @@ open class Label: UILabel, TokenizedControlInternal {
 
     private func initialize() {
         // textColor and font are assigned in super.init to a default value and so we need to reset our cache afterwards
-        _textColor = nil
-        _font = nil
+        labelTextColor = nil
+        labelFont = nil
 
         updateFont()
         updateTextColor()
@@ -123,7 +123,7 @@ open class Label: UILabel, TokenizedControlInternal {
             return
         }
 
-        let labelFont = _font ?? UIFont.fluent(tokenSet[.font].fontInfo)
+        let labelFont = labelFont ?? UIFont.fluent(tokenSet[.font].fontInfo)
         if maxFontSize > 0 && labelFont.pointSize > maxFontSize {
             super.font = labelFont.withSize(maxFontSize)
         } else {
@@ -136,7 +136,7 @@ open class Label: UILabel, TokenizedControlInternal {
         guard !isUsingCustomAttributedText else {
             return
         }
-        super.textColor = _textColor ?? UIColor(dynamicColor: tokenSet[.textColor].dynamicColor)
+        super.textColor = labelTextColor ?? UIColor(dynamicColor: tokenSet[.textColor].dynamicColor)
     }
 
     @objc private func handleContentSizeCategoryDidChange() {
@@ -145,8 +145,8 @@ open class Label: UILabel, TokenizedControlInternal {
         }
     }
 
-    private var _textColor: UIColor?
-    private var _font: UIFont?
+    private var labelTextColor: UIColor?
+    private var labelFont: UIFont?
     private var isUsingCustomAttributedText: Bool = false
     private var tokenSetSink: AnyCancellable?
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
#1602 introduced a regression where Label fonts weren't overriding default tokens unless you explicitly provided it in the init. Let's fix this by making font overridable.

Binary change:
Total increase: 6,128 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,888,720 bytes | 29,894,848 bytes | ⚠️ 6,128 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| Label.o | 109,768 bytes | 113,584 bytes | ⚠️ 3,816 bytes |
| __.SYMDEF | 4,617,424 bytes | 4,619,136 bytes | ⚠️ 1,712 bytes |
| BadgeLabelButton.o | 866,584 bytes | 867,184 bytes | ⚠️ 600 bytes |
</details>

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![IMG_0101 2](https://user-images.githubusercontent.com/31874971/223522807-7e8e2013-34d0-4bad-b245-27f915257d2c.PNG) | ![IMG_0102 2](https://user-images.githubusercontent.com/31874971/223522860-3f8e7132-e9e9-47a8-a251-77e8179f9637.PNG) |
| ![IMG_0104](https://user-images.githubusercontent.com/31874971/223522920-866bdac7-fad4-4bc1-9de0-c28f044acb7b.PNG) | ![IMG_0103](https://user-images.githubusercontent.com/31874971/223522885-fb2cfe83-b6e2-48b6-8e21-9dd8fa7dfb14.PNG) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)