### PR TITLE
Realign Drawer to fluent 2 design 

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -589,6 +589,9 @@ extension DrawerDemoController: DemoAppearanceDelegate {
         return [
             .drawerContentBackground: .dynamicColor { DynamicColor(light: GlobalTokens.sharedColors(.forest, .shade40),
                                                                    dark: GlobalTokens.sharedColors(.forest, .tint60))
+            },
+            .shadow: .shadowInfo {
+                self.view.fluentTheme.aliasTokens.shadow[.shadow02]
             }
         ]
     }

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -88,7 +88,7 @@ public extension ShadowInfo {
         view.layer.insertSublayer(keyShadow, below: ambientShadow)
     }
 
-    private func initializeShadowLayer(view: UIView, isAmbientShadow: Bool = false) -> CALayer {
+    func initializeShadowLayer(view: UIView, isAmbientShadow: Bool = false) -> CALayer {
         let layer = CALayer()
 
         layer.frame = view.bounds

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -99,14 +99,12 @@ public protocol DrawerControllerDelegate: AnyObject {
 
 @objc(MSFDrawerController)
 open class DrawerController: UIViewController, TokenizedControlInternal {
-    @objc public static func drawerBackground(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light,
-                                                  dark: fluentTheme.aliasTokens.colors[.background2].dark))
+    /// DrawerController colors with obj-c support
+    @objc public static var drawerBackgroundColor: UIColor {
+        UIColor(dynamicColor: DrawerTokenSet()[.drawerContentBackground].dynamicColor)
     }
-
-    @objc public static func popoverBackground(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background4].light,
-                                                  dark: fluentTheme.aliasTokens.colors[.background4].dark))
+    @objc public static var popoverBackgroundColor: UIColor {
+        UIColor(dynamicColor: DrawerTokenSet()[.popoverContentBackground].dynamicColor)
     }
 
     private struct Constants {

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -391,7 +391,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
 
     /// Shadow is required if background is transparent
     var shadowOffset: CGFloat {
-        return presentationBackground == .none ? tokenSet[.shadowOffset].float : 0
+        return presentationBackground == .none ? DrawerTokenSet.shadowOffset : 0
     }
 
     private let sourceView: UIView?

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -451,7 +451,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
               return
         }
         tokenSet.update(fluentTheme)
-        updateAppearance()
+        updateBackgroundColor()
     }
 
     /**
@@ -486,7 +486,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         tokenSetSink = tokenSet.objectWillChange.sink { [weak self] _ in
             // Values will be updated on the next run loop iteration.
             DispatchQueue.main.async {
-                self?.updateAppearance()
+                self?.updateBackgroundColor()
             }
         }
     }
@@ -545,7 +545,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         updateResizingHandleView()
         resizingGestureRecognizer?.isEnabled = false
 
-        updateAppearance()
+        updateBackgroundColor()
     }
 
     open override func viewDidAppear(_ animated: Bool) {
@@ -795,15 +795,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
             resizingHandleView?.accessibilityLabel = "Accessibility.Drawer.ResizingHandle.Label.Expand".localized
             resizingHandleView?.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
         }
-    }
-
-    private func updateAppearance() {
-        updateBackgroundColor()
-
-        guard let presentationController = (presentationController as? DrawerPresentationController) else {
-            return
-        }
-        presentationController.updateApperance()
     }
 
     private func offset(forResizingGesture gesture: UIPanGestureRecognizer) -> CGFloat {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -83,7 +83,7 @@ class DrawerPresentationController: UIPresentationController {
     // Shadow behind presented view (cannot be done on presented view itself because it's masked)
     private lazy var shadowView: DrawerShadowView = {
         // Uses function initializer to workaround a Swift compiler bug in Xcode 10.1
-        return DrawerShadowView(shadowDirection: actualPresentationOffset == 0 ? presentationDirection : nil, tokenSet: drawerTokenSet)
+        return DrawerShadowView(tokenSet: drawerTokenSet)
     }()
     // Imitates the bottom shadow of navigation bar or top shadow of toolbar because original ones are hidden by presented view
     private lazy var separator = Separator()

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -120,7 +120,6 @@ class DrawerPresentationController: UIPresentationController {
             contentView.addSubview(presentedViewController.view)
         }
         setPresentedViewMask()
-        updateApperance()
 
         backgroundView.alpha = 0.0
         presentingViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
@@ -286,12 +285,6 @@ class DrawerPresentationController: UIPresentationController {
             setContentViewFrame(newFrame)
             isUpdatingContentViewFrame = false
         }
-    }
-
-    func updateApperance() {
-        shadowView.updateApperance()
-        dimmingView.dimmedBlackColor = UIColor(dynamicColor: drawerTokenSet[.backgroundDimmedColor].dynamicColor)
-        backgroundView.backgroundColor = dimmingView.dimmedClearColor
     }
 
     private func setContentViewFrame(_ frame: CGRect) {

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -432,18 +432,18 @@ class DrawerPresentationController: UIPresentationController {
         switch presentationDirection {
         case .down:
             margins.top = presentationOffsetMargin
-            margins.bottom = max(drawerTokenSet[.minVerticalMargin].float, containerView.safeAreaInsets.bottom)
+            margins.bottom = max(DrawerTokenSet.minVerticalMargin, containerView.safeAreaInsets.bottom)
         case .up:
-            margins.top = max(drawerTokenSet[.minVerticalMargin].float, containerView.safeAreaInsets.top)
+            margins.top = max(DrawerTokenSet.minVerticalMargin, containerView.safeAreaInsets.top)
             margins.bottom = presentationOffsetMargin
             if actualPresentationOffset == 0 && keyboardHeight > 0 {
                 margins.bottom += safeAreaPresentationOffset
             }
         case .fromLeading:
             margins.left = presentationOffsetMargin
-            margins.right = max(drawerTokenSet[.minHorizontalMargin].float, containerView.safeAreaInsets.right)
+            margins.right = max(DrawerTokenSet.minHorizontalMargin, containerView.safeAreaInsets.right)
         case .fromTrailing:
-            margins.left = max(drawerTokenSet[.minHorizontalMargin].float, containerView.safeAreaInsets.left)
+            margins.left = max(DrawerTokenSet.minHorizontalMargin, containerView.safeAreaInsets.left)
             margins.right = presentationOffsetMargin
         }
         return margins

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -83,7 +83,7 @@ class DrawerPresentationController: UIPresentationController {
     // Shadow behind presented view (cannot be done on presented view itself because it's masked)
     private lazy var shadowView: DrawerShadowView = {
         // Uses function initializer to workaround a Swift compiler bug in Xcode 10.1
-        return DrawerShadowView(tokenSet: drawerTokenSet)
+        return DrawerShadowView(shadowDirection: actualPresentationOffset == 0 ? presentationDirection : nil, tokenSet: drawerTokenSet)
     }()
     // Imitates the bottom shadow of navigation bar or top shadow of toolbar because original ones are hidden by presented view
     private lazy var separator = Separator()

--- a/ios/FluentUI/Drawer/DrawerShadowView.swift
+++ b/ios/FluentUI/Drawer/DrawerShadowView.swift
@@ -48,7 +48,6 @@ class DrawerShadowView: UIView, Shadowable {
         self.drawerTokenSet = tokenSet
         super.init(frame: .zero)
         updateShadow()
-        layer.cornerRadius = DrawerTokenSet.shadowOffset
         backgroundColor = .clear
         isAccessibilityElement = false
         isUserInteractionEnabled = false

--- a/ios/FluentUI/Drawer/DrawerShadowView.swift
+++ b/ios/FluentUI/Drawer/DrawerShadowView.swift
@@ -40,17 +40,17 @@ class DrawerShadowView: UIView, Shadowable {
         }
     }
 
-    private var shadowDirection: DrawerPresentationDirection?
-
     private var animationDuration: TimeInterval = 0
+
+    private var shadowDirection: DrawerPresentationDirection?
 
     private var drawerTokenSet: DrawerTokenSet
 
     init(shadowDirection: DrawerPresentationDirection?, tokenSet: DrawerTokenSet) {
         self.drawerTokenSet = tokenSet
         super.init(frame: .zero)
-        updateShadow()
-        backgroundColor = .clear
+        self.shadowDirection = shadowDirection
+        setupShadows()
         isAccessibilityElement = false
         isUserInteractionEnabled = false
     }
@@ -63,16 +63,16 @@ class DrawerShadowView: UIView, Shadowable {
         owner = nil
     }
 
-    private func updateShadow() {
+    private func setupShadows() {
         let shadowInfo = drawerTokenSet[.shadow].shadowInfo
         ambientShadow = shadowInfo.initializeShadowLayer(view: self, isAmbientShadow: true)
         keyShadow = shadowInfo.initializeShadowLayer(view: self, isAmbientShadow: false)
 
-        guard let ambientShadow = ambientShadow, let keyShadow = keyShadow else {
+        guard let direction = shadowDirection, let ambientShadow = ambientShadow, let keyShadow = keyShadow else {
             return
         }
 
-        if let direction = shadowDirection, direction.isHorizontal {
+        if direction.isHorizontal {
             layer.insertSublayer(ambientShadow, at: 0)
             layer.insertSublayer(keyShadow, below: ambientShadow)
         } else {

--- a/ios/FluentUI/Drawer/DrawerShadowView.swift
+++ b/ios/FluentUI/Drawer/DrawerShadowView.swift
@@ -40,11 +40,13 @@ class DrawerShadowView: UIView, Shadowable {
         }
     }
 
+    private var shadowDirection: DrawerPresentationDirection?
+
     private var animationDuration: TimeInterval = 0
 
     private var drawerTokenSet: DrawerTokenSet
 
-    init(tokenSet: DrawerTokenSet) {
+    init(shadowDirection: DrawerPresentationDirection?, tokenSet: DrawerTokenSet) {
         self.drawerTokenSet = tokenSet
         super.init(frame: .zero)
         updateShadow()
@@ -63,7 +65,19 @@ class DrawerShadowView: UIView, Shadowable {
 
     private func updateShadow() {
         let shadowInfo = drawerTokenSet[.shadow].shadowInfo
-        shadowInfo.applyShadow(to: self)
+        ambientShadow = shadowInfo.initializeShadowLayer(view: self, isAmbientShadow: true)
+        keyShadow = shadowInfo.initializeShadowLayer(view: self, isAmbientShadow: false)
+
+        guard let ambientShadow = ambientShadow, let keyShadow = keyShadow else {
+            return
+        }
+
+        if let direction = shadowDirection, direction.isHorizontal {
+            layer.insertSublayer(ambientShadow, at: 0)
+            layer.insertSublayer(keyShadow, below: ambientShadow)
+        } else {
+            layer.insertSublayer(ambientShadow, at: 0)
+        }
     }
 
     override func didMoveToSuperview() {

--- a/ios/FluentUI/Drawer/DrawerShadowView.swift
+++ b/ios/FluentUI/Drawer/DrawerShadowView.swift
@@ -120,9 +120,9 @@ class DrawerShadowView: UIView {
         if let shadowDirection = shadowDirection {
             switch shadowDirection {
             case .down:
-                offset.height = drawerTokenSet[.shadowOffset].float
+                offset.height = DrawerTokenSet.shadowOffset
             case .up:
-                offset.height = -drawerTokenSet[.shadowOffset].float
+                offset.height = -DrawerTokenSet.shadowOffset
             case .fromLeading:
                 let shadowInfo = drawerTokenSet[.shadow].shadowInfo
                 offset.width = isFirst ? shadowInfo.xKey : shadowInfo.xAmbient

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -29,16 +29,7 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
             switch token {
             case .shadow:
                 return .shadowInfo({
-                    ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0, g: 0, b: 0, a: 0.03),
-                                                      dark: ColorValue(r: 0, g: 0, b: 0, a: 0.07)),
-                               keyBlur: 14,
-                               xKey: 0,
-                               yKey: 14,
-                               ambientColor: DynamicColor(light: ColorValue(r: 0, g: 0, b: 0, a: 0.33),
-                                                          dark: ColorValue(r: 0, g: 0, b: 0, a: 0.66)),
-                               ambientBlur: 4,
-                               xAmbient: 0,
-                               yAmbient: 0)
+                    theme.aliasTokens.shadow[.shadow28]
                 })
 
             case .drawerContentBackground:

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -11,9 +11,6 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
         /// `ShadowInfo` for the shadow used in the `Drawer` control.
         case shadow
 
-        /// Color used when dimming the background while showing the `Drawer` control.
-        case backgroundDimmedColor
-
         /// Color used for the background of the content of the `Drawer` control.
         case drawerContentBackground
 
@@ -51,12 +48,6 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
                                ambientBlur: 4,
                                xAmbient: 0,
                                yAmbient: 0)
-                })
-
-            case .backgroundDimmedColor:
-                return .dynamicColor({
-                    DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.66),
-                                 dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.99))
                 })
 
             case .drawerContentBackground:

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -28,7 +28,9 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
         super.init { token, theme in
             switch token {
             case .cornerRadius:
-                return .float({ 14 })
+                return .float({
+                    GlobalTokens.corner(.radius120)
+                })
 
             case .drawerContentBackground:
                 return .dynamicColor({

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -8,34 +8,37 @@ import UIKit
 /// Design token set for the `Drawer` control
 public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
-        /// `ShadowInfo` for the shadow used in the `Drawer` control.
-        case shadow
+        /// Corner radius for the popover style `Drawer` control.
+        case cornerRadius
 
         /// Color used for the background of the content of the `Drawer` control.
         case drawerContentBackground
 
-        /// Color used for the background of the popover style `Drawer` control.
-        case popoverContentBackground
-
         /// Color used for the navigation bar of the `Drawer` control.
         case navigationBarBackground
 
-        /// Corner radius for the popover style `Drawer` control.
-        case cornerRadius
+        /// Color used for the background of the popover style `Drawer` control.
+        case popoverContentBackground
+
+        /// `ShadowInfo` for the shadow used in the `Drawer` control.
+        case shadow
     }
 
     init() {
         super.init { token, theme in
             switch token {
-            case .shadow:
-                return .shadowInfo({
-                    theme.aliasTokens.shadow[.shadow28]
-                })
+            case .cornerRadius:
+                return .float({ 14 })
 
             case .drawerContentBackground:
                 return .dynamicColor({
                     DynamicColor(light: theme.aliasTokens.colors[.background2].light,
                                  dark: theme.aliasTokens.colors[.background2].dark)
+                })
+
+            case .navigationBarBackground:
+                return .dynamicColor({
+                    theme.aliasTokens.colors[.background3]
                 })
 
             case .popoverContentBackground:
@@ -44,14 +47,10 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
                                  dark: theme.aliasTokens.colors[.background4].dark)
                 })
 
-            case .navigationBarBackground:
-                return .dynamicColor({
-                    theme.aliasTokens.colors[.background3]
+            case .shadow:
+                return .shadowInfo({
+                    theme.aliasTokens.shadow[.shadow28]
                 })
-
-            case .cornerRadius:
-                return .float({ 14 })
-
             }
         }
     }

--- a/ios/FluentUI/Drawer/DrawerTokenSet.swift
+++ b/ios/FluentUI/Drawer/DrawerTokenSet.swift
@@ -22,15 +22,6 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
 
         /// Corner radius for the popover style `Drawer` control.
         case cornerRadius
-
-        /// Minimum horizontal margin for the `Drawer` control.
-        case minHorizontalMargin
-
-        /// Minimum vertical margin for the `Drawer` control.
-        case minVerticalMargin
-
-        /// Offset of the shadow for the `Drawer` control.
-        case shadowOffset
     }
 
     init() {
@@ -70,15 +61,18 @@ public class DrawerTokenSet: ControlTokenSet<DrawerTokenSet.Tokens> {
             case .cornerRadius:
                 return .float({ 14 })
 
-            case .minHorizontalMargin:
-                return .float({ GlobalTokens.spacing(.size480) })
-
-            case .minVerticalMargin:
-                return .float({ GlobalTokens.spacing(.size200) })
-
-            case .shadowOffset:
-                return .float({ GlobalTokens.spacing(.size80) })
             }
         }
     }
+}
+
+extension DrawerTokenSet {
+    /// Minimum horizontal margin for the `Drawer` control.
+    static let minHorizontalMargin: CGFloat = GlobalTokens.spacing(.size480)
+
+    /// Minimum vertical margin for the `Drawer` control.
+    static let minVerticalMargin: CGFloat = GlobalTokens.spacing(.size200)
+
+    /// Offset of the shadow for the `Drawer` control.
+    static let shadowOffset: CGFloat = GlobalTokens.spacing(.size80)
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Tokenized drawer on the tokens branch needed to be realigned to match design and better fit our fluent 2 tokenization philosophy.
- Padding and shadow offset tokens have been moved to a DrawerTokenSet extension to make them not overridable.
- The objc colors now pull the colors from the DrawerTokenSet instead of accessing the tokens from a passed in FluentTheme
- DrawerShadowView now conforms to Shadowable to use the fluent 2 shadows API. Unused functions animate(withDuration duration:, animations:) and shadowOffset(for shadowDirection:, isFirst:) have been removed.
- ShadowInfo's initializeShadowLayer function has been changed to public since it's now used in DrawerShadowView

Note on DrawerShadowView

The way shadows are applied on the drawer is quite messy and presents a few issues. 
- DrawerShadowView gets an owner view from DrawerPresentationController and observes its bounds and frame. Every time either changes, DrawerShadowView updates its frame and redraws the shadow paths. Therefore, the updateFrame function gets called many many times whenever we open or close a drawer. 
- Also, for some obscure reason, applying the keyShadow to a vertical drawer seems to get clipped and makes the drawer look as if its shadow doesn't have rounded corners. I couldn't find a quick workaround so I left the shadow logic as is meaning horizontal drawer gets both key and ambient shadows whereas vertical drawer gets only the ambient shadow applied.
<img width="489" alt="Screenshot 2023-03-10 at 1 08 08 AM" src="https://user-images.githubusercontent.com/106181067/224273516-607d7efc-baa7-4d3b-abb2-9f53e88c32f9.png">

Dealing with these DrawerShadowView issues is a bit out of scope for this tokens -> main merge but I think we should be addressing them as soon as we can after the merge. A more efficient way to apply shadows would be to do what BottomSheet does and embed the drawer's content on a shadow view. This would remove the need for having observers for frame changes, allow us to have both key and ambient shadows on vertical drawer and also get rid of DrawerShadowView which could save us some binary size.

### Binary change

Total increase: 48 bytes
Total decrease: -38,016 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 33,687,560 bytes | 33,649,592 bytes | 🎉 -37,968 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BadgeLabelButton.o | 865,056 bytes | 865,104 bytes | ⚠️ 48 bytes |
| PopupMenuController.o | 366,872 bytes | 366,832 bytes | 🎉 -40 bytes |
| ShadowInfo.o | 54,704 bytes | 54,216 bytes | 🎉 -488 bytes |
| DrawerController.o | 530,552 bytes | 528,048 bytes | 🎉 -2,504 bytes |
| DrawerTokenSet.o | 59,208 bytes | 53,456 bytes | 🎉 -5,752 bytes |
| __.SYMDEF | 5,282,152 bytes | 5,275,384 bytes | 🎉 -6,768 bytes |
| DrawerShadowView.o | 88,664 bytes | 78,152 bytes | 🎉 -10,512 bytes |
| DrawerPresentationController.o | 275,040 bytes | 263,088 bytes | 🎉 -11,952 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="489" alt="before_bot" src="https://user-images.githubusercontent.com/106181067/224271213-af822860-97e4-4021-946f-1f98540885e3.png"> | <img width="489" alt="after_bot" src="https://user-images.githubusercontent.com/106181067/224271244-09248e99-b269-4416-a0a8-4256c648a9a8.png"> |
| <img width="489" alt="before_bot_clear" src="https://user-images.githubusercontent.com/106181067/224271311-be455a11-229f-467c-bff3-2056b6e56fe7.png"> | <img width="489" alt="after_bot_clear" src="https://user-images.githubusercontent.com/106181067/224271341-80af0aa0-d6aa-4b05-aef0-e6aabea30049.png"> |
| <img width="489" alt="before_bot_clear_dark" src="https://user-images.githubusercontent.com/106181067/224271445-d6606414-6e1b-49bd-bc58-02993babc1f5.png"> | <img width="489" alt="after_bot_clear_dark" src="https://user-images.githubusercontent.com/106181067/224271483-a98b23dc-8a36-487f-959c-37d2e0a55b5d.png"> |
| <img width="489" alt="before_bot_dark" src="https://user-images.githubusercontent.com/106181067/224271537-72c43892-dd31-4b24-b912-9af0558bc09d.png"> | <img width="489" alt="after_bot_dark" src="https://user-images.githubusercontent.com/106181067/224271563-99dda0c1-ccb3-433d-be66-84a896851525.png"> |
| <img width="489" alt="before_left" src="https://user-images.githubusercontent.com/106181067/224271636-19fc97c8-e1d3-42f2-95d7-cd78ff70a977.png"> | <img width="489" alt="after_left" src="https://user-images.githubusercontent.com/106181067/224271661-bd76349f-b041-4870-8fab-9678c4e05d2e.png"> |
| <img width="489" alt="before_left_dark" src="https://user-images.githubusercontent.com/106181067/224271710-cbd96f57-4f1e-4c62-946d-7de143149829.png"> | <img width="489" alt="after_left_dark" src="https://user-images.githubusercontent.com/106181067/224271727-856166ef-748f-42e2-a50f-fc8716894a6b.png"> |
| <img width="489" alt="before_right" src="https://user-images.githubusercontent.com/106181067/224271812-f6bde45b-76bb-48ac-b847-bc7fc8d4ecda.png"> | <img width="489" alt="after_right" src="https://user-images.githubusercontent.com/106181067/224271838-672a804a-35f9-4698-8e89-f4cd784296b2.png"> |
| <img width="489" alt="before_right_dark" src="https://user-images.githubusercontent.com/106181067/224271900-45ec3060-def0-4064-a3d6-70f3d2076de5.png"> | <img width="489" alt="after_right_dark" src="https://user-images.githubusercontent.com/106181067/224271945-86f1a5e3-9490-4611-b9a9-c0c778db8ca5.png"> |
| <img width="489" alt="before_top" src="https://user-images.githubusercontent.com/106181067/224272009-0d622104-5ac9-4867-8b47-d18484d202b5.png"> | <img width="489" alt="after_top" src="https://user-images.githubusercontent.com/106181067/224272072-b63b5e09-5c6d-4e65-8627-5d8a39c421cc.png"> |
| <img width="489" alt="before_top_clear" src="https://user-images.githubusercontent.com/106181067/224272151-20e726ad-18a0-47fb-8d9e-fca8a78ba394.png"> | <img width="489" alt="after_top_clear" src="https://user-images.githubusercontent.com/106181067/224272185-194568cd-566e-46c4-9d38-b0fb5c060313.png"> |
| <img width="489" alt="before_top_clear_dark" src="https://user-images.githubusercontent.com/106181067/224272261-30df42de-20b3-451d-abae-c67f5b9e2ac0.png"> | <img width="489" alt="after_top_clear_dark" src="https://user-images.githubusercontent.com/106181067/224272309-73949aef-58b2-473f-b35e-2cde31e497d6.png"> |
| <img width="489" alt="before_top_dark" src="https://user-images.githubusercontent.com/106181067/224272377-32712817-dc76-401d-b670-e06fb7832e84.png"> | <img width="489" alt="after_top_dark" src="https://user-images.githubusercontent.com/106181067/224272399-6662c8cf-8292-47ea-8590-33ba66ec38dc.png"> |
| ![before_anim](https://user-images.githubusercontent.com/106181067/224272942-3c993b67-20b3-4964-8dc4-219a05f145e1.gif) | ![after_anim](https://user-images.githubusercontent.com/106181067/224272985-1675195c-8281-4581-bb4a-d1e157dee434.gif) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1640)