### PR TITLE
Reapply #1499

### DIFF
--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -351,7 +351,9 @@ open class SideTabBar: UIView, TokenizedControlInternal {
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),
                                                     forToken: .selectedColor)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemUnselectedColor),
-                                                    forToken: .unselectedColor)
+                                                    forToken: .unselectedImageColor)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemUnselectedColor),
+                                                    forToken: .unselectedTextColor)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontPortrait),
                                                     forToken: .titleLabelFontPortrait)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontLandscape),

--- a/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemTokenSet.swift
@@ -14,6 +14,9 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
         /// The radii of the four corners of the `BadgeLabel`.
         case badgeCornerRadii
 
+        /// Defines the foreground color of the `TabBarItem` when disabled.
+        case disabledColor
+
         /// The size of the image associated with the `TabBarItem` when the device is in landscape mode.
         case landscapeImageSize
 
@@ -23,7 +26,7 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
         /// The size of the image associated with the `TabBarItem` when the device is in portrait mode and has a label.
         case portraitImageWithLabelSize
 
-        /// Defines the background color of the  of the `TabBarItem` when selected.
+        /// Defines the foreground color of the `TabBarItem` when selected.
         case selectedColor
 
         /// Font info for the title label when in portrait view.
@@ -35,8 +38,11 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
         /// The size of the unread dot.
         case unreadDotSize
 
-        /// Defines the background color of the  of the `TabBarItem` when not selected.
-        case unselectedColor
+        /// Defines the image color of the `TabBarItem` when not selected.
+        case unselectedImageColor
+
+        /// Defines the text color of the `TabBarItem` when not selected.
+        case unselectedTextColor
     }
 
     init() {
@@ -48,6 +54,9 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
             case .badgeCornerRadii:
                 return .float { 10.0 }
 
+            case .disabledColor:
+                return .uiColor { theme.color(.foregroundDisabled1) }
+
             case .landscapeImageSize:
                 return .float { GlobalTokens.icon(.size240) }
 
@@ -58,9 +67,7 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
                 return .float { GlobalTokens.icon(.size240) }
 
             case .selectedColor:
-                return .uiColor {
-                    return theme.color(.brandForeground1)
-                }
+                return .uiColor { theme.color(.brandForeground1) }
 
             case .titleLabelFontPortrait:
                 return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
@@ -71,10 +78,11 @@ class TabBarItemTokenSet: ControlTokenSet<TabBarItemTokenSet.Tokens> {
             case .unreadDotSize:
                 return .float { 8.0 }
 
-            case .unselectedColor:
-                return .uiColor {
-                    return theme.color(.foreground3)
-                }
+            case .unselectedImageColor:
+                return .uiColor { return theme.color(.foreground3) }
+
+            case .unselectedTextColor:
+                return .uiColor { return theme.color(.foreground2) }
             }
         }
     }

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -205,7 +205,6 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
     private lazy var imageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = tokenSet[.unselectedColor].uiColor
 
         if canResizeImage {
             let sizeConstraints = (
@@ -225,7 +224,6 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         let titleLabel = Label()
         titleLabel.lineBreakMode = .byTruncatingTail
         titleLabel.textAlignment = .center
-        titleLabel.textColor = tokenSet[.unselectedColor].uiColor
 
         return titleLabel
     }()
@@ -257,9 +255,11 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
     }
 
     private func updateColors() {
-        let foregroundColor = isSelected ? tokenSet[.selectedColor].uiColor : tokenSet[.unselectedColor].uiColor
-        titleLabel.textColor = foregroundColor
-        imageView.tintColor = foregroundColor
+        let selectedColor = tokenSet[.selectedColor].uiColor
+        let disabledColor = tokenSet[.disabledColor].uiColor
+
+        titleLabel.textColor = isEnabled ? (isSelected ? selectedColor : tokenSet[.unselectedTextColor].uiColor) : disabledColor
+        imageView.tintColor = isEnabled ? (isSelected ? selectedColor : tokenSet[.unselectedImageColor].uiColor) : disabledColor
     }
 
     private func updateImage() {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -188,7 +188,9 @@ open class TabBarView: UIView, TokenizedControlInternal {
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),
                                                     forToken: .selectedColor)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemUnselectedColor),
-                                                    forToken: .unselectedColor)
+                                                    forToken: .unselectedImageColor)
+                tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemUnselectedColor),
+                                                    forToken: .unselectedTextColor)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontPortrait),
                                                     forToken: .titleLabelFontPortrait)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontLandscape),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In #1677 we regressed the fix from #1499, so I'm restoring that fix. To do that, I added some new tokens to the `TabBarItemTokenSet`, which is internal, so the APIs are unaffected.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="549" alt="TabBarItem_Enabled_Light_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/f862068c-40b4-4562-87bb-f07044809886"> | <img width="549" alt="TabBarItem_Enabled_Light_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/274216c8-001f-4022-9553-f442e874f66e"> |
| <img width="549" alt="TabBarItem_Disabled_Light_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/09213702-eab6-49b2-98fe-d5df2c60cf5b"> | <img width="549" alt="TabBarItem_Disabled_Light_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/0291cd63-0aaf-4d50-9178-0d3d9770523b"> |
| <img width="549" alt="TabBarItem_Enabled_Dark_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/11b84c65-d278-4a80-b2de-44b24cb1651e"> | <img width="549" alt="TabBarItem_Enabled_Dark_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e84da5b8-f95f-4146-9f6a-eff5a19bf49f"> |
| <img width="505" alt="TabBarItem_Disabled_Dark_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/768c70c6-c4f7-4c0f-b8c8-205957b87dd5"> | <img width="549" alt="TabBarItem_Disabled_Dark_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/4a2124b5-12ce-49df-b009-9e194e829728"> |
</details>



### Pull request checklist
This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1808&drop=dogfoodAlpha