### PR TITLE
Fix PillButtonBar's button sizes

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -254,6 +254,7 @@ open class PillButtonBar: UIScrollView {
     private func initStackView() -> UIStackView {
         let view = UIStackView()
         view.alignment = .center
+        view.distribution = .fillProportionally
         view.spacing = Constants.minButtonsSpacing
         return view
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Somewhere between fixing iOS 15 deprecation warnings for the PillButtonBar in #1165 , and all the various merges, back outs, and reorganization of the code in PillButtonBar.swift between main and fluent2-tokens, we stopped setting the distribution of the stack view in the PillButtonBar to prevent all the buttons from being the same size. Setting the distribution to `.fillProportionally` again fixes that.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![PillButtonBar_Before](https://user-images.githubusercontent.com/67026548/233210482-f6cc80d8-ad52-4629-8757-d2973c43dd31.png) | ![PillButtonBar_After](https://user-images.githubusercontent.com/67026548/233210494-362c4db8-1ab8-4d86-8958-a9a63dcb5a06.png) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1709)