### PR TITLE
Converting uses of `AliasTokens` to new `FluentTheme` API

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -67,7 +67,7 @@ class DemoController: UIViewController {
         container.addArrangedSubview(titleLabel)
     }
 
-    func addRow(text: String = "", items: [UIView], textStyle: AliasTokens.TypographyTokens = .body1Strong, textWidth: CGFloat = Constants.rowTextWidth, itemSpacing: CGFloat = Constants.horizontalSpacing, stretchItems: Bool = false, centerItems: Bool = false) {
+    func addRow(text: String = "", items: [UIView], textStyle: FluentTheme.TypographyToken = .body1Strong, textWidth: CGFloat = Constants.rowTextWidth, itemSpacing: CGFloat = Constants.horizontalSpacing, stretchItems: Bool = false, centerItems: Bool = false) {
         let itemsContainer = UIStackView()
         itemsContainer.axis = .vertical
         itemsContainer.alignment = stretchItems ? .fill : (centerItems ? .center : .leading)
@@ -79,7 +79,7 @@ class DemoController: UIViewController {
         itemRow.spacing = itemSpacing
 
         if !text.isEmpty {
-            let label = Label(style: textStyle, colorStyle: .regular)
+            let label = Label(textStyle: textStyle, colorStyle: .regular)
             label.text = text
             label.widthAnchor.constraint(equalToConstant: textWidth).isActive = true
             itemRow.addArrangedSubview(label)
@@ -137,7 +137,7 @@ class DemoController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background1))
 
         if allowsContentToScroll {
             view.addSubview(scrollingContainer)

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -31,8 +31,8 @@ class DemoListViewController: DemoTableViewController {
         self.theme = theme
         if let provider = self.provider {
             window.setColorProvider(provider)
-            let aliasTokens = self.view.fluentTheme.aliasTokens
-            let primaryColor = UIColor(dynamicColor: aliasTokens.colors[.brandBackground1])
+            let fluentTheme = self.view.fluentTheme
+            let primaryColor = UIColor(dynamicColor: fluentTheme.color(.brandBackground1))
             FluentUIFramework.initializeAppearance(with: primaryColor, whenContainedInInstancesOf: [type(of: window)])
         } else {
             FluentUIFramework.initializeAppearance(with: UIColor(light: UIColor(colorValue: GlobalTokens.brandColors(.comm80)), dark: UIColor(colorValue: GlobalTokens.brandColors(.comm90))))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -30,7 +30,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
         let section = AliasColorTokensDemoSection.allCases[indexPath.section]
         let row = section.rows[indexPath.row]
 
-        cell.backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: aliasTokens.colors[row])
+        cell.backgroundConfiguration?.backgroundColor = UIColor(dynamicColor: fluentTheme.color(row))
         cell.selectionStyle = .none
 
         var contentConfiguration = cell.defaultContentConfiguration()
@@ -45,7 +45,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
         return cell
     }
 
-    private func textColor(for token: AliasTokens.ColorsTokens) -> UIColor {
+    private func textColor(for token: FluentTheme.ColorToken) -> UIColor {
         switch token {
         case .background1,
              .background1Pressed,
@@ -81,7 +81,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .successBackground1,
              .warningBackground1,
              .severeBackground1:
-            return UIColor(dynamicColor: aliasTokens.colors[.foreground1])
+            return UIColor(dynamicColor: fluentTheme.color(.foreground1))
         case .foreground1,
              .foreground2,
              .foreground3,
@@ -103,12 +103,12 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .severeBackground2,
              .severeForeground1,
              .severeForeground2:
-            return UIColor(dynamicColor: aliasTokens.colors[.foregroundOnColor])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundOnColor))
         case .foregroundLightStatic,
              .backgroundLightStatic,
              .backgroundLightStaticDisabled,
              .warningBackground2:
-            return UIColor(dynamicColor: aliasTokens.colors[.foregroundDarkStatic])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundDarkStatic))
         case .brandForeground1,
              .brandForeground1Selected,
              .brandForegroundDisabled1,
@@ -126,14 +126,13 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .presenceDnd,
              .presenceAvailable,
              .presenceOof:
-            return UIColor(dynamicColor: aliasTokens.colors[.foregroundLightStatic])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundLightStatic))
         }
     }
 
-    private var aliasTokens: AliasTokens {
-        return self.view.fluentTheme.aliasTokens
+    private var fluentTheme: FluentTheme {
+        return self.view.fluentTheme
     }
-
 }
 
 private enum AliasColorTokensDemoSection: CaseIterable {
@@ -167,7 +166,7 @@ private enum AliasColorTokensDemoSection: CaseIterable {
         }
     }
 
