### PR TITLE
Fix `TwoLineTitleView` overrides (for real this time)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -64,6 +64,8 @@ extension TextColorStyle {
             return "Regular"
         case .secondary:
             return "Secondary"
+        case .secondaryOnColor:
+            return "Secondary on Color"
         case .white:
             return "White"
         case .primary:

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -209,6 +209,7 @@ extension TwoLineTitleViewDemoController: DemoAppearanceDelegate {
                 UIColor(light: GlobalTokens.sharedColor(.green, .primary),
                         dark: GlobalTokens.sharedColor(.green, .tint30))
             },
+            .titleFont: .uiFont { UIFont(descriptor: .init(name: "Verdana", size: 17), size: 17) },
             .subtitleColor: .uiColor {
                 UIColor(light: GlobalTokens.sharedColor(.red, .primary),
                         dark: GlobalTokens.sharedColor(.red, .tint30))

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -64,9 +64,7 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
         // Make a copy so we write all the values at once
         var valueOverrideCopy = valueOverrides ?? [:]
         mapping.forEach { (thisToken, otherToken) in
-            if let overrideToken = otherTokenSet.overrideValue(forToken: otherToken) {
-                valueOverrideCopy[thisToken] = overrideToken
-            }
+            valueOverrideCopy[thisToken] = otherTokenSet.overrideValue(forToken: otherToken)
         }
         valueOverrides = valueOverrideCopy
     }

--- a/ios/FluentUI/Label/LabelTokenSet.swift
+++ b/ios/FluentUI/Label/LabelTokenSet.swift
@@ -11,6 +11,7 @@ import UIKit
 public enum TextColorStyle: Int, CaseIterable {
     case regular
     case secondary
+    case secondaryOnColor
     case white
     case primary
     case error
@@ -39,6 +40,9 @@ public class LabelTokenSet: ControlTokenSet<LabelTokenSet.Tokens> {
                         return theme.color(.foreground1)
                     case .secondary:
                         return theme.color(.foreground2)
+                    case .secondaryOnColor:
+                        return UIColor(light: theme.color(.foregroundOnColor),
+                                       dark: theme.color(.foreground2))
                     case .white:
                         return theme.color(.foregroundLightStatic)
                     case .primary:

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -320,24 +320,12 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         titleButtonLabel.colorStyle = TokenSetType.defaultTitleColorStyle(for: currentStyle)
         subtitleButtonLabel.colorStyle = TokenSetType.defaultSubtitleColorStyle(for: currentStyle)
 
-        // Title
-        if let titleOverride = tokenSet.overrideValue(forToken: .titleColor) {
-            titleButtonLabel.tokenSet[.textColor] = titleOverride
-        } else {
-            titleButtonLabel.tokenSet.removeOverride(.textColor)
-        }
-
+        titleButtonLabel.tokenSet.setOverrides(from: tokenSet, mapping: [.textColor: .titleColor])
         let titleColor = titleButtonLabel.tokenSet[.textColor].uiColor
         titleButtonLeadingImageView.tintColor = titleColor
         titleButtonTrailingImageView.tintColor = titleColor
 
-        // Subtitle
-        if let subtitleOverride = tokenSet.overrideValue(forToken: .subtitleColor) {
-            subtitleButtonLabel.tokenSet[.textColor] = subtitleOverride
-        } else {
-            subtitleButtonLabel.tokenSet.removeOverride(.textColor)
-        }
-
+        subtitleButtonLabel.tokenSet.setOverrides(from: tokenSet, mapping: [.textColor: .subtitleColor])
         subtitleButtonImageView.tintColor = subtitleButtonLabel.tokenSet[.textColor].uiColor
     }
 
@@ -404,17 +392,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private func updateFonts() {
-        if let parentOverrideToken = tokenSet.overrideValue(forToken: .titleFont) {
-            titleButtonLabel.tokenSet[.font] = parentOverrideToken
-        } else {
-            titleButtonLabel.tokenSet.removeOverride(.font)
-        }
-
-        if let parentOverrideToken = tokenSet.overrideValue(forToken: .subtitleFont) {
-            subtitleButtonLabel.tokenSet[.font] = parentOverrideToken
-        } else {
-            subtitleButtonLabel.tokenSet.removeOverride(.font)
-        }
+        titleButtonLabel.tokenSet.setOverrides(from: tokenSet, mapping: [.font: .titleFont])
+        subtitleButtonLabel.tokenSet.setOverrides(from: tokenSet, mapping: [.font: .subtitleFont])
 
         invalidateIntrinsicContentSize()
         setNeedsLayout()

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -156,9 +156,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private lazy var titleButtonLabel: Label = {
-        let label = Label()
+        let label = Label(textStyle: TokenSetType.defaultTitleStyle)
         label.lineBreakMode = .byTruncatingTail
-        label.tokenSet[.font] = tokenSet[.titleFont]
         label.textAlignment = .center
         return label
     }()
@@ -176,9 +175,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private lazy var subtitleButtonLabel: Label = {
-        let label = Label()
+        let label = Label(textStyle: TokenSetType.defaultSubtitleStyle)
         label.lineBreakMode = .byTruncatingMiddle
-        label.tokenSet[.font] = tokenSet[.subtitleFont]
         return label
     }()
 
@@ -238,8 +236,6 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         subtitleButtonLabel.showsLargeContentViewer = true
 
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
-
-        updateFonts()
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -320,12 +316,26 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     // MARK: Highlighting
 
     private func applyStyle() {
-        let titleColor = tokenSet[.titleColor].uiColor
+        let titleColor: UIColor
+        if let parentOverrideToken = tokenSet.overrideValue(forToken: .titleColor) {
+            titleColor = parentOverrideToken.uiColor
+        } else if let titleLabelOverrideToken = titleButtonLabel.tokenSet.overrideValue(forToken: .textColor) {
+            titleColor = titleLabelOverrideToken.uiColor
+        } else {
+            titleColor = tokenSet[.titleColor].uiColor
+        }
         titleButtonLabel.textColor = titleColor
         titleButtonLeadingImageView.tintColor = titleColor
         titleButtonTrailingImageView.tintColor = titleColor
 
-        let subtitleColor = tokenSet[.subtitleColor].uiColor
+        let subtitleColor: UIColor
+        if let parentOverrideToken = tokenSet.overrideValue(forToken: .subtitleColor) {
+            subtitleColor = parentOverrideToken.uiColor
+        } else if let subtitleLabelOverrideToken = subtitleButtonLabel.tokenSet.overrideValue(forToken: .textColor) {
+            subtitleColor = subtitleLabelOverrideToken.uiColor
+        } else {
+            subtitleColor = tokenSet[.subtitleColor].uiColor
+        }
         subtitleButtonLabel.textColor = subtitleColor
         subtitleButtonImageView.tintColor = subtitleColor
     }
@@ -393,8 +403,25 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private func updateFonts() {
-        titleButtonLabel.font = tokenSet[.titleFont].uiFont
-        subtitleButtonLabel.font = tokenSet[.subtitleFont].uiFont
+        let titleFont: UIFont
+        if let parentOverrideToken = tokenSet.overrideValue(forToken: .titleFont) {
+            titleFont = parentOverrideToken.uiFont
+        } else if let titleLabelOverrideToken = titleButtonLabel.tokenSet.overrideValue(forToken: .font) {
+            titleFont = titleLabelOverrideToken.uiFont
+        } else {
+            titleFont = tokenSet[.titleFont].uiFont
+        }
+        titleButtonLabel.font = titleFont
+
+        let subtitleFont: UIFont
+        if let parentOverrideToken = tokenSet.overrideValue(forToken: .subtitleFont) {
+            subtitleFont = parentOverrideToken.uiFont
+        } else if let subtitleLabelOverrideToken = subtitleButtonLabel.tokenSet.overrideValue(forToken: .font) {
+            subtitleFont = subtitleLabelOverrideToken.uiFont
+        } else {
+            subtitleFont = tokenSet[.subtitleFont].uiFont
+        }
+        subtitleButtonLabel.font = subtitleFont
 
         invalidateIntrinsicContentSize()
         setNeedsLayout()

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -156,7 +156,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private lazy var titleButtonLabel: Label = {
-        let label = Label(textStyle: TokenSetType.defaultTitleStyle)
+        let label = Label(textStyle: TokenSetType.defaultTitleFont)
         label.lineBreakMode = .byTruncatingTail
         label.textAlignment = .center
         return label
@@ -175,7 +175,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private lazy var subtitleButtonLabel: Label = {
-        let label = Label(textStyle: TokenSetType.defaultSubtitleStyle)
+        let label = Label(textStyle: TokenSetType.defaultSubtitleFont)
         label.lineBreakMode = .byTruncatingMiddle
         return label
     }()
@@ -316,28 +316,29 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     // MARK: Highlighting
 
     private func applyStyle() {
-        let titleColor: UIColor
-        if let parentOverrideToken = tokenSet.overrideValue(forToken: .titleColor) {
-            titleColor = parentOverrideToken.uiColor
-        } else if let titleLabelOverrideToken = titleButtonLabel.tokenSet.overrideValue(forToken: .textColor) {
-            titleColor = titleLabelOverrideToken.uiColor
+        // Reset color styles since they might have changed
+        titleButtonLabel.colorStyle = TokenSetType.defaultTitleColorStyle(for: currentStyle)
+        subtitleButtonLabel.colorStyle = TokenSetType.defaultSubtitleColorStyle(for: currentStyle)
+
+        // Title
+        if let titleOverride = tokenSet.overrideValue(forToken: .titleColor) {
+            titleButtonLabel.tokenSet[.textColor] = titleOverride
         } else {
-            titleColor = tokenSet[.titleColor].uiColor
+            titleButtonLabel.tokenSet.removeOverride(.textColor)
         }
-        titleButtonLabel.textColor = titleColor
+
+        let titleColor = titleButtonLabel.tokenSet[.textColor].uiColor
         titleButtonLeadingImageView.tintColor = titleColor
         titleButtonTrailingImageView.tintColor = titleColor
 
-        let subtitleColor: UIColor
-        if let parentOverrideToken = tokenSet.overrideValue(forToken: .subtitleColor) {
-            subtitleColor = parentOverrideToken.uiColor
-        } else if let subtitleLabelOverrideToken = subtitleButtonLabel.tokenSet.overrideValue(forToken: .textColor) {
-            subtitleColor = subtitleLabelOverrideToken.uiColor
+        // Subtitle
+        if let subtitleOverride = tokenSet.overrideValue(forToken: .subtitleColor) {
+            subtitleButtonLabel.tokenSet[.textColor] = subtitleOverride
         } else {
-            subtitleColor = tokenSet[.subtitleColor].uiColor
+            subtitleButtonLabel.tokenSet.removeOverride(.textColor)
         }
-        subtitleButtonLabel.textColor = subtitleColor
-        subtitleButtonImageView.tintColor = subtitleColor
+
+        subtitleButtonImageView.tintColor = subtitleButtonLabel.tokenSet[.textColor].uiColor
     }
 
     private func setupTitleButtonColor(highlighted: Bool, animated: Bool) {
@@ -403,25 +404,17 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     }
 
     private func updateFonts() {
-        let titleFont: UIFont
         if let parentOverrideToken = tokenSet.overrideValue(forToken: .titleFont) {
-            titleFont = parentOverrideToken.uiFont
-        } else if let titleLabelOverrideToken = titleButtonLabel.tokenSet.overrideValue(forToken: .font) {
-            titleFont = titleLabelOverrideToken.uiFont
+            titleButtonLabel.tokenSet[.font] = parentOverrideToken
         } else {
-            titleFont = tokenSet[.titleFont].uiFont
+            titleButtonLabel.tokenSet.removeOverride(.font)
         }
-        titleButtonLabel.font = titleFont
 
-        let subtitleFont: UIFont
         if let parentOverrideToken = tokenSet.overrideValue(forToken: .subtitleFont) {
-            subtitleFont = parentOverrideToken.uiFont
-        } else if let subtitleLabelOverrideToken = subtitleButtonLabel.tokenSet.overrideValue(forToken: .font) {
-            subtitleFont = subtitleLabelOverrideToken.uiFont
+            subtitleButtonLabel.tokenSet[.font] = parentOverrideToken
         } else {
-            subtitleFont = tokenSet[.subtitleFont].uiFont
+            subtitleButtonLabel.tokenSet.removeOverride(.font)
         }
-        subtitleButtonLabel.font = subtitleFont
 
         invalidateIntrinsicContentSize()
         setNeedsLayout()

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -23,6 +23,7 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
 
     init(style: @escaping () -> TwoLineTitleView.Style) {
         super.init { [style] token, theme in
+            assertionFailure("TwoLineTitleView is a compound control, so we shouldn't be accessing its default token values directly")
             switch token {
             case .subtitleColor:
                 return .uiColor {
@@ -36,7 +37,7 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
                 }
             case .subtitleFont:
                 return .uiFont {
-                    theme.typography(Self.defaultSubtitleStyle)
+                    theme.typography(Self.defaultSubtitleFont)
                 }
             case .titleColor:
                 return .uiColor {
@@ -50,7 +51,7 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
                 }
             case .titleFont:
                 return .uiFont {
-                    theme.typography(Self.defaultTitleStyle)
+                    theme.typography(Self.defaultTitleFont)
                 }
             }
         }
@@ -64,8 +65,26 @@ extension TwoLineTitleViewTokenSet {
         highlighted ? 0.4 : 1
     }
 
-    static let defaultTitleStyle: FluentTheme.TypographyToken = .body1Strong
-    static let defaultSubtitleStyle: FluentTheme.TypographyToken = .caption1
+    static let defaultTitleFont: FluentTheme.TypographyToken = .body1Strong
+    static let defaultSubtitleFont: FluentTheme.TypographyToken = .caption1
+
+    static func defaultTitleColorStyle(for style: TwoLineTitleView.Style) -> TextColorStyle {
+        switch style {
+        case .primary:
+            return .white // Equivalent to .foregroundOnColor on light, .foreground1 on dark
+        case .system:
+            return .regular
+        }
+    }
+
+    static func defaultSubtitleColorStyle(for style: TwoLineTitleView.Style) -> TextColorStyle {
+        switch style {
+        case .primary:
+            return .secondaryOnColor // Equivalent to .foregroundColor on light, .foreground2 on dark
+        case .system:
+            return .secondary
+        }
+    }
 
     static let leadingImageSize = GlobalTokens.icon(.size160)
     static let leadingImageMargin = GlobalTokens.spacing(.size40)

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleViewTokenSet.swift
@@ -36,7 +36,7 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
                 }
             case .subtitleFont:
                 return .uiFont {
-                    theme.typography(.caption1)
+                    theme.typography(Self.defaultSubtitleStyle)
                 }
             case .titleColor:
                 return .uiColor {
@@ -50,7 +50,7 @@ public class TwoLineTitleViewTokenSet: ControlTokenSet<TwoLineTitleViewTokenSet.
                 }
             case .titleFont:
                 return .uiFont {
-                    theme.typography(.body1Strong)
+                    theme.typography(Self.defaultTitleStyle)
                 }
             }
         }
@@ -63,6 +63,9 @@ extension TwoLineTitleViewTokenSet {
     static func textColorAlpha(highlighted: Bool) -> CGFloat {
         highlighted ? 0.4 : 1
     }
+
+    static let defaultTitleStyle: FluentTheme.TypographyToken = .body1Strong
+    static let defaultSubtitleStyle: FluentTheme.TypographyToken = .caption1
 
     static let leadingImageSize = GlobalTokens.icon(.size160)
     static let leadingImageMargin = GlobalTokens.spacing(.size40)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

We found issues with different overrides stomping on each other in `TwoLineTitleView`. This should fix it once and for all.

I'm genuinely not thrilled about having to add another case to `TextColorStyle` since this isn't very future-proof, but it seems like this is the only way to do this without adding a lot of annoying glue code. Hopefully we can fix this at a later time.

### Verification

<details>
<summary>Visual Verification</summary>

| No overrides | 2LTV override | Label override | Both overrides |
|-|-|-|-|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 15 35](https://user-images.githubusercontent.com/717674/232630679-5846905a-94b0-4982-8c40-b1b875a74078.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 15 45](https://user-images.githubusercontent.com/717674/232630790-9a83c59e-3c59-4a73-a5a1-29f75ab80b2e.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 16 04](https://user-images.githubusercontent.com/717674/232630853-0ff51ceb-6bf4-40ef-b390-e9b5fc464780.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 15 57](https://user-images.githubusercontent.com/717674/232630912-afd7b208-ef3e-401a-9fff-e2352f4704cf.png) |

| Light | Brand | Dark |
|-|-|-|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 21 14](https://user-images.githubusercontent.com/717674/232631460-855087c6-2eec-41e4-935d-8bf069297486.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 21 17](https://user-images.githubusercontent.com/717674/232631481-bd08ef90-a875-4f08-b00f-e2c808d2ed38.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-17 at 16 21 28](https://user-images.githubusercontent.com/717674/232631492-7ca77815-733f-494d-b8bf-19d51870dcb7.png) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1703)