### PR TITLE
Update TVC's checkmark to use theme color

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -43,7 +43,7 @@ public enum TableViewCellAccessoryType: Int {
         case .detailButton:
             return tokenSet[.accessoryDetailButtonColor].uiColor
         case .checkmark:
-            return fluentTheme.color(.brandForeground1)
+            return tokenSet[.accessoryCheckmarkColor].uiColor
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -57,8 +57,11 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         /// The color for the accessoryDisclosureIndicator.
         case accessoryDisclosureIndicatorColor
 
-        /// The color for the accessoryDetailButtonColor.
+        /// The color for the accessoryDetailButton.
         case accessoryDetailButtonColor
+
+        /// The color for the accessoryCheckmark.
+        case accessoryCheckmarkColor
 
         /// The main brand text color..
         case brandTextColor
@@ -148,6 +151,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
 
             case .accessoryDetailButtonColor:
                 return .uiColor { theme.color(.foreground3) }
+
+            case .accessoryCheckmarkColor:
+                return .uiColor { theme.color(.brandForeground1) }
 
             case .dangerTextColor:
                 return .uiColor { theme.color(.dangerForeground2) }

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -63,7 +63,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         /// The color for the accessoryCheckmark.
         case accessoryCheckmarkColor
 
-        /// The main brand text color..
+        /// The main brand text color.
         case brandTextColor
 
         /// The brand background color for the boolean cell.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated tvc's checkmark to use the correct theme color. Previously, it was pulling the color from `fluentTheme`, which was inaccurate in cases where the theme was different. This change adds a new token `accessoryCheckmarkColor` that pulls the color from `theme`.

### Binary change

Total increase: 3,352 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 46,007,296 bytes | 46,010,648 bytes | ⚠️ 3,352 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewCellTokenSet.o | 251,040 bytes | 253,920 bytes | ⚠️ 2,880 bytes |
| TableViewCell.o | 1,465,744 bytes | 1,466,216 bytes | ⚠️ 472 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-05-01 at 11 39 07](https://user-images.githubusercontent.com/55368679/235482785-aff75bb7-4ebd-49f1-9a39-13e784c5b65e.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-05-01 at 11 49 53](https://user-images.githubusercontent.com/55368679/235482806-4f4fa66e-3828-41d4-b050-db4bdf105696.png) |
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-05-01 at 11 39 07](https://user-images.githubusercontent.com/55368679/235482938-325b8ac9-87bb-4d5b-9b5f-a965327a72bf.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-05-01 at 11 49 53](https://user-images.githubusercontent.com/55368679/235482964-99a99a3c-55b6-4881-b05d-4f0eee82530f.png) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1723)