### PR TITLE
Fix disclosure arrow bug

### DIFF
--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -361,16 +361,18 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     private func setupButton(_ button: UIButton, label: UILabel, trailingImageView: UIImageView, text: String?, interactive: Bool, accessoryType: AccessoryType) {
         button.isUserInteractionEnabled = interactive
         button.accessibilityLabel = text
+        label.text = text
+
         if interactive {
             button.accessibilityTraits.insert(.button)
             button.accessibilityTraits.remove(.staticText)
+            trailingImageView.image = accessoryType.image
         } else {
             button.accessibilityTraits.insert(.staticText)
             button.accessibilityTraits.remove(.button)
+            trailingImageView.image = nil
         }
 
-        label.text = text
-        trailingImageView.image = interactive ? accessoryType.image : nil
         trailingImageView.isHidden = trailingImageView.image == nil
     }
 

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -370,7 +370,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         }
 
         label.text = text
-        trailingImageView.image = accessoryType.image
+        trailingImageView.image = interactive ? accessoryType.image : nil
         trailingImageView.isHidden = trailingImageView.image == nil
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

How to repro this issue:
1. Open a navigation controller from the test page.
2. Open child 6.
3. Back out.
4. Open child 11.

The screenshots speak for themselves.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 11 58 00](https://user-images.githubusercontent.com/717674/236302431-31ff37b9-013c-4b3b-bd81-95648fbac5b9.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 11 57 32](https://user-images.githubusercontent.com/717674/236302388-5ffe45fd-9811-4604-8472-09ab1670b803.png) |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1728)