### PR TITLE
Navbar appearance tweaks plus font stuff

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -332,6 +332,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.subtitle = ""
             $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
             $0.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
+        },
+        14: TitleViewFeature(name: "Centered, image, disclosure") {
+            $0.subtitle = ""
+            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
         }
     ]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -93,7 +93,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showRegularTitleWithShyAccessoryAndSubtitle() {
-        presentController(withLargeTitle: false, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
+        presentController(withLargeTitle: false, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
     @objc func showRegularTitleWithFixedAccessory() {
@@ -101,7 +101,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showSystemTitleWithFixedAccessoryAndSubtitle() {
-        presentController(withLargeTitle: false, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+        presentController(withLargeTitle: false, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -85,7 +85,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithSystemStyleAndPillSegment() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
+        presentController(withLargeTitle: true, style: .system, accessoryView: createSegmentedControl(compatibleWith: .system), contractNavigationBarOnScroll: false)
     }
 
     @objc func showSystemTitleWithShyAccessory() {
@@ -131,7 +131,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithPillSegment() {
-        presentController(withLargeTitle: true, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
+        presentController(withLargeTitle: true, accessoryView: createSegmentedControl(compatibleWith: .primary), contractNavigationBarOnScroll: false)
     }
 
     private enum LeadingItem {
@@ -223,11 +223,11 @@ class NavigationControllerDemoController: DemoController {
         return searchBar
     }
 
-    private func createSegmentedControl() -> UIView {
+    private func createSegmentedControl(compatibleWith style: NavigationBar.Style) -> UIView {
         let segmentItems: [SegmentItem] = [
             SegmentItem(title: "First"),
             SegmentItem(title: "Second")]
-        let pillControl = SegmentedControl(items: segmentItems, style: .onBrandPill)
+        let pillControl = SegmentedControl(items: segmentItems, style: style == .system ? .primaryPill : .onBrandPill)
         pillControl.shouldSetEqualWidthForSegments = false
         pillControl.isFixedWidth = false
         pillControl.contentInset = .zero

--- a/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/FontInfo.swift
@@ -47,7 +47,7 @@ public class FontInfo: NSObject {
         return textStyle
     }
 
-    private static var sizeTuples: [(size: CGFloat, textStyle: Font.TextStyle)] = [
+    fileprivate static var sizeTuples: [(size: CGFloat, textStyle: Font.TextStyle)] = [
         (34.0, .largeTitle),
         (28.0, .title),
         (22.0, .title2),
@@ -76,22 +76,44 @@ public extension Font {
 
 extension UIFont {
     @objc public static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
-        let unscaledFont: UIFont
+        return fluent(fontInfo, shouldScale: shouldScale, contentSizeCategory: nil)
+    }
+
+    static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true, contentSizeCategory: UIContentSizeCategory?) -> UIFont {
+        let traitCollection: UITraitCollection?
+        if let contentSizeCategory = contentSizeCategory {
+            traitCollection = .init(preferredContentSizeCategory: contentSizeCategory)
+        } else {
+            traitCollection = nil
+        }
+
+        let weight = uiWeight(fontInfo.weight)
 
         if let name = fontInfo.name,
            let font = UIFont(name: name, size: fontInfo.size) {
             // Named font
-            unscaledFont = font.withWeight(uiWeight(fontInfo.weight))
+            let unscaledFont = font.withWeight(weight)
+            if shouldScale {
+                let fontMetrics = UIFontMetrics(forTextStyle: uiTextStyle(fontInfo.textStyle))
+                return fontMetrics.scaledFont(for: unscaledFont, compatibleWith: traitCollection)
+            } else {
+                return unscaledFont
+            }
         } else {
             // System font
-            unscaledFont = .systemFont(ofSize: fontInfo.size, weight: uiWeight(fontInfo.weight))
-        }
+            if !shouldScale {
+                return .systemFont(ofSize: fontInfo.size, weight: weight)
+            }
 
-        if shouldScale {
-            let fontMetrics = UIFontMetrics(forTextStyle: uiTextStyle(fontInfo.textStyle))
-            return fontMetrics.scaledFont(for: unscaledFont)
-        } else {
-            return unscaledFont
+            let textStyle = uiTextStyle(fontInfo.textStyle)
+            if FontInfo.sizeTuples.contains(where: { $0.size == fontInfo.size }) {
+                // System-recognized font size, let the OS scale it for us
+                return UIFont.preferredFont(forTextStyle: textStyle, compatibleWith: traitCollection).withWeight(weight)
+            }
+
+            // Custom font size, we need to scale it ourselves
+            let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
+            return fontMetrics.scaledFont(for: .systemFont(ofSize: fontInfo.size, weight: weight), compatibleWith: traitCollection)
         }
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -114,7 +114,7 @@ open class Label: UILabel, TokenizedControlInternal {
             return
         }
 
-        let defaultFont = UIFont.fluent(tokenSet[.font].fontInfo)
+        let defaultFont = UIFont.fluent(tokenSet[.font].fontInfo, shouldScale: adjustsFontForContentSizeCategory)
         if maxFontSize > 0 && defaultFont.pointSize > maxFontSize {
             font = defaultFont.withSize(maxFontSize)
         } else {

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -33,6 +33,10 @@ class BadgeLabelButton: UIButton {
                                                selector: #selector(badgeValueDidChange),
                                                name: UIBarButtonItem.badgeValueDidChangeNotification,
                                                object: item)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(contentSizeCategoryDidChange(notification:)),
+                                               name: UIContentSizeCategory.didChangeNotification,
+                                               object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -53,6 +57,9 @@ class BadgeLabelButton: UIButton {
         static let badgeBorderWidth: CGFloat = 2
         static let badgeHorizontalPadding: CGFloat = 10
         static let badgeCornerRadii: CGFloat = 10
+
+        static let maximumContentSizeCategory: UIContentSizeCategory = .extraExtraLarge
+        static let minimumContentSizeCategory: UIContentSizeCategory = .large
     }
 
     private let badgeLabel = BadgeLabel()
@@ -221,6 +228,31 @@ class BadgeLabelButton: UIButton {
     @objc private func badgeValueDidChange() {
         updateBadgeLabel()
         updateAccessibilityLabel()
+    }
+
+    @objc private func contentSizeCategoryDidChange(notification: Notification) {
+        guard let titleLabel = titleLabel else {
+            return
+        }
+
+        let requestedContentSizeCategory = (notification.userInfo?[UIContentSizeCategory.newValueUserInfoKey] as? UIContentSizeCategory) ?? .unspecified
+
+        let cappedContentSizeCategory: UIContentSizeCategory
+        if requestedContentSizeCategory > Constants.maximumContentSizeCategory {
+            cappedContentSizeCategory = Constants.maximumContentSizeCategory
+        } else if requestedContentSizeCategory < Constants.minimumContentSizeCategory {
+            cappedContentSizeCategory = Constants.minimumContentSizeCategory
+        } else {
+            cappedContentSizeCategory = requestedContentSizeCategory
+        }
+
+        // For some reason, titleLabel doesn't resize to fit the new font size, so we do it ourselves.
+        titleLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1], contentSizeCategory: cappedContentSizeCategory)
+        titleLabel.sizeToFit()
+        sizeToFit()
+        if superview != nil {
+            centerInSuperview(horizontally: false, vertically: true)
+        }
     }
 
     private func updateAccessibilityLabel() {

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -58,6 +58,7 @@ class BadgeLabelButton: UIButton {
         static let badgeHorizontalPadding: CGFloat = 10
         static let badgeCornerRadii: CGFloat = 10
 
+        // These are consistent with UIKit's default navigation bar buttons
         static let maximumContentSizeCategory: UIContentSizeCategory = .extraExtraLarge
         static let minimumContentSizeCategory: UIContentSizeCategory = .large
     }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -191,7 +191,7 @@ class BadgeLabelButton: UIButton {
                                      width: computedBadgeWidth,
                                      height: Constants.badgeHeight)
             let badgeCutoutPath = UIBezierPath(rect: CGRect(x: badgeBoundsOriginX,
-                                                            y: 0,
+                                                            y: badgeBounds.origin.y,
                                                             width: frame.size.width + computedBadgeWidth / 2,
                                                             height: frame.size.height))
             // Adding the path for the cutout on the button's titleLabel or imageView where the badge label will be placed on top of.

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -855,7 +855,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             // Use default behavior of requesting an accessory expansion
             customTitleView.delegate = self
         }
-        navigationItem.titleView = customTitleView
+        // For some strange reason, embedding the TwoLineTitleView inside a UIStackView
+        // makes its labels resize properly according to content size changes.
+        navigationItem.titleView = UIStackView(arrangedSubviews: [customTitleView])
     }
 
     // MARK: Content expansion/contraction

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -335,6 +335,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var leftBarButtonItemsObserver: NSKeyValueObservation?
     private var rightBarButtonItemsObserver: NSKeyValueObservation?
     private var titleObserver: NSKeyValueObservation?
+    private var subtitleObserver: NSKeyValueObservation?
+    private var titleAccessoryObserver: NSKeyValueObservation?
+    private var titleImageObserver: NSKeyValueObservation?
     private var navigationBarColorObserver: NSKeyValueObservation?
     private var accessoryViewObserver: NSKeyValueObservation?
     private var topAccessoryViewObserver: NSKeyValueObservation?
@@ -630,6 +633,15 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             self.navigationItemDidUpdate(item)
         }
         titleObserver = navigationItem.observe(\UINavigationItem.title) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        subtitleObserver = navigationItem.observe(\UINavigationItem.subtitle) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        titleAccessoryObserver = navigationItem.observe(\UINavigationItem.titleAccessory) { [unowned self] item, _ in
+            self.navigationItemDidUpdate(item)
+        }
+        titleImageObserver = navigationItem.observe(\UINavigationItem.titleImage) { [unowned self] item, _ in
             self.navigationItemDidUpdate(item)
         }
         accessoryViewObserver = navigationItem.observe(\UINavigationItem.accessoryView) { [unowned self] item, _ in

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -483,6 +483,12 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         bottom.priority = .defaultHigh
 
         NSLayoutConstraint.activate([leading, trailing, top, bottom])
+
+        if #available(iOS 15.0, *) {
+            // These are consistent with UIKit's default navigation bar
+            contentStackView.minimumContentSizeCategory = .large
+            contentStackView.maximumContentSizeCategory = .extraExtraLarge
+        }
     }
 
     private func updateContentStackViewMargins(forExpandedContent contentIsExpanded: Bool) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -167,9 +167,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         static let normalContentHeight: CGFloat = 44
         static let expandedContentHeight: CGFloat = 48
 
-        static let leftBarButtonItemLeadingMargin: CGFloat = 8
-        static let leftBarButtonItemTrailingMargin: CGFloat = 8
-        static let rightBarButtonItemHorizontalPadding: CGFloat = 10
+        static let leftBarButtonItemLeadingMargin: CGFloat = GlobalTokens.spacing(.size80)
+        static let leftBarButtonItemTrailingMargin: CGFloat = GlobalTokens.spacing(.size80)
+        static let rightBarButtonItemHorizontalPadding: CGFloat = GlobalTokens.spacing(.size100)
 
         static let obscuringAnimationDuration: TimeInterval = 0.12
         static let revealingAnimationDuration: TimeInterval = 0.25

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -574,7 +574,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     private func updateElementSizes() {
         titleView.avatarSize = currentAvatarSize
-        titleView.titleSize = currentTitleSize
         barHeight = currentBarHeight
     }
 

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -15,7 +15,7 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
     }
 
     private struct Constants {
-        static let horizontalSpacing: CGFloat = 10
+        static let horizontalSpacing: CGFloat = GlobalTokens.spacing(.size100)
 
         static let compactAvatarSize: MSFAvatarSize = .size24
         static let avatarSize: MSFAvatarSize = .size32

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -19,9 +19,6 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
 
         static let compactAvatarSize: MSFAvatarSize = .size24
         static let avatarSize: MSFAvatarSize = .size32
-
-        // Once we are iOS 14 minimum, we can use Fonts.largeTitle.withSize() function instead
-        static let compactTitleFont = UIFont.systemFont(ofSize: 26, weight: .bold)
     }
 
     var personaData: Persona? {
@@ -82,19 +79,6 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
             titleButton.setTitleColor(colorForStyle, for: .normal)
             twoLineTitleView.currentStyle = style == .primary ? .primary : .system
             avatar?.state.style = style == .primary ? .default : .accent
-        }
-    }
-
-    var titleSize: NavigationBar.ElementSize = .automatic {
-        didSet {
-            switch titleSize {
-            case .automatic:
-                return
-            case .contracted:
-                titleButton.titleLabel?.font = Constants.compactTitleFont
-            case .expanded:
-                titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
-            }
         }
     }
 
@@ -229,7 +213,7 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
 
         // title button setup
         titleButton.setTitle(nil, for: .normal)
-        titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
+        titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1], shouldScale: false) // Don't scale because navigation bar height doesn't scale either
         titleButton.setTitleColor(colorForStyle, for: .normal)
         titleButton.titleLabel?.textAlignment = .left
         titleButton.contentHorizontalAlignment = .left
@@ -248,10 +232,6 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
     }
 
     private func expansionAnimation() {
-        if titleSize == .automatic {
-            titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
-        }
-
         if avatarSize == .automatic {
             avatar?.state.size = Constants.avatarSize
         }
@@ -260,10 +240,6 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
     }
 
     private func contractionAnimation() {
-        if titleSize == .automatic {
-            titleButton.titleLabel?.font = Constants.compactTitleFont
-        }
-
         if avatarSize == .automatic {
             avatar?.state.size = Constants.compactAvatarSize
         }
@@ -354,7 +330,7 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
     /// - Parameter animated: to animate the block or not
     func expand(animated: Bool) {
         // Exit early if neither element's size is automatic
-        guard titleSize == .automatic || avatarSize == .automatic else {
+        guard avatarSize == .automatic else {
             return
         }
 
@@ -371,7 +347,7 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
     /// - Parameter animated: to animate the block or not
     func contract(animated: Bool) {
         // Exit early if neither element's size is automatic
-        guard titleSize == .automatic || avatarSize == .automatic else {
+        guard avatarSize == .automatic else {
             return
         }
         if animated {

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -165,7 +165,7 @@ open class TwoLineTitleView: UIView {
         let label = Label()
         label.lineBreakMode = .byTruncatingTail
         label.style = .body1Strong
-        label.maxFontSize = 17
+        label.maxFontSize = fluentTheme.aliasTokens.typography[.body1Strong].size
         label.textAlignment = .center
         return label
     }()
@@ -186,7 +186,7 @@ open class TwoLineTitleView: UIView {
         let label = Label()
         label.lineBreakMode = .byTruncatingMiddle
         label.style = .caption1
-        label.maxFontSize = 12
+        label.maxFontSize = fluentTheme.aliasTokens.typography[.caption1].size
         return label
     }()
 

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -290,6 +290,9 @@ open class TwoLineTitleView: UIView {
         titleButtonLeadingImageView.image = titleImage
         titleButtonLeadingImageView.isHidden = titleImage == nil
 
+        let subtitleIsNilOrEmpty = subtitle?.isEmpty ?? true
+        titleButtonLabel.maxFontSize = subtitleIsNilOrEmpty ? 0 : fluentTheme.aliasTokens.typography[.body1Strong].size
+
         setupButton(titleButton, label: titleButtonLabel, trailingImageView: titleButtonTrailingImageView, text: title, interactive: interactivePart.contains(.title), accessoryType: accessoryType)
         // Check for strict equality for the subtitle button's interactivity.
         // If the whole area is active, we'll stretch the title button to adjust the hit area


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR consists of a bunch of minor tweaks and bug fixes that may not necessarily warrant PRs on their own.

Some focus areas here include:
* Dynamic Type compatibility (including #1644)
* Using token values instead of hard-coded constants
* Minor fixes to the NavBar demo page

### Verification

Validated by playing around with the preferred content size as seen below.

<details>
<summary>Visual Verification</summary>

| Example 1 | Example 2 | Example 3 |
|-|-|-|
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-03-14 at 11 58 19](https://user-images.githubusercontent.com/717674/225127526-8a141f61-20ee-45d5-a516-cdd74947810e.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-03-14 at 12 02 16](https://user-images.githubusercontent.com/717674/225127558-e41eb5cd-2717-4a36-9132-ac7afff68aff.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-03-14 at 12 06 41](https://user-images.githubusercontent.com/717674/225127574-1387fc04-122f-4343-be1d-9dd80d2969be.gif) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1646)