### PR TITLE
Tokenized HeaderFooterView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -44,6 +44,7 @@ struct Demos {
         DemoDescriptor("SideTabBar", SideTabBarDemoController.self),
         DemoDescriptor("TabBarView", TabBarViewDemoController.self),
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self),
+        DemoDescriptor("TableViewHeaderFooterView", TableViewHeaderFooterViewDemoController.self),
         DemoDescriptor("Text Field", TextFieldDemoController.self),
         DemoDescriptor("Tooltip", TooltipDemoController.self)
     ]
@@ -64,8 +65,7 @@ struct Demos {
         DemoDescriptor("PeoplePicker", PeoplePickerDemoController.self),
         DemoDescriptor("PersonaListView", PersonaListViewDemoController.self),
         DemoDescriptor("TableViewCellFileAccessoryView", TableViewCellFileAccessoryViewDemoController.self),
-        DemoDescriptor("TableViewCellShimmer", TableViewCellShimmerDemoController.self),
-        DemoDescriptor("TableViewHeaderFooterView", TableViewHeaderFooterViewDemoController.self)
+        DemoDescriptor("TableViewCellShimmer", TableViewCellShimmerDemoController.self)
     ]
 
     static let debug: [DemoDescriptor] = [

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -13,16 +13,12 @@ class TableViewHeaderFooterViewDemoController: DemoTableViewController {
     private var collapsedSections: [Bool] = [Bool](repeating: false, count: TableViewHeaderFooterSampleData.groupedSections.count)
     private var overrideTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue]?
 
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
     required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
-    }
-
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(style: .insetGrouped)
-    }
-
-    override init(style: UITableView.Style) {
-        super.init(style: .insetGrouped)
     }
 
     override func viewDidLoad() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -167,11 +167,11 @@ extension TableViewHeaderFooterViewDemoController: DemoAppearanceDelegate {
         }
 
         fluentTheme.register(tokenSetType: TableViewHeaderFooterViewTokenSet.self,
-                             tokenSet: isOverrideEnabled ? themeWideOverrideTableViewCellTokens : nil)
+                             tokenSet: isOverrideEnabled ? themeWideOverrideTableViewHeaderFooterTokens : nil)
     }
 
     func perControlOverrideDidChange(isOverrideEnabled: Bool) {
-        overrideTokens = isOverrideEnabled ? perControlOverrideTableViewCellTokens : nil
+        overrideTokens = isOverrideEnabled ? perControlOverrideTableViewHeaderFooterTokens : nil
         self.tableView.reloadData()
     }
 
@@ -180,7 +180,7 @@ extension TableViewHeaderFooterViewDemoController: DemoAppearanceDelegate {
     }
 
     // MARK: - Custom tokens
-    private var themeWideOverrideTableViewCellTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
+    private var themeWideOverrideTableViewHeaderFooterTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
         return [
             .textColor: .uiColor {
                 // "Grape"
@@ -190,7 +190,7 @@ extension TableViewHeaderFooterViewDemoController: DemoAppearanceDelegate {
         ]
     }
 
-    private var perControlOverrideTableViewCellTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
+    private var perControlOverrideTableViewHeaderFooterTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
         return [
             .textFont: .uiFont {
                 // "Brass"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -8,43 +8,48 @@ import UIKit
 
 // MARK: TableViewHeaderFooterViewDemoController
 
-class TableViewHeaderFooterViewDemoController: DemoController {
+class TableViewHeaderFooterViewDemoController: DemoTableViewController {
     private let groupedSections: [TableViewHeaderFooterSampleData.Section] = TableViewHeaderFooterSampleData.groupedSections
-    private lazy var groupedTableView: UITableView = createTableView(style: .insetGrouped)
     private var collapsedSections: [Bool] = [Bool](repeating: false, count: TableViewHeaderFooterSampleData.groupedSections.count)
+    private var overrideTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue]?
+
+    required init?(coder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(style: .insetGrouped)
+    }
+
+    override init(style: UITableView.Style) {
+        super.init(style: .insetGrouped)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.addSubview(groupedTableView)
-        groupedTableView.frame = view.bounds
-        groupedTableView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        scrollingContainer.removeFromSuperview()
-    }
-
-    func createTableView(style: UITableView.Style) -> UITableView {
-        let tableView = UITableView(frame: .zero, style: style)
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
-        tableView.dataSource = self
-        tableView.delegate = self
-        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
         tableView.separatorStyle = .none
-        return tableView
+    }
+
+    private func updateTableView() {
+        tableView.backgroundColor = TableViewCell.tableBackgroundGroupedColor
+        tableView.reloadData()
     }
 }
 
 // MARK: - TableViewHeaderFooterViewDemoController: UITableViewDataSource
 
-extension TableViewHeaderFooterViewDemoController: UITableViewDataSource {
-    func numberOfSections(in tableView: UITableView) -> Int {
+extension TableViewHeaderFooterViewDemoController {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return  groupedSections.count
     }
 
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return collapsedSections[section] ? 0 : TableViewHeaderFooterSampleData.numberOfItemsInSection
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: TableViewCell.identifier) as? TableViewCell else {
             return UITableViewCell()
         }
@@ -66,13 +71,13 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDataSource {
 
 // MARK: - TableViewHeaderFooterViewDemoController: UITableViewDelegate
 
-extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+extension TableViewHeaderFooterViewDemoController {
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         let section = groupedSections[section]
         return section.hasFooter ? UITableView.automaticDimension : 0
     }
 
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
         let index = section
         let section = groupedSections[section]
@@ -89,6 +94,7 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
         header?.titleNumberOfLines = section.numberOfLines
         header?.accessoryButtonStyle = section.accessoryButtonStyle
         header?.onAccessoryButtonTapped = { [weak self] in self?.showAlertForAccessoryTapped(title: section.title) }
+        header?.tokenSet.replaceAllOverrides(with: overrideTokens)
 
         return header
     }
@@ -105,7 +111,7 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
         return UIImageView(image: UIImage(named: imageName))
     }
 
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if tableView.style == .grouped && groupedSections[section].hasFooter {
             let footer = tableView.dequeueReusableHeaderFooterView(withIdentifier: TableViewHeaderFooterView.identifier) as? TableViewHeaderFooterView
             let section = groupedSections[section]
@@ -124,12 +130,13 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
                 }
             }
             footer?.titleNumberOfLines = section.numberOfLines
+            footer?.tokenSet.replaceAllOverrides(with: overrideTokens)
             return footer
         }
         return nil
     }
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
@@ -142,7 +149,7 @@ extension TableViewHeaderFooterViewDemoController: UITableViewDelegate {
 
     private func forHeaderTapped(header: TableViewHeaderFooterView, section: Int) {
         collapsedSections[section] = !collapsedSections[section]
-        groupedTableView.reloadSections(IndexSet(integer: section), with: UITableView.RowAnimation.fade)
+        tableView.reloadSections(IndexSet(integer: section), with: UITableView.RowAnimation.fade)
     }
 }
 
@@ -154,5 +161,50 @@ extension TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDele
         alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         present(alertController, animated: true, completion: nil)
         return false
