### PR TITLE
Tokenize TwoLineTitleView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		532FE3DC26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3DA26EA6D8D007539C0 /* ActivityIndicatorDemoController_SwiftUI.swift */; };
 		5336B17D27F7817300B01E0D /* HUDDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17B27F7817300B01E0D /* HUDDemoController_SwiftUI.swift */; };
 		5373D55F2694C3070032A3B4 /* AvatarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */; };
+		66963D0C29CB792E006F5FA9 /* TwoLineTitleViewDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66963D0B29CB792E006F5FA9 /* TwoLineTitleViewDemoController.swift */; };
 		6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */; };
 		6FC8AD3B28DBAF280010C0F8 /* ReadmeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC8AD3A28DBAF280010C0F8 /* ReadmeViewController.swift */; };
 		6FEED93B28A6E5520099D178 /* AliasColorTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */; };
@@ -203,6 +204,7 @@
 		5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarDemoController.swift; sourceTree = "<group>"; };
 		5373F95426F28D3A007F1410 /* IndeterminateProgressBarDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		5373F95626F28D9B007F1410 /* IndeterminateProgressBarDemoController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndeterminateProgressBarDemoController.swift; sourceTree = "<group>"; };
+		66963D0B29CB792E006F5FA9 /* TwoLineTitleViewDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLineTitleViewDemoController.swift; sourceTree = "<group>"; };
 		6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowTokensDemoController.swift; sourceTree = "<group>"; };
 		6FC8AD3A28DBAF280010C0F8 /* ReadmeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadmeViewController.swift; sourceTree = "<group>"; };
 		6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasColorTokensDemoController.swift; sourceTree = "<group>"; };
@@ -540,6 +542,7 @@
 				EC98E2B72992FE6900B9DF91 /* TextFieldObjCDemoController.h */,
 				EC98E2B52992FE5000B9DF91 /* TextFieldObjCDemoController.m */,
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
+				66963D0B29CB792E006F5FA9 /* TwoLineTitleViewDemoController.swift */,
 				92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */,
 				6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */,
 				6F453CA428AC536300ED91A4 /* ShadowTokensDemoController.swift */,
@@ -790,6 +793,7 @@
 				5336B17D27F7817300B01E0D /* HUDDemoController_SwiftUI.swift in Sources */,
 				92561E732718AD090072ED00 /* DemoTableViewController.swift in Sources */,
 				43488C4A270FB7E800124C71 /* NotificationViewDemoController_SwiftUI.swift in Sources */,
