### PR TITLE
New FluentTheme APIs for fetching alias tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -30,8 +30,7 @@
     self.container = [self createVerticalContainer];
     self.scrollingContainer = [[UIScrollView alloc] initWithFrame:CGRectZero];
 
-    MSFAliasTokens *aliasTokens = [[[self view] fluentTheme] aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBackground1];
+    MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorAliasTokensBackground1];
     self.view.backgroundColor = [[UIColor alloc] initWithDynamicColor:primaryColor];
     [self setupTitleView];
 
@@ -93,8 +92,7 @@
 
     // Add alias-colored label too
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
-    MSFAliasTokens *aliasTokens = [fluentTheme aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandBackground3];
+    MSFDynamicColor *primaryColor = [fluentTheme colorForToken:MSFColorAliasTokensBrandBackground3];
     [self addLabelWithText:@"Test label with alias color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }
@@ -102,16 +100,14 @@
 - (void)overridesButtonPressed:(id)sender {
     [[self view] setColorProvider:[[ObjectiveCDemoColorProviding alloc] init]];
 
-    MSFAliasTokens *aliasTokens = [[[self view] fluentTheme] aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
+    MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorAliasTokensBrandForeground1];
 
     [self addLabelWithText:@"Test label with override brand color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     // Remove the overrides
     [[self view] resetFluentTheme];
-    aliasTokens = [[[self view] fluentTheme] aliasTokens];
-    primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBrandForeground1];
+    primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorAliasTokensBrandForeground1];
 
     [self addLabelWithText:@"Test label with override color removed"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -30,7 +30,7 @@
     self.container = [self createVerticalContainer];
     self.scrollingContainer = [[UIScrollView alloc] initWithFrame:CGRectZero];
 
-    MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorAliasTokensBackground1];
+    MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorTokenBackground1];
     self.view.backgroundColor = [[UIColor alloc] initWithDynamicColor:primaryColor];
     [self setupTitleView];
 
@@ -92,7 +92,7 @@
 
     // Add alias-colored label too
     MSFFluentTheme *fluentTheme = [[self view] fluentTheme];
-    MSFDynamicColor *primaryColor = [fluentTheme colorForToken:MSFColorAliasTokensBrandBackground3];
+    MSFDynamicColor *primaryColor = [fluentTheme colorForToken:MSFColorTokenBrandBackground3];
     [self addLabelWithText:@"Test label with alias color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 }
@@ -100,14 +100,14 @@
 - (void)overridesButtonPressed:(id)sender {
     [[self view] setColorProvider:[[ObjectiveCDemoColorProviding alloc] init]];
 
-    MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorAliasTokensBrandForeground1];
+    MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorTokenBrandForeground1];
 
     [self addLabelWithText:@"Test label with override brand color"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     // Remove the overrides
     [[self view] resetFluentTheme];
-    primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorAliasTokensBrandForeground1];
+    primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorTokenBrandForeground1];
 
     [self addLabelWithText:@"Test label with override color removed"
                  textColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		9231491428BF026A001B033E /* MSFHeadsUpDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532299FF27FE108400C016A2 /* MSFHeadsUpDisplay.swift */; };
 		9231491528BF026A001B033E /* HUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17227F77EB700B01E0D /* HUD.swift */; };
 		9231491628BF02B9001B033E /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC23020E451D00016922A /* Button.swift */; };
+		9231F10329BB99090079CD94 /* FluentTheme+Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9231F10229BB99090079CD94 /* FluentTheme+Tokens.swift */; };
 		923DB9D4274CB65700D8E58A /* TokenizedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923DB9D2274CB65700D8E58A /* TokenizedControl.swift */; };
 		923DB9D5274CB65700D8E58A /* FluentTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923DB9D3274CB65700D8E58A /* FluentTheme.swift */; };
 		923DB9D7274CB66D00D8E58A /* ControlHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923DB9D6274CB66D00D8E58A /* ControlHostingView.swift */; };
@@ -306,6 +307,7 @@
 		92088EF72666DB2C003F571A /* PersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButton.swift; sourceTree = "<group>"; };
 		920945472703DDA000B38E1A /* CardNudgeTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeTokenSet.swift; sourceTree = "<group>"; };
 		922A34DE27BB87990062721F /* TokenizedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizedControlView.swift; sourceTree = "<group>"; };
+		9231F10229BB99090079CD94 /* FluentTheme+Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FluentTheme+Tokens.swift"; sourceTree = "<group>"; };
 		923DB9D2274CB65700D8E58A /* TokenizedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenizedControl.swift; sourceTree = "<group>"; };
 		923DB9D3274CB65700D8E58A /* FluentTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentTheme.swift; sourceTree = "<group>"; };
 		923DB9D6274CB66D00D8E58A /* ControlHostingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlHostingView.swift; sourceTree = "<group>"; };
@@ -755,6 +757,7 @@
 			children = (
 				925D461A26FD126800179583 /* Tokens */,
 				923DB9D3274CB65700D8E58A /* FluentTheme.swift */,
+				9231F10229BB99090079CD94 /* FluentTheme+Tokens.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -1569,6 +1572,7 @@
 				5314E0A725F010070099271A /* DrawerController.swift in Sources */,
 				5314E07125F00F140099271A /* DatePickerSelectionManager.swift in Sources */,
 				5373D5672694D65C0032A3B4 /* Avatar.swift in Sources */,
