### PR TITLE
Update Button's large text support

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -75,6 +75,11 @@ class ButtonDemoController: DemoController {
         container.addArrangedSubview(UIView())
 
         let customButton = createButton(with: .accent, sizeCategory: .small, title: "ToolBar Test Button")
+        customButton.tokenSet[.titleFont] = .uiFont { [weak self] in
+            let theme = self?.view.fluentTheme ?? FluentTheme.shared
+            return theme.typography(.caption1Strong, adjustsForContentSizeCategory: false)
+        }
+        customButton.showsLargeContentViewer = true
         let buttonBarItem = UIBarButtonItem.init(customView: customButton)
         customButton.sizeToFit()
         toolbarItems = [
@@ -100,6 +105,11 @@ class ButtonDemoController: DemoController {
         if let title = title {
             button.setTitle(title, for: .normal)
             button.titleLabel?.numberOfLines = 0
+            if style.isFloating {
+                button.showsLargeContentViewer = true
+            }
+        } else {
+            button.showsLargeContentViewer = true
         }
         if let image = image {
             button.image = image

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -94,6 +94,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         }
 
         minHeightConstraint.isActive = true
+        addInteraction(UILargeContentViewerInteraction())
     }
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -53,9 +53,12 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         }
     }
 
+    /// The content insets of the buton.
+    /// If these insets are not equal to `defaultEdgeInsets()`, the minimum height constraint will be disabled.
     open lazy var edgeInsets: NSDirectionalEdgeInsets = defaultEdgeInsets() {
         didSet {
             isUsingCustomContentEdgeInsets = edgeInsets != defaultEdgeInsets()
+            minHeightConstraint.isActive = !isUsingCustomContentEdgeInsets
 
             invalidateIntrinsicContentSize()
 
@@ -67,22 +70,6 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
             configuration.contentInsets = edgeInsets
             self.configuration = configuration
         }
-    }
-
-    open override var intrinsicContentSize: CGSize {
-        return sizeThatFits(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
-    }
-
-    open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        var contentSize = titleLabel?.systemLayoutSizeFitting(size) ?? .zero
-        contentSize.width = ceil(contentSize.width + edgeInsets.leading + edgeInsets.trailing)
-        contentSize.height = ceil(max(contentSize.height, ButtonTokenSet.minContainerHeight(style: style, size: sizeCategory)) + edgeInsets.top + edgeInsets.bottom)
-
-        if let image = image(for: .normal) {
-            contentSize.width += image.size.width
-        }
-
-        return contentSize
     }
 
     open func initialize() {
@@ -107,6 +94,8 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.update()
         }
+
+        minHeightConstraint.isActive = true
     }
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
@@ -231,6 +220,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
 
         if !isUsingCustomContentEdgeInsets {
             edgeInsets = defaultEdgeInsets()
+            minHeightConstraint.constant = ButtonTokenSet.minContainerHeight(style: style, size: sizeCategory)
         }
     }
 
@@ -305,6 +295,8 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
 
         return ringView
     }()
+
+    private lazy var minHeightConstraint: NSLayoutConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: ButtonTokenSet.minContainerHeight(style: style, size: sizeCategory))
 
     private var normalImageTintColor: UIColor?
     private var highlightedImageTintColor: UIColor?

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -63,22 +63,9 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
                 adjustCustomContentEdgeInsetsForImage()
             }
 
-            if #available(iOS 15.0, *) {
-                var configuration = self.configuration ?? UIButton.Configuration.plain()
-                configuration.contentInsets = edgeInsets
-                self.configuration = configuration
-            } else {
-                let left: CGFloat
-                let right: CGFloat
-                if effectiveUserInterfaceLayoutDirection == .leftToRight {
-                    left = edgeInsets.leading
-                    right = edgeInsets.trailing
-                } else {
-                    left = edgeInsets.trailing
-                    right = edgeInsets.leading
-                }
-                contentEdgeInsets = UIEdgeInsets(top: edgeInsets.top, left: left, bottom: edgeInsets.bottom, right: right)
-            }
+            var configuration = self.configuration ?? UIButton.Configuration.plain()
+            configuration.contentInsets = edgeInsets
+            self.configuration = configuration
         }
     }
 
@@ -93,13 +80,6 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
 
         if let image = image(for: .normal) {
             contentSize.width += image.size.width
-            if #available(iOS 15.0, *) {
-                contentSize.width += ButtonTokenSet.titleImageSpacing(style: style, size: sizeCategory)
-            }
-
-            if titleLabel?.text?.count ?? 0 == 0 {
-                contentSize.width -= ButtonTokenSet.titleImageSpacing(style: style, size: sizeCategory)
-            }
         }
 
         return contentSize
@@ -109,20 +89,17 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         layer.cornerRadius = style.isFloating ? layer.frame.height / 2 : tokenSet[.cornerRadius].float
         layer.cornerCurve = .continuous
 
-        titleLabel?.font = tokenSet[.titleFont].uiFont
         titleLabel?.adjustsFontForContentSizeCategory = !style.isFloating
 
-        if #available(iOS 15, *) {
-            var configuration = UIButton.Configuration.plain()
-            configuration.contentInsets = edgeInsets
-            let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
-                var outgoing = incoming
-                outgoing.font = self.tokenSet[.titleFont].uiFont
-                return outgoing
-            }
-            configuration.titleTextAttributesTransformer = titleTransformer
-            self.configuration = configuration
+        var configuration = UIButton.Configuration.plain()
+        configuration.contentInsets = edgeInsets
+        let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = self.tokenSet[.titleFont].uiFont
+            return outgoing
         }
+        configuration.titleTextAttributesTransformer = titleTransformer
+        self.configuration = configuration
 
         update()
 
