### PR TITLE
[Cherry-pick][main_0.17] Revert changes to viewControllerNeedsWrapping (#1761)

### DIFF
--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -128,7 +128,13 @@ open class NavigationController: UINavigationController {
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
-        return !(viewController is ShyHeaderController)
+        if viewController is ShyHeaderController {
+            return false
+        }
+        if viewController.navigationItem.titleStyle == .largeLeading || viewController.navigationItem.accessoryView != nil {
+            return true
+        }
+        return false
     }
 
     func updateNavigationBar(for viewController: UIViewController) {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

This PR cherry-picks #1761 to `main_0.17`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1763)