### PR TITLE
Update SegmentedControl over NavigationBar

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -7,8 +7,9 @@ import FluentUI
 import UIKit
 
 enum ColoredPillBackgroundStyle: Int {
-    case neutral
-    case brand
+    case neutralNavBar
+    case brandNavBar
+    case canvas
 }
 
 class ColoredPillBackgroundView: UIView {
@@ -48,10 +49,12 @@ class ColoredPillBackgroundView: UIView {
 
     func updateBackgroundColor() {
         switch style {
-        case .neutral:
+        case .neutralNavBar:
             backgroundColor = NavigationBar.Style.system.backgroundColor(fluentTheme: fluentTheme)
-        case .brand:
+        case .brandNavBar:
             backgroundColor = NavigationBar.Style.primary.backgroundColor(fluentTheme: fluentTheme)
+        case .canvas:
+            backgroundColor = fluentTheme.color(.backgroundCanvas)
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift
@@ -93,9 +93,9 @@ class PillButtonBarDemoController: DemoController {
         let backgroundStyle: ColoredPillBackgroundStyle = {
             switch style {
             case .primary:
-                return .neutral
+                return .neutralNavBar
             case .onBrand:
-                return .brand
+                return .brandNavBar
             }
         }()
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -93,7 +93,7 @@ class SegmentedControlDemoController: DemoController {
                        enabled: true)
 
         // on brand canvas
-        addTitle(text: "On Brand Over Canvas Pill")
+        addTitle(text: "Brand Over Canvas Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(3)),
                        style: .brandOverCanvasPill,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -85,14 +85,12 @@ class SegmentedControlDemoController: DemoController {
                        style: .brandOverNavBarPill,
                        enabled: false)
 
-        // neutral canvas
         addTitle(text: "Over Canvas Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(3)),
                        style: .neutralOverCanvasPill,
                        enabled: true)
 
-        // on brand canvas
         addTitle(text: "Brand Over Canvas Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(3)),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -35,13 +35,13 @@ class SegmentedControlDemoController: DemoController {
         container.layoutMargins.left = 0
         container.layoutMargins.right = 0
 
-        addTitle(text: "Primary Pill")
+        addTitle(text: "Nav Bar Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(3)),
                        style: .neutralOverNavBarPill)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "Primary Pill")
+        addTitle(text: "Nav Bar Pill")
         addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(10)),
                        style: .neutralOverNavBarPill,
@@ -49,7 +49,7 @@ class SegmentedControlDemoController: DemoController {
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "Primary Pill")
+        addTitle(text: "Nav Bar Pill")
         addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
                        style: .neutralOverNavBarPill,
@@ -57,14 +57,14 @@ class SegmentedControlDemoController: DemoController {
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "Disabled Primary Pill")
+        addTitle(text: "Disabled Nav Bar Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
                        style: .neutralOverNavBarPill,
                        enabled: false)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "On Brand Pill")
+        addTitle(text: "On Brand Nav Bar Pill")
         addDescription(text: "not fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(10)),
                        style: .brandOverNavBarPill,
@@ -72,18 +72,32 @@ class SegmentedControlDemoController: DemoController {
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "On Brand Pill")
+        addTitle(text: "On Brand Nav Bar Pill")
         addDescription(text: "not fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
                        style: .brandOverNavBarPill,
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
-        addTitle(text: "Disabled On Brand Pill")
+        addTitle(text: "Disabled On Brand Nav Bar Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
                        style: .brandOverNavBarPill,
                        enabled: false)
+
+        // neutral canvas
+        addTitle(text: "Over Canvas Pill")
+        addDescription(text: "fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(3)),
+                       style: .neutralOverCanvasPill,
+                       enabled: true)
+
+        // on brand canvas
+        addTitle(text: "On Brand Over Canvas Pill")
+        addDescription(text: "fixed width, equal buttons", textAlignment: .center)
+        addPillControl(items: Array(segmentItems.prefix(3)),
+                       style: .brandOverCanvasPill,
+                       enabled: true)
     }
 
     @objc func updateLabel(forControl control: SegmentedControl) {
@@ -105,10 +119,12 @@ class SegmentedControlDemoController: DemoController {
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
             switch style {
-            case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill, .brandOverCanvasPill:
-                return .neutral
+            case .primaryPill, .neutralOverNavBarPill:
+                return .neutralNavBar
             case .onBrandPill, .brandOverNavBarPill:
-                return .brand
+                return .brandNavBar
+            case .neutralOverCanvasPill, .brandOverCanvasPill:
+                return .canvas
             }
         }()
         let backgroundView = ColoredPillBackgroundView(style: backgroundStyle)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift
@@ -38,13 +38,13 @@ class SegmentedControlDemoController: DemoController {
         addTitle(text: "Primary Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(3)),
-                       style: .primaryPill)
+                       style: .neutralOverNavBarPill)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Primary Pill")
         addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(10)),
-                       style: .primaryPill,
+                       style: .neutralOverNavBarPill,
                        equalSegments: false,
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
@@ -52,7 +52,7 @@ class SegmentedControlDemoController: DemoController {
         addTitle(text: "Primary Pill")
         addDescription(text: "not fixed width, unequal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
-                       style: .primaryPill,
+                       style: .neutralOverNavBarPill,
                        equalSegments: false,
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
@@ -60,14 +60,14 @@ class SegmentedControlDemoController: DemoController {
         addTitle(text: "Disabled Primary Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
-                       style: .primaryPill,
+                       style: .neutralOverNavBarPill,
                        enabled: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "On Brand Pill")
         addDescription(text: "not fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(10)),
-                       style: .onBrandPill,
+                       style: .brandOverNavBarPill,
                        equalSegments: true,
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
@@ -75,14 +75,14 @@ class SegmentedControlDemoController: DemoController {
         addTitle(text: "On Brand Pill")
         addDescription(text: "not fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
-                       style: .onBrandPill,
+                       style: .brandOverNavBarPill,
                        isFixedWidth: false)
         container.addArrangedSubview(UIView())
 
         addTitle(text: "Disabled On Brand Pill")
         addDescription(text: "fixed width, equal buttons", textAlignment: .center)
         addPillControl(items: Array(segmentItems.prefix(2)),
-                       style: .onBrandPill,
+                       style: .brandOverNavBarPill,
                        enabled: false)
     }
 
@@ -105,9 +105,9 @@ class SegmentedControlDemoController: DemoController {
 
         let backgroundStyle: ColoredPillBackgroundStyle = {
             switch style {
-            case .primaryPill:
+            case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill, .brandOverCanvasPill:
                 return .neutral
-            case .onBrandPill:
+            case .onBrandPill, .brandOverNavBarPill:
                 return .brand
             }
         }()

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -228,7 +228,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if let segmentedControl = segmentedControl, previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle {
-            segmentedControl.style = (traitCollection.userInterfaceStyle == .dark) ? .onBrandPill : .primaryPill
+            segmentedControl.style = (traitCollection.userInterfaceStyle == .dark) ? .brandOverNavBarPill : .neutralOverNavBarPill
         }
     }
 
@@ -256,7 +256,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
             let items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
                          SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
             let segmentedControl = SegmentedControl(items: items,
-                                                style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
+                                                style: traitCollection.userInterfaceStyle == .dark ? .brandOverNavBarPill : .neutralOverNavBarPill)
             segmentedControl.onSelectAction = { [weak self] (_, index) in
                 guard let strongSelf = self else {
                     return

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -182,7 +182,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
             items = [SegmentItem(title: customStartTabTitle ?? "MSDateTimePicker.StartDate".localized),
                      SegmentItem(title: customEndTabTitle ?? "MSDateTimePicker.EndDate".localized)]
         }
-        let segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .onBrandPill : .primaryPill)
+        let segmentedControl = SegmentedControl(items: items, style: traitCollection.userInterfaceStyle == .dark ? .brandOverNavBarPill : .neutralOverNavBarPill)
         segmentedControl.onSelectAction = { [weak self] (_, index) in
             guard let strongSelf = self else {
                 return

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -191,7 +191,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     ///
     /// - Parameter items: An array of Segmented Items representing the segments for this control.
     /// - Parameter style: A style used for rendering of the control.
-    @objc public init(items: [SegmentItem], style: SegmentedControlStyle = .primaryPill) {
+    @objc public init(items: [SegmentItem], style: SegmentedControlStyle = .neutralOverNavBarPill) {
         self.style = style
 
         super.init(frame: .zero)
@@ -436,7 +436,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
 
     public typealias TokenSetKeyType = SegmentedControlTokenSet.Tokens
     lazy public var tokenSet: SegmentedControlTokenSet = .init(style: { [weak self] in
-        return self?.style ?? .primaryPill
+        return self?.style ?? .neutralOverNavBarPill
     })
 
     private let selectionChangeAnimationDuration: TimeInterval = 0.2

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -215,7 +215,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
 @objc(MSFSegmentedControlStyle)
 public enum SegmentedControlStyle: Int {
     /// Segments are shown as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
-    @available(*, deprecated, message: "primaryPill is now deprecated. Please use neutralOverCanvasPill.")
+    @available(*, deprecated, message: "primaryPill is now deprecated. Please use neutralOverNavBarPill.")
     case primaryPill
     /// Segments are shown as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
     /// Selection is indicated by a thumb under the selected label.

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -166,7 +166,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledSelectedLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill,. neutralOverNavBarPill:
+                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
                         return theme.color(.brandForegroundDisabled1)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForegroundDisabled2).light,

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -64,34 +64,41 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .restTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
-                        return UIColor(light: theme.color(.background5).light,
-                                       dark: theme.color(.background5).dark)
-                    case .onBrandPill:
+                    case .primaryPill, .neutralOverCanvasPill, .brandOverCanvasPill:
+                        return theme.color(.background3)
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandBackground2).light,
                                        dark: theme.color(.background5).dark)
+                    case .neutralOverNavBarPill:
+                        return theme.color(.background5)
                     }
                 }
 
             case .selectedTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
+                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
                         return theme.color(.brandBackground1)
-                    case .onBrandPill:
-                        return UIColor(light: theme.color(.background1).light,
+                    case .onBrandPill, .brandOverNavBarPill:
+                        return UIColor(light: theme.color(.background3).light,
                                        dark: theme.color(.background5Selected).dark)
+                    case .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.brandBackground1).light,
+                                       dark: theme.color(.background3Selected).dark)
                     }
                 }
 
             case .disabledTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
-                        return UIColor(light: theme.color(.background5).light,
-                                       dark: theme.color(.background5).dark)
-                    case .onBrandPill:
+                    case .primaryPill, .neutralOverCanvasPill, .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.background3).light,
+                                       dark: theme.color(.background3).dark)
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandBackground2).light,
+                                       dark: theme.color(.background5).dark)
+                    case .neutralOverNavBarPill:
+                        return UIColor(light: theme.color(.background5).light,
                                        dark: theme.color(.background5).dark)
                     }
                 }