-    var rows: [AliasTokens.ColorsTokens] {
+    var rows: [FluentTheme.ColorToken] {
         switch self {
         case .neutralBackgrounds:
             return [.background1,
@@ -257,7 +256,7 @@ private enum AliasColorTokensDemoSection: CaseIterable {
     }
 }
 
-private extension AliasTokens.ColorsTokens {
+private extension FluentTheme.ColorToken {
     var text: String {
         switch self {
         case .foreground1:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -274,7 +274,7 @@ class BottomCommandingDemoController: UIViewController {
 
     private lazy var customPopoverViewController: UIViewController = {
         let viewController = UIViewController()
-        viewController.view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        viewController.view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
         viewController.preferredContentSize = CGSize(width: 300, height: 300)
         viewController.modalPresentationStyle = .popover
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -163,7 +163,7 @@ class CommandBarDemoController: DemoController {
     lazy var textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        textField.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
         textField.placeholder = "Text Field"
 
         return textField
@@ -176,21 +176,21 @@ class CommandBarDemoController: DemoController {
 
         container.layoutMargins.right = 0
         container.layoutMargins.left = 0
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background4))
 
         container.addArrangedSubview(createLabelWithText("Default"))
 
         let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
         commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
-        commandBar.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        commandBar.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
         container.addArrangedSubview(commandBar)
         defaultCommandBar = commandBar
 
         let itemCustomizationContainer = UIStackView()
         itemCustomizationContainer.spacing = CommandBarDemoController.verticalStackViewSpacing
         itemCustomizationContainer.axis = .vertical
-        itemCustomizationContainer.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        itemCustomizationContainer.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
 
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
@@ -278,13 +278,13 @@ class CommandBarDemoController: DemoController {
 
         let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
         fixedButtonCommandBar.translatesAutoresizingMaskIntoConstraints = false
-        fixedButtonCommandBar.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        fixedButtonCommandBar.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
         container.addArrangedSubview(fixedButtonCommandBar)
 
         container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
 
         let textFieldContainer = UIView()
-        textFieldContainer.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        textFieldContainer.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
         textFieldContainer.addSubview(textField)
         NSLayoutConstraint.activate([
             textField.topAnchor.constraint(equalTo: textFieldContainer.topAnchor, constant: 16.0),
@@ -376,7 +376,7 @@ class CommandBarDemoController: DemoController {
         )
 
         commandBarItem.accentImage = command.accentImage
-        commandBarItem.accentImageTintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground1])
+        commandBarItem.accentImageTintColor = UIColor(dynamicColor: view.fluentTheme.color(.brandForeground1))
 
         if command == .customView {
             commandBarItem.customControlView = { () -> UIView in
@@ -534,7 +534,7 @@ extension CommandBarDemoController: CommandBarDelegate {
             let originalBackgroundColor = commandBar.backgroundColor
 
             UIView.animate(withDuration: 1.0, delay: 0.0, options: [.allowUserInteraction]) {
-                commandBar.backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.aliasTokens.colors[.brandBackground1])
+                commandBar.backgroundColor = UIColor(dynamicColor: self.view.fluentTheme.color(.brandBackground1))
             } completion: { _ in
                 commandBar.backgroundColor = originalBackgroundColor
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DividerDemoController.swift
@@ -111,7 +111,7 @@ class DividerDemoController: DemoTableViewController {
 
     private func makeDivider(orientation: MSFDividerOrientation = .horizontal, spacing: MSFDividerSpacing, customColor: Bool) -> MSFDivider {
         let divider = MSFDivider(orientation: orientation, spacing: spacing)
-        if customColor, let color = self.view.window?.fluentTheme.aliasTokens.brandColors[.primary] {
+        if customColor, let color = self.view.window?.fluentTheme.brandColors(.primary) {
             divider.tokenSet[.color] = .dynamicColor({ color })
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift
@@ -134,7 +134,7 @@ class DrawerDemoController: DemoController {
             UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         ]
 
-        let backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        let backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
 
         controller.view.addSubview(content)
         content.frame = controller.view.bounds
@@ -285,7 +285,7 @@ class DrawerDemoController: DemoController {
                                    contentController: contentController,
                                    resizingBehavior: .dismissOrExpand)
 
-        drawer.resizingHandleViewBackgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+        drawer.resizingHandleViewBackgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
         drawer.contentScrollView = personaListView
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift
@@ -288,17 +288,17 @@ extension HUDDemoController: DemoAppearanceDelegate {
     // MARK: - Custom tokens
 
     private var themeWideOverrideActivityHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
-        let aliasTokens = self.view.fluentTheme.aliasTokens
+        let fluentTheme = self.view.fluentTheme
         return [
-            .backgroundColor: .dynamicColor { aliasTokens.colors[.brandBackground1] }
+            .backgroundColor: .dynamicColor { fluentTheme.color(.brandBackground1) }
         ]
     }
 
     private var perControlOverrideHeadsUpDisplayTokens: [HeadsUpDisplayTokenSet.Tokens: ControlTokenValue] {
-        let aliasTokens = self.view.fluentTheme.aliasTokens
+        let fluentTheme = self.view.fluentTheme
         return [
             .cornerRadius: .float { GlobalTokens.corner(.radius120) },
-            .labelColor: .dynamicColor { aliasTokens.colors[.brandForeground1] }
+            .labelColor: .dynamicColor { fluentTheme.color(.brandForeground1) }
         ]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -16,8 +16,8 @@ class LabelDemoController: DemoController {
 
         addLabel(text: "Text Styles", style: .body1Strong, colorStyle: .regular).textAlignment = .center
 
-        for style in AliasTokens.TypographyTokens.allCases {
-            let fontInfo = view.fluentTheme.aliasTokens.typography[style]
+        for style in FluentTheme.TypographyToken.allCases {
+            let fontInfo = view.fluentTheme.typography(style)
             let fontWeight = UIFont.fluent(fontInfo).fontDescriptor.weightDescriptor
             let detailedDescription = "\(style.description) is \(fontWeight) \(Int(fontInfo.size))pt"
             dynamicLabels.append(addLabel(text: detailedDescription, style: style, colorStyle: .regular))
@@ -36,8 +36,8 @@ class LabelDemoController: DemoController {
     }
 
     @discardableResult
-    func addLabel(text: String, style: AliasTokens.TypographyTokens, colorStyle: TextColorStyle) -> Label {
-        let label = Label(style: style, colorStyle: colorStyle)
+    func addLabel(text: String, style: FluentTheme.TypographyToken, colorStyle: TextColorStyle) -> Label {
+        let label = Label(textStyle: style, colorStyle: colorStyle)
         label.text = text
         label.numberOfLines = 0
         if colorStyle == .white {
@@ -49,9 +49,9 @@ class LabelDemoController: DemoController {
 
     @objc private func handleContentSizeCategoryDidChange() {
         for label in dynamicLabels {
-            let fontInfo = view.fluentTheme.aliasTokens.typography[label.style]
+            let fontInfo = view.fluentTheme.typography(label.textStyle)
             let fontWeight = UIFont.fluent(fontInfo).fontDescriptor.weightDescriptor
-            let detailedDescription = "\(label.style.description) is \(fontWeight) \(Int(fontInfo.size))pt"
+            let detailedDescription = "\(label.textStyle.description) is \(fontWeight) \(Int(fontInfo.size))pt"
             label.text = detailedDescription
         }
     }
@@ -74,7 +74,7 @@ extension TextColorStyle {
     }
 }
 
-extension AliasTokens.TypographyTokens {
+extension FluentTheme.TypographyToken {
     var description: String {
         switch self {
         case .display:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -199,7 +199,7 @@ class NavigationControllerDemoController: DemoController {
         stackView.alignment = .center
         let button = UIButton(type: .system)
         button.setImage(UIImage(named: "ic_fluent_filter_28"), for: .normal)
-        button.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
+        button.tintColor = UIColor(dynamicColor: view.fluentTheme.color(.foregroundLightStatic))
         stackView.addArrangedSubview(button)
         return stackView
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -66,7 +66,7 @@ class NotificationViewDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
         readmeString = "Notifications deliver helpful messages related to the action someone is taking. They should communicate information people can use right away.\n\nNotifications are great for giving people feedback or communicating a task’s status. If you need to show recommendations or upsell features of your app, try a card nudge instead."
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background4])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background4))
 
         addTitle(text: "SwiftUI Demo")
         container.addArrangedSubview(createButton(title: "Show", action: #selector(showSwiftUIDemo)))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -75,7 +75,7 @@
 
 - (void)addLabelWithText:(NSString *)text
                textColor:(UIColor *)textColor {
-    MSFLabel *label = [[MSFLabel alloc] initWithStyle:MSFTypographyAliasTokensBody1 colorStyle:MSFTextColorStyleRegular];
+    MSFLabel *label = [[MSFLabel alloc] initWithStyle:MSFTypographyTokenBody1 colorStyle:MSFTextColorStyleRegular];
     [label setTextAlignment:NSTextAlignmentCenter];
     [label setText:text];
     [label setTextColor:textColor];
@@ -138,7 +138,7 @@
 }
 
 - (void)addTitleWithText:(NSString*)text {
-    MSFLabel* titleLabel = [[MSFLabel alloc] initWithStyle:MSFTypographyAliasTokensBody1 colorStyle:MSFTextColorStyleRegular];
+    MSFLabel* titleLabel = [[MSFLabel alloc] initWithStyle:MSFTypographyTokenBody1 colorStyle:MSFTextColorStyleRegular];
     titleLabel.text = text;
     titleLabel.textAlignment = NSTextAlignmentCenter;
     [self.container addArrangedSubview:titleLabel];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift
@@ -28,7 +28,7 @@ class OtherCellsDemoController: DemoController {
         tableView.dataSource = self
         tableView.delegate = self
         tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
-        tableView.separatorColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stroke2])
+        tableView.separatorColor = UIColor(dynamicColor: view.fluentTheme.color(.stroke2))
         tableView.tableFooterView = UIView(frame: .zero)
         view.addSubview(tableView)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -78,8 +78,8 @@ class PillButtonBarDemoController: DemoController {
     }
 
     func createBar(items: [PillButtonBarItem], style: PillButtonStyle = .primary, centerAligned: Bool = false, disabledItems: Bool = false, useCustomPillsColors: Bool = false) -> UIView {
-        let accentColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foregroundOnColor])
-        let textColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground1])
+        let accentColor = UIColor(dynamicColor: view.fluentTheme.color(.foregroundOnColor))
+        let textColor = UIColor(dynamicColor: view.fluentTheme.color(.foreground1))
         let pillButtonBackgroundColor = useCustomPillsColors ? accentColor : nil
         let pillSelectedButtonBackgroundColor = useCustomPillsColors ? textColor : nil
         let pillButtonTextColor = useCustomPillsColors ? textColor : nil

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
@@ -29,8 +29,7 @@
     UIView *view = [self view];
     [view addSubview:stack];
 
-    MSFAliasTokens *aliasTokens = [[view fluentTheme] aliasTokens];
-    MSFDynamicColor *primaryColor = [aliasTokens aliasColorForToken:MSFColorAliasTokensBackground1];
+    MSFDynamicColor *primaryColor = [[view fluentTheme] colorForToken:MSFColorTokenBackground1];
     [view setBackgroundColor:[[UIColor alloc] initWithDynamicColor:primaryColor]];
 
     UILayoutGuide *safeArea = [view safeAreaLayoutGuide];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -28,7 +28,7 @@ class SegmentedControlDemoController: DemoController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background1])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background1))
 
         readmeString = "A segmented control lets someone select one option from a set of two or more segments in a single, horizontal container.\n\nSegmented controls work well for changing states of elements or views within a single context, like filtering search results. It’s best not to use them to initiate actions or navigate to a new page. To let people navigate between the main sections of an app, use the tab bar."
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShadowTokensDemoController.swift
@@ -11,7 +11,7 @@ class ShadowTokensDemoController: DemoController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.stencil2])
+        view.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.stencil2))
 
         container.alignment = .center
         container.spacing = 120
@@ -22,8 +22,8 @@ class ShadowTokensDemoController: DemoController {
     }
 
     private func initializeShadowViews() {
-        for shadowToken in AliasTokens.ShadowTokens.allCases {
-            let shadowView = ShadowView(shadowInfo: container.fluentTheme.aliasTokens.shadow[shadowToken],
+        for shadowToken in FluentTheme.ShadowToken.allCases {
+            let shadowView = ShadowView(shadowInfo: container.fluentTheme.shadow(shadowToken),
                                         title: shadowToken.title)
             container.addArrangedSubview(shadowView)
         }
@@ -41,11 +41,11 @@ private class ShadowView: UIView, Shadowable {
         layer.borderWidth = Constants.borderWidth
         layer.cornerRadius = Constants.cornerRadius
 
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        backgroundColor = UIColor(dynamicColor: fluentTheme.color(.background2))
 
         label.text = title
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+        label.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground1))
         addSubview(label)
 
         setupLayoutConstraints()
@@ -89,7 +89,7 @@ private class ShadowView: UIView, Shadowable {
     private let label = Label()
 }
 
-private extension AliasTokens.ShadowTokens {
+private extension FluentTheme.ShadowToken {
     var title: String {
         switch self {
         case .clear:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SideTabBarDemoController.swift
@@ -81,7 +81,7 @@ class SideTabBarDemoController: DemoController {
         sideTabBar.topItems[2].isUnreadDotVisible = true
 
         var premiumImage = UIImage(named: "ic_fluent_premium_24_regular")!
-        let primaryColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForegroundTint])
+        let primaryColor = UIColor(dynamicColor: view.fluentTheme.color(.brandForegroundTint))
         premiumImage = premiumImage.withTintColor(primaryColor, renderingMode: .alwaysOriginal)
 
         sideTabBar.bottomItems = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -167,10 +167,10 @@ extension TableViewCellDemoController {
         if section.title == "Inverted double line cell" {
             cell.setup(
                 attributedTitle: NSAttributedString(string: item.text1,
-                                                    attributes: [.font: UIFont.fluent(fluentTheme.aliasTokens.typography[.body1]),
+                                                    attributes: [.font: UIFont.fluent(fluentTheme.typography(.body1)),
                                                                  .foregroundColor: UIColor.purple]),
                 attributedSubtitle: NSAttributedString(string: item.text2,
-                                                       attributes: [.font: UIFont.fluent(fluentTheme.aliasTokens.typography[.caption1]),
+                                                       attributes: [.font: UIFont.fluent(fluentTheme.typography(.caption1)),
                                                                     .foregroundColor: UIColor.red]),
                 footer: TableViewCellSampleData.hasFullLengthLabelAccessoryView(at: indexPath) ? "" : item.text3,
                 customView: TableViewSampleData.createCustomView(imageName: item.image),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -49,7 +49,7 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDataSource {
             return UITableViewCell()
         }
         cell.backgroundStyleType = TableViewCellBackgroundStyleType.custom
-        cell.backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
+        cell.backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background2))
         cell.setup(title: TableViewHeaderFooterSampleData.itemTitle)
         var isLastInSection = indexPath.row == tableView.numberOfRows(inSection: indexPath.section) - 1
         if tableView.style == .grouped {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldObjCDemoController.m
@@ -45,8 +45,7 @@
 
     UIView *view = [self view];
     [view addSubview:stack];
-    MSFAliasTokens *aliasTokens = [[view fluentTheme] aliasTokens];
-    MSFDynamicColor *background1 = [aliasTokens aliasColorForToken:MSFColorAliasTokensBackground1];
+    MSFDynamicColor *background1 = [[view fluentTheme] colorForToken:MSFColorTokenBackground1];
     [view setBackgroundColor:[[UIColor alloc] initWithDynamicColor:background1]];
 
     UILayoutGuide *safeArea = [view safeAreaLayoutGuide];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TypographyTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TypographyTokensDemoController.swift
@@ -18,12 +18,12 @@ class TypographyTokensDemoController: DemoTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return AliasTokens.TypographyTokens.allCases.count
+        return FluentTheme.TypographyToken.allCases.count
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellID, for: indexPath)
-        let typographyToken = AliasTokens.TypographyTokens.allCases[indexPath.row]
+        let typographyToken = FluentTheme.TypographyToken.allCases[indexPath.row]
 
         cell.selectionStyle = .none
 
@@ -31,16 +31,12 @@ class TypographyTokensDemoController: DemoTableViewController {
         let text = "\(typographyToken.text)"
         contentConfiguration.attributedText = NSAttributedString(string: text,
                                                                  attributes: [
-                                                                    .font: UIFont.fluent(aliasTokens.typography[typographyToken])
+                                                                    .font: UIFont.fluent(view.fluentTheme.typography(typographyToken))
                                                                  ])
         contentConfiguration.textProperties.alignment = .center
         cell.contentConfiguration = contentConfiguration
 
         return cell
-    }
-
-    private var aliasTokens: AliasTokens {
-        return self.view.fluentTheme.aliasTokens
     }
 
     private struct Constants {
@@ -50,7 +46,7 @@ class TypographyTokensDemoController: DemoTableViewController {
 
 // MARK: - Private extensions
 
-private extension AliasTokens.TypographyTokens {
+private extension FluentTheme.TypographyToken {
     var text: String {
         switch self {
         case .display:

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
@@ -172,7 +172,7 @@ class TableViewCellSampleData: TableViewSampleData {
         stackView.axis = .vertical
 
         let label = Label(style: .caption1)
-        label.textColor = UIColor(dynamicColor: stackView.fluentTheme.aliasTokens.colors[.foreground3])
+        label.textColor = UIColor(dynamicColor: stackView.fluentTheme.color(.foreground3))
         label.text = text
         stackView.addArrangedSubview(label)
 
@@ -189,7 +189,7 @@ class TableViewCellSampleData: TableViewSampleData {
 
         if withBorder {
             container.layer.borderWidth = 0.5
-            container.layer.borderColor = UIColor(dynamicColor: stackView.fluentTheme.aliasTokens.colors[.foreground3]).cgColor
+            container.layer.borderColor = UIColor(dynamicColor: stackView.fluentTheme.color(.foreground3)).cgColor
             container.layer.cornerRadius = 3
         }
 

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -80,11 +80,11 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                     case .size16, .size20:
                         return .init(size: 9, weight: GlobalTokens.fontWeight(.regular))
                     case .size24:
-                        return theme.aliasTokens.typography[.caption2]
+                        return theme.typography(.caption2)
                     case .size32:
-                        return theme.aliasTokens.typography[.caption1]
+                        return theme.typography(.caption1)
                     case .size40:
-                        return theme.aliasTokens.typography[.body2]
+                        return theme.typography(.body2)
                     case .size56:
                         return .init(size: GlobalTokens.fontSize(.size500), weight: GlobalTokens.fontWeight(.regular))
                     case .size72:
@@ -96,15 +96,15 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .dynamicColor({
                     switch style() {
                     case .default, .group, .accent, .outlinedPrimary:
-                        return theme.aliasTokens.colors[.brandStroke1]
+                        return theme.color(.brandStroke1)
                     case .outlined, .overflow:
-                        return theme.aliasTokens.colors[.strokeAccessible]
+                        return theme.color(.strokeAccessible)
                     }
                 })
 
             case .ringGapColor:
                 return .dynamicColor({
-                    theme.aliasTokens.colors[.background1]
+                    theme.color(.background1)
                 })
 
             case .ringThickness:
@@ -151,30 +151,30 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
 
             case .borderColor:
                 return .dynamicColor({
-                    theme.aliasTokens.colors[.background1]
+                    theme.color(.background1)
                 })
 
             case .activityForegroundColor:
                 return .dynamicColor({
-                    theme.aliasTokens.colors[.foreground1]
+                    theme.color(.foreground1)
                 })
 
             case .activityBackgroundColor:
                 return .dynamicColor({
-                    theme.aliasTokens.colors[.background5]
+                    theme.color(.background5)
                 })
 
             case .backgroundDefaultColor:
                 return .dynamicColor({
                     switch style() {
                     case .default, .group:
-                        return theme.aliasTokens.colors[.background1]
+                        return theme.color(.background1)
                     case .accent:
-                        return theme.aliasTokens.colors[.brandBackground1]
+                        return theme.color(.brandBackground1)
                     case .outlined, .overflow:
-                        return theme.aliasTokens.colors[.background5]
+                        return theme.color(.background5)
                     case .outlinedPrimary:
-                        return theme.aliasTokens.colors[.brandBackgroundTint]
+                        return theme.color(.brandBackgroundTint)
                     }
                 })
 
@@ -182,13 +182,13 @@ public class AvatarTokenSet: ControlTokenSet<AvatarTokenSet.Tokens> {
                 return .dynamicColor({
                     switch style() {
                     case .default, .group:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .accent:
-                        return theme.aliasTokens.colors[.foregroundOnColor]
+                        return theme.color(.foregroundOnColor)
                     case .outlined, .overflow:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .outlinedPrimary:
-                        return theme.aliasTokens.colors[.brandForegroundTint]
+                        return theme.color(.brandForegroundTint)
                     }
                 })
             }

--- a/ios/FluentUI/Avatar/MSFAvatarPresence.swift
+++ b/ios/FluentUI/Avatar/MSFAvatarPresence.swift
@@ -23,15 +23,15 @@ import SwiftUI
         case .none:
             break
         case .available:
-            color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceAvailable])
+            color = UIColor(dynamicColor: fluentTheme.color(.presenceAvailable))
         case .away:
-            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceAway])
+            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.color(.presenceOof)) : UIColor(dynamicColor: fluentTheme.color(.presenceAway))
         case .busy, .blocked, .doNotDisturb:
-            color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceDnd])
+            color = UIColor(dynamicColor: fluentTheme.color(.presenceDnd))
         case .offline:
-            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.presenceOof]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.color(.presenceOof)) : UIColor(dynamicColor: fluentTheme.color(.foreground3))
         case .unknown:
-            color = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+            color = UIColor(dynamicColor: fluentTheme.color(.foreground3))
         }
 
         return Color(color)

--- a/ios/FluentUI/Avatar/MSFAvatarPresence.swift
+++ b/ios/FluentUI/Avatar/MSFAvatarPresence.swift
@@ -17,24 +17,24 @@ import SwiftUI
     case unknown
 
     func color(isOutOfOffice: Bool, fluentTheme: FluentTheme) -> Color {
-        var color = UIColor.clear
+        let colorToken: FluentTheme.ColorToken
 
         switch self {
         case .none:
-            break
+            return .clear
         case .available:
-            color = UIColor(dynamicColor: fluentTheme.color(.presenceAvailable))
+            colorToken = .presenceAvailable
         case .away:
-            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.color(.presenceOof)) : UIColor(dynamicColor: fluentTheme.color(.presenceAway))
+            colorToken = isOutOfOffice ? .presenceOof : .presenceAway
         case .busy, .blocked, .doNotDisturb:
-            color = UIColor(dynamicColor: fluentTheme.color(.presenceDnd))
+            colorToken = .presenceDnd
         case .offline:
-            color = isOutOfOffice ? UIColor(dynamicColor: fluentTheme.color(.presenceOof)) : UIColor(dynamicColor: fluentTheme.color(.foreground3))
+            colorToken = isOutOfOffice ? .presenceOof : .foreground3
         case .unknown:
-            color = UIColor(dynamicColor: fluentTheme.color(.foreground3))
+            colorToken = .foreground3
         }
 
-        return Color(color)
+        return Color(dynamicColor: fluentTheme.color(colorToken))
     }
 
     func image(isOutOfOffice: Bool) -> Image {

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -210,7 +210,7 @@ open class BadgeField: UIView {
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+        backgroundColor = UIColor(dynamicColor: fluentTheme.color(.background1))
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -246,7 +246,7 @@ open class BadgeField: UIView {
     }
 
     private func setupTextField(_ textField: UITextField) {
-        textField.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
+        textField.font = UIFont.fluent(fluentTheme.typography(.body1))
         textField.autocapitalizationType = .none
         textField.autocorrectionType = .no
         textField.keyboardType = .emailAddress

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -72,7 +72,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
         case small
         case medium
 
-        var labelTextStyle: AliasTokens.TypographyTokens {
+        var labelTextStyle: FluentTheme.TypographyToken {
             switch self {
             case .small:
                 return .caption1
@@ -144,17 +144,17 @@ open class BadgeView: UIView, TokenizedControlInternal {
             }
             switch style {
             case .default:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForegroundTint])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandForegroundTint))
             case .warning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.warningForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.warningForeground1))
             case .error:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.dangerForeground1))
             case .neutral:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2))
             case .severeWarning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.severeForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.severeForeground1))
             case .success:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.successForeground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.successForeground1))
             }
         }
         set {
@@ -174,15 +174,15 @@ open class BadgeView: UIView, TokenizedControlInternal {
 
             switch style {
             case .default:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundOnColor])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.foregroundOnColor))
             case .warning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundDarkStatic])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.foregroundDarkStatic))
             case .error,
                  .severeWarning,
                  .success:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundLightStatic])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.foregroundLightStatic))
             case .neutral:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground1))
             }
         }
         set {
@@ -200,9 +200,9 @@ open class BadgeView: UIView, TokenizedControlInternal {
                 return customDisabledLabelTextColor
             }
 
-            let textDisabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+            let textDisabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foregroundDisabled1))
             if style == .default {
-                return UIColor(light: UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]), dark: textDisabledColor)
+                return UIColor(light: UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandForegroundDisabled1)), dark: textDisabledColor)
             } else {
                 return textDisabledColor
             }