+				9231F10329BB99090079CD94 /* FluentTheme+Tokens.swift in Sources */,
 				5314E1A425F01A7C0099271A /* CenteredLabelCell.swift in Sources */,
 				5314E1A125F01A7C0099271A /* TableViewCellFileAccessoryView.swift in Sources */,
 				5314E1D625F01E4A0099271A /* SearchBar.swift in Sources */,

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -82,29 +82,29 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .accent:
-                        return theme.aliasTokens.colors[.brandBackground1]
+                        return theme.color(.brandBackground1)
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .danger:
-                        return theme.aliasTokens.colors[.dangerBackground2]
+                        return theme.color(.dangerBackground2)
                     }
                 }
             case .backgroundFocusedColor:
                 return .dynamicColor {
                     switch style() {
                     case .accent:
-                        return theme.aliasTokens.colors[.brandBackground1Selected]
+                        return theme.color(.brandBackground1Selected)
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .danger:
-                        return theme.aliasTokens.colors[.dangerBackground2]
+                        return theme.color(.dangerBackground2)
                     }
                 }
             case .backgroundDisabledColor:
                 return .dynamicColor {
                     switch style() {
                     case .accent, .danger:
-                        return theme.aliasTokens.colors[.background5]
+                        return theme.color(.background5)
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     }
@@ -113,11 +113,11 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .accent:
-                        return theme.aliasTokens.colors[.brandBackground1Pressed]
+                        return theme.color(.brandBackground1Pressed)
                     case .outline, .subtle, .dangerOutline, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .danger:
-                        return theme.aliasTokens.colors[.dangerBackground2]
+                        return theme.color(.dangerBackground2)
                     }
                 }
             case .borderColor:
@@ -126,9 +126,9 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .accent, .subtle, .danger, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .outline:
-                        return theme.aliasTokens.colors[.brandStroke1]
+                        return theme.color(.brandStroke1)
                     case .dangerOutline:
-                        return theme.aliasTokens.colors[.dangerForeground2]
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .borderFocusedColor:
@@ -137,9 +137,9 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .accent, .subtle, .danger, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .outline:
-                        return theme.aliasTokens.colors[.strokeFocus2]
+                        return theme.color(.strokeFocus2)
                     case .dangerOutline:
-                        return theme.aliasTokens.colors[.dangerForeground2]
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .borderDisabledColor:
@@ -148,7 +148,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .accent, .subtle, .danger, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .outline, .dangerOutline:
-                        return theme.aliasTokens.colors[.strokeDisabled]
+                        return theme.color(.strokeDisabled)
                     }
                 }
             case .borderPressedColor:
@@ -157,9 +157,9 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     case .accent, .subtle, .danger, .dangerSubtle:
                         return DynamicColor(light: ColorValue.clear)
                     case .outline:
-                        return theme.aliasTokens.colors[.brandStroke1Pressed]
+                        return theme.color(.brandStroke1Pressed)
                     case .dangerOutline:
-                        return theme.aliasTokens.colors[.dangerForeground2]
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .borderWidth:
@@ -184,37 +184,37 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .accent:
-                        return theme.aliasTokens.colors[.foregroundOnColor]
+                        return theme.color(.foregroundOnColor)
                     case .outline, .subtle:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .danger:
-                        return theme.aliasTokens.colors[.foregroundLightStatic]
+                        return theme.color(.foregroundLightStatic)
                     case .dangerOutline, .dangerSubtle:
