### PR TITLE
Fix ShyHeaderController regression

### DIFF
--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -124,6 +124,11 @@ class ShyHeaderController: UIViewController {
         updateNavigationBarStyle()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateNavigationBarStyle()
+    }
+
     // MARK: - Base Construction
 
     /// Constructs the UI for the gesture-based configuration

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -124,6 +124,7 @@ class ShyHeaderController: UIViewController {
         updateNavigationBarStyle()
     }
 
+    // This is needed as a safety measure to ensure the colors are updated with the correct theme
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateNavigationBarStyle()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a bug in partner apps where the view of the `ShyHeaderController` gets comm blue colors. 
This is caused by the parent view not registering the custom theme in `viewWillAppear`. Since this only happens after backing out of a file, I added back the color update in `viewDidAppear` as a safety measure in case the update in `viewWillAppear` is too early and returns the shared theme. 

### Binary change

Total increase: 1,960 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,156,968 bytes | 30,158,928 bytes | ⚠️ 1,960 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ShyHeaderController.o | 252,984 bytes | 254,504 bytes | ⚠️ 1,520 bytes |
| __.SYMDEF | 4,723,104 bytes | 4,723,544 bytes | ⚠️ 440 bytes |
</details>

### Verification

The bug was not reproducible on our demo app but it's been verified and fixed on all partner apps.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1722)