### PR TITLE
Fix maximumContentOffset calculation in SegmentedControl

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -632,7 +632,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     }
 
     private var maximumContentOffset: CGFloat {
-        return (stackView.frame.size.width + 2 * Constants.pillContainerHorizontalInset) - scrollView.frame.size.width
+        return contentInset.leading + stackView.frame.size.width + contentInset.trailing - scrollView.frame.size.width
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fix bug where we assume users always have our defined insets on the SegmentedControl

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![SegmentedControl_Gradient_Before](https://user-images.githubusercontent.com/67026548/229204232-86bf6145-0421-4646-80e6-939c9f3c55a9.png) | ![SegmentedControl_Gradient_After](https://user-images.githubusercontent.com/67026548/229204239-768a54e5-e861-466b-9588-baf65b9e3b20.png) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1683)