@@ -223,17 +223,17 @@ open class BadgeView: UIView, TokenizedControlInternal {
             }
             switch style {
             case .default:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackgroundTint])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandBackgroundTint))
             case .warning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.warningBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.warningBackground1))
             case .error:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.dangerBackground1))
             case .neutral:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background5])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.background5))
             case .severeWarning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.severeBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.severeBackground1))
             case .success:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.successBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.successBackground1))
             }
         }
         set {
@@ -252,17 +252,17 @@ open class BadgeView: UIView, TokenizedControlInternal {
             }
             switch style {
             case .default:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground1])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandBackground1))
             case .warning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.warningBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.warningBackground2))
             case .error:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.dangerBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.dangerBackground2))
             case .neutral:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background5Selected])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.background5Selected))
             case .severeWarning:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.severeBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.severeBackground2))
             case .success:
-                return UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.successBackground2])
+                return UIColor(dynamicColor: tokenSet.fluentTheme.color(.successBackground2))
             }
         }
         set {
@@ -289,9 +289,9 @@ open class BadgeView: UIView, TokenizedControlInternal {
                 return customDisabledBackgroundColor
             }
 
-            let backgroundDisabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background5])
+            let backgroundDisabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.background5))
             if style == .default {
-                return UIColor(light: UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground3]), dark: backgroundDisabledColor)
+                return UIColor(light: UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandBackground3)), dark: backgroundDisabledColor)
             } else {
                 return backgroundDisabledColor
             }
@@ -337,7 +337,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
 
     private var size: Size = .medium {
         didSet {
-            label.style = size.labelTextStyle
+            label.textStyle = size.labelTextStyle
             invalidateIntrinsicContentSize()
         }
     }
@@ -414,9 +414,9 @@ open class BadgeView: UIView, TokenizedControlInternal {
     private func updateFonts() {
         switch size {
         case .small:
-            label.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.caption1])
+            label.font = UIFont.fluent(tokenSet.fluentTheme.typography(.caption1))
         case .medium:
-            label.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.body2])
+            label.font = UIFont.fluent(tokenSet.fluentTheme.typography(.body2))
         }
     }
 

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -872,8 +872,8 @@ open class BottomCommandingController: UIViewController {
     }
 
     private lazy var tableViewIconTintColor: UIColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey50))
-    private lazy var tableViewBackgroundColor: UIColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
-    private lazy var bottomBarBackgroundColor: UIColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background2])
+    private lazy var tableViewBackgroundColor: UIColor = UIColor(dynamicColor: view.fluentTheme.color(.background2))
+    private lazy var bottomBarBackgroundColor: UIColor = UIColor(dynamicColor: view.fluentTheme.color(.background2))
 
     private struct Constants {
         static let defaultHeroButtonHeight: CGFloat = 40

--- a/ios/FluentUI/Bottom Sheet/BottomSheetTokenSet.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetTokenSet.swift
@@ -16,13 +16,13 @@ public class BottomSheetTokenSet: ControlTokenSet<BottomSheetTokenSet.Tokens> {
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor { DynamicColor(light: theme.aliasTokens.colors[.background2].light,
-                                                    dark: theme.aliasTokens.colors[.background2].dark)
+                return .dynamicColor { DynamicColor(light: theme.color(.background2).light,
+                                                    dark: theme.color(.background2).dark)
                 }
             case .cornerRadius:
                 return .float { GlobalTokens.corner(.radius120) }
             case .shadow:
-                return .shadowInfo { theme.aliasTokens.shadow[.shadow28] }
+                return .shadowInfo { theme.shadow(.shadow28) }
             }
         }
     }

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -68,7 +68,7 @@ class CalendarView: UIView {
     }
 
     private func updateCollectionViewBackgroundColor() {
-        collectionView.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        collectionView.backgroundColor = UIColor(dynamicColor: fluentTheme.color(.background2))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayCell.swift
@@ -105,9 +105,9 @@ class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
 
         super.init(frame: frame)
 
-        dateLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
-        dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
-        dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
+        dateLabel.font = UIFont.fluent(fluentTheme.typography(.body1))
+        dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground3))
+        dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground3))
 
         contentView.addSubview(selectionOverlayView)
         contentView.addSubview(dateLabel)
@@ -120,8 +120,8 @@ class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
 
     func updateAppearance() {
         updateViews()
-        dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
-        dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
+        dotView.color = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground3))
+        dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground3))
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -209,26 +209,26 @@ class CalendarViewDayCell: UICollectionViewCell, TokenizedControlInternal {
     private func updateViews() {
         switch textStyle {
         case .primary:
-            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
+            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground1))
         case .secondary:
-            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
+            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2))
         }
 
         switch backgroundStyle {
         case .primary:
-            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.aliasTokens.colors[.background2].light, dark: tokenSet.fluentTheme.aliasTokens.colors[.background2].dark))
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.color(.background2).light, dark: tokenSet.fluentTheme.color(.background2).dark))
         case .secondary:
-            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.aliasTokens.colors[.backgroundCanvas].light, dark: tokenSet.fluentTheme.aliasTokens.colors[.backgroundCanvas].dark))
+            contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: tokenSet.fluentTheme.color(.backgroundCanvas).light, dark: tokenSet.fluentTheme.color(.backgroundCanvas).dark))
         }
 
         if isHighlighted || isSelected {
             dotView.isHidden = true
-            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            dateLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foregroundOnColor))
         } else {
             dotView.isHidden = false
         }
 
-        selectionOverlayView.activeColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandBackground1])
+        selectionOverlayView.activeColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandBackground1))
 
         setNeedsLayout()
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthCell.swift
@@ -35,7 +35,7 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
 
         super.init(frame: frame)
 
-        monthLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
+        monthLabel.font = UIFont.fluent(fluentTheme.typography(.caption2))
         updateMonthLabelColor()
         contentView.addSubview(monthLabel)
     }
@@ -46,7 +46,7 @@ class CalendarViewDayMonthCell: CalendarViewDayCell {
     }
 
     private func updateMonthLabelColor() {
-        monthLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+        monthLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayMonthYearCell.swift
@@ -30,8 +30,8 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
 
         super.init(frame: frame)
 
-        yearLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
-        yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        yearLabel.font = UIFont.fluent(fluentTheme.typography(.caption2))
+        yearLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground3))
         contentView.addSubview(yearLabel)
     }
 
@@ -64,9 +64,9 @@ class CalendarViewDayMonthYearCell: CalendarViewDayMonthCell {
     private func updateYearLabelColor(textStyle: CalendarViewDayCellTextStyle) {
         switch textStyle {
         case .primary:
-            yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+            yearLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground3))
         case .secondary:
-            yearLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            yearLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground1))
         }
     }
 

--- a/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewDayTodayCell.swift
@@ -46,21 +46,21 @@ class CalendarViewDayTodayCell: CalendarViewDayCell {
     }
 
     private func configureBackgroundColor() {
-        contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        contentView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light, dark: fluentTheme.color(.background2).dark))
     }
 
     private func configureFontColor() {
-        dateLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
+        dateLabel.font = UIFont.fluent(fluentTheme.typography(.body1))
 
         if isHighlighted || isSelected {
-            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            dateLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foregroundOnColor))
             dateLabel.showsLargeContentViewer = true
         } else {
             switch textStyle {
             case .primary:
-                dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+                dateLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground1))
             case .secondary:
-                dateLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+                dateLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground3))
             }
         }
     }

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -44,7 +44,7 @@ class CalendarViewWeekdayHeadingView: UIView {
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light, dark: fluentTheme.color(.background2).dark))
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -109,9 +109,9 @@ class CalendarViewWeekdayHeadingView: UIView {
             let label = UILabel()
             label.textAlignment = .center
             label.text = weekdaySymbol
-            label.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption2])
+            label.font = UIFont.fluent(fluentTheme.typography(.caption2))
             label.showsLargeContentViewer = true
-            label.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            label.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
             headingLabels.append(label)
             addSubview(label)
         }

--- a/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeTokenSet.swift
@@ -60,29 +60,29 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
             switch token {
             case .accentColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.brandForeground1]
+                    theme.color(.brandForeground1)
                 }
 
             case .backgroundColor:
                 switch style() {
                 case .standard:
                     return .dynamicColor {
-                        theme.aliasTokens.colors[.backgroundCanvas]
+                        theme.color(.backgroundCanvas)
                     }
                 case .outline:
                     return .dynamicColor {
-                        theme.aliasTokens.colors[.background1]
+                        theme.color(.background1)
                     }
             }
 
             case .buttonBackgroundColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.brandBackgroundTint]
+                    theme.color(.brandBackgroundTint)
                 }
 
             case .buttonForegroundColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.brandForegroundTint]
+                    theme.color(.brandForegroundTint)
                 }
 
             case .circleRadius:
@@ -99,11 +99,11 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
                 switch style() {
                 case .standard:
                     return .dynamicColor {
-                        theme.aliasTokens.colors[.backgroundCanvas]
+                        theme.color(.backgroundCanvas)
                     }
                 case .outline:
                     return .dynamicColor {
-                        theme.aliasTokens.colors[.stroke2]
+                        theme.color(.stroke2)
                     }
                 }
 
@@ -114,22 +114,22 @@ public class CardNudgeTokenSet: ControlTokenSet<CardNudgeTokenSet.Tokens> {
 
             case .subtitleTextColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.foreground2]
+                    theme.color(.foreground2)
                 }
 
             case .textColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.foreground1]
+                    theme.color(.foreground1)
                 }
 
             case .titleFont:
                 return .fontInfo {
-                    theme.aliasTokens.typography[.body2Strong]
+                    theme.typography(.body2Strong)
                 }
 
             case .subtitleFont:
                 return .fontInfo {
-                    theme.aliasTokens.typography[.caption1]
+                    theme.typography(.caption1)
                 }
             }
         }

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -209,7 +209,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     }
 
     /// Set `customBackgroundColor` in order to set the background color when using the custom color style
