### PR TITLE
use sizeToFit rather than layoutifneeded

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -106,9 +106,7 @@ class DemoListViewController: DemoTableViewController {
             }
             cellTypeButton.menu = UIMenu(title: "Type", children: [insetGroupedType, plainType])
             cellTypeButton.showsMenuAsPrimaryAction = true
-            let stackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 60, height: 28))
-            stackView.addArrangedSubview(cellTypeButton)
-            cell.setup(title: demo.title, customAccessoryView: stackView)
+            cell.setup(title: demo.title, customAccessoryView: cellTypeButton)
         } else {
             cell.setup(title: demo.title, accessoryType: .disclosureIndicator)
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -58,11 +58,8 @@ class BottomCommandingDemoController: UIViewController {
 
     private lazy var badgeCommand: CommandingItem = {
         let badge = BadgeView(dataSource: BadgeViewDataSource(text: "Badge"))
-        let stackView = UIStackView(frame: CGRect(x: 0, y: 0, width: 60, height: 25))
-        stackView.addArrangedSubview(badge)
-
         let item = CommandingItem(title: "Badge Item ", image: homeImage, action: commandAction)
-        item.trailingView = stackView
+        item.trailingView = badge
         return item
     }()
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -648,7 +648,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         let customAccessoryViewAreaWidth: CGFloat
         if let customAccessoryView = customAccessoryView {
             // Trigger layout so we can have the frame calculated correctly at this point in time
-            customAccessoryView.layoutIfNeeded()
+            customAccessoryView.sizeToFit()
             customAccessoryViewAreaWidth = customAccessoryView.frame.width + customAccessoryViewMarginLeading
         } else {
             customAccessoryViewAreaWidth = 0


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
When we try to use the static function to figure out the cell's height, we try to take customAccessoryView size into account. However, https://github.com/microsoft/fluentui-apple/pull/612 calls layoutIfNeeded which isn't entirely correct because the accessoryView might not be layout at this point. Rather, lets call sizeToFit() which tried to get the intrinsic contentsize of the accessoryView to calculate. 

miscellaneous:
remove all the workaround when we were adding badge in the tableviewcell in the demo.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

Total increase: 104 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,761,528 bytes | 29,761,632 bytes | ⚠️ 104 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewCell.o | 822,672 bytes | 822,776 bytes | ⚠️ 104 bytes |
</details>

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/20715435/225412164-c9c158a8-6d61-40d4-80e9-6a61fd9f4475.png)|![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-15 at 11 12 12](https://user-images.githubusercontent.com/20715435/225405948-ffa95973-081f-4b76-bfff-9ec962a5411e.png)  |
|![image](https://user-images.githubusercontent.com/20715435/225412535-3478f3c7-a816-4115-9064-fa2efd38e0f9.png) | ![image](https://user-images.githubusercontent.com/20715435/225406053-9ec1dbed-636c-4cd6-a95d-f8ca8245deb0.png)|
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)