### PR TITLE
Check for existing titleView before creating a custom titleView

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -849,7 +849,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
         // We also want to hide the backgroundView and the contentStackView for gradient style regular title to
         // avoid displaying duplicated navigation bar items.
-        if usesLeadingTitle || (style != .gradient && systemWantsCompactNavigationBar) {
+        if usesLeadingTitle || (style != .gradient && systemWantsCompactNavigationBar && navigationItem?.titleView == nil) {
             if backgroundView.isHidden {
                 backgroundView.isHidden = false
             }
@@ -906,9 +906,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     }
 
     private func updateSubtitleView(for navigationItem: UINavigationItem?) {
-        guard let navigationItem = navigationItem, !usesLeadingTitle else {
-            // Use the default title view
-            navigationItem?.titleView = nil
+        guard let navigationItem = navigationItem, navigationItem.titleView == nil, !usesLeadingTitle else {
             return
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

`updateSubtitleView` in `NavigationBar` uses the navigation item's properties to create its own custom `TwoLineTitleView` and applies it as the item's `titleView`. This causes a bug in a client app where their custom title view would not show up on the navigation bar. To fix this bug, we check whether the client passed in a custom `titleView` before we change it.

In such scenarios, we also would need to hide the fake navigation bar if the client passed in their own title view otherwise it will cover it.

### Binary change

Total increase: 1,496 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,390,360 bytes | 30,391,856 bytes | ⚠️ 1,496 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| NavigationBar.o | 534,744 bytes | 535,664 bytes | ⚠️ 920 bytes |
| __.SYMDEF | 4,726,536 bytes | 4,727,112 bytes | ⚠️ 576 bytes |
</details>


### Verification

The bug wasn't reproducible on our demo app but the fix was verified on all partner apps.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1792)