@@ -99,21 +106,31 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledSelectedTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
-                        return theme.color(.brandBackground1)
-                    case .onBrandPill:
+                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
+                        return UIColor(light: theme.color(.brandBackground1).light,
+                                       dark: theme.color(.brandBackground1).dark)
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.background1).light,
                                        dark: theme.color(.background5Selected).dark)
+                    case .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.brandBackground1Selected).light,
+                                       dark: theme.color(.background3Selected).dark)
                     }
                 }
 
             case .restLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
+                    case .primaryPill, .neutralOverCanvasPill:
                         return theme.color(.foreground2)
-                    case .onBrandPill:
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.foregroundOnColor).light,
+                                       dark: theme.color(.foreground2).dark)
+                    case .neutralOverNavBarPill:
+                        return UIColor(light: theme.color(.foreground2).light,
+                                       dark: theme.color(.foreground2).dark)
+                    case .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.brandForeground1).light,
                                        dark: theme.color(.foreground2).dark)
                     }
                 }
@@ -121,10 +138,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .selectedLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
+                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
                         return theme.color(.foregroundOnColor)
-                    case .onBrandPill:
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForeground1).light,
+                                       dark: theme.color(.foreground1).dark)
+                    case .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.foregroundOnColor).light,
                                        dark: theme.color(.foreground1).dark)
                     }
                 }
