### PR TITLE
Update Label's textColor/font to use tokenSet

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -12,10 +12,10 @@ import UIKit
 open class Label: UILabel, TokenizedControlInternal {
     @objc open var colorStyle: TextColorStyle = .regular {
         didSet {
-            labelTextColor = nil
             updateTextColor()
         }
     }
+
     @objc open var style: AliasTokens.TypographyTokens {
         get {
             return AliasTokens.TypographyTokens(rawValue: textStyle.rawValue)!
@@ -24,9 +24,9 @@ open class Label: UILabel, TokenizedControlInternal {
             self.textStyle = FluentTheme.TypographyToken(rawValue: newValue.rawValue)!
         }
     }
+
     @objc open var textStyle: FluentTheme.TypographyToken = .body1 {
         didSet {
-            labelFont = nil
             updateFont()
         }
     }
@@ -43,16 +43,20 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     open override var textColor: UIColor! {
-        didSet {
-            labelTextColor = textColor
-            updateTextColor()
+        get {
+            return tokenSet[.textColor].uiColor
+        }
+        set {
+            tokenSet[.textColor] = .uiColor { newValue }
         }
     }
 
     open override var font: UIFont! {
-        didSet {
-            labelFont = font
-            updateFont()
+        get {
+            return tokenSet[.font].uiFont
+        }
+        set {
+            tokenSet[.font] = .uiFont { newValue }
         }
     }
 
@@ -67,8 +71,8 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     open override var attributedText: NSAttributedString? {
-      didSet {
-          isUsingCustomAttributedText = attributedText != nil
+        didSet {
+            isUsingCustomAttributedText = attributedText != nil
         }
     }
 
@@ -103,10 +107,6 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     private func initialize() {
-        // textColor and font are assigned in super.init to a default value and so we need to reset our cache afterwards
-        labelTextColor = nil
-        labelFont = nil
-
         updateFont()
         updateTextColor()
         adjustsFontForContentSizeCategory = true
@@ -129,7 +129,7 @@ open class Label: UILabel, TokenizedControlInternal {
             return
         }
 
-        let labelFont = labelFont ?? tokenSet[.font].uiFont
+        let labelFont = tokenSet[.font].uiFont
         if maxFontSize > 0 && labelFont.pointSize > maxFontSize {
             super.font = labelFont.withSize(maxFontSize)
         } else {
@@ -142,7 +142,7 @@ open class Label: UILabel, TokenizedControlInternal {
         guard !isUsingCustomAttributedText else {
             return
         }
-        super.textColor = labelTextColor ?? tokenSet[.textColor].uiColor
+        super.textColor = tokenSet[.textColor].uiColor
     }
 
     @objc private func handleContentSizeCategoryDidChange() {
@@ -151,7 +151,5 @@ open class Label: UILabel, TokenizedControlInternal {
         }
     }
 
-    private var labelTextColor: UIColor?
-    private var labelFont: UIFont?
     private var isUsingCustomAttributedText: Bool = false
 }

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -107,6 +107,10 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     private func initialize() {
+        // textColor and font in the tokenSet are assigned in super.init to a default value and so we need to remove the override
+        tokenSet.removeOverride(.textColor)
+        tokenSet.removeOverride(.font)
+
         updateFont()
         updateTextColor()
         adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Previously, `Label` had stored its `textColor` and `font` in ivars for token overrides since attempting to set `UILabel`'s font/color to nil would set it to a default font. With the new changes to token types (#1655) and discussions in #1629, this PR updates Label to store textColor and font directly in the tokenSet.

### Binary change

Total increase: 0 bytes
Total decrease: -8,728 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 45,784,704 bytes | 45,775,976 bytes | 🎉 -8,728 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 2,861,896 bytes | 2,861,096 bytes | 🎉 -800 bytes |
| Label.o | 187,744 bytes | 179,816 bytes | 🎉 -7,928 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-13 at 11 36 33](https://user-images.githubusercontent.com/55368679/231852832-838e2c92-d966-4e58-a7e3-7c76b81d980a.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-13 at 11 35 20](https://user-images.githubusercontent.com/55368679/231852799-3da1631d-33e0-45d1-b34c-00012d28812b.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-13 at 11 36 35](https://user-images.githubusercontent.com/55368679/231852847-6e9f2934-30a3-4902-8359-d0163071900d.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-13 at 11 35 23](https://user-images.githubusercontent.com/55368679/231852818-f2cf3031-e0e5-4698-af0d-be40fdf2cdd5.png) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1699)