### PR TITLE
[main_0.18] Add a trailing constraint for CommandBar's scroll view (#1801)

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -255,6 +255,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
 
     private lazy var scrollViewConstraints: [NSLayoutConstraint] = {
         return [scrollView.contentLayoutGuide.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+                scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: mainCommandGroupsView.trailingAnchor),
                 scrollView.topAnchor.constraint(equalTo: containerView.topAnchor),
                 scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
                 scrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Cherry-picks #1801 into main_0.18.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1803&drop=dogfoodAlpha