### PR TITLE
Bring tokenized BadgeView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -22,6 +22,7 @@ struct Demos {
         DemoDescriptor("ActivityIndicator", ActivityIndicatorDemoController.self),
         DemoDescriptor("Avatar", AvatarDemoController.self),
         DemoDescriptor("AvatarGroup", AvatarGroupDemoController.self),
+        DemoDescriptor("BadgeView", BadgeViewDemoController.self),
         DemoDescriptor("BottomSheetController", BottomSheetDemoController.self),
         DemoDescriptor("Button", ButtonDemoController.self),
         DemoDescriptor("CardNudge", CardNudgeDemoController.self),
@@ -56,7 +57,6 @@ struct Demos {
 
     static let controls: [DemoDescriptor] = [
         DemoDescriptor("BadgeField", BadgeFieldDemoController.self),
-        DemoDescriptor("BadgeView", BadgeViewDemoController.self),
         DemoDescriptor("BottomCommandingController", BottomCommandingDemoController.self),
         DemoDescriptor("Card", CardViewDemoController.self),
         DemoDescriptor("DateTimePicker", DateTimePickerDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -7,13 +7,15 @@ import FluentUI
 import UIKit
 
 class BadgeViewDemoController: DemoController {
+    private var badges = [BadgeView]()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         readmeString = "A badge is a compact, interactive, \ntextual representation of a person. It is generally a representation of user-input text that maps to an entry in a database."
 
         addBadgeSection(title: "Default badge", style: .default)
-        addBadgeSection(title: "Error badge", style: .error)
+        addBadgeSection(title: "Danger badge", style: .danger)
         addBadgeSection(title: "Warning badge", style: .warning)
         addBadgeSection(title: "Neutral badge", style: .neutral)
         addBadgeSection(title: "Severe Warning badge", style: .severeWarning)
@@ -29,7 +31,7 @@ class BadgeViewDemoController: DemoController {
     func createBadge(
         text: String,
         style: BadgeView.Style,
-        size: BadgeView.Size,
+        sizeCategory: BadgeView.SizeCategory,
         isEnabled: Bool,
         customView: UIView? = nil,
         customViewVerticalPadding: NSNumber? = nil,
@@ -39,7 +41,7 @@ class BadgeViewDemoController: DemoController {
         let dataSource = BadgeViewDataSource(
             text: text,
             style: style,
-            size: size,
+            sizeCategory: sizeCategory,
             customView: customView,
             customViewVerticalPadding: customViewVerticalPadding,
             customViewPaddingLeft: customViewLeftPadding,
@@ -49,25 +51,38 @@ class BadgeViewDemoController: DemoController {
         let badge = BadgeView(dataSource: dataSource)
         badge.delegate = self
         badge.isActive = isEnabled
+        badges.append(badge)
         return badge
     }
 
     func addBadgeSection(title: String, style: BadgeView.Style, isEnabled: Bool = true, overrideColor: Bool = false) {
         addTitle(text: title)
-        for size in BadgeView.Size.allCases.reversed() {
-            let badge = createBadge(text: "Kat Larsson", style: style, size: size, isEnabled: isEnabled)
+        for sizeCategory in BadgeView.SizeCategory.allCases.reversed() {
+            let badge = createBadge(text: "Kat Larsson", style: style, sizeCategory: sizeCategory, isEnabled: isEnabled)
             if overrideColor {
                 if isEnabled {
-                    badge.backgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(.purple, .primary))
-                    badge.selectedBackgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(.darkTeal, .tint20))
-                    badge.labelTextColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey94))
-                    badge.selectedLabelTextColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey88))
+                    badge.tokenSet[.backgroundTintColor] = .uiColor {
+                        .init(light: GlobalTokens.sharedColor(.purple, .primary))
+                    }
+                    badge.tokenSet[.backgroundFilledColor] = .uiColor {
+                        .init(light: GlobalTokens.sharedColor(.darkTeal, .tint20))
+                    }
+                    badge.tokenSet[.foregroundTintColor] = .uiColor {
+                        .init(light: GlobalTokens.neutralColor(.grey94))
+                    }
+                    badge.tokenSet[.foregroundFilledColor] = .uiColor {
+                        .init(light: GlobalTokens.neutralColor(.grey88))
+                    }
                 } else {
-                    badge.disabledBackgroundColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey88))
-                    badge.disabledLabelTextColor = UIColor(colorValue: GlobalTokens.neutralColors(.grey26))
+                    badge.tokenSet[.backgroundDisabledColor] = .uiColor {
+                        .init(light: GlobalTokens.neutralColor(.grey88))
+                    }
+                    badge.tokenSet[.foregroundDisabledColor] = .uiColor {
+                        .init(light: GlobalTokens.neutralColor(.grey26))
+                    }
                 }
             }
-            addRow(text: size.description, items: [badge])
+            addRow(text: sizeCategory.description, items: [badge])
         }
         container.addArrangedSubview(UIView())
     }
@@ -82,26 +97,28 @@ class BadgeViewDemoController: DemoController {
         let avatar = MSFAvatar(style: .default, size: .size16)
         avatar.state.image = UIImage(named: "avatar_kat_larsson")
 
-        let dataSource: [(BadgeView.Size, UIView)] = [
+        let dataSource: [(BadgeView.SizeCategory, UIView)] = [
             (.medium, imageView),
             (.small, avatar)
         ]
 
-        for (size, customView) in dataSource {
+        for (sizeCategory, customView) in dataSource {
             let badge = createBadge(
                 text: "Kat Larsson",
                 style: .default,
-                size: size,
+                sizeCategory: sizeCategory,
                 isEnabled: false,
                 customView: customView,
                 customViewVerticalPadding: 3
             )
-            badge.disabledBackgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(.purple, .primary))
-            badge.disabledLabelTextColor = .white
-
-            addRow(text: size.description, items: [badge])
+            badge.tokenSet[.backgroundDisabledColor] = .uiColor {
+                .init(light: GlobalTokens.sharedColor(.purple, .primary))
+            }
+            badge.tokenSet[.foregroundDisabledColor] = .uiColor {
+                .init(light: GlobalTokens.neutralColor(.white))
+            }
+            addRow(text: sizeCategory.description, items: [badge])
         }
-
         container.addArrangedSubview(UIView())
     }
 }
@@ -118,7 +135,70 @@ extension BadgeViewDemoController: BadgeViewDelegate {
     }
 }
 
-extension BadgeView.Size {
+extension BadgeViewDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        fluentTheme.register(tokenSetType: BadgeViewTokenSet.self, tokenSet: isOverrideEnabled ? themeWideOverrideBadgeViewTokens : nil)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        for badge in badges {
+            badge.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideBadgeViewTokens : nil)
+        }
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokens(for: BadgeViewTokenSet.self)?.isEmpty == false
+    }
+
+    // MARK: - Custom tokens
+    private var themeWideOverrideBadgeViewTokens: [BadgeViewTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .backgroundTintColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.plum, .tint40),
+                               dark: GlobalTokens.sharedColor(.plum, .shade30))
+            },
+            .backgroundFilledColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.berry, .shade30),
+                               dark: GlobalTokens.sharedColor(.berry, .tint40))
+            },
+            .foregroundTintColor: .uiColor {
+                return UIColor(light: GlobalTokens.neutralColor(.white),
+                               dark: GlobalTokens.neutralColor(.grey98))
+            },
+            .foregroundFilledColor: .uiColor {
+                return UIColor(light: GlobalTokens.neutralColor(.white),
+                               dark: GlobalTokens.neutralColor(.black))
+            }
+        ]
+    }
+
+    private var perControlOverrideBadgeViewTokens: [BadgeViewTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .backgroundTintColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.forest, .tint40),
+                               dark: GlobalTokens.sharedColor(.forest, .shade30))
+            },
+            .backgroundFilledColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.seafoam, .shade30),
+                               dark: GlobalTokens.sharedColor(.seafoam, .tint40))
+            },
+            .foregroundTintColor: .uiColor {
+                return UIColor(light: GlobalTokens.neutralColor(.black),
+                               dark: GlobalTokens.neutralColor(.white))
+            },
+            .foregroundFilledColor: .uiColor {
+                return UIColor(light: GlobalTokens.neutralColor(.white),
+                               dark: GlobalTokens.neutralColor(.black))
+            }
+        ]
+    }
+}
+
+extension BadgeView.SizeCategory {
     var description: String {
         switch self {
         case .small:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -55,7 +55,7 @@ class PopupMenuDemoController: DemoController {
     }
 
     private func createAccessoryView(text: String) -> UIView {
-        let accessoryView = BadgeView(dataSource: BadgeViewDataSource(text: text, style: .default, size: .small))
+        let accessoryView = BadgeView(dataSource: BadgeViewDataSource(text: text, style: .default, sizeCategory: .small))
         accessoryView.isUserInteractionEnabled = false
         accessoryView.sizeToFit()
         return accessoryView

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -105,8 +105,8 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         let dataSource = BadgeViewDataSource(text: text, customView: customView)
         let badge = BadgeView(dataSource: dataSource)
         badge.lineBreakMode = .byTruncatingTail
-        badge.disabledBackgroundColor = UIColor(colorValue: GlobalTokens.sharedColors(.purple, .primary))
-        badge.disabledLabelTextColor = .white
+        badge.tokenSet[.backgroundDisabledColor] = .uiColor { .init(light: GlobalTokens.sharedColor(.purple, .primary)) }
+        badge.tokenSet[.foregroundDisabledColor] = .uiColor { .init(light: GlobalTokens.neutralColor(.white)) }
         badge.isActive = false
         badge.maxFontSize = Constants.badgeViewMaxFontSize
         return badge

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		6F3CB7F029D3A2B700284353 /* DrawerTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3CB7EF29D3A2B700284353 /* DrawerTokenSet.swift */; };
 		6F3CB7F229D3A5DE00284353 /* ResizingHandleTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3CB7F129D3A5DE00284353 /* ResizingHandleTokenSet.swift */; };
 		6FBFD62629CBB5F1002F3C81 /* SearchBarTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBFD62529CBB5F1002F3C81 /* SearchBarTokenSet.swift */; };
+		6FC3705E29E7707F0096B239 /* BadgeViewTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC3705D29E7707F0096B239 /* BadgeViewTokenSet.swift */; };
 		8035CAB62633A4DB007B3FD1 /* BottomCommandingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8035CAAA2633A442007B3FD1 /* BottomCommandingController.swift */; };
 		8035CAD026377C17007B3FD1 /* CommandingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8035CACA26377C14007B3FD1 /* CommandingItem.swift */; };
 		8035CADE2638E435007B3FD1 /* CommandingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8035CADC2638E435007B3FD1 /* CommandingSection.swift */; };
