### PR TITLE
Add NavigationBar gradient style

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -179,12 +179,10 @@ class NavigationControllerDemoController: DemoController {
             changeStyleContinuously(in: content.navigationItem)
         }
 
-        let controller: NavigationController
-        if style == .gradient {
-            controller = NavigationController(rootViewController: content, gradient: gradient, mask: gradientMask)
-        } else {
-            controller = NavigationController(rootViewController: content)
-        }
+        let controller = NavigationController(rootViewController: content)
+        controller.msfNavigationBar.gradient = gradient
+        controller.msfNavigationBar.gradientMask = gradientMask
+
         if showAvatar {
             controller.msfNavigationBar.personaData = content.personaData
             controller.msfNavigationBar.onAvatarTapped = handleAvatarTapped

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -120,7 +120,7 @@ class NavigationControllerDemoController: DemoController {
                                    updateStylePeriodically: Bool = false) -> NavigationController {
         let content = RootViewController()
         content.navigationItem.usesLargeTitle = useLargeTitle
-        content.navigationItem.navigationBarStyle = style
+        content.navigationItem.navigationBarStyle = .customGradient
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
         content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
@@ -168,7 +168,7 @@ class NavigationControllerDemoController: DemoController {
                 newStyle = .primary
             case .primary:
                 newStyle = .system
-            case .system:
+            case .system, .customGradient:
                 newStyle = .custom
             }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -175,12 +175,13 @@ class NavigationControllerDemoController: DemoController {
         }
 
         let controller = NavigationController(rootViewController: content)
-        controller.msfNavigationBar.gradient = gradient
-        controller.msfNavigationBar.gradientMask = gradientMask
+        let navigationBar = controller.msfNavigationBar
+        navigationBar.gradient = gradient
+        navigationBar.gradientMask = gradientMask
 
         if showAvatar {
-            controller.msfNavigationBar.personaData = content.personaData
-            controller.msfNavigationBar.onAvatarTapped = handleAvatarTapped
+            navigationBar.personaData = content.personaData
+            navigationBar.onAvatarTapped = handleAvatarTapped
         } else {
             content.allowsCellSelection = true
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -35,7 +35,6 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showRegularTitleWithShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: #selector(showRegularTitleWithFixedAccessory)))
-        container.addArrangedSubview(createButton(title: "Show \"gradient\" with collapsible search bar", action: #selector(showRegularTitleWithGradientStyleAndShyAccessory)))
 
         addTitle(text: "Size Customization")
         container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: #selector(showLargeTitleWithCustomizedElementSizes)))
@@ -123,10 +122,6 @@ class NavigationControllerDemoController: DemoController {
 
     @objc func showRegularTitleWithFixedAccessory() {
         presentController(withLargeTitle: false, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
-    }
-
-    @objc func showRegularTitleWithGradientStyleAndShyAccessory() {
-        presentController(withLargeTitle: false, style: .gradient, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -50,8 +50,8 @@ class NavigationControllerDemoController: DemoController {
     }
 
     let gradient: CAGradientLayer = {
-        let redColor = UIColor(colorValue: ColorValue(0xAE7EE1)).withAlphaComponent(0.4).cgColor
-        let blueColor = UIColor(colorValue: ColorValue(0x4162FF)).withAlphaComponent(0.4).cgColor
+        let redColor = CGColor(red: 0.68, green: 0.49, blue: 0.88, alpha: 0.4)
+        let blueColor = CGColor(red: 0.25, green: 0.38, blue: 1.00, alpha: 0.4)
         let gradient = CAGradientLayer()
         gradient.type = .conic
         gradient.startPoint = CGPoint(x: 0.5, y: -0.7)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -106,11 +106,11 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithGradientStyleAndShyAccessory() {
-        presentController(withLargeTitle: true, style: .gradient, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true)
+        presentController(withLargeTitle: true, style: .gradient, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithGradientStyleAndFixedAccessory() {
-        presentController(withLargeTitle: true, style: .gradient, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: false)
+        presentController(withLargeTitle: true, style: .gradient, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithGradientStyleAndPillSegment() {
@@ -126,7 +126,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showRegularTitleWithGradientStyleAndShyAccessory() {
-        presentController(withLargeTitle: false, style: .gradient, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true)
+        presentController(withLargeTitle: false, style: .gradient, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -26,9 +26,16 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithSystemStyleAndFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithSystemStyleAndPillSegment)))
 
+        addTitle(text: "Large Title with Gradient style")
+        container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitleWithGradientStyle)))
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithGradientStyleAndShyAccessory)))
+        container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithGradientStyleAndFixedAccessory)))
+        container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithGradientStyleAndPillSegment)))
+
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showRegularTitleWithShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: #selector(showRegularTitleWithFixedAccessory)))
+        container.addArrangedSubview(createButton(title: "Show \"gradient\" with collapsible search bar", action: #selector(showRegularTitleWithGradientStyleAndShyAccessory)))
 
         addTitle(text: "Size Customization")
         container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: #selector(showLargeTitleWithCustomizedElementSizes)))
@@ -42,6 +49,25 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))
     }
+
+    let gradient: CAGradientLayer = {
+        let redColor = UIColor(colorValue: ColorValue(0xAE7EE1)).withAlphaComponent(0.4).cgColor
+        let blueColor = UIColor(colorValue: ColorValue(0x4162FF)).withAlphaComponent(0.4).cgColor
+        let gradient = CAGradientLayer()
+        gradient.type = .conic
+        gradient.startPoint = CGPoint(x: 0.5, y: -0.7)
+        gradient.endPoint = CGPoint(x: 0.5, y: -1)
+        gradient.colors = [blueColor, redColor, blueColor]
+        gradient.locations = [0.48, 0.5, 0.52]
+        return gradient
+    }()
+
+    let gradientMask: CAGradientLayer = {
+        let gradientMask = CAGradientLayer()
+        gradientMask.colors = [UIColor.white.cgColor, UIColor.clear.cgColor]
+        gradientMask.locations = [0.3, 1]
+        return gradientMask
+    }()
 
     @objc func showLargeTitle() {
         presentController(withLargeTitle: true)
@@ -75,12 +101,32 @@ class NavigationControllerDemoController: DemoController {
         presentController(withLargeTitle: true, style: .system, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
     }
 
+    @objc func showLargeTitleWithGradientStyle() {
+        presentController(withLargeTitle: true, style: .gradient)
+    }
+
+    @objc func showLargeTitleWithGradientStyleAndShyAccessory() {
+        presentController(withLargeTitle: true, style: .gradient, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true)
+    }
+
+    @objc func showLargeTitleWithGradientStyleAndFixedAccessory() {
+        presentController(withLargeTitle: true, style: .gradient, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: false)
+    }
+
+    @objc func showLargeTitleWithGradientStyleAndPillSegment() {
+        presentController(withLargeTitle: true, style: .gradient, accessoryView: createSegmentedControl(), contractNavigationBarOnScroll: false)
+    }
+
     @objc func showRegularTitleWithShyAccessory() {
         presentController(withLargeTitle: false, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showRegularTitleWithFixedAccessory() {
         presentController(withLargeTitle: false, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+    }
+
+    @objc func showRegularTitleWithGradientStyleAndShyAccessory() {
+        presentController(withLargeTitle: false, style: .gradient, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {
@@ -120,7 +166,7 @@ class NavigationControllerDemoController: DemoController {
                                    updateStylePeriodically: Bool = false) -> NavigationController {
         let content = RootViewController()
         content.navigationItem.usesLargeTitle = useLargeTitle
-        content.navigationItem.navigationBarStyle = .customGradient
+        content.navigationItem.navigationBarStyle = style
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
         content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
@@ -133,7 +179,12 @@ class NavigationControllerDemoController: DemoController {
             changeStyleContinuously(in: content.navigationItem)
         }
 
-        let controller = NavigationController(rootViewController: content)
+        let controller: NavigationController
+        if style == .gradient {
+            controller = NavigationController(rootViewController: content, gradient: gradient, mask: gradientMask)
+        } else {
+            controller = NavigationController(rootViewController: content)
+        }
         if showAvatar {
             controller.msfNavigationBar.personaData = content.personaData
             controller.msfNavigationBar.onAvatarTapped = handleAvatarTapped
@@ -168,7 +219,7 @@ class NavigationControllerDemoController: DemoController {
                 newStyle = .primary
             case .primary:
                 newStyle = .system
-            case .system, .customGradient:
+            case .system, .gradient:
                 newStyle = .custom
             }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -61,6 +61,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         case primary
         case system
         case custom
+        case customGradient
 
         func tintColor(fluentTheme: FluentTheme) -> UIColor {
             switch self {
@@ -68,6 +69,8 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
                 return UIColor(light: fluentTheme.color(.foregroundOnColor).light,
                                dark: fluentTheme.color(.foreground2).dark)
             case .system:
+                return fluentTheme.color(.foreground2)
+            case .customGradient:
                 return fluentTheme.color(.foreground2)
             }
         }
@@ -77,7 +80,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             case .primary, .default, .custom:
                 return UIColor(light: fluentTheme.color(.foregroundOnColor).light,
                                dark: fluentTheme.color(.foreground1).dark)
-            case .system:
+            case .system, .customGradient:
                 return fluentTheme.color(.foreground1)
             }
         }
@@ -92,6 +95,8 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
                 return fluentTheme.color(.background3)
             case .custom:
                 return customColor ?? defaultColor
+            case .customGradient:
+                return fluentTheme.color(.background1)
             }
         }
     }
@@ -520,12 +525,12 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         switch style {
         case .primary, .default, .custom:
             titleView.style = .primary
-        case .system:
+        case .system, .customGradient:
             titleView.style = .system
         }
 
         standardAppearance.backgroundColor = color
-        backgroundView.backgroundColor = color
+        backgroundView.backgroundColor = (style == .customGradient) ? .clear : color
         tintColor = style.tintColor(fluentTheme: tokenSet.fluentTheme)
         standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: tokenSet.fluentTheme)
         standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: tokenSet.fluentTheme)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -71,7 +71,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             case .system:
                 return fluentTheme.color(.foreground2)
             case .gradient:
-                return fluentTheme.color(.foreground2)
+                return fluentTheme.color(.foreground1)
             }
         }
 
@@ -555,7 +555,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
 
     func updateColors(for navigationItem: UINavigationItem?) {
         let color = navigationItem?.navigationBarColor(fluentTheme: tokenSet.fluentTheme)
-        let shouldSetTitleColors: Bool = (style == .gradient && showsLargeTitle)
+        let shouldHideRegularTitle: Bool = (style == .gradient && showsLargeTitle)
 
         switch style {
         case .primary, .default, .custom:
@@ -564,10 +564,10 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             titleView.style = .system
         }
 
-        standardAppearance.backgroundColor = color
+        standardAppearance.backgroundColor = !showsLargeTitle ? fluentTheme.color(.background3) : color
         backgroundView.backgroundColor = (style == .gradient) ? .clear : color
         tintColor = style.tintColor(fluentTheme: tokenSet.fluentTheme)
-        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = shouldSetTitleColors ? .clear : style.titleColor(fluentTheme: tokenSet.fluentTheme)
+        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = shouldHideRegularTitle ? .clear : style.titleColor(fluentTheme: tokenSet.fluentTheme)
         standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: tokenSet.fluentTheme)
 
         // Update the scroll edge appearance to match the new standard appearance

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -101,20 +101,29 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         }
     }
 
