### PR TITLE
Make TwoLineTitleView respect child theme overrides

### DIFF
--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -319,14 +319,13 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     // MARK: Highlighting
 
     private func applyStyle() {
-        let titleColor = tokenSet[.titleColor].uiColor
-        titleButtonLabel.textColor = titleColor
+        titleButtonLabel.tokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .titleColor), forToken: .textColor)
+        let titleColor = titleButtonLabel.tokenSet[.textColor].uiColor
         titleButtonLeadingImageView.tintColor = titleColor
         titleButtonTrailingImageView.tintColor = titleColor
 
-        let subtitleColor = tokenSet[.subtitleColor].uiColor
-        subtitleButtonLabel.textColor = subtitleColor
-        subtitleButtonImageView.tintColor = subtitleColor
+        subtitleButtonLabel.tokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .subtitleColor), forToken: .textColor)
+        subtitleButtonImageView.tintColor = subtitleButtonLabel.tokenSet[.textColor].uiColor
     }
 
     private func setupTitleButtonColor(highlighted: Bool, animated: Bool) {
@@ -392,8 +391,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private func updateFonts() {
-        titleButtonLabel.font = tokenSet[.titleFont].uiFont
-        subtitleButtonLabel.font = tokenSet[.subtitleFont].uiFont
+        titleButtonLabel.tokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .titleFont), forToken: .font)
+        subtitleButtonLabel.tokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .subtitleFont), forToken: .font)
 
         invalidateIntrinsicContentSize()
         setNeedsLayout()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This fixes some issues where theme overrides on a `Label` were not being respected by `TwoLineTitleView`.

### Verification

Steps:
1. Open the Label test page and enable theme overrides.
2. Back out and go to the TwoLineTitleView test page.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      | After (with preset overrides) |
|----------------------------------------------|--------------------------------------------|-|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-10 at 12 52 22](https://user-images.githubusercontent.com/717674/230999872-fbf2f276-4f8a-48fe-84ae-dcc79043e4b5.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-10 at 13 57 05](https://user-images.githubusercontent.com/717674/230999962-42581b58-4d7e-43d9-9ffa-e65fdfe3faa7.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-10 at 13 57 25](https://user-images.githubusercontent.com/717674/230999986-2f527a3e-6fb3-4bbb-b580-1a5f72656f7b.png) |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1696)