-                        return theme.aliasTokens.colors[.dangerForeground2]
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .foregroundDisabledColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foregroundDisabled1] }
+                return .dynamicColor { theme.color(.foregroundDisabled1) }
             case .foregroundPressedColor:
                 return .dynamicColor {
                     switch style() {
                     case .accent:
-                        return theme.aliasTokens.colors[.foregroundOnColor]
+                        return theme.color(.foregroundOnColor)
                     case .outline, .subtle:
-                        return theme.aliasTokens.colors[.brandForeground1Pressed]
+                        return theme.color(.brandForeground1Pressed)
                     case .danger:
-                        return theme.aliasTokens.colors[.foregroundLightStatic]
+                        return theme.color(.foregroundLightStatic)
                     case .dangerOutline, .dangerSubtle:
-                        return theme.aliasTokens.colors[.dangerForeground2]
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .titleFont:
                 return .fontInfo {
                     switch size() {
                     case .large:
-                        return theme.aliasTokens.typography[.body1Strong]
+                        return theme.typography(.body1Strong)
                     case .medium, .small:
-                        return theme.aliasTokens.typography[.caption1Strong]
+                        return theme.typography(.caption1Strong)
                     }
                 }
             }

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -100,13 +100,11 @@ private func brandColorOverrides(provider: ColorProviding,
     /// - Parameters:
     ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
     @objc(setColorProvider:)
-    @discardableResult
-    func setColorProvider(_ provider: ColorProviding) -> FluentTheme {
+    func setColorProvider(_ provider: ColorProviding) {
         // Create an updated fluent theme as well
         let brandColors = brandColorOverrides(provider: provider, for: self)
         let fluentTheme = FluentTheme(colorOverrides: brandColors)
         self.fluentTheme = fluentTheme
-        return fluentTheme
     }
 
     /// Removes any associated `ColorProvider` from the given `UIView`.

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -100,14 +100,13 @@ private func brandColorOverrides(provider: ColorProviding,
     /// - Parameters:
     ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
     @objc(setColorProvider:)
-    func setColorProvider(_ provider: ColorProviding) {
+    @discardableResult
+    func setColorProvider(_ provider: ColorProviding) -> FluentTheme {
         // Create an updated fluent theme as well
         let brandColors = brandColorOverrides(provider: provider, for: self)
-        let fluentTheme = FluentTheme()
-        brandColors.forEach { token, value in
-            fluentTheme.aliasTokens.colors[token] = value
-        }
+        let fluentTheme = FluentTheme(colorOverrides: brandColors)
         self.fluentTheme = fluentTheme
+        return fluentTheme
     }
 
     /// Removes any associated `ColorProvider` from the given `UIView`.

--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -5,9 +5,9 @@
 
 import Foundation
 
-extension FluentTheme {
+public extension FluentTheme {
     @objc(MSFColorToken)
-    public enum ColorToken: Int, TokenSetKey {
+    enum ColorToken: Int, TokenSetKey {
         // Neutral colors - Background
         case background1
         case background1Pressed
@@ -102,7 +102,7 @@ extension FluentTheme {
     }
 
     @objc(MSFShadowToken)
-    public enum ShadowToken: Int, TokenSetKey {
+    enum ShadowToken: Int, TokenSetKey {
         case clear
         case shadow02
         case shadow04
@@ -113,7 +113,7 @@ extension FluentTheme {
     }
 
     @objc(MSFTypographyToken)
-    public enum TypographyToken: Int, TokenSetKey {
+    enum TypographyToken: Int, TokenSetKey {
         case display
         case largeTitle
         case title1
@@ -133,7 +133,7 @@ extension FluentTheme {
     /// - Parameter token: The `ColorsTokens` value to be retrieved.
     /// - Returns: A `DynamicColor` for the given token.
     @objc(colorForToken:)
-    public func color(_ token: ColorToken) -> DynamicColor {
+    func color(_ token: ColorToken) -> DynamicColor {
         return aliasTokens.colors[AliasTokens.ColorsTokens(rawValue: token.rawValue)!]
     }
 
@@ -142,7 +142,7 @@ extension FluentTheme {
     /// - Parameter token: The `ShadowTokens` value to be retrieved.
     /// - Returns: A `ShadowInfo` for the given token.
     @objc(shadowForToken:)
-    public func shadow(_ token: ShadowToken) -> ShadowInfo {
+    func shadow(_ token: ShadowToken) -> ShadowInfo {
         return aliasTokens.shadow[AliasTokens.ShadowTokens(rawValue: token.rawValue)!]
     }
 
@@ -151,7 +151,7 @@ extension FluentTheme {
     /// - Parameter token: The `TypographyTokens` value to be retrieved.
     /// - Returns: A `FontInfo` for the given token.
     @objc(typographyForToken:)
-    public func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
+    func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
         return aliasTokens.typography[AliasTokens.TypographyTokens(rawValue: token.rawValue)!]
     }
 }

--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -1,0 +1,157 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+extension FluentTheme {
+    @objc(MSFColorToken)
+    public enum ColorToken: Int, TokenSetKey {
+        // Neutral colors - Background
+        case background1
+        case background1Pressed
+        case background1Selected
+        case background2
+        case background2Pressed
+        case background2Selected
+        case background3
+        case background3Pressed
+        case background3Selected
+        case background4
+        case background4Pressed
+        case background4Selected
+        case background5
+        case background5Pressed
+        case background5Selected
+        case background6
+        case backgroundCanvas
+        case backgroundDarkStatic
+        case backgroundLightStatic
+        case backgroundLightStaticDisabled
+        case backgroundInverted
+        case backgroundDisabled
+        case stencil1
+        case stencil2
+
+        // Neutral colors - Foreground
+        case foreground1
+        case foreground2
+        case foreground3
+        case foregroundDisabled1
+        case foregroundDisabled2
+        case foregroundOnColor
+        case foregroundDarkStatic
+        case foregroundLightStatic
+
+        // Neutral colors - Stroke
+        case stroke1
+        case stroke2
+        case strokeAccessible
+        case strokeFocus1
+        case strokeFocus2
+        case strokeDisabled
+
+        // Brand colors - Brand background
+        case brandBackground1
+        case brandBackground1Pressed
+        case brandBackground1Selected
+        case brandBackground2
+        case brandBackground2Pressed
+        case brandBackground2Selected
+        case brandBackground3
+        case brandBackgroundTint
+        case brandBackgroundDisabled
+
+        // Brand colors - Brand foreground
+        case brandForeground1
+        case brandForeground1Pressed
+        case brandForeground1Selected
+        case brandForegroundTint
+        case brandForegroundDisabled1
+        case brandForegroundDisabled2
+
+        // Brand colors - Brand stroke
+        case brandStroke1
+        case brandStroke1Pressed
+        case brandStroke1Selected
+
+        // Shared colors - Error & Status
+        case dangerBackground1
+        case dangerBackground2
+        case dangerForeground1
+        case dangerForeground2
+        case successBackground1
+        case successBackground2
+        case successForeground1
+        case successForeground2
+        case warningBackground1
+        case warningBackground2
+        case warningForeground1
+        case warningForeground2
+        case severeBackground1
+        case severeBackground2
+        case severeForeground1
+        case severeForeground2
+
+        // Shared colors - Presence
+        case presenceAway
+        case presenceDnd
+        case presenceAvailable
+        case presenceOof
+    }
+
+    @objc(MSFShadowToken)
+    public enum ShadowToken: Int, TokenSetKey {
+        case clear
+        case shadow02
+        case shadow04
+        case shadow08
+        case shadow16
+        case shadow28
+        case shadow64
+    }
+
+    @objc(MSFTypographyToken)
+    public enum TypographyToken: Int, TokenSetKey {
+        case display
+        case largeTitle
+        case title1
+        case title2
+        case title3
+        case body1Strong
+        case body1
+        case body2Strong
+        case body2
+        case caption1Strong
+        case caption1
+        case caption2
+    }
+
+    /// Returns the color value for the given token.
+    ///
+    /// - Parameter token: The `ColorsTokens` value to be retrieved.
+    /// - Returns: A `DynamicColor` for the given token.
+    @objc(colorForToken:)
+    public func color(_ token: ColorToken) -> DynamicColor {
+        return aliasTokens.colors[AliasTokens.ColorsTokens(rawValue: token.rawValue)!]
+    }
+
+    /// Returns the shadow value for the given token.
+    ///
+    /// - Parameter token: The `ShadowTokens` value to be retrieved.
+    /// - Returns: A `ShadowInfo` for the given token.
+    @objc(shadowForToken:)
+    public func shadow(_ token: ShadowToken) -> ShadowInfo {
+        return aliasTokens.shadow[AliasTokens.ShadowTokens(rawValue: token.rawValue)!]
+    }
+
+    /// Returns the font value for the given token.
+    ///
+    /// - Parameter token: The `TypographyTokens` value to be retrieved.
+    /// - Returns: A `FontInfo` for the given token.
+    @objc(typographyForToken:)
+    public func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
+        return aliasTokens.typography[AliasTokens.TypographyTokens(rawValue: token.rawValue)!]
+    }
+}

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -11,12 +11,24 @@ import SwiftUI
 public class FluentTheme: NSObject, ObservableObject {
     /// Initializes and returns a new `FluentTheme`.
     ///
-    /// Once created, a `FluentTheme` can have its `AliasTokens` customized by setting custom values on the
-    ///  `aliasTokens` property. Control tokens can be customized via `register(controlType:tokens:) `.
-    ///  See the descriptions of those two for additional information.
+    /// A `FluentTheme` receives any custom alias tokens on initialization via arguments here.
+    /// Control tokens can be customized via `register(controlType:tokens:) `;
+    /// see that method's description for additional information.
     ///
-    /// - Returns: An initialized `FluentTheme` instance.
-    public override init() { }
+    /// - Parameters:
+    ///   - colorOverrides: A `Dictionary` of override values mapped to `ColorTokens`.
+    ///   - shadowOverrides: A `Dictionary` of override values mapped to `ShadowTokens`.
+    ///   - typographyOverrides: A `Dictionary` of override values mapped to `TypographyTokens`.
+    ///
+    /// - Returns: An initialized `FluentTheme` instance, with optional overrides.
+    public init(colorOverrides: [AliasTokens.ColorsTokens: DynamicColor]? = nil,
+                shadowOverrides: [AliasTokens.ShadowTokens: ShadowInfo]? = nil,
+                typographyOverrides: [AliasTokens.TypographyTokens: FontInfo]? = nil) {
+        // Pass overrides to AliasTokens
+        aliasTokens = .init(colorOverrides: colorOverrides,
+                            shadowOverrides: shadowOverrides,
+                            typographyOverrides: typographyOverrides)
+    }
 
     /// Registers a custom set of `ControlTokenValue` instances for a given `ControlTokenSet`.
     ///
@@ -37,7 +49,7 @@ public class FluentTheme: NSObject, ObservableObject {
     }
 
     /// The associated `AliasTokens` for this theme.
-    @objc public let aliasTokens: AliasTokens = .init()
+    @objc public let aliasTokens: AliasTokens
 
     static var shared: FluentTheme = .init()
 
@@ -46,6 +58,23 @@ public class FluentTheme: NSObject, ObservableObject {
     }
 
     private var controlTokenSets: [String: Any] = [:]
+}
+
+@objc public extension FluentTheme {
+    @objc(colorForToken:)
+    func color(_ token: AliasTokens.ColorsTokens) -> DynamicColor {
+        return aliasTokens.colors[token]
+    }
+
+    @objc(shadowForToken:)
+    func shadow(_ token: AliasTokens.ShadowTokens) -> ShadowInfo {
+        return aliasTokens.shadow[token]
+    }
+
+    @objc(typographyForToken:)
+    func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
+        return aliasTokens.typography[token]
+    }
 }
 
 // MARK: - FluentThemeable

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -61,16 +61,28 @@ public class FluentTheme: NSObject, ObservableObject {
 }
 
 @objc public extension FluentTheme {
+    /// Returns the color value for the given token.
+    ///
+    /// - Parameter token: The `ColorsTokens` value to be retrieved.
+    /// - Returns: A `DynamicColor` for the given token.
     @objc(colorForToken:)
     func color(_ token: AliasTokens.ColorsTokens) -> DynamicColor {
         return aliasTokens.colors[token]
     }
 
+    /// Returns the shadow value for the given token.
+    ///
+    /// - Parameter token: The `ShadowTokens` value to be retrieved.
+    /// - Returns: A `ShadowInfo` for the given token.
     @objc(shadowForToken:)
     func shadow(_ token: AliasTokens.ShadowTokens) -> ShadowInfo {
         return aliasTokens.shadow[token]
     }
 
+    /// Returns the font value for the given token.
+    ///
+    /// - Parameter token: The `TypographyTokens` value to be retrieved.
+    /// - Returns: A `FontInfo` for the given token.
     @objc(typographyForToken:)
     func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
         return aliasTokens.typography[token]
@@ -85,6 +97,10 @@ public class FluentTheme: NSObject, ObservableObject {
 }
 
 public extension Notification.Name {
+    /// The notification that will fire when a new `FluentTheme` is set on a view.
+    ///
+    /// The `object` for the fired `Notification` will be the `UIView` whose `fluentTheme` has changed.
+    /// Listeners will likely only want to redraw if they are a descendent of this view.
     static let didChangeTheme = Notification.Name("FluentUI.stylesheet.theme")
 }
 

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -60,35 +60,6 @@ public class FluentTheme: NSObject, ObservableObject {
     private var controlTokenSets: [String: Any] = [:]
 }
 
-@objc public extension FluentTheme {
-    /// Returns the color value for the given token.
-    ///
-    /// - Parameter token: The `ColorsTokens` value to be retrieved.
-    /// - Returns: A `DynamicColor` for the given token.
-    @objc(colorForToken:)
-    func color(_ token: AliasTokens.ColorsTokens) -> DynamicColor {
-        return aliasTokens.colors[token]
-    }
-
-    /// Returns the shadow value for the given token.
-    ///
-    /// - Parameter token: The `ShadowTokens` value to be retrieved.
-    /// - Returns: A `ShadowInfo` for the given token.
-    @objc(shadowForToken:)
-    func shadow(_ token: AliasTokens.ShadowTokens) -> ShadowInfo {
-        return aliasTokens.shadow[token]
-    }
-
-    /// Returns the font value for the given token.
-    ///
-    /// - Parameter token: The `TypographyTokens` value to be retrieved.
-    /// - Returns: A `FontInfo` for the given token.
-    @objc(typographyForToken:)
-    func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
-        return aliasTokens.typography[token]
-    }
-}
-
 // MARK: - FluentThemeable
 
 /// Public protocol that, when implemented, allows any container to store and yield a `FluentTheme`.

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -32,47 +32,7 @@ public final class AliasTokens: NSObject {
         return typography[token]
     }
 
-    lazy public var typography: TokenSet<TypographyTokens, FontInfo> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
-        switch token {
-        case .display:
-            return .init(size: GlobalTokens.fontSize(.size900),
-                         weight: GlobalTokens.fontWeight(.bold))
-        case .largeTitle:
-            return .init(size: GlobalTokens.fontSize(.size800),
-                         weight: GlobalTokens.fontWeight(.bold))
-        case .title1:
-            return .init(size: GlobalTokens.fontSize(.size700),
-                         weight: GlobalTokens.fontWeight(.bold))
-        case .title2:
-            return .init(size: GlobalTokens.fontSize(.size600),
-                         weight: GlobalTokens.fontWeight(.semibold))
-        case .title3:
-            return .init(size: GlobalTokens.fontSize(.size500),
-                         weight: GlobalTokens.fontWeight(.semibold))
-        case .body1Strong:
-            return .init(size: GlobalTokens.fontSize(.size400),
-                         weight: GlobalTokens.fontWeight(.semibold))
-        case .body1:
-            return .init(size: GlobalTokens.fontSize(.size400),
-                         weight: GlobalTokens.fontWeight(.regular))
-        case .body2Strong:
-            return .init(size: GlobalTokens.fontSize(.size300),
-                         weight: GlobalTokens.fontWeight(.semibold))
-        case .body2:
-            return .init(size: GlobalTokens.fontSize(.size300),
-                         weight: GlobalTokens.fontWeight(.regular))
-        case .caption1Strong:
-            return .init(size: GlobalTokens.fontSize(.size200),
-                         weight: GlobalTokens.fontWeight(.semibold))
-        case .caption1:
-            return .init(size: GlobalTokens.fontSize(.size200),
-                         weight: GlobalTokens.fontWeight(.regular))
-        case .caption2:
-            return .init(size: GlobalTokens.fontSize(.size100),
-                         weight: GlobalTokens.fontWeight(.regular))
-        }
-    }
+    public let typography: TokenSet<TypographyTokens, FontInfo>
 
     // MARK: - Shadow
 
@@ -93,85 +53,7 @@ public final class AliasTokens: NSObject {
         return shadow[token]
     }
 
-    public var shadow: TokenSet<ShadowTokens, ShadowInfo> = .init { token in
-        switch token {
-        case .clear:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue.clear),
-                              keyBlur: 0.0,
-                              xKey: 0.0,
-                              yKey: 0.0,
-                              ambientColor: DynamicColor(light: ColorValue.clear),
-                              ambientBlur: 0.0,
-                              xAmbient: 0.0,
-                              yAmbient: 0.0)
-        case .shadow02:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
-                              keyBlur: 2,
-                              xKey: 0,
-                              yKey: 1,
-                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
-                              ambientBlur: 2,
-                              xAmbient: 0,
-                              yAmbient: 0)
-        case .shadow04:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
-                              keyBlur: 4,
-                              xKey: 0,
-                              yKey: 2,
-                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
-                              ambientBlur: 2,
-                              xAmbient: 0,
-                              yAmbient: 0)
-        case .shadow08:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
-                              keyBlur: 8,
-                              xKey: 0,
-                              yKey: 4,
-                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
-                              ambientBlur: 2,
-                              xAmbient: 0,
-                              yAmbient: 0)
-        case .shadow16:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
-                              keyBlur: 16,
-                              xKey: 0,
-                              yKey: 8,
-                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
-                              ambientBlur: 2,
-                              xAmbient: 0,
-                              yAmbient: 0)
-        case .shadow28:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48)),
-                              keyBlur: 28,
-                              xKey: 0,
-                              yKey: 14,
-                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40)),
-                              ambientBlur: 8,
-                              xAmbient: 0,
-                              yAmbient: 0)
-        case .shadow64:
-            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48)),
-                              keyBlur: 64,
-                              xKey: 0,
-                              yKey: 32,
-                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
-                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40)),
-                              ambientBlur: 8,
-                              xAmbient: 0,
-                              yAmbient: 0)
-        }
-    }
+    public let shadow: TokenSet<ShadowTokens, ShadowInfo>
 
     // MARK: - Colors
 
