### PR TITLE
Add tappableSize to Button

### DIFF
--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -136,7 +136,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
     }
 
     open override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        guard let tappableSize else {
+        guard tappableSize != .zero else {
             return super.point(inside: point, with: event)
         }
 
@@ -188,8 +188,8 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
     public var ambientShadow: CALayer?
     public var keyShadow: CALayer?
 
-    /// Optional var to increase the default tappable size of the button.
-    public var tappableSize: CGSize?
+    /// Used to increase the default tappable size of the button.
+    @objc public var tappableSize: CGSize = .zero
 
     lazy public var tokenSet: ButtonTokenSet = .init(style: { [weak self] in
         return self?.style ?? .outline

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -135,6 +135,17 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         updateProposedTitleLabelWidth()
     }
 
+    open override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        guard let tappableSize else {
+            return super.point(inside: point, with: event)
+        }
+
+        let growX = max(0, (tappableSize.width - bounds.size.width) / 2)
+        let growY = max(0, (tappableSize.height - bounds.size.height) / 2)
+
+        return bounds.insetBy(dx: -growX, dy: -growY).contains(point)
+    }
+
     @objc public init(style: ButtonStyle = .outline) {
         self.style = style
         super.init(frame: .zero)
@@ -176,6 +187,9 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
     public typealias TokenSetKeyType = ButtonTokenSet.Tokens
     public var ambientShadow: CALayer?
     public var keyShadow: CALayer?
+
+    /// Optional var to increase the default tappable size of the button.
+    public var tappableSize: CGSize?
 
     lazy public var tokenSet: ButtonTokenSet = .init(style: { [weak self] in
         return self?.style ?? .outline


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

A partner team wanted to be able to adjust the tappable size of the `Button` like they could with the `EasyTapButton`, so we're updating the `Button`. This PR largely copies the logic over from the `EasyTapButton`.

### Binary change

Total increase: 11,376 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,537,576 bytes | 31,548,952 bytes | ⚠️ 11,376 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| Button.o | 213,088 bytes | 222,176 bytes | ⚠️ 9,088 bytes |
| __.SYMDEF | 4,743,160 bytes | 4,744,696 bytes | ⚠️ 1,536 bytes |
| FocusRingView.o | 773,624 bytes | 774,376 bytes | ⚠️ 752 bytes |
</details>

### Verification

I updated the small button to have a tappable width of 100.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![ButtonTap_Before](https://github.com/microsoft/fluentui-apple/assets/67026548/b7c5b5a3-9538-4e9d-931e-3bff8c7a2c41) | ![ButtonTap_After](https://github.com/microsoft/fluentui-apple/assets/67026548/a10ac07a-9cdd-4896-827d-921e00559b9f) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1821&drop=dogfoodAlpha