+    }
+}
+
+extension TableViewHeaderFooterViewDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        fluentTheme.register(tokenSetType: TableViewHeaderFooterViewTokenSet.self,
+                             tokenSet: isOverrideEnabled ? themeWideOverrideTableViewCellTokens : nil)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        overrideTokens = isOverrideEnabled ? perControlOverrideTableViewCellTokens : nil
+        self.tableView.reloadData()
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokens(for: TableViewHeaderFooterViewTokenSet.self) != nil
+    }
+
+    // MARK: - Custom tokens
+    private var themeWideOverrideTableViewCellTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .textColor: .uiColor {
+                // "Grape"
+                return UIColor(light: GlobalTokens.sharedColor(.grape, .tint10),
+                               dark: GlobalTokens.sharedColor(.grape, .shade40))
+            }
+        ]
+    }
+
+    private var perControlOverrideTableViewCellTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
+        return [
+            .textFont: .uiFont {
+                // "Brass"
+                return UIFont(descriptor: .init(name: "Times", size: 20.0), size: 20.0)
+            },
+            .accessoryButtonTextColor: .uiColor {
+                // "Hot Pink"
+                return UIColor(light: GlobalTokens.sharedColor(.hotPink, .tint10),
+                               dark: GlobalTokens.sharedColor(.hotPink, .shade40))
+            }
+        ]
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -193,7 +193,6 @@ extension TableViewHeaderFooterViewDemoController: DemoAppearanceDelegate {
     private var perControlOverrideTableViewHeaderFooterTokens: [TableViewHeaderFooterViewTokenSet.Tokens: ControlTokenValue] {
         return [
             .textFont: .uiFont {
-                // "Brass"
                 return UIFont(descriptor: .init(name: "Times", size: 20.0), size: 20.0)
             },
             .accessoryButtonTextColor: .uiColor {

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A84A6F029EDC489005DBC3D /* SeparatorTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A84A6EF29EDC489005DBC3D /* SeparatorTokenSet.swift */; };
 		0A8E61FB291DC11F009E412D /* CommandBarTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8E61FA291DC11F009E412D /* CommandBarTokenSet.swift */; };
+		0AE3041D29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE3041C29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift */; };
 		2A9745DE281733D700E1A1FD /* TableViewCellTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9745DD281733D700E1A1FD /* TableViewCellTokenSet.swift */; };
 		3AFB0FD629C1365600FEC1A9 /* MultilineCommandBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFB0FD529C1365600FEC1A9 /* MultilineCommandBar.swift */; };
 		43488C46270FAD1300124C71 /* FluentNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43488C44270FAD0200124C71 /* FluentNotification.swift */; };
@@ -252,6 +253,7 @@
 		0A0516BE2940A3CE006DE0A2 /* Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
 		0A84A6EF29EDC489005DBC3D /* SeparatorTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeparatorTokenSet.swift; sourceTree = "<group>"; };
 		0A8E61FA291DC11F009E412D /* CommandBarTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandBarTokenSet.swift; sourceTree = "<group>"; };
+		0AE3041C29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterViewTokenSet.swift; sourceTree = "<group>"; };
 		0BCEFADD2485FEC00088CEE5 /* PopupMenuProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuProtocols.swift; sourceTree = "<group>"; };
 		1168630222E131CF0088B302 /* TabBarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemView.swift; sourceTree = "<group>"; };
 		1168630322E131CF0088B302 /* TabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -1047,6 +1049,7 @@
 				B498141321E424920077B48D /* TableViewCell.swift */,
 				2A9745DD281733D700E1A1FD /* TableViewCellTokenSet.swift */,
 				B4EF66502294A664007FEAB0 /* TableViewHeaderFooterView.swift */,
+				0AE3041C29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift */,
 			);
 			path = "Table View";
 			sourceTree = "<group>";
@@ -1691,6 +1694,7 @@
 				5314E19825F019650099271A /* SideTabBar.swift in Sources */,
 				5314E10A25F014600099271A /* Obscurable.swift in Sources */,
 				5314E07D25F00F1A0099271A /* DateTimePickerViewComponentTableView.swift in Sources */,
+				0AE3041D29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift in Sources */,
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,
 				5314E08925F00F2D0099271A /* CommandBarButtonGroupView.swift in Sources */,
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -519,7 +519,7 @@ private class TableViewHeaderFooterTitleView: UITextView {
     }
 
     private func updateLinkTextColor() {
-        linkTextAttributes = [.foregroundColor: linkColor ?? fluentTheme.color(.brandForeground1)]
+        linkTextAttributes = [.foregroundColor: linkColor]
     }
 
     override var selectedTextRange: UITextRange? {
@@ -534,9 +534,11 @@ private class TableViewHeaderFooterTitleView: UITextView {
         }
     }
 
-    var linkColor: UIColor? {
+    lazy var linkColor: UIColor = fluentTheme.color(.brandForeground1) {
         didSet {
-            updateLinkTextColor()
+            if linkColor != oldValue {
+                updateLinkTextColor()
+            }
         }
     }
 }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -452,7 +452,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         }
 
         titleView.font = tokenSet[.textFont].uiFont
