### PR TITLE
Fix DrawerController crash on iPad

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -120,24 +120,13 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     }
 
     /// Set `backgroundColor` to customize background color of the drawer
-    @objc open var backgroundColor: UIColor {
-        get {
-            let color: DynamicColor
-            if presentationController is UIPopoverPresentationController {
-                color = tokenSet[.popoverContentBackground].dynamicColor
-            } else if useNavigationBarBackgroundColor {
-                color = tokenSet[.navigationBarBackground].dynamicColor
-            } else {
-                color = tokenSet[.drawerContentBackground].dynamicColor
-            }
-            return UIColor(dynamicColor: color)
-        }
-        set {
+    @objc lazy open var backgroundColor: UIColor = DrawerController.drawerBackground(fluentTheme: view.fluentTheme) {
+        didSet {
             if isViewLoaded {
-                view.backgroundColor = newValue
+                view.backgroundColor = backgroundColor
             }
 
-            guard let newColor = newValue.dynamicColor else {
+            guard let newColor = backgroundColor.dynamicColor else {
                 return
             }
             tokenSet[.popoverContentBackground] = .dynamicColor { newColor }
@@ -464,6 +453,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
               return
         }
         tokenSet.update(fluentTheme)
+        updateAppearance()
     }
 
     /**
@@ -501,6 +491,18 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
                 self?.updateAppearance()
             }
         }
+    }
+
+    private func updateBackgroundColor() {
+        let color: DynamicColor
+        if presentationController is UIPopoverPresentationController {
+            color = tokenSet[.popoverContentBackground].dynamicColor
+        } else if useNavigationBarBackgroundColor {
+            color = tokenSet[.navigationBarBackground].dynamicColor
+        } else {
+            color = tokenSet[.drawerContentBackground].dynamicColor
+        }
+        view.backgroundColor = UIColor(dynamicColor: color)
     }
 
     open func willDismiss() {
@@ -798,7 +800,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     }
 
     private func updateAppearance() {
-        view.backgroundColor = backgroundColor
+        updateBackgroundColor()
 
         guard let presentationController = (presentationController as? DrawerPresentationController) else {
             return

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -120,7 +120,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     }
 
     /// Set `backgroundColor` to customize background color of the drawer
-    @objc lazy open var backgroundColor: UIColor = DrawerController.drawerBackground(fluentTheme: view.fluentTheme) {
+    @objc lazy open var backgroundColor: UIColor = UIColor(dynamicColor: tokenSet[.drawerContentBackground].dynamicColor) {
         didSet {
             if isViewLoaded {
                 view.backgroundColor = backgroundColor


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a bug on iPad where opening a drawer crashes the app. This was due to `presentationController` being accessed in `backgroundColor`'s getter at a point in which it's nil and not initialized yet. 
To reliably fix this bug, I removed the getter and the colors now get updated in `viewWillAppear` through `updateAppearance`.

Binary change:
<!---
These steps are for iOS. Feel free to skip on Mac.
Please include the output of scripts/GenerateBinaryDiffTable.swift, using the following steps:
  1. Ensure that your working branch is up to date with the base branch.
  2. Build the base branch Demo.Release scheme for Any iOS Device (arm64)
  3. Navigate to left panel: FluentUI -> Products -> libFluentUI.a
  4. Show libFluentUI.a in Finder, and copy libFluentUI.a to a safe location for use later.
    a. <Optional> Also grab FluentUI.Demo while you're there, and likewise move it somewhere safe.
  5. Switch to your working branch and repeat steps 2-4.
  6. Now that you have both your old and new builds, you can run the script. From the root of this repo, 
     you can run `swift ./scripts/GenerateBinaryDiffTable.swift <path to old build> <path to new build>`.
     This will generate a table that compares any changes in .o files between the two builds.
  7. Copy the output of the script to this PR.
  8. <Optional> The default output will only show the total changes outside of the summary,
                but you might want to include any especially relevant or noteworthy changes
                in the initial table.
  9. <Optional> Another delta worth showing in the initial table comes from the demo app.
             a. Navigate to FluentUI.Demo that you saved in before steps 4.a, right click,
                and select "Show package contents"
             b. Find the FluentUI.Demo inside FluentUI.Demo, right click, and select "Get Info"
             c. Create a new row in the initial table, titled "unstripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             d. Run ` /usr/bin/strip -Sx <path to FluentUI.Demo/FluentUI.Demo>`
             e. Create a new row in the initial table, titled "stripped FluentUI.Demo/FluentUI.Demo",
                and paste this value into the "Before" column.
             f. Repeat steps a-e for the after build.
             g. Calculate the difference between the before and after builds, and put them in the "Delta" column.
--->
Total increase: 7,216 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 33,678,952 bytes | 33,686,168 bytes | ⚠️ 7,216 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| DrawerController.o | 523,616 bytes | 529,160 bytes | ⚠️ 5,544 bytes |
| __.SYMDEF | 5,281,024 bytes | 5,282,152 bytes | ⚠️ 1,128 bytes |
| BadgeLabelButton.o | 864,544 bytes | 865,056 bytes | ⚠️ 512 bytes |
| PopupMenuController.o | 366,840 bytes | 366,872 bytes | ⚠️ 32 bytes |
### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| 'crash' | ![drawer-fix](https://user-images.githubusercontent.com/106181067/223894583-c0eac0e1-9893-42db-b301-b6d9c76aada4.gif) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1636)