### PR TITLE
Remove deprecated API `shouldAutorotate` in DrawerController

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -363,10 +363,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         return super.preferredContentSize.height == 0 && preferredContentHeight == 0 && (contentController?.preferredContentSize.height ?? 0) == 0
     }
 
-    open override var shouldAutorotate: Bool {
-        return presentingViewController?.shouldAutorotate ?? super.shouldAutorotate
-    }
-
     open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return presentingViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
     }

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -520,6 +520,10 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: view) { [weak self] in
             self?.updateBackgroundColor()
         }
+
+        if #available(iOS 16, *) {
+            setNeedsUpdateOfSupportedInterfaceOrientations()
+        }
     }
 
     open override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

To help partners with their preparation for iOS 17 release, we're removing the override of `shouldAutorotate` since it's a deprecated API in iOS 16. 
For iOS 15 and below our drawer uses the default value of true for `shouldAutorotate`. Since we've already overridden `supportedInterfaceOrientations` to conform to the presenting view controller's orientations, the drawer will now always adapt to the presenting controller's orientation.
For iOS 16, Apple wants us to explicitly call `setNeedsUpdateOfSupportedInterfaceOrientations()` as well so we're doing that in `viewDidLoad`.

### Binary change

Total increase: 0 bytes
Total decrease: -2,944 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,391,856 bytes | 30,388,912 bytes | 🎉 -2,944 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 4,727,112 bytes | 4,726,416 bytes | 🎉 -696 bytes |
| DrawerController.o | 490,800 bytes | 488,552 bytes | 🎉 -2,248 bytes |
</details>

### Verification

This was validated for iOS 15 and 16 on our demo app and partner apps.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="484" alt="before_portrait" src="https://github.com/microsoft/fluentui-apple/assets/106181067/ae0d5804-2206-4a50-8be8-62eb34fd194d"> | <img width="484" alt="after_portrait" src="https://github.com/microsoft/fluentui-apple/assets/106181067/2a6a1f80-b783-4940-b318-2ea07849cb3d"> |
| <img width="845" alt="before_landscape" src="https://github.com/microsoft/fluentui-apple/assets/106181067/0d035871-ae44-49a2-8c6b-09158ceb5861"> | <img width="845" alt="after_landscape" src="https://github.com/microsoft/fluentui-apple/assets/106181067/adfca62c-9867-4b39-8b25-309ea7a62b1a"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1796)