### PR TITLE
Remove font scaling from TabBar titles

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
@@ -66,7 +66,7 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .titleLabelFontLandscape:
-                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
+                return .uiFont { theme.typography(.caption2) }
 
             case .unreadDotSize:
                 return .float { 8.0 }

--- a/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
@@ -63,10 +63,10 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 }
 
             case .titleLabelFontPortrait:
-                return .uiFont { theme.typography(.caption2) }
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .titleLabelFontLandscape:
-                return .uiFont { theme.typography(.caption2) }
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .unreadDotSize:
                 return .float { 8.0 }

--- a/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
@@ -66,7 +66,7 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .titleLabelFontLandscape:
-                return .uiFont { theme.typography(.caption2) }
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .unreadDotSize:
                 return .float { 8.0 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The tab titles on our tab bar on large text mode push the images out of the tab bar. The default behavior before the tokenization of tab bar was to not allow the titles on tab bar to scale for large text mode. 
So this PR reverts to that behavior to fix this bug on partner apps.

### Verification
<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="484" alt="before_tabbar" src="https://github.com/microsoft/fluentui-apple/assets/106181067/234aec56-df80-481d-9d19-026e6345783a"> | <img width="484" alt="after_tabbar" src="https://github.com/microsoft/fluentui-apple/assets/106181067/163257c2-f3e8-47b5-aa5b-830ddd8f4204"> |
| <img width="484" alt="before_sidetabbar" src="https://github.com/microsoft/fluentui-apple/assets/106181067/68386d7c-308f-4121-96d3-c5c0247fef4d"> | <img width="484" alt="after_sidetabbar" src="https://github.com/microsoft/fluentui-apple/assets/106181067/3c609284-a61c-4278-8237-e60871298280"> |
| <img width="845" alt="before_landscape" src="https://github.com/microsoft/fluentui-apple/assets/106181067/bd354699-d318-45b0-8b3c-8e39ba32cd56"> | ![Screenshot 2023-06-12 at 1 06 43 PM](https://github.com/microsoft/fluentui-apple/assets/106181067/1e87f504-a1ed-48a7-acc9-29da84e892c4) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1780)