### PR TITLE
Add ability to top-align title accessory views

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -198,6 +198,9 @@ extension TableViewCellDemoController {
         cell.footerLeadingAccessoryView = showsLabelAccessoryView ? item.text3LeadingAccessoryView() : nil
         cell.footerTrailingAccessoryView = showsLabelAccessoryView ? item.text3TrailingAccessoryView() : nil
 
+        cell.titleLeadingAccessoryViewVerticalAlignment = item.text1LeadingAccessoryViewVerticalAlignment
+        cell.titleTrailingAccessoryViewVerticalAlignment = item.text1TrailingAccessoryViewVerticalAlignment
+
         cell.titleNumberOfLines = section.numberOfLines
         cell.subtitleNumberOfLines = section.numberOfLines
         cell.footerNumberOfLines = section.numberOfLines

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
@@ -93,6 +93,17 @@ class TableViewCellSampleData: TableViewSampleData {
             ],
             numberOfLines: 0,
             allowsMultipleSelection: false
+        ),
+        Section(
+            title: "Cell with top-aligned title accessory view",
+            items: [
+                Item(text1: "This is a cell with a long text1 as an example of how this label will render",
+                     image: "excelIcon",
+                     text1TrailingAccessoryView: { createTextAccessoryView(text: "10:21 AM") },
+                     text1TrailingAccessoryViewVerticalAlignment: .top)
+            ],
+            numberOfLines: 0,
+            allowsMultipleSelection: false
         )
     ]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewSampleData.swift