@@ -311,6 +312,7 @@
 		6F3CB7EF29D3A2B700284353 /* DrawerTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerTokenSet.swift; sourceTree = "<group>"; };
 		6F3CB7F129D3A5DE00284353 /* ResizingHandleTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleTokenSet.swift; sourceTree = "<group>"; };
 		6FBFD62529CBB5F1002F3C81 /* SearchBarTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarTokenSet.swift; sourceTree = "<group>"; };
+		6FC3705D29E7707F0096B239 /* BadgeViewTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeViewTokenSet.swift; sourceTree = "<group>"; };
 		7D0931C224AAAC8C0072458A /* SideTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideTabBar.swift; sourceTree = "<group>"; };
 		7DC2FB2724C0ED1100367A55 /* TableViewCellFileAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCellFileAccessoryView.swift; sourceTree = "<group>"; };
 		8035CAAA2633A442007B3FD1 /* BottomCommandingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomCommandingController.swift; sourceTree = "<group>"; };
@@ -1065,6 +1067,7 @@
 				B45EB78F219E310F008646A2 /* BadgeField.swift */,
 				B4A8BBCC21BF6D6900D5E3ED /* BadgeStringExtractor.swift */,
 				B444D6B52183A9740002B4D4 /* BadgeView.swift */,
