### PR TITLE
Rename LargeTitleView to AvatarTitleView

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		5314E0ED25F012C40099271A /* ContentScrollViewTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD41C86E22DD13230086F899 /* ContentScrollViewTraits.swift */; };
 		5314E0F225F012C80099271A /* ShyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD41C87122DD13230086F899 /* ShyHeaderView.swift */; };
 		5314E0F325F012C80099271A /* ShyHeaderController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD41C87022DD13230086F899 /* ShyHeaderController.swift */; };
-		5314E0F825F012CB0099271A /* LargeTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD41C87A22DD13230086F899 /* LargeTitleView.swift */; };
+		5314E0F825F012CB0099271A /* AvatarTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD41C87A22DD13230086F899 /* AvatarTitleView.swift */; };
 		5314E10A25F014600099271A /* Obscurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BCB0CD253A4E8C00620960 /* Obscurable.swift */; };
 		5314E11625F015EA0099271A /* PersonaBadgeViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BA27872319DC0D0001563C /* PersonaBadgeViewDataSource.swift */; };
 		5314E11725F015EA0099271A /* PersonaCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B46D3F922151D95F0029772C /* PersonaCell.swift */; };
@@ -415,7 +415,7 @@
 		FD41C86E22DD13230086F899 /* ContentScrollViewTraits.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentScrollViewTraits.swift; sourceTree = "<group>"; };
 		FD41C87022DD13230086F899 /* ShyHeaderController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShyHeaderController.swift; sourceTree = "<group>"; };
 		FD41C87122DD13230086F899 /* ShyHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShyHeaderView.swift; sourceTree = "<group>"; };
-		FD41C87A22DD13230086F899 /* LargeTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LargeTitleView.swift; sourceTree = "<group>"; };
+		FD41C87A22DD13230086F899 /* AvatarTitleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarTitleView.swift; sourceTree = "<group>"; };
 		FD41C87B22DD13230086F899 /* NavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationBar.swift; sourceTree = "<group>"; };
 		FD41C87E22DD13230086F899 /* SearchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		FD41C87F22DD13230086F899 /* NavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
@@ -1179,7 +1179,7 @@
 		FD41C87922DD13230086F899 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				FD41C87A22DD13230086F899 /* LargeTitleView.swift */,
+				FD41C87A22DD13230086F899 /* AvatarTitleView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1511,7 +1511,7 @@
 				C708B064260A87F7007190FA /* SegmentItem.swift in Sources */,
 				5328D97126FBA3D700F3723B /* IndeterminateProgressBarTokenSet.swift in Sources */,
 				5314E14325F016860099271A /* CardTransitionAnimator.swift in Sources */,
-				5314E0F825F012CB0099271A /* LargeTitleView.swift in Sources */,
+				5314E0F825F012CB0099271A /* AvatarTitleView.swift in Sources */,
 				8035CAB62633A4DB007B3FD1 /* BottomCommandingController.swift in Sources */,
 				5314E13725F016370099271A /* PopupMenuProtocols.swift in Sources */,
 				5314E19725F019650099271A /* TabBarItem.swift in Sources */,

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -301,7 +301,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         }
     }
 
-    var titleView = LargeTitleView() {
+    var titleView = AvatarTitleView() {
         willSet {
             titleView.removeFromSuperview()
         }

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -254,8 +254,8 @@ class ShyHeaderController: UIViewController {
             }
         }
 
-        // if the originator is a LargeTitleView, make sure it belongs to this heirarchy
-        if let originatorTitleView = expansionRequestOriginator as? LargeTitleView {
+        // if the originator is an AvatarTitleView, make sure it belongs to this heirarchy
+        if let originatorTitleView = expansionRequestOriginator as? AvatarTitleView {
             guard originatorTitleView == msfNavigationController?.msfNavigationBar.titleView else {
                 return false
             }

--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -5,10 +5,10 @@
 
 import UIKit
 
-// MARK: LargeTitleView
+// MARK: AvatarTitleView
 
 /// Large Header and custom profile button container
-class LargeTitleView: UIView, TwoLineTitleViewDelegate {
+class AvatarTitleView: UIView, TwoLineTitleViewDelegate {
     enum Style: Int {
         case primary
         case system
@@ -218,12 +218,12 @@ class LargeTitleView: UIView, TwoLineTitleViewDelegate {
         titleButton.titleLabel?.textAlignment = .left
         titleButton.contentHorizontalAlignment = .left
         titleButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        titleButton.addTarget(self, action: #selector(LargeTitleView.titleButtonTapped(sender:)), for: .touchUpInside)
+        titleButton.addTarget(self, action: #selector(AvatarTitleView.titleButtonTapped(sender:)), for: .touchUpInside)
         titleButton.setContentCompressionResistancePriority(.required,
                                                             for: .horizontal)
 
         // tap gesture for entire titleView
-        tapGesture.addTarget(self, action: #selector(LargeTitleView.handleTitleViewTapped(sender:)))
+        tapGesture.addTarget(self, action: #selector(AvatarTitleView.handleTitleViewTapped(sender:)))
         addGestureRecognizer(tapGesture)
 
         titleButton.showsLargeContentViewer = true


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`LargeTitleView` is a bit of a misnomer now that it can host a `TwoLineTitleView`.

One of the distinguishing features of this view is that it can display an avatar, hence the rename.

### Verification

It builds, and it still works.
![Simulator Screen Recording - iPhone 14 Pro - 2023-03-31 at 18 52 06](https://user-images.githubusercontent.com/717674/229260200-d2461f63-3fd9-45c6-9950-55efb42f1e39.gif)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1686)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1686)