-    @objc open lazy var customBackgroundColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background2]) {
+    @objc open lazy var customBackgroundColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.background2)) {
         didSet {
             if customBackgroundColor != oldValue {
                 setupColors()
@@ -218,7 +218,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     }
 
     /// Set `customTitleColor` in order to set the title's text color when using the custom color style
-    @objc open lazy var customTitleColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1]) {
+    @objc open lazy var customTitleColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground1)) {
         didSet {
             if customTitleColor != oldValue {
                 setupColors()
@@ -227,7 +227,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     }
 
     /// Set `customSubtitleColor` in order to set the subtitle's text color when using the custom color style
-    @objc open lazy var customSubtitleColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2]) {
+    @objc open lazy var customSubtitleColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2)) {
         didSet {
             if customSubtitleColor != oldValue {
                 setupColors()
@@ -236,7 +236,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     }
 
     /// Set `customIconTintColor` in order to set the icon's tint color when using the custom color style
-    @objc open lazy var customIconTintColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2]) {
+    @objc open lazy var customIconTintColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2)) {
         didSet {
             if customIconTintColor != oldValue {
                 setupColors()
@@ -245,7 +245,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     }
 
     /// Set `customBorderColor` in order to set the border's color when using the custom color style
-    @objc open lazy var customBorderColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]) {
+    @objc open lazy var customBorderColor: UIColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.stroke1)) {
         didSet {
             if customBorderColor != oldValue {
                 setupColors()
@@ -369,7 +369,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     public var keyShadow: CALayer?
 
     private func updateShadow() {
-        let shadowInfo = tokenSet.fluentTheme.aliasTokens.shadow[.shadow02]
+        let shadowInfo = tokenSet.fluentTheme.shadow(.shadow02)
         shadowInfo.applyShadow(to: self)
     }
 
@@ -391,9 +391,9 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
                 // Update border color
                 switch colorStyle {
                 case .appColor:
-                    layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+                    layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.stroke1)).cgColor
                 case .neutral:
-                    layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+                    layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.stroke1)).cgColor
                 case .custom:
                     layer.borderColor = customBorderColor.cgColor
                 }
@@ -414,17 +414,17 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
     private func setupColors() {
         switch colorStyle {
         case .appColor:
-            primaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
-            secondaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
-            iconView.tintColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForeground1])
-            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background2])
-            layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+            primaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground1))
+            secondaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2))
+            iconView.tintColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandForeground1))
+            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.background2))
+            layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.stroke1)).cgColor
         case .neutral:
-            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background2])
-            primaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground1])
-            secondaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
-            iconView.tintColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
-            layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.stroke1]).cgColor
+            backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.background2))
+            primaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground1))
+            secondaryLabel.textColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2))
+            iconView.tintColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2))
+            layer.borderColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.stroke1)).cgColor
         case .custom:
             backgroundColor = customBackgroundColor
             primaryLabel.textColor = customTitleColor

--- a/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
+++ b/ios/FluentUI/Command Bar/CommandBarTokenSet.swift
@@ -58,34 +58,34 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarTokenSet.Tokens> {
                 return .float { GlobalTokens.corner(.radius120) }
 
             case .itemBackgroundColorRest:
-                return .dynamicColor { theme.aliasTokens.colors[.background5] }
+                return .dynamicColor { theme.color(.background5) }
 
             case .itemBackgroundColorHover:
-                return .dynamicColor { theme.aliasTokens.colors[.background5] }
+                return .dynamicColor { theme.color(.background5) }
 
             case .itemBackgroundColorPressed:
-                return .dynamicColor { theme.aliasTokens.colors[.background5Pressed] }
+                return .dynamicColor { theme.color(.background5Pressed) }
 
             case .itemBackgroundColorSelected:
-                return .dynamicColor { theme.aliasTokens.colors[.brandBackgroundTint] }
+                return .dynamicColor { theme.color(.brandBackgroundTint) }
 
             case .itemBackgroundColorDisabled:
-                return .dynamicColor { theme.aliasTokens.colors[.background5] }
+                return .dynamicColor { theme.color(.background5) }
 
             case .itemIconColorRest:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground1] }
+                return .dynamicColor { theme.color(.foreground1) }
 
             case .itemIconColorHover:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground1] }
+                return .dynamicColor { theme.color(.foreground1) }
 
             case .itemIconColorPressed:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground1] }
+                return .dynamicColor { theme.color(.foreground1) }
 
             case .itemIconColorSelected:
-                return .dynamicColor { theme.aliasTokens.colors[.brandForegroundTint] }
+                return .dynamicColor { theme.color(.brandForegroundTint) }
 
             case .itemIconColorDisabled:
-                return .dynamicColor { theme.aliasTokens.colors[.foregroundDisabled1] }
+                return .dynamicColor { theme.color(.foregroundDisabled1) }
             }
         }
     }

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -33,8 +33,8 @@ public protocol ColorProviding {
 }
 
 private func brandColorOverrides(provider: ColorProviding,
-                                 for themeable: FluentThemeable) -> [AliasTokens.ColorsTokens: DynamicColor] {
-    var brandColors: [AliasTokens.ColorsTokens: DynamicColor] = [:]
+                                 for themeable: FluentThemeable) -> [FluentTheme.ColorToken: DynamicColor] {
+    var brandColors: [FluentTheme.ColorToken: DynamicColor] = [:]
     if let brandBackground1 = provider.brandBackground1(for: themeable)?.dynamicColor {
         brandColors[.brandBackground1] = brandBackground1
     }

--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -32,8 +32,7 @@ public class FluentUIFramework: NSObject {
 
     @available(*, deprecated, renamed: "initializeAppearance(with:whenContainedInInstancesOf:)")
     @objc public static func initializeAppearance() {
-        let aliasTokens = FluentTheme.shared.aliasTokens
-        let primaryColor = UIColor(dynamicColor: aliasTokens.colors[.brandBackground1])
+        let primaryColor = UIColor(dynamicColor: FluentTheme.shared.color(.brandBackground1))
         initializeAppearance(with: primaryColor)
     }
 
@@ -44,9 +43,9 @@ public class FluentUIFramework: NSObject {
         func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .normal:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
+                return UIColor(dynamicColor: fluentTheme.color(.background3))
             case .dateTimePicker:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light, dark: fluentTheme.color(.background2).dark))
             }
         }
     }
@@ -69,15 +68,15 @@ public class FluentUIFramework: NSObject {
         let toolbar = UIToolbar.appearance()
         toolbar.isTranslucent = false
 
-        let aliasTokens = fluentTheme?.aliasTokens ?? AliasTokens()
+        let fluentTheme = fluentTheme ?? FluentTheme.shared
 
-        toolbar.barTintColor = UIColor(dynamicColor: aliasTokens.colors[.background3])
-        toolbar.tintColor = UIColor(dynamicColor: aliasTokens.colors[.foreground3])
+        toolbar.barTintColor = UIColor(dynamicColor: fluentTheme.color(.background3))
+        toolbar.tintColor = UIColor(dynamicColor: fluentTheme.color(.foreground3))
 
         // UIBarButtonItem
         let barButtonItem = UIBarButtonItem.appearance()
         var titleAttributes = barButtonItem.titleTextAttributes(for: .normal) ?? [:]
-        titleAttributes[.font] = UIFont.fluent(aliasTokens.typography[.body1])
+        titleAttributes[.font] = UIFont.fluent(fluentTheme.typography(.body1))
         barButtonItem.setTitleTextAttributes(titleAttributes, for: .normal)
 
         let switchAppearance = containerTypes != nil ? UISwitch.appearance(whenContainedInInstancesOf: containerTypes!) : UISwitch.appearance()
@@ -85,7 +84,7 @@ public class FluentUIFramework: NSObject {
 
         let progressViewAppearance = containerTypes != nil ? UIProgressView.appearance(whenContainedInInstancesOf: containerTypes!) : UIProgressView.appearance()
         progressViewAppearance.progressTintColor = primaryColor
-        progressViewAppearance.trackTintColor = UIColor(dynamicColor: aliasTokens.colors[.stroke1])
+        progressViewAppearance.trackTintColor = UIColor(dynamicColor: fluentTheme.color(.stroke1))
     }
 
     static func initializeUINavigationBarAppearance(_ navigationBar: UINavigationBar, traits: UITraitCollection? = nil, navigationBarStyle: NavigationBarStyle = .normal, fluentTheme: FluentTheme? = nil) {
@@ -93,24 +92,18 @@ public class FluentUIFramework: NSObject {
 
         let standardAppearance = navigationBar.standardAppearance
 
-        let aliasTokens: AliasTokens
-        if let fluentTheme = fluentTheme {
-            navigationBar.standardAppearance.backgroundColor = navigationBarStyle.backgroundColor(fluentTheme: fluentTheme)
-            aliasTokens = fluentTheme.aliasTokens
-        } else {
-            aliasTokens = AliasTokens()
-            navigationBar.standardAppearance.backgroundColor = UIColor(dynamicColor: aliasTokens.colors[.background3])
-        }
+        let fluentTheme = fluentTheme ?? FluentTheme.shared
+        navigationBar.standardAppearance.backgroundColor = navigationBarStyle.backgroundColor(fluentTheme: fluentTheme)
 
-        navigationBar.tintColor = UIColor(dynamicColor: aliasTokens.colors[.foreground2])
+        navigationBar.tintColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
 
         let traits = traits ?? navigationBar.traitCollection
         // Removing built-in shadow for Dark Mode
         navigationBar.shadowImage = traits.userInterfaceStyle == .dark ? UIImage() : nil
 
         var titleAttributes = standardAppearance.titleTextAttributes
-        titleAttributes[.font] = UIFont.fluent(aliasTokens.typography[.body1Strong])
-        titleAttributes[.foregroundColor] = UIColor(dynamicColor: aliasTokens.colors[.foreground1])
+        titleAttributes[.font] = UIFont.fluent(fluentTheme.typography(.body1Strong))
+        titleAttributes[.foregroundColor] = UIColor(dynamicColor: fluentTheme.color(.foreground1))
 
         standardAppearance.titleTextAttributes = titleAttributes
 

--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -151,7 +151,7 @@ public extension FluentTheme {
     /// - Parameter token: The `TypographyTokens` value to be retrieved.
     /// - Returns: A `FontInfo` for the given token.
     @objc(typographyForToken:)
-    func typography(_ token: AliasTokens.TypographyTokens) -> FontInfo {
+    func typography(_ token: TypographyToken) -> FontInfo {
         return aliasTokens.typography[AliasTokens.TypographyTokens(rawValue: token.rawValue)!]
     }
 }

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -21,13 +21,28 @@ public class FluentTheme: NSObject, ObservableObject {
     ///   - typographyOverrides: A `Dictionary` of override values mapped to `TypographyTokens`.
     ///
     /// - Returns: An initialized `FluentTheme` instance, with optional overrides.
-    public init(colorOverrides: [AliasTokens.ColorsTokens: DynamicColor]? = nil,
-                shadowOverrides: [AliasTokens.ShadowTokens: ShadowInfo]? = nil,
-                typographyOverrides: [AliasTokens.TypographyTokens: FontInfo]? = nil) {
+    public init(colorOverrides: [ColorToken: DynamicColor]? = nil,
+                shadowOverrides: [ShadowToken: ShadowInfo]? = nil,
+                typographyOverrides: [TypographyToken: FontInfo]? = nil) {
+        let fixedColorOverrides = colorOverrides?.map({ (key: ColorToken, value: DynamicColor) in
+            let newKey = AliasTokens.ColorsTokens(rawValue: key.rawValue)!
+            return (newKey, value)
+        }) ?? [(AliasTokens.ColorsTokens, DynamicColor)]()
+
+        let fixedShadowOverrides = shadowOverrides?.map({ (key: ShadowToken, value: ShadowInfo) in
+            let newKey = AliasTokens.ShadowTokens(rawValue: key.rawValue)!
+            return (newKey, value)
+        }) ?? [(AliasTokens.ShadowTokens, ShadowInfo)]()
+
+        let fixedTypographyOverrides = typographyOverrides?.map({ (key: TypographyToken, value: FontInfo) in
+            let newKey = AliasTokens.TypographyTokens(rawValue: key.rawValue)!
+            return (newKey, value)
+        }) ?? [(AliasTokens.TypographyTokens, FontInfo)]()
+
         // Pass overrides to AliasTokens
-        aliasTokens = .init(colorOverrides: colorOverrides,
-                            shadowOverrides: shadowOverrides,
-                            typographyOverrides: typographyOverrides)
+        aliasTokens = .init(colorOverrides: Dictionary(uniqueKeysWithValues: fixedColorOverrides),
+                            shadowOverrides: Dictionary(uniqueKeysWithValues: fixedShadowOverrides),
+                            typographyOverrides: Dictionary(uniqueKeysWithValues: fixedTypographyOverrides))
     }
 
     /// Registers a custom set of `ControlTokenValue` instances for a given `ControlTokenSet`.

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -189,7 +189,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBackgroundColor() {
-        view.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.aliasTokens.colors[.background2].light, dark: view.fluentTheme.aliasTokens.colors[.background2].dark))
+        view.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.color(.background2).light, dark: view.fluentTheme.color(.background2).dark))
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -219,8 +219,8 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBarButtonColors() {
-        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground1])
-        navigationItem.leftBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.color(.brandForeground1))
+        navigationItem.leftBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.color(.foreground2))
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -143,7 +143,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBackgroundColor() {
-        view.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.aliasTokens.colors[.background2].light, dark: view.fluentTheme.aliasTokens.colors[.background2].dark))
+        view.backgroundColor = UIColor(dynamicColor: DynamicColor(light: view.fluentTheme.color(.background2).light, dark: view.fluentTheme.color(.background2).dark))
     }
 
     override func viewWillLayoutSubviews() {
@@ -163,8 +163,8 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
     }
 
     private func updateBarButtonColors() {
-        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.brandForeground1])
-        navigationItem.leftBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.foreground2])
+        navigationItem.rightBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.color(.brandForeground1))
+        navigationItem.leftBarButtonItem?.tintColor = UIColor(dynamicColor: view.fluentTheme.color(.foreground2))
     }
 
     override func accessibilityPerformEscape() -> Bool {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -59,7 +59,7 @@ class DateTimePickerView: UIControl {
     }
 
     private func updateGradientLayerColors(gradientLayer: CAGradientLayer) {
-        let backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background2])
+        let backgroundColor = UIColor(dynamicColor: fluentTheme.color(.background2))
         let transparentColor = backgroundColor.withAlphaComponent(0)
         gradientLayer.colors = [backgroundColor.cgColor, transparentColor.cgColor, transparentColor.cgColor, backgroundColor.cgColor]
     }
