### PR TITLE
Add accessibilityIdentifier to BottomCommandingController's more button

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -501,7 +501,11 @@ open class BottomCommandingController: UIViewController {
         heroViews.forEach { heroCommandStack.addArrangedSubview($0) }
     }
 
-    private lazy var moreHeroItem: CommandingItem = CommandingItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage(), action: handleMoreCommandTap)
+    private lazy var moreHeroItem: CommandingItem = {
+        let moreItem = CommandingItem(title: Constants.BottomBar.moreButtonTitle, image: Constants.BottomBar.moreButtonIcon ?? UIImage(), action: handleMoreCommandTap)
+        moreItem.accessibilityIdentifier = "More"
+        return moreItem
+    }()
 
     private lazy var heroCommandStack: UIStackView = {
         let stackView = UIStackView()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added an `accessibilityIdentifier` to `BottomCommandingController`'s more button.

### Binary change

Total increase: 2,136 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 46,042,072 bytes | 46,044,208 bytes | ⚠️ 2,136 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomCommandingController.o | 983,776 bytes | 985,912 bytes | ⚠️ 2,136 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

<img width="627" alt="image" src="https://github.com/microsoft/fluentui-apple/assets/55368679/84ebf2a1-d656-4512-bd61-30885ffdaf3b">
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1743)