### PR TITLE
Remove SPM dependencies to old Resources target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,9 +29,6 @@ let package = Package(
         ),
         .target(
             name: "FluentUI_ios",
-            dependencies: [
-                .target(name: "FluentUIResources")
-            ],
             path: "ios/FluentUI",
             exclude: [
                 "Avatar/Avatar.resources.xcfilelist",
@@ -50,9 +47,6 @@ let package = Package(
         ),
         .target(
             name: "FluentUI_macos",
-            dependencies: [
-                .target(name: "FluentUIResources")
-            ],
             path: "macos/FluentUI",
             exclude: [
                 "FluentUI-Info.plist"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Our `Package.swift` file still referenced a now-deleted `Resources` target as dependencies for both iOS and macOS. This PR removes those dependencies.

### Binary change

n/a

### Verification

Created a test app to consume this commit as a package, and everything builds and runs as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1656)