### PR TITLE
[Cherry-pick][main_0.14_gradient_navigation_bar]Add new ColorProviding protocol for Mac Fluent colors (#1758)

### DIFF
--- a/macos/FluentUI/Core/ColorProviding.swift
+++ b/macos/FluentUI/Core/ColorProviding.swift
@@ -1,0 +1,23 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AppKit
+
+// MARK: ColorProviding
+
+/// Protocol through which consumers can provide colors to "theme" their experiences
+/// The view associated with the passed in theme will display the set colors to allow apps to provide different experiences per each view
+@objc(MSFColorProviding)
+public protocol ColorProviding {
+	/// If this protocol is not conformed to, communicationBlue variants will be used
+	@objc var primary: NSColor { get }
+	@objc var primaryShade10: NSColor { get }
+	@objc var primaryShade20: NSColor { get }
+	@objc var primaryShade30: NSColor { get }
+	@objc var primaryTint10: NSColor { get }
+	@objc var primaryTint20: NSColor { get }
+	@objc var primaryTint30: NSColor { get }
+	@objc var primaryTint40: NSColor { get }
+}

--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -438,22 +438,83 @@ public final class Colors: NSObject {
 	}
 
 	// MARK: Primary
+	@objc public static var primary: NSColor {
+		get {
+			return colorProvider?.primary ?? _primary
+		}
+		set {
+			_primary = newValue
+		}
+	}
+	@objc public static var primaryShade10: NSColor {
+		get {
+			return colorProvider?.primaryShade10 ?? _primaryShade10
+		}
+		set {
+			_primaryShade10 = newValue
+		}
+	}
+	@objc public static var primaryShade20: NSColor {
+		get {
+			return colorProvider?.primaryShade20 ?? _primaryShade20
+		}
+		set {
+			_primaryShade20 = newValue
+		}
+	}
+	@objc public static var primaryShade30: NSColor {
+		get {
+			return colorProvider?.primaryShade30 ?? _primaryShade30
+		}
+		set {
+			_primaryShade30 = newValue
+		}
+	}
+	@objc public static var primaryTint10: NSColor {
+		get {
+			return colorProvider?.primaryTint10 ?? _primaryTint10
+		}
+		set {
+			_primaryTint10 = newValue
+		}
+	}
+	@objc public static var primaryTint20: NSColor {
+		get {
+			return colorProvider?.primaryTint20 ?? _primaryTint20
+		}
+		set {
+			_primaryTint20 = newValue
+		}
+	}
+	@objc public static var primaryTint30: NSColor {
+		get {
+			return colorProvider?.primaryTint30 ?? _primaryTint30
+		}
+		set {
+			_primaryTint30 = newValue
+		}
+	}
+	@objc public static var primaryTint40: NSColor {
+		get {
+			return colorProvider?.primaryTint40 ?? _primaryTint40
+		}
+		set {
+			_primaryTint40 = newValue
+		}
+	}
 
-	@objc public static var primary: NSColor = Colors.Palette.communicationBlue.color
+	/// Color provider object. When a Color Provider is present, colors will be retrieved from the provider vs. internally.
+	@objc public static var colorProvider: ColorProviding?
 
-	@objc public static var primaryTint10: NSColor = Colors.Palette.communicationBlueTint10.color
-
-	@objc public static var primaryTint20: NSColor = Colors.Palette.communicationBlueTint20.color
-
-	@objc public static var primaryTint30: NSColor = Colors.Palette.communicationBlueTint30.color
-
-	@objc public static var primaryTint40: NSColor = Colors.Palette.communicationBlueTint40.color
-
-	@objc public static var primaryShade10: NSColor = Colors.Palette.communicationBlueShade10.color
-
-	@objc public static var primaryShade20: NSColor = Colors.Palette.communicationBlueShade20.color
-
-	@objc public static var primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color
+	/// These are initialized with the Communication Blue defaults.
+	private static var _primary: NSColor = Colors.Palette.communicationBlue.color
+	private static var _primaryShade10: NSColor = Colors.Palette.communicationBlueShade10.color
+	private static var _primaryShade20: NSColor = Colors.Palette.communicationBlueShade20.color
+	private static var _primaryShade30: NSColor = Colors.Palette.communicationBlueShade30.color
+	private static var _primaryTint10: NSColor = Colors.Palette.communicationBlueTint10.color
+	private static var _primaryTint20: NSColor = Colors.Palette.communicationBlueTint20.color
+	private static var _primaryTint30: NSColor = Colors.Palette.communicationBlueTint30.color
+	private static var _primaryTint40: NSColor = Colors.Palette.communicationBlueTint40.color
 }
 
 /// Make palette enum CaseIterable for unit testing purposes

