### PR TITLE
Expose badge style from TabBar and SideTabBar

### DIFF
--- a/ios/FluentUI/Label/BadgeLabel.swift
+++ b/ios/FluentUI/Label/BadgeLabel.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: BadgeLabel
 
 class BadgeLabel: UILabel, TokenizedControlInternal {
-    var style: Style = .system {
+    var style: TabBarItem.BadgeStyle = .system {
         didSet {
             updateColors()
         }
@@ -16,7 +16,7 @@ class BadgeLabel: UILabel, TokenizedControlInternal {
 
     typealias TokenSetKeyType = BadgeLabelTokenSet.Tokens
     lazy var tokenSet: BadgeLabelTokenSet = .init(style: { [weak self] in
-        return self?.style ?? .brand
+        return self?.style ?? .system
     })
 
     override init(frame: CGRect) {

--- a/ios/FluentUI/Label/BadgeLabelTokenSet.swift
+++ b/ios/FluentUI/Label/BadgeLabelTokenSet.swift
@@ -15,31 +15,31 @@ class BadgeLabelTokenSet: ControlTokenSet<BadgeLabelTokenSet.Tokens> {
         case textColor
     }
 
-    init(style: @escaping () -> BadgeLabel.Style) {
+    init(style: @escaping () -> TabBarItem.BadgeStyle) {
         self.style = style
         super.init { [style] token, theme in
             switch token {
             case .textColor:
                 return .uiColor {
                     switch style() {
-                    case .brand:
+                    case .onPrimary:
                         return UIColor(light: theme.color(.brandForeground1).light,
                                        dark: GlobalTokens.neutralColor(.white))
                     case .system:
                         return GlobalTokens.neutralColor(.white)
-                    case .gradient:
+                    case .brand:
                         return theme.color(.foregroundOnColor)
                     }
                 }
             case .backgroundColor:
                 return .uiColor {
                     switch style() {
-                    case .brand:
+                    case .onPrimary:
                         return UIColor(light: GlobalTokens.neutralColor(.white),
                                        dark: theme.color(.brandBackground1).dark)
                     case .system:
                         return theme.color(.dangerBackground2)
-                    case .gradient:
+                    case .brand:
                         return theme.color(.brandBackground1)
                     }
                 }
@@ -48,15 +48,5 @@ class BadgeLabelTokenSet: ControlTokenSet<BadgeLabelTokenSet.Tokens> {
     }
 
     /// Defines the style of the BadgeLabel.
-    var style: () -> BadgeLabel.Style
-}
-
-// MARK: BadgeLabel.Style
-
-extension BadgeLabel {
-    enum Style: Int {
-        case brand
-        case system
-        case gradient
-    }
+    var style: () -> TabBarItem.BadgeStyle
 }

--- a/ios/FluentUI/Navigation/BadgeLabelButton.swift
+++ b/ios/FluentUI/Navigation/BadgeLabelButton.swift
@@ -14,7 +14,7 @@ class BadgeLabelButton: UIButton {
         }
     }
 
-    var badgeLabelStyle: BadgeLabel.Style = .system {
+    var badgeLabelStyle: TabBarItem.BadgeStyle = .system {
         didSet {
             badgeLabel.style = badgeLabelStyle
         }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -725,9 +725,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         if style == .system {
             button.badgeLabelStyle = .system
         } else if style == .gradient {
-            button.badgeLabelStyle = .gradient
-        } else {
             button.badgeLabelStyle = .brand
+        } else {
+            button.badgeLabelStyle = .onPrimary
         }
 
         // We want to hide the native right bar button items for non-system title styles when using the gradient style.

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -92,6 +92,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         }
     }
 
+    /// The badge style to be used for all `TabBarItemView`s.
     @objc public var badgeStyle: TabBarItem.BadgeStyle = .system {
         didSet {
             updateAppearance()
@@ -353,7 +354,7 @@ open class SideTabBar: UIView, TokenizedControlInternal {
             if let tabBarItemView = subview as? TabBarItemView {
                 let tabBarItemTokenSet = tabBarItemView.tokenSet
                 let badge = tabBarItemView.badgeView as? BadgeLabel
-                badge?.style = badgeStyle.getActualStyle()
+                badge?.style = badgeStyle
 
                 /// Directly map our custom values to theirs.
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),

--- a/ios/FluentUI/Tab Bar/SideTabBar.swift
+++ b/ios/FluentUI/Tab Bar/SideTabBar.swift
@@ -92,6 +92,12 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         }
     }
 
+    @objc public var badgeStyle: TabBarItem.BadgeStyle = .system {
+        didSet {
+            updateAppearance()
+        }
+    }
+
     @objc public var showTopItemTitles: Bool = false {
         didSet {
             if oldValue != showTopItemTitles {
@@ -346,6 +352,8 @@ open class SideTabBar: UIView, TokenizedControlInternal {
         for subview in stackView(in: section).arrangedSubviews {
             if let tabBarItemView = subview as? TabBarItemView {
                 let tabBarItemTokenSet = tabBarItemView.tokenSet
+                let badge = tabBarItemView.badgeView as? BadgeLabel
+                badge?.style = badgeStyle.getActualStyle()
 
                 /// Directly map our custom values to theirs.
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -139,3 +139,23 @@ open class TabBarItem: NSObject {
         }
     }
 }
+
+public extension TabBarItem {
+    @objc(MSFTabBarItemBadgeStyle)
+    enum BadgeStyle: Int {
+        case brand
+        case system
+        case gradient
+
+        internal func getActualStyle() -> BadgeLabel.Style {
+            switch self {
+            case .brand:
+                return .brand
+            case .system:
+                return .system
+            case .gradient:
+                return .gradient
+            }
+        }
+    }
+}

--- a/ios/FluentUI/Tab Bar/TabBarItem.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItem.swift
@@ -140,22 +140,13 @@ open class TabBarItem: NSObject {
     }
 }
 
+// MARK: BadgeStyle
+
 public extension TabBarItem {
     @objc(MSFTabBarItemBadgeStyle)
     enum BadgeStyle: Int {
-        case brand
+        case onPrimary
         case system
-        case gradient
-
-        internal func getActualStyle() -> BadgeLabel.Style {
-            switch self {
-            case .brand:
-                return .brand
-            case .system:
-                return .system
-            case .gradient:
-                return .gradient
-            }
-        }
+        case brand
     }
 }

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -45,6 +45,12 @@ open class TabBarView: UIView, TokenizedControlInternal {
         }
     }
 
+    @objc public var badgeStyle: TabBarItem.BadgeStyle = .system {
+        didSet {
+            updateAppearance()
+        }
+    }
+
     @objc open var selectedItem: TabBarItem? {
         willSet {
             if let item = selectedItem {
@@ -183,6 +189,8 @@ open class TabBarView: UIView, TokenizedControlInternal {
         for subview in arrangedSubviews {
             if let tabBarItemView = subview as? TabBarItemView {
                 let tabBarItemTokenSet = tabBarItemView.tokenSet
+                let badge = tabBarItemView.badgeView as? BadgeLabel
+                badge?.style = badgeStyle.getActualStyle()
 
                 /// Directly map our custom values to theirs.
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -45,6 +45,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
         }
     }
 
+    /// The badge style to be used for all `TabBarItemView`s.
     @objc public var badgeStyle: TabBarItem.BadgeStyle = .system {
         didSet {
             updateAppearance()
@@ -190,7 +191,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
             if let tabBarItemView = subview as? TabBarItemView {
                 let tabBarItemTokenSet = tabBarItemView.tokenSet
                 let badge = tabBarItemView.badgeView as? BadgeLabel
-                badge?.style = badgeStyle.getActualStyle()
+                badge?.style = badgeStyle
 
                 /// Directly map our custom values to theirs.
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemSelectedColor),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There's a request to change the badge color for tab bar items. Since the colors needed are satisfied by one of the existing badge styles, we can leverage that and add a `badgeStyle` property that will allow the client to override the badge style of all items within tab bar and side tab bar.

Since `BadgeLabel.Style` was internal, I created a new `BadgeStyle` in `TabBarItem` that will be used to set the badge colors.

### Binary change

Total increase: 31,032 bytes
Total decrease: -18,624 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,946,488 bytes | 29,958,896 bytes | ⚠️ 12,408 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| SideTabBar.o | 193,608 bytes | 202,696 bytes | ⚠️ 9,088 bytes |
| TabBarItem.o | 68,864 bytes | 77,944 bytes | ⚠️ 9,080 bytes |
| TabBarView.o | 127,360 bytes | 135,488 bytes | ⚠️ 8,128 bytes |
| __.SYMDEF | 4,653,392 bytes | 4,656,104 bytes | ⚠️ 2,712 bytes |
| FocusRingView.o | 789,952 bytes | 791,416 bytes | ⚠️ 1,464 bytes |
| BadgeLabel.o | 56,296 bytes | 56,656 bytes | ⚠️ 360 bytes |
| NavigationBar.o | 542,392 bytes | 542,520 bytes | ⚠️ 128 bytes |
| BadgeLabelButton.o | 110,360 bytes | 110,432 bytes | ⚠️ 72 bytes |
| PopupMenuSectionHeaderView.o | 28,240 bytes | 28,088 bytes | 🎉 -152 bytes |
| FluentTheme.o | 181,880 bytes | 181,176 bytes | 🎉 -704 bytes |
| TableViewHeaderFooterViewTokenSet.o | 83,920 bytes | 80,856 bytes | 🎉 -3,064 bytes |
| TableViewHeaderFooterView.o | 282,256 bytes | 275,312 bytes | 🎉 -6,944 bytes |
| BadgeLabelTokenSet.o | 55,488 bytes | 47,728 bytes | 🎉 -7,760 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="484" alt="tabbar_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/fd69c132-04d3-44af-a682-adb79bdc5d5c"> | <img width="484" alt="tabbar_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/b0b28f51-3720-4da8-88b9-397e286f13a0"> |
| <img width="484" alt="sidetabbar_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/99ae4ef0-d769-4db5-9a3d-55f9a6693e38"> | <img width="484" alt="sidetabbar_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/e19ff6e6-b502-4d6c-9af3-b80d1fa4a8d3"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)