### PR TITLE
Remove item limit on SideTabBar

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -148,7 +148,6 @@ open class SideTabBar: UIView, TokenizedControlInternal {
     }
 
     private struct Constants {
-        static let maxTabCount: Int = 5
         static let numberOfTitleLines: Int = 2
     }
 
@@ -228,17 +227,12 @@ open class SideTabBar: UIView, TokenizedControlInternal {
             subview.removeFromSuperview()
         }
 
-        let allItems = items(in: section)
-        let numberOfItems = allItems.count
-        if numberOfItems > Constants.maxTabCount {
-            preconditionFailure("tab bar items can't be more than \(Constants.maxTabCount)")
-        }
-
         let stackView = self.stackView(in: section)
         let badgePadding = section == .top ? SideTabBarTokenSet.badgeTopSectionPadding : SideTabBarTokenSet.badgeBottomSectionPadding
         let showItemTitles = section == .top ? showTopItemTitles : showBottomItemTitles
         var didRestoreSelection = false
 
+        let allItems = items(in: section)
         for item in allItems {
             let tabBarItemView = TabBarItemView(item: item, showsTitle: showItemTitles, canResizeImage: false)
             tabBarItemView.translatesAutoresizingMaskIntoConstraints = false

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -203,6 +203,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         layoutConstraints.append(contentsOf: [
             topStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             topStackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor),
+            bottomStackView.topAnchor.constraint(greaterThanOrEqualTo: topStackView.bottomAnchor, constant: SideTabBarTokenSet.tabBarItemSpacing),
             bottomStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             bottomStackView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor),
             bottomSafeConstraint,


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Removes the limit of 5 items in the SideTabBar, and adds a constraint to make sure the top stack doesn't go over the bottom stack. 

Worth noting that landscape iPhone isn't actually a supported scenario for the SideTabBar, but the added constraint does improve it. There are still SafeArea issues on iPhone in landscape, but they won't be addressed in this PR.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| n/a | <img width="672" alt="SideTabBar_iPad_WayTooMany_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/0134228c-df3f-4708-bd15-f44ad4dfebc3"> |
| <img width="716" alt="SideTabBar_iPad_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/a437db0d-e999-4834-974a-a8143ea1b044"> | <img width="716" alt="SideTabBar_iPad_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/7d78386b-be0a-4f58-ba6d-a89ad116df8d"> |
| <img width="565" alt="SideTabBar_iPhone_Portrait_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/299e6cfd-b0ab-4d37-a7ee-1152d1c2fcfa"> | <img width="565" alt="SideTabBar_iPhone_Portrait_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/f6d490e1-6e25-4783-99db-76d680e4cb9e"> |
| <img width="1006" alt="SideTabBar_iPhone_Landscape_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/88211fca-3d6f-4d9f-82cc-88cbf0dd00df"> | <img width="1006" alt="SideTabBar_iPhone_Landscape_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/ad9d39bd-45e5-46e9-ba24-6c49fc8da4e2"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1785)