### PR TITLE
Fix Swift Package Manager builds on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
                 "Other Cells/OtherCells.resources.xcfilelist",
                 "Resources/Localization/CultureMapping.json",
                 "Table View/TableView.resources.xcfilelist",
+                "TextField/TextField.resources.xcfilelist",
                 "Tooltip/Tooltip.resources.xcfilelist",
                 "TwoLineTitleView/TwoLineTitleView.resources.xcfilelist",
             ]

--- a/macos/FluentUI/Core/FluentUIResources.swift
+++ b/macos/FluentUI/Core/FluentUIResources.swift
@@ -3,10 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-/// Note: SWIFT_PACKAGE is automatically defined whenever the code is being built by the Swift Package Manager.
-#if SWIFT_PACKAGE
-import FluentUIResources
-#endif
 import AppKit
 
 /// A class for accessing the bundle and resource bundle associated with the FluentUI Framework

--- a/macos/FluentUI/Notification/NotificationBarView.swift
+++ b/macos/FluentUI/Notification/NotificationBarView.swift
@@ -186,12 +186,12 @@ public struct NotificationBarView: View {
 	var foregroundColor: Color
 
 	private struct Constants {
-		static let accentBackgroundColor: Color = Color(FluentUI.Colors.primaryTint30)
-		static let accentForegroundColor: Color = Color(FluentUI.Colors.primaryShade20)
+		static let accentBackgroundColor: Color = Color(Colors.primaryTint30)
+		static let accentForegroundColor: Color = Color(Colors.primaryShade20)
 		static let subtleBackgroundColor: Color = Color(.white)
-		static let subtleForegroundColor: Color = Color(FluentUI.Colors.primary)
-		static let neutralBackgroundColor: Color = Color(FluentUI.Colors.Palette.gray100.color)
-		static let neutralForegroundColor: Color = Color(FluentUI.Colors.Palette.gray900.color)
+		static let subtleForegroundColor: Color = Color(Colors.primary)
+		static let neutralBackgroundColor: Color = Color(Colors.Palette.gray100.color)
+		static let neutralForegroundColor: Color = Color(Colors.Palette.gray900.color)
 
 		static let horizontalPadding: CGFloat = 16
 		static let horizontalSpacing: CGFloat = 16


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Issue describe in more detail in #1701 

Pull request #1544 removed the FluentUIResources module but didn't remove the code that conditionally imports it when compiling via Swift Package Manager. Fix that by just removing the import as it's no longer relevant.

When macOS Notification bar support was added in #1590, it references the FluentUI namespace directly. I'm not actually sure why this works in Xcode builds but not SPM builds, but removing the FluentUI namespace works to fix both.

While here, fix up a warning that `TextField/TextField.resources.xcfilelist` should be excluded from our SPM build on iOS

### Binary change

macOS changes don't need binary size comparisons.

### Verification

Ensure `swift build` works as expected with no warnings or errors. Sanity check that the notification bar view test app looks the same before and after, paying close attention to colors.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="912" alt="image" src="https://user-images.githubusercontent.com/658243/232331879-839895d3-a35f-4672-9a84-8da806502e5f.png"> | <img width="912" alt="image" src="https://user-images.githubusercontent.com/658243/232331860-1285d26f-f2a3-47d6-a247-8f1625b69d5d.png"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1702)