### PR TITLE
[main_0.18] Use base 10 integer literals for InteractivePart (#1791)

### DIFF
--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -52,9 +52,9 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     public enum InteractivePart: Int {
         // The @objc requirement doesn't let us use OptionSet, so we provide the bitmasks and the `contains` method ourselves
         case none = 0
-        case title = 0b01
-        case subtitle = 0b10
-        case all = 0b11
+        case title = 1 // 0b01
+        case subtitle = 2 // 0b10
+        case all = 3 // 0b11
 
         func contains(_ other: InteractivePart) -> Bool {
             return rawValue & other.rawValue != 0


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Cherry-picks #1791 to main_0.18.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1793)