### PR TITLE
Revert changes to `viewControllerNeedsWrapping` in `NavigationController`

### DIFF
--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -128,7 +128,13 @@ open class NavigationController: UINavigationController {
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
-        return !(viewController is ShyHeaderController)
+        if viewController is ShyHeaderController {
+            return false
+        }
+        if viewController.navigationItem.titleStyle == .largeLeading || viewController.navigationItem.accessoryView != nil {
+            return true
+        }
+        return false
     }
 
     func updateNavigationBar(for viewController: UIViewController) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The changes introduced to `viewControllerNeedsWrapping` in #1731 cause crashes on a partner app so we are reverting them for now. However, this introduces a bug where the central `TwoLineTitleView` gets cropped on landscape mode (see screenshots.)

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="847" alt="before" src="https://github.com/microsoft/fluentui-apple/assets/106181067/dfcb121e-adad-40d0-a7a2-b8e9ed6a9874"> | <img width="847" alt="after" src="https://github.com/microsoft/fluentui-apple/assets/106181067/8f557142-2284-43fd-aab7-e812913405cd"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1761)