--- a/macos/FluentUITestViewControllers/TestColorViewController.swift
+++ b/macos/FluentUITestViewControllers/TestColorViewController.swift
@@ -6,7 +6,7 @@
 import AppKit
 import FluentUI
 
-class TestColorViewController: NSViewController {
+class TestColorViewController: NSViewController, ColorProviding {
 	var primaryColorsStackView = NSStackView()
 	var subviewConstraints = [NSLayoutConstraint]()
 	var toggleTextView = NSTextView(frame: NSRect(x: 0, y: 0, width: 100, height: 20))
@@ -31,7 +31,7 @@ class TestColorViewController: NSViewController {
 			colorsStackView.addArrangedSubview(createColorRowStackView(name: color.name, color: color.color))
 		}
 
-		loadPrimaryColors(state: NSControl.StateValue.off)
+		loadPrimaryColors()
 
 		let documentView = NSView()
 		documentView.translatesAutoresizingMaskIntoConstraints = false
@@ -52,8 +52,9 @@ class TestColorViewController: NSViewController {
 
 		let switchButton = NSSwitch(frame: CGRect(x: 1, y: 1, width: 100, height: 50))
 		switchButton.target = self
+		switchButton.state = useColorProvider ? .on : .off
 		switchButton.action = #selector(toggleClicked)
-		toggleTextView.string = "Default"
+		toggleTextView.string = "Use ColorProvider"
 		toggleTextView.font = .systemFont(ofSize: 20)
 		toggleTextView.isEditable = false
 		toggleTextView.isSelectable = false
@@ -78,6 +79,19 @@ class TestColorViewController: NSViewController {
 		view = containerView
 	}
 
+	// MARK: ColorProviding Protocol
+
+	var primary: NSColor = (NSColor(named: "Colors/DemoPrimaryColor"))!
+	var primaryShade10: NSColor = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
+	var primaryShade20: NSColor = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
+	var primaryShade30: NSColor = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
+	var primaryTint10: NSColor = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
+	var primaryTint20: NSColor = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
+	var primaryTint30: NSColor = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
+	var primaryTint40: NSColor = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
+
+	// MARK: Private
+
 	private func createColorRowStackView(name: String?, color: NSColor?) -> NSStackView {
 		let rowStackView = NSStackView()
 		let textView = NSTextField(labelWithString: name!)
@@ -92,21 +106,16 @@ class TestColorViewController: NSViewController {
 
 	@objc private func toggleClicked(button: NSSwitch?) {
 		primaryColorsStackView.subviews.removeAll()
-		loadPrimaryColors(state: button?.state ?? NSControl.StateValue.off)
+		useColorProvider = button?.state == .on ? true : false
+		loadPrimaryColors()
 	}
 
-	private func loadPrimaryColors(state: NSControl.StateValue) {
-		if state == NSControl.StateValue.on {
-			Colors.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
-			Colors.primaryShade10 = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
-			Colors.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
-			Colors.primaryShade30 = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
-			Colors.primaryTint10 = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
-			Colors.primaryTint20 = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
-			Colors.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
-			Colors.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
-			toggleTextView.string = "Green"
+	private func loadPrimaryColors() {
+		if useColorProvider {
+			Colors.colorProvider = self
 		} else {
+			// If we aren't using the new ColorProvider, clear it and fall back to initializing all the colors at onced
+			Colors.colorProvider = nil
 			Colors.primary = Colors.Palette.communicationBlue.color
 			Colors.primaryShade10 = Colors.Palette.communicationBlueShade10.color
 			Colors.primaryShade20 = Colors.Palette.communicationBlueShade20.color
@@ -115,7 +124,6 @@ class TestColorViewController: NSViewController {
 			Colors.primaryTint20 = Colors.Palette.communicationBlueTint20.color
 			Colors.primaryTint30 = Colors.Palette.communicationBlueTint30.color
 			Colors.primaryTint40 = Colors.Palette.communicationBlueTint40.color
-			toggleTextView.string = "Default"
 		}
 
 		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: Colors.primary))
@@ -154,3 +162,6 @@ class ColorRectView: NSView {
 }
 
 private let colorRowSpacing: CGFloat = 10.0
+
+// Default to using the new ColorProvider protocol for fetching the Fluent Primary Colors
+private var useColorProvider = true

--- a/macos/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/macos/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		921AF7D7269CD3C900255791 /* FluentUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 921AF7B1269CD39C00255791 /* FluentUI.strings */; };
 		9B4AEBA42703CADB00B68020 /* FilledTemplateImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AEBA22703CADB00B68020 /* FilledTemplateImageView.swift */; };
 		9B4AEBAB2705206300B68020 /* TestFilledTemplateImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AEBAA2705206300B68020 /* TestFilledTemplateImageViewController.swift */; };
+		9BE619162A1576BD0046463A /* ColorProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE619152A1576BD0046463A /* ColorProviding.swift */; };
 		A257F81E2512DE45002CAA6E /* TestColorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A257F81C2512DDF7002CAA6E /* TestColorViewController.swift */; };
 		A257F826251D987E002CAA6E /* FluentUI-macos.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F825251D987E002CAA6E /* FluentUI-macos.xcassets */; };
 		AC7235D82492E0D000D0DCA8 /* FluentUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E61C96B22295E8D60006561F /* FluentUI.framework */; };
