### PR TITLE
Update the localization action, again

### DIFF
--- a/.github/workflows/localize.yml
+++ b/.github/workflows/localize.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   Localize:
     runs-on: ubuntu-18.04
+    environment: localization
 
     steps:
     - uses: actions/checkout@v3
@@ -28,4 +29,6 @@ jobs:
     - name: Create Pull Request
       run: scripts/create_localization_pr.sh
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MSF_TOKEN }}
+          EMAIL: ${{ secrets.EMAIL }}
+          NAME: ${{ vars.NAME }}

--- a/.github/workflows/localize.yml
+++ b/.github/workflows/localize.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   Localize:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     environment: localization
 
     steps:

--- a/scripts/create_localization_pr.sh
+++ b/scripts/create_localization_pr.sh
@@ -4,6 +4,15 @@
 
 newBranch="tdbuild`date +%s`"
 
-git checkout -b $newBranch
-git push --set-upstream origin $newBranch
-gh pr create -B main -H $newBranch --title '[Localization] Localized Resource Files' --body  'Latest localized resource files from Touchdown Build' -l 'Automated PR'
+if [[ `git status --porcelain` ]]; then
+  echo "Pushing new localization changes"
+  git config --global user.email $EMAIL
+  git config --global user.name $NAME
+  git add .
+  git commit -m 'Latest localized resource files from Touchdown Build'
+  git checkout -b $newBranch
+  git push --set-upstream origin $newBranch
+  gh pr create -B main -H $newBranch --title '[Localization] Localized Resource Files' --body  'Latest localized resource files from Touchdown Build' -l 'Automated PR'
+else
+  echo "No changes found"
+fi


### PR DESCRIPTION
### Description of changes

Addressing a few things in this one:
 - `ubuntu-18.04` is being deprecated. We didn't seem to have any particular reason to run on that one, so changing to `ubuntu-latest` rather than a new specific version
 - The script/action would create a new branch every day, which is excessive.
 - Added a new `localization` environment for actions, which has variables/secrets for the token, email, and name to use. The new commits will look like they're coming from me, so I also added myself as a required reviewer to any PR made in the `localization` environment.

These changes should keep us in a good state for a while, and let the action run. This also brings us much more inline with how Fluent UI Android is handling their localization action.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1674)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1674)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1674)