-        titleView.updateLinkTextColor(tokenSet.fluentTheme)
+        titleView.linkColor = tokenSet[.linkTextColor].uiColor
     }
 
     private func updateAccessoryButtonTitleColor() {
@@ -507,11 +507,7 @@ private class TableViewHeaderFooterTitleView: UITextView {
         self.textContainer.lineFragmentPadding = 0
         textContainerInset = .zero
         layoutManager.usesFontLeading = false
-        updateLinkTextColor(fluentTheme)
-    }
-
-    func updateLinkTextColor(_ fluentTheme: FluentTheme) {
-        linkTextAttributes = [.foregroundColor: fluentTheme.color(.brandForeground1)]
+        updateLinkTextColor()
     }
 
     required init?(coder: NSCoder) {
@@ -520,6 +516,10 @@ private class TableViewHeaderFooterTitleView: UITextView {
 
     override func becomeFirstResponder() -> Bool {
         return false
+    }
+
+    private func updateLinkTextColor() {
+        linkTextAttributes = [.foregroundColor: linkColor ?? fluentTheme.color(.brandForeground1)]
     }
 
     override var selectedTextRange: UITextRange? {
@@ -531,6 +531,12 @@ private class TableViewHeaderFooterTitleView: UITextView {
         set {
             // No-op because we don't want to allow this property to be set.
             // It should always return nil which indicates there is no current selection (https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange)
+        }
+    }
+
+    var linkColor: UIColor? {
+        didSet {
+            updateLinkTextColor()
         }
     }
 }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -22,58 +22,6 @@ public protocol TableViewHeaderFooterViewDelegate: AnyObject {
 /// Use `titleNumberOfLines` to configure the number of lines for the `title`. Headers generally use the default number of lines of 1 while footers may use a multiple number of lines.
 @objc(MSFTableViewHeaderFooterView)
 open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedControlInternal {
-    @objc(MSFTableViewHeaderFooterViewAccessoryButtonStyle)
-    public enum AccessoryButtonStyle: Int {
-        case regular
-        case primary
-
-        func textColor(fluentTheme: FluentTheme) -> UIColor {
-            switch self {
-            case .regular:
-                return fluentTheme.color(.foreground2)
-            case .primary:
-                return fluentTheme.color(.brandForeground1)
-            }
-        }
-    }
-
-    /// Defines the visual style of the view
-    @objc(MSFTableViewHeaderFooterViewStyle)
-    public enum Style: Int {
-        case header
-        case footer
-        case headerPrimary
-
-        func textColor(fluentTheme: FluentTheme) -> UIColor {
-            switch self {
-            case .header, .footer:
-                return fluentTheme.color(.foreground2)
-            case .headerPrimary:
-                return fluentTheme.color(.foreground1)
-            }
-        }
-
-        func textFont() -> UIFont {
-            switch self {
-            case .headerPrimary:
-                return FluentTheme.shared.typography(.body1Strong)
-            case .header, .footer:
-                return FluentTheme.shared.typography(.caption1)
-            }
-        }
-    }
-
-    private struct Constants {
-        static let horizontalMargin: CGFloat = 16
-
-        static let titleDefaultTopMargin: CGFloat = 24
-        static let titleDefaultBottomMargin: CGFloat = 8
-        static let titleDividerVerticalMargin: CGFloat = 3
-
-        static let accessoryViewBottomMargin: CGFloat = 2
-        static let accessoryViewMarginLeft: CGFloat = 8
-    }
-
     @objc public static var identifier: String { return String(describing: self) }
 
     /// The height of the view based on the height of its content.
@@ -85,21 +33,26 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - containerWidth: The width of the view's super view (e.g. the table view's width).
     ///   - accessoryView: An optional accessory view that appears near the trailing edge of the view.
     /// - Returns: a value representing the calculated height of the view.
-    @objc public class func height(style: Style, title: String, titleNumberOfLines: Int = 1, containerWidth: CGFloat = .greatestFiniteMagnitude, accessoryView: UIView? = nil) -> CGFloat {
+    @objc public class func height(style: Style,
+                                   title: String,
+                                   titleNumberOfLines: Int = 1,
+                                   containerWidth: CGFloat = .greatestFiniteMagnitude,
+                                   accessoryView: UIView? = nil) -> CGFloat {
+        let tokenSet: TableViewHeaderFooterViewTokenSet = .init(style: { style }, accessoryButtonStyle: { AccessoryButtonStyle.regular })
         let verticalMargin: CGFloat
-        let font = style.textFont()
+        let font = tokenSet[.textFont].uiFont
         switch style {
         case .header, .footer:
-            verticalMargin = Constants.titleDefaultTopMargin + Constants.titleDefaultBottomMargin
+            verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
         case .headerPrimary:
-            verticalMargin = Constants.titleDefaultTopMargin + Constants.titleDefaultBottomMargin
+            verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
         }
 
         if let accessoryView = accessoryView {
             accessoryView.frame.size = accessoryView.systemLayoutSizeFitting(CGSize(width: containerWidth, height: .infinity))
         }
 
-        let titleWidth = containerWidth - (Constants.horizontalMargin + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView) + TableViewHeaderFooterView.titleLeadingOffset())
+        let titleWidth = containerWidth - (TableViewHeaderFooterViewTokenSet.horizontalMargin + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView) + TableViewHeaderFooterView.titleLeadingOffset())
         let titleHeight = title.preferredSize(for: font, width: titleWidth, numberOfLines: titleNumberOfLines).height
 
         return verticalMargin + titleHeight
@@ -113,18 +66,22 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - accessoryView: An optional accessory view that appears near the trailing edge of the view.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     /// - Returns: a value representing the calculated preferred width of the view.
-    @objc public class func preferredWidth(style: Style, title: String, accessoryView: UIView? = nil, leadingView: UIView? = nil) -> CGFloat {
-        let font = style.textFont()
+    @objc public class func preferredWidth(style: Style,
+                                           title: String,
+                                           accessoryView: UIView? = nil,
+                                           leadingView: UIView? = nil) -> CGFloat {
+        let tokenSet: TableViewHeaderFooterViewTokenSet = .init(style: { style }, accessoryButtonStyle: { AccessoryButtonStyle.regular })
+        let font = tokenSet[.textFont].uiFont
         let titleSize = title.preferredSize(for: font)
 
-        var width = Constants.horizontalMargin + titleSize.width + Constants.horizontalMargin
+        var width = TableViewHeaderFooterViewTokenSet.horizontalMargin + titleSize.width + TableViewHeaderFooterViewTokenSet.horizontalMargin
 
         if let accessoryView = accessoryView {
-            width += Constants.accessoryViewMarginLeft + accessoryView.frame.width
+            width += TableViewHeaderFooterViewTokenSet.accessoryViewMarginLeading + accessoryView.frame.width
         }
 
         if let leadingView = leadingView {
-            width += Constants.accessoryViewMarginLeft + leadingView.frame.width
+            width += TableViewHeaderFooterViewTokenSet.accessoryViewMarginLeading + leadingView.frame.width
         }
 
         return width
@@ -132,17 +89,17 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     private static func titleLeadingOffset(leadingView: UIView? = nil) -> CGFloat {
         let leadingViewSpacing = leadingView?.frame.width ?? 0
-        return leadingViewSpacing + Constants.horizontalMargin
+        return leadingViewSpacing + TableViewHeaderFooterViewTokenSet.horizontalMargin
     }
 
     private static func titleTrailingOffset(accessoryView: UIView? = nil) -> CGFloat {
         let accessoryViewSpacing: CGFloat
         if let accessoryView = accessoryView {
-            accessoryViewSpacing = Constants.accessoryViewMarginLeft + accessoryView.frame.width
+            accessoryViewSpacing = TableViewHeaderFooterViewTokenSet.accessoryViewMarginLeading + accessoryView.frame.width
         } else {
             accessoryViewSpacing = 0
         }
-        return accessoryViewSpacing + Constants.horizontalMargin
+        return accessoryViewSpacing + TableViewHeaderFooterViewTokenSet.horizontalMargin
     }
 
     @objc open var accessoryButtonStyle: AccessoryButtonStyle = .regular {
@@ -206,8 +163,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         }
     }
 
-    public typealias TokenSetKeyType = EmptyTokenSet.Tokens
-    public var tokenSet: EmptyTokenSet = .init()
+    public typealias TokenSetKeyType = TableViewHeaderFooterViewTokenSet.Tokens
+    lazy public var tokenSet: TableViewHeaderFooterViewTokenSet = .init(style: { [weak self] in
+        return self?.style ?? .header
+    },
+                                                                        accessoryButtonStyle: { [weak self] in
+        return self?.accessoryButtonStyle ?? .regular
+    })
 
     private var style: Style = .header {
         didSet {
@@ -382,17 +344,17 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         leadingView?.sizeToFit()
 
         let titleWidth = contentView.frame.width - (TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView) + TableViewHeaderFooterView.titleLeadingOffset(leadingView: leadingView))
-        var titleXOffset = Constants.horizontalMargin
+        var titleXOffset = TableViewHeaderFooterViewTokenSet.horizontalMargin
         let titleHeight: CGFloat
         let titleYOffset: CGFloat
         switch style {
         case .header, .footer, .headerPrimary:
-            titleYOffset = style == .footer ? Constants.titleDefaultBottomMargin : Constants.titleDefaultTopMargin
-            titleHeight = contentView.frame.height - titleYOffset - Constants.titleDefaultBottomMargin
+            titleYOffset = style == .footer ? TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin : TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin
+            titleHeight = contentView.frame.height - titleYOffset - TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
         }
 
         if let leadingView = leadingView {
-            let xOffset = Constants.accessoryViewMarginLeft
+            let xOffset = TableViewHeaderFooterViewTokenSet.accessoryViewMarginLeading
             let yOffset = floor(titleYOffset + (titleHeight - leadingView.frame.height) / 2)
             leadingView.frame = CGRect(
                 origin: CGPoint(x: xOffset, y: yOffset),
@@ -409,8 +371,8 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         )
 
         if let accessoryView = accessoryView {
-            let xOffset = titleView.frame.maxX + Constants.accessoryViewMarginLeft
-            let yOffset = contentView.frame.height - accessoryView.frame.height - Constants.accessoryViewBottomMargin
+            let xOffset = titleView.frame.maxX + TableViewHeaderFooterViewTokenSet.accessoryViewMarginLeading
+            let yOffset = contentView.frame.height - accessoryView.frame.height - TableViewHeaderFooterViewTokenSet.accessoryViewBottomMargin
             accessoryView.frame = CGRect(
                 origin: CGPoint(x: xOffset, y: yOffset),
                 size: accessoryView.frame.size
@@ -468,7 +430,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     private func updateTitleViewFont() {
         if let window = window {
-            let titleFont = style.textFont()
+            let titleFont = tokenSet[.textFont].uiFont
             titleView.font = titleFont
             // offset text container to center its content
             let scale = window.rootViewController?.view.contentScaleFactor ?? window.screen.scale
@@ -479,26 +441,26 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     }
 
     private func updateTitleAndBackgroundColors() {
-        titleView.textColor = style.textColor(fluentTheme: tokenSet.fluentTheme)
+        titleView.textColor = tokenSet[.textColor].uiColor
 
         if tableViewCellStyle == .grouped {
-            backgroundView?.backgroundColor = tokenSet.fluentTheme.color(.backgroundCanvas)
+            backgroundView?.backgroundColor = tokenSet[.backgroundColorGrouped].uiColor
         } else if tableViewCellStyle == .plain {
-            backgroundView?.backgroundColor = tokenSet.fluentTheme.color(.background1)
+            backgroundView?.backgroundColor = tokenSet[.backgroundColorPlain].uiColor
         } else {
             backgroundView?.backgroundColor = .clear
         }
 
-        titleView.font = style.textFont()
+        titleView.font = tokenSet[.textFont].uiFont
         titleView.updateLinkTextColor(tokenSet.fluentTheme)
     }
 
     private func updateAccessoryButtonTitleColor() {
-        accessoryButton?.setTitleColor(accessoryButtonStyle.textColor(fluentTheme: tokenSet.fluentTheme), for: .normal)
+        accessoryButton?.setTitleColor(tokenSet[.accessoryButtonTextColor].uiColor, for: .normal)
     }
 
     private func updateAccessoryButtonTitleStyle() {
-        accessoryButton?.titleLabel?.font = tokenSet.fluentTheme.typography(.caption1Strong)
+        accessoryButton?.titleLabel?.font = tokenSet[.accessoryButtonTextFont].uiFont
         updateAccessoryButtonTitleColor()
     }
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
@@ -1,0 +1,121 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+import UIKit
+
+public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderFooterViewTokenSet.Tokens> {
+    public enum Tokens: TokenSetKey {
+        /// The background color in plain mode.
+        case backgroundColorPlain
+
+        /// The background color in grouped mode.
+        case backgroundColorGrouped
+
+        /// The color of the header/footer text.
+        case textColor
+
+        /// The font of the header/footer text.
+        case textFont
+
+        /// The color of the accessory button text.
+        case accessoryButtonTextColor
+
+        /// The font of the accessory button text.
+        case accessoryButtonTextFont
+    }
+
+    init(style: @escaping () -> TableViewHeaderFooterView.Style,
+         accessoryButtonStyle: @escaping () -> TableViewHeaderFooterView.AccessoryButtonStyle) {
+        self.style = style
+        self.accessoryButtonStyle = accessoryButtonStyle
+        super.init { [style, accessoryButtonStyle] token, theme in
+            switch token {
+            case .backgroundColorPlain:
+                return .uiColor { theme.color(.background1) }
+
+            case .backgroundColorGrouped:
+                return .uiColor { theme.color(.backgroundCanvas) }
+
+            case .textColor:
+                return .uiColor {
+                    switch style() {
+                    case .headerPrimary:
+                        return theme.color(.foreground1)
+                    case .header, .footer:
+                        return theme.color(.foreground2)
+                    }
+                }
+
+            case .textFont:
+                return .uiFont {
+                    switch style() {
+                    case .headerPrimary:
+                        return theme.typography(.body1Strong)
+                    case .header, .footer:
+                        return theme.typography(.caption1)
+                    }
+                }
+
+            case .accessoryButtonTextColor:
+                return .uiColor {
+                    switch accessoryButtonStyle() {
+                    case .primary:
+                        return theme.color(.brandForeground1)
+                    case .regular:
+                        return theme.color(.foreground2)
+                    }
+                }
+
+            case .accessoryButtonTextFont:
+                return .uiFont { theme.typography(.caption1Strong) }
+            }
+        }
+    }
+
+    /// Defines the style of the `PillButton`.
+    var style: () -> TableViewHeaderFooterView.Style
+
+    /// Defines the style of the accessory button.
+    var accessoryButtonStyle: () -> TableViewHeaderFooterView.AccessoryButtonStyle
+}
+
+// MARK: Constants
+
+extension TableViewHeaderFooterViewTokenSet {
+    ///The horizontal margin of the HeaderFooter view.
+    static let horizontalMargin: CGFloat = GlobalTokens.spacing(.size160)
+
+    ///The default top margin for the title.
+    static let titleDefaultTopMargin: CGFloat = GlobalTokens.spacing(.size240)
+
+    /// The default bottom margin for the title.
+    static let titleDefaultBottomMargin: CGFloat = GlobalTokens.spacing(.size80)
+
+    /// The vertical divider margin for the title
+    static let titleDividerVerticalMargin: CGFloat = 3
+
+    /// The bottom margin for the accessory view.
+    static let accessoryViewBottomMargin: CGFloat = GlobalTokens.spacing(.size20)
+
+    /// The leading margin for the accessory view.
+    static let accessoryViewMarginLeading: CGFloat = GlobalTokens.spacing(.size80)
+}
+
+public extension TableViewHeaderFooterView {
+    /// The style of the accessory button in the TableView HeaderFooterView.
+    @objc(MSFTableViewHeaderFooterViewAccessoryButtonStyle)
+    enum AccessoryButtonStyle: Int {
+        case primary
+        case regular
+    }
+
+    /// Defines the visual style of the view
+    @objc(MSFTableViewHeaderFooterViewStyle)
+    enum Style: Int {
+        case headerPrimary
+        case header
+        case footer
+    }
+
+}

--- a/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
@@ -23,6 +23,9 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
 
         /// The font of the accessory button text.
         case accessoryButtonTextFont
+
+        /// The color of the link text in the TableViewHeaderFooterViewTitleView.
+        case linkTextColor
     }
 
     init(style: @escaping () -> TableViewHeaderFooterView.Style,
@@ -69,6 +72,9 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
 
             case .accessoryButtonTextFont:
                 return .uiFont { theme.typography(.caption1Strong) }
+
+            case .linkTextColor:
+                return .uiColor { theme.color(.brandForeground1) }
             }
         }
     }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
@@ -73,7 +73,7 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
         }
     }
 
-    /// Defines the style of the `PillButton`.
+    /// Defines the style of the `TableViewHeaderFooterView`.
     var style: () -> TableViewHeaderFooterView.Style
 
     /// Defines the style of the accessory button.
@@ -110,7 +110,7 @@ public extension TableViewHeaderFooterView {
         case regular
     }
 
-    /// Defines the visual style of the view
+    /// Defines the visual style of the HeaderFooterView.
     @objc(MSFTableViewHeaderFooterViewStyle)
     enum Style: Int {
         case headerPrimary

--- a/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
@@ -117,5 +117,4 @@ public extension TableViewHeaderFooterView {
         case header
         case footer
     }
-
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- TableViewHeaderFooterViewTokenSet.swift: New file defining tokens for TableViewHeaderFooterView
- TableViewHeaderFooterView.swift: Integrated new tokens
- TableViewHeaderFooterViewDemoController.swift: Using new demo controller + added token overrides

### Binary change

Total increase: 147,752 bytes
Total decrease: -76,224 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,613,600 bytes | 29,685,128 bytes | 🛑 71,528 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterViewTokenSet.o | 0 bytes | 79,456 bytes | 🛑 79,456 bytes |
| FocusRingView.o | 721,176 bytes | 762,088 bytes | ⚠️ 40,912 bytes |
| BadgeView.o | 486,008 bytes | 498,936 bytes | ⚠️ 12,928 bytes |
| __.SYMDEF | 4,487,088 bytes | 4,499,600 bytes | ⚠️ 12,512 bytes |
| FluentTheme.o | 155,312 bytes | 157,080 bytes | ⚠️ 1,768 bytes |
| TextFieldTokenSet.o | 89,480 bytes | 89,656 bytes | ⚠️ 176 bytes |
| PopupMenuSectionHeaderView.o | 28,048 bytes | 28,040 bytes | 🎉 -8 bytes |
| FluentUIFramework.o | 98,680 bytes | 89,768 bytes | 🎉 -8,912 bytes |
| BottomCommandingController.o | 693,152 bytes | 678,920 bytes | 🎉 -14,232 bytes |
| PopupMenuController.o | 403,824 bytes | 384,536 bytes | 🎉 -19,288 bytes |
| TableViewHeaderFooterView.o | 304,176 bytes | 270,392 bytes | 🎉 -33,784 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://user-images.githubusercontent.com/22566866/235069550-69c47f34-ee4b-4279-9491-2e421accc8f1.png) | ![image](https://user-images.githubusercontent.com/22566866/235068242-f06d25e1-6302-4c21-8e29-2a48b0e6a6a0.png) |
| ![image](https://user-images.githubusercontent.com/22566866/235069593-c3dd7e40-970f-4f84-8394-ed0137e3bb60.png) | ![image](https://user-images.githubusercontent.com/22566866/235068281-063ce2bc-942c-4525-9cf3-82588d5ed85c.png) |
| ![image](https://user-images.githubusercontent.com/22566866/235069660-4ec45790-24c9-4222-bb6c-1c1c055ad38b.png) | ![image](https://user-images.githubusercontent.com/22566866/235068306-41ba6ae0-6f16-4b32-9ae1-cb04425d8de4.png) |
| ![image](https://user-images.githubusercontent.com/22566866/235069997-075cfa5e-7101-43a7-9aaf-9e0f9fa6029d.png) | ![image](https://user-images.githubusercontent.com/22566866/235070231-0feca502-cfee-494f-b65d-7494011b8a7d.png) |
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-04-27 at 23 19 51](https://user-images.githubusercontent.com/22566866/235069863-5d70577d-a373-4a22-af2c-ca296472ad35.gif) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-04-27 at 23 13 29](https://user-images.githubusercontent.com/22566866/235068763-7266c1b6-3f14-4359-8284-b4820c41145d.gif) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1719)