### PR TITLE
Use base 10 integer literals for InteractivePart

### DIFF
--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -52,9 +52,9 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     public enum InteractivePart: Int {
         // The @objc requirement doesn't let us use OptionSet, so we provide the bitmasks and the `contains` method ourselves
         case none = 0
-        case title = 0b01
-        case subtitle = 0b10
-        case all = 0b11
+        case title = 1 // 0b01
+        case subtitle = 2 // 0b10
+        case all = 3 // 0b11
 
         func contains(_ other: InteractivePart) -> Bool {
             return rawValue & other.rawValue != 0


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

One downstream consumer of FUA is using a compiler that doesn't like binary literals in the generated FluentUI-Swift.h file. No sweat off our backs, I guess, but we might as well keep the binary literals commented for the sake of future readers.

### Binary change

Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,907,176 bytes | 31,907,176 bytes | 🎉 0 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
</details>

### Verification

The resulting "before" and "after" binaries are literally the same file.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1791)