+				6FC3705D29E7707F0096B239 /* BadgeViewTokenSet.swift */,
 			);
 			path = "Badge Field";
 			sourceTree = "<group>";
@@ -1547,6 +1550,7 @@
 				5314E13725F016370099271A /* PopupMenuProtocols.swift in Sources */,
 				5314E19725F019650099271A /* TabBarItem.swift in Sources */,
 				EC98E2B4298D989100B9DF91 /* FluentTextInputError.swift in Sources */,
+				6FC3705E29E7707F0096B239 /* BadgeViewTokenSet.swift in Sources */,
 				92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */,
 				5314E1BB25F01B070099271A /* TouchForwardingView.swift in Sources */,
 				5314E2EC25F025710099271A /* DayOfMonth.swift in Sources */,

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -10,29 +10,29 @@ import UIKit
 open class BadgeViewDataSource: NSObject {
     @objc open var text: String
     @objc open var style: BadgeView.Style
-    @objc open var size: BadgeView.Size
+    @objc open var sizeCategory: BadgeView.SizeCategory
     @objc open var customView: UIView?
     @objc open var customViewVerticalPadding: NSNumber?
     @objc open var customViewPaddingLeft: NSNumber?
     @objc open var customViewPaddingRight: NSNumber?
 
-    @objc public init(text: String, style: BadgeView.Style = .default, size: BadgeView.Size = .medium) {
+    @objc public init(text: String, style: BadgeView.Style = .default, sizeCategory: BadgeView.SizeCategory = .medium) {
         self.text = text
         self.style = style
-        self.size = size
+        self.sizeCategory = sizeCategory
         super.init()
     }
 
     @objc public convenience init(
         text: String,
         style: BadgeView.Style = .default,
-        size: BadgeView.Size = .medium,
+        sizeCategory: BadgeView.SizeCategory = .medium,
         customView: UIView? = nil,
         customViewVerticalPadding: NSNumber? = nil,
         customViewPaddingLeft: NSNumber? = nil,
         customViewPaddingRight: NSNumber? = nil
     ) {
-        self.init(text: text, style: style, size: size)
+        self.init(text: text, style: style, sizeCategory: sizeCategory)
 
         self.customView = customView
         self.customViewVerticalPadding = customViewVerticalPadding
@@ -57,54 +57,6 @@ public protocol BadgeViewDelegate {
  */
 @objc(MSFBadgeView)
 open class BadgeView: UIView, TokenizedControlInternal {
-    @objc(MSFBadgeViewStyle)
-    public enum Style: Int {
-        case `default`
-        case warning
-        case error
-        case neutral
-        case severeWarning
-        case success
-    }
-
-    @objc(MSFBadgeViewSize)
-    public enum Size: Int, CaseIterable {
-        case small
-        case medium
-
-        var labelTextStyle: FluentTheme.TypographyToken {
-            switch self {
-            case .small:
-                return .caption1
-            case .medium:
-                return .body2
-            }
-        }
-
-        var horizontalPadding: CGFloat {
-            switch self {
-            case .small:
-                return 4
-            case .medium:
-                return 5
-            }
-        }
-
-        var verticalPadding: CGFloat {
-            switch self {
-            case .small:
-                return 1.5
-            case .medium:
-                return 4
-            }
-        }
-    }
-
-    private struct Constants {
-        static let defaultMinWidth: CGFloat = 25
-        static let backgroundCornerRadius: CGFloat = 3
-    }
-
     @objc open var dataSource: BadgeViewDataSource? {
         didSet {
             reload()
@@ -136,144 +88,6 @@ open class BadgeView: UIView, TokenizedControlInternal {
         }
     }
 
-    private var _labelTextColor: UIColor?
-    @objc open var labelTextColor: UIColor? {
-        get {
-            if let customLabelTextColor = _labelTextColor {
-                return customLabelTextColor
-            }
-            switch style {
-            case .default:
-                return tokenSet.fluentTheme.color(.brandForegroundTint)
-            case .warning:
-                return tokenSet.fluentTheme.color(.warningForeground1)
-            case .error:
-                return tokenSet.fluentTheme.color(.dangerForeground1)
-            case .neutral:
-                return tokenSet.fluentTheme.color(.foreground2)
-            case .severeWarning:
-                return tokenSet.fluentTheme.color(.severeForeground1)
-            case .success:
-                return tokenSet.fluentTheme.color(.successForeground1)
-            }
-        }
-        set {
-            if labelTextColor != newValue {
-                _labelTextColor = newValue
-                updateColors()
-            }
-        }
-    }
-
-    private var _selectedLabelTextColor: UIColor?
-    @objc open var selectedLabelTextColor: UIColor {
-        get {
-            if let customSelectedLabelTextColor = _selectedLabelTextColor {
-                return customSelectedLabelTextColor
-            }
-
-            switch style {
-            case .default:
-                return tokenSet.fluentTheme.color(.foregroundOnColor)
-            case .warning:
-                return tokenSet.fluentTheme.color(.foregroundDarkStatic)
-            case .error,
-                 .severeWarning,
-                 .success:
-                return tokenSet.fluentTheme.color(.foregroundLightStatic)
-            case .neutral:
-                return tokenSet.fluentTheme.color(.foreground1)
-            }
-        }
-        set {
-            if selectedLabelTextColor != newValue {
-                _selectedLabelTextColor = newValue
-                updateColors()
-            }
-        }
-    }
-
-    private var _disabledLabelTextColor: UIColor?
-    @objc open var disabledLabelTextColor: UIColor? {
-        get {
-            if let customDisabledLabelTextColor = _disabledLabelTextColor {
-                return customDisabledLabelTextColor
-            }
-
-            let textDisabledColor = tokenSet.fluentTheme.color(.foregroundDisabled1)
-            if style == .default {
-                return UIColor(light: tokenSet.fluentTheme.color(.brandForegroundDisabled1),
-                               dark: textDisabledColor)
-            } else {
-                return textDisabledColor
-            }
-        }
-        set {
-            if disabledBackgroundColor != newValue {
-                _disabledLabelTextColor = newValue
-                updateColors()
-            }
-        }
-    }
-
-    private var _backgroundColor: UIColor?
-    @objc open override var backgroundColor: UIColor? {
-        get {
-            if let customBackgroundColor = _backgroundColor {
-                return customBackgroundColor
-            }
-            switch style {
-            case .default:
-                return tokenSet.fluentTheme.color(.brandBackgroundTint)
-            case .warning:
-                return tokenSet.fluentTheme.color(.warningBackground1)
-            case .error:
-                return tokenSet.fluentTheme.color(.dangerBackground1)
-            case .neutral:
-                return tokenSet.fluentTheme.color(.background5)
-            case .severeWarning:
-                return tokenSet.fluentTheme.color(.severeBackground1)
-            case .success:
-                return tokenSet.fluentTheme.color(.successBackground1)
-            }
-        }
-        set {
-            if backgroundColor != newValue {
-                _backgroundColor = newValue
-                updateColors()
-            }
-        }
-    }
-
-    private var _selectedBackgroundColor: UIColor?
-    @objc open var selectedBackgroundColor: UIColor? {
-        get {
-            if let customSelectedBackgroundColor = _selectedBackgroundColor {
-                return customSelectedBackgroundColor
-            }
-            switch style {
-            case .default:
-                return tokenSet.fluentTheme.color(.brandBackground1)
-            case .warning:
-                return tokenSet.fluentTheme.color(.warningBackground2)
-            case .error:
-                return tokenSet.fluentTheme.color(.dangerBackground2)
-            case .neutral:
-                return tokenSet.fluentTheme.color(.background5Selected)
-            case .severeWarning:
-                return tokenSet.fluentTheme.color(.severeBackground2)
-            case .success:
-                return tokenSet.fluentTheme.color(.successBackground2)
-            }
-        }
-        set {
-            if selectedBackgroundColor != newValue {
-                _selectedBackgroundColor = newValue
-                updateColors()
-            }
-        }
-    }
-
     @objc open var lineBreakMode: NSLineBreakMode {
         set {
             label.lineBreakMode = newValue
@@ -283,29 +97,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
         }
     }
 
-    private var _disabledBackgroundColor: UIColor?
-    open var disabledBackgroundColor: UIColor? {
-        get {
-            if let customDisabledBackgroundColor = _disabledBackgroundColor {
-                return customDisabledBackgroundColor
-            }
-
-            let backgroundDisabledColor = tokenSet.fluentTheme.color(.background5)
-            if style == .default {
-                return UIColor(light: tokenSet.fluentTheme.color(.brandBackground3), dark: backgroundDisabledColor)
-            } else {
-                return backgroundDisabledColor
-            }
-        }
-        set {
-            if disabledBackgroundColor != newValue {
-                _disabledBackgroundColor = newValue
-                updateColors()
-            }
-        }
-    }
-
-    @objc open var minWidth: CGFloat = Constants.defaultMinWidth {
+    @objc open var minWidth: CGFloat = BadgeViewTokenSet.defaultMinWidth {
         didSet {
             setNeedsLayout()
         }
@@ -327,8 +119,13 @@ open class BadgeView: UIView, TokenizedControlInternal {
         return sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
     }
 
-    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
-    public var tokenSet: EmptyTokenSet = .init()
+    public typealias TokenSetKeyType = BadgeViewTokenSet.Tokens
+    lazy public var tokenSet: BadgeViewTokenSet = .init(style: { [weak self] in
+        return self?.style ?? .default
+    },
+                                                     sizeCategory: { [weak self] in
+        return self?.sizeCategory ?? .medium
+    })
 
     private var style: Style = .default {
         didSet {
@@ -336,9 +133,9 @@ open class BadgeView: UIView, TokenizedControlInternal {
         }
     }
 
-    private var size: Size = .medium {
+    private var sizeCategory: SizeCategory = .medium {
         didSet {
-            label.textStyle = size.labelTextStyle
+            label.style = sizeCategory.labelTextStyle
             invalidateIntrinsicContentSize()
         }
     }
@@ -357,8 +154,8 @@ open class BadgeView: UIView, TokenizedControlInternal {
             }
             return defaultValue
         }
-        let defaultVerticalPadding = size.verticalPadding
-        let defaultHorizontalPadding = size.horizontalPadding
+        let defaultVerticalPadding = BadgeViewTokenSet.verticalPadding
+        let defaultHorizontalPadding = BadgeViewTokenSet.horizontalPadding(sizeCategory)
         return UIEdgeInsets(
             top: getFloat(dataSource?.customViewVerticalPadding, defaultVerticalPadding),
             left: getFloat(dataSource?.customViewPaddingLeft, defaultHorizontalPadding),
@@ -374,7 +171,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
     @objc public init(dataSource: BadgeViewDataSource) {
         super.init(frame: .zero)
 
-        backgroundView.layer.cornerRadius = Constants.backgroundCornerRadius
+        backgroundView.layer.cornerRadius = tokenSet[.borderRadius].float
         backgroundView.layer.cornerCurve = .continuous
 
         addSubview(backgroundView)
@@ -413,7 +210,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
     }
 
     private func updateFonts() {
-        switch size {
+        switch sizeCategory {
         case .small:
             label.font = tokenSet.fluentTheme.typography(.caption1)
         case .medium:
@@ -432,7 +229,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
             let labelSizeThatFits = CGSize(width: frame.size.width - labelOrigin.x, height: labelSize.height)
             label.frame = CGRect(origin: labelOrigin, size: labelSizeThatFits)
         } else {
-            label.frame = bounds.insetBy(dx: size.horizontalPadding, dy: size.verticalPadding)
+            label.frame = bounds.insetBy(dx: BadgeViewTokenSet.horizontalPadding(sizeCategory), dy: BadgeViewTokenSet.verticalPadding)
         }
 
         flipSubviewsForRTL()
@@ -441,7 +238,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
     func reload() {
         label.text = dataSource?.text
         style = dataSource?.style ?? .default
-        size = dataSource?.size ?? .medium
+        sizeCategory = dataSource?.sizeCategory ?? .medium
 
         dataSource?.customView?.removeFromSuperview()
         if let customView = dataSource?.customView {
@@ -457,12 +254,12 @@ open class BadgeView: UIView, TokenizedControlInternal {
 
         if let customViewSize = customViewSize(for: size), customViewSize != .zero {
             let heightForCustomView = customViewSize.height + customViewPadding.top + customViewPadding.bottom
-            let heightForLabel = labelSize.height + self.size.verticalPadding * 2
+            let heightForLabel = labelSize.height + BadgeViewTokenSet.verticalPadding * 2
             height = max(heightForCustomView, heightForLabel)
-            width = labelSize.width + customViewSize.width + customViewPadding.left + customViewPadding.right + self.size.horizontalPadding * 2
+            width = labelSize.width + customViewSize.width + customViewPadding.left + customViewPadding.right + BadgeViewTokenSet.horizontalPadding(self.sizeCategory) * 2
         } else {
-            height = labelSize.height + self.size.verticalPadding * 2
-            width = labelSize.width + self.size.horizontalPadding * 2
+            height = labelSize.height + BadgeViewTokenSet.verticalPadding * 2
+            width = labelSize.width + BadgeViewTokenSet.horizontalPadding(self.sizeCategory) * 2
         }
 
         let maxWidth = size.width > 0 ? size.width : .infinity
@@ -494,12 +291,12 @@ open class BadgeView: UIView, TokenizedControlInternal {
     }
 
     private func updateBackgroundColor() {
-        backgroundView.backgroundColor = isActive ? (isSelected ? selectedBackgroundColor : backgroundColor) : disabledBackgroundColor
+        backgroundView.backgroundColor = isActive ? (isSelected ? tokenSet[.backgroundFilledColor].uiColor : tokenSet[.backgroundTintColor].uiColor) : tokenSet[.backgroundDisabledColor].uiColor
         super.backgroundColor = .clear
     }
 
     private func updateLabelTextColor() {
-        label.textColor = isActive ? (isSelected ? selectedLabelTextColor : labelTextColor) : disabledLabelTextColor
+        label.textColor = isActive ? (isSelected ? tokenSet[.foregroundFilledColor].uiColor : tokenSet[.foregroundTintColor].uiColor) : tokenSet[.foregroundDisabledColor].uiColor
     }
 
     @objc private func badgeTapped() {
@@ -517,4 +314,11 @@ open class BadgeView: UIView, TokenizedControlInternal {
         get { return dataSource?.accessibilityLabel ?? label.text }
         set { }
     }
+
+#if DEBUG
+    open override var accessibilityIdentifier: String? {
+        get { return "Badge with label \(label.text ?? "") in style \(style.rawValue)" }
+        set { }
+    }
+#endif
 }

--- a/ios/FluentUI/Badge Field/BadgeViewTokenSet.swift
+++ b/ios/FluentUI/Badge Field/BadgeViewTokenSet.swift
@@ -1,0 +1,184 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Design token set for the `BadgeView` control.
+public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
+    public enum Tokens: TokenSetKey {
+        /// The background tint color of the Badge.
+        case backgroundTintColor
+
+        /// The background filled color of the Badge.
+        case backgroundFilledColor
+
+        /// The background color of the Badge when disabled.
+        case backgroundDisabledColor
+
+        /// The foreground tint color of the Badge.
+        case foregroundTintColor
+
+        /// The foreground filled color of the Badge.
+        case foregroundFilledColor
+
+        /// The foreground color of the Badge when disabled.
+        case foregroundDisabledColor
+
+        /// The border radius of the Badge.
+        case borderRadius
+    }
+
+    init(style: @escaping () -> BadgeView.Style,
+         sizeCategory: @escaping () -> BadgeView.SizeCategory) {
+        self.style = style
+        self.sizeCategory = sizeCategory
+        super.init { [style] token, theme in
+            switch token {
+            case .backgroundTintColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.brandBackgroundTint)
+                    case .danger:
+                        return theme.color(.dangerBackground1)
+                    case .severeWarning:
+                        return theme.color(.severeBackground1)
+                    case .warning:
+                        return theme.color(.warningBackground1)
+                    case .success:
+                        return theme.color(.successBackground1)
+                    case .neutral:
+                        return theme.color(.background5)
+                    }
+                }
+            case .backgroundFilledColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.brandBackground1)
+                    case .danger:
+                        return theme.color(.dangerBackground2)
+                    case .severeWarning:
+                        return theme.color(.severeBackground2)
+                    case .warning:
+                        return theme.color(.warningBackground2)
+                    case .success:
+                        return theme.color(.successBackground2)
+                    case .neutral:
+                        return theme.color(.background5Selected)
+                    }
+                }
+            case .backgroundDisabledColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.brandBackground3)
+                    case .danger, .severeWarning, .warning, .success, .neutral:
+                        return theme.color(.background5)
+                    }
+                }
+            case .foregroundTintColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.brandForegroundTint)
+                    case .danger:
+                        return theme.color(.dangerForeground1)
+                    case .severeWarning:
+                        return theme.color(.severeForeground1)
+                    case .warning:
+                        return theme.color(.warningForeground1)
+                    case .success:
+                        return theme.color(.successForeground1)
+                    case .neutral:
+                        return theme.color(.foreground2)
+                    }
+                }
+            case .foregroundFilledColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.foregroundOnColor)
+                    case .danger, .severeWarning, .success:
+                        return theme.color(.foregroundLightStatic)
+                    case .warning:
+                        return theme.color(.foregroundDarkStatic)
+                    case .neutral:
+                        return theme.color(.foreground1)
+                    }
+                }
+            case .foregroundDisabledColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.brandForegroundDisabled1)
+                    case .danger, .severeWarning, .warning, .success, .neutral:
+                        return theme.color(.foregroundDisabled1)
+                    }
+                }
+            case .borderRadius:
+                return .float({
+                    switch sizeCategory() {
+                    case .small:
+                        return GlobalTokens.corner(.radius20)
+                    case .medium:
+                        return GlobalTokens.corner(.radius40)
+                    }
+                })
+            }
+        }
+    }
+
+    /// Defines the style of the Badge.
+    var style: () -> BadgeView.Style
+
+    /// Defines the sizeCategory of the Badge.
+    var sizeCategory: () -> BadgeView.SizeCategory
+}
+
+// MARK: Constants
+extension BadgeViewTokenSet {
+    static func horizontalPadding(_ sizeCategory: BadgeView.SizeCategory) -> CGFloat {
+        switch sizeCategory {
+        case .small:
+            return GlobalTokens.spacing(.size40)
+        case .medium:
+            return GlobalTokens.spacing(.size80)
+        }
+    }
+
+    static let verticalPadding: CGFloat = GlobalTokens.spacing(.size20)
+
+    static let defaultMinWidth: CGFloat = 25
+}
+
+public extension BadgeView {
+    /// Pre-defined styles of the Badge.
+    @objc(MSFBadgeViewStyle)
+    enum Style: Int {
+        case `default`
+        case danger
+        case severeWarning
+        case warning
+        case success
+        case neutral
+    }
+
+    /// Pre-defined sizeCategories of the Badge.
+    @objc(MSFBadgeViewSizeCategory)
+    enum SizeCategory: Int, CaseIterable {
+        case small
+        case medium
+
+        var labelTextStyle: AliasTokens.TypographyTokens {
+            switch self {
+            case .small:
+                return .caption1
+            case .medium:
+                return .body2
+            }
+        }
+    }
+}