@@ -275,8 +157,27 @@ public final class AliasTokens: NSObject {
     public func color(_ token: ColorsTokens) -> DynamicColor {
         return colors[token]
     }
-    public lazy var colors: TokenSet<ColorsTokens, DynamicColor> = .init { [weak self] token in
-        guard let strongSelf = self else { preconditionFailure() }
+    public let colors: TokenSet<ColorsTokens, DynamicColor>
+
+    // MARK: Initialization
+
+    init(colorOverrides: [ColorsTokens: DynamicColor]? = nil,
+         shadowOverrides: [ShadowTokens: ShadowInfo]? = nil,
+         typographyOverrides: [TypographyTokens: FontInfo]? = nil) {
+
+        self.colors = .init(AliasTokens.defaultColors(_:), colorOverrides)
+        self.shadow = .init(AliasTokens.defaultShadows(_:), shadowOverrides)
+        self.typography = .init(AliasTokens.defaultTypography(_:), typographyOverrides)
+
+        super.init()
+    }
+}
+
+// MARK: - AliasTokens default values
+
+extension AliasTokens {
+
+    private static func defaultColors(_ token: ColorsTokens) -> DynamicColor {
         switch token {
         case .foreground1:
             return DynamicColor(light: GlobalTokens.neutralColors(.grey14),
@@ -527,7 +428,124 @@ public final class AliasTokens: NSObject {
         }
     }
 
-    // MARK: Initialization
+    private static func defaultShadows(_ token: ShadowTokens) -> ShadowInfo {
+        switch token {
+        case .clear:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue.clear),
+                              keyBlur: 0.0,
+                              xKey: 0.0,
+                              yKey: 0.0,
+                              ambientColor: DynamicColor(light: ColorValue.clear),
+                              ambientBlur: 0.0,
+                              xAmbient: 0.0,
+                              yAmbient: 0.0)
+        case .shadow02:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
+                              keyBlur: 2,
+                              xKey: 0,
+                              yKey: 1,
+                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
+                              ambientBlur: 2,
+                              xAmbient: 0,
+                              yAmbient: 0)
+        case .shadow04:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
+                              keyBlur: 4,
+                              xKey: 0,
+                              yKey: 2,
+                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
+                              ambientBlur: 2,
+                              xAmbient: 0,
+                              yAmbient: 0)
+        case .shadow08:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
+                              keyBlur: 8,
+                              xKey: 0,
+                              yKey: 4,
+                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
+                              ambientBlur: 2,
+                              xAmbient: 0,
+                              yAmbient: 0)
+        case .shadow16:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.14),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.28)),
+                              keyBlur: 16,
+                              xKey: 0,
+                              yKey: 8,
+                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.12),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20)),
+                              ambientBlur: 2,
+                              xAmbient: 0,
+                              yAmbient: 0)
+        case .shadow28:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48)),
+                              keyBlur: 28,
+                              xKey: 0,
+                              yKey: 14,
+                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40)),
+                              ambientBlur: 8,
+                              xAmbient: 0,
+                              yAmbient: 0)
+        case .shadow64:
+            return ShadowInfo(keyColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.24),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.48)),
+                              keyBlur: 64,
+                              xKey: 0,
+                              yKey: 32,
+                              ambientColor: DynamicColor(light: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.20),
+                                                     dark: ColorValue(r: 0.0, g: 0.0, b: 0.0, a: 0.40)),
+                              ambientBlur: 8,
+                              xAmbient: 0,
+                              yAmbient: 0)
+        }
+    }
 
