### PR TITLE
Fix ColorProviding comment

### DIFF
--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -60,10 +60,10 @@ private func brandColorOverrides(provider: ColorProviding) -> [FluentTheme.Color
 // MARK: Colors
 
 @objc public extension UIView {
-    /// Associates a `ColorProvider2` with a given `UIView`.
+    /// Associates a `ColorProvider` with a given `UIView`.
     ///
     /// - Parameters:
-    ///   - provider: The `ColorProvider2` whose colors should be used for controls in this theme.
+    ///   - provider: The `ColorProvider` whose colors should be used for controls in this theme.
     @objc(setColorProvider:)
     func setColorProvider(_ provider: ColorProviding) {
         // Create an updated fluent theme as well


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

We used to have ColorProvider2 during the fluent 2 update. This PR just removes '2' from the comment.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1770)