@@ -253,6 +254,7 @@
 		921AF7D5269CD39C00255791 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/FluentUI.strings; sourceTree = "<group>"; };
 		9B4AEBA22703CADB00B68020 /* FilledTemplateImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilledTemplateImageView.swift; sourceTree = "<group>"; };
 		9B4AEBAA2705206300B68020 /* TestFilledTemplateImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFilledTemplateImageViewController.swift; sourceTree = "<group>"; };
+		9BE619152A1576BD0046463A /* ColorProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorProviding.swift; sourceTree = "<group>"; };
 		A257F81C2512DDF7002CAA6E /* TestColorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestColorViewController.swift; sourceTree = "<group>"; };
 		A257F825251D987E002CAA6E /* FluentUI-macos.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-macos.xcassets"; path = "../FluentUI/Resources/FluentUI-macos.xcassets"; sourceTree = "<group>"; };
 		AC97EFE3247541E100DADC99 /* TestButtonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestButtonViewController.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 			isa = PBXGroup;
 			children = (
 				53BCB0E1253A72E000620960 /* FluentUIResources.swift */,
+				9BE619152A1576BD0046463A /* ColorProviding.swift */,
 				53BCB0DA253A72AD00620960 /* Colors.swift */,
 			);
 			path = Core;
@@ -990,6 +993,7 @@
 				3F2506DB25F2C7A90049ED54 /* DynamicColor.swift in Sources */,
 				9B4AEBA42703CADB00B68020 /* FilledTemplateImageView.swift in Sources */,
 				8061BF7F22EF936800F2D245 /* DatePickerController.swift in Sources */,
+				9BE619162A1576BD0046463A /* ColorProviding.swift in Sources */,
 				53BCB0F4253A75CF00620960 /* Button.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

Cherry picks #1758 into main_0.14_gradient_navigation_bar.

### Verification

Verified using the FluentUITestApp for Mac. See above PR for full details of what this provides.

### Pull request checklist
 See above PR for details.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1759)