+				66963D0C29CB792E006F5FA9 /* TwoLineTitleViewDemoController.swift in Sources */,
 				497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */,
 				B4EF53C5215C45C400573E8F /* PersonaListViewDemoController.swift in Sources */,
 				A5DCA75E211E3A92005F4CB7 /* DrawerDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -36,7 +36,8 @@ struct Demos {
         DemoDescriptor("ShimmerView", ShimmerViewDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
         DemoDescriptor("Text Field", TextFieldDemoController.self),
-        DemoDescriptor("Tooltip", TooltipDemoController.self)
+        DemoDescriptor("Tooltip", TooltipDemoController.self),
+        DemoDescriptor("TwoLineTitleView", TwoLineTitleViewDemoController.self)
     ]
 
     static let fluent2DesignTokens: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -12,7 +12,7 @@ class TwoLineTitleViewDemoController: DemoController {
 
         // Give it a visible margin so we can confirm it centers properly
         twoLineTitleView.widthAnchor.constraint(equalToConstant: 200).isActive = true
-        twoLineTitleView.layer.borderWidth = 1
+        twoLineTitleView.layer.borderWidth = GlobalTokens.stroke(.width10)
         twoLineTitleView.layer.borderColor = GlobalTokens.neutralColor(.grey50).cgColor
 
         return twoLineTitleView

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+
+class TwoLineTitleViewDemoController: DemoController {
+    private let displayedNavigationItem = UINavigationItem()
+    private let twoLineTitleView = TwoLineTitleView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        readmeString = "TwoLineTitleView is intended to be used in a navigation bar or the title of a sheet. It features the ability to show custom icons, a disclosure chevron, and other things."
+
+        container.alignment = .leading
+
+        twoLineTitleView.widthAnchor.constraint(equalToConstant: 200).isActive = true
+        twoLineTitleView.layer.borderWidth = 1
+
+        displayedNavigationItem.title = "Title"
+        displayedNavigationItem.titleImage = UIImage(systemName: "f.circle")
+        displayedNavigationItem.subtitle = "Subtitle"
+        displayedNavigationItem.usesLargeTitle = false
+
+        twoLineTitleView.setup(navigationItem: displayedNavigationItem)
+        addRow(items: [twoLineTitleView])
+    }
+}
+
+extension TwoLineTitleViewDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        fluentTheme.register(tokenSetType: TwoLineTitleViewTokenSet.self,
+                             tokenSet: isOverrideEnabled ? themeWideOverrideTokens : nil)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        twoLineTitleView.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideTokens : nil)
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokens(for: TwoLineTitleViewTokenSet.self) != nil
+    }
+
+    private var themeWideOverrideTokens: [TwoLineTitleViewTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .titleColor: .uiColor { GlobalTokens.sharedColor(.orange, .primary) },
+            .subtitleColor: .uiColor { GlobalTokens.sharedColor(.red, .primary) }
+        ]
+    }
+
+    private var perControlOverrideTokens: [TwoLineTitleViewTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .titleColor: .uiColor { GlobalTokens.sharedColor(.blue, .primary) },
+            .titleFont: .uiFont { UIFont(descriptor: .init(name: "Papyrus", size: 12), size: 12) },
+            .subtitleColor: .uiColor { GlobalTokens.sharedColor(.green, .primary) },
+            .subtitleFont: .uiFont { UIFont(descriptor: .init(name: "Papyrus", size: 10), size: 10) }
+        ]
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -107,7 +107,7 @@ extension TwoLineTitleViewDemoController: DemoAppearanceDelegate {
 
     private var themeWideOverrideTokens: [TwoLineTitleViewTokenSet.Tokens: ControlTokenValue] {
         return [
-            .titleColor: .uiColor { GlobalTokens.sharedColor(.orange, .primary) },
+            .titleColor: .uiColor { GlobalTokens.sharedColor(.green, .primary) },
             .subtitleColor: .uiColor { GlobalTokens.sharedColor(.red, .primary) }
         ]
     }
@@ -116,7 +116,7 @@ extension TwoLineTitleViewDemoController: DemoAppearanceDelegate {
         return [
             .titleColor: .uiColor { GlobalTokens.sharedColor(.blue, .primary) },
             .titleFont: .uiFont { UIFont(descriptor: .init(name: "Papyrus", size: 12), size: 12) },
-            .subtitleColor: .uiColor { GlobalTokens.sharedColor(.green, .primary) },
+            .subtitleColor: .uiColor { GlobalTokens.sharedColor(.orange, .primary) },
             .subtitleFont: .uiFont { UIFont(descriptor: .init(name: "Papyrus", size: 10), size: 10) }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -7,8 +7,65 @@ import FluentUI
 import UIKit
 
 class TwoLineTitleViewDemoController: DemoController {
-    private let displayedNavigationItem = UINavigationItem()
-    private let twoLineTitleView = TwoLineTitleView()
+    private static func createDemoTitleView() -> TwoLineTitleView {
+        let twoLineTitleView = TwoLineTitleView()
+
+        // Give it a visible margin so we can confirm it centers properly
+        twoLineTitleView.widthAnchor.constraint(equalToConstant: 200).isActive = true
+        twoLineTitleView.layer.borderWidth = 1
+        twoLineTitleView.layer.borderColor = GlobalTokens.neutralColor(.grey50).cgColor
+
+        return twoLineTitleView
+    }
+
+    private static func makeNavigationTitleView(_ navigationItemModifier: (UINavigationItem) -> Void) -> TwoLineTitleView {
+        let twoLineTitleView = createDemoTitleView()
+
+        let aNavigationItem = UINavigationItem()
+        navigationItemModifier(aNavigationItem)
+
+        twoLineTitleView.setup(navigationItem: aNavigationItem)
+
+        return twoLineTitleView
+    }
+
+    private static func makeStandardTitleView(title: String, titleImage: UIImage? = nil, subtitle: String? = nil, alignment: TwoLineTitleView.Alignment = .center, interactivePart: TwoLineTitleView.InteractivePart = .none, animatesWhenPressed: Bool = true, accessoryType: TwoLineTitleView.AccessoryType = .none) -> TwoLineTitleView {
+        let twoLineTitleView = createDemoTitleView()
+        twoLineTitleView.setup(title: title, titleImage: titleImage, subtitle: subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType)
+        return twoLineTitleView
+    }
+
+    private let setupExamples: [TwoLineTitleView] = [
+        makeStandardTitleView(title: "Title here", subtitle: "Optional subtitle", animatesWhenPressed: false),
+        makeStandardTitleView(title: "Custom image", titleImage: UIImage(named: "ic_fluent_star_16_regular"), animatesWhenPressed: false),
+        makeStandardTitleView(title: "This one", subtitle: "can be tapped", interactivePart: .all),
+        makeStandardTitleView(title: "All the bells", titleImage: UIImage(named: "ic_fluent_star_16_regular"), subtitle: "and whistles", alignment: .leading, interactivePart: .subtitle, accessoryType: .disclosure)
+    ]
+
+    private let navigationExamples: [TwoLineTitleView] = [
+        makeNavigationTitleView {
+            $0.title = "Title here"
+        },
+        makeNavigationTitleView {
+            $0.title = "Another title"
+            $0.subtitle = "With a subtitle"
+        },
+        makeNavigationTitleView {
+            $0.title = "This one"
+            $0.subtitle = "has an image"
+            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+        },
+        makeNavigationTitleView {
+            $0.title = "This one"
+            $0.subtitle = "has a disclosure chevron"
+            $0.titleAccessory = .init(location: .title, style: .disclosure)
+        },
+        makeNavigationTitleView {
+            $0.title = "They can also be"
+            $0.subtitle = "leading-aligned"
+            $0.usesLargeTitle = true
+        }
+    ]
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,16 +73,15 @@ class TwoLineTitleViewDemoController: DemoController {
 
         container.alignment = .leading
 
-        twoLineTitleView.widthAnchor.constraint(equalToConstant: 200).isActive = true
-        twoLineTitleView.layer.borderWidth = 1
+        addTitle(text: "Made by calling TwoLineTitleView.setup")
+        setupExamples.forEach {
+            addRow(items: [$0])
+        }
 
-        displayedNavigationItem.title = "Title"
-        displayedNavigationItem.titleImage = UIImage(systemName: "f.circle")
-        displayedNavigationItem.subtitle = "Subtitle"
-        displayedNavigationItem.usesLargeTitle = false
-
-        twoLineTitleView.setup(navigationItem: displayedNavigationItem)
-        addRow(items: [twoLineTitleView])
+        addTitle(text: "Made from UINavigationItem")
+        navigationExamples.forEach {
+            addRow(items: [$0])
+        }
     }
 }
 
@@ -40,7 +96,9 @@ extension TwoLineTitleViewDemoController: DemoAppearanceDelegate {
     }
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
-        twoLineTitleView.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideTokens : nil)
+        (setupExamples + navigationExamples).forEach {
+            $0.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideTokens : nil)
+        }
     }
 
     func isThemeWideOverrideApplied() -> Bool {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -51,7 +51,7 @@ class TwoLineTitleViewDemoController: DemoController {
         makeStandardTitleView(title: "Title here", subtitle: "Optional subtitle", animatesWhenPressed: false),
         makeStandardTitleView(title: "Custom image", titleImage: UIImage(named: "ic_fluent_star_16_regular"), animatesWhenPressed: false),
         makeStandardTitleView(title: "This one", subtitle: "can be tapped", interactivePart: .all),
-        makeStandardTitleView(title: "All the bells", titleImage: UIImage(named: "ic_fluent_star_16_regular"), subtitle: "and whistles", alignment: .leading, interactivePart: .subtitle, accessoryType: .disclosure)
+        makeStandardTitleView(title: "All the bells", titleImage: UIImage(named: "ic_fluent_star_16_regular"), subtitle: "and whistles", alignment: .leading, interactivePart: .subtitle, accessoryType: .downArrow)
     ]
 
     private let navigationExamples: [TwoLineTitleView] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -29,9 +29,21 @@ class TwoLineTitleViewDemoController: DemoController {
         return twoLineTitleView
     }
 
-    private static func makeStandardTitleView(title: String, titleImage: UIImage? = nil, subtitle: String? = nil, alignment: TwoLineTitleView.Alignment = .center, interactivePart: TwoLineTitleView.InteractivePart = .none, animatesWhenPressed: Bool = true, accessoryType: TwoLineTitleView.AccessoryType = .none) -> TwoLineTitleView {
+    private static func makeStandardTitleView(title: String,
+                                              titleImage: UIImage? = nil,
+                                              subtitle: String? = nil,
+                                              alignment: TwoLineTitleView.Alignment = .center,
+                                              interactivePart: TwoLineTitleView.InteractivePart = .none,
+                                              animatesWhenPressed: Bool = true,
+                                              accessoryType: TwoLineTitleView.AccessoryType = .none) -> TwoLineTitleView {
         let twoLineTitleView = createDemoTitleView()
-        twoLineTitleView.setup(title: title, titleImage: titleImage, subtitle: subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType)
+        twoLineTitleView.setup(title: title,
+                               titleImage: titleImage,
+                               subtitle: subtitle,
+                               alignment: alignment,
+                               interactivePart: interactivePart,
+                               animatesWhenPressed: animatesWhenPressed,
+                               accessoryType: accessoryType)
         return twoLineTitleView
     }
 

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		53E2EE0527860D010086D30D /* MSFActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E2EE0427860D010086D30D /* MSFActivityIndicator.swift */; };
 		53E2EE07278799B30086D30D /* MSFIndeterminateProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E2EE06278799B30086D30D /* MSFIndeterminateProgressBar.swift */; };
 		566C664A28CB99830032314C /* module.modulemap in Copy module.modulemap */ = {isa = PBXBuildFile; fileRef = 566C664828CB97210032314C /* module.modulemap */; };
