### PR TITLE
Fix failing XCUITests on tokens branch

### DIFF
--- a/ios/FluentUI.Demo/FluentUIDemoTests/AvatarTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/AvatarTest_SwiftUI.swift
@@ -45,7 +45,7 @@ class AvatarTestSwiftUI: BaseTest {
         XCTAssert(!avatarExists(predicate: icon))
 
         textField.doubleTap()
-        textField.typeText(String(XCUIKeyboardKey.delete.rawValue))
+        textField.typeText(String(XCUIKeyboardKey.delete.rawValue) + "\n")
         XCTAssert(!avatarExists(predicate: image))
         XCTAssert(!avatarExists(predicate: initials))
         XCTAssert(avatarExists(predicate: icon))
@@ -132,7 +132,7 @@ class AvatarTestSwiftUI: BaseTest {
         XCTAssert(avatarWithAttributeExists(attribute: "activity 1"))
         // removes name and image to set icon
         textField.doubleTap()
-        textField.typeText(String(XCUIKeyboardKey.delete.rawValue))
+        textField.typeText(String(XCUIKeyboardKey.delete.rawValue) + "\n")
         app.switches["Set image"].tap()
         XCTAssert(!avatarWithAttributeExists(attribute: "activity"))
 
@@ -142,7 +142,7 @@ class AvatarTestSwiftUI: BaseTest {
         XCTAssert(!avatarWithAttributeExists(attribute: "activity"))
         // adds name back
         textField.tap()
-        textField.typeText("Kat Larsson")
+        textField.typeText("Kat Larsson\n")
         XCTAssert(avatarWithAttributeExists(attribute: "activity 2"))
         app.switches["Set image"].tap()
         XCTAssert(avatarWithAttributeExists(attribute: "activity 2"))

--- a/ios/FluentUI.Demo/FluentUIDemoTests/AvatarTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/AvatarTest_SwiftUI.swift
@@ -27,6 +27,8 @@ class AvatarTestSwiftUI: BaseTest {
     }
 
     func testImages() throws {
+        let textField: XCUIElement = app.textFields.firstMatch
+
         let setImageSwitch: XCUIElement = app.switches["Set image"]
         let image: NSPredicate = NSPredicate(format: "identifier MATCHES %@", "Avatar.*image.*")
         let initials: NSPredicate = NSPredicate(format: "identifier MATCHES %@", "Avatar.*initials.*")
@@ -42,8 +44,8 @@ class AvatarTestSwiftUI: BaseTest {
         XCTAssert(avatarExists(predicate: initials))
         XCTAssert(!avatarExists(predicate: icon))
 
-        app.textFields.firstMatch.doubleTap()
-        app.menuItems["Cut"].tap()
+        textField.doubleTap()
+        textField.typeText(String(XCUIKeyboardKey.delete.rawValue))
         XCTAssert(!avatarExists(predicate: image))
         XCTAssert(!avatarExists(predicate: initials))
         XCTAssert(avatarExists(predicate: icon))
@@ -117,6 +119,8 @@ class AvatarTestSwiftUI: BaseTest {
 
     // ensures that activity is only visible with images/initials (on default style, size 56)
     func testActivitiesImage() throws {
+        let textField: XCUIElement = app.textFields.firstMatch
+
         app.switches["Show image"].tap()
         app.buttons.matching(NSPredicate(format: "label CONTAINS '.none'")).element(boundBy: 1).tap()
         app.buttons[".circle"].tap()
@@ -127,8 +131,8 @@ class AvatarTestSwiftUI: BaseTest {
         app.switches["Set image"].tap()
         XCTAssert(avatarWithAttributeExists(attribute: "activity 1"))
         // removes name and image to set icon
-        app.textFields.firstMatch.doubleTap()
-        app.menuItems["Cut"].tap()
+        textField.doubleTap()
+        textField.typeText(String(XCUIKeyboardKey.delete.rawValue))
         app.switches["Set image"].tap()
         XCTAssert(!avatarWithAttributeExists(attribute: "activity"))
 
@@ -137,8 +141,8 @@ class AvatarTestSwiftUI: BaseTest {
 
         XCTAssert(!avatarWithAttributeExists(attribute: "activity"))
         // adds name back
-        app.textFields.firstMatch.tap()
-        app.menuItems["Paste"].tap()
+        textField.tap()
+        textField.typeText("Kat Larsson")
         XCTAssert(avatarWithAttributeExists(attribute: "activity 2"))
         app.switches["Set image"].tap()
         XCTAssert(avatarWithAttributeExists(attribute: "activity 2"))

--- a/ios/FluentUI.Demo/FluentUIDemoTests/HUDTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/HUDTest_SwiftUI.swift
@@ -53,7 +53,7 @@ class HUDTestSwiftUI: BaseTest {
         let textField: XCUIElement = app.textFields.firstMatch
         XCTAssert(app.images.element(matching: NSPredicate(format: "identifier CONTAINS %@", "HUD with no label")).exists)
         textField.tap()
-        textField.typeText("label")
+        textField.typeText("label\n")
         XCTAssert(app.images.element(matching: NSPredicate(format: "identifier CONTAINS %@", "HUD with label \"label\"")).exists)
     }
 

--- a/ios/FluentUI.Demo/FluentUIDemoTests/HUDTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/HUDTest_SwiftUI.swift
@@ -50,11 +50,10 @@ class HUDTestSwiftUI: BaseTest {
     }
 
     func testLabels() throws {
+        let textField: XCUIElement = app.textFields.firstMatch
         XCTAssert(app.images.element(matching: NSPredicate(format: "identifier CONTAINS %@", "HUD with no label")).exists)
-        app.textFields.firstMatch.tap()
-        UIPasteboard.general.string = "label"
-        app.textFields.element.doubleTap()
-        app.menuItems["Paste"].tap()
+        textField.tap()
+        textField.typeText("label")
         XCTAssert(app.images.element(matching: NSPredicate(format: "identifier CONTAINS %@", "HUD with label \"label\"")).exists)
     }
 

--- a/ios/FluentUI.Demo/FluentUIDemoTests/NotificationViewTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/NotificationViewTest_SwiftUI.swift
@@ -27,20 +27,18 @@ class NotificationViewTestSwiftUI: BaseTest {
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View.*message \"Mail Archived\".*action button titled \"Undo\".*")).element.exists)
 
         titleTextField.tap()
-        titleTextField.typeText("title")
-        // taps different part of screen to dismiss keyboard
-        app.otherElements.firstMatch.tap()
+        titleTextField.typeText("title\n")
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View with title \"title\", message \"Mail Archived\".*action button titled \"Undo\".*")).element.exists)
 
         attributedTextSwitch.tap()
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View with attributed title \"title\", attributed message \"Mail Archived\".*action button titled \"Undo\".*")).element.exists)
 
         titleTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        titleTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
+        titleTextField.typeText(String(XCUIKeyboardKey.delete.rawValue) + "\n")
         messageTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        messageTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
+        messageTextField.typeText(String(XCUIKeyboardKey.delete.rawValue) + "\n")
         actionButtonTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        actionButtonTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
+        actionButtonTextField.typeText(String(XCUIKeyboardKey.delete.rawValue) + "\n")
         // if there is no action button title, there should be a dismiss button
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View with no title, no message.*dismiss button.*")).element.exists)
     }
