### PR TITLE
[main_0.18] Remove deprecated API `shouldAutorotate` in DrawerController (#1796)

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -363,10 +363,6 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         return super.preferredContentSize.height == 0 && preferredContentHeight == 0 && (contentController?.preferredContentSize.height ?? 0) == 0
     }
 
-    open override var shouldAutorotate: Bool {
-        return presentingViewController?.shouldAutorotate ?? super.shouldAutorotate
-    }
-
     open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return presentingViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
     }
@@ -523,6 +519,10 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
 
         tokenSet.registerOnUpdate(for: view) { [weak self] in
             self?.updateBackgroundColor()
+        }
+
+        if #available(iOS 16, *) {
+            setNeedsUpdateOfSupportedInterfaceOrientations()
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picks #1796 to main_0.18.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1797)