+		66963D0A29CA7F89006F5FA9 /* TwoLineTitleViewTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66963D0929CA7F89006F5FA9 /* TwoLineTitleViewTokenSet.swift */; };
 		6EB4B25F270ED6B30005B808 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB4B25D270ED6450005B808 /* BadgeLabel.swift */; };
 		6ED5E55126D3D39400D8BE81 /* BadgeLabelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED4C11C2696AE4000C30BD6 /* BadgeLabelButton.swift */; };
 		6ED5E55226D3D39400D8BE81 /* UIBarButtonItem+BadgeValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ED4C11A2695A6E800C30BD6 /* UIBarButtonItem+BadgeValue.swift */; };
@@ -289,6 +290,7 @@
 		53FC90F925673627008A06FD /* FluentUILib_common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FluentUILib_common.xcconfig; sourceTree = "<group>"; };
 		53FC90FA25673627008A06FD /* FluentUIResources.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FluentUIResources.xcconfig; sourceTree = "<group>"; };
 		566C664828CB97210032314C /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		66963D0929CA7F89006F5FA9 /* TwoLineTitleViewTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoLineTitleViewTokenSet.swift; sourceTree = "<group>"; };
 		6EB4B25D270ED6450005B808 /* BadgeLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		6ED4C11A2695A6E800C30BD6 /* UIBarButtonItem+BadgeValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+BadgeValue.swift"; sourceTree = "<group>"; };
 		6ED4C11C2696AE4000C30BD6 /* BadgeLabelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeLabelButton.swift; sourceTree = "<group>"; };
@@ -686,6 +688,7 @@
 			isa = PBXGroup;
 			children = (
 				FD5BBE40214C6AF3008964B4 /* TwoLineTitleView.swift */,