@@ -132,10 +152,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledLabelColor, .disabledUnreadDotColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
+                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
                         return theme.color(.foregroundDisabled1)
-                    case .onBrandPill:
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForegroundDisabled1).light,
+                                       dark: theme.color(.foregroundDisabled1).dark)
+                    case .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.brandForegroundDisabled2).light,
                                        dark: theme.color(.foregroundDisabled1).dark)
                     }
                 }
@@ -143,10 +166,13 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledSelectedLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
+                    case .primaryPill, .neutralOverCanvasPill,. neutralOverNavBarPill:
                         return theme.color(.brandForegroundDisabled1)
-                    case .onBrandPill:
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForegroundDisabled2).light,
+                                       dark: theme.color(.foregroundDisabled2).dark)
+                    case .brandOverCanvasPill:
+                        return UIColor(light: theme.color(.brandForegroundDisabled1).light,
                                        dark: theme.color(.foregroundDisabled2).dark)
                     }
                 }
@@ -154,10 +180,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .enabledUnreadDotColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill:
+                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill, .brandOverCanvasPill:
                         return UIColor(light: theme.color(.brandForeground1).light,
                                        dark: theme.color(.foreground1).dark)
-                    case .onBrandPill:
+                    case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.foregroundOnColor).light,
                                        dark: theme.color(.foreground1).dark)
                     }
