### PR TITLE
Allow HUD to grow for long texts

### DIFF
--- a/ios/FluentUI/HUD/HUDModifiers.swift
+++ b/ios/FluentUI/HUD/HUDModifiers.swift
@@ -73,6 +73,9 @@ struct SquareShapedViewModifier: ViewModifier {
     }
 
     init(minSize: CGFloat, maxSize: CGFloat) {
+        // Starts size at maxSize to give long labels enough space.
+        // If the HUD contents will fit in a smaller size,
+        // calculations with viewDimensions will shrink the HUD.
         size = maxSize
         self.minSize = minSize
         self.maxSize = maxSize

--- a/ios/FluentUI/HUD/HUDModifiers.swift
+++ b/ios/FluentUI/HUD/HUDModifiers.swift
@@ -61,13 +61,7 @@ struct SquareShapedViewModifier: ViewModifier {
 
                         // Don't let the size be bigger than
                         // the maximum defined by the caller.
-                        let maximumCalculatedSize = min(maxSize,
-                                                        minimumCalculatedSize)
-
-                        // Ensures the View does not shrink compared to its
-                        // previous size (calculated based on its content).
-                        size = max(size,
-                                   maximumCalculatedSize)
+                        size = min(maxSize, minimumCalculatedSize)
                     }
 
                     return viewDimensions[HorizontalAlignment.center]
@@ -79,7 +73,7 @@ struct SquareShapedViewModifier: ViewModifier {
     }
 
     init(minSize: CGFloat, maxSize: CGFloat) {
-        size = minSize
+        size = maxSize
         self.minSize = minSize
         self.maxSize = maxSize
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixed a bug with `HUD` where HUDs with long labels would truncate before growing to the `maxSize`. This was because size started at `minSize`, limiting `viewDimensions`, which was used to calculate `size`. This change starts size at `maxSize` instead.

### Binary change

Total increase: 0 bytes
Total decrease: -512 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 44,604,888 bytes | 44,604,376 bytes | 🎉 -512 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| HUDModifiers.o | 125,296 bytes | 124,784 bytes | 🎉 -512 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 50 45](https://user-images.githubusercontent.com/55368679/227375735-32e906a2-c9b4-480c-bf48-f70822fd0049.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 56 18](https://user-images.githubusercontent.com/55368679/227375758-18c8f814-d9d8-4084-9582-a7fd53a76a5d.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 29](https://user-images.githubusercontent.com/55368679/227375773-10e90dca-6623-4994-ba22-a9536bc3f0b0.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 57 53](https://user-images.githubusercontent.com/55368679/227375917-42d88a3c-fa0f-49ec-9453-4de3e2c805aa.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 33](https://user-images.githubusercontent.com/55368679/227375784-6f4864a9-227a-41af-9a05-0b7462d69bfa.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 57 57](https://user-images.githubusercontent.com/55368679/227375940-11ce3b48-77ef-4b35-9c82-fac760e158cd.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 35](https://user-images.githubusercontent.com/55368679/227375794-052141da-9861-460e-810e-0e26786b12a6.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 58 02](https://user-images.githubusercontent.com/55368679/227375969-42b019d1-ed5f-488e-8e44-e74729327bf1.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 36](https://user-images.githubusercontent.com/55368679/227375812-d599d502-f860-4b9c-9384-48737a57045f.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 58 06](https://user-images.githubusercontent.com/55368679/227375985-34748bc9-bd97-4419-94f9-995bd3a04c2c.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 38](https://user-images.githubusercontent.com/55368679/227375825-9203d60d-8687-49ab-b21c-2ce2095c980b.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 58 11](https://user-images.githubusercontent.com/55368679/227376012-d7ae57f5-a899-4b1c-aeeb-792d5c5f7a47.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 43](https://user-images.githubusercontent.com/55368679/227375837-1d5ee1af-96e8-47c6-8a27-2219f27d182c.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 58 32](https://user-images.githubusercontent.com/55368679/227376028-c2c1a49e-df4c-45f1-b891-e61097d3c7cc.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 47](https://user-images.githubusercontent.com/55368679/227375849-73f7e4cd-ac18-41d6-a26d-f2ed734db4a0.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 58 36](https://user-images.githubusercontent.com/55368679/227376038-f01bb873-adea-43e2-b953-dbc87765005b.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 15 55 54](https://user-images.githubusercontent.com/55368679/227375883-d57493ee-cdf7-4c0c-a462-cb9e77ff731b.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-23 at 17 58 50](https://user-images.githubusercontent.com/55368679/227376057-94a3447f-b89d-4a0e-a2b8-4189cbea104f.png) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1667)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1667)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1667)