### PR TITLE
[main_0.19] Add internal init for PillButton that takes token overrides #1809

### DIFF
--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -28,8 +28,15 @@ open class PillButton: UIButton, TokenizedControlInternal {
         updateAppearance()
     }
 
-    @objc public init(pillBarItem: PillButtonBarItem,
-                      style: PillButtonStyle = .primary) {
+    @objc convenience public init(pillBarItem: PillButtonBarItem,
+                                  style: PillButtonStyle = .primary) {
+        self.init(pillBarItem: pillBarItem, style: style, tokenOverrides: nil)
+    }
+
+    /// Internal init used by the `PillButtonBar` to initialized buttons with overrides.
+    init(pillBarItem: PillButtonBarItem,
+         style: PillButtonStyle = .primary,
+         tokenOverrides: [PillButtonTokenSet.Tokens: ControlTokenValue]?) {
         self.pillBarItem = pillBarItem
         self.style = style
         self.tokenSet = PillButtonTokenSet(style: { style })
@@ -46,6 +53,9 @@ open class PillButton: UIButton, TokenizedControlInternal {
                                                name: PillButtonBarItem.titleValueDidChangeNotification,
                                                object: pillBarItem)
 
+        if let tokenOverrides {
+            tokenSet.replaceAllOverrides(with: tokenOverrides)
+        }
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateAppearance()
         }

--- a/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButtonBar.swift
@@ -62,12 +62,6 @@ open class PillButtonBarItem: NSObject {
 /// Once a button is selected, the previously selected button will be deselected.
 @objc(MSFPillButtonBar)
 open class PillButtonBar: UIScrollView {
-    open override func didMoveToWindow() {
-        super.didMoveToWindow()
-
-        updatePillButtonAppearance()
-    }
-
     open override func layoutSubviews() {
         super.layoutSubviews()
 
@@ -269,10 +263,6 @@ open class PillButtonBar: UIScrollView {
             if shouldAddAccessibilityHint {
                 button.accessibilityHint = String.localizedStringWithFormat("Accessibility.MSPillButtonBar.Hint".localized, index + 1, items.count)
             }
-
-            if pillButtonOverrideTokens != nil {
-                updatePillButtonAppearance()
-            }
         }
     }
 
@@ -379,7 +369,7 @@ open class PillButtonBar: UIScrollView {
     }
 
     private func createButtonWithItem(_ item: PillButtonBarItem) -> PillButton {
-        let button = PillButton(pillBarItem: item, style: pillButtonStyle)
+        let button = PillButton(pillBarItem: item, style: pillButtonStyle, tokenOverrides: pillButtonOverrideTokens)
         button.addTarget(self, action: #selector(selectButton(_:)), for: .touchUpInside)
         return button
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry pick of
 - #1809 
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1811&drop=dogfoodAlpha