### PR TITLE
Fix duplicated navigation bar on gradient style landscape

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -571,11 +571,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             updateViewsForLargeTitlePresentation(for: topItem)
             updateFakeCenterTitleConstraints()
 
-            // We don't want to alter the hidden state of the backgroundView and the contentStackView for the gradient style when the traitCollection changes.
-            if style != .gradient {
-                updateViewsForLargeTitlePresentation(for: topItem)
-            }
-
             // change bar button image size and title inset depending on device rotation
             if let navigationItem = topItem {
                 updateSubtitleView(for: navigationItem)
@@ -851,7 +846,10 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         // UINavigationBar's internal view hierarchy, we can't propagate touch events on
         // parts that are outside that 32px range to the actual title view.
         // We therefore depend on the "fake" navigation bar that we use for leading titles to save the day.
-        if usesLeadingTitle || systemWantsCompactNavigationBar {
+
+        // We also want to hide the backgroundView and the contentStackView for gradient style regular title to
+        // avoid displaying duplicated navigation bar items.
+        if usesLeadingTitle || (style != .gradient && systemWantsCompactNavigationBar) {
             if backgroundView.isHidden {
                 backgroundView.isHidden = false
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There's a bug where gradient nav bar regular title on landscape mode would show duplicated items. Attempting to fix the bug in `traitCollectionDidChange`  partially fixes the issue when switching from portrait to landscape but not when the app boots in landscape.
Since the problematic function here is `updateViewsForLargeTitlePresentation`, I just added a check where non-leading gradient title hide `backgroundView` and `contentStackView` for both portrait and landscape.

### Binary change

Total increase: 1,136 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,392,056 bytes | 30,393,192 bytes | ⚠️ 1,136 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 4,726,000 bytes | 4,726,576 bytes | ⚠️ 576 bytes |
| NavigationBar.o | 534,184 bytes | 534,744 bytes | ⚠️ 560 bytes |
</details>

### Verification

The fix was validated on both our demo app and on the partner app.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="860" alt="before_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/d48dd1b6-dfc2-4e90-ad9a-7f7071e9b1df"> | <img width="860" alt="after_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/a6640182-b7ad-476e-8004-7405e2d6c37c"> |
| <img width="860" alt="before_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/e6d39383-6a69-4a2e-ada8-6383f777f468"> | <img width="860" alt="after_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/cfee0c1c-b738-4ac8-89b6-364151fec4fa"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1784)