### PR TITLE
Allow Tooltip to take host view parameter

### DIFF
--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -57,13 +57,13 @@ open class Tooltip: NSObject, TokenizedControlInternal {
                                                       tokenSet: tokenSet)
         self.anchorView = anchorView
         guard let tooltipViewController = tooltipViewController,
-              let tooltipView = tooltipViewController.view else {
+              let tooltipView = tooltipViewController.view,
+              let hostVC = hostViewController ?? window.rootViewController else {
             return
         }
 
-        let hostVC = hostViewController ?? window.rootViewController
-        let hostView = hostVC?.view
-        hostVC?.addChild(tooltipViewController)
+        let hostView = hostVC.view
+        hostVC.addChild(tooltipViewController)
         self.onTap = onTap
         self.dismissMode = UIAccessibility.isVoiceOverRunning ? .tapOnTooltip : dismissMode
         let gestureView = TouchForwardingView(frame: window.bounds)

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -62,7 +62,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
             return
         }
 
-        let hostView = hostVC.view
+        let hostView: UIView! = hostVC.view
         hostVC.addChild(tooltipViewController)
         self.onTap = onTap
         self.dismissMode = UIAccessibility.isVoiceOverRunning ? .tapOnTooltip : dismissMode
@@ -70,8 +70,8 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         self.gestureView = gestureView
         switch self.dismissMode {
         case .tapAnywhere:
-            hostView?.addSubview(tooltipView)
-            hostView?.addSubview(gestureView)
+            hostView.addSubview(tooltipView)
+            hostView.addSubview(gestureView)
             gestureView.onTouches = { [weak self] _ in
                 guard let strongSelf = self else {
                     return
@@ -79,8 +79,8 @@ open class Tooltip: NSObject, TokenizedControlInternal {
                 strongSelf.handleTapGesture()
             }
         case .tapOnTooltip, .tapOnTooltipOrAnchor:
-            hostView?.addSubview(gestureView)
-            hostView?.addSubview(tooltipView)
+            hostView.addSubview(gestureView)
+            hostView.addSubview(tooltipView)
             gestureView.forwardsTouches = false
             tooltipView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGesture)))
             if self.dismissMode == .tapOnTooltipOrAnchor {

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -27,6 +27,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
     ///   - message: The text to be displayed on the new tooltip view.
     ///   - title: The optional bolded text to be displayed above the message on the new tooltip view.
     ///   - anchorView: The view to point to with the new tooltip's arrow.
+    ///   - hostViewController: The view controller that should host the Tooltip. If not set, the default is the window's root view controller.
     ///   - preferredArrowDirection: The preferrred direction for the tooltip's arrow. Only the arrow's axis is guaranteed; the direction may be changed based on available space between the anchorView and the screen's margins. Defaults to down.
     ///   - offset: An offset from the tooltip's default position.
     ///   - dismissMode: The mode of tooltip dismissal. Defaults to tapping anywhere.
@@ -34,6 +35,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
     @objc public func show(with message: String,
                            title: String?,
                            for anchorView: UIView,
+                           with hostViewController: UIViewController? = nil,
                            preferredArrowDirection: ArrowDirection = .down,
                            offset: CGPoint = CGPoint(x: 0, y: 0),
                            dismissOn dismissMode: DismissMode = .tapAnywhere,
@@ -45,6 +47,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         }
 
         tooltipViewController = TooltipViewController(anchorView: anchorView,
+                                                      hostViewController: hostViewController,
                                                       message: message,
                                                       title: title,
                                                       textAlignment: textAlignment,
@@ -58,17 +61,17 @@ open class Tooltip: NSObject, TokenizedControlInternal {
             return
         }
 
-        let rootViewController = window.rootViewController
-        let rootView = rootViewController?.view
-        rootViewController?.addChild(tooltipViewController)
+        let hostVC = hostViewController ?? window.rootViewController
+        let hostView = hostVC?.view
+        hostVC?.addChild(tooltipViewController)
         self.onTap = onTap
         self.dismissMode = UIAccessibility.isVoiceOverRunning ? .tapOnTooltip : dismissMode
         let gestureView = TouchForwardingView(frame: window.bounds)
         self.gestureView = gestureView
         switch self.dismissMode {
         case .tapAnywhere:
-            rootView?.addSubview(tooltipView)
-            rootView?.addSubview(gestureView)
+            hostView?.addSubview(tooltipView)
+            hostView?.addSubview(gestureView)
             gestureView.onTouches = { [weak self] _ in
                 guard let strongSelf = self else {
                     return
@@ -76,8 +79,8 @@ open class Tooltip: NSObject, TokenizedControlInternal {
                 strongSelf.handleTapGesture()
             }
         case .tapOnTooltip, .tapOnTooltipOrAnchor:
-            rootView?.addSubview(gestureView)
-            rootView?.addSubview(tooltipView)
+            hostView?.addSubview(gestureView)
+            hostView?.addSubview(tooltipView)
             gestureView.forwardsTouches = false
             tooltipView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTapGesture)))
             if self.dismissMode == .tapOnTooltipOrAnchor {
@@ -91,7 +94,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
             }
         }
 
-        tooltipViewController.didMove(toParent: rootViewController)
+        tooltipViewController.didMove(toParent: hostViewController)
 
         // Animate tooltip
         tooltipView.alpha = 0.0

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -58,11 +58,11 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         self.anchorView = anchorView
         guard let tooltipViewController = tooltipViewController,
               let tooltipView = tooltipViewController.view,
-              let hostVC = hostViewController ?? window.rootViewController else {
+              let hostVC = hostViewController ?? window.rootViewController,
+              let hostView = hostVC.view else {
             return
         }
 
-        let hostView: UIView! = hostVC.view
         hostVC.addChild(tooltipViewController)
         self.onTap = onTap
         self.dismissMode = UIAccessibility.isVoiceOverRunning ? .tapOnTooltip : dismissMode

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -112,6 +112,34 @@ open class Tooltip: NSObject, TokenizedControlInternal {
     ///
     /// - Parameters:
     ///   - message: The text to be displayed on the new tooltip view.
+    ///   - title: The optional bolded text to be displayed above the message on the new tooltip view.
+    ///   - anchorView: The view to point to with the new tooltip's arrow.
+    ///   - preferredArrowDirection: The preferrred direction for the tooltip's arrow. Only the arrow's axis is guaranteed; the direction may be changed based on available space between the anchorView and the screen's margins. Defaults to down.
+    ///   - offset: An offset from the tooltip's default position.
+    ///   - dismissMode: The mode of tooltip dismissal. Defaults to tapping anywhere.
+    ///   - onTap: An optional closure used to do work after the user taps
+    @objc public func show(with message: String,
+                           title: String?,
+                           for anchorView: UIView,
+                           preferredArrowDirection: ArrowDirection = .down,
+                           offset: CGPoint = CGPoint(x: 0, y: 0),
+                           dismissOn dismissMode: DismissMode = .tapAnywhere,
+                           onTap: (() -> Void)? = nil) {
+        show(with: message,
+             title: title,
+             for: anchorView,
+             with: nil,
+             preferredArrowDirection: preferredArrowDirection,
+             offset: offset,
+             dismissOn: dismissMode,
+             onTap: onTap)
+    }
+
+    /// Displays a tooltip based on the current settings, pointing to the supplied anchorView.
+    /// If another tooltip view is already showing, it will be dismissed and the new tooltip will be shown.
+    ///
+    /// - Parameters:
+    ///   - message: The text to be displayed on the new tooltip view.
     ///   - anchorView: The view to point to with the new tooltip's arrow.
     ///   - preferredArrowDirection: The preferrred direction for the tooltip's arrow. Only the arrow's axis is guaranteed; the direction may be changed based on available space between the anchorView and the screen's margins. Defaults to down.
     ///   - offset: An offset from the tooltip's default position.
@@ -126,6 +154,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
         show(with: message,
              title: nil,
              for: anchorView,
+             with: nil,
              preferredArrowDirection: preferredArrowDirection,
              offset: offset,
              dismissOn: dismissMode,

--- a/ios/FluentUI/Tooltip/TooltipView.swift
+++ b/ios/FluentUI/Tooltip/TooltipView.swift
@@ -9,6 +9,7 @@ import UIKit
 class TooltipView: UIView, Shadowable {
 
     init(anchorView: UIView,
+         hostViewController: UIViewController?,
          message: String,
          title: String? = nil,
          textAlignment: NSTextAlignment,
@@ -17,6 +18,7 @@ class TooltipView: UIView, Shadowable {
          arrowMargin: CGFloat,
          tokenSet: TooltipTokenSet) {
         self.anchorView = anchorView
+        self.hostViewController = hostViewController
         self.message = message
         self.titleMessage = title
         self.preferredArrowDirection = preferredArrowDirection
@@ -312,10 +314,10 @@ class TooltipView: UIView, Shadowable {
         var idealPosition: CGFloat
         var maxPosition: CGFloat
         if arrowDirection.isVertical {
-            idealPosition = sourcePointInWindow.x - tooltipRect.minX - arrowWidth / 2
+            idealPosition = sourcePointInHost.x - tooltipRect.minX - arrowWidth / 2
             maxPosition = tooltipRect.width - arrowMargin - arrowWidth
         } else {
-            idealPosition = sourcePointInWindow.y - tooltipRect.minY - arrowWidth / 2
+            idealPosition = sourcePointInHost.y - tooltipRect.minY - arrowWidth / 2
             maxPosition = tooltipRect.height - arrowMargin - arrowWidth
         }
         return max(minPosition, min(idealPosition, maxPosition))
@@ -324,13 +326,13 @@ class TooltipView: UIView, Shadowable {
     private var idealTooltipOrigin: CGPoint {
         switch arrowDirection {
         case .up:
-            return CGPoint(x: sourcePointInWindow.x - tooltipSize.width / 2, y: sourcePointInWindow.y)
+            return CGPoint(x: sourcePointInHost.x - tooltipSize.width / 2, y: sourcePointInHost.y)
         case .down:
-            return CGPoint(x: sourcePointInWindow.x - tooltipSize.width / 2, y: sourcePointInWindow.y - tooltipSize.height)
+            return CGPoint(x: sourcePointInHost.x - tooltipSize.width / 2, y: sourcePointInHost.y - tooltipSize.height)
         case .left:
-            return CGPoint(x: sourcePointInWindow.x, y: sourcePointInWindow.y - tooltipSize.height / 2)
+            return CGPoint(x: sourcePointInHost.x, y: sourcePointInHost.y - tooltipSize.height / 2)
         case .right:
-            return CGPoint(x: sourcePointInWindow.x - tooltipSize.width, y: sourcePointInWindow.y - tooltipSize.height / 2)
+            return CGPoint(x: sourcePointInHost.x - tooltipSize.width, y: sourcePointInHost.y - tooltipSize.height / 2)
         }
     }
 
@@ -352,13 +354,13 @@ class TooltipView: UIView, Shadowable {
         }
     }
 
-    private var sourcePointInWindow: CGPoint {
+    private var sourcePointInHost: CGPoint {
         guard let anchorView = anchorView else {
             assertionFailure("Can't find anchorView")
             return CGPoint.zero
         }
 
-        return anchorView.convert(sourcePointInAnchorView, to: window)
+        return anchorView.convert(sourcePointInAnchorView, to: hostViewController?.view ?? window)
     }
 
     private var boundingRect: CGRect {
@@ -381,7 +383,7 @@ class TooltipView: UIView, Shadowable {
             return inset
         }
 
-        let anchorViewFrame = anchorView.convert(anchorView.bounds, to: window)
+        let anchorViewFrame = anchorView.convert(anchorView.bounds, to: hostViewController?.view ?? window)
         switch arrowDirection {
         case .up:
             inset.top = max(anchorViewFrame.maxY - boundingRect.minY, 0)
@@ -396,6 +398,7 @@ class TooltipView: UIView, Shadowable {
     }
 
     private weak var anchorView: UIView?
+    private weak var hostViewController: UIViewController?
     private let message: String
     private let titleMessage: String?
     private let arrowImageView: UIImageView

--- a/ios/FluentUI/Tooltip/TooltipViewController.swift
+++ b/ios/FluentUI/Tooltip/TooltipViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 class TooltipViewController: UIViewController {
 
     init(anchorView: UIView,
+         hostViewController: UIViewController?,
          message: String,
          title: String? = nil,
          textAlignment: NSTextAlignment,
@@ -17,6 +18,7 @@ class TooltipViewController: UIViewController {
          arrowMargin: CGFloat,
          tokenSet: TooltipTokenSet) {
         tooltipView = TooltipView(anchorView: anchorView,
+                                  hostViewController: hostViewController,
                                   message: message,
                                   title: title,
                                   textAlignment: textAlignment,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
Currently, we assume that Tooltip will only be a child/subview of the root view controller, however, there are actually instances in which it isn't. For example, if the anchor view for the Tooltip is within a modally presented view controller, the Tooltip will be presented below the intended view controller. Let's allow consumers to pass in their own host view controllers to avoid this.

Binary change:
Total increase: 4,856 bytes
Total decrease: -2,544 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,894,944 bytes | 29,897,256 bytes | ⚠️ 2,312 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 4,619,016 bytes | 4,621,752 bytes | ⚠️ 2,736 bytes |
| Tooltip.o | 141,488 bytes | 143,264 bytes | ⚠️ 1,776 bytes |
| TooltipViewController.o | 47,480 bytes | 47,824 bytes | ⚠️ 344 bytes |
| TooltipView.o | 212,792 bytes | 210,248 bytes | 🎉 -2,544 bytes |
</details>

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-08 at 23 46 47](https://user-images.githubusercontent.com/31874971/223964962-b961ef7c-6b0e-4473-81a1-99a2aa1770eb.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-09 at 00 28 35](https://user-images.githubusercontent.com/31874971/223964976-3a9c569f-232d-4920-87ee-13ed521f72e2.png) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1637)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1637)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1637)