### PR TITLE
Simplifying `ColorProviding` API

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
@@ -35,176 +35,176 @@ enum DemoColorTheme: CaseIterable {
 }
 
 class DemoColorDefaultTheme: NSObject, ColorProviding {
-    func brandBackground1(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
                                                   dark: GlobalTokens.brandColors(.comm100)))
     }
 
-    func brandBackground1Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground1Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm50),
                                                   dark: GlobalTokens.brandColors(.comm140)))
     }
 
-    func brandBackground1Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground1Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                                   dark: GlobalTokens.brandColors(.comm120)))
     }
 
-    func brandBackground2(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground2: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm70)))
     }
 
-    func brandBackground2Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground2Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandBackground2Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground2Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80)))
     }
 
-    func brandBackground3(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground3: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                                   dark: GlobalTokens.brandColors(.comm120)))
     }
 
-    func brandBackgroundTint(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackgroundTint: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm150),
                                                   dark: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandBackgroundDisabled(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackgroundDisabled: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm140),
                                                   dark: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandForeground1(for themeable: FluentThemeable) -> UIColor? {
+    var brandForeground1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
                                                   dark: GlobalTokens.brandColors(.comm100)))
     }
 
-    func brandForeground1Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandForeground1Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm50),
                                                   dark: GlobalTokens.brandColors(.comm140)))
     }
 
-    func brandForeground1Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandForeground1Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                                   dark: GlobalTokens.brandColors(.comm120)))
     }
 
-    func brandForegroundTint(for themeable: FluentThemeable) -> UIColor? {
+    var brandForegroundTint: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                                   dark: GlobalTokens.brandColors(.comm130)))
     }
 
-    func brandForegroundDisabled1(for themeable: FluentThemeable) -> UIColor? {
+    var brandForegroundDisabled1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm90)))
     }
 
-    func brandForegroundDisabled2(for themeable: FluentThemeable) -> UIColor? {
+    var brandForegroundDisabled2: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm140),
                                                   dark: GlobalTokens.brandColors(.comm40)))
     }
 
-    func brandStroke1(for themeable: FluentThemeable) -> UIColor? {
+    var brandStroke1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm80),
                                                   dark: GlobalTokens.brandColors(.comm100)))
     }
 
-    func brandStroke1Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandStroke1Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm50),
                                                   dark: GlobalTokens.brandColors(.comm140)))
     }
 
-    func brandStroke1Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandStroke1Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: GlobalTokens.brandColors(.comm60),
                                                   dark: GlobalTokens.brandColors(.comm120)))
     }
 }
 
 class DemoColorGreenTheme: NSObject, ColorProviding {
-    func brandBackground1(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x107C41),
                                                   dark: ColorValue(0x55B17E)))
     }
 
-    func brandBackground1Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground1Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325),
                                                   dark: ColorValue(0xCAEAD8)))
     }
 
-    func brandBackground1Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground1Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B),
                                                   dark: ColorValue(0x60BD82)))
     }
 
-    func brandBackground2(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground2: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B)))
     }
 
-    func brandBackground2Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground2Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x052912)))
     }
 
-    func brandBackground2Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground2Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325)))
     }
 
-    func brandBackground3(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackground3: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325)))
     }
 
-    func brandBackgroundTint(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackgroundTint: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0xCAEAD8),
                                                   dark: ColorValue(0x094624)))
     }
 
-    func brandBackgroundDisabled(for themeable: FluentThemeable) -> UIColor? {
+    var brandBackgroundDisabled: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0xA0D8B9),
                                                   dark: ColorValue(0x0A5325)))
     }
 
-    func brandForeground1(for themeable: FluentThemeable) -> UIColor? {
+    var brandForeground1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x107C41),
                                                   dark: ColorValue(0x55B17E)))
     }
 
-    func brandForeground1Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandForeground1Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325),
                                                   dark: ColorValue(0xCAEAD8)))
     }
 
-    func brandForeground1Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandForeground1Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B),
                                                   dark: ColorValue(0x60BD82)))
     }
 
-    func brandForegroundTint(for themeable: FluentThemeable) -> UIColor? {
+    var brandForegroundTint: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0C5F32),
                                                   dark: ColorValue(0x60BD82)))
     }
 
-    func brandForegroundDisabled1(for themeable: FluentThemeable) -> UIColor? {
+    var brandForegroundDisabled1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x37A660),
                                                   dark: ColorValue(0x218D51)))
     }
 
