### PR TITLE
Cherry-picking: Changing animation for AvatarGroup (#1676)

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -199,14 +199,14 @@ public struct AvatarGroup: View, TokenizedControlView {
             HStack(spacing: 0) {
                 ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
                     avatarView(at: index, for: avatar)
-                        .transition(AnyTransition.move(edge: .leading))
+                        .transition(AnyTransition.opacity)
                 }
 
                 if hasOverflow {
                     VStack {
                         overflowAvatar
                     }
-                    .transition(AnyTransition.move(edge: .leading))
+                    .transition(AnyTransition.opacity)
                 }
             }
             .animation(animation, value: state.avatars)


### PR DESCRIPTION

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- (cherry picked from commit d85d4eec15339ee2b4c84ee5f055bfa4dfcf9532) #1676

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1678)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1678)