### PR TITLE
Update logic between setting vars on Label and updating tokenSet

### DIFF
--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -59,11 +59,11 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     open override var font: UIFont! {
-        get {
-            return tokenSet[.font].uiFont
-        }
-        set {
-            tokenSet[.font] = .uiFont { newValue }
+        didSet {
+            if font != oldValue,
+               let newFont = font {
+                tokenSet[.font] = .uiFont { newFont }
+            }
         }
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -50,11 +50,11 @@ open class Label: UILabel, TokenizedControlInternal {
     }
 
     open override var textColor: UIColor! {
-        get {
-            return tokenSet[.textColor].uiColor
-        }
-        set {
-            tokenSet[.textColor] = .uiColor { newValue }
+        didSet {
+            if textColor != oldValue,
+               let newColor = textColor {
+                tokenSet[.textColor] = .uiColor { newColor }
+            }
         }
     }
 

--- a/ios/FluentUI/Label/Label.swift
+++ b/ios/FluentUI/Label/Label.swift
@@ -51,8 +51,7 @@ open class Label: UILabel, TokenizedControlInternal {
 
     open override var textColor: UIColor! {
         didSet {
-            if textColor != oldValue,
-               let newColor = textColor {
+            if textColor != oldValue, let newColor = textColor {
                 tokenSet[.textColor] = .uiColor { newColor }
             }
         }
@@ -60,8 +59,7 @@ open class Label: UILabel, TokenizedControlInternal {
 
     open override var font: UIFont! {
         didSet {
-            if font != oldValue,
-               let newFont = font {
+            if font != oldValue, let newFont = font {
                 tokenSet[.font] = .uiFont { newFont }
             }
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The label was always returning the values for font and color from the tokenSet, which aren't always the values we end up using. Updating the tokens on `didSet` will let us just return the same values as `super`.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Label_Font_Before](https://github.com/microsoft/fluentui-apple/assets/67026548/eac1874a-093d-4625-aafe-21fc1fd40f9b) | ![Label_Font_After](https://github.com/microsoft/fluentui-apple/assets/67026548/51764bcc-5104-4996-ac09-bea9b5752197) |
| ![Label_Color_Before](https://github.com/microsoft/fluentui-apple/assets/67026548/e044c189-c583-4fb9-ae57-69160542946f) | ![Label_Color_After](https://github.com/microsoft/fluentui-apple/assets/67026548/723024d4-8fdb-498b-bb93-64a730a000a7) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1750)