### PR TITLE
Add accessibility identifier to NavigationBar's back button

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -342,7 +342,14 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var navigationBarShadowObserver: NSKeyValueObservation?
     private var titleStyleObserver: NSKeyValueObservation?
 
-    private let backButtonItem: UIBarButtonItem = UIBarButtonItem(image: UIImage.staticImageNamed("back-24x24"), style: .plain, target: nil, action: #selector(NavigationBarBackButtonDelegate.backButtonWasPressed))
+    private let backButtonItem: UIBarButtonItem = {
+        let backButtonitem = UIBarButtonItem(image: UIImage.staticImageNamed("back-24x24"),
+                                             style: .plain,
+                                             target: nil,
+                                             action: #selector(NavigationBarBackButtonDelegate.backButtonWasPressed))
+        backButtonitem.accessibilityIdentifier = "Back"
+        return backButtonitem
+    }()
 
     weak var backButtonDelegate: NavigationBarBackButtonDelegate? {
         didSet {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -343,12 +343,12 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var titleStyleObserver: NSKeyValueObservation?
 
     private let backButtonItem: UIBarButtonItem = {
-        let backButtonitem = UIBarButtonItem(image: UIImage.staticImageNamed("back-24x24"),
+        let backButtonItem = UIBarButtonItem(image: UIImage.staticImageNamed("back-24x24"),
                                              style: .plain,
                                              target: nil,
                                              action: #selector(NavigationBarBackButtonDelegate.backButtonWasPressed))
-        backButtonitem.accessibilityIdentifier = "Back"
-        return backButtonitem
+        backButtonItem.accessibilityIdentifier = "Back"
+        return backButtonItem
     }()
 
     weak var backButtonDelegate: NavigationBarBackButtonDelegate? {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Some partner xcui tests fail because they cannot find the item with "Back" as its accessibility identifier. This is caused by the new `NavigationBar` using a custom `UIBarButtonItem` as its back button item without setting its accessibility identifier. To fix the test failures, we're setting the accessibility identifier of `backButtonItem` to "Back".

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1767)