### PR TITLE
Fix VoiceOver bug in DatePicker NSMenu

### DIFF
--- a/macos/FluentUITestViewControllers/TestDatePickerController.swift
+++ b/macos/FluentUITestViewControllers/TestDatePickerController.swift
@@ -67,7 +67,6 @@ class TestDatePickerController: NSViewController {
 
 		let popoverButton = NSButton(title: "NSPopover", target: self, action: #selector(showPopover))
 
-		menuButton.pullsDown = true
 		let menu = NSMenu()
 		datePickerMenuItem = NSMenuItem(title: "NSMenu", action: nil, keyEquivalent: "")
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Fixed bug where DatePicker in NSMenu was not getting VoiceOver focus.

### Binary change

N/A for macOS changes

### Verification

<details>
<summary>Visual Verification</summary>

![vo](https://user-images.githubusercontent.com/55368679/234384610-3839c5b5-3c60-431e-9f0e-b3b392b5d4ff.gif)

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1715)