### PR TITLE
Add internal init for PillButton that takes token overrides

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -53,7 +53,9 @@ open class PillButton: UIButton, TokenizedControlInternal {
                                                name: PillButtonBarItem.titleValueDidChangeNotification,
                                                object: pillBarItem)
 
-        tokenSet.replaceAllOverrides(with: tokenOverrides)
+        if let tokenOverrides {
+            tokenSet.replaceAllOverrides(with: tokenOverrides)
+        }
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -28,8 +28,15 @@ open class PillButton: UIButton, TokenizedControlInternal {
         updateAppearance()
     }
 
-    @objc public init(pillBarItem: PillButtonBarItem,
-                      style: PillButtonStyle = .primary) {
+    @objc convenience public init(pillBarItem: PillButtonBarItem,
+                                  style: PillButtonStyle = .primary) {
+        self.init(pillBarItem: pillBarItem, style: style, tokenOverrides: nil)
+    }
+
+    /// Internal init used by the `PillButtonBar` to initialized buttons with overrides.
+    init(pillBarItem: PillButtonBarItem,
+         style: PillButtonStyle = .primary,
+         tokenOverrides: [PillButtonTokenSet.Tokens: ControlTokenValue]?) {
         self.pillBarItem = pillBarItem
         self.style = style
         self.tokenSet = PillButtonTokenSet(style: { style })
@@ -46,6 +53,7 @@ open class PillButton: UIButton, TokenizedControlInternal {
                                                name: PillButtonBarItem.titleValueDidChangeNotification,
                                                object: pillBarItem)
 
+        tokenSet.replaceAllOverrides(with: tokenOverrides)
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -62,12 +62,6 @@ open class PillButtonBarItem: NSObject {
 /// Once a button is selected, the previously selected button will be deselected.
 @objc(MSFPillButtonBar)
 open class PillButtonBar: UIScrollView {
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-
-        updatePillButtonAppearance()
-    }
-
     open override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -269,10 +269,6 @@ open class PillButtonBar: UIScrollView {
             if shouldAddAccessibilityHint {
                 button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
             }
-
-            if pillButtonOverrideTokens != nil {
-                updatePillButtonAppearance()
-            }
         }
     }
 
@@ -379,7 +375,7 @@ open class PillButtonBar: UIScrollView {
     }
 
     private func createButtonWithItem(_ item: PillButtonBarItem) -> PillButton {
-        let button = PillButton(pillBarItem: item, style: pillButtonStyle)
+        let button = PillButton(pillBarItem: item, style: pillButtonStyle, tokenOverrides: pillButtonOverrideTokens)
         button.addTarget(self, action: #selector(selectButton(_:)), for: .touchUpInside)
         return button
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A client app has been experiencing a bug since we added the tokenized `PillButtonBar` where the `PillButtonBar` would load in, and then flash with default colors. Since the `PillButtonBar` knows what overrides it wants to apply to new `PillButton`s, applying them in init means that the `PillButton` never has a chance to load the wrong color. It also has the added benefit of being able to apply the overrides to the `tokenSet` before calling `registerOnUpdate`, so we don't call the closure from `registerOnUpdate` again for each override value.

I also removed the `PillButtonBar`'s `didMoveToWindow` override. The `PillButton` already has an implementation of `willMove(toWindow)`, so the buttons take care of updating themselves.

### Verification

No visual difference in our test app, but verified in the client app that the `PillButtonBar` is no longer flashing.
The blue/green toggle in our test app still works.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1809&drop=dogfoodAlpha