### PR TITLE
Update TableViewHeaderFooterView tokens

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -232,9 +232,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         NotificationCenter.default.addObserver(self, selector: #selector(handleContentSizeCategoryDidChange), name: UIContentSizeCategory.didChangeNotification, object: nil)
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
-            self?.updateTitleAndBackgroundColors()
-            self?.updateLeadingViewColor()
-            self?.updateAccessoryButtonTitleColor()
+            self?.updateTokenizedValues()
         }
     }
 
@@ -426,6 +424,12 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             return
         }
         tokenSet.update(newWindow.fluentTheme)
+        updateTitleAndBackgroundColors()
+        updateLeadingViewColor()
+        updateAccessoryButtonTitleColor()
+    }
+
+    private func updateTokenizedValues() {
         updateTitleAndBackgroundColors()
         updateLeadingViewColor()
         updateAccessoryButtonTitleColor()

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -206,6 +206,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             oldValue?.removeFromSuperview()
             if let leadingView = leadingView {
                 contentView.addSubview(leadingView)
+                updateLeadingViewColor()
             }
         }
     }
@@ -232,6 +233,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTitleAndBackgroundColors()
+            self?.updateLeadingViewColor()
             self?.updateAccessoryButtonTitleColor()
         }
     }
@@ -425,6 +427,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         }
         tokenSet.update(newWindow.fluentTheme)
         updateTitleAndBackgroundColors()
+        updateLeadingViewColor()
         updateAccessoryButtonTitleColor()
     }
 
@@ -453,6 +456,10 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
         titleView.font = tokenSet[.textFont].uiFont
         titleView.linkColor = tokenSet[.linkTextColor].uiColor
+    }
+
+    private func updateLeadingViewColor() {
+        leadingView?.tintColor = tokenSet[.leadingViewColor].uiColor
     }
 
     private func updateAccessoryButtonTitleColor() {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -424,9 +424,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             return
         }
         tokenSet.update(newWindow.fluentTheme)
-        updateTitleAndBackgroundColors()
-        updateLeadingViewColor()
-        updateAccessoryButtonTitleColor()
+        updateTokenizedValues()
     }
 
     private func updateTokenizedValues() {

--- a/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
@@ -18,6 +18,9 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
         /// The font of the header/footer text.
         case textFont
 
+        /// The color of the leading view.
+        case leadingViewColor
+
         /// The color of the accessory button text.
         case accessoryButtonTextColor
 
@@ -60,6 +63,9 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
                     }
                 }
 
+            case .leadingViewColor:
+                return .uiColor { theme.color(.foreground3) }
+
             case .accessoryButtonTextColor:
                 return .uiColor {
                     switch accessoryButtonStyle() {
@@ -71,7 +77,14 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
                 }
 
             case .accessoryButtonTextFont:
-                return .uiFont { theme.typography(.caption1Strong) }
+                return .uiFont {
+                    switch style() {
+                    case .headerPrimary:
+                        return theme.typography(.body2Strong)
+                    case .header, .footer:
+                        return theme.typography(.caption1Strong)
+                    }
+                }
 
             case .linkTextColor:
                 return .uiColor { theme.color(.brandForeground1) }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updated `TableViewHeaderFooterView` tokens to match Figma designs. This included updating the `leadingView` to be `foreground3` and `accessoryButtonTextFont`to be `body2Strong` for the `headerPrimary` style.

### Binary change

Total increase: 7,736 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 46,340,048 bytes | 46,347,784 bytes | ⚠️ 7,736 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterViewTokenSet.o | 183,336 bytes | 187,608 bytes | ⚠️ 4,272 bytes |
| TableViewHeaderFooterView.o | 490,016 bytes | 493,240 bytes | ⚠️ 3,224 bytes |
| PopupMenuSectionHeaderView.o | 45,968 bytes | 46,096 bytes | ⚠️ 128 bytes |
| __.SYMDEF | 2,872,120 bytes | 2,872,232 bytes | ⚠️ 112 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/2284a2bc-e530-491f-9a15-9e64c40040c7) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/d2acb3bd-e6f6-4858-86d3-57cd54ebabad) |
| ![before dark](https://github.com/microsoft/fluentui-apple/assets/55368679/7ef07332-fead-4e9a-8cf3-9572e14c62ce) | ![after dark](https://github.com/microsoft/fluentui-apple/assets/55368679/6f1bb6f0-9098-482a-9890-5f2246b90ecf) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1816&drop=dogfoodAlpha