--- a/ios/FluentUI/People Picker/PeoplePicker.swift
+++ b/ios/FluentUI/People Picker/PeoplePicker.swift
@@ -346,7 +346,7 @@ open class PeoplePicker: BadgeField {
             return
         }
         let isValid = delegate?.peoplePicker?(self, personaIsValid: personaBadgeDataSource.persona) ?? true
-        personaBadgeDataSource.style = isValid ? .default : .error
+        personaBadgeDataSource.style = isValid ? .default : .danger
         badge.reload()
         super.addBadge(badge)
     }

--- a/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
+++ b/ios/FluentUI/People Picker/PersonaBadgeViewDataSource.swift
@@ -11,13 +11,13 @@ import UIKit
 open class PersonaBadgeViewDataSource: BadgeViewDataSource {
     @objc open var persona: Persona
 
-    @objc public init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium) {
+    @objc public init(persona: Persona, style: BadgeView.Style = .default, sizeCategory: BadgeView.SizeCategory = .medium) {
         self.persona = persona
-        super.init(text: persona.name, style: style, size: size)
+        super.init(text: persona.name, style: style, sizeCategory: sizeCategory)
     }
 
-    @objc public convenience init(persona: Persona, style: BadgeView.Style = .default, size: BadgeView.Size = .medium, customView: UIView? = nil) {
-        self.init(persona: persona, style: style, size: size)
+    @objc public convenience init(persona: Persona, style: BadgeView.Style = .default, sizeCategory: BadgeView.SizeCategory = .medium, customView: UIView? = nil) {
+        self.init(persona: persona, style: style, sizeCategory: sizeCategory)
         super.customView = customView
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR brings tokenized BadgeView from fluent2-tokens to main.

### Binary change

Total increase: 93,024 bytes
Total decrease: -113,824 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,915,336 bytes | 30,894,536 bytes | 🎉 -20,800 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BadgeViewTokenSet.o | 0 bytes | 87,008 bytes | 🛑 87,008 bytes |
| TabBarView.o | 266,216 bytes | 271,016 bytes | ⚠️ 4,800 bytes |
| PersonaBadgeViewDataSource.o | 37,248 bytes | 37,664 bytes | ⚠️ 416 bytes |
| BadgeLabelButton.o | 148,608 bytes | 148,904 bytes | ⚠️ 296 bytes |
| PeoplePicker.o | 293,240 bytes | 293,440 bytes | ⚠️ 200 bytes |
| TextFieldTokenSet.o | 96,432 bytes | 96,632 bytes | ⚠️ 200 bytes |
| BadgeField.o | 539,152 bytes | 539,232 bytes | ⚠️ 80 bytes |
| ControlTokenSet.o | 83,672 bytes | 83,688 bytes | ⚠️ 16 bytes |
| HeadsUpDisplay.o | 285,928 bytes | 285,936 bytes | ⚠️ 8 bytes |
| __.SYMDEF | 4,721,904 bytes | 4,721,432 bytes | 🎉 -472 bytes |
| FocusRingView.o | 797,272 bytes | 767,064 bytes | 🎉 -30,208 bytes |
| BadgeView.o | 492,688 bytes | 458,176 bytes | 🎉 -34,512 bytes |
| ActionsCell.o | 207,424 bytes | 158,792 bytes | 🎉 -48,632 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_badgeview](https://user-images.githubusercontent.com/106181067/231610614-a4ac22cf-dc13-4cfe-b91b-aae95223faef.png) | ![after_badgeview](https://user-images.githubusercontent.com/106181067/231610626-fbb55bc1-ee50-453e-821f-0868622a3893.png) |
| ![before_searchbar](https://user-images.githubusercontent.com/106181067/231610640-a87e1485-ee59-4468-ba71-142c68d3171e.png) | ![after_searchbar](https://user-images.githubusercontent.com/106181067/231610647-73b2cc5a-e588-4a55-9b37-96c0603adc87.png) |
| n/a | ![after_badgeview_override](https://user-images.githubusercontent.com/106181067/231610687-66026395-10dc-49a8-8f9b-5e58f62c4679.png) |
| n/a | ![after_theme-wide](https://user-images.githubusercontent.com/106181067/231610701-7a520ba3-d49b-47f8-af6b-a3ee302063fd.png) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)