-    override init() {}
+    private static func defaultTypography(_ token: TypographyTokens) -> FontInfo {
+        switch token {
+        case .display:
+            return .init(size: GlobalTokens.fontSize(.size900),
+                         weight: GlobalTokens.fontWeight(.bold))
+        case .largeTitle:
+            return .init(size: GlobalTokens.fontSize(.size800),
+                         weight: GlobalTokens.fontWeight(.bold))
+        case .title1:
+            return .init(size: GlobalTokens.fontSize(.size700),
+                         weight: GlobalTokens.fontWeight(.bold))
+        case .title2:
+            return .init(size: GlobalTokens.fontSize(.size600),
+                         weight: GlobalTokens.fontWeight(.semibold))
+        case .title3:
+            return .init(size: GlobalTokens.fontSize(.size500),
+                         weight: GlobalTokens.fontWeight(.semibold))
+        case .body1Strong:
+            return .init(size: GlobalTokens.fontSize(.size400),
+                         weight: GlobalTokens.fontWeight(.semibold))
+        case .body1:
+            return .init(size: GlobalTokens.fontSize(.size400),
+                         weight: GlobalTokens.fontWeight(.regular))
+        case .body2Strong:
+            return .init(size: GlobalTokens.fontSize(.size300),
+                         weight: GlobalTokens.fontWeight(.semibold))
+        case .body2:
+            return .init(size: GlobalTokens.fontSize(.size300),
+                         weight: GlobalTokens.fontWeight(.regular))
+        case .caption1Strong:
+            return .init(size: GlobalTokens.fontSize(.size200),
+                         weight: GlobalTokens.fontWeight(.semibold))
+        case .caption1:
+            return .init(size: GlobalTokens.fontSize(.size200),
+                         weight: GlobalTokens.fontWeight(.regular))
+        case .caption2:
+            return .init(size: GlobalTokens.fontSize(.size100),
+                         weight: GlobalTokens.fontWeight(.regular))
+        }
+    }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/TokenSet.swift
@@ -3,8 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import Combine
-
 /// Defines the key used for token value indexing.
 public typealias TokenSetKey = Hashable & CaseIterable
 
