### PR TITLE
[Cherry-pick][main_0.17] Remove font scaling from TabBar titles (#1780)

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
@@ -63,10 +63,10 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 }
 
             case .titleLabelFontPortrait:
-                return .uiFont { theme.typography(.caption2) }
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .titleLabelFontLandscape:
-                return .uiFont { theme.typography(.caption2) }
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
 
             case .unreadDotSize:
                 return .float { 8.0 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-pick #1780 to main_0.17.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1783)