### PR TITLE
Hide avatar for centered titles on small phones

### DIFF
--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -99,9 +99,9 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
 
     private let titleContainerView = UIView()
 
-    private var showsLargeTitle: Bool = false {
+    private var titleStyle: NavigationBar.TitleStyle = .system {
         didSet {
-            if oldValue != showsLargeTitle {
+            if oldValue != titleStyle {
                 updateTitleContainerView()
             }
         }
@@ -303,12 +303,12 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
     // MARK: - Content Update Methods
 
     private func updateProfileButtonVisibility() {
-        showsProfileButton = !hasLeftBarButtonItems && (personaData != nil || avatarOverrideStyle != nil)
+        showsProfileButton = !titleStyle.usesLeadingAlignment && !hasLeftBarButtonItems && (personaData != nil || avatarOverrideStyle != nil)
     }
 
     private func updateTitleContainerView() {
         titleContainerView.removeAllSubviews()
-        titleContainerView.contain(view: showsLargeTitle ? titleButton : twoLineTitleView)
+        titleContainerView.contain(view: titleStyle == .largeLeading ? titleButton : twoLineTitleView)
     }
 
     /// Sets the interface with the provided item's details
@@ -317,7 +317,7 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
     func update(with navigationItem: UINavigationItem) {
         hasLeftBarButtonItems = !(navigationItem.leftBarButtonItems?.isEmpty ?? true)
         titleButton.setTitle(navigationItem.title, for: .normal)
-        showsLargeTitle = navigationItem.titleStyle == .largeLeading
+        titleStyle = navigationItem.titleStyle
         twoLineTitleView.setup(navigationItem: navigationItem)
         if navigationItem.titleAccessory == nil {
             // Use default behavior of requesting an accessory expansion

--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -103,6 +103,7 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
         didSet {
             if oldValue != titleStyle {
                 updateTitleContainerView()
+                updateProfileButtonVisibility()
             }
         }
     }

--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -303,7 +303,7 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
     // MARK: - Content Update Methods
 
     private func updateProfileButtonVisibility() {
-        showsProfileButton = !titleStyle.usesLeadingAlignment && !hasLeftBarButtonItems && (personaData != nil || avatarOverrideStyle != nil)
+        showsProfileButton = titleStyle.usesLeadingAlignment && !hasLeftBarButtonItems && (personaData != nil || avatarOverrideStyle != nil)
     }
 
     private func updateTitleContainerView() {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This is a small bug fix for "small" phones in landscape mode where we always emulate a system-style title view. Specifically, we don't want to show the avatar in this case. See verification images.

### Binary change

Total increase: 2,912 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,694,192 bytes | 31,697,104 bytes | ⚠️ 2,912 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| AvatarTitleView.o | 196,304 bytes | 197,912 bytes | ⚠️ 1,608 bytes |
| __.SYMDEF | 4,768,584 bytes | 4,769,888 bytes | ⚠️ 1,304 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

Screenshots taken on an iPhone 14 Pro simulator.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-16 at 15 39 56](https://github.com/microsoft/fluentui-apple/assets/717674/3ed4af51-706f-42e5-90fa-643165557ffe) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-05-16 at 15 51 29](https://github.com/microsoft/fluentui-apple/assets/717674/0532d336-a2b9-42f3-82cd-e15fe833bb15) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1751)