### PR TITLE
Fix Tooltip XCUITest

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
@@ -145,7 +145,7 @@ class TooltipDemoController: DemoController {
 
 extension TooltipDemoController: TwoLineTitleViewDelegate {
     func twoLineTitleViewDidTapOnTitle(_ twoLineTitleView: TwoLineTitleView) {
-        let alert = UIAlertController(title: nil, message: "The title button was pressed", preferredStyle: .alert)
+        let alert = UIAlertController(title: nil, message: "The two line title view was pressed", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         present(alert, animated: true)
     }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/TooltipTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/TooltipTest.swift
@@ -104,7 +104,7 @@ class TooltipTest: BaseTest {
 
         showTooltipButton.tap()
         XCTAssert(tooltip.exists)
-        app.buttons["Tooltip"].tap()
+        app.staticTexts["Tooltip"].firstMatch.tap()
         // dismisses alert
         app.buttons["OK"].tap()
         XCTAssert(!tooltip.exists)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixed the failing Tooltip XCUITest. #1731 updated the `TwoLineTitleView` to use a `Label` instead of an `EasyTapButton` for the title. However, the tooltip test was not updated to search for a label instead of a button. This PR updates it accordingly.

### Binary change

Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 46,711,784 bytes | 46,711,784 bytes | 🎉 0 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
</details>

### Verification

<details>
<summary>Visual Verification</summary>

![Simulator Screen Recording - iPhone 14 Pro - 2023-05-16 at 10 52 25](https://github.com/microsoft/fluentui-apple/assets/55368679/0f3717c4-ac83-44ae-b3c1-64f9a4d90a8e)
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1748)