### PR TITLE
Restore Button's proposedTitleLabelWidth

### DIFF
--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -76,19 +76,10 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
         var contentSize = titleLabel?.systemLayoutSizeFitting(CGSize(width: proposedTitleLabelWidth <= 0 ? size.width : proposedTitleLabelWidth, height: size.height)) ?? .zero
-        contentSize.width = ceil(contentSize.width + edgeInsets.leading + edgeInsets.trailing)
         contentSize.height = ceil(max(contentSize.height + edgeInsets.top + edgeInsets.bottom, ButtonTokenSet.minContainerHeight(style: style, size: sizeCategory)))
 
-        if let image = image(for: .normal) {
-            contentSize.width += image.size.width
-
-            if titleLabel?.text?.count ?? 0 != 0 {
-                contentSize.width += ButtonTokenSet.titleImageSpacing(style: style, size: sizeCategory)
-            }
-        }
-
         let superSize = super.sizeThatFits(size)
-        contentSize.width = max(contentSize.width, superSize.width)
+        contentSize.width = superSize.width
 
         return contentSize
     }

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -87,6 +87,9 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
             }
         }
 
+        let superSize = super.sizeThatFits(size)
+        contentSize.width = max(contentSize.width, superSize.width)
+
         return contentSize
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Attempting to replace `proposedTitleLabelWidth` with constraints in #1753 has led to the button growing in height unexpectedly, and not sizing correctly in the TVC, so I'm bringing it back. I also updated `sizeThatFits` to get the width from `super`. We weren't able to reliably figure out the correct width, but `super` couldn't figure out the correct height. But if we combine our height calculation with `super`'s width calculation, we get buttons of the correct size.

### Verification

Also tested in the partner app that reported the unusually tall buttons, buttons are normally sized after this change.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="564" alt="Button_TVC_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/9c9fe1cc-6cda-49f3-9430-49877bde0b76"> | <img width="564" alt="Button_TVC_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/74a32572-5b3b-430f-80f1-541b9f26206d"> |
| <img width="564" alt="Button_DefaultText_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/d37976ed-3530-40bf-a380-b390f2d93f96"> | <img width="520" alt="Button_DefaultText_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/90ce3f22-ac2d-4916-b5d6-5ca4c0813608"> |
| <img width="564" alt="Button_LargeText_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/9db36c68-a5a8-453e-b820-8754fc23cb82"> | <img width="564" alt="Button_LargeText_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/bf140e15-a6f9-40c6-9ddb-8f4d4358df2e"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1776)