@@ -190,9 +216,25 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
 
 @objc(MSFSegmentedControlStyle)
 public enum SegmentedControlStyle: Int {
-    /// Segments are shows as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
+    /// Segments are shown as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.
+    @available(*, deprecated, message: "primaryPill is now deprecated. Please use neutralOverCanvasPill.")
     case primaryPill
-    /// Segments are shows as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
+    /// Segments are shown as labels inside a pill for use on a branded background that features a prominent brand color in light mode and a muted grey in dark mode.
     /// Selection is indicated by a thumb under the selected label.
+    @available(*, deprecated, message: "onBrandPill is now deprecated. Please use brandOverNavBarPill.")
     case onBrandPill
+
+    /// Segments are shown as labels inside a pill for use with a neutral or white backround,
+    /// when the buttons should be a prominent brand color in light mode and a muted grey in dark mode.
+    case brandOverCanvasPill
+
+    /// Segments are shown as labels inside a pill for use with branded Navigation Bar where the background features
+    /// a prominent brand color in light mode and a muted gray in dark mode.
+    case brandOverNavBarPill
+
+    /// Segments are shown as labels inside a pill for use with a neutral or white background.
+    case neutralOverCanvasPill
+
+    /// Segments are shown as labels inside a pill for use with a non-brand-colored Navigation Bar.
+    case neutralOverNavBarPill
 }

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -64,13 +64,14 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .restTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .brandOverCanvasPill:
+                    case .primaryPill, .neutralOverNavBarPill:
+                        return UIColor(light: theme.color(.background5).light,
+                                       dark: theme.color(.background5).dark)
+                    case .neutralOverCanvasPill, .brandOverCanvasPill:
                         return theme.color(.background3)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandBackground2).light,
                                        dark: theme.color(.background5).dark)
-                    case .neutralOverNavBarPill:
-                        return theme.color(.background5)
                     }
                 }
 
@@ -91,14 +92,14 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .brandOverCanvasPill:
+                    case .primaryPill, .neutralOverNavBarPill:
+                        return UIColor(light: theme.color(.background5).light,
+                                       dark: theme.color(.background5).dark)
+                    case .neutralOverCanvasPill, .brandOverCanvasPill:
                         return UIColor(light: theme.color(.background3).light,
                                        dark: theme.color(.background3).dark)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandBackground2).light,
-                                       dark: theme.color(.background5).dark)
-                    case .neutralOverNavBarPill:
-                        return UIColor(light: theme.color(.background5).light,
                                        dark: theme.color(.background5).dark)
                     }
                 }
@@ -106,7 +107,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledSelectedTabColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
+                    case .primaryPill, .neutralOverNavBarPill, .neutralOverCanvasPill:
                         return UIColor(light: theme.color(.brandBackground1).light,
                                        dark: theme.color(.brandBackground1).dark)
                     case .onBrandPill, .brandOverNavBarPill:
@@ -121,13 +122,10 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .restLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill:
+                    case .primaryPill, .neutralOverNavBarPill, .neutralOverCanvasPill:
                         return theme.color(.foreground2)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.foregroundOnColor).light,
-                                       dark: theme.color(.foreground2).dark)
-                    case .neutralOverNavBarPill:
-                        return UIColor(light: theme.color(.foreground2).light,
                                        dark: theme.color(.foreground2).dark)
                     case .brandOverCanvasPill:
                         return UIColor(light: theme.color(.brandForeground1).light,
@@ -138,7 +136,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .selectedLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
+                    case .primaryPill, .neutralOverNavBarPill, .neutralOverCanvasPill:
                         return theme.color(.foregroundOnColor)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForeground1).light,
@@ -152,7 +150,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledLabelColor, .disabledUnreadDotColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
+                    case .primaryPill, .neutralOverNavBarPill, .neutralOverCanvasPill:
                         return theme.color(.foregroundDisabled1)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForegroundDisabled1).light,
