### PR TITLE
Fix new swiftlint warnings

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -287,9 +287,9 @@ class BottomCommandingDemoController: UIViewController {
         return viewController
     }()
 
-    private let homeImage = UIImage(named: "Home_24")!
-    private let homeSelectedImage = UIImage(named: "Home_Selected_24")!
-    private let boldImage = UIImage(named: "textBold24Regular")!
+    private let homeImage: UIImage = .init(named: "Home_24")!
+    private let homeSelectedImage: UIImage = .init(named: "Home_Selected_24")!
+    private let boldImage: UIImage = .init(named: "textBold24Regular")!
 
     private var heroIconChanged: Bool = false
     private var listIconChanged: Bool = false

--- a/ios/FluentUI/Calendar/CalendarConfiguration.swift
+++ b/ios/FluentUI/Calendar/CalendarConfiguration.swift
@@ -15,8 +15,7 @@ open class CalendarConfiguration: NSObject {
         static let endYearsInterval: Int = 10
     }
 
-    // swiftlint:disable:next explicit_type_interface
-    @objc public static let `default` = CalendarConfiguration()
+    @objc public static let `default`: CalendarConfiguration = .init()
 
     /// By default, this is Sunday ('1')
     @objc open var firstWeekday: Int = Calendar.current.firstWeekday

--- a/ios/FluentUI/Date Time Pickers/DayOfMonth.swift
+++ b/ios/FluentUI/Date Time Pickers/DayOfMonth.swift
@@ -59,7 +59,7 @@ public enum DayOfWeek: Int {
         return daysOfWeek
     }
 
-    private static let weekdaySymbols = Calendar.sharedCalendarWithTimeZone(nil).weekdaySymbols
+    private static let weekdaySymbols: [String] = Calendar.sharedCalendarWithTimeZone(nil).weekdaySymbols
 
     public var label: String {
         return DayOfWeek.weekdaySymbols[rawValue]

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -447,7 +447,7 @@ open class AvatarView: NSView {
 	static let maximumNumberOfInitials: Int = 2
 
 	/// the color used for the border
-	static let defaultBorderColor = NSColor(named: "AvatarView/borderColor", bundle: FluentUIResources.resourceBundle)!
+	static let defaultBorderColor: NSColor = .init(named: "AvatarView/borderColor", bundle: FluentUIResources.resourceBundle)!
 
 	static let borderWidth: CGFloat = 2.0
 
@@ -606,7 +606,7 @@ extension Character {
 
 fileprivate extension Unicode.Scalar {
 	/// Unicode representation of a  zero width space
-	static let zeroWidthSpace = Unicode.Scalar(0x200B)!
+	static let zeroWidthSpace: Unicode.Scalar = .init(0x200B)!
 }
 
 extension AvatarView {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Looks like there's a new swiftlint version, so we have a few warnings to go take care of. The big one we had was 
 - `Explicit Type Interface Violation: Properties should have a type interface (explicit_type_interface)`

 But there was also one
 - `Superfluous Disable Command Violation: SwiftLint rule 'explicit_type_interface' did not trigger a violation in the disabled region; remove the disable command (superfluous_disable_command)`

### Verification

Ran swiftlint
 - `Done linting! Found 0 violations, 0 serious in 363 files.`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1691)