-    @objc public var gradient: CAGradientLayer?
-    @objc public var gradientMask: CAGradientLayer?
+    @objc public var gradient: CAGradientLayer? {
+        didSet {
+            updateGradient()
+        }
+    }
+
+    @objc public var gradientMask: CAGradientLayer? {
+        didSet {
+            updateGradient()
+        }
+    }
 
     @objc public static func navigationBarBackgroundColor(fluentTheme: FluentTheme) -> UIColor {
         return Style.system.backgroundColor(fluentTheme: fluentTheme)
     }
 
     private func updateGradient() {
-        if !applyGradient || (style != .gradient) {
+        if /*!applyGradient || */(style != .gradient) {
             return
         }
 
         guard let gradient = gradient else {
-            assertionFailure("gradient cannot be nil when using the customGradient style")
+            assertionFailure("gradient cannot be nil when using the gradient style")
             return
         }
 
@@ -320,13 +329,13 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             updateViewsForLargeTitlePresentation(for: topItem)
         }
     }
-    internal var applyGradient: Bool = true {
-        didSet {
-            if !applyGradient && style == .gradient {
-                standardAppearance.backgroundImage = nil
-            }
-        }
-    }
+//    internal var applyGradient: Bool = true {
+//        didSet {
+//            if !applyGradient && style == .gradient {
+//                standardAppearance.backgroundImage = nil
+//            }
+//        }
+//    }
     private var leftBarButtonItemsObserver: NSKeyValueObservation?
     private var rightBarButtonItemsObserver: NSKeyValueObservation?
     private var titleObserver: NSKeyValueObservation?
