### PR TITLE
Add accessibilityIdentifier to TabBarItem

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -84,7 +84,6 @@ class TabBarViewDemoController: DemoController {
             ]
         } else {
             homeItem = homeItem(shouldShowTitle: false)
-            homeItem.accessibilityIdentifier = "yo"
             updatedTabBarView.items = [
                 homeItem,
                 TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -84,6 +84,7 @@ class TabBarViewDemoController: DemoController {
             ]
         } else {
             homeItem = homeItem(shouldShowTitle: false)
+            homeItem.accessibilityIdentifier = "yo"
             updatedTabBarView.items = [
                 homeItem,
                 TabBarItem(title: "New", image: UIImage(named: "New_28")!, selectedImage: UIImage(named: "New_Selected_28")!, landscapeImage: UIImage(named: "New_24")!, landscapeSelectedImage: UIImage(named: "New_Selected_24")!),

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -30,6 +30,9 @@ open class TabBarItem: NSObject {
        }
    }
 
+    /// A string that uniquely identifies the element, typically for automation purposes.
+    @objc public var accessibilityIdentifier: String?
+
     /// Convenience method to set the badge value to a number.
     /// If the number is zero, the badge value will be hidden.
     @objc public func setBadgeNumber(_ number: UInt) {
@@ -73,36 +76,6 @@ open class TabBarItem: NSObject {
                   accessibilityLabelBadgeFormatString: nil)
     }
 
-#if DEBUG
-    /// Initializes `TabBarItem`
-    /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
-    /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
-    /// - Parameter selectedImage: Used for imageView when tabbar item view is selected.  If it is nil, it will use `image`.
-    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. The image will be used in portrait mode if the tab bar item shows a label.
-    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
-    /// - Parameter largeContentImage: Used for tabbar item view's accessibility largeContentImage.
-    /// - Parameter accessibilityLabelBadgeFormatString: Format string to use for the tabbar item's accessibility label when the badge number is greater than zero. When the badge number is zero, the accessibility label is set to the item's title. By default, when the badge number is greater than zero, the following format is used to builds the accessibility label: "%@, %ld items" where the item's title and the badge number are used to populate the format specifiers. If a format string is provided through this parameter, it must contain "%@" and "%ld" in the same order and will be populated with the title and badge number.
-    /// - Parameter accessibilityIdentifier: Used for UI testing.
-    @objc public convenience init(title: String,
-                                  image: UIImage,
-                                  selectedImage: UIImage? = nil,
-                                  landscapeImage: UIImage? = nil,
-                                  landscapeSelectedImage: UIImage? = nil,
-                                  largeContentImage: UIImage? = nil,
-                                  accessibilityLabelBadgeFormatString: String? = nil,
-                                  accessibilityIdentifier: String? = nil) {
-        self.init(title: title,
-                  image: image,
-                  selectedImage: selectedImage,
-                  landscapeImage: landscapeImage,
-                  landscapeSelectedImage: landscapeSelectedImage,
-                  largeContentImage: nil,
-                  accessibilityLabelBadgeFormatString: nil)
-        self.accessibilityIdentifier = accessibilityIdentifier
-    }
-
-#endif
-
     /// Initializes `TabBarItem`
     /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
     /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
@@ -140,9 +113,6 @@ open class TabBarItem: NSObject {
     let landscapeSelectedImage: UIImage?
     let largeContentImage: UIImage?
     let accessibilityLabelBadgeFormatString: String?
-#if DEBUG
-    var accessibilityIdentifier: String?
-#endif
 
     func selectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -31,7 +31,13 @@ open class TabBarItem: NSObject {
    }
 
     /// A string that uniquely identifies the element, typically for automation purposes.
-    @objc public var accessibilityIdentifier: String?
+    @objc public var accessibilityIdentifier: String? {
+        didSet {
+            if accessibilityIdentifier != oldValue {
+                NotificationCenter.default.post(name: TabBarItem.accessibilityIdentifierDidChangeNotification, object: self)
+            }
+        }
+    }
 
     /// Convenience method to set the badge value to a number.
     /// If the number is zero, the badge value will be hidden.
@@ -106,6 +112,9 @@ open class TabBarItem: NSObject {
 
     /// Notification sent when item's `isUnread` value changes.
     static let isUnreadValueDidChangeNotification = NSNotification.Name(rawValue: "TabBarItemisUnreadValueDidChangeNotification")
+
+    /// Notification sent when item's `accessibilityIdentifier` value changes.
+    static let accessibilityIdentifierDidChangeNotification = NSNotification.Name(rawValue: "TabBarItemAccessibilityIdentifierDidChangeNotification")
 
     let image: UIImage
     let selectedImage: UIImage?

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -73,6 +73,36 @@ open class TabBarItem: NSObject {
                   accessibilityLabelBadgeFormatString: nil)
     }
 
+#if DEBUG
+    /// Initializes `TabBarItem`
+    /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
+    /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
+    /// - Parameter selectedImage: Used for imageView when tabbar item view is selected.  If it is nil, it will use `image`.
+    /// - Parameter landscapeImage: Used for imageView when tabbar item view in landscape. If it is nil, it will use `image`. The image will be used in portrait mode if the tab bar item shows a label.
+    /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
+    /// - Parameter largeContentImage: Used for tabbar item view's accessibility largeContentImage.
+    /// - Parameter accessibilityLabelBadgeFormatString: Format string to use for the tabbar item's accessibility label when the badge number is greater than zero. When the badge number is zero, the accessibility label is set to the item's title. By default, when the badge number is greater than zero, the following format is used to builds the accessibility label: "%@, %ld items" where the item's title and the badge number are used to populate the format specifiers. If a format string is provided through this parameter, it must contain "%@" and "%ld" in the same order and will be populated with the title and badge number.
+    /// - Parameter accessibilityIdentifier: Used for UI testing.
+    @objc public convenience init(title: String,
+                                  image: UIImage,
+                                  selectedImage: UIImage? = nil,
+                                  landscapeImage: UIImage? = nil,
+                                  landscapeSelectedImage: UIImage? = nil,
+                                  largeContentImage: UIImage? = nil,
+                                  accessibilityLabelBadgeFormatString: String? = nil,
+                                  accessibilityIdentifier: String? = nil) {
+        self.init(title: title,
+                  image: image,
+                  selectedImage: selectedImage,
+                  landscapeImage: landscapeImage,
+                  landscapeSelectedImage: landscapeSelectedImage,
+                  largeContentImage: nil,
+                  accessibilityLabelBadgeFormatString: nil)
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+#endif
+
     /// Initializes `TabBarItem`
     /// - Parameter title: Used for tabbar item view's label and for its accessibilityLabel.
     /// - Parameter image: Used for tabbar item view's imageView and for its accessibility largeContentImage unless `largeContentImage` is specified.
@@ -110,6 +140,9 @@ open class TabBarItem: NSObject {
     let landscapeSelectedImage: UIImage?
     let largeContentImage: UIImage?
     let accessibilityLabelBadgeFormatString: String?
+#if DEBUG
+    var accessibilityIdentifier: String?
+#endif
 
     func selectedImage(isInPortraitMode: Bool, labelIsHidden: Bool) -> UIImage? {
         if isInPortraitMode {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -124,6 +124,11 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
                                                name: TabBarItem.isUnreadValueDidChangeNotification,
                                                object: item)
 
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(accessibilityIdentifierDidChange),
+                                               name: TabBarItem.accessibilityIdentifierDidChangeNotification,
+                                               object: item)
+
         badgeValue = item.badgeValue
         updateLayout()
     }
@@ -209,6 +214,10 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         updateBadgeView()
         updateAccessibilityLabel()
         setNeedsLayout()
+    }
+
+    @objc private func accessibilityIdentifierDidChange() {
+        accessibilityIdentifier = item.accessibilityIdentifier
     }
 
     private var isUnreadDotVisible: Bool = false

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -31,13 +31,6 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         }
     }
 
-#if DEBUG
-    override var accessibilityIdentifier: String? {
-        get { return item.accessibilityIdentifier }
-        set { }
-    }
-#endif
-
     /// Maximum width for the badge view where the badge value is displayed.
     var maxBadgeWidth: CGFloat = Constants.defaultBadgeMaxWidth {
         didSet {
@@ -103,6 +96,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
 
         isAccessibilityElement = true
         updateAccessibilityLabel()
+        accessibilityIdentifier = item.accessibilityIdentifier
 
         self.largeContentImage = item.largeContentImage ?? item.image
         largeContentTitle = item.title

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -31,6 +31,13 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         }
     }
 
+#if DEBUG
+    override var accessibilityIdentifier: String? {
+        get { return item.accessibilityIdentifier }
+        set { }
+    }
+#endif
+
     /// Maximum width for the badge view where the badge value is displayed.
     var maxBadgeWidth: CGFloat = Constants.defaultBadgeMaxWidth {
         didSet {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->

Total increase: 8,120 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,808,832 bytes | 29,816,952 bytes | ⚠️ 8,120 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TabBarItem.o | 63,864 bytes | 69,520 bytes | ⚠️ 5,656 bytes |
| TabBarItemView.o | 213,968 bytes | 215,248 bytes | ⚠️ 1,280 bytes |
| __.SYMDEF | 4,559,648 bytes | 4,560,536 bytes | ⚠️ 888 bytes |
| BadgeLabelButton.o | 863,720 bytes | 864,016 bytes | ⚠️ 296 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

<img width="839" alt="Screenshot 2023-03-08 at 3 03 58 PM" src="https://user-images.githubusercontent.com/55368679/223872760-c3ac3b30-d7a6-47e1-b0fb-581937e84668.png">
</details>

Added an `accessibilityIdentifier` to `TabBarItem`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1633)