### PR TITLE
Fix badge color for gradient NavigationBar

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -639,7 +639,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal {
     private func createBarButtonItemButton(with item: UIBarButtonItem, isLeftItem: Bool) -> UIButton {
         let button = BadgeLabelButton(type: .system)
         button.item = item
-        button.shouldUseWindowColorInBadge = style != .system
+        button.shouldUseWindowColorInBadge = style != .system && style != .gradient
 
         // We want to hide the native right bar button items when using the gradient style.
         if style == .gradient {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The right buttons badge colors blend into the background of the gradient style navigation bar. 
To fix this we change the badge to use non brand style colors. 

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_gradient_light](https://user-images.githubusercontent.com/106181067/235799080-badf0332-940e-49cd-a666-b69c80096641.png) | ![after_gradient_light](https://user-images.githubusercontent.com/106181067/235799098-45da2d4a-bc13-4c75-97bb-5080c42ac803.png) |
| ![before_gradient_dark](https://user-images.githubusercontent.com/106181067/235799126-42581df0-140e-4b7c-acf6-5c985a3f24d6.png) | ![after_gradient_dark](https://user-images.githubusercontent.com/106181067/235799140-0e118a43-de76-4216-8d1c-8fe5a7574134.png) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1724)