### PR TITLE
Validate `NavigationBar` token overrides

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -963,13 +963,13 @@ extension NavigationControllerDemoController: DemoAppearanceDelegate {
     private func themeWideOverrideTokens(_ theme: FluentTheme) -> [NavigationBarTokenSet.Tokens: ControlTokenValue] {
         return [
             .titleColor: .uiColor {
-                UIColor(light: GlobalTokens.sharedColor(.green, .primary),
-                        dark: GlobalTokens.sharedColor(.green, .tint30))
+                UIColor(light: GlobalTokens.sharedColor(.hotPink, .primary),
+                        dark: GlobalTokens.sharedColor(.hotPink, .tint30))
             },
             .titleFont: .uiFont { theme.typography(.caption1Strong) },
             .subtitleColor: .uiColor {
-                UIColor(light: GlobalTokens.sharedColor(.red, .primary),
-                        dark: GlobalTokens.sharedColor(.red, .tint30))
+                UIColor(light: GlobalTokens.sharedColor(.lime, .primary),
+                        dark: GlobalTokens.sharedColor(.lime, .tint30))
             },
             .buttonTintColor: .uiColor {
                 UIColor(light: GlobalTokens.sharedColor(.orange, .primary),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR ensures that token overrides work as we expect in the navigation bar.

While this isn't much of a change, it does distinguish NavBar-specific overrides (hot pink and lime) from standard `TwoLineTitleView` overrides (green and red), so this is more of a "yes, it works" kind of PR.

### Verification

<details>
<summary>Visual Verification</summary>

These screenshots come from a version of the app where we change `DemoListViewController` to use Fluent's `NavigationController` instead of UIKit's `UINavigationController`, just to show that overrides can be more easily applied.

I'm fully aware that green on brand blue is very difficult to read on its own. That being said, this is just to show that overrides do stack on each other (as well as the importance of consumers using overrides responsibly).
| No overrides | Label override | Label and 2LTV overrides | NavBar override | Label and NavBar override |
|-|-|-|-|-|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 16 52 54](https://user-images.githubusercontent.com/717674/232930836-568229c5-a0fa-46c8-a951-0c0635d609ea.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 16 53 07](https://user-images.githubusercontent.com/717674/232930849-a7c61688-8943-41e2-bef9-06add8fbe7b4.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 16 53 23](https://user-images.githubusercontent.com/717674/232930863-f2df84ff-1e5e-42fe-bc74-56b6725d1cda.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 17 07 50](https://user-images.githubusercontent.com/717674/232930885-91cdb30a-3ca3-451f-9e98-e2c526b19ee8.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-04-18 at 17 18 49](https://user-images.githubusercontent.com/717674/232934130-c9dceecf-f1ab-4ad3-8882-a47b8301487a.png) |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1708)