### PR TITLE
Use a minimum 44px height navigation bar everywhere

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -30,6 +30,7 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Leading with TwoLineTitleView")
         container.addArrangedSubview(createButton(title: "Show with fixed search bar and subtitle", action: #selector(showLeadingTitleWithFixedAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar and subtitle", action: #selector(showLeadingTitleWithSystemStyleShyAccessoryAndSubtitle)))
+        container.addArrangedSubview(createButton(title: "Show with custom leading button", action: #selector(showLeadingTitleWithSubtitleAndCustomLeadingButton)))
 
         addTitle(text: "Centered Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showSystemTitleWithShyAccessory)))
@@ -38,6 +39,7 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show \"system\" with fixed search bar and subtitle", action: #selector(showSystemTitleWithFixedAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show \"system\"", action: #selector(showSystemTitle)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with subtitle", action: #selector(showRegularTitleWithSubtitle)))
+        container.addArrangedSubview(createButton(title: "Show \"primary\" with custom leading button", action: #selector(showRegularTitleWithSubtitleAndCustomLeadingButton)))
 
         addTitle(text: "Size Customization")
         container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: #selector(showLargeTitleWithCustomizedElementSizes)))
@@ -92,6 +94,10 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .leading, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
 
+    @objc func showLeadingTitleWithSubtitleAndCustomLeadingButton() {
+        presentController(withTitleStyle: .leading, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true, leadingItem: .customButton)
+    }
+
     @objc func showSystemTitleWithShyAccessory() {
         presentController(withTitleStyle: .system, style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true)
     }
@@ -114,6 +120,10 @@ class NavigationControllerDemoController: DemoController {
 
     @objc func showRegularTitleWithSubtitle() {
         presentController(withTitleStyle: .system, subtitle: "Subtitle goes here")
+    }
+
+    @objc func showRegularTitleWithSubtitleAndCustomLeadingButton() {
+        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: true, leadingItem: .customButton)
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -33,12 +33,12 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with custom leading button", action: #selector(showLeadingTitleWithSubtitleAndCustomLeadingButton)))
 
         addTitle(text: "Centered Title")
+        container.addArrangedSubview(createButton(title: "Show \"system\"", action: #selector(showSystemTitle)))
+        container.addArrangedSubview(createButton(title: "Show \"primary\" with subtitle", action: #selector(showRegularTitleWithSubtitle)))
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showSystemTitleWithShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with collapsible search bar and subtitle", action: #selector(showRegularTitleWithShyAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: #selector(showRegularTitleWithFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show \"system\" with fixed search bar and subtitle", action: #selector(showSystemTitleWithFixedAccessoryAndSubtitle)))
-        container.addArrangedSubview(createButton(title: "Show \"system\"", action: #selector(showSystemTitle)))
-        container.addArrangedSubview(createButton(title: "Show \"primary\" with subtitle", action: #selector(showRegularTitleWithSubtitle)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with custom leading button", action: #selector(showRegularTitleWithSubtitleAndCustomLeadingButton)))
 
         addTitle(text: "Size Customization")

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -313,9 +313,10 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         4: TitleViewFeature(name: "Large title") {
             $0.navigationItem.titleStyle = .largeLeading
         },
-        5: TitleViewFeature(name: "Leading-aligned, two titles") {
+        5: TitleViewFeature(name: "Leading-aligned, two titles, collapsible") {
             $0.navigationItem.titleStyle = .leading
             $0.navigationItem.subtitle = "Subtitle"
+            $0.navigationItem.contentScrollView = $0.tableView
         },
         6: TitleViewFeature(name: "Two titles with subtitle disclosure") {
             $0.navigationItem.subtitle = "Press me!"

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -31,11 +31,13 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with fixed search bar and subtitle", action: #selector(showLeadingTitleWithFixedAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar and subtitle", action: #selector(showLeadingTitleWithSystemStyleShyAccessoryAndSubtitle)))
 
-        addTitle(text: "Regular Title")
+        addTitle(text: "Centered Title")
         container.addArrangedSubview(createButton(title: "Show \"system\" with collapsible search bar", action: #selector(showSystemTitleWithShyAccessory)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with collapsible search bar and subtitle", action: #selector(showRegularTitleWithShyAccessoryAndSubtitle)))
         container.addArrangedSubview(createButton(title: "Show \"primary\" with fixed search bar", action: #selector(showRegularTitleWithFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show \"system\" with fixed search bar and subtitle", action: #selector(showSystemTitleWithFixedAccessoryAndSubtitle)))
+        container.addArrangedSubview(createButton(title: "Show \"system\"", action: #selector(showSystemTitle)))
+        container.addArrangedSubview(createButton(title: "Show \"primary\" with subtitle", action: #selector(showRegularTitleWithSubtitle)))
 
         addTitle(text: "Size Customization")
         container.addArrangedSubview(createButton(title: "Show with expanded avatar, contracted title", action: #selector(showLargeTitleWithCustomizedElementSizes)))
@@ -99,11 +101,19 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showRegularTitleWithFixedAccessory() {
-        presentController(withTitleStyle: .system, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .system, accessoryView: createAccessoryView())
     }
 
     @objc func showSystemTitleWithFixedAccessoryAndSubtitle() {
         presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .darkContent), contractNavigationBarOnScroll: false)
+    }
+
+    @objc func showSystemTitle() {
+        presentController(withTitleStyle: .system, style: .system)
+    }
+
+    @objc func showRegularTitleWithSubtitle() {
+        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here")
     }
 
     @objc func showLargeTitleWithCustomizedElementSizes() {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -149,8 +149,11 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     private static var defaultStyle: Style = .primary
 
+    // These two constants are based on OS default values
+    static let systemHeight: CGFloat = 44
+    static let compactSystemHeight: CGFloat = 32
+
     private struct Constants {
-        static let systemHeight: CGFloat = 44
         static let normalContentHeight: CGFloat = 44
         static let expandedContentHeight: CGFloat = 48
 
@@ -478,7 +481,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,
             leading: contentLeadingMargin,
-            bottom: -(contentHeight - Constants.systemHeight),
+            bottom: -(contentHeight - Self.systemHeight),
             trailing: contentTrailingMargin
         )
     }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -882,7 +882,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private func needsShadow(for navigationItem: UINavigationItem?) -> Bool {
         switch navigationItem?.navigationBarShadow ?? .automatic {
         case .automatic:
-            return !usesLeadingTitle && style == .system && navigationItem?.accessoryView == nil
+            return !usesLeadingTitle && style == .system && !systemWantsCompactNavigationBar && navigationItem?.accessoryView == nil
         case .alwaysHidden:
             return false
         }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -478,10 +478,12 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     private func updateContentStackViewMargins(forExpandedContent contentIsExpanded: Bool) {
         let contentHeight = contentIsExpanded ? Constants.expandedContentHeight : Constants.normalContentHeight
+        let systemHeight = (traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .compact) ? Self.compactSystemHeight : Self.systemHeight
+
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,
             leading: contentLeadingMargin,
-            bottom: -(contentHeight - Self.systemHeight),
+            bottom: systemHeight - contentHeight,
             trailing: contentTrailingMargin
         )
     }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -166,7 +166,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         static let revealingAnimationDuration: TimeInterval = 0.25
     }
 
-    var systemWantsCompactNavigationBar: Bool {
+    private var systemWantsCompactNavigationBar: Bool {
         return traitCollection.horizontalSizeClass == .compact && traitCollection.verticalSizeClass == .compact
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -847,7 +847,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     }
 
     private func updateSubtitleView(for navigationItem: UINavigationItem?) {
-        guard let navigationItem = navigationItem else {
+        guard let navigationItem = navigationItem, !usesLeadingTitle else {
             // Use the default title view
             navigationItem?.titleView = nil
             return

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -128,13 +128,7 @@ open class NavigationController: UINavigationController {
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
-        if viewController is ShyHeaderController {
-            return false
-        }
-        if viewController.navigationItem.titleStyle.usesLeadingAlignment || viewController.navigationItem.accessoryView != nil {
-            return true
-        }
-        return false
+        return !(viewController is ShyHeaderController)
     }
 
     func updateNavigationBar(for viewController: UIViewController) {
@@ -143,6 +137,11 @@ open class NavigationController: UINavigationController {
         setNeedsStatusBarAppearanceUpdate()
         if let backgroundColor = msfNavigationBar.backgroundView.backgroundColor {
             transitionAnimator.tintColor = backgroundColor
+        }
+        // ShyHeaderController sets its padding before the navigation item loads in,
+        // so tell it to reload its padding if necessary
+        if viewController.navigationItem.titleStyle == .system {
+            (topViewController as? ShyHeaderController)?.updatePadding()
         }
     }
 

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -139,10 +139,8 @@ open class NavigationController: UINavigationController {
             transitionAnimator.tintColor = backgroundColor
         }
         // ShyHeaderController sets its padding before the navigation item loads in,
-        // so tell it to reload its padding if necessary
-        if viewController.navigationItem.titleStyle == .system {
-            (topViewController as? ShyHeaderController)?.updatePadding()
-        }
+        // so we need to recalculate its padding now
+        (topViewController as? ShyHeaderController)?.updatePadding()
     }
 
     private func updateNavigationBarVisibility(for viewController: UIViewController, animated: Bool) {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -142,7 +142,7 @@ class ShyHeaderController: UIViewController {
         paddingHeightConstraint = paddingHeight
 
         let paddingLeading = paddingView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        paddingHeight.identifier = "paddingView_leading"
+        paddingLeading.identifier = "paddingView_leading"
         constraints.append(paddingLeading)
 
         let paddingTrailing = paddingView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -150,7 +150,7 @@ class ShyHeaderController: UIViewController {
         constraints.append(paddingTrailing)
 
         let paddingTop = paddingView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
-        paddingTop.identifier = "shyView_top"
+        paddingTop.identifier = "paddingView_top"
         constraints.append(paddingTop)
 
         // ShyHeaderView

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -275,7 +275,7 @@ class ShyHeaderController: UIViewController {
         }
     }
 
-    private func updatePadding() {
+    func updatePadding() {
         shyHeaderView.lockedInContractedState = msfNavigationController?.msfNavigationBar.barHeight == .contracted
         paddingHeightConstraint?.constant = paddingIsStatic ? paddingViewHeight : 0
         shyViewHeightConstraint?.constant = shyHeaderView.maxHeight

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -146,6 +146,10 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         if traitCollection.verticalSizeClass == .compact {
             return traitCollection.horizontalSizeClass == .compact ? Constants.maxHeightNoAccessoryCompact : Constants.maxHeightNoAccessoryCompactForLargePhone
         }
+        if traitCollection.horizontalSizeClass == .compact && parentController?.msfNavigationController?.msfNavigationBar.usesLeadingTitle == false {
+            // This is a portrait phone with a system-style title, the navigation bar is already 44px tall
+            return 0
+        }
         return lockedInContractedState ? 0.0 : Constants.maxHeightNoAccessory
     }
     var maxHeightChanged: (() -> Void)?

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -62,9 +62,9 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         static let contentBottomPadding: CGFloat = 10
         static let contentBottomPaddingCompact: CGFloat = 6
         static let accessoryHeight: CGFloat = 36
-        static let maxHeightNoAccessory: CGFloat = 56 - 44  // navigation bar - design: 56, system: 44
-        static let maxHeightNoAccessoryCompact: CGFloat = 44 - 32   // navigation bar - design: 44, system: 32
-        static let maxHeightNoAccessoryCompactForLargePhone: CGFloat = 44 - 44   // navigation bar - design: 44, system: 44
+        static let maxHeightNoAccessory: CGFloat = 56 - NavigationBar.systemHeight  // navigation bar - design: 56, system: 44
+        static let maxHeightNoAccessoryCompact: CGFloat = 44 - NavigationBar.compactSystemHeight   // navigation bar - design: 44, system: 32
+        static let maxHeightNoAccessoryCompactForLargePhone: CGFloat = 44 - NavigationBar.systemHeight   // navigation bar - design: 44, system: 44
     }
 
     convenience init() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

By default, "small" phones in landscape mode will show a compact navigation bar that's only 32px tall instead of the usual 44px. For the sake of consistency between different kinds of title views and not having a two-line title view look so cramped, we still want to use that 44px tall bar in this case.

### Verification

Most testing involved navigating between screens and constantly rotating the device. Testing was done on simulators for the iPhone 14 Pro ("small") and the iPhone 14 Pro Max ("large").

<details>
<summary>Visual Verification</summary>

Screenshots are taken from an iPhone 14 Pro (which is considered a "small" phone).

| Before | After |
|-|-|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 16 33 56](https://user-images.githubusercontent.com/717674/236073479-364c1c53-236e-44a0-8980-767ee8d13be9.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 16 32 37](https://user-images.githubusercontent.com/717674/236073489-2af9b63b-aa3e-4fec-af7c-1d45b12de629.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 16 34 00](https://user-images.githubusercontent.com/717674/236073516-a8b599e5-e40d-4227-949c-b09e6179831d.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 16 32 45](https://user-images.githubusercontent.com/717674/236073527-af43251f-77f1-443a-bea0-51a9a409932d.png) |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 16 34 04](https://user-images.githubusercontent.com/717674/236073545-98375533-15b1-4f22-808f-731799778ff7.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-03 at 16 32 51](https://user-images.githubusercontent.com/717674/236073556-6e1fe76c-ae31-4256-8683-307e1537a6e8.png) |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1727)