@@ -150,29 +127,6 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         }
         tokenSet.update(newWindow.fluentTheme)
         update()
-    }
-
-    open override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
-        var rect = CGRect.zero
-        if #available(iOS 15, *) {
-            assertionFailure("imageRect(forContentRect: ) has been deprecated in iOS 15.0")
-        } else {
-            rect = super.imageRect(forContentRect: contentRect)
-
-            if let image = image {
-                let imageHeight = image.size.height
-
-                // If the entire image doesn't fit in the default rect, increase the rect's height
-                // to fit the entire image and reposition the origin to keep the image centered.
-                if imageHeight > rect.size.height {
-                    rect.origin.y -= round((imageHeight - rect.size.height) / 2.0)
-                    rect.size.height = imageHeight
-                }
-
-                rect.size.width = image.size.width
-            }
-        }
-        return rect
     }
 
     @objc public init(style: ButtonStyle = .outline) {
@@ -216,11 +170,6 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         setTitleColor(foregroundColor, for: .focused)
         setTitleColor(tokenSet[.foregroundPressedColor].uiColor, for: .highlighted)
         setTitleColor(tokenSet[.foregroundDisabledColor].uiColor, for: .disabled)
-
-        if #available(iOS 15.0, *) {
-        } else {
-            titleLabel?.font = tokenSet[.titleFont].uiFont
-        }
 
         invalidateIntrinsicContentSize()
     }
@@ -294,21 +243,10 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
             spacing = -spacing
         }
 
-        if #available(iOS 15.0, *) {
             var configuration = self.configuration ?? UIButton.Configuration.plain()
             configuration.contentInsets = edgeInsets
             configuration.imagePadding = spacing
             self.configuration = configuration
-        } else {
-            edgeInsets.trailing += spacing
-            if effectiveUserInterfaceLayoutDirection == .leftToRight {
-                titleEdgeInsets.left += spacing
-                titleEdgeInsets.right -= spacing
-            } else {
-                titleEdgeInsets.right += spacing
-                titleEdgeInsets.left -= spacing
-            }
-        }
 
         isAdjustingCustomContentEdgeInsetsForImage = false
     }

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -304,7 +304,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         layer.cornerCurve = .continuous
         layer.cornerRadius = style.isFloating ? frame.height / 2 : configuration.background.cornerRadius
 
-        let shadowInfo = !isEnabled || isHighlighted || isFocused ? tokenSet[.shadowPressed].shadowInfo : tokenSet[.shadowRest].shadowInfo
+        let shadowInfo = (!isEnabled || isHighlighted || isFocused) ? tokenSet[.shadowPressed].shadowInfo : tokenSet[.shadowRest].shadowInfo
         shadowInfo.applyShadow(to: self)
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#1692 broke large text support in the button by removing `proposedTitleLabelWidth` in an attempt to fix the title breaking in to two lines when there was still space for a single line. The root of that issue was that the button would get into a try to base the content size on the size of the bounds, and then shrink it to guess how much space was left for the button. By changing to just finding the `systemLayoutSizeFitting(size)`, where size was the max value for both height and width, we were getting returned a size of a height we wanted (for a single line), but the width wasn't correctly bound by the space available to the button.

The end goal of the overridden `sizeThatFits` was to provide a lower bound on the height of the button. However, `UIButton.ButtonConfiguration` doesn't provide any way to do so, it only allows the user to set the `contentInsets`. Our designers have opted for defining a minimum height to guarantee that the button will fit in to a 4pt grid, rather than try to react to changes in the font to get the correct insets. Since the goal is to add a minimum height, I've added a constraint on the height of the button to be greater than or equal to the minimum height defined in the token set. I also tried getting `super.sizeThatFits()` and adjusting the height of that to meet the minimum, but that lead to the buttons growing in height rather than width. The minimum height constraint will automatically be disabled if the edge insets are anything other than the default, allowing users to create custom buttons of a smaller size.

I also noticed that the floating button styles would sometimes load in with no shadow and as rectangles, so I've updated the logic to try and leverage the `.capsule` corner style from the configuration. I encountered an issue there with the configuration not updating the layer/view of the button in a way that our shadow layers could recognize, so I had to set the corner radius, corner style, and background color manually before applying shadows. We also didn't have large content viewer support, so I added that.

I couldn't figure out a good way to dynamically set `showsLargeContentViewer`, so the current implementation still requires the client to set `showsLargeContentViewer` on button they need to show the large content viewer. We needed to be able to support the large content viewer in the floating buttons, or when our button had either no text or text that wouldn't scale, but there weren't sufficient ways to listen for all of those settings.

### Binary change

Total increase: 7,104 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,811,536 bytes | 31,818,640 bytes | ⚠️ 7,104 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| Button.o | 202,608 bytes | 208,176 bytes | ⚠️ 5,568 bytes |
| __.SYMDEF | 4,780,208 bytes | 4,781,096 bytes | ⚠️ 888 bytes |
| FocusRingView.o | 788,352 bytes | 789,000 bytes | ⚠️ 648 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="564" alt="Button_DefaultTextSize_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/2327d02b-28ff-43cc-b7b9-21ff8acc6ce3"> | <img width="564" alt="Button_DefaultTextSize_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/b185c626-c091-486b-8f18-163c2e2a4316"> |
| <img width="564" alt="Button_MaxTextSize_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e6169b78-0842-45c9-8c12-f81d15472e90"> | <img width="520" alt="Button_MaxTextSize_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/ebd6c554-7530-4edc-bb3c-2c950f383cd5"> |
| n/a | <img width="564" alt="Button_LargeContentViewer_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e3d86087-340c-486b-aa38-480b3605cc0b"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1753)