+				66963D0929CA7F89006F5FA9 /* TwoLineTitleViewTokenSet.swift */,
 			);
 			path = TwoLineTitleView;
 			sourceTree = "<group>";
@@ -1625,6 +1628,7 @@
 				92DEE2252723D34400E31ED0 /* ControlTokenSet.swift in Sources */,
 				5314E0E425F012C00099271A /* NavigationController.swift in Sources */,
 				925728F7276D6AF800EE1019 /* ShadowInfo.swift in Sources */,
+				66963D0A29CA7F89006F5FA9 /* TwoLineTitleViewTokenSet.swift in Sources */,
 				5328D97326FBA3D700F3723B /* IndeterminateProgressBarModifiers.swift in Sources */,
 				923DB9D7274CB66D00D8E58A /* ControlHostingView.swift in Sources */,
 				5314E03B25F00E3D0099271A /* BadgeStringExtractor.swift in Sources */,

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -420,6 +420,16 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         setNeedsLayout()
     }
 
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
+        applyStyle()
+        updateFonts()
+    }
+
     open override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -242,18 +242,6 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
         updateFonts()
-
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        tokenSet.update(themeView.fluentTheme)
     }
 
     public required init?(coder aDecoder: NSCoder) {

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -415,6 +415,9 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     private func updateFonts() {
         titleButtonLabel.font = tokenSet[.titleFont].uiFont
         subtitleButtonLabel.font = tokenSet[.subtitleFont].uiFont
+
+        invalidateIntrinsicContentSize()
+        setNeedsLayout()
     }
 
     open override func layoutSubviews() {

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -52,17 +52,6 @@ public protocol TwoLineTitleViewDelegate: AnyObject {
 
 @objc(MSFTwoLineTitleView)
 open class TwoLineTitleView: UIView, TokenizedControlInternal {
-    private struct Constants {
-        static let titleButtonLabelMarginBottomRegular: CGFloat = GlobalTokens.spacing(.sizeNone)
-        static let titleButtonLabelMarginBottomCompact: CGFloat = -GlobalTokens.spacing(.size20)
-        static let titleButtonLeadingImageSize: CGFloat = GlobalTokens.icon(.size160)
-        static let titleButtonLeadingImageMargin: CGFloat = GlobalTokens.spacing(.size40)
-        static let titleButtonLeadingImageTotalPadding: CGFloat = titleButtonLeadingImageSize + titleButtonLeadingImageMargin
-        static let colorAnimationDuration: TimeInterval = 0.2
-        static let colorAlpha: CGFloat = 1.0
-        static let colorHighlightedAlpha: CGFloat = 0.4
-    }
-
     @objc(MSFTwoLineTitleViewStyle)
     public enum Style: Int {
         case primary
@@ -179,7 +168,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     private var titleButtonTrailingImageView = UIImageView()
 
     private var titleButtonLeadingImageAreaWidth: CGFloat {
-        return titleButtonLeadingImageView.image != nil ? 2 * Constants.titleButtonLeadingImageTotalPadding : 0
+        return titleButtonLeadingImageView.image != nil ? 2 * TokenSetType.LeadingImageConstants.totalPadding : 0
     }
 
     private let subtitleButton = EasyTapButton()
@@ -366,15 +355,17 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
     private func setupColor(highlighted: Bool, animated: Bool, onLabel label: UILabel, onImageViews imageViews: [UIImageView]) {
         // Highlighting is never animated to match iOS
-        let duration = !highlighted && animated ? Constants.colorAnimationDuration : 0
+        let duration = !highlighted && animated ? TokenSetType.ColorConstants.animationDuration : 0
 
         UIView.animate(withDuration: duration) {
+            let alpha = TokenSetType.ColorConstants.alpha(highlighted: highlighted)
+
             // Button label
-            label.alpha = (highlighted) ? Constants.colorHighlightedAlpha : Constants.colorAlpha
+            label.alpha = alpha
 
             // Button image views
             imageViews.forEach {
-                $0.alpha = (highlighted) ? Constants.colorHighlightedAlpha : Constants.colorAlpha
+                $0.alpha = alpha
             }
         }
     }
@@ -433,10 +424,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     open override func layoutSubviews() {
         super.layoutSubviews()
 
-        let isCompact = traitCollection.verticalSizeClass == .compact
-
         let titleButtonHeight = titleButtonLabel.font.lineHeight
-        let titleBottomMargin = isCompact ? Constants.titleButtonLabelMarginBottomCompact : Constants.titleButtonLabelMarginBottomRegular
+        let titleBottomMargin = TokenSetType.titleSpacing(for: traitCollection.verticalSizeClass)
         let subtitleButtonHeight = subtitleButtonLabel.font.lineHeight
         let totalContentHeight = titleButtonHeight + titleBottomMargin + subtitleButtonHeight
         var top = ceil((bounds.height - totalContentHeight) / 2.0)
@@ -463,14 +452,14 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
         if titleButtonLeadingImageView.image != nil {
             titleButtonLeadingImageView.frame = CGRect(
-                origin: CGPoint(x: titleButtonLabel.frame.minX - Constants.titleButtonLeadingImageTotalPadding, y: 0),
-                size: CGSize(width: Constants.titleButtonLeadingImageSize, height: Constants.titleButtonLeadingImageSize))
+                origin: CGPoint(x: titleButtonLabel.frame.minX - TokenSetType.LeadingImageConstants.totalPadding, y: 0),
+                size: CGSize(width: TokenSetType.LeadingImageConstants.size, height: TokenSetType.LeadingImageConstants.size))
             titleButtonLeadingImageView.centerInSuperview(horizontally: false, vertically: true)
 
             if alignment == .leading {
                 // Shift everything over so the leading image lines up with the leading side instead of the text
                 titleButton.subviews.forEach {
-                    $0.frame.origin.x += Constants.titleButtonLeadingImageTotalPadding
+                    $0.frame.origin.x += TokenSetType.LeadingImageConstants.totalPadding
                 }
             }
         }

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -168,7 +168,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     private var titleButtonTrailingImageView = UIImageView()
 
     private var titleButtonLeadingImageAreaWidth: CGFloat {
-        return titleButtonLeadingImageView.image != nil ? 2 * TokenSetType.LeadingImageConstants.totalPadding : 0
+        return titleButtonLeadingImageView.image != nil ? 2 * TokenSetType.leadingImageTotalPadding : 0
     }
 
     private let subtitleButton = EasyTapButton()
@@ -343,10 +343,10 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
     private func setupColor(highlighted: Bool, animated: Bool, onLabel label: UILabel, onImageViews imageViews: [UIImageView]) {
         // Highlighting is never animated to match iOS
-        let duration = !highlighted && animated ? TokenSetType.ColorConstants.animationDuration : 0
+        let duration = !highlighted && animated ? TokenSetType.textColorAnimationDuration : 0
 
         UIView.animate(withDuration: duration) {
-            let alpha = TokenSetType.ColorConstants.alpha(highlighted: highlighted)
+            let alpha = TokenSetType.textColorAlpha(highlighted: highlighted)
 
             // Button label
             label.alpha = alpha
@@ -440,14 +440,14 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
         if titleButtonLeadingImageView.image != nil {
             titleButtonLeadingImageView.frame = CGRect(
-                origin: CGPoint(x: titleButtonLabel.frame.minX - TokenSetType.LeadingImageConstants.totalPadding, y: 0),
-                size: CGSize(width: TokenSetType.LeadingImageConstants.size, height: TokenSetType.LeadingImageConstants.size))
+                origin: CGPoint(x: titleButtonLabel.frame.minX - TokenSetType.leadingImageTotalPadding, y: 0),
+                size: CGSize(width: TokenSetType.leadingImageSize, height: TokenSetType.leadingImageSize))
             titleButtonLeadingImageView.centerInSuperview(horizontally: false, vertically: true)
 
             if alignment == .leading {
                 // Shift everything over so the leading image lines up with the leading side instead of the text
                 titleButton.subviews.forEach {
-                    $0.frame.origin.x += TokenSetType.LeadingImageConstants.totalPadding
+                    $0.frame.origin.x += TokenSetType.leadingImageTotalPadding
                 }
             }
         }

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -125,11 +125,6 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         }
     }
 
-    public typealias TokenSetKeyType = TwoLineTitleViewTokenSet.Tokens
-    public lazy var tokenSet: TwoLineTitleViewTokenSet = .init(style: { [weak self] in
-        self?.currentStyle ?? .system
-    })
-
     @objc open var titleAccessibilityHint: String? {
         get { return titleButton.accessibilityHint }
         set { titleButton.accessibilityHint = newValue }
@@ -147,6 +142,11 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         get { return subtitleButton.accessibilityTraits }
         set { subtitleButton.accessibilityTraits = newValue }
     }
+
+    public typealias TokenSetKeyType = TwoLineTitleViewTokenSet.Tokens
+    public lazy var tokenSet: TwoLineTitleViewTokenSet = .init(style: { [weak self] in
+        self?.currentStyle ?? .system
+    })
 
     @objc public weak var delegate: TwoLineTitleViewDelegate?
 

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -56,3 +56,27 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
         }
     }
 }
+
+extension TwoLineTitleViewTokenSet {
+    enum ColorConstants {
+        static func alpha(highlighted: Bool) -> CGFloat {
+            highlighted ? 0.4 : 1
+        }
+        static let animationDuration: TimeInterval = 0.2
+    }
+
+    enum LeadingImageConstants {
+        static let size = GlobalTokens.icon(.size160)
+        static let margin = GlobalTokens.spacing(.size40)
+        static let totalPadding: CGFloat = size + margin
+    }
+
+    static func titleSpacing(for verticalSizeClass: UIUserInterfaceSizeClass) -> CGFloat {
+        switch verticalSizeClass {
+        case .compact:
+            return -GlobalTokens.spacing(.size20)
+        default:
+            return GlobalTokens.spacing(.sizeNone)
+        }
+    }
+}

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -58,18 +58,14 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
 }
 
 extension TwoLineTitleViewTokenSet {
-    enum ColorConstants {
-        static func alpha(highlighted: Bool) -> CGFloat {
-            highlighted ? 0.4 : 1
-        }
-        static let animationDuration: TimeInterval = 0.2
+    static func textColorAlpha(highlighted: Bool) -> CGFloat {
+        highlighted ? 0.4 : 1
     }
+    static let textColorAnimationDuration: TimeInterval = 0.2
 
-    enum LeadingImageConstants {
-        static let size = GlobalTokens.icon(.size160)
-        static let margin = GlobalTokens.spacing(.size40)
-        static let totalPadding: CGFloat = size + margin
-    }
+    static let leadingImageSize = GlobalTokens.icon(.size160)
+    static let leadingImageMargin = GlobalTokens.spacing(.size40)
+    static let leadingImageTotalPadding: CGFloat = leadingImageSize + leadingImageMargin
 
     static func titleSpacing(for verticalSizeClass: UIUserInterfaceSizeClass) -> CGFloat {
         switch verticalSizeClass {

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.Tokens> {
+    public enum Tokens: TokenSetKey {
+        case subtitleColor
+        case subtitleFont
+        case titleColor
+        case titleFont
+    }
+
+    init(style: @escaping () -> TwoLineTitleView.Style) {
+        super.init { [style] token, theme in
+            switch token {
+            case .subtitleColor:
+                return .uiColor {
+                    switch style() {
+                    case .primary:
+                        return UIColor(light: theme.color(.foregroundOnColor).light,
+                                       dark: theme.color(.foreground2).dark)
+                    case .system:
+                        return theme.color(.foreground2)
+                    }
+                }
+            case .subtitleFont:
+                return .uiFont {
+                    theme.typography(.caption1)
+                }
+            case .titleColor:
+                return .uiColor {
+                    switch style() {
+                    case .primary:
+                        return UIColor(light: theme.color(.foregroundOnColor).light,
+                                       dark: theme.color(.foreground1).dark)
+                    case .system:
+                        return theme.color(.foreground1)
+                    }
+                }
+            case .titleFont:
+                return .uiFont {
+                    theme.typography(.body1Strong)
+                }
+            }
+        }
+    }
+}

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -58,10 +58,11 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
 }
 
 extension TwoLineTitleViewTokenSet {
+    static let textColorAnimationDuration: TimeInterval = 0.2
+
     static func textColorAlpha(highlighted: Bool) -> CGFloat {
         highlighted ? 0.4 : 1
     }
-    static let textColorAnimationDuration: TimeInterval = 0.2
 
     static let leadingImageSize = GlobalTokens.icon(.size160)
     static let leadingImageMargin = GlobalTokens.spacing(.size40)

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -5,11 +5,19 @@
 
 import UIKit
 
+/// Design token set for the `TwoLineTitleView` control.
 public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
+        /// Describes the color of the subtitle.
         case subtitleColor
+
+        /// Describes the font used for the subtitle.
         case subtitleFont
+
+        /// Describes the color of the title.
         case titleColor
+
+        /// Describes the font used for the title.
         case titleFont
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This tokenizes `TwoLineTitleView`. Pretty self-explanatory.

### Verification

Validated that there are no visual changes to `TwoLineTitleView` as used in `NavigationBar`, `DateTimePicker`, and the Objective-C test page.

Also, there's a new test page.

| Example 1 | Example 2 | Example 3 |
|-|-|-|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 17 09 20](https://user-images.githubusercontent.com/717674/227066706-1e18a6a2-834f-4fd1-8fc3-9e9ed2e37cc1.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 17 10 22](https://user-images.githubusercontent.com/717674/227066722-092ab617-80f8-4a3b-88f8-94fc2a6fe8a4.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 17 10 29](https://user-images.githubusercontent.com/717674/227066730-46120dce-40c7-44bc-8776-7d6db46b0d48.png) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1659)