### PR TITLE
[Cherry-pick][main_0.17] Fix duplicated headers on gradient landscape (#1784)

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -571,11 +571,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             updateViewsForLargeTitlePresentation(for: topItem)
             updateFakeCenterTitleConstraints()
 
-            // We don't want to alter the hidden state of the backgroundView and the contentStackView for the gradient style when the traitCollection changes.
-            if style != .gradient {
-                updateViewsForLargeTitlePresentation(for: topItem)
-            }
-
             // change bar button image size and title inset depending on device rotation
             if let navigationItem = topItem {
                 updateSubtitleView(for: navigationItem)
@@ -851,7 +846,10 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         // UINavigationBar's internal view hierarchy, we can't propagate touch events on
         // parts that are outside that 32px range to the actual title view.
         // We therefore depend on the "fake" navigation bar that we use for leading titles to save the day.
-        if usesLeadingTitle || systemWantsCompactNavigationBar {
+
+        // We also want to hide the backgroundView and the contentStackView for gradient style regular title to
+        // avoid displaying duplicated navigation bar items.
+        if usesLeadingTitle || (style != .gradient && systemWantsCompactNavigationBar) {
             if backgroundView.isHidden {
                 backgroundView.isHidden = false
             }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Cherry-picks #1784 to `main_0.17`

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1786)