@@ -58,7 +56,7 @@ class NotificationViewTestSwiftUI: BaseTest {
         // as long as there is a action button title, there should be no trailing image
         XCTAssert(!app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View.*trailing image.*")).element.exists)
         actionButtonTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        actionButtonTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
+        actionButtonTextField.typeText(String(XCUIKeyboardKey.delete.rawValue) + "\n")
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View.*trailing image.*")).element.exists)
         setTrailingImageSwitch.tap()
         // if there is no action button title, there should be a dismiss button

--- a/ios/FluentUI.Demo/FluentUIDemoTests/NotificationViewTest_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/NotificationViewTest_SwiftUI.swift
@@ -27,20 +27,20 @@ class NotificationViewTestSwiftUI: BaseTest {
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View.*message \"Mail Archived\".*action button titled \"Undo\".*")).element.exists)
 
         titleTextField.tap()
-        UIPasteboard.general.string = "title"
-        titleTextField.doubleTap()
-        app.menuItems["Paste"].tap()
+        titleTextField.typeText("title")
+        // taps different part of screen to dismiss keyboard
+        app.otherElements.firstMatch.tap()
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View with title \"title\", message \"Mail Archived\".*action button titled \"Undo\".*")).element.exists)
 
         attributedTextSwitch.tap()
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View with attributed title \"title\", attributed message \"Mail Archived\".*action button titled \"Undo\".*")).element.exists)
 
         titleTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        app.menuItems["Cut"].tap()
+        titleTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
         messageTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        app.menuItems["Cut"].tap()
+        messageTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
         actionButtonTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        app.menuItems["Cut"].tap()
+        actionButtonTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
         // if there is no action button title, there should be a dismiss button
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View with no title, no message.*dismiss button.*")).element.exists)
     }
@@ -58,7 +58,7 @@ class NotificationViewTestSwiftUI: BaseTest {
         // as long as there is a action button title, there should be no trailing image
         XCTAssert(!app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View.*trailing image.*")).element.exists)
         actionButtonTextField.tap(withNumberOfTaps: 3, numberOfTouches: 1)
-        app.menuItems["Cut"].tap()
+        actionButtonTextField.typeText(String(XCUIKeyboardKey.delete.rawValue))
         XCTAssert(app.otherElements.containing(NSPredicate(format: "identifier MATCHES %@", "Notification View.*trailing image.*")).element.exists)
         setTrailingImageSwitch.tap()
         // if there is no action button title, there should be a dismiss button


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixed the XCUITests that were using `app.menuItem` to copy/paste since they were causing failures on the tokens branch. Instead, used `textField.typeText` to modify text fields.

### Binary change

Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 33,349,176 bytes | 33,349,176 bytes | 🎉 0 bytes |

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1642)