@@ -564,7 +573,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             titleView.style = .system
         }
 
-        standardAppearance.backgroundColor = /*!showsLargeTitle ? fluentTheme.color(.background3) :*/ color
+        standardAppearance.backgroundColor = color
         backgroundView.backgroundColor = (style == .gradient) ? .clear : color
         tintColor = style.tintColor(fluentTheme: tokenSet.fluentTheme)
         standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = shouldHideRegularTitle ? .clear : style.titleColor(fluentTheme: tokenSet.fluentTheme)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -109,7 +109,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
     }
 
     private func updateGradient() {
-        if style != .customGradient {
+        if !applyGradient || (style != .customGradient) {
             return
         }
 
@@ -320,7 +320,13 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             updateViewsForLargeTitlePresentation(for: topItem)
         }
     }
-
+    internal var applyGradient: Bool = true {
+        didSet {
+            if !applyGradient {
+                standardAppearance.backgroundImage = nil
+            }
+        }
+    }
     private var leftBarButtonItemsObserver: NSKeyValueObservation?
     private var rightBarButtonItemsObserver: NSKeyValueObservation?
     private var titleObserver: NSKeyValueObservation?
@@ -560,12 +566,11 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         standardAppearance.backgroundColor = color
         backgroundView.backgroundColor = (style == .customGradient) ? .clear : color
         tintColor = style.tintColor(fluentTheme: tokenSet.fluentTheme)