@@ -74,6 +74,8 @@ class TableViewSampleData {
         let text2TrailingAccessoryView: LabelAccessoryView
         let text3LeadingAccessoryView: LabelAccessoryView
         let text3TrailingAccessoryView: LabelAccessoryView
+        let text1LeadingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment
+        let text1TrailingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment
 
         init(
             text1: String = "",
@@ -85,7 +87,9 @@ class TableViewSampleData {
             text2LeadingAccessoryView: @escaping LabelAccessoryView = { return nil },
             text2TrailingAccessoryView: @escaping LabelAccessoryView = { return nil },
             text3LeadingAccessoryView: @escaping LabelAccessoryView = { return nil },
-            text3TrailingAccessoryView: @escaping LabelAccessoryView = { return nil }
+            text3TrailingAccessoryView: @escaping LabelAccessoryView = { return nil },
+            text1LeadingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment = .center,
+            text1TrailingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment = .center
         ) {
             self.text1 = text1
             self.text2 = text2
@@ -97,6 +101,8 @@ class TableViewSampleData {
             self.text2TrailingAccessoryView = text2TrailingAccessoryView
             self.text3LeadingAccessoryView = text3LeadingAccessoryView
             self.text3TrailingAccessoryView = text3TrailingAccessoryView
+            self.text1LeadingAccessoryViewVerticalAlignment = text1LeadingAccessoryViewVerticalAlignment
+            self.text1TrailingAccessoryViewVerticalAlignment = text1TrailingAccessoryViewVerticalAlignment
         }
     }
 

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -84,6 +84,15 @@ public enum TableViewCellBackgroundStyleType: Int {
     }
 }
 
+// Supported vertical alignment for accessory views in `TableViewCell`
+@objc(MSFTableViewCellAccessoryViewVerticalAlignment)
+public enum TableViewCellAccessoryViewVerticalAlignment: Int {
+    // Accessory view is vertically aligned with the top of its corresponding label
+    case top
+    // Accessory view is vertically centered with its corresponding label
+    case center
+}
+
 // MARK: - TableViewCell
 
 /**
@@ -889,10 +898,30 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
     }
 
+    /// Vertical alignment of the accessory view on the leading edge of the title
+    @objc open var titleLeadingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment = .center {
+        didSet {
+            guard titleLeadingAccessoryViewVerticalAlignment != oldValue else {
+                return
+            }
+            setNeedsLayout()
+        }
+    }
+
     /// The accessory view on the trailing edge of the title
     @objc open var titleTrailingAccessoryView: UIView? {
         didSet {
             updateLabelAccessoryView(oldValue: oldValue, newValue: titleTrailingAccessoryView, size: &titleTrailingAccessoryViewSize)
+        }
+    }
+
+    /// Vertical alignment of the accessory view on the trailing edge of the title
+    @objc open var titleTrailingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment = .center {
+        didSet {
+            guard titleTrailingAccessoryViewVerticalAlignment != oldValue else {
+                return
+            }
+            setNeedsLayout()
         }
     }
 
@@ -1532,8 +1561,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                          numberOfLines: titleNumberOfLines,
                          topOffset: 0,
                          leadingAccessoryView: titleLeadingAccessoryView,
+                         leadingAccessoryViewVerticalAlignment: titleLeadingAccessoryViewVerticalAlignment,
                          leadingAccessoryViewSize: titleLeadingAccessoryViewSize,
                          trailingAccessoryView: titleTrailingAccessoryView,
+                         trailingAccessoryViewVerticalAlignment: titleTrailingAccessoryViewVerticalAlignment,
                          trailingAccessoryViewSize: titleTrailingAccessoryViewSize,
                          labelAccessoryViewMarginTrailing: TableViewCellTokenSet.titleLabelAccessoryViewMarginTrailing)
 
@@ -1544,8 +1575,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                              numberOfLines: subtitleNumberOfLines,
                              topOffset: titleLabel.frame.maxY + TableViewCellTokenSet.labelVerticalSpacing,
                              leadingAccessoryView: subtitleLeadingAccessoryView,
+                             leadingAccessoryViewVerticalAlignment: .center,
                              leadingAccessoryViewSize: subtitleLeadingAccessoryViewSize,
                              trailingAccessoryView: subtitleTrailingAccessoryView,
+                             trailingAccessoryViewVerticalAlignment: .center,
                              trailingAccessoryViewSize: subtitleTrailingAccessoryViewSize,
                              labelAccessoryViewMarginTrailing: TableViewCellTokenSet.subtitleLabelAccessoryViewMarginTrailing)
 
@@ -1556,8 +1589,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                  numberOfLines: footerNumberOfLines,
                                  topOffset: subtitleLabel.frame.maxY + TableViewCellTokenSet.labelVerticalSpacing,
                                  leadingAccessoryView: footerLeadingAccessoryView,
+                                 leadingAccessoryViewVerticalAlignment: .center,
                                  leadingAccessoryViewSize: footerLeadingAccessoryViewSize,
                                  trailingAccessoryView: footerTrailingAccessoryView,
+                                 trailingAccessoryViewVerticalAlignment: .center,
                                  trailingAccessoryViewSize: footerTrailingAccessoryViewSize,
                                  labelAccessoryViewMarginTrailing: TableViewCellTokenSet.subtitleLabelAccessoryViewMarginTrailing)
             }
@@ -1608,8 +1643,10 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
                                   numberOfLines: Int,
                                   topOffset: CGFloat,
                                   leadingAccessoryView: UIView?,
+                                  leadingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment,
                                   leadingAccessoryViewSize: CGSize,
                                   trailingAccessoryView: UIView?,
+                                  trailingAccessoryViewVerticalAlignment: TableViewCellAccessoryViewVerticalAlignment,
                                   trailingAccessoryViewSize: CGSize,
                                   labelAccessoryViewMarginTrailing: CGFloat) {
         let textAreaLeadingOffset = TableViewCell.textAreaLeadingOffset(customViewSize: customViewSize,
@@ -1628,7 +1665,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         }
 
         if let leadingAccessoryView = leadingAccessoryView {
-            let yOffset = ceil(topOffset + (size.height - leadingAccessoryViewSize.height) / 2)
+            let yOffset: CGFloat
+            switch leadingAccessoryViewVerticalAlignment {
+            case .top:
+                yOffset = topOffset
+            case .center:
+                yOffset = ceil(topOffset + (size.height - leadingAccessoryViewSize.height) / 2)
+            }
+
             leadingAccessoryView.frame = CGRect(
                 x: textAreaLeadingOffset,
                 y: yOffset,
@@ -1657,7 +1701,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         )
 
         if let trailingAccessoryView = trailingAccessoryView {
-            let yOffset = ceil(topOffset + (labelSize.height - trailingAccessoryViewSize.height) / 2)
+            let yOffset: CGFloat
+            switch trailingAccessoryViewVerticalAlignment {
+            case .top:
+                yOffset = topOffset
+            case .center:
+                yOffset = ceil(topOffset + (labelSize.height - trailingAccessoryViewSize.height) / 2)
+            }
+
             let availableWidth = textAreaWidth - labelSize.width - leadingAccessoryAreaWidth
             let leadingMargin = TableViewCell.labelTrailingAccessoryMarginLeading(text: visibleText,
                                                                                   labelAccessoryViewMarginLeading: TableViewCellTokenSet.labelAccessoryViewMarginLeading)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This change adds the ability to top-align title accessory views, which appears to be a common design FluentUI design pattern

### Binary change

Okay, I don't know how these are the results, but I swear I followed the instructions at https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison to a T

Total increase: 0 bytes
Total decrease: -72,320 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,958,632 bytes | 29,886,312 bytes | 🎉 -72,320 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| CardNudgeModifiers.o | 39,512 bytes | 39,504 bytes | 🎉 -8 bytes |
| TokenizedControl.o | 13,232 bytes | 13,224 bytes | 🎉 -8 bytes |
| AnimationSynchronizer.o | 30,792 bytes | 30,784 bytes | 🎉 -8 bytes |
| GlobalTokens.o | 543,152 bytes | 543,144 bytes | 🎉 -8 bytes |
| PersonaButtonModifiers.o | 10,472 bytes | 10,456 bytes | 🎉 -16 bytes |
| FluentTextInputError.o | 22,576 bytes | 22,560 bytes | 🎉 -16 bytes |
| AvatarModifiers.o | 43,344 bytes | 43,328 bytes | 🎉 -16 bytes |
| CommandingSection.o | 27,704 bytes | 27,688 bytes | 🎉 -16 bytes |
| IndeterminateProgressBarModifiers.o | 16,616 bytes | 16,600 bytes | 🎉 -16 bytes |
| AvatarGroupModifiers.o | 10,464 bytes | 10,448 bytes | 🎉 -16 bytes |
| AccessibleViewDelegate.o | 15,192 bytes | 15,176 bytes | 🎉 -16 bytes |
| ContentScrollViewTraits.o | 15,312 bytes | 15,296 bytes | 🎉 -16 bytes |
| PersonaButtonCarouselModifiers.o | 10,512 bytes | 10,496 bytes | 🎉 -16 bytes |
| PopupMenuSection.o | 28,456 bytes | 28,440 bytes | 🎉 -16 bytes |
| PopupMenuTokenSet.o | 20,288 bytes | 20,272 bytes | 🎉 -16 bytes |
| GenericDateTimePicker.o | 13,000 bytes | 12,984 bytes | 🎉 -16 bytes |
| SegmentItem.o | 32,568 bytes | 32,544 bytes | 🎉 -24 bytes |
| MSFPersonaButton.o | 37,712 bytes | 37,688 bytes | 🎉 -24 bytes |
| CALayer+Extensions.o | 11,216 bytes | 11,192 bytes | 🎉 -24 bytes |
| DateComponents+Extensions.o | 11,432 bytes | 11,408 bytes | 🎉 -24 bytes |
| TokenSet.o | 18,616 bytes | 18,592 bytes | 🎉 -24 bytes |
| NSLayoutConstraint+Extensions.o | 24,912 bytes | 24,888 bytes | 🎉 -24 bytes |
| String+Extension.o | 23,480 bytes | 23,456 bytes | 🎉 -24 bytes |
| UIImage+Extensions.o | 11,248 bytes | 11,224 bytes | 🎉 -24 bytes |
| EmptyTokenSet.o | 37,176 bytes | 37,152 bytes | 🎉 -24 bytes |
| ContentHeightResolutionContext.o | 22,480 bytes | 22,456 bytes | 🎉 -24 bytes |
| Obscurable.o | 24,344 bytes | 24,320 bytes | 🎉 -24 bytes |
| PopupMenuProtocols.o | 26,632 bytes | 26,608 bytes | 🎉 -24 bytes |
| FluentTheme+Tokens.o | 61,400 bytes | 61,376 bytes | 🎉 -24 bytes |
| UIApplication+Extensions.o | 11,464 bytes | 11,440 bytes | 🎉 -24 bytes |
| MSFActivityIndicator.o | 30,720 bytes | 30,696 bytes | 🎉 -24 bytes |
| PersonaBadgeViewDataSource.o | 36,648 bytes | 36,624 bytes | 🎉 -24 bytes |
| MSFHeadsUpDisplay.o | 33,624 bytes | 33,600 bytes | 🎉 -24 bytes |
| ActivityIndicatorModifiers.o | 25,712 bytes | 25,688 bytes | 🎉 -24 bytes |
| UIViewController+Navigation.o | 15,456 bytes | 15,432 bytes | 🎉 -24 bytes |
| MSFAvatarGroup.o | 27,616 bytes | 27,584 bytes | 🎉 -32 bytes |
| MSFIndeterminateProgressBar.o | 28,200 bytes | 28,168 bytes | 🎉 -32 bytes |
| DynamicColor.o | 49,504 bytes | 49,472 bytes | 🎉 -32 bytes |
| BottomSheetPassthroughView.o | 21,384 bytes | 21,352 bytes | 🎉 -32 bytes |
| MSFCardNudge.o | 36,352 bytes | 36,320 bytes | 🎉 -32 bytes |
| PersonaCell.o | 63,040 bytes | 63,008 bytes | 🎉 -32 bytes |
| AvatarGroupTokenSet.o | 46,336 bytes | 46,304 bytes | 🎉 -32 bytes |
| MSFAvatar.o | 27,184 bytes | 27,152 bytes | 🎉 -32 bytes |
| TouchForwardingView.o | 33,640 bytes | 33,608 bytes | 🎉 -32 bytes |
| EasyTapButton.o | 27,560 bytes | 27,528 bytes | 🎉 -32 bytes |
| CardPresenterNavigationController.o | 27,480 bytes | 27,440 bytes | 🎉 -40 bytes |
| BlurringView.o | 34,424 bytes | 34,384 bytes | 🎉 -40 bytes |
| PopupMenuSectionHeaderView.o | 27,776 bytes | 27,736 bytes | 🎉 -40 bytes |
| UIScrollView+Extensions.o | 33,136 bytes | 33,096 bytes | 🎉 -40 bytes |
| LabelTokenSet.o | 57,888 bytes | 57,848 bytes | 🎉 -40 bytes |
| UIKit+SwiftUI_interoperability.o | 45,688 bytes | 45,648 bytes | 🎉 -40 bytes |
| CalendarConfiguration.o | 49,616 bytes | 49,576 bytes | 🎉 -40 bytes |
| PersonaButtonCarouselTokenSet.o | 41,672 bytes | 41,632 bytes | 🎉 -40 bytes |
| BadgeLabelTokenSet.o | 55,192 bytes | 55,152 bytes | 🎉 -40 bytes |
| MSFPersonaButtonCarousel.o | 32,328 bytes | 32,288 bytes | 🎉 -40 bytes |
| TokenizedControlView.o | 166,160 bytes | 166,120 bytes | 🎉 -40 bytes |
| LinearGradientInfo.o | 45,216 bytes | 45,176 bytes | 🎉 -40 bytes |
| SeparatorTokenSet.o | 40,208 bytes | 40,168 bytes | 🎉 -40 bytes |
| BottomSheetTokenSet.o | 46,800 bytes | 46,752 bytes | 🎉 -48 bytes |
| IndeterminateProgressBarTokenSet.o | 44,096 bytes | 44,048 bytes | 🎉 -48 bytes |
| TwoLineTitleView+Navigation.o | 27,416 bytes | 27,368 bytes | 🎉 -48 bytes |
| DotView.o | 31,616 bytes | 31,568 bytes | 🎉 -48 bytes |
| ControlTokenSet.o | 69,840 bytes | 69,792 bytes | 🎉 -48 bytes |
| ShadowInfo.o | 47,848 bytes | 47,800 bytes | 🎉 -48 bytes |
| ActivityIndicatorTokenSet.o | 62,312 bytes | 62,264 bytes | 🎉 -48 bytes |
| MSFAvatarPresence.o | 43,232 bytes | 43,184 bytes | 🎉 -48 bytes |
| ColorProviding.o | 38,136 bytes | 38,088 bytes | 🎉 -48 bytes |
| ResizingHandleTokenSet.o | 44,536 bytes | 44,488 bytes | 🎉 -48 bytes |
| UIBarButtonItem+BadgeValue.o | 31,000 bytes | 30,952 bytes | 🎉 -48 bytes |
| HUDModifiers.o | 67,000 bytes | 66,944 bytes | 🎉 -56 bytes |
| DayOfMonth.o | 59,128 bytes | 59,072 bytes | 🎉 -56 bytes |
| HeadsUpDisplayTokenSet.o | 53,168 bytes | 53,112 bytes | 🎉 -56 bytes |
| SwiftUI+ViewAnimation.o | 48,928 bytes | 48,872 bytes | 🎉 -56 bytes |
| BarButtonItems.o | 28,336 bytes | 28,280 bytes | 🎉 -56 bytes |
| ShapeCutout.o | 37,224 bytes | 37,168 bytes | 🎉 -56 bytes |
| Persona.o | 73,832 bytes | 73,776 bytes | 🎉 -56 bytes |
| TabBarTokenSet.o | 44,864 bytes | 44,800 bytes | 🎉 -64 bytes |
| FontInfo.o | 70,008 bytes | 69,944 bytes | 🎉 -64 bytes |
| NotificationModifiers.o | 71,320 bytes | 71,256 bytes | 🎉 -64 bytes |
| CalendarViewMonthBannerView.o | 27,440 bytes | 27,376 bytes | 🎉 -64 bytes |
| PersonaButtonTokenSet.o | 65,776 bytes | 65,712 bytes | 🎉 -64 bytes |
| FluentUIHostingController.o | 32,456 bytes | 32,392 bytes | 🎉 -64 bytes |
| SwiftUI+ViewPresentation.o | 58,840 bytes | 58,776 bytes | 🎉 -64 bytes |
| SideTabBarTokenSet.o | 50,384 bytes | 50,320 bytes | 🎉 -64 bytes |
| CommandBarButtonGroupView.o | 59,104 bytes | 59,040 bytes | 🎉 -64 bytes |
| PopupMenuItemTokenSet.o | 32,112 bytes | 32,040 bytes | 🎉 -72 bytes |
| TwoLineTitleViewTokenSet.o | 57,304 bytes | 57,232 bytes | 🎉 -72 bytes |
| AvatarTitleViewTokenSet.o | 51,304 bytes | 51,232 bytes | 🎉 -72 bytes |
| DateTimePickerViewLayout.o | 45,216 bytes | 45,136 bytes | 🎉 -80 bytes |
| SwiftUI+ViewModifiers.o | 161,568 bytes | 161,488 bytes | 🎉 -80 bytes |
| Separator.o | 72,176 bytes | 72,096 bytes | 🎉 -80 bytes |
| TableViewHeaderFooterViewTokenSet.o | 80,352 bytes | 80,272 bytes | 🎉 -80 bytes |
| Date+CellFileAccessoryView.o | 53,512 bytes | 53,432 bytes | 🎉 -80 bytes |
| DatePickerSelectionManager.o | 57,584 bytes | 57,504 bytes | 🎉 -80 bytes |
| UINavigationItem+Navigation.o | 72,472 bytes | 72,392 bytes | 🎉 -80 bytes |
| DimmingView.o | 51,288 bytes | 51,200 bytes | 🎉 -88 bytes |
| DrawerTokenSet.o | 54,304 bytes | 54,216 bytes | 🎉 -88 bytes |
| String+Date.o | 60,688 bytes | 60,600 bytes | 🎉 -88 bytes |
| FluentUIFramework.o | 89,464 bytes | 89,368 bytes | 🎉 -96 bytes |
| Date+Extensions.o | 48,360 bytes | 48,264 bytes | 🎉 -96 bytes |
| FluentTheme.o | 158,520 bytes | 158,424 bytes | 🎉 -96 bytes |
| AliasTokens.o | 242,848 bytes | 242,752 bytes | 🎉 -96 bytes |
| CalendarViewDayTodayCell.o | 36,080 bytes | 35,984 bytes | 🎉 -96 bytes |
| CommandingItem.o | 87,440 bytes | 87,344 bytes | 🎉 -96 bytes |
| TooltipTokenSet.o | 56,456 bytes | 56,360 bytes | 🎉 -96 bytes |
| TooltipViewController.o | 45,904 bytes | 45,808 bytes | 🎉 -96 bytes |
| CalendarViewDayMonthYearCell.o | 40,960 bytes | 40,864 bytes | 🎉 -96 bytes |
| UIColor+Extensions.o | 80,824 bytes | 80,720 bytes | 🎉 -104 bytes |
| ControlHostingView.o | 62,064 bytes | 61,960 bytes | 🎉 -104 bytes |
| AccessibilityContainerView.o | 36,560 bytes | 36,456 bytes | 🎉 -104 bytes |
| TabBarItem.o | 68,200 bytes | 68,096 bytes | 🎉 -104 bytes |
| TabBarItemTokenSet.o | 60,624 bytes | 60,520 bytes | 🎉 -104 bytes |
| BadgeViewTokenSet.o | 95,792 bytes | 95,688 bytes | 🎉 -104 bytes |
| ResizingHandleView.o | 72,968 bytes | 72,864 bytes | 🎉 -104 bytes |
| ActivityIndicatorCell.o | 82,424 bytes | 82,312 bytes | 🎉 -112 bytes |
| NavigationBarTokenSet.o | 72,944 bytes | 72,832 bytes | 🎉 -112 bytes |
| CalendarViewDayMonthCell.o | 42,248 bytes | 42,136 bytes | 🎉 -112 bytes |
| CardTransitionAnimator.o | 66,520 bytes | 66,408 bytes | 🎉 -112 bytes |
| PopupMenuItem.o | 121,312 bytes | 121,200 bytes | 🎉 -112 bytes |
| DateTimePickerViewComponentTableView.o | 67,024 bytes | 66,912 bytes | 🎉 -112 bytes |
| SearchBarTokenSet.o | 79,648 bytes | 79,528 bytes | 🎉 -120 bytes |
| BooleanCell.o | 90,960 bytes | 90,840 bytes | 🎉 -120 bytes |
| Calendar+Extensions.o | 46,448 bytes | 46,328 bytes | 🎉 -120 bytes |
| CardPresentationController.o | 46,744 bytes | 46,624 bytes | 🎉 -120 bytes |
| CalendarViewWeekdayHeadingView.o | 85,976 bytes | 85,856 bytes | 🎉 -120 bytes |
| CommandBarTokenSet.o | 63,176 bytes | 63,056 bytes | 🎉 -120 bytes |
| PillButtonTokenSet.o | 88,480 bytes | 88,360 bytes | 🎉 -120 bytes |
| ShimmerTokenSet.o | 72,032 bytes | 71,912 bytes | 🎉 -120 bytes |
| CommandBarItem.o | 106,408 bytes | 106,280 bytes | 🎉 -128 bytes |
| CenteredLabelCell.o | 85,440 bytes | 85,312 bytes | 🎉 -128 bytes |
| UIView+Extensions.o | 44,872 bytes | 44,744 bytes | 🎉 -128 bytes |
| BadgeLabel.o | 55,576 bytes | 55,448 bytes | 🎉 -128 bytes |
| BadgeStringExtractor.o | 62,912 bytes | 62,784 bytes | 🎉 -128 bytes |
| FluentTextFieldInternal.o | 47,744 bytes | 47,608 bytes | 🎉 -136 bytes |
| CommandBarButton.o | 97,008 bytes | 96,864 bytes | 🎉 -144 bytes |
| ShimmerLinesView.o | 107,176 bytes | 107,032 bytes | 🎉 -144 bytes |
| CardNudgeTokenSet.o | 81,928 bytes | 81,784 bytes | 🎉 -144 bytes |
| CalendarViewLayout.o | 73,712 bytes | 73,568 bytes | 🎉 -144 bytes |
| TextFieldTokenSet.o | 89,424 bytes | 89,280 bytes | 🎉 -144 bytes |
| DrawerTransitionAnimator.o | 70,792 bytes | 70,648 bytes | 🎉 -144 bytes |
| SegmentedControlTokenSet.o | 91,016 bytes | 90,864 bytes | 🎉 -152 bytes |
| NotificationTokenSet.o | 90,712 bytes | 90,560 bytes | 🎉 -152 bytes |
| SegmentPillButton.o | 90,200 bytes | 90,048 bytes | 🎉 -152 bytes |
| Tooltip.o | 123,808 bytes | 123,648 bytes | 🎉 -160 bytes |
| DateTimePickerViewComponentCell.o | 57,416 bytes | 57,256 bytes | 🎉 -160 bytes |
| MultilineCommandBar.o | 145,008 bytes | 144,840 bytes | 🎉 -168 bytes |
| PersonaButtonCarousel.o | 169,024 bytes | 168,856 bytes | 🎉 -168 bytes |
| AvatarTokenSet.o | 118,480 bytes | 118,304 bytes | 🎉 -176 bytes |
| MSFNotification.o | 135,784 bytes | 135,608 bytes | 🎉 -176 bytes |
| ButtonTokenSet.o | 120,688 bytes | 120,512 bytes | 🎉 -176 bytes |
| PersonaListView.o | 175,544 bytes | 175,360 bytes | 🎉 -184 bytes |
| CommandBarCommandGroupsView.o | 200,800 bytes | 200,616 bytes | 🎉 -184 bytes |
| PageCardPresenterController.o | 146,552 bytes | 146,368 bytes | 🎉 -184 bytes |
| DrawerShadowView.o | 77,800 bytes | 77,616 bytes | 🎉 -184 bytes |
| CalendarViewDataSource.o | 126,864 bytes | 126,680 bytes | 🎉 -184 bytes |
| DateTimePicker.o | 165,072 bytes | 164,880 bytes | 🎉 -192 bytes |
| NavigationAnimator.o | 113,352 bytes | 113,152 bytes | 🎉 -200 bytes |
| CardNudge.o | 385,888 bytes | 385,680 bytes | 🎉 -208 bytes |
| HeadsUpDisplay.o | 247,040 bytes | 246,832 bytes | 🎉 -208 bytes |
| ActivityIndicator.o | 180,872 bytes | 180,664 bytes | 🎉 -208 bytes |
| NavigationController.o | 157,112 bytes | 156,904 bytes | 🎉 -208 bytes |
| TabBarView.o | 125,896 bytes | 125,688 bytes | 🎉 -208 bytes |
| ShimmerView.o | 206,976 bytes | 206,760 bytes | 🎉 -216 bytes |
| HUD.o | 264,416 bytes | 264,200 bytes | 🎉 -216 bytes |
| TableViewCellTokenSet.o | 107,816 bytes | 107,592 bytes | 🎉 -224 bytes |
| DateTimePickerViewComponent.o | 134,928 bytes | 134,696 bytes | 🎉 -232 bytes |
| BadgeLabelButton.o | 109,088 bytes | 108,856 bytes | 🎉 -232 bytes |
| CalendarView.o | 71,024 bytes | 70,792 bytes | 🎉 -232 bytes |
| IndeterminateProgressBar.o | 231,112 bytes | 230,872 bytes | 🎉 -240 bytes |
| Label.o | 135,896 bytes | 135,632 bytes | 🎉 -264 bytes |
| CommandBar.o | 204,752 bytes | 204,480 bytes | 🎉 -272 bytes |
| PillButton.o | 163,128 bytes | 162,840 bytes | 🎉 -288 bytes |
| DateTimePickerController.o | 138,608 bytes | 138,320 bytes | 🎉 -288 bytes |
| CalendarViewDayCell.o | 130,424 bytes | 130,128 bytes | 🎉 -296 bytes |
| ShyHeaderView.o | 119,880 bytes | 119,584 bytes | 🎉 -296 bytes |
| FluentTextField.o | 193,560 bytes | 193,256 bytes | 🎉 -304 bytes |
| AvatarGroup.o | 320,416 bytes | 320,112 bytes | 🎉 -304 bytes |
| ActionsCell.o | 166,304 bytes | 165,992 bytes | 🎉 -312 bytes |
| CardView.o | 254,760 bytes | 254,424 bytes | 🎉 -336 bytes |
| PillButtonBar.o | 253,216 bytes | 252,872 bytes | 🎉 -344 bytes |
| DateTimePickerView.o | 208,968 bytes | 208,616 bytes | 🎉 -352 bytes |
| PopupMenuController.o | 380,944 bytes | 380,568 bytes | 🎉 -376 bytes |
| TwoLineTitleView.o | 253,304 bytes | 252,912 bytes | 🎉 -392 bytes |
| SideTabBar.o | 193,848 bytes | 193,448 bytes | 🎉 -400 bytes |
| TooltipView.o | 217,992 bytes | 217,584 bytes | 🎉 -408 bytes |
| Button.o | 204,648 bytes | 204,232 bytes | 🎉 -416 bytes |
| BadgeView.o | 575,760 bytes | 575,312 bytes | 🎉 -448 bytes |
| PersonaButton.o | 243,936 bytes | 243,488 bytes | 🎉 -448 bytes |
| PopupMenuItemCell.o | 177,568 bytes | 177,112 bytes | 🎉 -456 bytes |
| TableViewHeaderFooterView.o | 273,056 bytes | 272,600 bytes | 🎉 -456 bytes |
| TabBarItemView.o | 219,536 bytes | 219,064 bytes | 🎉 -472 bytes |
| FluentNotification.o | 687,848 bytes | 687,328 bytes | 🎉 -520 bytes |
| PeoplePicker.o | 291,536 bytes | 291,008 bytes | 🎉 -528 bytes |
| SegmentedControl.o | 341,024 bytes | 340,488 bytes | 🎉 -536 bytes |
| SearchBar.o | 394,624 bytes | 394,088 bytes | 🎉 -536 bytes |
| AvatarTitleView.o | 244,368 bytes | 243,792 bytes | 🎉 -576 bytes |
| Avatar.o | 525,976 bytes | 525,400 bytes | 🎉 -576 bytes |
| ShyHeaderController.o | 241,704 bytes | 241,120 bytes | 🎉 -584 bytes |
| DrawerPresentationController.o | 239,664 bytes | 239,048 bytes | 🎉 -616 bytes |
| TableViewCellFileAccessoryView.o | 316,160 bytes | 315,536 bytes | 🎉 -624 bytes |
| DateTimePickerViewDataSource.o | 275,904 bytes | 275,200 bytes | 🎉 -704 bytes |
| DatePickerController.o | 315,496 bytes | 314,744 bytes | 🎉 -752 bytes |
| BottomSheetController.o | 484,608 bytes | 483,704 bytes | 🎉 -904 bytes |
| NavigationBar.o | 529,584 bytes | 528,656 bytes | 🎉 -928 bytes |
| BadgeField.o | 549,376 bytes | 548,392 bytes | 🎉 -984 bytes |
| BottomCommandingController.o | 678,000 bytes | 676,976 bytes | 🎉 -1,024 bytes |
| DrawerController.o | 485,752 bytes | 484,704 bytes | 🎉 -1,048 bytes |
| TableViewCell.o | 809,888 bytes | 808,168 bytes | 🎉 -1,720 bytes |
| FocusRingView.o | 793,544 bytes | 790,640 bytes | 🎉 -2,904 bytes |
| __.SYMDEF | 4,558,488 bytes | 4,524,664 bytes | 🎉 -33,824 bytes |
</details>

### Verification

Tested by adding new table view cells to demo app

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| | <img width="375" alt="image" src="https://github.com/microsoft/fluentui-apple/assets/35238115/1f904b0b-e69d-4abf-96c4-fa699fc032d7"> |
</details>

### Pull request checklist

This PR has considered, but most should be not applicable:
- Light and Dark appearances
- iOS supported versions (all major versions greater than or equal current target deployment version)
- VoiceOver and Keyboard Accessibility
- Internationalization and Right to Left layouts
- Different resolutions (1x, 2x, 3x)
- Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1779)