@@ -13,31 +11,15 @@ public final class TokenSet<T: TokenSetKey, V> {
 
     /// Allows us to index into this token set using square brackets.
     ///
-    /// We can use square brackets to both read and write into this `TokenSet`. For example:
+    /// We can use square brackets to read from this `TokenSet`. For example:
     /// ```
-    /// let value = tokenSet[.primary]   // exercises the `get`
-    /// tokenSet[.secondary] = newValue  // exercises the `set`
+    /// let value = tokenSet[.primary]
     /// ```
     public subscript(token: T) -> V {
-        get {
-            if let value = valueOverrides?[token] {
-                return value
-            }
-            return defaultValues(token)
+        if let value = valueOverrides?[token] {
+            return value
         }
-        set(value) {
-            if valueOverrides == nil {
-                valueOverrides = [:]
-            }
-            valueOverrides?[token] = value
-        }
-    }
-
-    /// Removes a stored override for a given token value.
-    ///
-    /// - Parameter token: The token value whose override should be removed.
-    public func removeOverride(_ token: T) {
-        valueOverrides?[token] = nil
+        return defaultValues(token)
     }
 
     /// Initializes this token set with a callback to fetch its default values as needed.
@@ -56,10 +38,12 @@ public final class TokenSet<T: TokenSetKey, V> {
     /// each value, or (B) unnecessary value storage in memory.
     ///
     /// - Parameter defaultValues: A closure that provides default values for this token set.
-    init(_ defaultValues: @escaping ((_ token: T) -> V)) {
+    init(_ defaultValues: @escaping ((_ token: T) -> V),
+         _ overrideValues: [T: V]? = nil) {
         self.defaultValues = defaultValues
+        self.valueOverrides = overrideValues
     }
 
-    private var defaultValues: ((_ token: T) -> V)
-    @Published private var valueOverrides: [T: V]?
+    private let valueOverrides: [T: V]?
+    private let defaultValues: ((_ token: T) -> V)
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change brings in a new set of APIs for fetching alias tokens - directly from a `FluentTheme`, instead of going through `AliasTokens`. The ultimate goal will be for `AliasTokens` to be fully deprecated and removed, though this will happen over a few releases, to give clients time to transition.

First, changes to `AliasTokens`. Previously it was possible to override token values in `AliasTokens` at any time, though they would not take effect until the next render of the control (no automatic updates). Now, all customization must be provided at initialization of the `FluentTheme`. If a client wishes to change these values later, our official guidance is to create and set a new `FluentTheme` with the updated values - this will also force a redraw of all components, reflecting the new values immediately.

Next, token definitions. There are now new copies of all of our alias token definitions in `FluentTheme+Tokens.swift`. Here's a quick comparison of the naming changes (note the unusual pluralization in “before”):

```swift
// Previous definition
public final class AliasTokens: NSObject {
    @objc(MSFColorAliasTokens)
    public enum ColorsTokens: Int, TokenSetKey {}
}

let token = AliasTokens.ColorsTokens.background1

////////////////////////////////////////////////////////////////////////////////
////////////////////////////////////////////////////////////////////////////////

// New API
public final class FluentTheme: NSObject {
    @objc(MSFColorToken)
    public enum ColorToken: Int, TokenSetKey {}
}

let token = FluentTheme.ColorToken.background1
```

Finally, the new token APIs themselves. The new API is designed to be simpler to consume in both Swift and Objective-C. Now that tokens are read-only, they are more easily accessed via a simple function call, similar to GlobalTokens. See below for examples:

```swift
// Before
let brandBackgroundOld = theme.aliasTokens.colors[.brandBackground1]

// After
let brandBackgroundNew = theme.color(.brandBackground1)
```

```objc
// Before
MSFAliasTokens *aliasTokens = [[[self view] fluentTheme] aliasTokens];
MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBackground1];

// After
MSFDynamicColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorTokenBackground1];
```

More changes are on their way in future PRs, particularly regarding access to shared color values. Stay tuned!

### Binary change

Total increase: 91,168 bytes
Total decrease: -22,576 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,790,832 bytes | 29,859,424 bytes | 🛑 68,592 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentTheme+Tokens.o | 0 bytes | 59,312 bytes | 🛑 59,312 bytes |
| BadgeView.o | 430,200 bytes | 439,984 bytes | ⚠️ 9,784 bytes |
| __.SYMDEF | 4,575,080 bytes | 4,583,664 bytes | ⚠️ 8,584 bytes |
| PillButtonStyle.o | 63,280 bytes | 66,920 bytes | ⚠️ 3,640 bytes |
| SearchBar.o | 446,608 bytes | 447,880 bytes | ⚠️ 1,272 bytes |
| SegmentedControlTokenSet.o | 93,328 bytes | 94,328 bytes | ⚠️ 1,000 bytes |
| NotificationTokenSet.o | 98,816 bytes | 99,624 bytes | ⚠️ 808 bytes |
| AvatarTokenSet.o | 128,856 bytes | 129,592 bytes | ⚠️ 736 bytes |
| TextFieldTokenSet.o | 97,160 bytes | 97,704 bytes | ⚠️ 544 bytes |
| CardView.o | 280,064 bytes | 280,576 bytes | ⚠️ 512 bytes |
| TableViewHeaderFooterView.o | 287,592 bytes | 287,968 bytes | ⚠️ 376 bytes |
| ColorProviding.o | 41,504 bytes | 41,856 bytes | ⚠️ 352 bytes |
| MSFAvatarPresence.o | 45,512 bytes | 45,856 bytes | ⚠️ 344 bytes |
| NavigationBar.o | 554,384 bytes | 554,640 bytes | ⚠️ 256 bytes |
| LabelTokenSet.o | 65,992 bytes | 66,224 bytes | ⚠️ 232 bytes |
| Separator.o | 57,920 bytes | 58,144 bytes | ⚠️ 224 bytes |
| CalendarViewDayTodayCell.o | 38,480 bytes | 38,704 bytes | ⚠️ 224 bytes |
| LargeTitleView.o | 163,208 bytes | 163,424 bytes | ⚠️ 216 bytes |
| CalendarViewDayCell.o | 149,384 bytes | 149,600 bytes | ⚠️ 216 bytes |
| TwoLineTitleView.o | 212,424 bytes | 212,640 bytes | ⚠️ 216 bytes |
| TableViewCellFileAccessoryView.o | 333,296 bytes | 333,488 bytes | ⚠️ 192 bytes |
| CalendarViewDayMonthYearCell.o | 50,528 bytes | 50,712 bytes | ⚠️ 184 bytes |
| PopupMenuItemCell.o | 167,480 bytes | 167,664 bytes | ⚠️ 184 bytes |
| TabBarItemView.o | 211,752 bytes | 211,920 bytes | ⚠️ 168 bytes |
| PeoplePicker.o | 294,544 bytes | 294,688 bytes | ⚠️ 144 bytes |
| PersonaButtonTokenSet.o | 69,448 bytes | 69,584 bytes | ⚠️ 136 bytes |
| DrawerController.o | 492,296 bytes | 492,416 bytes | ⚠️ 120 bytes |
| DatePickerController.o | 355,152 bytes | 355,272 bytes | ⚠️ 120 bytes |
| ShimmerTokenSet.o | 79,528 bytes | 79,632 bytes | ⚠️ 104 bytes |
| DateTimePickerViewComponentCell.o | 54,296 bytes | 54,400 bytes | ⚠️ 104 bytes |
| CalendarViewDayMonthCell.o | 42,784 bytes | 42,888 bytes | ⚠️ 104 bytes |
| PersonaButtonCarouselTokenSet.o | 43,840 bytes | 43,920 bytes | ⚠️ 80 bytes |
| IndeterminateProgressBarTokenSet.o | 45,792 bytes | 45,864 bytes | ⚠️ 72 bytes |
| CalendarView.o | 73,592 bytes | 73,664 bytes | ⚠️ 72 bytes |
| HeadsUpDisplayTokenSet.o | 57,776 bytes | 57,848 bytes | ⚠️ 72 bytes |
| CommandBarTokenSet.o | 68,776 bytes | 68,848 bytes | ⚠️ 72 bytes |
| ResizingHandleView.o | 52,104 bytes | 52,176 bytes | ⚠️ 72 bytes |
| TableViewCell.o | 825,712 bytes | 825,776 bytes | ⚠️ 64 bytes |
| CardNudgeTokenSet.o | 88,144 bytes | 88,208 bytes | ⚠️ 64 bytes |
| DateTimePickerController.o | 165,912 bytes | 165,976 bytes | ⚠️ 64 bytes |
| PillButton.o | 197,720 bytes | 197,768 bytes | ⚠️ 48 bytes |
| BottomCommandingController.o | 744,000 bytes | 744,040 bytes | ⚠️ 40 bytes |
| TableViewCellTokenSet.o | 116,048 bytes | 116,064 bytes | ⚠️ 16 bytes |
| CalendarViewWeekdayHeadingView.o | 96,224 bytes | 96,240 bytes | ⚠️ 16 bytes |
| BadgeLabel.o | 53,448 bytes | 53,456 bytes | ⚠️ 8 bytes |
| PageCardPresenterController.o | 159,144 bytes | 159,136 bytes | 🎉 -8 bytes |
| BottomSheetTokenSet.o | 49,536 bytes | 49,520 bytes | 🎉 -16 bytes |
| DateTimePickerViewLayout.o | 42,928 bytes | 42,872 bytes | 🎉 -56 bytes |
| PopupMenuController.o | 368,808 bytes | 368,744 bytes | 🎉 -64 bytes |
| TokenSet.o | 18,968 bytes | 18,880 bytes | 🎉 -88 bytes |
| DateTimePickerView.o | 276,856 bytes | 276,760 bytes | 🎉 -96 bytes |
| PopupMenuItem.o | 115,576 bytes | 115,424 bytes | 🎉 -152 bytes |
| DateTimePickerViewComponentTableView.o | 72,224 bytes | 72,056 bytes | 🎉 -168 bytes |
| DateTimePickerViewComponent.o | 148,480 bytes | 148,288 bytes | 🎉 -192 bytes |
| PersonaListView.o | 187,152 bytes | 186,480 bytes | 🎉 -672 bytes |
| TooltipTokenSet.o | 60,408 bytes | 59,712 bytes | 🎉 -696 bytes |
| BadgeField.o | 540,328 bytes | 539,496 bytes | 🎉 -832 bytes |
| ButtonTokenSet.o | 120,736 bytes | 119,520 bytes | 🎉 -1,216 bytes |
| FluentUIFramework.o | 80,752 bytes | 78,984 bytes | 🎉 -1,768 bytes |
| AliasTokens.o | 202,960 bytes | 198,336 bytes | 🎉 -4,624 bytes |
| BadgeLabelButton.o | 864,896 bytes | 859,896 bytes | 🎉 -5,000 bytes |
| FluentTheme.o | 71,264 bytes | 64,336 bytes | 🎉 -6,928 bytes |
</details>

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

Button, which has been updated to the new API

https://user-images.githubusercontent.com/4934719/224445292-fc29d7ea-ec57-47f6-89f1-6422e513b681.mp4

CardNudge, which still leverages the legacy API

https://user-images.githubusercontent.com/4934719/224445288-3d231370-8d94-46a7-9809-dc3e38e08b10.mp4

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1641)