### PR TITLE
Update Textfield tokens

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController.swift
@@ -99,6 +99,7 @@ class AliasColorTokensDemoController: DemoTableViewController {
              .dangerForeground1,
              .dangerForeground2,
              .dangerStroke1,
+             .dangerStroke2,
              .successBackground2,
              .successForeground1,
              .successForeground2,
@@ -252,6 +253,7 @@ private enum AliasColorTokensDemoSection: CaseIterable {
                     .dangerForeground1,
                     .dangerForeground2,
                     .dangerStroke1,
+                    .dangerStroke2,
                     .successBackground1,
                     .successBackground2,
                     .successForeground1,
@@ -409,6 +411,8 @@ private extension FluentTheme.ColorToken {
             return "DangerForeground2"
         case .dangerStroke1:
             return "DangerStroke1"
+        case .dangerStroke2:
+            return "DangerStroke2"
         case .successBackground1:
             return "SuccessBackground1"
         case .successBackground2:

--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -94,6 +94,7 @@ public extension FluentTheme {
         case dangerForeground1
         case dangerForeground2
         case dangerStroke1
+        case dangerStroke2
         case successBackground1
         case successBackground2
         case successForeground1

--- a/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/AliasTokens.swift
@@ -142,6 +142,7 @@ public final class AliasTokens: NSObject {
         case dangerForeground1
         case dangerForeground2
         case dangerStroke1
+        case dangerStroke2
         case successBackground1
         case successBackground2
         case successForeground1
@@ -431,6 +432,9 @@ extension AliasTokens {
         case .dangerStroke1:
             return DynamicColor(light: GlobalTokens.sharedColors(.red, .tint20),
                                 dark: GlobalTokens.sharedColors(.red, .tint20))
+        case .dangerStroke2:
+            return DynamicColor(light: GlobalTokens.sharedColors(.red, .primary),
+                                dark: GlobalTokens.sharedColors(.red, .tint30))
         case .successBackground1:
             return DynamicColor(light: GlobalTokens.sharedColors(.green, .tint60),
                                 dark: GlobalTokens.sharedColors(.green, .shade40))

--- a/ios/FluentUI/TextField/TextFieldTokenSet.swift
+++ b/ios/FluentUI/TextField/TextFieldTokenSet.swift
@@ -62,7 +62,7 @@ public class TextFieldTokenSet: ControlTokenSet<TextFieldTokenSet.Tokens> {
                     case .unfocused, .focused:
                         return theme.color(.foreground2)
                     case .error:
-                        return theme.color(.dangerForeground1)
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .assistiveTextFont:
@@ -92,9 +92,9 @@ public class TextFieldTokenSet: ControlTokenSet<TextFieldTokenSet.Tokens> {
                     case .unfocused:
                         return theme.color(.stroke1)
                     case .focused:
-                        return theme.color(.brandForeground1)
+                        return theme.color(.brandStroke1)
                     case .error:
-                        return theme.color(.dangerForeground1)
+                        return theme.color(.dangerStroke2)
                     }
                 }
             case .titleLabelColor:
@@ -105,7 +105,7 @@ public class TextFieldTokenSet: ControlTokenSet<TextFieldTokenSet.Tokens> {
                     case .focused:
                         return theme.color(.brandForeground1)
                     case .error:
-                        return theme.color(.dangerForeground1)
+                        return theme.color(.dangerForeground2)
                     }
                 }
             case .titleLabelFont:


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The tokens for the error foreground and stroke (including adding a new `.dangerStroke2`) were changes, so updating to match spec. I also updated the focused stroke from `.brandForeground1` to `.brandStroke1` to match the spec, but I'm not sure if `.brandStroke1` wasn't available before or if that was a mistake.

### Binary change

Total increase: 1,104 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,537,576 bytes | 31,538,680 bytes | ⚠️ 1,104 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| AliasTokens.o | 238,440 bytes | 239,544 bytes | ⚠️ 1,104 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="561" alt="TextField_Error_Light_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/80862261-9b72-46e8-998e-963722911208"> | <img width="561" alt="TextField_Error_Light_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/b0c1d141-e484-4128-8d44-f4bc82ed81dc"> |
| <img width="561" alt="TextField_Error_Dark_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/001937f1-b9f5-4d05-9461-d182f84104ae"> | <img width="561" alt="TextField_Error_Dark_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/d1c7e8cc-ff67-4b38-9fef-b906bb471848"> |
| <img width="561" alt="TextField_Focus_Light_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e3ba61f8-2a07-4919-8d72-f58f6eec24f6"> | <img width="561" alt="TextField_Focus_Light_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/2e9b5145-8ea2-449d-ab84-0bacbed03a50"> |
| <img width="561" alt="TextField_Focus_Dark_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/6ee8f857-d79f-41b4-8102-ec96cbc301b5"> | <img width="561" alt="TextField_Focus_Dark_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/7fc6a922-74a1-4041-8002-cb602398c11b"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1820&drop=dogfoodAlpha