### PR TITLE
Add `forcesCompactBarExpansion` to `NavigationController`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -229,7 +229,7 @@ class NavigationControllerDemoController: DemoController {
             changeStyleContinuously(in: content.navigationItem)
         }
 
-        let controller = NavigationController(rootViewController: content)
+        let controller = NavigationController(rootViewController: content, forcesCompactBarExpansion: true)
         let navigationBar = controller.msfNavigationBar
         navigationBar.gradient = gradient
         navigationBar.gradientMask = gradientMask

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -351,6 +351,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         return backButtonItem
     }()
 
+    // A default UINavigationItem doesn't have any traits that require an expanded navigation bar
+    private var itemCanBeCompact: Bool = true
+
     weak var backButtonDelegate: NavigationBarBackButtonDelegate? {
         didSet {
             backButtonItem.target = backButtonDelegate
@@ -516,12 +519,14 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     private func updateContentStackViewMargins(forExpandedContent contentIsExpanded: Bool) {
         let contentHeight = contentIsExpanded ? TokenSetType.expandedContentHeight : TokenSetType.normalContentHeight
-        let systemHeight = systemWantsCompactNavigationBar ? TokenSetType.compactSystemHeight : TokenSetType.systemHeight
+
+        let desiredHeight = (systemWantsCompactNavigationBar && itemCanBeCompact) ? TokenSetType.compactSystemHeight : TokenSetType.systemHeight
+        print("desiredHeight is \(desiredHeight)")
 
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,
             leading: contentLeadingMargin,
-            bottom: systemHeight - contentHeight,
+            bottom: desiredHeight - contentHeight,
             trailing: contentTrailingMargin
         )
     }
@@ -657,6 +662,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         updateShadow(for: navigationItem)
         updateTopAccessoryView(for: navigationItem)
         updateSubtitleView(for: navigationItem)
+
+        itemCanBeCompact = navigationItem.canBeCompact
+        updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
 
         titleView.update(with: navigationItem)
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -521,7 +521,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         let contentHeight = contentIsExpanded ? TokenSetType.expandedContentHeight : TokenSetType.normalContentHeight
 
         let desiredHeight = (systemWantsCompactNavigationBar && itemCanBeCompact) ? TokenSetType.compactSystemHeight : TokenSetType.systemHeight
-        print("desiredHeight is \(desiredHeight)")
 
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -128,13 +128,7 @@ open class NavigationController: UINavigationController {
     }
 
     private func viewControllerNeedsWrapping(_ viewController: UIViewController) -> Bool {
-        if viewController is ShyHeaderController {
-            return false
-        }
-        if viewController.navigationItem.titleStyle == .largeLeading || viewController.navigationItem.accessoryView != nil {
-            return true
-        }
-        return false
+        return !(viewController is ShyHeaderController)
     }
 
     func updateNavigationBar(for viewController: UIViewController) {

--- a/ios/FluentUI/Navigation/NavigationController.swift
+++ b/ios/FluentUI/Navigation/NavigationController.swift
@@ -43,7 +43,7 @@ open class NavigationController: UINavigationController {
     }
     private weak var _delegate: UINavigationControllerDelegate?
 
-    let forcesCompactBarExpansion: Bool
+    private let forcesCompactBarExpansion: Bool
 
     // Using "lazy var" instead of "let" to avoid memory leak issue in iOS 12
     private lazy var transitionAnimator = NavigationAnimator()

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -153,6 +153,6 @@ extension UINavigationItem {
             return true
         }
 
-        return subtitle == nil && titleStyle != .largeLeading && accessoryView == nil
+        return subtitle == nil && accessoryView == nil
     }
 }

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -145,3 +145,14 @@ import UIKit
         }
     }
 }
+
+extension UINavigationItem {
+    var canBeCompact: Bool {
+        // Large leading titles already do the right thing in compact nav bars
+        if titleStyle == .largeLeading {
+            return true
+        }
+
+        return subtitle == nil && titleStyle != .largeLeading && accessoryView == nil
+    }
+}

--- a/ios/docs/Controls/Navigation.md
+++ b/ios/docs/Controls/Navigation.md
@@ -4,7 +4,17 @@
 
 Use a `NavigationController` to enable users to navigate through hierarchical data. `NavigationController`, along with [extensions to `UINavigationItem`](https://github.com/microsoft/fluentui-apple/blob/main/ios/FluentUI/Navigation/UINavigationItem%2BNavigation.swift), allow you to render all relevant information with a Fluent look and feel.
 
-### Appearance Examples
+## Notes on Bar Height
+
+By default, iOS can show navigation bars in one of two different appearances: regular and compact, with heights of 44px and 32px respectively. The compact appearance is reserved for "small" iPhones (e.g., the iPhone 14 or iPhone 14 Pro) held horizontally.
+
+Due to its reduced footprint, the compact navigation bar doesn't play nicely with larger or two-line title views. Therefore, we always enforce a 44px-tall bar whenever we detract from a system-style title. In cases where a compact appearance style will do, we provide an optional parameter `forcesCompactBarExpansion` to the initializer of `NavigationController`. This value is set to `false` by default.
+
+This value should be to `true` for the root navigation controller, which usually displays more information. It should be left as `false` for any navigation-enabled sheets or dialogs the app spawns, since these will generally have simpler hierarchies.
+
+## Examples
+
+### Basic Appearance
 
 | `NavigationBar.Style` | Example |
 |-|-|


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This adds a new argument for `NavigationController` to allow clients to opt out of our more eager approach of wrapping view controllers in `ShyHeaderController`. This allows for a client-side fix where a navigation controller on a drawer doesn't properly show its content.

We make `forcesCompactBarExpansion` false by default because hacking the appearance of the navigation bar has proven to be a rather messy affair, and we'd rather not touch it unless we absolutely have to or if the user explicitly asks for it.

We also add documentation, because documentation is nice.

A better fix might be to better separate the "add extra padding to the navigation bar" and "have a bit that can expand and contract" components of the shy header. However, this should still be workable in the short term.

### Verification

Validated by applying this change to the client apps that originally reported the bug and noticing that it no longer repros.

| Before | After |
|-|-|
| <img width="898" alt="Screenshot 2023-07-07 at 1 43 54 PM" src="https://github.com/microsoft/fluentui-apple/assets/717674/953aaa9c-0411-4eac-94e5-4f4232ec2077"> | <img width="898" alt="Screenshot 2023-07-07 at 1 46 43 PM" src="https://github.com/microsoft/fluentui-apple/assets/717674/5b1b8143-7558-4dc7-a745-ecb6ac327e34"> |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1799)