-        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = (style == .customGradient && titleView.window != nil) ? .clear : style.titleColor(fluentTheme: tokenSet.fluentTheme)
+        standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = (style == .customGradient && showsLargeTitle) ? .clear : style.titleColor(fluentTheme: tokenSet.fluentTheme)
         standardAppearance.largeTitleTextAttributes[NSAttributedString.Key.foregroundColor] = style.titleColor(fluentTheme: tokenSet.fluentTheme)
 
         // Update the scroll edge appearance to match the new standard appearance
         scrollEdgeAppearance = standardAppearance
-        updateGradient()
 
         navigationBarColorObserver = navigationItem?.observe(\.customNavigationBarColor) { [unowned self] navigationItem, _ in
             // Unlike title or barButtonItems that depends on the topItem, navigation bar color can be set from the parentViewController's navigationItem
@@ -577,6 +582,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         let (actualStyle, actualItem) = actualStyleAndItem(for: navigationItem)
         style = actualStyle
         updateColors(for: actualItem)
+        updateGradient()
         showsLargeTitle = navigationItem.usesLargeTitle
         updateShadow(for: navigationItem)
         updateTopAccessoryView(for: navigationItem)
@@ -676,11 +682,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             leftBarButtonItemsStackView.isHidden = true
         }
         refresh(barButtonStack: rightBarButtonItemsStackView, with: navigationItem.rightBarButtonItems?.reversed(), isLeftItem: false)
-        if let items = navigationItem.rightBarButtonItems, style == .customGradient {
-            for button in items {
-                button.tintColor = .clear
-            }
-        }
     }
 
     private func refresh(barButtonStack: UIStackView, with items: [UIBarButtonItem]?, isLeftItem: Bool) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -564,7 +564,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             titleView.style = .system
         }
 
-        standardAppearance.backgroundColor = !showsLargeTitle ? fluentTheme.color(.background3) : color
+        standardAppearance.backgroundColor = /*!showsLargeTitle ? fluentTheme.color(.background3) :*/ color
         backgroundView.backgroundColor = (style == .gradient) ? .clear : color
         tintColor = style.tintColor(fluentTheme: tokenSet.fluentTheme)
         standardAppearance.titleTextAttributes[NSAttributedString.Key.foregroundColor] = shouldHideRegularTitle ? .clear : style.titleColor(fluentTheme: tokenSet.fluentTheme)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -643,13 +643,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
 
         // We want to hide the native right bar button items when using the gradient style.
         if style == .gradient {
-            if #available(iOS 16.0, *), let usesLargeTitle = topItem?.usesLargeTitle, usesLargeTitle {
-                item.isHidden = true
-            } else {
-                item.tintColor = .clear
-                // Since changing the native item's tintColor gets passed down to the button, we need to re-set its tintColor.
-                button.tintColor = style.tintColor(fluentTheme: fluentTheme)
-            }
+            item.tintColor = .clear
+            // Since changing the native item's tintColor gets passed down to the button, we need to re-set its tintColor.
+            button.tintColor = style.tintColor(fluentTheme: fluentTheme)
         }
 
         if #available(iOS 15.0, *) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -650,10 +650,13 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         button.item = item
         button.shouldUseWindowColorInBadge = style != .system
 