@@ -97,7 +97,7 @@ class DateTimePickerView: UIControl {
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light, dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light, dark: fluentTheme.color(.background2).dark))
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerViewComponentCell.swift
@@ -17,7 +17,7 @@ class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal
     static let identifier: String = "DateTimePickerViewComponentCell"
 
     class var idealHeight: CGFloat {
-        let font = UIFont.fluent(FluentTheme.shared.aliasTokens.typography[.body1])
+        let font = UIFont.fluent(FluentTheme.shared.typography(.body1))
         return max(Constants.verticalPadding * 2 + font.lineHeight, Constants.baseHeight)
     }
 
@@ -39,7 +39,7 @@ class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal
 
         textLabel?.textAlignment = .center
         textLabel?.showsLargeContentViewer = true
-        textLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1])
+        textLabel?.font = UIFont.fluent(fluentTheme.typography(.body1))
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTextLabelColor()
@@ -78,6 +78,6 @@ class DateTimePickerViewComponentCell: UITableViewCell, TokenizedControlInternal
     }
 
     private func updateTextLabelColor() {
-        textLabel?.textColor = emphasized ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+        textLabel?.textColor = emphasized ? UIColor(dynamicColor: fluentTheme.color(.brandForeground1)) : UIColor(dynamicColor: fluentTheme.color(.foreground2))
     }
 }

--- a/ios/FluentUI/Divider/DividerTokenSet.swift
+++ b/ios/FluentUI/Divider/DividerTokenSet.swift
@@ -37,7 +37,7 @@ public class DividerTokenSet: ControlTokenSet<DividerTokenSet.Tokens> {
                 }
 
             case .color:
-                return .dynamicColor { theme.aliasTokens.colors[.stroke2] }
+                return .dynamicColor { theme.color(.stroke2) }
             }
         }
     }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -99,13 +99,13 @@ public protocol DrawerControllerDelegate: AnyObject {
 @objc(MSFDrawerController)
 open class DrawerController: UIViewController {
     @objc public static func drawerBackground(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light,
-                                                  dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light,
+                                                  dark: fluentTheme.color(.background2).dark))
     }
 
     @objc public static func popoverBackground(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background4].light,
-                                                  dark: fluentTheme.aliasTokens.colors[.background4].dark))
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background4).light,
+                                                  dark: fluentTheme.color(.background4).dark))
     }
 
     private struct Constants {
@@ -130,13 +130,13 @@ open class DrawerController: UIViewController {
     }
 
     private func drawerBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light,
-                                                  dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light,
+                                                  dark: fluentTheme.color(.background2).dark))
     }
 
     private func popoverBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background4].light,
