### PR TITLE
Changed naming of Border in AvatarGroup demo to Activity Ring

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -169,52 +169,52 @@ class AvatarGroupDemoController: DemoTableViewController {
 
     private enum AvatarGroupDemoSection: CaseIterable {
         case settings
-        case avatarStackNoBorder
-        case avatarStackWithBorder
-        case avatarStackWithMixedBorder
-        case avatarPileNoBorder
-        case avatarPileWithBorder
-        case avatarPileWithMixedBorder
+        case avatarStackNoActivityRing
+        case avatarStackWithActivityRing
+        case avatarStackWithMixedActivityRing
+        case avatarPileNoActivityRing
+        case avatarPileWithActivityRing
+        case avatarPileWithMixedActivityRing
 
         var avatarStyle: MSFAvatarGroupStyle {
             switch self {
-            case .avatarStackNoBorder,
-                 .avatarStackWithBorder,
-                 .avatarStackWithMixedBorder:
+            case .avatarStackNoActivityRing,
+                 .avatarStackWithActivityRing,
+                 .avatarStackWithMixedActivityRing:
                 return .stack
-            case .avatarPileNoBorder,
-                 .avatarPileWithBorder,
-                 .avatarPileWithMixedBorder:
+            case .avatarPileNoActivityRing,
+                 .avatarPileWithActivityRing,
+                 .avatarPileWithMixedActivityRing:
                 return .pile
             case .settings:
                 preconditionFailure("Settings rows should not display an Avatar Group")
             }
         }
 
-        var showBorders: Bool {
+        var showActivityRing: Bool {
             switch self {
-            case .avatarStackNoBorder,
-                 .avatarPileNoBorder:
+            case .avatarStackNoActivityRing,
+                 .avatarPileNoActivityRing:
                 return false
-            case .avatarStackWithBorder,
-                 .avatarStackWithMixedBorder,
-                 .avatarPileWithBorder,
-                 .avatarPileWithMixedBorder:
+            case .avatarStackWithActivityRing,
+                 .avatarStackWithMixedActivityRing,
+                 .avatarPileWithActivityRing,
+                 .avatarPileWithMixedActivityRing:
                 return true
             case .settings:
                 preconditionFailure("Settings rows should not display an Avatar Group")
             }
         }
 
-        var isMixedBorder: Bool {
+        var isMixedActivityRing: Bool {
             switch self {
-            case .avatarPileWithMixedBorder,
-                 .avatarStackWithMixedBorder:
+            case .avatarPileWithMixedActivityRing,
+                 .avatarStackWithMixedActivityRing:
                 return true
-            case .avatarStackWithBorder,
-                 .avatarStackNoBorder,
-                 .avatarPileWithBorder,
-                 .avatarPileNoBorder:
+            case .avatarStackWithActivityRing,
+                 .avatarStackNoActivityRing,
+                 .avatarPileWithActivityRing,
+                 .avatarPileNoActivityRing:
                 return false
             case .settings:
                 preconditionFailure("Settings rows should not display an Avatar Group")
@@ -229,18 +229,18 @@ class AvatarGroupDemoController: DemoTableViewController {
             switch self {
             case .settings:
                 return "Settings"
-            case .avatarStackNoBorder:
-                return "Avatar Stack No Border"
-            case .avatarStackWithBorder:
-                return "Avatar Stack With Border"
-            case .avatarStackWithMixedBorder:
-                return "Avatar Stack With Mixed Border"
-            case .avatarPileNoBorder:
-                return "Avatar Pile No Border"
-            case .avatarPileWithBorder:
-                return "Avatar Pile With Border"
-            case .avatarPileWithMixedBorder:
-                return "Avatar Pile With Mixed Border"
+            case .avatarStackNoActivityRing:
+                return "Avatar Stack No Activity Ring"
+            case .avatarStackWithActivityRing:
+                return "Avatar Stack With Activity Ring"
+            case .avatarStackWithMixedActivityRing:
+                return "Avatar Stack With Mixed Activity Ring"
+            case .avatarPileNoActivityRing:
+                return "Avatar Pile No Activity Ring"
+            case .avatarPileWithActivityRing:
+                return "Avatar Pile With Activity Ring"
+            case .avatarPileWithMixedActivityRing:
+                return "Avatar Pile With Mixed Activity Ring"
             }
         }
 
@@ -252,12 +252,12 @@ class AvatarGroupDemoController: DemoTableViewController {
                         .customRingColor,
                         .maxDisplayedAvatars,
                         .overflow]
-            case .avatarStackNoBorder,
-                 .avatarStackWithBorder,
-                 .avatarStackWithMixedBorder,
-                 .avatarPileNoBorder,
-                 .avatarPileWithBorder,
-                 .avatarPileWithMixedBorder:
+            case .avatarStackNoActivityRing,
+                 .avatarStackWithActivityRing,
+                 .avatarStackWithMixedActivityRing,
+                 .avatarPileNoActivityRing,
+                 .avatarPileWithActivityRing,
+                 .avatarPileWithMixedActivityRing:
                 return [.titleSize72,
                         .groupViewSize72,
                         .titleSize56,
@@ -502,7 +502,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                         for index in 0..<avatarCount {
                             let samplePersona = samplePersonas[index]
                             avatarState!.image = samplePersona.image
-                            avatarState!.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                            avatarState!.isRingVisible = section.isMixedActivityRing ? index % 2 == 0 : section.showActivityRing
                             avatarState!.primaryText = samplePersona.name
                             avatarState!.secondaryText = samplePersona.email
                         }
@@ -581,7 +581,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                     let avatarState = avatarGroup.state.createAvatar()
                     let samplePersona = samplePersonas[index]
                     avatarState.image = samplePersona.image
-                    avatarState.isRingVisible = section.isMixedBorder ? index % 2 == 0 : section.showBorders
+                    avatarState.isRingVisible = section.isMixedActivityRing ? index % 2 == 0 : section.showActivityRing
                     avatarState.primaryText = samplePersona.name
                     avatarState.secondaryText = samplePersona.email
                 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In AvatarGroupDemoController.swift, changed all references to the AvatarGroup "Border" to an "activity ring"

### Binary change

n/a

### Verification

Visually inspected the demo app for each occurrence of the "Border" text and verified it had been changed to "Activity Ring"

<details>
<summary>Visual Verification</summary>

<img width="1462" alt="image" src="https://github.com/microsoft/fluentui-apple/assets/26831152/362b94cd-6bd5-452b-83be-1cf88e4155b0">

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1742)