-    func brandForegroundDisabled2(for themeable: FluentThemeable) -> UIColor? {
+    var brandForegroundDisabled2: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0xCAEAD8),
                                                   dark: ColorValue(0x0F703B)))
     }
 
-    func brandStroke1(for themeable: FluentThemeable) -> UIColor? {
+    var brandStroke1: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x107C41),
                                                   dark: ColorValue(0x55B17E)))
     }
 
-    func brandStroke1Pressed(for themeable: FluentThemeable) -> UIColor? {
+    var brandStroke1Pressed: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0A5325),
                                                   dark: ColorValue(0xCAEAD8)))
     }
 
-    func brandStroke1Selected(for themeable: FluentThemeable) -> UIColor? {
+    var brandStroke1Selected: UIColor {
         return UIColor(dynamicColor: DynamicColor(light: ColorValue(0x0F703B),
                                                   dark: ColorValue(0x60BD82)))
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoColorProviding.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoColorProviding.m
@@ -13,7 +13,7 @@
 
 @implementation ObjectiveCDemoColorProviding
 
-- (UIColor * _Nullable)brandBackgroundColor:(MSFFluentTheme * _Nonnull)theme {
+- (UIColor *)brandBackgroundColor {
     MSFColorValue *lightColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
                                                                   token:MSFSharedColorsTokensTint40];
     MSFColorValue *darkColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
@@ -31,7 +31,7 @@
     return [[UIColor alloc] initWithDynamicColor:dynamicColor];
 }
 
-- (UIColor * _Nullable)brandForegroundColor:(MSFFluentTheme * _Nonnull)theme {
+- (UIColor *)brandForegroundColor {
     MSFColorValue *lightColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
                                                                   token:MSFSharedColorsTokensShade30];
     MSFColorValue *darkColor = [MSFGlobalTokens sharedColorForColorSet:MSFSharedColorSetsOrchid
@@ -49,80 +49,80 @@
     return [[UIColor alloc] initWithDynamicColor:dynamicColor];
 }
 
-- (UIColor * _Nullable)brandStrokeColor:(MSFFluentTheme * _Nonnull)theme {
+- (UIColor *)brandStrokeColor {
     return nil;
 }
 
-- (UIColor * _Nullable)brandBackground1For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground1 {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackground1PressedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground1Pressed {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackground1SelectedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground1Selected {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackground2For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground2 {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackground2PressedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground2Pressed {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackground2SelectedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground2Selected {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackground3For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackground3 {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackgroundDisabledFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackgroundDisabled {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandBackgroundTintFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandBackgroundColor:theme];
+- (UIColor *)brandBackgroundTint {
+    return [self brandBackgroundColor];
 }
 
-- (UIColor * _Nullable)brandForeground1For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandForegroundColor:theme];
+- (UIColor *)brandForeground1 {
+    return [self brandForegroundColor];
 }
 
-- (UIColor * _Nullable)brandForeground1PressedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandForegroundColor:theme];
+- (UIColor *)brandForeground1Pressed {
+    return [self brandForegroundColor];
 }
 
-- (UIColor * _Nullable)brandForeground1SelectedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandForegroundColor:theme];
+- (UIColor *)brandForeground1Selected {
+    return [self brandForegroundColor];
 }
 
-- (UIColor * _Nullable)brandForegroundDisabled1For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandForegroundColor:theme];
+- (UIColor *)brandForegroundDisabled1 {
+    return [self brandForegroundColor];
 }
 
-- (UIColor * _Nullable)brandForegroundDisabled2For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandForegroundColor:theme];
+- (UIColor *)brandForegroundDisabled2 {
+    return [self brandForegroundColor];
 }
 
-- (UIColor * _Nullable)brandForegroundTintFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandForegroundColor:theme];
+- (UIColor *)brandForegroundTint {
+    return [self brandForegroundColor];
 }
 
-- (UIColor * _Nullable)brandStroke1For:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandStrokeColor:theme];
+- (UIColor *)brandStroke1 {
+    return [self brandStrokeColor];
 }
 
-- (UIColor * _Nullable)brandStroke1PressedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandStrokeColor:theme];
+- (UIColor *)brandStroke1Pressed {
+    return [self brandStrokeColor];
 }
 
-- (UIColor * _Nullable)brandStroke1SelectedFor:(MSFFluentTheme * _Nonnull)theme {
-    return [self brandStrokeColor:theme];
+- (UIColor *)brandStroke1Selected {
+    return [self brandStrokeColor];
 }
 
 @end

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -57,7 +57,6 @@ private func brandColorOverrides(provider: ColorProviding) -> [FluentTheme.Color
     return brandColors
 }
 
-
 // MARK: Colors
 
 @objc public extension UIView {

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -12,85 +12,51 @@ import UIKit
 @objc(MSFColorProviding)
 public protocol ColorProviding {
     /// If this protocol is not conformed to, communicationBlue variants will be used
-    @objc func brandBackground1(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackground1Pressed(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackground1Selected(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackground2(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackground2Pressed(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackground2Selected(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackground3(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackgroundTint(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandBackgroundDisabled(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandForeground1(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandForeground1Pressed(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandForeground1Selected(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandForegroundTint(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandForegroundDisabled1(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandForegroundDisabled2(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandStroke1(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandStroke1Pressed(for themeable: FluentThemeable) -> UIColor?
-    @objc func brandStroke1Selected(for themeable: FluentThemeable) -> UIColor?
+    @objc var brandBackground1: UIColor { get }
+    @objc var brandBackground1Pressed: UIColor { get }
+    @objc var brandBackground1Selected: UIColor { get }
+    @objc var brandBackground2: UIColor { get }
+    @objc var brandBackground2Pressed: UIColor { get }
+    @objc var brandBackground2Selected: UIColor { get }
+    @objc var brandBackground3: UIColor { get }
+    @objc var brandBackgroundTint: UIColor { get }
+    @objc var brandBackgroundDisabled: UIColor { get }
+    @objc var brandForeground1: UIColor { get }
+    @objc var brandForeground1Pressed: UIColor { get }
+    @objc var brandForeground1Selected: UIColor { get }
+    @objc var brandForegroundTint: UIColor { get }
+    @objc var brandForegroundDisabled1: UIColor { get }
+    @objc var brandForegroundDisabled2: UIColor { get }
+    @objc var brandStroke1: UIColor { get }
+    @objc var brandStroke1Pressed: UIColor { get }
+    @objc var brandStroke1Selected: UIColor { get }
 }
 
-private func brandColorOverrides(provider: ColorProviding,
-                                 for themeable: FluentThemeable) -> [AliasTokens.ColorsTokens: DynamicColor] {
+private func brandColorOverrides(provider: ColorProviding) -> [AliasTokens.ColorsTokens: DynamicColor] {
     var brandColors: [AliasTokens.ColorsTokens: DynamicColor] = [:]
-    if let brandBackground1 = provider.brandBackground1(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground1] = brandBackground1
-    }
-    if let brandBackground1Pressed = provider.brandBackground1Pressed(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground1Pressed] = brandBackground1Pressed
-    }
-    if let brandBackground1Selected = provider.brandBackground1Selected(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground1Selected] = brandBackground1Selected
-    }
-    if let brandBackground2 = provider.brandBackground2(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground2] = brandBackground2
-    }
-    if let brandBackground2Pressed = provider.brandBackground2Pressed(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground2Pressed] = brandBackground2Pressed
-    }
-    if let brandBackground2Selected = provider.brandBackground2Selected(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground2Selected] = brandBackground2Selected
-    }
-    if let brandBackground3 = provider.brandBackground3(for: themeable)?.dynamicColor {
-        brandColors[.brandBackground3] = brandBackground3
-    }
-    if let brandBackgroundTint = provider.brandBackgroundTint(for: themeable)?.dynamicColor {
-        brandColors[.brandBackgroundTint] = brandBackgroundTint
-    }
-    if let brandBackgroundDisabled = provider.brandBackgroundDisabled(for: themeable)?.dynamicColor {
-        brandColors[.brandBackgroundDisabled] = brandBackgroundDisabled
-    }
-    if let brandForeground1 = provider.brandForeground1(for: themeable)?.dynamicColor {
-        brandColors[.brandForeground1] = brandForeground1
-    }
-    if let brandForeground1Pressed = provider.brandForeground1Pressed(for: themeable)?.dynamicColor {
-        brandColors[.brandForeground1Pressed] = brandForeground1Pressed
-    }
-    if let brandForeground1Selected = provider.brandForeground1Selected(for: themeable)?.dynamicColor {
-        brandColors[.brandForeground1Selected] = brandForeground1Selected
-    }
-    if let brandForegroundTint = provider.brandForegroundTint(for: themeable)?.dynamicColor {
-        brandColors[.brandForegroundTint] = brandForegroundTint
-    }
-    if let brandForegroundDisabled1 = provider.brandForegroundDisabled1(for: themeable)?.dynamicColor {
-        brandColors[.brandForegroundDisabled1] = brandForegroundDisabled1
-    }
-    if let brandForegroundDisabled2 = provider.brandForegroundDisabled2(for: themeable)?.dynamicColor {
-        brandColors[.brandForegroundDisabled2] = brandForegroundDisabled2
-    }
-    if let brandStroke1 = provider.brandStroke1(for: themeable)?.dynamicColor {
-        brandColors[.brandStroke1] = brandStroke1
-    }
-    if let brandStroke1Pressed = provider.brandStroke1Pressed(for: themeable)?.dynamicColor {
-        brandColors[.brandStroke1Pressed] = brandStroke1Pressed
-    }
-    if let brandStroke1Selected = provider.brandStroke1Selected(for: themeable)?.dynamicColor {
-        brandColors[.brandStroke1Selected] = brandStroke1Selected
-    }
+
+    brandColors[.brandBackground1] = provider.brandBackground1.dynamicColor
+    brandColors[.brandBackground1Pressed] = provider.brandBackground1Pressed.dynamicColor
+    brandColors[.brandBackground1Selected] = provider.brandBackground1Selected.dynamicColor
+    brandColors[.brandBackground2] = provider.brandBackground2.dynamicColor
+    brandColors[.brandBackground2Pressed] = provider.brandBackground2Pressed.dynamicColor
+    brandColors[.brandBackground2Selected] = provider.brandBackground2Selected.dynamicColor
+    brandColors[.brandBackground3] = provider.brandBackground3.dynamicColor
+    brandColors[.brandBackgroundTint] = provider.brandBackgroundTint.dynamicColor
+    brandColors[.brandBackgroundDisabled] = provider.brandBackgroundDisabled.dynamicColor
+    brandColors[.brandForeground1] = provider.brandForeground1.dynamicColor
+    brandColors[.brandForeground1Pressed] = provider.brandForeground1Pressed.dynamicColor
+    brandColors[.brandForeground1Selected] = provider.brandForeground1Selected.dynamicColor
+    brandColors[.brandForegroundTint] = provider.brandForegroundTint.dynamicColor
+    brandColors[.brandForegroundDisabled1] = provider.brandForegroundDisabled1.dynamicColor
+    brandColors[.brandForegroundDisabled2] = provider.brandForegroundDisabled2.dynamicColor
+    brandColors[.brandStroke1] = provider.brandStroke1.dynamicColor
+    brandColors[.brandStroke1Pressed] = provider.brandStroke1Pressed.dynamicColor
+    brandColors[.brandStroke1Selected] = provider.brandStroke1Selected.dynamicColor
+
     return brandColors
 }
+
 
 // MARK: Colors
 
@@ -102,7 +68,7 @@ private func brandColorOverrides(provider: ColorProviding,
     @objc(setColorProvider:)
     func setColorProvider(_ provider: ColorProviding) {
         // Create an updated fluent theme as well
-        let brandColors = brandColorOverrides(provider: provider, for: self)
+        let brandColors = brandColorOverrides(provider: provider)
         let fluentTheme = FluentTheme(colorOverrides: brandColors)
         self.fluentTheme = fluentTheme
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updating the `ColorProviding` API to not pass a themeable. This will make it easier for clients to create and reuse a static shared implementation for both us and their own use.

### Binary change

Total increase: 0 bytes
Total decrease: -848 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,858,272 bytes | 29,857,424 bytes | 🎉 -848 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ColorProviding.o | 41,584 bytes | 40,736 bytes | 🎉 -848 bytes |
</details>

### FluentUI.Demo

| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,053,510 bytes | 31,046,438 bytes | 🎉 -7072 bytes |

### Verification

Ensured that theme swapping still works as expected.

<details>
<summary>Visual Verification</summary>

https://user-images.githubusercontent.com/4934719/225718991-a33e18ab-f470-4a85-9293-7655d119eeb8.mp4

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1653)