-                                                  dark: fluentTheme.aliasTokens.colors[.background4].dark))
+        return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background4).light,
+                                                  dark: fluentTheme.color(.background4).dark))
     }
 
     /**
@@ -536,7 +536,7 @@ open class DrawerController: UIViewController {
             if presentationController is UIPopoverPresentationController {
                 backgroundColor = popoverBackgroundColor(fluentTheme: view.fluentTheme)
             } else if useNavigationBarBackgroundColor {
-                backgroundColor = UIColor(dynamicColor: view.fluentTheme.aliasTokens.colors[.background3])
+                backgroundColor = UIColor(dynamicColor: view.fluentTheme.color(.background3))
             } else {
                 backgroundColor = drawerBackgroundColor(fluentTheme: view.fluentTheme)
             }

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -27,7 +27,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
             switch token {
             case .backgroundColor:
                 return .dynamicColor {
-                    return theme.aliasTokens.colors[.backgroundDarkStatic]
+                    return theme.color(.backgroundDarkStatic)
                 }
 
             case .cornerRadius:
@@ -43,7 +43,7 @@ public class HeadsUpDisplayTokenSet: ControlTokenSet<HeadsUpDisplayTokenSet.Toke
 
             case .labelColor:
                 return .dynamicColor {
-                    return theme.aliasTokens.colors[.foregroundLightStatic]
+                    return theme.color(.foregroundLightStatic)
                 }
             }
         }

--- a/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokenSet.swift
+++ b/ios/FluentUI/IndeterminateProgressBar/IndeterminateProgressBarTokenSet.swift
@@ -21,12 +21,12 @@ public class IndeterminateProgressBarTokenSet: ControlTokenSet<IndeterminateProg
             switch token {
             case .backgroundColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.stroke1]
+                    theme.color(.stroke1)
                 }
 
             case .gradientColor:
                 return .dynamicColor {
-                    theme.aliasTokens.colors[.brandBackground1]
+                    theme.color(.brandBackground1)
                 }
             }
         }

--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -49,15 +49,15 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
     }
 
     private func updateColors() {
-        let colors = tokenSet.fluentTheme.aliasTokens.colors
+        let colorValues = tokenSet.fluentTheme.color
         if shouldUseWindowColor {
-            textColor = UIColor(dynamicColor: DynamicColor(light: colors[.brandForeground1].light,
+            textColor = UIColor(dynamicColor: DynamicColor(light: colorValues(.brandForeground1).light,
                                                            dark: GlobalTokens.neutralColors(.white)))
             backgroundColor = UIColor(dynamicColor: DynamicColor(light: GlobalTokens.neutralColors(.white),
-                                                                 dark: colors[.brandBackground1].dark))
+                                                                 dark: colorValues(.brandBackground1).dark))
         } else {
             textColor = UIColor(colorValue: GlobalTokens.neutralColors(.white))
-            backgroundColor = UIColor(dynamicColor: colors[.dangerBackground2])
+            backgroundColor = UIColor(dynamicColor: colorValues(.dangerBackground2))
         }
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -16,12 +16,21 @@ open class Label: UILabel, TokenizedControlInternal {
             updateTextColor()
         }
     }
-    @objc open var style: AliasTokens.TypographyTokens = .body1 {
+    @objc open var style: AliasTokens.TypographyTokens {
+        get {
+            return AliasTokens.TypographyTokens(rawValue: textStyle.rawValue)!
+        }
+        set {
+            self.textStyle = FluentTheme.TypographyToken(rawValue: newValue.rawValue)!
+        }
+    }
+    @objc open var textStyle: FluentTheme.TypographyToken = .body1 {
         didSet {
             labelFont = nil
             updateFont()
         }
     }
+
     /**
      The maximum allowed size point for the receiver's font. This property can be used
      to restrict the largest size of the label when scaling due to Dynamic Type. The
@@ -64,17 +73,28 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     public typealias TokenSetKeyType = LabelTokenSet.Tokens
-    lazy public var tokenSet: LabelTokenSet = .init(style: { [weak self] in
-        return self?.style ?? .body1
+    lazy public var tokenSet: LabelTokenSet = .init(textStyle: { [weak self] in
+        return self?.textStyle ?? .body1
     },
                                                     colorStyle: { [weak self] in
         return self?.colorStyle ?? .regular
     })
 
+    @objc convenience public init() {
+        self.init(textStyle: .body1, colorStyle: .regular)
+    }
+
     @objc public init(style: AliasTokens.TypographyTokens = .body1, colorStyle: TextColorStyle = .regular) {
+        super.init(frame: .zero)
         self.style = style
         self.colorStyle = colorStyle
+        initialize()
+    }
+
+    @objc public init(textStyle: FluentTheme.TypographyToken = .body1, colorStyle: TextColorStyle = .regular) {
         super.init(frame: .zero)
+        self.textStyle = textStyle
+        self.colorStyle = colorStyle
         initialize()
     }
 

--- a/ios/FluentUI/Label/LabelTokenSet.swift
+++ b/ios/FluentUI/Label/LabelTokenSet.swift
@@ -22,29 +22,29 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
         case textColor
     }
 
-    init(style: @escaping () -> AliasTokens.TypographyTokens,
+    init(textStyle: @escaping () -> FluentTheme.TypographyToken,
          colorStyle: @escaping () -> TextColorStyle) {
-        self.style = style
+        self.textStyle = textStyle
         self.colorStyle = colorStyle
         super.init { [colorStyle] token, theme in
             switch token {
             case .font:
                 return .fontInfo {
-                    return theme.aliasTokens.typography[style()]
+                    return theme.typography(textStyle())
                 }
             case .textColor:
                 return .dynamicColor {
                     switch colorStyle() {
                     case .regular:
-                        return theme.aliasTokens.colors[.foreground1]
+                        return theme.color(.foreground1)
                     case .secondary:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .white:
                         return DynamicColor(light: GlobalTokens.neutralColors(.white))
                     case .primary:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .error:
-                        return theme.aliasTokens.colors[.dangerForeground2]
+                        return theme.color(.dangerForeground2)
                     }
                 }
             }
@@ -52,7 +52,7 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
     }
 
     /// Defines the text typography style of the label.
-    var style: () -> AliasTokens.TypographyTokens
+    var textStyle: () -> FluentTheme.TypographyToken
     /// Defines the text color style of the label.
     var colorStyle: () -> TextColorStyle
 }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -65,28 +65,28 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         func tintColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primary, .default, .custom:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground2).dark))
             case .system:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground2))
             }
         }
 
         func titleColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .primary, .default, .custom:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground1).dark))
             case .system:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground1))
             }
         }
 
         public func backgroundColor(fluentTheme: FluentTheme, customColor: UIColor? = nil) -> UIColor {
-            let defaultColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground1].light, dark: fluentTheme.aliasTokens.colors[.background3].dark))
+            let defaultColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandBackground1).light, dark: fluentTheme.color(.background3).dark))
             switch self {
             case .primary, .default:
                 return defaultColor
             case .system:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background3])
+                return UIColor(dynamicColor: fluentTheme.color(.background3))
             case .custom:
                 return customColor ?? defaultColor
             }

--- a/ios/FluentUI/Navigation/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar.swift
@@ -30,46 +30,46 @@ open class SearchBar: UIView, TokenizedControlInternal {
         func backgroundColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background5])
+                return UIColor(dynamicColor: fluentTheme.color(.background5))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2].light, dark: fluentTheme.aliasTokens.colors[.background5].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandBackground2).light, dark: fluentTheme.color(.background5).dark))
             }
         }
 
         func cancelButtonColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground1))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground1).dark))
             }
         }
 
         func clearIconColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground2))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground2).dark))
             }
         }
 
         func placeholderColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground3))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground3).dark))
             }
         }
 
         func searchIconColor(fluentTheme: FluentTheme, isSearching: Bool = false) -> UIColor {
-            let searchBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
-            let idleBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+            let searchBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground1).dark))
+            let idleBrandColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground3).dark))
 
             switch self {
             case .darkContent:
-                return isSearching ? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]) : UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+                return isSearching ? UIColor(dynamicColor: fluentTheme.color(.foreground1)) : UIColor(dynamicColor: fluentTheme.color(.foreground3))
             case .lightContent:
                 return isSearching ? searchBrandColor : idleBrandColor
             }
@@ -78,27 +78,27 @@ open class SearchBar: UIView, TokenizedControlInternal {
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground1))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground1).dark))
             }
         }
 
         func tintColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground3))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground3).dark))
             }
         }
 
         func progressSpinnerColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .darkContent:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground3))
             case .lightContent:
-                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light, dark: fluentTheme.aliasTokens.colors[.foreground3].dark))
+                return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light, dark: fluentTheme.color(.foreground3).dark))
             }
         }
     }
@@ -187,7 +187,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
     // user interaction point
     private lazy var searchTextField: SearchBarTextField = {
         let textField = SearchBarTextField()
-        textField.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.body1]).withSize(Constants.fontSize)
+        textField.font = UIFont.fluent(tokenSet.fluentTheme.typography(.body1)).withSize(Constants.fontSize)
         textField.delegate = self
         textField.returnKeyType = .search
         textField.enablesReturnKeyAutomatically = true
@@ -231,7 +231,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
     // hidden when the textfield is not active
     private lazy var cancelButton: UIButton = {
         let button = UIButton(type: .system)
-        button.titleLabel?.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.body1])
+        button.titleLabel?.font = UIFont.fluent(tokenSet.fluentTheme.typography(.body1))
         button.setTitle("Common.Cancel".localized, for: .normal)
         button.addTarget(self, action: #selector(SearchBar.cancelButtonTapped(sender:)), for: .touchUpInside)
         button.alpha = 0.0

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -92,7 +92,7 @@ class LargeTitleView: UIView {
             case .contracted:
                 titleButton.titleLabel?.font = Constants.compactTitleFont
             case .expanded:
-                titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
+                titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.typography(.title1))
             }
         }
     }
@@ -115,10 +115,10 @@ class LargeTitleView: UIView {
     private var colorForStyle: UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light,
+                                                      dark: fluentTheme.color(.foreground1).dark))
         case .system:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            return UIColor(dynamicColor: fluentTheme.color(.foreground1))
         }
     }
 
@@ -212,7 +212,7 @@ class LargeTitleView: UIView {
         // title button setup
         contentStackView.addArrangedSubview(titleButton)
         titleButton.setTitle(nil, for: .normal)
-        titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
+        titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.typography(.title1))
         titleButton.setTitleColor(colorForStyle, for: .normal)
         titleButton.titleLabel?.textAlignment = .left
         titleButton.contentHorizontalAlignment = .left
@@ -232,7 +232,7 @@ class LargeTitleView: UIView {
 
     private func expansionAnimation() {
         if titleSize == .automatic {
-            titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.title1])
+            titleButton.titleLabel?.font = UIFont.fluent(fluentTheme.typography(.title1))
         }
 
         if avatarSize == .automatic {

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -112,17 +112,17 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.aliasTokens.colors[.brandBackgroundTint]
+                        return theme.color(.brandBackgroundTint)
                     case .neutralToast:
-                        return theme.aliasTokens.colors[.background4]
+                        return theme.color(.background4)
                     case .primaryOutlineBar:
-                        return theme.aliasTokens.colors[.background1]
+                        return theme.color(.background1)
                     case .neutralBar:
-                        return theme.aliasTokens.colors[.background5]
+                        return theme.color(.background5)
                     case .dangerToast:
-                        return theme.aliasTokens.colors[.dangerBackground1]
+                        return theme.color(.dangerBackground1)
                     case .warningToast:
-                        return theme.aliasTokens.colors[.warningBackground1]
+                        return theme.color(.warningBackground1)
                     }
                 }
 
@@ -131,16 +131,16 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.aliasTokens.colors[.brandForegroundTint]
+                        return theme.color(.brandForegroundTint)
                     case .neutralToast,
                             .neutralBar:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .primaryOutlineBar:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .dangerToast:
-                        return theme.aliasTokens.colors[.dangerForeground1]
+                        return theme.color(.dangerForeground1)
                     case .warningToast:
-                        return theme.aliasTokens.colors[.warningForeground1]
+                        return theme.color(.warningForeground1)
                     }
                 }
 
@@ -149,16 +149,16 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.aliasTokens.colors[.brandForegroundTint]
+                        return theme.color(.brandForegroundTint)
                     case .neutralToast,
                             .neutralBar:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .primaryOutlineBar:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .dangerToast:
-                        return theme.aliasTokens.colors[.dangerForeground1]
+                        return theme.color(.dangerForeground1)
                     case .warningToast:
-                        return theme.aliasTokens.colors[.warningForeground1]
+                        return theme.color(.warningForeground1)
                     }
                 }
 
@@ -197,7 +197,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case .primaryToast, .neutralToast, .primaryBar, .neutralBar, .dangerToast, .warningToast:
                         return DynamicColor(light: ColorValue.clear)
                     case .primaryOutlineBar:
-                        return theme.aliasTokens.colors[.stroke2]
+                        return theme.color(.stroke2)
                     }
                 }
 
@@ -207,17 +207,17 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
             case .shadow:
                 return .shadowInfo {
                     if style().isToast {
-                        return theme.aliasTokens.shadow[.shadow16]
+                        return theme.shadow(.shadow16)
                     } else {
-                        return theme.aliasTokens.shadow[.clear]
+                        return theme.shadow(.clear)
                     }
                 }
 
             case .boldTextFont:
-                return .fontInfo { theme.aliasTokens.typography[.body2Strong] }
+                return .fontInfo { theme.typography(.body2Strong) }
 
             case .regularTextFont:
-                return .fontInfo { theme.aliasTokens.typography[.body2] }
+                return .fontInfo { theme.typography(.body2) }
             }
         }
     }

--- a/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
+++ b/ios/FluentUI/Other Cells/TableViewCellFileAccessoryView.swift
@@ -239,7 +239,7 @@ open class TableViewCellFileAccessoryView: UIView {
 
     private func updateSharedStatus() {
         let imageName = isShared ? "ic_fluent_people_24_regular" : "ic_fluent_person_24_regular"
-        let imageColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+        let imageColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
         sharedStatusImageView.image = UIImage.staticImageNamed(imageName)?.withTintColor(imageColor, renderingMode: .alwaysOriginal)
         sharedStatusLabel.text = isShared ? "Common.Shared".localized : "Common.OnlyMe".localized
     }
@@ -535,11 +535,11 @@ private class FileAccessoryViewActionView: UIButton {
 
     private func updateActionColor() {
         if action.useAppPrimaryColor {
-            tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+            tintColor = UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
         } else if action.isEnabled {
-            tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            tintColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
         } else {
-            tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+            tintColor = UIColor(dynamicColor: fluentTheme.color(.foregroundDisabled1))
         }
     }
 

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -164,8 +164,8 @@ open class PeoplePicker: BadgeField {
             self.pickPersona(persona: persona)
         }
         personaListView.searchDirectoryDelegate = self
-        personaListView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background2].light,
-                                                                             dark: fluentTheme.aliasTokens.colors[.background2].dark))
+        personaListView.backgroundColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background2).light,
+                                                                             dark: fluentTheme.color(.background2).dark))
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleKeyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -107,7 +107,7 @@ open class PersonaListView: UITableView {
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.background1])
+        backgroundColor = UIColor(dynamicColor: fluentTheme.color(.background1))
     }
 
     @objc public required init(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
@@ -53,26 +53,26 @@ public class PersonaButtonTokenSet: ControlTokenSet<PersonaButtonTokenSet.Tokens
         super.init { [size] token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1] }
+                return .dynamicColor { theme.color(.background1) }
 
             case .labelColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground1] }
+                return .dynamicColor { theme.color(.foreground1) }
 
             case .labelFont:
                 return .fontInfo {
                     switch size() {
                     case .small:
-                        return theme.aliasTokens.typography[.caption1]
+                        return theme.typography(.caption1)
                     case .large:
-                        return theme.aliasTokens.typography[.body2]
+                        return theme.typography(.body2)
                     }
                 }
 
             case .sublabelColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
+                return .dynamicColor { theme.color(.foreground3) }
 
             case .sublabelFont:
-                return .fontInfo { theme.aliasTokens.typography[.caption1] }
+                return .fontInfo { theme.typography(.caption1) }
             }
         }
     }

--- a/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselTokenSet.swift
+++ b/ios/FluentUI/PersonaButtonCarousel/PersonaButtonCarouselTokenSet.swift
@@ -17,7 +17,7 @@ public class PersonaButtonCarouselTokenSet: ControlTokenSet<PersonaButtonCarouse
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1] }
+                return .dynamicColor { theme.color(.background1) }
             }
         }
     }

--- a/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonStyle.swift
@@ -27,29 +27,29 @@ public extension PillButton {
     static func normalBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background5].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background5).light,
+                                                      dark: fluentTheme.color(.background3).dark,
+                                                      darkElevated: fluentTheme.color(.background5).darkElevated))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandBackground2).light,
+                                                      dark: fluentTheme.color(.background3).dark,
+                                                      darkElevated: fluentTheme.color(.background5).darkElevated))
         }
     }
 
     static func titleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            return UIColor(dynamicColor: fluentTheme.color(.foreground2))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foreground2].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground2].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light,
+                                                      dark: fluentTheme.color(.foreground2).dark,
+                                                      darkElevated: fluentTheme.color(.foreground2).darkElevated))
         }
     }
 
     static func titleFont(for fluentTheme: FluentTheme) -> FontInfo {
-        return fluentTheme.aliasTokens.typography[.body2]
+        return fluentTheme.typography(.body2)
     }
 
     // MARK: selected state
@@ -57,23 +57,23 @@ public extension PillButton {
     static func selectedBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
+            return UIColor(dynamicColor: fluentTheme.color(.brandBackground1))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3Selected].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Selected].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background1).light,
+                                                      dark: fluentTheme.color(.background3Selected).dark,
+                                                      darkElevated: fluentTheme.color(.background5Selected).darkElevated))
         }
     }
 
     static func selectedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundOnColor))
 
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground1].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandForeground1).light,
+                                                      dark: fluentTheme.color(.foreground1).dark,
+                                                      darkElevated: fluentTheme.color(.foreground1).darkElevated))
         }
     }
 
@@ -86,11 +86,11 @@ public extension PillButton {
     static func disabledTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundDisabled1))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foregroundDisabled1].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.foregroundDisabled1].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandForegroundDisabled1).light,
+                                                      dark: fluentTheme.color(.foregroundDisabled1).dark,
+                                                      darkElevated: fluentTheme.color(.foregroundDisabled1).darkElevated))
         }
     }
 
@@ -98,23 +98,23 @@ public extension PillButton {
     static func selectedDisabledBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1])
+            return UIColor(dynamicColor: fluentTheme.color(.brandBackground1))
 
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3Selected].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Selected].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background1).light,
+                                                      dark: fluentTheme.color(.background3Selected).dark,
+                                                      darkElevated: fluentTheme.color(.background5Selected).darkElevated))
         }
     }
 
     static func selectedDisabledTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1])
+            return UIColor(dynamicColor: fluentTheme.color(.brandForegroundDisabled1))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForegroundDisabled2].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foregroundDisabled2].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.foregroundDisabled2].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandForegroundDisabled2).light,
+                                                      dark: fluentTheme.color(.foregroundDisabled2).dark,
+                                                      darkElevated: fluentTheme.color(.foregroundDisabled2).darkElevated))
         }
     }
 
@@ -123,24 +123,24 @@ public extension PillButton {
     static func highlightedBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background5Pressed].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3Pressed].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Pressed].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background5Pressed).light,
+                                                      dark: fluentTheme.color(.background3Pressed).dark,
+                                                      darkElevated: fluentTheme.color(.background5Pressed).darkElevated))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandBackground2Pressed].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3Pressed].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background5Pressed].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandBackground2Pressed).light,
+                                                      dark: fluentTheme.color(.background3Pressed).dark,
+                                                      darkElevated: fluentTheme.color(.background5Pressed).darkElevated))
         }
     }
 
     static func highlightedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+            return UIColor(dynamicColor: fluentTheme.color(.foreground1))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground1].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light,
+                                                      dark: fluentTheme.color(.foreground1).dark,
+                                                      darkElevated: fluentTheme.color(.foreground1).darkElevated))
         }
     }
 
@@ -149,22 +149,22 @@ public extension PillButton {
     static func selectedHighlightedBackgroundColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandBackground1Pressed])
+            return UIColor(dynamicColor: fluentTheme.color(.brandBackground1Pressed))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.background1].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.background3Pressed].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.background3Pressed].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.background1).light,
+                                                      dark: fluentTheme.color(.background3Pressed).dark,
+                                                      darkElevated: fluentTheme.color(.background3Pressed).darkElevated))
         }
     }
 
     static func selectedHighlightedTitleColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundOnColor))
         case .onBrand:
-            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.brandForeground1Pressed].light,
-                                                      dark: fluentTheme.aliasTokens.colors[.foreground1].dark,
-                                                      darkElevated: fluentTheme.aliasTokens.colors[.foreground1].darkElevated))
+            return UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.brandForeground1Pressed).light,
+                                                      dark: fluentTheme.color(.foreground1).dark,
+                                                      darkElevated: fluentTheme.color(.foreground1).darkElevated))
         }
     }
 
@@ -173,21 +173,21 @@ public extension PillButton {
     static func enabledUnreadDotColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1]),
-                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]))
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.color(.brandForeground1)),
+                           dark: UIColor(dynamicColor: fluentTheme.color(.foreground2)))
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundOnColor]),
-                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]))
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.color(.foregroundOnColor)),
+                           dark: UIColor(dynamicColor: fluentTheme.color(.foreground1)))
         }
     }
 
     static func disabledUnreadDotColor(for fluentTheme: FluentTheme, for style: PillButtonStyle) -> UIColor {
         switch style {
         case .primary:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+            return UIColor(dynamicColor: fluentTheme.color(.foregroundDisabled1))
         case .onBrand:
-            return UIColor(light: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForegroundDisabled1]),
-                           dark: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foregroundDisabled1]))
+            return UIColor(light: UIColor(dynamicColor: fluentTheme.color(.brandForegroundDisabled1)),
+                           dark: UIColor(dynamicColor: fluentTheme.color(.foregroundDisabled1)))
         }
     }
 }

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -117,12 +117,12 @@ open class PopupMenuController: DrawerController {
     }
 
     /// set `separatorColor` to customize separator colors of  PopupMenuItem cells and the drawer
-    @objc open var separatorColor: UIColor = { return UIColor(dynamicColor: FluentTheme.shared.aliasTokens.colors[.stroke2]) }() {
-            didSet {
-                guard let separator = separator else {
-                    return
-                }
-                separator.backgroundColor = UIColor(cgColor: separatorColor.cgColor)
+    @objc open var separatorColor: UIColor = { return UIColor(dynamicColor: FluentTheme.shared.color(.stroke2)) }() {
+        didSet {
+            guard let separator = separator else {
+                return
+            }
+            separator.backgroundColor = UIColor(cgColor: separatorColor.cgColor)
         }
     }
 
@@ -224,7 +224,7 @@ open class PopupMenuController: DrawerController {
     }
 
     private func updateDescriptionLabelColor() {
-        descriptionLabel.textColor = UIColor(dynamicColor: tableView.fluentTheme.aliasTokens.colors[.foreground2])
+        descriptionLabel.textColor = UIColor(dynamicColor: tableView.fluentTheme.color(.foreground2))
     }
 
     @objc override func themeDidChange(_ notification: Notification) {

--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -28,19 +28,19 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem, FluentThemeable {
 
     /// `title` color
     @objc public var titleColor: UIColor {
-        get { return customTitleColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1]) }
+        get { return customTitleColor ?? UIColor(dynamicColor: fluentTheme.color(.foreground1)) }
         set { customTitleColor = newValue }
     }
     var customTitleColor: UIColor?
     /// `subtitle` color
     @objc public var subtitleColor: UIColor {
-        get { return customSubtitleColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]) }
+        get { return customSubtitleColor ?? UIColor(dynamicColor: fluentTheme.color(.foreground2)) }
         set { customSubtitleColor = newValue }
     }
     var customSubtitleColor: UIColor?
     /// `image` tint color if it is rendered as template
     @objc public var imageColor: UIColor {
-        get { return customImageColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2]) }
+        get { return customImageColor ?? UIColor(dynamicColor: fluentTheme.color(.foreground2)) }
         set { customImageColor = newValue }
     }
     var customImageColor: UIColor?

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -193,24 +193,24 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
     }
 
     private func updateColors() {
-        accessoryImageView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground3])
+        accessoryImageView.tintColor = UIColor(dynamicColor: fluentTheme.color(.foreground3))
 
         if let item = item {
             _imageView.tintColor = isSelected
-                ? item.imageSelectedColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+                ? item.imageSelectedColor ?? UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
             : item.imageColor
             titleLabel.textColor = isSelected
-            ? item.titleSelectedColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+            ? item.titleSelectedColor ?? UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
                 : item.titleColor
             subtitleLabel.textColor = isSelected
-                ? item.subtitleSelectedColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+                ? item.subtitleSelectedColor ?? UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
                 : item.subtitleColor
             backgroundColor = item.backgroundColor
         }
 
         if isSelected && item?.isAccessoryCheckmarkVisible == true {
             _accessoryType = .checkmark
-            accessoryTypeView?.customTintColor = item?.accessoryCheckmarkColor ?? UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+            accessoryTypeView?.customTintColor = item?.accessoryCheckmarkColor ?? UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
         } else {
             _accessoryType = .none
         }

--- a/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
+++ b/ios/FluentUI/ResizingHandleView/ResizingHandleView.swift
@@ -48,7 +48,7 @@ open class ResizingHandleView: UIView {
    }
 
     private func updateMarkLayerBackgroundColor() {
-        markLayer.backgroundColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.strokeAccessible]).cgColor
+        markLayer.backgroundColor = UIColor(dynamicColor: fluentTheme.color(.strokeAccessible)).cgColor
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -65,11 +65,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
-                                            dark: theme.aliasTokens.colors[.background5].dark)
+                        return DynamicColor(light: theme.color(.background5).light,
+                                            dark: theme.color(.background5).dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
-                                            dark: theme.aliasTokens.colors[.background5].dark)
+                        return DynamicColor(light: theme.color(.brandBackground2).light,
+                                            dark: theme.color(.background5).dark)
                     }
                 }
 
@@ -77,10 +77,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.colors[.brandBackground1]
+                        return theme.color(.brandBackground1)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                            dark: theme.aliasTokens.colors[.background5Selected].dark)
+                        return DynamicColor(light: theme.color(.background1).light,
+                                            dark: theme.color(.background5Selected).dark)
                     }
                 }
 
@@ -88,11 +88,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.background5].light,
-                                            dark: theme.aliasTokens.colors[.background5].dark)
+                        return DynamicColor(light: theme.color(.background5).light,
+                                            dark: theme.color(.background5).dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandBackground2].light,
-                                            dark: theme.aliasTokens.colors[.background5].dark)
+                        return DynamicColor(light: theme.color(.brandBackground2).light,
+                                            dark: theme.color(.background5).dark)
                     }
                 }
 
@@ -100,10 +100,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.colors[.brandBackground1]
+                        return theme.color(.brandBackground1)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.background1].light,
-                                            dark: theme.aliasTokens.colors[.background5Selected].dark)
+                        return DynamicColor(light: theme.color(.background1).light,
+                                            dark: theme.color(.background5Selected).dark)
                     }
                 }
 
@@ -111,10 +111,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground2].dark)
+                        return DynamicColor(light: theme.color(.foregroundOnColor).light,
+                                            dark: theme.color(.foreground2).dark)
                     }
                 }
 
@@ -122,10 +122,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.colors[.foregroundOnColor]
+                        return theme.color(.foregroundOnColor)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark)
+                        return DynamicColor(light: theme.color(.brandForeground1).light,
+                                            dark: theme.color(.foreground1).dark)
                     }
                 }
 
@@ -133,10 +133,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.colors[.foregroundDisabled1]
+                        return theme.color(.foregroundDisabled1)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled1].light,
-                                            dark: theme.aliasTokens.colors[.foregroundDisabled1].dark)
+                        return DynamicColor(light: theme.color(.brandForegroundDisabled1).light,
+                                            dark: theme.color(.foregroundDisabled1).dark)
                     }
                 }
 
@@ -144,10 +144,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return theme.aliasTokens.colors[.brandForegroundDisabled1]
+                        return theme.color(.brandForegroundDisabled1)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandForegroundDisabled2].light,
-                                            dark: theme.aliasTokens.colors[.foregroundDisabled2].dark)
+                        return DynamicColor(light: theme.color(.brandForegroundDisabled2).light,
+                                            dark: theme.color(.foregroundDisabled2).dark)
                     }
                 }
 
@@ -155,11 +155,11 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .dynamicColor {
                     switch style() {
                     case .primaryPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.brandForeground1].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark)
+                        return DynamicColor(light: theme.color(.brandForeground1).light,
+                                            dark: theme.color(.foreground1).dark)
                     case .onBrandPill:
-                        return DynamicColor(light: theme.aliasTokens.colors[.foregroundOnColor].light,
-                                            dark: theme.aliasTokens.colors[.foreground1].dark)
+                        return DynamicColor(light: theme.color(.foregroundOnColor).light,
+                                            dark: theme.color(.foreground1).dark)
                     }
                 }
 
@@ -179,7 +179,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
                 return .float { 6.0 }
 
             case .font:
-                return .fontInfo { theme.aliasTokens.typography[.body2] }
+                return .fontInfo { theme.typography(.body2) }
             }
         }
     }

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -39,7 +39,7 @@ open class Separator: UIView {
     @objc public static var thickness: CGFloat { return GlobalTokens.stroke(.width05) }
 
     @objc public static func separatorDefaultColor(fluentTheme: FluentTheme) -> UIColor {
-        return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.stroke2])
+        return UIColor(dynamicColor: fluentTheme.color(.stroke2))
     }
 
     private func initialize(orientation: SeparatorOrientation) {

--- a/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
+++ b/ios/FluentUI/Shimmer/ShimmerTokenSet.swift
@@ -72,9 +72,9 @@ public class ShimmerTokenSet: ControlTokenSet<ShimmerTokenSet.Tokens> {
                 return .dynamicColor {
                     switch style() {
                     case .concealing:
-                        return theme.aliasTokens.colors[.stencil2]
+                        return theme.color(.stencil2)
                     case .revealing:
-                        return theme.aliasTokens.colors[.stencil1]
+                        return theme.color(.stencil1)
                     }
                 }
 

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -272,10 +272,10 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
     }
 
     private func updateColors() {
-        let selectedColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.brandForeground1])
-        let unselectedImageColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground3])
-        let unselectedTextColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foreground2])
-        let disabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.foregroundDisabled1])
+        let selectedColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.brandForeground1))
+        let unselectedImageColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground3))
+        let unselectedTextColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foreground2))
+        let disabledColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.foregroundDisabled1))
 
         titleLabel.textColor = isEnabled ? (isSelected ? selectedColor : unselectedTextColor) : disabledColor
         imageView.tintColor = isEnabled ? (isSelected ? selectedColor : unselectedImageColor) : disabledColor

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -43,7 +43,7 @@ public enum TableViewCellAccessoryType: Int {
         case .detailButton:
             return UIColor(dynamicColor: tokenSet[.accessoryDetailButtonColor].dynamicColor)
         case .checkmark:
-            return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+            return UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -78,22 +78,22 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1] }
+                return .dynamicColor { theme.color(.background1) }
 
             case .backgroundGroupedColor:
-                return .dynamicColor { theme.aliasTokens.colors[.backgroundCanvas] }
+                return .dynamicColor { theme.color(.backgroundCanvas) }
 
             case .cellBackgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1] }
+                return .dynamicColor { theme.color(.background1) }
 
             case .cellBackgroundGroupedColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background3] }
+                return .dynamicColor { theme.color(.background3) }
 
             case .cellBackgroundSelectedColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1Pressed] }
+                return .dynamicColor { theme.color(.background1Pressed) }
 
             case .imageColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
+                return .dynamicColor { theme.color(.foreground3) }
 
             case .customViewDimensions:
                 return .float {
@@ -120,43 +120,43 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
                 }
 
             case .titleColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground1] }
+                return .dynamicColor { theme.color(.foreground1) }
 
             case .subtitleColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground2] }
+                return .dynamicColor { theme.color(.foreground2) }
 
             case .footerColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground2] }
+                return .dynamicColor { theme.color(.foreground2) }
 
             case .selectionIndicatorOffColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
+                return .dynamicColor { theme.color(.foreground3) }
 
             case .titleFont:
-                return .fontInfo { theme.aliasTokens.typography[.body1] }
+                return .fontInfo { theme.typography(.body1) }
 
             case .subtitleTwoLinesFont:
-                return .fontInfo { theme.aliasTokens.typography[.caption1] }
+                return .fontInfo { theme.typography(.caption1) }
 
             case .subtitleThreeLinesFont:
-                return .fontInfo { theme.aliasTokens.typography[.body2] }
+                return .fontInfo { theme.typography(.body2) }
 
             case .footerFont:
-                return .fontInfo { theme.aliasTokens.typography[.caption1] }
+                return .fontInfo { theme.typography(.caption1) }
 
             case .accessoryDisclosureIndicatorColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
+                return .dynamicColor { theme.color(.foreground3) }
 
             case .accessoryDetailButtonColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
+                return .dynamicColor { theme.color(.foreground3) }
 
             case .dangerTextColor:
-                return .dynamicColor { theme.aliasTokens.colors[.dangerForeground2] }
+                return .dynamicColor { theme.color(.dangerForeground2) }
 
             case .brandTextColor:
-                return .dynamicColor { theme.aliasTokens.colors[.brandForeground1] }
+                return .dynamicColor { theme.color(.brandForeground1) }
 
             case .booleanCellBrandColor:
-                return .dynamicColor { theme.aliasTokens.colors[.brandBackground1] }
+                return .dynamicColor { theme.color(.brandBackground1) }
 
             case .communicationTextColor:
                 return .dynamicColor {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -30,9 +30,9 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .regular:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground2))
             case .primary:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])
+                return UIColor(dynamicColor: fluentTheme.color(.brandForeground1))
             }
         }
     }
@@ -47,18 +47,18 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         func textColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
             case .header, .footer:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground2))
             case .headerPrimary:
-                return UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
+                return UIColor(dynamicColor: fluentTheme.color(.foreground1))
             }
         }
 
         func textFont() -> UIFont {
             switch self {
             case .headerPrimary:
-                return UIFont.fluent(FluentTheme.shared.aliasTokens.typography[.body1Strong])
+                return UIFont.fluent(FluentTheme.shared.typography(.body1Strong))
             case .header, .footer:
-                return UIFont.fluent(FluentTheme.shared.aliasTokens.typography[.caption1])
+                return UIFont.fluent(FluentTheme.shared.typography(.caption1))
             }
         }
     }
@@ -482,9 +482,9 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         titleView.textColor = style.textColor(fluentTheme: tokenSet.fluentTheme)
 
         if tableViewCellStyle == .grouped {
-            backgroundView?.backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.backgroundCanvas])
+            backgroundView?.backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.backgroundCanvas))
         } else if tableViewCellStyle == .plain {
-            backgroundView?.backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.aliasTokens.colors[.background1])
+            backgroundView?.backgroundColor = UIColor(dynamicColor: tokenSet.fluentTheme.color(.background1))
         } else {
             backgroundView?.backgroundColor = .clear
         }
@@ -498,7 +498,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     }
 
     private func updateAccessoryButtonTitleStyle() {
-        accessoryButton?.titleLabel?.font = UIFont.fluent(tokenSet.fluentTheme.aliasTokens.typography[.caption1Strong])
+        accessoryButton?.titleLabel?.font = UIFont.fluent(tokenSet.fluentTheme.typography(.caption1Strong))
         updateAccessoryButtonTitleColor()
     }
 
@@ -549,7 +549,7 @@ private class TableViewHeaderFooterTitleView: UITextView {
     }
 
     func updateLinkTextColor(_ fluentTheme: FluentTheme) {
-        linkTextAttributes = [.foregroundColor: UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.brandForeground1])]
+        linkTextAttributes = [.foregroundColor: UIColor(dynamicColor: fluentTheme.color(.brandForeground1))]
     }
 
     required init?(coder: NSCoder) {

--- a/ios/FluentUI/TextField/TextFieldTokenSet.swift
+++ b/ios/FluentUI/TextField/TextFieldTokenSet.swift
@@ -60,59 +60,59 @@ public class TextFieldTokenSet: ControlTokenSet<TextFieldTokenSet.Tokens> {
                 return .dynamicColor {
                     switch state() {
                     case .unfocused, .focused:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .error:
-                        return theme.aliasTokens.colors[.dangerForeground1]
+                        return theme.color(.dangerForeground1)
                     }
                 }
             case .assistiveTextFont:
-                return .fontInfo { theme.aliasTokens.typography[.caption2] }
+                return .fontInfo { theme.typography(.caption2) }
             case .backgroundColor:
-                return .dynamicColor { theme.aliasTokens.colors[.background1] }
+                return .dynamicColor { theme.color(.background1) }
             case .cursorColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground3] }
+                return .dynamicColor { theme.color(.foreground3) }
             case .inputTextColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground1] }
+                return .dynamicColor { theme.color(.foreground1) }
             case .inputTextFont:
-                return .fontInfo { theme.aliasTokens.typography[.body1] }
+                return .fontInfo { theme.typography(.body1) }
             case .leadingIconColor:
                 return .dynamicColor {
                     switch state() {
                     case .unfocused, .error:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .focused:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     }
                 }
             case .placeholderColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foreground2] }
+                return .dynamicColor { theme.color(.foreground2) }
             case .strokeColor:
                 return .dynamicColor {
                     switch state() {
                     case .unfocused:
-                        return theme.aliasTokens.colors[.stroke1]
+                        return theme.color(.stroke1)
                     case .focused:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .error:
-                        return theme.aliasTokens.colors[.dangerForeground1]
+                        return theme.color(.dangerForeground1)
                     }
                 }
             case .titleLabelColor:
                 return .dynamicColor {
                     switch state() {
                     case .unfocused:
-                        return theme.aliasTokens.colors[.foreground2]
+                        return theme.color(.foreground2)
                     case .focused:
-                        return theme.aliasTokens.colors[.brandForeground1]
+                        return theme.color(.brandForeground1)
                     case .error:
-                        return theme.aliasTokens.colors[.dangerForeground1]
+                        return theme.color(.dangerForeground1)
                     }
                 }
             case .titleLabelFont:
-                return .fontInfo { theme.aliasTokens.typography[.caption2] }
+                return .fontInfo { theme.typography(.caption2) }
             case .trailingIconColor:
                 return .dynamicColor {
-                    return theme.aliasTokens.colors[.foreground2]
+                    return theme.color(.foreground2)
                 }
             }
         }

--- a/ios/FluentUI/Tooltip/TooltipTokenSet.swift
+++ b/ios/FluentUI/Tooltip/TooltipTokenSet.swift
@@ -40,22 +40,22 @@ public class TooltipTokenSet: ControlTokenSet<TooltipTokenSet.Tokens> {
         super.init { token, theme in
             switch token {
             case .tooltipColor:
-                return .dynamicColor { theme.aliasTokens.colors[.backgroundDarkStatic] }
+                return .dynamicColor { theme.color(.backgroundDarkStatic) }
 
             case .textColor:
-                return .dynamicColor { theme.aliasTokens.colors[.foregroundLightStatic] }
+                return .dynamicColor { theme.color(.foregroundLightStatic) }
 
             case .shadowInfo:
-                return .shadowInfo { theme.aliasTokens.shadow[.shadow16] }
+                return .shadowInfo { theme.shadow(.shadow16) }
 
             case .backgroundCornerRadius:
                 return .float { GlobalTokens.corner(.radius80) }
 
             case .messageLabelTextStyle:
-                return .fontInfo { theme.aliasTokens.typography[.body2] }
+                return .fontInfo { theme.typography(.body2) }
 
             case .titleLabelTextStyle:
-                return .fontInfo { theme.aliasTokens.typography[.body1Strong] }
+                return .fontInfo { theme.typography(.body1Strong) }
 
             case .maximumWidth:
                 return .float { 250.0 }

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -216,16 +216,16 @@ open class TwoLineTitleView: UIView {
     private func applyStyle() {
         switch currentStyle {
         case .system:
-            titleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground1])
-            subtitleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
-            titleButtonImageView.tintColor = UIColor(dynamicColor: fluentTheme.aliasTokens.colors[.foreground2])
+            titleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground1))
+            subtitleButtonLabel.textColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
+            titleButtonImageView.tintColor = UIColor(dynamicColor: fluentTheme.color(.foreground2))
         case .primary:
-            titleButtonLabel.textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
-                                                                            dark: fluentTheme.aliasTokens.colors[.foreground1].dark))
-            subtitleButtonLabel.textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
-                                                                               dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
-            titleButtonImageView.tintColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.aliasTokens.colors[.foregroundOnColor].light,
-                                                                                dark: fluentTheme.aliasTokens.colors[.foreground2].dark))
+            titleButtonLabel.textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light,
+                                                                            dark: fluentTheme.color(.foreground1).dark))
+            subtitleButtonLabel.textColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light,
+                                                                               dark: fluentTheme.color(.foreground2).dark))
+            titleButtonImageView.tintColor = UIColor(dynamicColor: DynamicColor(light: fluentTheme.color(.foregroundOnColor).light,
+                                                                                dark: fluentTheme.color(.foreground2).dark))
         }
 
         // unlike title accessory image view, subtitle accessory image view should be the same color as subtitle label
@@ -282,8 +282,8 @@ open class TwoLineTitleView: UIView {
     }
 
     private func updateFonts() {
-        titleButtonLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.body1Strong])
-        subtitleButtonLabel.font = UIFont.fluent(fluentTheme.aliasTokens.typography[.caption1])
+        titleButtonLabel.font = UIFont.fluent(fluentTheme.typography(.body1Strong))
+        subtitleButtonLabel.font = UIFont.fluent(fluentTheme.typography(.caption1))
     }
 
     open override func layoutSubviews() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

* e238ab6895b5fefd37fea3eb57731520893f1bf2: Updates the new `FluentTheme` custom token initializers to use `FluentTheme` tokens, instead of the old `AliasTokens` values. This includes fixing one wrapper that was using the wrong type in the initial commit.
* 300532439c67695627ee1fcd24aebff03985e340: Search through the FluentUI framework and remove all component references to `AliasTokens`, replacing them with direct `FluentTheme` access.
* 9d7b87d88acbc98cbca011039c8d632dff387ceb: Update FluentUI demo app to use the new public FluentTheme tokens and APIs, migrating off the AliasTokens APIs.

An important note: the repo fully builds and runs _without commit 9d7b87d88acbc98cbca011039c8d632dff387ceb_, demonstrating that these API changes are non-breaking. All library changes are either fully internal (e.g. in `AvatarTokenSet.swift`), or purely additive (e.g. the new initializer in `Label.swift`).

### Binary change

Total increase: 90,064 bytes
Total decrease: -71,416 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,884,776 bytes | 29,903,424 bytes | ⚠️ 18,648 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentTheme.o | 64,336 bytes | 114,552 bytes | 🛑 50,216 bytes |
| Label.o | 101,816 bytes | 113,320 bytes | ⚠️ 11,504 bytes |
| __.SYMDEF | 4,589,264 bytes | 4,598,952 bytes | ⚠️ 9,688 bytes |
| CalendarViewWeekdayHeadingView.o | 96,240 bytes | 104,912 bytes | ⚠️ 8,672 bytes |
| LinearGradientInfo.o | 87,504 bytes | 89,848 bytes | ⚠️ 2,344 bytes |
| CalendarViewDataSource.o | 153,200 bytes | 155,200 bytes | ⚠️ 2,000 bytes |
| BadgeLabel.o | 53,456 bytes | 55,352 bytes | ⚠️ 1,896 bytes |
| AliasTokens.o | 198,336 bytes | 200,168 bytes | ⚠️ 1,832 bytes |
| DateTimePickerViewComponentCell.o | 54,400 bytes | 54,904 bytes | ⚠️ 504 bytes |
| BadgeLabelButton.o | 860,296 bytes | 860,744 bytes | ⚠️ 448 bytes |
| CalendarViewDayMonthCell.o | 42,888 bytes | 43,328 bytes | ⚠️ 440 bytes |
| CalendarView.o | 73,664 bytes | 73,832 bytes | ⚠️ 168 bytes |
| PersonaListView.o | 186,480 bytes | 186,640 bytes | ⚠️ 160 bytes |
| ResizingHandleView.o | 52,176 bytes | 52,320 bytes | ⚠️ 144 bytes |
| IndeterminateProgressBarTokenSet.o | 45,864 bytes | 45,888 bytes | ⚠️ 24 bytes |
| PersonaButtonCarouselTokenSet.o | 43,920 bytes | 43,928 bytes | ⚠️ 8 bytes |
| PageCardPresenterController.o | 159,136 bytes | 159,144 bytes | ⚠️ 8 bytes |
| ControlTokenSet.o | 85,928 bytes | 85,936 bytes | ⚠️ 8 bytes |
| CardNudgeTokenSet.o | 88,208 bytes | 88,168 bytes | 🎉 -40 bytes |
| FluentTheme+Tokens.o | 59,312 bytes | 59,248 bytes | 🎉 -64 bytes |
| TooltipTokenSet.o | 59,712 bytes | 59,616 bytes | 🎉 -96 bytes |
| BadgeField.o | 539,496 bytes | 539,384 bytes | 🎉 -112 bytes |
| FluentTextField.o | 206,024 bytes | 205,912 bytes | 🎉 -112 bytes |
| String+Extension.o | 58,048 bytes | 57,912 bytes | 🎉 -136 bytes |
| PillButton.o | 197,768 bytes | 197,624 bytes | 🎉 -144 bytes |
| CommandBarTokenSet.o | 68,848 bytes | 68,696 bytes | 🎉 -152 bytes |
| TooltipView.o | 210,208 bytes | 210,040 bytes | 🎉 -168 bytes |
| BottomSheetTokenSet.o | 49,520 bytes | 49,344 bytes | 🎉 -176 bytes |
| HeadsUpDisplayTokenSet.o | 57,848 bytes | 57,664 bytes | 🎉 -184 bytes |
| FluentUIFramework.o | 78,984 bytes | 78,728 bytes | 🎉 -256 bytes |
| DateTimePickerViewLayout.o | 42,872 bytes | 42,600 bytes | 🎉 -272 bytes |
| TableViewCellTokenSet.o | 116,064 bytes | 115,760 bytes | 🎉 -304 bytes |
| DrawerController.o | 492,416 bytes | 492,008 bytes | 🎉 -408 bytes |
| PeoplePicker.o | 294,688 bytes | 294,224 bytes | 🎉 -464 bytes |
| Separator.o | 58,144 bytes | 57,560 bytes | 🎉 -584 bytes |
| TableViewCell.o | 825,776 bytes | 825,192 bytes | 🎉 -584 bytes |
| PopupMenuItem.o | 115,424 bytes | 114,816 bytes | 🎉 -608 bytes |
| DateTimePickerView.o | 276,760 bytes | 276,136 bytes | 🎉 -624 bytes |
| DatePickerController.o | 355,272 bytes | 354,640 bytes | 🎉 -632 bytes |
| MSFAvatarPresence.o | 45,856 bytes | 45,216 bytes | 🎉 -640 bytes |
| DateTimePickerViewComponentTableView.o | 72,056 bytes | 71,392 bytes | 🎉 -664 bytes |
| LabelTokenSet.o | 66,224 bytes | 65,528 bytes | 🎉 -696 bytes |
| PersonaButtonTokenSet.o | 69,584 bytes | 68,888 bytes | 🎉 -696 bytes |
| NavigationBar.o | 554,640 bytes | 553,928 bytes | 🎉 -712 bytes |
| ShimmerTokenSet.o | 79,632 bytes | 78,856 bytes | 🎉 -776 bytes |
| CalendarViewDayTodayCell.o | 38,704 bytes | 37,744 bytes | 🎉 -960 bytes |
| DateTimePickerController.o | 165,976 bytes | 165,000 bytes | 🎉 -976 bytes |
| TabBarItemView.o | 216,672 bytes | 215,608 bytes | 🎉 -1,064 bytes |
| LargeTitleView.o | 163,424 bytes | 162,272 bytes | 🎉 -1,152 bytes |
| TableViewCellFileAccessoryView.o | 333,488 bytes | 332,296 bytes | 🎉 -1,192 bytes |
| PopupMenuItemCell.o | 167,664 bytes | 166,408 bytes | 🎉 -1,256 bytes |
| TableViewHeaderFooterView.o | 287,968 bytes | 286,544 bytes | 🎉 -1,424 bytes |
| TwoLineTitleView.o | 212,640 bytes | 211,200 bytes | 🎉 -1,440 bytes |
| SegmentedControlTokenSet.o | 94,328 bytes | 92,848 bytes | 🎉 -1,480 bytes |
| CalendarViewDayCell.o | 149,600 bytes | 148,056 bytes | 🎉 -1,544 bytes |
| AvatarTokenSet.o | 129,592 bytes | 127,872 bytes | 🎉 -1,720 bytes |
| TextFieldTokenSet.o | 97,704 bytes | 95,432 bytes | 🎉 -2,272 bytes |
| BottomCommandingController.o | 744,040 bytes | 741,656 bytes | 🎉 -2,384 bytes |
| DateTimePickerViewComponent.o | 148,288 bytes | 145,608 bytes | 🎉 -2,680 bytes |
| SearchBar.o | 447,880 bytes | 445,112 bytes | 🎉 -2,768 bytes |
| CardView.o | 280,576 bytes | 277,784 bytes | 🎉 -2,792 bytes |
| PopupMenuController.o | 368,744 bytes | 365,856 bytes | 🎉 -2,888 bytes |
| ColorProviding.o | 41,784 bytes | 38,352 bytes | 🎉 -3,432 bytes |
| NotificationTokenSet.o | 99,624 bytes | 95,968 bytes | 🎉 -3,656 bytes |
| CalendarViewDayMonthYearCell.o | 50,712 bytes | 46,880 bytes | 🎉 -3,832 bytes |
| PillButtonStyle.o | 66,920 bytes | 62,264 bytes | 🎉 -4,656 bytes |
| BadgeView.o | 439,984 bytes | 424,440 bytes | 🎉 -15,544 bytes |
</details>

### Verification

Ensured components render correctly using
* Default theme
* Switching to green theme
* Launching as green theme
* Using per-control overrides
* Using theme-wide overrides

<details>
<summary>Visual Verification</summary>

https://user-images.githubusercontent.com/4934719/225459979-312f55fe-296c-46da-a775-d628f9ef636a.mp4

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1650)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1650)