### PR TITLE
Deprecate direct setting of primary colors in favor or using ColorProviding protocol for Mac Fluent colors

### DIFF
--- a/macos/FluentUI/Core/Colors.swift
+++ b/macos/FluentUI/Core/Colors.swift
@@ -442,6 +442,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primary ?? _primary
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primary = newValue
 		}
@@ -450,6 +451,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryShade10 ?? _primaryShade10
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryShade10 = newValue
 		}
@@ -458,6 +460,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryShade20 ?? _primaryShade20
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryShade20 = newValue
 		}
@@ -466,6 +469,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryShade30 ?? _primaryShade30
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryShade30 = newValue
 		}
@@ -474,6 +478,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryTint10 ?? _primaryTint10
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryTint10 = newValue
 		}
@@ -482,6 +487,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryTint20 ?? _primaryTint20
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryTint20 = newValue
 		}
@@ -490,6 +496,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryTint30 ?? _primaryTint30
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryTint30 = newValue
 		}
@@ -498,6 +505,7 @@ public final class Colors: NSObject {
 		get {
 			return colorProvider?.primaryTint40 ?? _primaryTint40
 		}
+		@available(*, deprecated, message: "Setting Primary colors directly is now deprecated in favor of using the ColorProviding protocol to retrieve them on demand")
 		set {
 			_primaryTint40 = newValue
 		}

--- a/macos/FluentUITestViewControllers/TestBadgeViewController.swift
+++ b/macos/FluentUITestViewControllers/TestBadgeViewController.swift
@@ -14,11 +14,9 @@ class TestBadgeViewController: NSViewController {
 
 		containerView.addView(BadgeView(title: "Default"), in: .center)
 
-		// Load Excel app color as primary to distinguish .primary and .communicationBlue accentColors
-		Colors.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
-		Colors.primaryTint40 = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
-		Colors.primaryTint30 = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
-		Colors.primaryShade20 = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
+		// Set our Test Color Provider singleton
+		Colors.colorProvider = TestColorProvider()
+
 		containerView.addView(BadgeView(title: "Primary", style: .primary), in: .center)
 
 		let customBadge = BadgeView(title: "Custom")

--- a/macos/FluentUITestViewControllers/TestBadgeViewController.swift
+++ b/macos/FluentUITestViewControllers/TestBadgeViewController.swift
@@ -15,7 +15,7 @@ class TestBadgeViewController: NSViewController {
 		containerView.addView(BadgeView(title: "Default"), in: .center)
 
 		// Set our Test Color Provider singleton
-		Colors.colorProvider = TestColorProvider()
+		Colors.colorProvider = TestColorProvider.shared
 
 		containerView.addView(BadgeView(title: "Primary", style: .primary), in: .center)
 

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -162,8 +162,8 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 		toolsGrid.insertColumn(at: 0, with: [])
 		toolsGrid.addColumn(with: [])
 
-		// Load Excel app color as primary to distinguish .primary and .communicationBlue accentColors
-		Colors.primary = (NSColor(named: "Colors/DemoPrimaryColor"))!
+		// Set our Test Color Provider singleton
+		Colors.colorProvider = TestColorProvider()
 		let communicationBlue = Colors.Palette.communicationBlue.color
 
 		// ButtonFormats: each will apply to a whole row of sample controls

--- a/macos/FluentUITestViewControllers/TestButtonViewController.swift
+++ b/macos/FluentUITestViewControllers/TestButtonViewController.swift
@@ -163,7 +163,7 @@ class TestButtonViewController: NSViewController, NSMenuDelegate {
 		toolsGrid.addColumn(with: [])
 
 		// Set our Test Color Provider singleton
-		Colors.colorProvider = TestColorProvider()
+		Colors.colorProvider = TestColorProvider.shared
 		let communicationBlue = Colors.Palette.communicationBlue.color
 
 		// ButtonFormats: each will apply to a whole row of sample controls

--- a/macos/FluentUITestViewControllers/TestColorProvider.swift
+++ b/macos/FluentUITestViewControllers/TestColorProvider.swift
@@ -10,6 +10,10 @@ class TestColorProvider: ColorProviding {
 	// This ensures this is a singleton where only one of these exists
 	static let shared = TestColorProvider()
 
+	private init() {
+	  // Make the init private so no one can make separate instances
+	}
+
 	// MARK: ColorProvider
 	var primary: NSColor = (NSColor(named: "Colors/DemoPrimaryColor"))!
 	var primaryShade10: NSColor = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!

--- a/macos/FluentUITestViewControllers/TestColorProvider.swift
+++ b/macos/FluentUITestViewControllers/TestColorProvider.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AppKit
+import FluentUI
+
+class TestColorProvider: ColorProviding {
+	// This ensures this is a singleton where only one of these exists
+	static let shared = TestColorProvider()
+
+	// MARK: ColorProvider
+	var primary: NSColor = (NSColor(named: "Colors/DemoPrimaryColor"))!
+	var primaryShade10: NSColor = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
+	var primaryShade20: NSColor = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
+	var primaryShade30: NSColor = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
+	var primaryTint10: NSColor = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
+	var primaryTint20: NSColor = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
+	var primaryTint30: NSColor = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
+	var primaryTint40: NSColor = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
+}

--- a/macos/FluentUITestViewControllers/TestColorViewController.swift
+++ b/macos/FluentUITestViewControllers/TestColorViewController.swift
@@ -102,7 +102,7 @@ class TestColorViewController: NSViewController {
 	private func loadPrimaryColors() {
 		if useColorProvider {
 			// Set our Test Color Provider singleton
-			Colors.colorProvider = TestColorProvider()
+			Colors.colorProvider = TestColorProvider.shared
 		} else {
 			// Clear Test Color Provider singleton so communication blue defaults will be used
 			Colors.colorProvider = nil

--- a/macos/FluentUITestViewControllers/TestColorViewController.swift
+++ b/macos/FluentUITestViewControllers/TestColorViewController.swift
@@ -6,7 +6,7 @@
 import AppKit
 import FluentUI
 
-class TestColorViewController: NSViewController, ColorProviding {
+class TestColorViewController: NSViewController {
 	var primaryColorsStackView = NSStackView()
 	var subviewConstraints = [NSLayoutConstraint]()
 	var toggleTextView = NSTextView(frame: NSRect(x: 0, y: 0, width: 100, height: 20))
@@ -79,17 +79,6 @@ class TestColorViewController: NSViewController, ColorProviding {
 		view = containerView
 	}
 
-	// MARK: ColorProviding Protocol
-
-	var primary: NSColor = (NSColor(named: "Colors/DemoPrimaryColor"))!
-	var primaryShade10: NSColor = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!
-	var primaryShade20: NSColor = (NSColor(named: "Colors/DemoPrimaryShade20Color"))!
-	var primaryShade30: NSColor = (NSColor(named: "Colors/DemoPrimaryShade30Color"))!
-	var primaryTint10: NSColor = (NSColor(named: "Colors/DemoPrimaryTint10Color"))!
-	var primaryTint20: NSColor = (NSColor(named: "Colors/DemoPrimaryTint20Color"))!
-	var primaryTint30: NSColor = (NSColor(named: "Colors/DemoPrimaryTint30Color"))!
-	var primaryTint40: NSColor = (NSColor(named: "Colors/DemoPrimaryTint40Color"))!
-
 	// MARK: Private
 
 	private func createColorRowStackView(name: String?, color: NSColor?) -> NSStackView {
@@ -112,18 +101,11 @@ class TestColorViewController: NSViewController, ColorProviding {
 
 	private func loadPrimaryColors() {
 		if useColorProvider {
-			Colors.colorProvider = self
+			// Set our Test Color Provider singleton
+			Colors.colorProvider = TestColorProvider()
 		} else {
-			// If we aren't using the new ColorProvider, clear it and fall back to initializing all the colors at onced
+			// Clear Test Color Provider singleton so communication blue defaults will be used
 			Colors.colorProvider = nil
-			Colors.primary = Colors.Palette.communicationBlue.color
-			Colors.primaryShade10 = Colors.Palette.communicationBlueShade10.color
-			Colors.primaryShade20 = Colors.Palette.communicationBlueShade20.color
-			Colors.primaryShade30 = Colors.Palette.communicationBlueShade30.color
-			Colors.primaryTint10 = Colors.Palette.communicationBlueTint10.color
-			Colors.primaryTint20 = Colors.Palette.communicationBlueTint20.color
-			Colors.primaryTint30 = Colors.Palette.communicationBlueTint30.color
-			Colors.primaryTint40 = Colors.Palette.communicationBlueTint40.color
 		}
 
 		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primary", color: Colors.primary))

--- a/macos/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/macos/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		921AF7D7269CD3C900255791 /* FluentUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 921AF7B1269CD39C00255791 /* FluentUI.strings */; };
 		9B4AEBA42703CADB00B68020 /* FilledTemplateImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AEBA22703CADB00B68020 /* FilledTemplateImageView.swift */; };
 		9B4AEBAB2705206300B68020 /* TestFilledTemplateImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4AEBAA2705206300B68020 /* TestFilledTemplateImageViewController.swift */; };
+		9B8661772A4F5DAE00FA4F78 /* TestColorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8661752A4F5C4800FA4F78 /* TestColorProvider.swift */; };
 		9BE619162A1576BD0046463A /* ColorProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE619152A1576BD0046463A /* ColorProviding.swift */; };
 		A257F81E2512DE45002CAA6E /* TestColorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A257F81C2512DDF7002CAA6E /* TestColorViewController.swift */; };
 		A257F826251D987E002CAA6E /* FluentUI-macos.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F825251D987E002CAA6E /* FluentUI-macos.xcassets */; };
@@ -254,6 +255,7 @@
 		921AF7D5269CD39C00255791 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/FluentUI.strings; sourceTree = "<group>"; };
 		9B4AEBA22703CADB00B68020 /* FilledTemplateImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilledTemplateImageView.swift; sourceTree = "<group>"; };
 		9B4AEBAA2705206300B68020 /* TestFilledTemplateImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFilledTemplateImageViewController.swift; sourceTree = "<group>"; };
+		9B8661752A4F5C4800FA4F78 /* TestColorProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestColorProvider.swift; sourceTree = "<group>"; };
 		9BE619152A1576BD0046463A /* ColorProviding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorProviding.swift; sourceTree = "<group>"; };
 		A257F81C2512DDF7002CAA6E /* TestColorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestColorViewController.swift; sourceTree = "<group>"; };
 		A257F825251D987E002CAA6E /* FluentUI-macos.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-macos.xcassets"; path = "../FluentUI/Resources/FluentUI-macos.xcassets"; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 				8F250B8C22B3062A00142B0E /* TestAvatarViewController.swift */,
 				EC3AF6A526BDDD2A009118F4 /* TestBadgeViewController.swift */,
 				AC97EFE3247541E100DADC99 /* TestButtonViewController.swift */,
+				9B8661752A4F5C4800FA4F78 /* TestColorProvider.swift */,
 				A257F81C2512DDF7002CAA6E /* TestColorViewController.swift */,
 				8061BF8222EF957200F2D245 /* TestDatePickerController.swift */,
 				9B4AEBAA2705206300B68020 /* TestFilledTemplateImageViewController.swift */,
@@ -1021,6 +1024,7 @@
 				E6A92D3024BEA8AC00562BCA /* TestLinkViewController.swift in Sources */,
 				E6A92D2E24BEA8AC00562BCA /* TestAvatarViewController.swift in Sources */,
 				E6A92D4F24BEAEEA00562BCA /* TestViewControllers.swift in Sources */,
+				9B8661772A4F5DAE00FA4F78 /* TestColorProvider.swift in Sources */,
 				E6A92D3124BEA8AC00562BCA /* TestDatePickerController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### Platforms Impacted
  - [ ] iOS
  - [x] macOS
  
  ### Description of changes
  
Recently, we added a ColorProvider object for retrieving theme colors vs. initializing all the Fluent v1 colors via setters in Colors.swift, such as "Colors.primary = .blue" or "[MSFColors setPrimary:[NSColor blueColor]]" (Obj-C) type calls during application boot. Now that this change has been in place for awhile and implemented more broadly, we want to deprecate the usage of the setters in Colors.swift to encourage further use of the ColorProviding mechanism.

This change marks the setters for the variables in Colors.swift as deprecated, nothing the new protocol. This also modifies existing test code in the FluentUITestApp for Mac, to remove usage of these and add a simple TestColorProvider singleton class that can be used as an example. After this change is implemented, errors will occur when trying to compile using the deprecated setters.
    
  ### Verification
  
 This code was verified using the FluentUITestApp. After these changes, no visual differences were noted both when using the ColorProvider or letting the CommunicationBlue defaults take effect.
- Building with use of the deprecated setters puts up errors in XCode as expected.
- Colors, badge and button test view controllers behave as expected.
- Toggling the "Use ColorProvider" switch on the Colors panel behaves the same and shows the custom and default colors as expected.
  
  ### Pull request checklist
  
  This PR has considered:
  - [x] Light and Dark appearances
  - [x] macOS supported versions (all major versions greater than or equal current target deployment version)
  - [x] VoiceOver and Keyboard Accessibility (n/a)
  - [x] Internationalization and Right to Left layouts (n/a)
  - [x] Different resolutions (1x, 2x) (n/a)
  - [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1815&drop=dogfoodAlpha