### PR TITLE
Fix SearchBar tokens + update deprecation message

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -33,7 +33,7 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
 
     let segmentedControl: SegmentedControl = {
         let segmentedControl = SegmentedControl(items: [SegmentItem(title: "OnCanvas"),
-                                                        SegmentItem(title: "OnNavigationBar"),
+                                                        SegmentItem(title: "OnSystem"),
                                                         SegmentItem(title: "OnBrand")],
                                                 style: .neutralOverNavBarPill)
 

--- a/ios/FluentUI/Navigation/SearchBar/SearchBarTokenSet.swift
+++ b/ios/FluentUI/Navigation/SearchBar/SearchBarTokenSet.swift
@@ -49,9 +49,9 @@ public class SearchBarTokenSet: ControlTokenSet<SearchBarTokenSet.Tokens> {
             case .backgroundColor:
                 return .uiColor({
                     switch style() {
-                    case .darkContent, .onCanvas:
+                    case .onCanvas:
                         return theme.color(.background3)
-                    case .onSystemNavigationBar:
+                    case .darkContent, .onSystemNavigationBar:
                         return theme.color(.background5)
                     case .lightContent, .onBrandNavigationBar:
                         return UIColor(light: theme.color(.brandBackground2).light,
@@ -71,9 +71,9 @@ public class SearchBarTokenSet: ControlTokenSet<SearchBarTokenSet.Tokens> {
             case .clearIconColor:
                 return .uiColor({
                     switch style() {
-                    case .darkContent, .onCanvas:
+                    case .onCanvas:
                         return theme.color(.foreground2)
-                    case .onSystemNavigationBar:
+                    case .darkContent, .onSystemNavigationBar:
                         return theme.color(.foreground3)
                     case .lightContent, .onBrandNavigationBar:
                         return UIColor(light: theme.color(.foregroundOnColor).light,
@@ -182,7 +182,7 @@ public extension SearchBar {
     enum Style: Int {
         @available(*, deprecated, message: "lightContent is now deprecated. Please use onBrandNavigationBar.")
         case lightContent
-        @available(*, deprecated, message: "darkContent is now deprecated. Please use onCanvas.")
+        @available(*, deprecated, message: "darkContent is now deprecated. Please use onSystemNavigationBar.")
         case darkContent
         case onCanvas
         case onSystemNavigationBar


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`darkContent` is the same as `onSystemNavigationBar` so they should be using the same tokens. I verified the tokens against the design specs and fixed the deprecation message.

### Binary change
<details>
<summary> Full breakdown </summary>
Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 32,283,288 bytes | 32,283,288 bytes | 🎉 0 bytes |

| File | Before | After | Delta |
|------|-------:|------:|------:|
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="485" alt="before_nav_system_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/dbeb29c7-c38a-48f5-b75c-b4aa09c4d753"> | <img width="485" alt="after_nav_system_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/379aa421-ecde-4d88-96af-bb9f22f427c4"> |
| <img width="485" alt="before_nav_system_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/9802e8ca-6b52-490b-947a-875951aa0f9f"> | <img width="485" alt="after_nav_system_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/a622d953-aa65-48b6-857b-3d845ab20f37"> |
| <img width="485" alt="before_searchbar_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/321a85ba-9973-4458-a093-b8133b5e5549"> | <img width="485" alt="system_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/f6e60ea8-0a5b-4cd2-a61d-d8b278497318"> |
| <img width="485" alt="before_searchbar_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/e4c10911-1add-47c3-8c89-645cc21ce09c"> | <img width="485" alt="system_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/e1859ba3-626f-46c7-92f0-04e1f93ffea6"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1754)