### PR TITLE
Replace `NavigationBar`'s `usesLargeTitle` with `NavigationBar.TitleStyle`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -49,89 +49,89 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitle() {
-        presentController(withLargeTitle: true)
+        presentController(withTitleStyle: .largeLeading)
     }
 
     @objc func showLargeTitleWithShyAccessory() {
-        presentController(withLargeTitle: true, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithFixedAccessory() {
-        presentController(withLargeTitle: true, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithFixedAccessoryAndSubtitle() {
-        presentController(withLargeTitle: true, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .largeLeading, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithSystemStyle() {
-        presentController(withLargeTitle: true, style: .system)
+        presentController(withTitleStyle: .largeLeading, style: .system)
     }
 
     @objc func showLargeTitleWithSystemStyleAndNoShadow() {
-        presentController(withLargeTitle: true, style: .system, contractNavigationBarOnScroll: false, showShadow: false)
+        presentController(withTitleStyle: .largeLeading, style: .system, contractNavigationBarOnScroll: false, showShadow: false)
     }
 
     @objc func showLargeTitleWithSystemStyleAndShyAccessory() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithSystemStyleShyAccessoryAndSubtitle() {
-        presentController(withLargeTitle: true, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .largeLeading, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithSystemStyleAndFixedAccessory() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithSystemStyleAndPillSegment() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createSegmentedControl(compatibleWith: .system), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createSegmentedControl(compatibleWith: .system), contractNavigationBarOnScroll: false)
     }
 
     @objc func showSystemTitleWithShyAccessory() {
-        presentController(withLargeTitle: false, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .system, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showRegularTitleWithShyAccessoryAndSubtitle() {
-        presentController(withLargeTitle: false, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
     @objc func showRegularTitleWithFixedAccessory() {
-        presentController(withLargeTitle: false, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .system, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
     }
 
     @objc func showSystemTitleWithFixedAccessoryAndSubtitle() {
-        presentController(withLargeTitle: false, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {
-        let controller = presentController(withLargeTitle: true, accessoryView: createAccessoryView())
+        let controller = presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView())
         controller.msfNavigationBar.avatarSize = .expanded
         controller.msfNavigationBar.titleSize = .contracted
     }
 
     @objc func showLargeTitleWithCustomizedColor() {
-        presentController(withLargeTitle: true, style: .custom, accessoryView: createAccessoryView())
+        presentController(withTitleStyle: .largeLeading, style: .custom, accessoryView: createAccessoryView())
     }
 
     @objc func showLargeTitleWithoutAvatar() {
-        presentController(withLargeTitle: true, style: .primary, accessoryView: createAccessoryView(), leadingItem: .nothing)
+        presentController(withTitleStyle: .largeLeading, style: .primary, accessoryView: createAccessoryView(), leadingItem: .nothing)
     }
 
     @objc func showLargeTitleWithCustomLeadingButton() {
-        presentController(withLargeTitle: true, style: .primary, accessoryView: createAccessoryView(), leadingItem: .customButton)
+        presentController(withTitleStyle: .largeLeading, style: .primary, accessoryView: createAccessoryView(), leadingItem: .customButton)
     }
 
     @objc func showWithTopSearchBar() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false)
     }
 
     @objc func showSearchChangingStyleEverySecond() {
-        presentController(withLargeTitle: true, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false, updateStylePeriodically: true)
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .darkContent), showsTopAccessory: true, contractNavigationBarOnScroll: false, updateStylePeriodically: true)
     }
 
     @objc func showLargeTitleWithPillSegment() {
-        presentController(withLargeTitle: true, accessoryView: createSegmentedControl(compatibleWith: .primary), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .largeLeading, accessoryView: createSegmentedControl(compatibleWith: .primary), contractNavigationBarOnScroll: false)
     }
 
     private enum LeadingItem {
@@ -140,7 +140,7 @@ class NavigationControllerDemoController: DemoController {
         case customButton
     }
     @discardableResult
-    private func presentController(withLargeTitle useLargeTitle: Bool,
+    private func presentController(withTitleStyle titleStyle: NavigationBar.TitleStyle,
                                    subtitle: String? = nil,
                                    style: NavigationBar.Style = .primary,
                                    accessoryView: UIView? = nil,
@@ -150,7 +150,7 @@ class NavigationControllerDemoController: DemoController {
                                    leadingItem: LeadingItem = .avatar,
                                    updateStylePeriodically: Bool = false) -> NavigationController {
         let content = RootViewController()
-        content.navigationItem.usesLargeTitle = useLargeTitle
+        content.navigationItem.titleStyle = titleStyle
         content.navigationItem.subtitle = subtitle
         content.navigationItem.backButtonTitle = "99+"
         content.navigationItem.navigationBarStyle = style
@@ -184,7 +184,7 @@ class NavigationControllerDemoController: DemoController {
         }
 
         controller.modalPresentationStyle = .fullScreen
-        if useLargeTitle {
+        if titleStyle != .system {
             let leadingEdgeGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePan))
             leadingEdgeGesture.edges = view.effectiveUserInterfaceLayoutDirection == .leftToRight ? .left : .right
             leadingEdgeGesture.delegate = self
@@ -289,10 +289,10 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     lazy var titleViewFeaturesByRow: [Int: TitleViewFeature] = [
         4: TitleViewFeature(name: "Large title") {
-            $0.navigationItem.usesLargeTitle = true
+            $0.navigationItem.titleStyle = .largeLeading
         },
         5: TitleViewFeature(name: "Leading-aligned, two titles") {
-            $0.navigationItem.usesLargeTitle = true
+            $0.navigationItem.titleStyle = .leading
             $0.navigationItem.subtitle = "Subtitle"
         },
         6: TitleViewFeature(name: "Two titles with subtitle disclosure") {
@@ -300,7 +300,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .disclosure, delegate: self)
         },
         7: TitleViewFeature(name: "Leading-aligned, image, subtitle") {
-            $0.navigationItem.usesLargeTitle = true
+            $0.navigationItem.titleStyle = .leading
             $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
             $0.navigationItem.subtitle = "Subtitle"
         },
@@ -309,7 +309,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.navigationItem.subtitle = "Subtitle"
         },
         9: TitleViewFeature(name: "Leading-aligned, image, down arrow, subtitle") {
-            $0.navigationItem.usesLargeTitle = true
+            $0.navigationItem.titleStyle = .leading
             $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
             $0.navigationItem.subtitle = "Subtitle"
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
@@ -320,7 +320,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         11: TitleViewFeature(name: "Leading, down arrow") {
-            $0.navigationItem.usesLargeTitle = true
+            $0.navigationItem.titleStyle = .leading
             $0.navigationItem.subtitle = ""
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
@@ -328,13 +328,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         13: TitleViewFeature(name: "Leading, image, disclosure") {
-            $0.navigationItem.usesLargeTitle = true
-            $0.navigationItem.subtitle = ""
+            $0.navigationItem.titleStyle = .leading
             $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
         },
         14: TitleViewFeature(name: "Centered, image, disclosure") {
-            $0.navigationItem.subtitle = ""
             $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
         },
@@ -502,7 +500,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
-            let isSwitchEnabled = navigationItem.usesLargeTitle && msfNavigationController?.msfNavigationBar.personaData != nil
+            let isSwitchEnabled = navigationItem.titleStyle == .largeLeading && msfNavigationController?.msfNavigationBar.personaData != nil
             cell.setup(title: "Show rainbow ring on avatar",
                        isOn: showRainbowRingForAvatar,
                        isSwitchEnabled: isSwitchEnabled)
@@ -519,7 +517,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             }
             cell.setup(title: "Show badge on right bar button items",
                        isOn: showBadgeOnBarButtonItem,
-                       isSwitchEnabled: navigationItem.usesLargeTitle)
+                       isSwitchEnabled: navigationItem.titleStyle == .largeLeading)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowBadge(isOn: cell?.isOn ?? false)
@@ -578,7 +576,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             let selectedCount = tableView.indexPathsForSelectedRows?.count ?? 0
             navigationItem.title = selectedCount == 1 ? "1 item selected" : "\(selectedCount) items selected"
         } else {
-            navigationItem.title = navigationItem.usesLargeTitle ? "Large Title" : "Regular Title"
+            navigationItem.title = navigationItem.titleStyle == .largeLeading ? "Large Title" : "Regular Title"
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -321,7 +321,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         },
         11: TitleViewFeature(name: "Leading, down arrow") {
             $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.subtitle = ""
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         12: TitleViewFeature(name: "Centered, down arrow") {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -184,7 +184,7 @@ class NavigationControllerDemoController: DemoController {
         }
 
         controller.modalPresentationStyle = .fullScreen
-        if titleStyle != .system {
+        if titleStyle.usesLeadingAlignment {
             let leadingEdgeGesture = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(handleScreenEdgePan))
             leadingEdgeGesture.edges = view.effectiveUserInterfaceLayoutDirection == .leftToRight ? .left : .right
             leadingEdgeGesture.delegate = self

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -16,7 +16,6 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitle)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithFixedAccessory)))
-        container.addArrangedSubview(createButton(title: "Show with fixed search bar and subtitle", action: #selector(showLargeTitleWithFixedAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show without an avatar", action: #selector(showLargeTitleWithoutAvatar)))
         container.addArrangedSubview(createButton(title: "Show with a custom leading button", action: #selector(showLargeTitleWithCustomLeadingButton)))
         container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithPillSegment)))
@@ -25,9 +24,12 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitleWithSystemStyle)))
         container.addArrangedSubview(createButton(title: "Show without accessory and shadow", action: #selector(showLargeTitleWithSystemStyleAndNoShadow)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithSystemStyleAndShyAccessory)))
-        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and subtitle", action: #selector(showLargeTitleWithSystemStyleShyAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithSystemStyleAndFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show with pill segmented control", action: #selector(showLargeTitleWithSystemStyleAndPillSegment)))
+
+        addTitle(text: "Leading with TwoLineTitleView")
+        container.addArrangedSubview(createButton(title: "Show with fixed search bar and subtitle", action: #selector(showLeadingTitleWithFixedAccessoryAndSubtitle)))
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and subtitle", action: #selector(showLeadingTitleWithSystemStyleShyAccessoryAndSubtitle)))
 
         addTitle(text: "Regular Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showSystemTitleWithShyAccessory)))
@@ -60,10 +62,6 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
     }
 
-    @objc func showLargeTitleWithFixedAccessoryAndSubtitle() {
-        presentController(withTitleStyle: .largeLeading, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
-    }
-
     @objc func showLargeTitleWithSystemStyle() {
         presentController(withTitleStyle: .largeLeading, style: .system)
     }
@@ -76,16 +74,20 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
-    @objc func showLargeTitleWithSystemStyleShyAccessoryAndSubtitle() {
-        presentController(withTitleStyle: .largeLeading, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
-    }
-
     @objc func showLargeTitleWithSystemStyleAndFixedAccessory() {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
     }
 
     @objc func showLargeTitleWithSystemStyleAndPillSegment() {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createSegmentedControl(compatibleWith: .system), contractNavigationBarOnScroll: false)
+    }
+
+    @objc func showLeadingTitleWithFixedAccessoryAndSubtitle() {
+        presentController(withTitleStyle: .leading, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+    }
+
+    @objc func showLeadingTitleWithSystemStyleShyAccessoryAndSubtitle() {
+        presentController(withTitleStyle: .leading, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
     @objc func showSystemTitleWithShyAccessory() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -87,7 +87,7 @@ class TwoLineTitleViewDemoController: DemoController {
         makeExampleNavigationItem {
             $0.title = "They can also be"
             $0.subtitle = "leading-aligned"
-            $0.usesLargeTitle = true
+            $0.titleStyle = .leading
         }
     ]
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -193,7 +193,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     /// Returns the first match of an optional view for a bar button item with the given tag.
     @objc public func barButtonItemView(with tag: Int) -> UIView? {
-        if usesAvatarTitleView {
+        if usesLeadingTitle {
             let totalBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews + rightBarButtonItemsStackView.arrangedSubviews
             for view in totalBarButtonItemViews {
                 if view.tag == tag {
@@ -309,9 +309,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
-    private var usesAvatarTitleView: Bool = true {
+    private var usesLeadingTitle: Bool = true {
         didSet {
-            if usesAvatarTitleView == oldValue {
+            if usesLeadingTitle == oldValue {
                 return
             }
             updateAccessibilityElements()
@@ -524,7 +524,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
 
             // change bar button image size depending on device rotation
-            if usesAvatarTitleView, let navigationItem = topItem {
+            if usesLeadingTitle, let navigationItem = topItem {
                 updateBarButtonItems(with: navigationItem)
             }
         }
@@ -600,7 +600,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         let (actualStyle, actualItem) = actualStyleAndItem(for: navigationItem)
         style = actualStyle
         updateColors(for: actualItem)
-        usesAvatarTitleView = navigationItem.titleStyle.usesLeadingAlignment
+        usesLeadingTitle = navigationItem.titleStyle.usesLeadingAlignment
         updateShadow(for: navigationItem)
         updateTopAccessoryView(for: navigationItem)
         updateSubtitleView(for: navigationItem)
@@ -802,7 +802,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         // UIView.isHidden has a bug where a series of repeated calls with the same parameter can "glitch" the view into a permanent shown/hidden state
         // i.e. repeatedly trying to hide a UIView that is already in the hidden state
         // by adding a check to the isHidden property prior to setting, we avoid such problematic scenarios
-        if usesAvatarTitleView {
+        if usesLeadingTitle {
             if backgroundView.isHidden {
                 backgroundView.isHidden = false
             }
@@ -837,7 +837,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private func needsShadow(for navigationItem: UINavigationItem?) -> Bool {
         switch navigationItem?.navigationBarShadow ?? .automatic {
         case .automatic:
-            return !usesAvatarTitleView && style == .system && navigationItem?.accessoryView == nil
+            return !usesLeadingTitle && style == .system && navigationItem?.accessoryView == nil
         case .alwaysHidden:
             return false
         }
@@ -916,7 +916,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     // MARK: Accessibility
 
     private func updateAccessibilityElements() {
-        if usesAvatarTitleView {
+        if usesLeadingTitle {
             accessibilityElements = contentStackView.arrangedSubviews
         } else {
             accessibilityElements = nil

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -118,6 +118,10 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         case leading
         /// Shows a large title. This option always ignores the subtitle. Also capable of showing an avatar.
         case largeLeading
+
+        public var usesLeadingAlignment: Bool {
+            self != .system
+        }
     }
 
     @objc public static func navigationBarBackgroundColor(fluentTheme: FluentTheme?) -> UIColor {
@@ -596,7 +600,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         let (actualStyle, actualItem) = actualStyleAndItem(for: navigationItem)
         style = actualStyle
         updateColors(for: actualItem)
-        usesAvatarTitleView = navigationItem.titleStyle != .system
+        usesAvatarTitleView = navigationItem.titleStyle.usesLeadingAlignment
         updateShadow(for: navigationItem)
         updateTopAccessoryView(for: navigationItem)
         updateSubtitleView(for: navigationItem)

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -112,7 +112,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     @objc(MSFNavigationBarTitleStyle)
     /// Describes the style in which the title is shown in a navigation bar.
     public enum TitleStyle: Int {
-        /// Shows a center-aligned title and/or subtitle. Most closely aligned with UIKit's default. Not capable of showing an avatar. b
+        /// Shows a center-aligned title and/or subtitle. Most closely aligned with UIKit's default. Not capable of showing an avatar.
         case system
         /// Shows a leading-aligned title and/or subtitle. Also capable of showing an avatar.
         case leading

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -109,6 +109,17 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         case custom
     }
 
+    @objc(MSFNavigationBarTitleStyle)
+    /// Describes the style in which the title is shown in a navigation bar.
+    public enum TitleStyle: Int {
+        /// Shows a center-aligned title and/or subtitle. Most closely aligned with UIKit's default. Not capable of showing an avatar. b
+        case system
+        /// Shows a leading-aligned title and/or subtitle. Also capable of showing an avatar.
+        case leading
+        /// Shows a large title. This option always ignores the subtitle. Also capable of showing an avatar.
+        case largeLeading
+    }
+
     @objc public static func navigationBarBackgroundColor(fluentTheme: FluentTheme?) -> UIColor {
         return backgroundColor(for: .system, theme: fluentTheme)
     }
@@ -178,7 +189,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     /// Returns the first match of an optional view for a bar button item with the given tag.
     @objc public func barButtonItemView(with tag: Int) -> UIView? {
-        if showsLargeTitle {
+        if usesAvatarTitleView {
             let totalBarButtonItemViews = leftBarButtonItemsStackView.arrangedSubviews + rightBarButtonItemsStackView.arrangedSubviews
             for view in totalBarButtonItemViews {
                 if view.tag == tag {
@@ -294,9 +305,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
-    private var showsLargeTitle: Bool = true {
+    private var usesAvatarTitleView: Bool = true {
         didSet {
-            if showsLargeTitle == oldValue {
+            if usesAvatarTitleView == oldValue {
                 return
             }
             updateAccessibilityElements()
@@ -316,7 +327,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var topAccessoryViewAttributesObserver: NSKeyValueObservation?
     private var navigationBarStyleObserver: NSKeyValueObservation?
     private var navigationBarShadowObserver: NSKeyValueObservation?
-    private var usesLargeTitleObserver: NSKeyValueObservation?
+    private var titleStyleObserver: NSKeyValueObservation?
 
     private let backButtonItem: UIBarButtonItem = UIBarButtonItem(image: UIImage.staticImageNamed("back-24x24"), style: .plain, target: nil, action: #selector(NavigationBarBackButtonDelegate.backButtonWasPressed))
 
@@ -509,7 +520,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
 
             // change bar button image size depending on device rotation
-            if showsLargeTitle, let navigationItem = topItem {
+            if usesAvatarTitleView, let navigationItem = topItem {
                 updateBarButtonItems(with: navigationItem)
             }
         }
@@ -585,7 +596,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         let (actualStyle, actualItem) = actualStyleAndItem(for: navigationItem)
         style = actualStyle
         updateColors(for: actualItem)
-        showsLargeTitle = navigationItem.usesLargeTitle
+        usesAvatarTitleView = navigationItem.titleStyle != .system
         updateShadow(for: navigationItem)
         updateTopAccessoryView(for: navigationItem)
         updateSubtitleView(for: navigationItem)
@@ -633,7 +644,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         navigationBarShadowObserver = navigationItem.observe(\UINavigationItem.navigationBarShadow) { [unowned self] item, _ in
             self.navigationItemDidUpdate(item)
         }
-        usesLargeTitleObserver = navigationItem.observe(\UINavigationItem.usesLargeTitle) { [unowned self] item, _ in
+        titleStyleObserver = navigationItem.observe(\UINavigationItem.titleStyle) { [unowned self] item, _ in
             self.navigationItemDidUpdate(item)
         }
     }
@@ -716,7 +727,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
                 backButtonItem.title = topItem?.backButtonTitle
             }
 
-            if !navigationItem.usesLargeTitle {
+            if navigationItem.titleStyle == .system {
                 let button = createBarButtonItemButton(with: backButtonItem, isLeftItem: true)
                 // The OS already gives us the leading margin we want, so no need for additional insets
                 if #available(iOS 15.0, *) {
@@ -787,7 +798,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         // UIView.isHidden has a bug where a series of repeated calls with the same parameter can "glitch" the view into a permanent shown/hidden state
         // i.e. repeatedly trying to hide a UIView that is already in the hidden state
         // by adding a check to the isHidden property prior to setting, we avoid such problematic scenarios
-        if showsLargeTitle {
+        if usesAvatarTitleView {
             if backgroundView.isHidden {
                 backgroundView.isHidden = false
             }
@@ -822,7 +833,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private func needsShadow(for navigationItem: UINavigationItem?) -> Bool {
         switch navigationItem?.navigationBarShadow ?? .automatic {
         case .automatic:
-            return !showsLargeTitle && style == .system && navigationItem?.accessoryView == nil
+            return !usesAvatarTitleView && style == .system && navigationItem?.accessoryView == nil
         case .alwaysHidden:
             return false
         }
@@ -901,7 +912,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     // MARK: Accessibility
 
     private func updateAccessibilityElements() {
-        if showsLargeTitle {
+        if usesAvatarTitleView {
             accessibilityElements = contentStackView.arrangedSubviews
         } else {
             accessibilityElements = nil

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -131,7 +131,7 @@ open class NavigationController: UINavigationController {
         if viewController is ShyHeaderController {
             return false
         }
-        if viewController.navigationItem.usesLargeTitle || viewController.navigationItem.accessoryView != nil {
+        if viewController.navigationItem.titleStyle != .system || viewController.navigationItem.accessoryView != nil {
             return true
         }
         return false

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -131,7 +131,7 @@ open class NavigationController: UINavigationController {
         if viewController is ShyHeaderController {
             return false
         }
-        if viewController.navigationItem.titleStyle != .system || viewController.navigationItem.accessoryView != nil {
+        if viewController.navigationItem.titleStyle.usesLeadingAlignment || viewController.navigationItem.accessoryView != nil {
             return true
         }
         return false

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -110,13 +110,12 @@ import UIKit
         }
     }
 
+    @available(*, deprecated, message: "Use `titleStyle` instead")
     var usesLargeTitle: Bool {
         get {
-            assertionFailure("`usesLargeTitle` will be deprecated in a future release. Use `titleStyle` instead.")
             return titleStyle.usesLeadingAlignment
         }
         set {
-            assertionFailure("Setting `usesLargeTitle` will be deprecated in a future release. Use `titleStyle` instead.")
             titleStyle = newValue ? .largeLeading : .system
         }
     }

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -113,7 +113,7 @@ import UIKit
     var usesLargeTitle: Bool {
         get {
             assertionFailure("`usesLargeTitle` will be deprecated in a future release. Use `titleStyle` instead.")
-            return titleStyle != .system
+            return titleStyle.usesLeadingAlignment
         }
         set {
             assertionFailure("Setting `usesLargeTitle` will be deprecated in a future release. Use `titleStyle` instead.")

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -16,7 +16,7 @@ import UIKit
         static var navigationBarStyle: String = "navigationBarStyle"
         static var navigationBarShadow: String = "navigationBarShadow"
         static var subtitle: String = "subtitle"
-        static var usesLargeTitle: String = "usesLargeTitle"
+        static var titleStyle: String = "titleStyle"
         static var customNavigationBarColor: String = "customNavigationBarColor"
     }
 
@@ -101,12 +101,23 @@ import UIKit
         }
     }
 
-    var usesLargeTitle: Bool {
+    var titleStyle: NavigationBar.TitleStyle {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.usesLargeTitle) as? Bool ?? false
+            return objc_getAssociatedObject(self, &AssociatedKeys.titleStyle) as? NavigationBar.TitleStyle ?? .system
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.usesLargeTitle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKeys.titleStyle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    var usesLargeTitle: Bool {
+        get {
+            assertionFailure("`usesLargeTitle` will be deprecated in a future release. Use `titleStyle` instead.")
+            return titleStyle != .system
+        }
+        set {
+            assertionFailure("Setting `usesLargeTitle` will be deprecated in a future release. Use `titleStyle` instead.")
+            titleStyle = newValue ? .largeLeading : .system
         }
     }
 

--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -99,9 +99,9 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
 
     private let titleContainerView = UIView()
 
-    private var hasSubtitle: Bool = false {
+    private var showsLargeTitle: Bool = false {
         didSet {
-            if oldValue != hasSubtitle {
+            if oldValue != showsLargeTitle {
                 updateTitleContainerView()
             }
         }
@@ -308,7 +308,7 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
 
     private func updateTitleContainerView() {
         titleContainerView.removeAllSubviews()
-        titleContainerView.contain(view: hasSubtitle ? twoLineTitleView : titleButton)
+        titleContainerView.contain(view: showsLargeTitle ? titleButton : twoLineTitleView)
     }
 
     /// Sets the interface with the provided item's details
@@ -317,7 +317,7 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
     func update(with navigationItem: UINavigationItem) {
         hasLeftBarButtonItems = !(navigationItem.leftBarButtonItems?.isEmpty ?? true)
         titleButton.setTitle(navigationItem.title, for: .normal)
-        hasSubtitle = navigationItem.subtitle != nil
+        showsLargeTitle = navigationItem.titleStyle == .largeLeading
         twoLineTitleView.setup(navigationItem: navigationItem)
         if navigationItem.titleAccessory == nil {
             // Use default behavior of requesting an accessory expansion

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -292,7 +292,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
     @objc open func setup(navigationItem: UINavigationItem) {
         let title = navigationItem.title ?? ""
-        let alignment: Alignment = navigationItem.usesLargeTitle ? .leading : .center
+        let alignment: Alignment = navigationItem.titleStyle == .system ? .center : .leading
 
         let interactivePart: InteractivePart
         let accessoryType: AccessoryType


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Previously, there were two different styles of navigation bar title: the system style and the "large title view" style. Nowadays there's a third style: a leading-aligned title view with a normal-sized title (or a `TwoLineTitleView`), and we should make it easier for consumers of FluentUI to pick exactly which style they want.

We previously used `usesLargeTitle` to represent whether we use an `AvatarTitleView` (formerly known as `LargeTitleView`), so the most natural translation of `usesLargeTitle` is `titleStyle != .system`. Eventually we'll want to deprecate `usesLargeTitle`.

### Verification

Validated that there are no changes to the different navigation bars in appearance or behavior, both for parent views and child views.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1712)