### PR TITLE
[Fluent Button] Added support for Increase Contrast Accessibility

### DIFF
--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -113,6 +113,12 @@ open class Button: NSButton {
 		if size == defaultFormat.size {
 			setSizeParameters(forSize: size)
 		}
+
+		NSWorkspace.shared.notificationCenter.addObserver(forName: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+														  object: nil,
+														  queue: nil) {[weak self] _ in
+			self?.increaseContrastEnabled = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast
+		}
 	}
 
 	open override class var cellClass: AnyClass? {
@@ -352,6 +358,14 @@ open class Button: NSButton {
 	}
 
 	private func setColorValues(forStyle: ButtonStyle, accentColor: NSColor) {
+		if increaseContrastEnabled {
+			// Use "UI Element Colors" System Colors which respond correctly to accessibility
+			// settings like increase contrast
+			borderColorRest = .textColor
+			borderColorPressed = .textColor
+			borderColorDisabled = .textColor
+		}
+
 		switch forStyle {
 		case .primary:
 			contentTintColorRest = isWindowInactive ? .textColor : ButtonColor.neutralInverted
@@ -360,9 +374,11 @@ open class Button: NSButton {
 			backgroundColorRest = isWindowInactive ? ButtonColor.neutralBackground2 : accentColor
 			backgroundColorPressed = accentColor.withSystemEffect(.pressed)
 			backgroundColorDisabled = ButtonColor.brandBackgroundDisabled
-			borderColorRest = isWindowInactive ? ButtonColor.neutralStroke2 : .clear
-			borderColorPressed = .clear
-			borderColorDisabled = .clear
+			if !increaseContrastEnabled {
+				borderColorRest = isWindowInactive ? ButtonColor.neutralStroke2 : .clear
+				borderColorPressed = .clear
+				borderColorDisabled = .clear
+			}
 		case .secondary:
 			contentTintColorRest = .textColor
 			contentTintColorPressed = ButtonColor.neutralInverted?.withSystemEffect(.pressed)
@@ -370,9 +386,11 @@ open class Button: NSButton {
 			backgroundColorRest = ButtonColor.neutralBackground2
 			backgroundColorPressed = accentColor.withSystemEffect(.pressed)
 			backgroundColorDisabled = ButtonColor.neutralBackground2?.withSystemEffect(.disabled)
-			borderColorRest = ButtonColor.neutralStroke2
-			borderColorPressed = .clear
-			borderColorDisabled = ButtonColor.neutralStroke2?.withSystemEffect(.disabled)
+			if !increaseContrastEnabled {
+				borderColorRest = ButtonColor.neutralStroke2
+				borderColorPressed = .clear
+				borderColorDisabled = ButtonColor.neutralStroke2?.withSystemEffect(.disabled)
+			}
 		case .acrylic:
 			contentTintColorRest = ButtonColor.neutralForeground3
 			contentTintColorPressed = ButtonColor.neutralForeground3?.withSystemEffect(.pressed)
@@ -380,9 +398,11 @@ open class Button: NSButton {
 			backgroundColorRest = ButtonColor.neutralBackground3
 			backgroundColorPressed = ButtonColor.neutralBackground3?.withSystemEffect(.pressed)
 			backgroundColorDisabled = ButtonColor.neutralBackground3?.withSystemEffect(.disabled)
-			borderColorRest = .clear
-			borderColorPressed = .clear
-			borderColorDisabled = .clear
+			if !increaseContrastEnabled {
+				borderColorRest = .clear
+				borderColorPressed = .clear
+				borderColorDisabled = .clear
+			}
 		case .borderless:
 			contentTintColorRest = isWindowInactive ? .textColor : accentColor
 			contentTintColorPressed = accentColor.withSystemEffect(.deepPressed)
@@ -390,9 +410,11 @@ open class Button: NSButton {
 			backgroundColorRest = .clear
 			backgroundColorPressed = .clear
 			backgroundColorDisabled = .clear
-			borderColorRest = .clear
-			borderColorPressed = .clear
-			borderColorDisabled = .clear
+			if !increaseContrastEnabled {
+				borderColorRest = .clear
+				borderColorPressed = .clear
+				borderColorDisabled = .clear
+			}
 		}
 		updateContentTintColor()
 	}
@@ -479,6 +501,18 @@ open class Button: NSButton {
 				return
 			}
 			// Re-compute the Button's color values for the latest Window State, and re-render it
+			setColorValues(forStyle: style, accentColor: accentColor)
+			needsDisplay = true
+		}
+	}
+	
+	/// Indicates if the `Increase Contrast` Accessibility Setting is enabled
+	private var increaseContrastEnabled: Bool = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast {
+		didSet {
+			guard oldValue != increaseContrastEnabled else {
+				return
+			}
+			// Re-compute the Button's color values for the latest Contrast State, and re-render it
 			setColorValues(forStyle: style, accentColor: accentColor)
 			needsDisplay = true
 		}

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -498,7 +498,7 @@ open class Button: NSButton {
 			needsDisplay = true
 		}
 	}
-	
+
 	/// Indicates if the `Increase Contrast` Accessibility Setting is enabled
 	private var increaseContrastEnabled: Bool = NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast {
 		didSet {

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -358,13 +358,10 @@ open class Button: NSButton {
 	}
 
 	private func setColorValues(forStyle: ButtonStyle, accentColor: NSColor) {
-		if increaseContrastEnabled {
-			// Use "UI Element Colors" System Colors which respond correctly to accessibility
-			// settings like increase contrast
-			borderColorRest = .textColor
-			borderColorPressed = .textColor
-			borderColorDisabled = .textColor
-		}
+
+		// Use System Colors which respond correctly to accessibility settings like increase contrast
+		// https://developer.apple.com/documentation/appkit/nscolor/ui_element_colors
+		let increaseContrastBorderColor: NSColor = .textColor
 
 		switch forStyle {
 		case .primary:
@@ -374,11 +371,13 @@ open class Button: NSButton {
 			backgroundColorRest = isWindowInactive ? ButtonColor.neutralBackground2 : accentColor
 			backgroundColorPressed = accentColor.withSystemEffect(.pressed)
 			backgroundColorDisabled = ButtonColor.brandBackgroundDisabled
-			if !increaseContrastEnabled {
+			if increaseContrastEnabled {
+				borderColorRest = increaseContrastBorderColor
+			} else {
 				borderColorRest = isWindowInactive ? ButtonColor.neutralStroke2 : .clear
-				borderColorPressed = .clear
-				borderColorDisabled = .clear
 			}
+			borderColorPressed = increaseContrastEnabled ? increaseContrastBorderColor : .clear
+			borderColorDisabled = increaseContrastEnabled ? increaseContrastBorderColor : .clear
 		case .secondary:
 			contentTintColorRest = .textColor
 			contentTintColorPressed = ButtonColor.neutralInverted?.withSystemEffect(.pressed)
@@ -386,11 +385,9 @@ open class Button: NSButton {
 			backgroundColorRest = ButtonColor.neutralBackground2
 			backgroundColorPressed = accentColor.withSystemEffect(.pressed)
 			backgroundColorDisabled = ButtonColor.neutralBackground2?.withSystemEffect(.disabled)
-			if !increaseContrastEnabled {
-				borderColorRest = ButtonColor.neutralStroke2
-				borderColorPressed = .clear
-				borderColorDisabled = ButtonColor.neutralStroke2?.withSystemEffect(.disabled)
-			}
+			borderColorRest = increaseContrastEnabled ? increaseContrastBorderColor : ButtonColor.neutralStroke2
+			borderColorPressed = increaseContrastEnabled ? increaseContrastBorderColor : .clear
+			borderColorDisabled = increaseContrastEnabled ? increaseContrastBorderColor : ButtonColor.neutralStroke2?.withSystemEffect(.disabled)
 		case .acrylic:
 			contentTintColorRest = ButtonColor.neutralForeground3
 			contentTintColorPressed = ButtonColor.neutralForeground3?.withSystemEffect(.pressed)
@@ -398,11 +395,9 @@ open class Button: NSButton {
 			backgroundColorRest = ButtonColor.neutralBackground3
 			backgroundColorPressed = ButtonColor.neutralBackground3?.withSystemEffect(.pressed)
 			backgroundColorDisabled = ButtonColor.neutralBackground3?.withSystemEffect(.disabled)
-			if !increaseContrastEnabled {
-				borderColorRest = .clear
-				borderColorPressed = .clear
-				borderColorDisabled = .clear
-			}
+			borderColorRest = increaseContrastEnabled ? increaseContrastBorderColor : .clear
+			borderColorPressed = increaseContrastEnabled ? increaseContrastBorderColor : .clear
+			borderColorDisabled = increaseContrastEnabled ? increaseContrastBorderColor : .clear
 		case .borderless:
 			contentTintColorRest = isWindowInactive ? .textColor : accentColor
 			contentTintColorPressed = accentColor.withSystemEffect(.deepPressed)
@@ -410,11 +405,9 @@ open class Button: NSButton {
 			backgroundColorRest = .clear
 			backgroundColorPressed = .clear
 			backgroundColorDisabled = .clear
-			if !increaseContrastEnabled {
-				borderColorRest = .clear
-				borderColorPressed = .clear
-				borderColorDisabled = .clear
-			}
+			borderColorRest = increaseContrastEnabled ? increaseContrastBorderColor : .clear
+			borderColorPressed = increaseContrastEnabled ? increaseContrastBorderColor : .clear
+			borderColorDisabled = increaseContrastEnabled ? increaseContrastBorderColor : .clear
 		}
 		updateContentTintColor()
 	}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

**PROBLEM**
Fluent Button's don't support "Increase Contrast" Accessibility Setting. A default NSButton already subscribes to the HighContrast requirements but the Fluent Button which subclasses NSButton, doesn't have it.

**FIX**
- Determined that the Native NSButton's drawing code could not be leveraged for this setting. Only way to get this for free is to directly call any of NSButton's convenience initializers but because Fluent Button already has a designated init this wasn't possible - A super class's convenience init cannot be called from a subclassed designated init. Only other way to do this is to implement it ourselves..
- AppKit conveniently provides a `accessibilityDisplayShouldIncreaseContrast` property indicating if the HighContrast is enabled or not. This coupled with a Notification update API posted everytime this setting changes viz. [accessibilityDisplayOptionsDidChangeNotification](https://developer.apple.com/documentation/appkit/nsworkspace/1534227-accessibilitydisplayoptionsdidch) provides a straightforward solution to hook into the Fluent Button API
- chose to use the native OS ".textColor" NSColor for the Button border since this closely matches the button borders in native NSButton with Increase Contrast Enabled. Also this color responds correctly to Light/Dark modes as well as accessibility settings like Invert Colors and Increase Contrast.

**PRODUCT IMPACT**
Only impacts when "Increase Contrast" is enabled, where all the Fluent Buttons have darker borders.

**VERIFICATION**
[x] Light/Dark Mode
[x] Button's rest, pressed and disabled states
[x] Booting the test app when "increase contrast" is already enabled / Toggling increase contrast when test app is already booted
[x] All Button Style Formats and sizes - viz. the test app Button Pane
 
<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot 2023-05-02 at 16 00 27](https://user-images.githubusercontent.com/25355516/235808241-b44b5947-110d-4673-9419-36e1dd8ba2d9.png) | ![Screenshot 2023-05-02 at 16 01 01](https://user-images.githubusercontent.com/25355516/235808274-986540ab-d77b-449b-a761-4fd2774a321d.png) |

| After (Inactive State)                                       | After (Dark Mode)                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot 2023-05-02 at 16 00 53](https://user-images.githubusercontent.com/25355516/235808431-6d1706a4-cea4-4a19-a499-8fc28aba978f.png) | ![Screenshot 2023-05-02 at 16 01 16](https://user-images.githubusercontent.com/25355516/235808453-88845dc1-40b5-463f-bf98-3565fc3fcd38.png) |

</details>
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1725)