### PR TITLE
Add accessible stroke to BadgeView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -18,7 +18,7 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Danger badge", style: .danger)
         addBadgeSection(title: "Warning badge", style: .warning)
         addBadgeSection(title: "Neutral badge", style: .neutral)
-        addBadgeSection(title: "Severe Warning badge", style: .severeWarning)
+        addBadgeSection(title: "Severe Warning badge", style: .severe)
         addBadgeSection(title: "Success badge", style: .success)
         addBadgeSection(title: "Disabled badge Default", style: .default, isEnabled: false)
         addBadgeSection(title: "Disabled badge Neutral", style: .neutral, isEnabled: false)
@@ -26,6 +26,7 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Custom disabled badge", style: .default, isEnabled: false, overrideColor: true)
 
         addCustomBadgeSections()
+        addAccessibleBadges()
     }
 
     func createBadge(
@@ -121,6 +122,16 @@ class BadgeViewDemoController: DemoController {
         }
         container.addArrangedSubview(UIView())
     }
+
+    func addAccessibleBadges() {
+        addTitle(text: "Accessible Badges")
+        for style in BadgeView.Style.allCases {
+            let badge = createBadge(text: "Kat Larsson", style: style, sizeCategory: .medium, isEnabled: true)
+            badge.showAccessibleStroke = true
+            addRow(text: style.description, items: [badge])
+        }
+        container.addArrangedSubview(UIView())
+    }
 }
 
 extension BadgeViewDemoController: BadgeViewDelegate {
@@ -208,6 +219,25 @@ extension BadgeView.SizeCategory {
             return "Small"
         case .medium:
             return "Medium"
+        }
+    }
+}
+
+extension BadgeView.Style {
+    var description: String {
+        switch self {
+        case .default:
+            return "Brand"
+        case .danger:
+            return "Danger"
+        case .severe:
+            return "Severe"
+        case .warning:
+            return "Warning"
+        case .success:
+            return "Success"
+        case .neutral:
+            return "Neutral"
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift
@@ -18,7 +18,7 @@ class BadgeViewDemoController: DemoController {
         addBadgeSection(title: "Danger badge", style: .danger)
         addBadgeSection(title: "Warning badge", style: .warning)
         addBadgeSection(title: "Neutral badge", style: .neutral)
-        addBadgeSection(title: "Severe Warning badge", style: .severe)
+        addBadgeSection(title: "Severe badge", style: .severe)
         addBadgeSection(title: "Success badge", style: .success)
         addBadgeSection(title: "Disabled badge Default", style: .default, isEnabled: false)
         addBadgeSection(title: "Disabled badge Neutral", style: .neutral, isEnabled: false)

--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -652,6 +652,7 @@ open class BadgeField: UIView {
         } else {
             badge = BadgeView(dataSource: dataSource)
         }
+        badge.showAccessibleStroke = true
 
         return badge
     }
@@ -664,6 +665,7 @@ open class BadgeField: UIView {
         } else {
             moreBadge = BadgeView(dataSource: BadgeViewDataSource(text: "+\(dataSources.count)", style: .default))
         }
+        moreBadge.showAccessibleStroke = true
 
         return moreBadge
     }

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -115,6 +115,10 @@ open class BadgeView: UIView, TokenizedControlInternal {
         }
     }
 
+    /**
+     When set to true, the unselected Badge will have a stroke with a 3:1 contrast ratio against the background color.
+     This may be necessary for accessibility requirements with interactive Badges.
+     */
     open var showAccessibleStroke: Bool = false {
         didSet {
             updateStrokeColor()

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -115,6 +115,12 @@ open class BadgeView: UIView, TokenizedControlInternal {
         }
     }
 
+    open var showAccessibleStroke: Bool = false {
+        didSet {
+            updateStrokeColor()
+        }
+    }
+
     open override var intrinsicContentSize: CGSize {
         return sizeThatFits(CGSize(width: CGFloat.infinity, height: CGFloat.infinity))
     }
@@ -282,6 +288,7 @@ open class BadgeView: UIView, TokenizedControlInternal {
     private func updateColors() {
         updateBackgroundColor()
         updateLabelTextColor()
+        updateStrokeColor()
     }
 
     private func updateBackgroundColor() {
@@ -291,6 +298,15 @@ open class BadgeView: UIView, TokenizedControlInternal {
 
     private func updateLabelTextColor() {
         label.textColor = isActive ? (isSelected ? tokenSet[.foregroundFilledColor].uiColor : tokenSet[.foregroundTintColor].uiColor) : tokenSet[.foregroundDisabledColor].uiColor
+    }
+
+    private func updateStrokeColor() {
+        if showAccessibleStroke && !isSelected {
+            backgroundView.layer.borderColor = tokenSet[.strokeTintColor].uiColor.cgColor
+            backgroundView.layer.borderWidth = tokenSet[.strokeWidth].float
+        } else {
+            backgroundView.layer.borderWidth = 0
+        }
     }
 
     @objc private func badgeTapped() {

--- a/ios/FluentUI/Badge Field/BadgeViewTokenSet.swift
+++ b/ios/FluentUI/Badge Field/BadgeViewTokenSet.swift
@@ -26,6 +26,12 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
         /// The foreground color of the Badge when disabled.
         case foregroundDisabledColor
 
+        /// The stroke tint color of the Badge.
+        case strokeTintColor
+
+        /// The stroke width of the Badge.
+        case strokeWidth
+
         /// The border radius of the Badge.
         case borderRadius
 
@@ -46,7 +52,7 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
                         return theme.color(.brandBackgroundTint)
                     case .danger:
                         return theme.color(.dangerBackground1)
-                    case .severeWarning:
+                    case .severe:
                         return theme.color(.severeBackground1)
                     case .warning:
                         return theme.color(.warningBackground1)
@@ -63,7 +69,7 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
                         return theme.color(.brandBackground1)
                     case .danger:
                         return theme.color(.dangerBackground2)
-                    case .severeWarning:
+                    case .severe:
                         return theme.color(.severeBackground2)
                     case .warning:
                         return theme.color(.warningBackground2)
@@ -78,7 +84,7 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
                     switch style() {
                     case .default:
                         return theme.color(.brandBackground3)
-                    case .danger, .severeWarning, .warning, .success, .neutral:
+                    case .danger, .severe, .warning, .success, .neutral:
                         return theme.color(.background5)
                     }
                 }
@@ -89,7 +95,7 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
                         return theme.color(.brandForegroundTint)
                     case .danger:
                         return theme.color(.dangerForeground1)
-                    case .severeWarning:
+                    case .severe:
                         return theme.color(.severeForeground1)
                     case .warning:
                         return theme.color(.warningForeground1)
@@ -104,7 +110,7 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
                     switch style() {
                     case .default:
                         return theme.color(.foregroundOnColor)
-                    case .danger, .severeWarning, .success:
+                    case .danger, .severe, .success:
                         return theme.color(.foregroundLightStatic)
                     case .warning:
                         return theme.color(.foregroundDarkStatic)
@@ -117,28 +123,47 @@ public class BadgeViewTokenSet: ControlTokenSet<BadgeViewTokenSet.Tokens> {
                     switch style() {
                     case .default:
                         return theme.color(.brandForegroundDisabled1)
-                    case .danger, .severeWarning, .warning, .success, .neutral:
+                    case .danger, .severe, .warning, .success, .neutral:
                         return theme.color(.foregroundDisabled1)
                     }
                 }
+            case .strokeTintColor:
+                return .uiColor {
+                    switch style() {
+                    case .default:
+                        return theme.color(.brandForegroundTint)
+                    case .danger:
+                        return theme.color(.dangerStroke1)
+                    case .severe:
+                        return theme.color(.severeStroke1)
+                    case .warning:
+                        return theme.color(.warningStroke1)
+                    case .success:
+                        return theme.color(.successStroke1)
+                    case .neutral:
+                        return theme.color(.strokeAccessible)
+                    }
+                }
+            case .strokeWidth:
+                return .float { GlobalTokens.stroke(.width10) }
             case .borderRadius:
-                return .float({
+                return .float {
                     switch sizeCategory() {
                     case .small:
                         return GlobalTokens.corner(.radius20)
                     case .medium:
                         return GlobalTokens.corner(.radius40)
                     }
-                })
+                }
             case .labelFont:
-                return .uiFont({
+                return .uiFont {
                     switch sizeCategory() {
                     case .small:
                         return theme.typography(.caption1)
                     case .medium:
                         return theme.typography(.body2)
                     }
-                })
+                }
             }
         }
     }
@@ -169,10 +194,10 @@ extension BadgeViewTokenSet {
 public extension BadgeView {
     /// Pre-defined styles of the Badge.
     @objc(MSFBadgeViewStyle)
-    enum Style: Int {
+    enum Style: Int, CaseIterable {
         case `default`
         case danger
-        case severeWarning
+        case severe
         case warning
         case success
         case neutral

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -431,7 +431,7 @@ extension AliasTokens {
             return DynamicColor(light: GlobalTokens.sharedColors(.yellow, .shade30),
                                 dark: GlobalTokens.sharedColors(.yellow, .tint30))
         case .warningStroke1:
-            return DynamicColor(light: GlobalTokens.sharedColors(.yellow, .shade40),
+            return DynamicColor(light: GlobalTokens.sharedColors(.yellow, .shade30),
                                 dark: GlobalTokens.sharedColors(.yellow, .shade20))
         case .presenceAway:
             return DynamicColor(light: GlobalTokens.sharedColors(.marigold, .primary))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added the ability to show an accessible stroke to `BadgeView`. Setting `showAccessibleStroke` to true will reveal a border with 3:1 contrast ratio against the background color in the rest state. This PR also renames `severeWarning` to `severe` and fixes `warningStroke1` to be `shade30`.

### Binary change

Total increase: 22,416 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 46,019,656 bytes | 46,042,072 bytes | ⚠️ 22,416 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BadgeView.o | 396,768 bytes | 408,640 bytes | ⚠️ 11,872 bytes |
| BadgeViewTokenSet.o | 184,680 bytes | 194,096 bytes | ⚠️ 9,416 bytes |
| __.SYMDEF | 2,864,456 bytes | 2,865,584 bytes | ⚠️ 1,128 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 17 37 24](https://user-images.githubusercontent.com/55368679/236339748-595640ca-776d-4c0f-a9e2-eddd47a2c956.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 17 38 01](https://user-images.githubusercontent.com/55368679/236339770-11ccc1f9-bc35-4856-9372-e31ae035c24e.png) |

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 18 53 51](https://user-images.githubusercontent.com/55368679/236347358-f508c3dc-444f-456c-b409-1a555a005d59.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-04 at 18 53 33](https://user-images.githubusercontent.com/55368679/236347346-ad858ec9-21da-4065-bd1a-410ecc28c0fe.png)
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1729)