### PR TITLE
[Cherry pick][main_0.14_gradient_navigation_bar] Add accessibility identifier to CommandingItem (#1688)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -58,7 +58,7 @@ class BottomCommandingDemoController: UIViewController {
 
     private lazy var badgeCommand: CommandingItem = {
         let badge = BadgeView(dataSource: BadgeViewDataSource(text: "Badge"))
-        let item = CommandingItem(title: "Badge Item ", image: homeImage, action: commandAction)
+        let item = CommandingItem(title: "Badge Item", image: homeImage, action: commandAction)
         item.trailingView = badge
         return item
     }()

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -631,6 +631,7 @@ open class BottomCommandingController: UIViewController {
         itemView.accessibilityTraits.insert(.button)
         itemView.preferredLabelMaxLayoutWidth = Constants.heroButtonLabelMaxWidth
         itemView.setContentCompressionResistancePriority(.required, for: .vertical)
+        itemView.accessibilityIdentifier = item.accessibilityIdentifier
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleHeroCommandTap(_:)))
         itemView.addGestureRecognizer(tapGesture)
@@ -665,6 +666,7 @@ open class BottomCommandingController: UIViewController {
         cell.isEnabled = item.isEnabled
         cell.backgroundStyleType = .clear
         cell.backgroundColor = tableViewBackgroundColor
+        cell.accessibilityIdentifier = item.accessibilityIdentifier
 
         let shouldShowSeparator = expandedListSections
             .prefix(expandedListSections.count - 1)

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -82,8 +82,11 @@ open class CommandingItem: NSObject {
         }
     }
 
+    /// The accessibility identifier of the command item.
+    @objc open var accessibilityIdentifier: String?
+
     /// Applications can use this to keep track of items.
-	@objc public var tag: Int = 0
+    @objc public var tag: Int = 0
 
     /// Indicates whether `isOn` should be toggled automatically before `action` is called.
     @objc public let isToggleable: Bool


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

This PR cherry-picks #1688 to `main_0.14_gradient_navigation_bar`.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1717)