### PR TITLE
Add call to get absolute value of hash passed in for legacy Avatar colors on Mac

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -434,7 +434,7 @@ open class AvatarView: NSView {
 	@available(*, deprecated, message: "Use getInitialsColorSetFromPrimaryText:secondaryText: instead")
 	public static func getLegacyColor(for hashValue: Int) -> NSColor {
 		let legacyAvatarBackgroundColors = AvatarView.legacyAvatarViewBackgroundColor
-		return legacyAvatarBackgroundColors[hashValue % legacyAvatarBackgroundColors.count]
+		return legacyAvatarBackgroundColors[abs(hashValue) % legacyAvatarBackgroundColors.count]
 	}
 
 	/// the font size in the initials view will be scaled to this fraction of the avatarSize passed in


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

A partner repo is hitting a crash when calling to get legacy Avatar colors. I initially thought that the cause of this could be what we fixed by adding the turkey emoji in our newer hash algorithm, but the legacy algorithm has no problem hashing turkeys. Instead, my best guess for what's causing their crash is going from Swift's `Int` to Objective C's `NSUInteger` and back to Swift's `Int` resulting in a negative index for the color array. I've confirmed that `Int` -> `NSUInteger` -> `Int` can give a negative number, and performing the modulus operator on a negative number also gives you a negative number. Pair that with Swift's arrays crashing due to out of bounds errors if you try to use a negative number as an index, and it sounds like we weren't doing our due diligence on input validation.

### Verification

Since I have no idea what hash was causing the crash, I can't confirm that this fixes it, but I have confirmed that any positive hash will result in the same color as before.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1817&drop=dogfoodAlpha