-        if #available(iOS 16.0, *), let usesLargeTitle = topItem?.usesLargeTitle, usesLargeTitle {
-            item.isHidden = true
-        } else {
-            // Fallback on earlier versions
+        if (style == .gradient) {
+            if #available(iOS 16.0, *), let usesLargeTitle = topItem?.usesLargeTitle, usesLargeTitle {
+                item.isHidden = true
+            } else {
+                item.tintColor = .clear
+                button.tintColor = style.tintColor(fluentTheme: fluentTheme)
+            }
         }
 
         if #available(iOS 15.0, *) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -101,12 +101,14 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         }
     }
 
+    /// The main gradient layer to be applied to the NavigationBar's standardAppearance with the gradient style.
     @objc public var gradient: CAGradientLayer? {
         didSet {
             updateGradient()
         }
     }
 
+    /// The layer used to mask the main gradient of the NavigationBar. If unset, only the main gradient will be displayed on the NavigationBar.
     @objc public var gradientMask: CAGradientLayer? {
         didSet {
             updateGradient()
@@ -644,11 +646,13 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         button.item = item
         button.shouldUseWindowColorInBadge = style != .system
 
-        if (style == .gradient) {
+        // We want to hide the native right bar button items when using the gradient style.
+        if style == .gradient {
             if #available(iOS 16.0, *), let usesLargeTitle = topItem?.usesLargeTitle, usesLargeTitle {
                 item.isHidden = true
             } else {
                 item.tintColor = .clear
+                // Since changing the native item's tintColor gets passed down to the button, we need to re-set its tintColor.
                 button.tintColor = style.tintColor(fluentTheme: fluentTheme)
             }
         }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -422,20 +422,15 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
     }
 
     private func updateGradient() {
-        if style != .gradient {
-            return
-        }
-
-        guard let gradient = gradient else {
-            assertionFailure("gradient cannot be nil when using the gradient style")
+        guard style == .gradient, let gradient = gradient else {
             return
         }
 
         gradient.frame = bounds
 
-        if let customGradientMask = gradientMask {
-            customGradientMask.frame = gradient.bounds
-            gradient.mask = customGradientMask
+        if let gradientMask = gradientMask {
+            gradientMask.frame = gradient.bounds
+            gradient.mask = gradientMask
         }
 
         let renderer = UIGraphicsImageRenderer(bounds: gradient.bounds)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -117,31 +117,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
         return Style.system.backgroundColor(fluentTheme: fluentTheme)
     }
 
-    private func updateGradient() {
-        if /*!applyGradient || */(style != .gradient) {
-            return
-        }
-
-        guard let gradient = gradient else {
-            assertionFailure("gradient cannot be nil when using the gradient style")
-            return
-        }
-
-        gradient.frame = bounds
-
-        if let customGradientMask = gradientMask {
-            customGradientMask.frame = gradient.bounds
-            gradient.mask = customGradientMask
-        }
-
-        let renderer = UIGraphicsImageRenderer(bounds: gradient.bounds)
-        let gradientImage = renderer.image { rendererContext in
-            gradient.render(in: rendererContext.cgContext)
-        }
-
-        standardAppearance.backgroundImage = gradientImage
-    }
-
     /// Describes the sizing behavior of navigation bar elements (title, avatar, bar height)
     @objc(MSFNavigationBarElementSize)
     public enum ElementSize: Int {
@@ -329,13 +304,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
             updateViewsForLargeTitlePresentation(for: topItem)
         }
     }
-//    internal var applyGradient: Bool = true {
-//        didSet {
-//            if !applyGradient && style == .gradient {
-//                standardAppearance.backgroundImage = nil
-//            }
-//        }
-//    }
+
     private var leftBarButtonItemsObserver: NSKeyValueObservation?
     private var rightBarButtonItemsObserver: NSKeyValueObservation?
     private var titleObserver: NSKeyValueObservation?
@@ -448,6 +417,31 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
 
             NSLayoutConstraint.activate(topAccessoryViewConstraints)
         }
+    }
+
+    private func updateGradient() {
+        if style != .gradient {
+            return
+        }
+
+        guard let gradient = gradient else {
+            assertionFailure("gradient cannot be nil when using the gradient style")
+            return
+        }
+
+        gradient.frame = bounds
+
+        if let customGradientMask = gradientMask {
+            customGradientMask.frame = gradient.bounds
+            gradient.mask = customGradientMask
+        }
+
+        let renderer = UIGraphicsImageRenderer(bounds: gradient.bounds)
+        let gradientImage = renderer.image { rendererContext in
+            gradient.render(in: rendererContext.cgContext)
+        }
+
+        standardAppearance.backgroundImage = gradientImage
     }
 
     // Manually contains the content stack view with lower priority constraints in order to avoid invalid simultaneous constraints when nav bar is hidden.

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -560,7 +560,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
 
     func updateColors(for navigationItem: UINavigationItem?) {
         let color = navigationItem?.navigationBarColor(fluentTheme: tokenSet.fluentTheme)
-        let shouldHideRegularTitle: Bool = (style == .gradient && showsLargeTitle)
+        let shouldHideRegularTitle: Bool = (style == .gradient) && showsLargeTitle
 
         switch style {
         case .primary, .default, .custom:

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -32,7 +32,7 @@ open class NavigationController: UINavigationController {
         return nil
     }
     open override var preferredStatusBarStyle: UIStatusBarStyle {
-        return (msfNavigationBar.style == .system || msfNavigationBar.style == .customGradient) ? .default : .lightContent
+        return (msfNavigationBar.style == .system || msfNavigationBar.style == .gradient) ? .default : .lightContent
     }
 
     open override var delegate: UINavigationControllerDelegate? {
@@ -48,6 +48,14 @@ open class NavigationController: UINavigationController {
 
     @objc public convenience init() {
         self.init(navigationBarClass: NavigationBar.self, toolbarClass: nil)
+    }
+
+    @objc public convenience init(rootViewController: UIViewController,
+                                  gradient: CAGradientLayer,
+                                  mask: CAGradientLayer?) {
+        self.init(rootViewController: rootViewController)
+        msfNavigationBar.gradient = gradient
+        msfNavigationBar.gradientMask = mask
     }
 
     @objc public override init(navigationBarClass: AnyClass?, toolbarClass: AnyClass?) {
@@ -67,25 +75,6 @@ open class NavigationController: UINavigationController {
         super.init(coder: aDecoder)
     }
 
-    let gradient: CAGradientLayer = {
-        let redColor = UIColor(colorValue: ColorValue(0xAE7EE1)).withAlphaComponent(0.4).cgColor
-        let blueColor = UIColor(colorValue: ColorValue(0x4162FF)).withAlphaComponent(0.4).cgColor
-        let gradient = CAGradientLayer()
-        gradient.type = .conic
-        gradient.startPoint = CGPoint(x: 0.5, y: -0.7)
-        gradient.endPoint = CGPoint(x: 0.5, y: -1)
-        gradient.colors = [blueColor, redColor, blueColor]
-        gradient.locations = [0.48, 0.5, 0.52]
-        return gradient
-    }()
-
-    let gradientMask: CAGradientLayer = {
-        let gradientMask = CAGradientLayer()
-        gradientMask.colors = [UIColor.white.cgColor, UIColor.clear.cgColor]
-        gradientMask.locations = [0.3, 1]
-        return gradientMask
-    }()
-
     open override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -100,8 +89,6 @@ open class NavigationController: UINavigationController {
 
         // Allow subviews to display a custom background view
         view.subviews.forEach { $0.clipsToBounds = false }
-        msfNavigationBar.gradient = gradient
-        msfNavigationBar.gradientMask = gradientMask
     }
 
     open override func viewWillLayoutSubviews() {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -153,7 +153,7 @@ open class NavigationController: UINavigationController {
         return false
     }
 
-    func updateNavigationBar(for viewController: UIViewController, with navigationController: UINavigationController? = nil) {
+    func updateNavigationBar(for viewController: UIViewController) {
         msfNavigationBar.update(with: viewController.navigationItem)
         viewController.navigationItem.accessorySearchBar?.navigationController = self
         setNeedsStatusBarAppearanceUpdate()
@@ -242,7 +242,7 @@ open class NavigationController: UINavigationController {
 extension NavigationController: UINavigationControllerDelegate {
     public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
         updateNavigationBarVisibility(for: viewController, animated: animated)
-        updateNavigationBar(for: viewController, with: navigationController)
+        updateNavigationBar(for: viewController)
 
         _delegate?.navigationController?(navigationController, willShow: viewController, animated: animated)
     }

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -50,14 +50,6 @@ open class NavigationController: UINavigationController {
         self.init(navigationBarClass: NavigationBar.self, toolbarClass: nil)
     }
 
-    @objc public convenience init(rootViewController: UIViewController,
-                                  gradient: CAGradientLayer,
-                                  mask: CAGradientLayer?) {
-        self.init(rootViewController: rootViewController)
-        msfNavigationBar.gradient = gradient
-        msfNavigationBar.gradientMask = mask
-    }
-
     @objc public override init(navigationBarClass: AnyClass?, toolbarClass: AnyClass?) {
         super.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
     }
@@ -175,27 +167,13 @@ open class NavigationController: UINavigationController {
                 msfNavigationBar.obscureContent(animated: animated)
                 if searchIsActive(in: topViewController) {
                     navigationBarWasHiddenBySearchBar = true
-                    setShyHeaderGradient()
                 }
             } else {
                 msfNavigationBar.revealContent(animated: animated)
                 navigationBarWasHiddenBySearchBar = false
-                removeShyHeaderGradient()
             }
         }
         super.setNavigationBarHidden(hidden, animated: animated)
-    }
-
-    private func setShyHeaderGradient() {
-        guard let shyHeaderController = topViewController as? ShyHeaderController, let gradient = msfNavigationBar.gradient else {
-            return
-        }
-
-        shyHeaderController.view.layer.addSublayer(gradient)
-    }
-
-    private func removeShyHeaderGradient() {
-        msfNavigationBar.gradient?.removeFromSuperlayer()
     }
 
     private func searchIsActive(in viewController: UIViewController?) -> Bool {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -97,17 +97,17 @@ open class NavigationController: UINavigationController {
 
     open override func pushViewController(_ viewController: UIViewController, animated: Bool) {
         super.pushViewController(wrapViewControllerIfNeeded(viewController), animated: animated)
-        msfNavigationBar.applyGradient = false
+        //msfNavigationBar.applyGradient = false
     }
 
-    @discardableResult
-    open override func popViewController(animated: Bool) -> UIViewController? {
-        super.popViewController(animated: animated)
-        if self.topViewController == viewControllers.first {
-            msfNavigationBar.applyGradient = true
-        }
-        return nil
-    }
+//    @discardableResult
+//    open override func popViewController(animated: Bool) -> UIViewController? {
+//        super.popViewController(animated: animated)
+//        if self.topViewController == viewControllers.first {
+//            msfNavigationBar.applyGradient = true
+//        }
+//        return nil
+//    }
 
     open override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
         let viewControllers = viewControllers.map { wrapViewControllerIfNeeded($0) }

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -67,6 +67,25 @@ open class NavigationController: UINavigationController {
         super.init(coder: aDecoder)
     }
 
+    let gradient: CAGradientLayer = {
+        let redColor = UIColor(colorValue: ColorValue(0xAE7EE1)).withAlphaComponent(0.4).cgColor
+        let blueColor = UIColor(colorValue: ColorValue(0x4162FF)).withAlphaComponent(0.4).cgColor
+        let gradient = CAGradientLayer()
+        gradient.type = .conic
+        gradient.startPoint = CGPoint(x: 0.5, y: -0.7)
+        gradient.endPoint = CGPoint(x: 0.5, y: -1)
+        gradient.colors = [blueColor, redColor, blueColor]
+        gradient.locations = [0.48, 0.5, 0.52]
+        return gradient
+    }()
+
+    let gradientMask: CAGradientLayer = {
+        let gradientMask = CAGradientLayer()
+        gradientMask.colors = [UIColor.white.cgColor, UIColor.clear.cgColor]
+        gradientMask.locations = [0.3, 1]
+        return gradientMask
+    }()
+
     open override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -81,6 +100,8 @@ open class NavigationController: UINavigationController {
 
         // Allow subviews to display a custom background view
         view.subviews.forEach { $0.clipsToBounds = false }
+        msfNavigationBar.gradient = gradient
+        msfNavigationBar.gradientMask = gradientMask
     }
 
     open override func viewWillLayoutSubviews() {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -97,17 +97,7 @@ open class NavigationController: UINavigationController {
 
     open override func pushViewController(_ viewController: UIViewController, animated: Bool) {
         super.pushViewController(wrapViewControllerIfNeeded(viewController), animated: animated)
-        //msfNavigationBar.applyGradient = false
     }
-
-//    @discardableResult
-//    open override func popViewController(animated: Bool) -> UIViewController? {
-//        super.popViewController(animated: animated)
-//        if self.topViewController == viewControllers.first {
-//            msfNavigationBar.applyGradient = true
-//        }
-//        return nil
-//    }
 
     open override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
         let viewControllers = viewControllers.map { wrapViewControllerIfNeeded($0) }

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -81,7 +81,7 @@ import UIKit
     }
 
     func navigationBarColor(fluentTheme: FluentTheme) -> UIColor {
-        return navigationBarStyle.backgroundColor(fluentTheme: fluentTheme, customColor: customNavigationBarColor)
+        return navigationBarStyle.backgroundColor(fluentTheme: fluentTheme/*, customColor: customNavigationBarColor*/)
     }
 
     var customNavigationBarColor: UIColor? {

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -81,7 +81,7 @@ import UIKit
     }
 
     func navigationBarColor(fluentTheme: FluentTheme) -> UIColor {
-        return navigationBarStyle.backgroundColor(fluentTheme: fluentTheme/*, customColor: customNavigationBarColor*/)
+        return navigationBarStyle.backgroundColor(fluentTheme: fluentTheme, customColor: customNavigationBarColor)
     }
 
     var customNavigationBarColor: UIColor? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR adds a new gradient variant for the `NavigationBar`. 

**Implementation**:
- a new `gradient` style is added 
- There are 2 new public objc variables: `gradient` and `gradientMask` which are both optional `CAGradientLayer`s. `gradient` must be set when using the `gradient` style of the nav bar. `gradientMask` is actually optional since it's not necessarily needed for axial gradients, though it will most likely have to be provided for conic gradients. 
- If set, the mask will be applied on the main gradient, which will be rendered into a UIImage that is set as the background image of the nav bar's standard appearance.
- The background view, the native title and right bar buttons are set to clear colors or hidden in order to not inhibit the gradient.

**Design tweaks**
The original design from the partner request had a gradient for the shy header when searching. However, since the nav bar gets hidden and pushes up the shy header controller, we can only achieve that by applying the gradient to the shy header which led to this clunky animation below. After discussions with partner designers, they made the decision to hide the gradient when searching. But if time allows, we should look into whether we can fix the hierarchy to accommodate for the gradient on search bar post fork.
<details>
<summary> Clunky shy header animation </summary>

![shy](https://user-images.githubusercontent.com/106181067/233253884-f8400a95-a561-497d-bae5-ea7787e07c2e.gif)

</details>

### Binary change

Total increase: 30,368 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,120,816 bytes | 30,151,184 bytes | ⚠️ 30,368 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| NavigationBar.o | 554,744 bytes | 579,136 bytes | ⚠️ 24,392 bytes |
| __.SYMDEF | 4,717,736 bytes | 4,722,312 bytes | ⚠️ 4,576 bytes |
| NavigationController.o | 163,560 bytes | 164,304 bytes | ⚠️ 744 bytes |
| FocusRingView.o | 799,488 bytes | 800,144 bytes | ⚠️ 656 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="485" alt="light_large_title" src="https://user-images.githubusercontent.com/106181067/233252872-47c3a61a-7294-42d4-88d8-b4c2cc2f26bb.png"> | <img width="485" alt="dark_large_title" src="https://user-images.githubusercontent.com/106181067/233252908-9e4298e0-3276-4788-9011-d626c5c64474.png"> |
| <img width="485" alt="light_search_bar" src="https://user-images.githubusercontent.com/106181067/233252963-8d0b2a47-57df-45e7-85b1-7e2f41145c38.png"> | <img width="485" alt="dark_search_bar" src="https://user-images.githubusercontent.com/106181067/233252979-853d3288-21b5-4444-b620-604d14d04881.png"> |
| <img width="485" alt="light_pill" src="https://user-images.githubusercontent.com/106181067/233253006-d5f2ec3f-8d46-4581-b438-144a6fe8fba7.png"> | <img width="485" alt="dark_pill" src="https://user-images.githubusercontent.com/106181067/233253014-713a79c4-3cce-4a14-a33d-9f7376f589b4.png"> |
| ![light_collapsible](https://user-images.githubusercontent.com/106181067/233253046-8e02cdd2-acc7-4bcd-8ad4-feb32004a28d.gif) | ![dark_collapsible](https://user-images.githubusercontent.com/106181067/233253067-90b72738-1206-4e60-b606-216592ba4bc0.gif) |
| ![light_shy_search](https://user-images.githubusercontent.com/106181067/233253102-5bfb7eea-4c9c-40cc-9981-5b40f2b47692.gif) | ![dark_shy_search](https://user-images.githubusercontent.com/106181067/233253115-8b3b887e-331d-4a67-8670-5aebfefe0a2f.gif) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1711)