@@ -166,7 +164,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .disabledSelectedLabelColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill:
+                    case .primaryPill, .neutralOverNavBarPill, .neutralOverCanvasPill:
                         return theme.color(.brandForegroundDisabled1)
                     case .onBrandPill, .brandOverNavBarPill:
                         return UIColor(light: theme.color(.brandForegroundDisabled2).light,
@@ -180,7 +178,7 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlTokenSet.
             case .enabledUnreadDotColor:
                 return .uiColor {
                     switch style() {
-                    case .primaryPill, .neutralOverCanvasPill, .neutralOverNavBarPill, .brandOverCanvasPill:
+                    case .primaryPill, .neutralOverNavBarPill, .neutralOverCanvasPill, .brandOverCanvasPill:
                         return UIColor(light: theme.color(.brandForeground1).light,
                                        dark: theme.color(.foreground1).dark)
                     case .onBrandPill, .brandOverNavBarPill:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change updates the look and feel of the Segmented Control being used over the NavigationBar, and differentiates its use from over a canvas background.

### Binary change

Total increase: 4,048 bytes
Total decrease: -16 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,890,896 bytes | 30,894,928 bytes | ⚠️ 4,032 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| SegmentedControlTokenSet.o | 92,720 bytes | 96,768 bytes | ⚠️ 4,048 bytes |
| DateTimePickerController.o | 157,544 bytes | 157,536 bytes | 🎉 -8 bytes |
| DatePickerController.o | 351,608 bytes | 351,600 bytes | 🎉 -8 bytes |
</details>

### Verification

Added new demo cases for the two fundamentally new states, and compared screen shots of old and new against Figma designs.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![segControlLightBefore1](https://user-images.githubusercontent.com/23249106/235011049-9d400862-33fc-44dd-a64a-786b767dc1e2.png) | ![segControlLightAfter1](https://user-images.githubusercontent.com/23249106/235011064-63fbc25a-e1a6-4377-9af1-8fd4a5e251e7.png) |
| ![segControlLightBefore2](https://user-images.githubusercontent.com/23249106/235011048-fbc2e15b-a5eb-4732-98d1-90b28a045def.png) | ![segControlLightAfter2](https://user-images.githubusercontent.com/23249106/235011063-4cdb5ae2-39f3-4e89-ac92-04be97c9b678.png) |
| ![segControlDarkBefore1](https://user-images.githubusercontent.com/23249106/235011046-5bfe22a9-9ce4-4a14-bbdd-1a668bbf5ae7.png) | ![segControlDarkAfter1](https://user-images.githubusercontent.com/23249106/235011062-b31bd215-be92-401f-8b83-6b391aaf60b1.png) |
| ![segControlDarkBefore2](https://user-images.githubusercontent.com/23249106/235011239-a080c5f5-c5e8-421f-8fa3-34d80adc0418.png) | ![segControlDarkAfter2](https://user-images.githubusercontent.com/23249106/235011059-d42a7dc8-5fa2-413b-8c93-1d5bfd6e0781.png) |
| ![navBarLightBefore](https://user-images.githubusercontent.com/23249106/235011042-568a5e4c-b9f0-4388-9f3a-d30275965b91.png) | ![navBarLightAfter](https://user-images.githubusercontent.com/23249106/235011058-fce171a0-9c6b-4762-8324-5583b81e5eed.png) |
| ![navBarDarkBefore](https://user-images.githubusercontent.com/23249106/235011039-699277d9-8800-4b57-9866-4a13d216a015.png) | ![navBarDarkAfter](https://user-images.githubusercontent.com/23249106/235011056-f0a747b6-34df-49e1-9e47-e85afbaa4849.png) |
| ![datePickerLightBefore](https://user-images.githubusercontent.com/23249106/235011038-99a1d80c-ddd8-4c83-9177-f2b130e950cc.png) | ![datePickerLightAfter](https://user-images.githubusercontent.com/23249106/235011055-6407d3ab-8efa-4289-a9d4-6d8094d9151b.png) |
| ![datePickerDarkBefore](https://user-images.githubusercontent.com/23249106/235011036-c316b17e-fd5b-48ab-bb5e-d41c01ca6b8e.png) | ![datePickerDarkAfter](https://user-images.githubusercontent.com/23249106/235011051-176cc18e-e452-4069-b8dc-95f301feb7b5.png) |
</details>


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1718)