### PR TITLE
Add support for custom trailing image of TwoLineTitleView's subtitle

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -363,7 +363,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.navigationItem.titleStyle = .leading
             $0.navigationItem.subtitle = "Subtitle"
             $0.navigationItem.contentScrollView = $0.tableView
-            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_24_regular")
         },
         6: TitleViewFeature(name: "Two titles with subtitle disclosure") {
             $0.navigationItem.subtitle = "Press me!"
@@ -412,6 +411,12 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             searchBar.placeholderText = "Search"
             $0.navigationItem.accessoryView = searchBar
             $0.navigationItem.contentScrollView = $0.tableView
+        },
+        16: TitleViewFeature(name: "Leading-aligned, subtitle with custom trailing image") {
+            $0.navigationItem.titleStyle = .leading
+            $0.navigationItem.subtitle = "Subtitle"
+            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .custom, delegate: self)
         }
     ]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -366,7 +366,6 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         },
         6: TitleViewFeature(name: "Two titles with subtitle disclosure") {
             $0.navigationItem.subtitle = "Press me!"
-            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_24_regular")
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .disclosure, delegate: self)
         },
         7: TitleViewFeature(name: "Leading-aligned, image, subtitle") {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -363,9 +363,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             $0.navigationItem.titleStyle = .leading
             $0.navigationItem.subtitle = "Subtitle"
             $0.navigationItem.contentScrollView = $0.tableView
+            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_24_regular")
         },
         6: TitleViewFeature(name: "Two titles with subtitle disclosure") {
             $0.navigationItem.subtitle = "Press me!"
+            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_24_regular")
             $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .disclosure, delegate: self)
         },
         7: TitleViewFeature(name: "Leading-aligned, image, subtitle") {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -32,7 +32,7 @@
 
     UIColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorTokenBackground1];
     self.view.backgroundColor = primaryColor;
-    //[self setupTitleView];
+    [self setupTitleView];
 
     [self.view addSubview:self.scrollingContainer];
     [self.scrollingContainer setFrame:self.view.bounds];
@@ -129,12 +129,16 @@
     return container;
 }
 
-//- (void)setupTitleView {
-//    self.titleView = [[MSFTwoLineTitleView alloc] initWithStyle:MSFTwoLineTitleViewStyleSystem];
-//    [self.titleView setupWithTitle:self.title subtitle:nil interactivePart:MSFTwoLineTitleViewInteractivePartTitle accessoryType:MSFTwoLineTitleViewAccessoryTypeNone];
-//    self.titleView.delegate = self;
-//    self.navigationItem.titleView = self.titleView;
-//}
+- (void)setupTitleView {
+    self.titleView = [[MSFTwoLineTitleView alloc] initWithStyle:MSFTwoLineTitleViewStyleSystem];
+    [self.titleView setupWithTitle:self.title
+                          subtitle:nil
+                   interactivePart:MSFTwoLineTitleViewInteractivePartTitle
+                     accessoryType:MSFTwoLineTitleViewAccessoryTypeNone
+       customSubtitleTrailingImage:nil];
+    self.titleView.delegate = self;
+    self.navigationItem.titleView = self.titleView;
+}
 
 - (MSFButton *)createButtonWithTitle:(NSString *)title action:(SEL)action {
     MSFButton* button = [[MSFButton alloc] init];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ObjectiveCDemoController.m
@@ -32,7 +32,7 @@
 
     UIColor *primaryColor = [[[self view] fluentTheme] colorForToken:MSFColorTokenBackground1];
     self.view.backgroundColor = primaryColor;
-    [self setupTitleView];
+    //[self setupTitleView];
 
     [self.view addSubview:self.scrollingContainer];
     [self.scrollingContainer setFrame:self.view.bounds];
@@ -129,12 +129,12 @@
     return container;
 }
 
-- (void)setupTitleView {
-    self.titleView = [[MSFTwoLineTitleView alloc] initWithStyle:MSFTwoLineTitleViewStyleSystem];
-    [self.titleView setupWithTitle:self.title subtitle:nil interactivePart:MSFTwoLineTitleViewInteractivePartTitle accessoryType:MSFTwoLineTitleViewAccessoryTypeNone];
-    self.titleView.delegate = self;
-    self.navigationItem.titleView = self.titleView;
-}
+//- (void)setupTitleView {
+//    self.titleView = [[MSFTwoLineTitleView alloc] initWithStyle:MSFTwoLineTitleViewStyleSystem];
+//    [self.titleView setupWithTitle:self.title subtitle:nil interactivePart:MSFTwoLineTitleViewInteractivePartTitle accessoryType:MSFTwoLineTitleViewAccessoryTypeNone];
+//    self.titleView.delegate = self;
+//    self.navigationItem.titleView = self.titleView;
+//}
 
 - (MSFButton *)createButtonWithTitle:(NSString *)title action:(SEL)action {
     MSFButton* button = [[MSFButton alloc] init];

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -30,7 +30,8 @@ class TwoLineTitleViewDemoController: DemoController {
                                               alignment: TwoLineTitleView.Alignment = .center,
                                               interactivePart: TwoLineTitleView.InteractivePart = .none,
                                               animatesWhenPressed: Bool = true,
-                                              accessoryType: TwoLineTitleView.AccessoryType = .none) -> TwoLineTitleViewFactory {
+                                              accessoryType: TwoLineTitleView.AccessoryType = .none,
+                                              customSubtitleTrailingImage: UIImage? = nil) -> TwoLineTitleViewFactory {
         return {
             let twoLineTitleView = createDemoTitleView(forBottomSheet: $0)
             twoLineTitleView.setup(title: title,
@@ -39,7 +40,8 @@ class TwoLineTitleViewDemoController: DemoController {
                                    alignment: alignment,
                                    interactivePart: interactivePart,
                                    animatesWhenPressed: animatesWhenPressed,
-                                   accessoryType: accessoryType)
+                                   accessoryType: accessoryType,
+                                   customSubtitleTrailingImage: customSubtitleTrailingImage)
             return twoLineTitleView
         }
     }
@@ -54,7 +56,9 @@ class TwoLineTitleViewDemoController: DemoController {
         makeStandardTitleView(title: "Title here", subtitle: "Optional subtitle", animatesWhenPressed: false),
         makeStandardTitleView(title: "Custom image", titleImage: UIImage(named: "ic_fluent_star_16_regular"), animatesWhenPressed: false),
         makeStandardTitleView(title: "This one", subtitle: "can be tapped", interactivePart: .all),
-        makeStandardTitleView(title: "All the bells", titleImage: UIImage(named: "ic_fluent_star_16_regular"), subtitle: "and whistles", alignment: .leading, interactivePart: .subtitle, accessoryType: .downArrow)
+        makeStandardTitleView(title: "All the bells", titleImage: UIImage(named: "ic_fluent_star_16_regular"), subtitle: "and whistles", alignment: .leading, interactivePart: .subtitle, accessoryType: .downArrow),
+        makeStandardTitleView(title: "Leading title", subtitle: "Custom icon", alignment: .leading, interactivePart: .subtitle, accessoryType: .custom, customSubtitleTrailingImage: UIImage(named: "ic_fluent_star_16_regular")),
+        makeStandardTitleView(title: "Centered title", subtitle: "Custom icon", alignment: .center, interactivePart: .subtitle, accessoryType: .custom, customSubtitleTrailingImage: UIImage(named: "ic_fluent_star_16_regular"))
     ]
 
     private let exampleNavigationItems: [UINavigationItem] = [
@@ -79,6 +83,22 @@ class TwoLineTitleViewDemoController: DemoController {
             $0.title = "They can also be"
             $0.subtitle = "leading-aligned"
             $0.titleStyle = .leading
+        },
+        makeExampleNavigationItem {
+            $0.title = "Leading Title"
+            $0.titleStyle = .leading
+            $0.subtitle = "Custom icon"
+            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.titleAccessory = .init(location: .subtitle, style: .custom)
+        },
+        makeExampleNavigationItem {
+            $0.title = "Centered Title"
+            $0.titleStyle = .system
+            $0.subtitle = "Custom icon"
+            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.titleAccessory = .init(location: .subtitle, style: .custom)
         }
     ]
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -70,6 +70,7 @@ open class NavigationBarTitleAccessory: NSObject {
     public enum Style: Int {
         case disclosure
         case downArrow
+        case custom
     }
 
     /// The location of the accessory.

--- a/ios/FluentUI/Navigation/TwoLineTitleView+Navigation.swift
+++ b/ios/FluentUI/Navigation/TwoLineTitleView+Navigation.swift
@@ -62,7 +62,6 @@ extension TwoLineTitleView {
             animatesWhenPressed = false
         }
 
-        print("\(String(describing: navigationItem.customSubtitleTrailingImage))")
         setup(title: title, titleImage: navigationItem.titleImage, subtitle: navigationItem.subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType, customSubtitleTrailingImage: navigationItem.customSubtitleTrailingImage)
     }
 }

--- a/ios/FluentUI/Navigation/TwoLineTitleView+Navigation.swift
+++ b/ios/FluentUI/Navigation/TwoLineTitleView+Navigation.swift
@@ -35,6 +35,8 @@ fileprivate extension NavigationBarTitleAccessory.Style {
             return .downArrow
         case .disclosure:
             return .disclosure
+        case .custom:
+            return .custom
         }
     }
 }
@@ -50,13 +52,13 @@ extension TwoLineTitleView {
         if let titleAccessory = navigationItem.titleAccessory {
             // Use the custom action provided by the title accessory specification
             interactivePart = titleAccessory.location.twoLineTitleViewInteractivePart
-            accessoryType = .custom
+            accessoryType = titleAccessory.style.twoLineTitleViewAccessoryType
             animatesWhenPressed = true
             delegate = titleAccessory
         } else {
             // Use the default behavior of requesting expansion of the hosting navigation bar
             interactivePart = .all
-            accessoryType = .custom
+            accessoryType = .none
             animatesWhenPressed = false
         }
 

--- a/ios/FluentUI/Navigation/TwoLineTitleView+Navigation.swift
+++ b/ios/FluentUI/Navigation/TwoLineTitleView+Navigation.swift
@@ -50,16 +50,17 @@ extension TwoLineTitleView {
         if let titleAccessory = navigationItem.titleAccessory {
             // Use the custom action provided by the title accessory specification
             interactivePart = titleAccessory.location.twoLineTitleViewInteractivePart
-            accessoryType = titleAccessory.style.twoLineTitleViewAccessoryType
+            accessoryType = .custom
             animatesWhenPressed = true
             delegate = titleAccessory
         } else {
             // Use the default behavior of requesting expansion of the hosting navigation bar
             interactivePart = .all
-            accessoryType = .none
+            accessoryType = .custom
             animatesWhenPressed = false
         }
 
-        setup(title: title, titleImage: navigationItem.titleImage, subtitle: navigationItem.subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType)
+        print("\(String(describing: navigationItem.customSubtitleTrailingImage))")
+        setup(title: title, titleImage: navigationItem.titleImage, subtitle: navigationItem.subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType, customSubtitleTrailingImage: navigationItem.customSubtitleTrailingImage)
     }
 }

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -18,6 +18,7 @@ import UIKit
         static var subtitle: UInt8 = 0
         static var titleStyle: UInt8 = 0
         static var customNavigationBarColor: UInt8 = 0
+        static var customSubtitleTrailingImage: UInt8 = 0
     }
 
     var accessoryView: UIView? {
@@ -92,6 +93,15 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.navigationBarShadow, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    var customSubtitleTrailingImage: UIImage? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.customSubtitleTrailingImage) as? UIImage
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.customSubtitleTrailingImage, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -96,6 +96,7 @@ import UIKit
         }
     }
 
+    /// An optional image to show on the trailing end of the navigation bar's subtitle.
     var customSubtitleTrailingImage: UIImage? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.customSubtitleTrailingImage) as? UIImage

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -137,7 +137,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     // |  |--titleTrailingImageView (chevron, optional)
     // |--subtitleContainer
     // |  |--subtitleLabel
-    // |  |--subtitleImageView (chevron, custom, optional)
+    // |  |--subtitleImageView (optional)
 
     private lazy var containingStackView: UIStackView = {
         let stackView = UIStackView()
@@ -341,10 +341,10 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         container.addArrangedSubview(label)
 
         if interactive {
-            let showCustomSubtitleImage = (accessoryType == .custom) && (container == subtitleContainer)
+            let isTitle = container == titleContainer
             container.accessibilityTraits.insert(.button)
             container.accessibilityTraits.remove(.staticText)
-            trailingImageView.image = showCustomSubtitleImage ? customSubtitleTrailingImage : accessoryType.image(isTitle: container == titleContainer)
+            trailingImageView.image = (!isTitle && accessoryType == .custom) ? customSubtitleTrailingImage : accessoryType.image(isTitle: isTitle)
         } else {
             container.accessibilityTraits.insert(.staticText)
             container.accessibilityTraits.remove(.button)

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -74,9 +74,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
                 return UIImage.staticImageNamed(isTitle ? "chevron-right-16x16" : "chevron-right-12x12")
             case .downArrow:
                 return UIImage.staticImageNamed(isTitle ? "chevron-down-16x16" : "chevron-down-12x12")
-            case .none:
-                return nil
-            case .custom:
+            case .none, .custom:
                 return nil
             }
         }
@@ -276,7 +274,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
         // Check for strict equality for the subtitle button's interactivity.
         // If the whole area is active, we'll use the title as the main accessibility item.
-        setupTitleLine(subtitleContainer, label: subtitleLabel, trailingImageView: subtitleImageView, text: subtitle, interactive: interactivePart == .subtitle, accessoryType: accessoryType, customSubtitleTrailingImage: customSubtitleTrailingImage)
+        setupTitleLine(subtitleContainer, label: subtitleLabel, trailingImageView: subtitleImageView, text: subtitle, interactive: interactivePart.contains(.subtitle), accessoryType: accessoryType)
 
         minimumContentSizeCategory = .large
 
@@ -333,7 +331,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         }
     }
 
-    private func setupTitleLine(_ container: UIStackView, label: UILabel, trailingImageView: UIImageView, text: String?, interactive: Bool, accessoryType: AccessoryType, customSubtitleTrailingImage: UIImage? = nil) {
+    private func setupTitleLine(_ container: UIStackView, label: UILabel, trailingImageView: UIImageView, text: String?, interactive: Bool, accessoryType: AccessoryType) {
         container.accessibilityLabel = text
         label.text = text
 

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -66,6 +66,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         case none
         case disclosure
         case downArrow
+        case custom
 
         public func image(isTitle: Bool) -> UIImage? {
             switch self {
@@ -75,9 +76,13 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
                 return UIImage.staticImageNamed(isTitle ? "chevron-down-16x16" : "chevron-down-12x12")
             case .none:
                 return nil
+            case .custom:
+                return nil
             }
         }
     }
+
+    private var customSubtitleTrailingImage: UIImage?
 
     @objc open var titleAccessibilityHint: String? {
         get { return titleLabel.accessibilityHint }
@@ -240,8 +245,8 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     ///   - subtitle: An optional subtitle string. If nil, title will take up entire frame.
     ///   - interactivePart: Determines which line, if any, of the view will have interactive button behavior.
     ///   - accessoryType: Determines which accessory will be shown with the `interactivePart` of the view, if any. Ignored if `interactivePart` is `.none`.
-    @objc open func setup(title: String, subtitle: String? = nil, interactivePart: InteractivePart = .none, accessoryType: AccessoryType = .none) {
-        setup(title: title, subtitle: subtitle, alignment: .center, interactivePart: interactivePart, animatesWhenPressed: true, accessoryType: accessoryType)
+    @objc open func setup(title: String, subtitle: String? = nil, interactivePart: InteractivePart = .none, accessoryType: AccessoryType = .none, customSubtitleTrailingImage: UIImage? = nil) {
+        setup(title: title, subtitle: subtitle, alignment: .center, interactivePart: interactivePart, animatesWhenPressed: true, accessoryType: accessoryType, customSubtitleTrailingImage: customSubtitleTrailingImage)
     }
 
     /// Sets the relevant strings and button styles for the title and subtitle.
@@ -254,11 +259,12 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     ///   - interactivePart: Determines which line, if any, of the view will have interactive button behavior.
     ///   - animatesWhenPressed: If true, the text color will flash when pressed. Ignored if `interactivePart` is `.none`.
     ///   - accessoryType: Determines which accessory will be shown with the `interactivePart` of the view, if any. Ignored if `interactivePart` is `.none`.
-    @objc open func setup(title: String, titleImage: UIImage? = nil, subtitle: String? = nil, alignment: Alignment = .center, interactivePart: InteractivePart = .none, animatesWhenPressed: Bool = true, accessoryType: AccessoryType = .none) {
+    @objc open func setup(title: String, titleImage: UIImage? = nil, subtitle: String? = nil, alignment: Alignment = .center, interactivePart: InteractivePart = .none, animatesWhenPressed: Bool = true, accessoryType: AccessoryType = .none, customSubtitleTrailingImage: UIImage? = nil) {
         self.alignment = alignment
         self.interactivePart = interactivePart
         self.animatesWhenPressed = animatesWhenPressed
         self.accessoryType = accessoryType
+        self.customSubtitleTrailingImage = customSubtitleTrailingImage
 
         titleLeadingImageView.image = titleImage
         titleLeadingImageView.isHidden = titleImage == nil
@@ -270,7 +276,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
 
         // Check for strict equality for the subtitle button's interactivity.
         // If the whole area is active, we'll use the title as the main accessibility item.
-        setupTitleLine(subtitleContainer, label: subtitleLabel, trailingImageView: subtitleImageView, text: subtitle, interactive: interactivePart == .subtitle, accessoryType: accessoryType)
+        setupTitleLine(subtitleContainer, label: subtitleLabel, trailingImageView: subtitleImageView, text: subtitle, interactive: interactivePart == .subtitle, accessoryType: accessoryType, customSubtitleTrailingImage: customSubtitleTrailingImage)
 
         minimumContentSizeCategory = .large
 
@@ -327,7 +333,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         }
     }
 
-    private func setupTitleLine(_ container: UIStackView, label: UILabel, trailingImageView: UIImageView, text: String?, interactive: Bool, accessoryType: AccessoryType) {
+    private func setupTitleLine(_ container: UIStackView, label: UILabel, trailingImageView: UIImageView, text: String?, interactive: Bool, accessoryType: AccessoryType, customSubtitleTrailingImage: UIImage? = nil) {
         container.accessibilityLabel = text
         label.text = text
 
@@ -337,7 +343,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         if interactive {
             container.accessibilityTraits.insert(.button)
             container.accessibilityTraits.remove(.staticText)
-            trailingImageView.image = accessoryType.image(isTitle: container == titleContainer)
+            trailingImageView.image = (accessoryType == .custom) ? customSubtitleTrailingImage : accessoryType.image(isTitle: container == titleContainer)
         } else {
             container.accessibilityTraits.insert(.staticText)
             container.accessibilityTraits.remove(.button)

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -137,7 +137,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     // |  |--titleTrailingImageView (chevron, optional)
     // |--subtitleContainer
     // |  |--subtitleLabel
-    // |  |--subtitleImageView (chevron, optional)
+    // |  |--subtitleImageView (chevron, custom, optional)
 
     private lazy var containingStackView: UIStackView = {
         let stackView = UIStackView()
@@ -243,6 +243,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     ///   - subtitle: An optional subtitle string. If nil, title will take up entire frame.
     ///   - interactivePart: Determines which line, if any, of the view will have interactive button behavior.
     ///   - accessoryType: Determines which accessory will be shown with the `interactivePart` of the view, if any. Ignored if `interactivePart` is `.none`.
+    ///   - customSubtitleTrailingImage: An optional image to be used as the trailing image of the subtitle if `interactivePart` is `.custom`.
     @objc open func setup(title: String, subtitle: String? = nil, interactivePart: InteractivePart = .none, accessoryType: AccessoryType = .none, customSubtitleTrailingImage: UIImage? = nil) {
         setup(title: title, subtitle: subtitle, alignment: .center, interactivePart: interactivePart, animatesWhenPressed: true, accessoryType: accessoryType, customSubtitleTrailingImage: customSubtitleTrailingImage)
     }
@@ -257,6 +258,7 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
     ///   - interactivePart: Determines which line, if any, of the view will have interactive button behavior.
     ///   - animatesWhenPressed: If true, the text color will flash when pressed. Ignored if `interactivePart` is `.none`.
     ///   - accessoryType: Determines which accessory will be shown with the `interactivePart` of the view, if any. Ignored if `interactivePart` is `.none`.
+    ///   - customSubtitleTrailingImage: An optional image to be used as the trailing image of the subtitle if `interactivePart` is `.custom`.
     @objc open func setup(title: String, titleImage: UIImage? = nil, subtitle: String? = nil, alignment: Alignment = .center, interactivePart: InteractivePart = .none, animatesWhenPressed: Bool = true, accessoryType: AccessoryType = .none, customSubtitleTrailingImage: UIImage? = nil) {
         self.alignment = alignment
         self.interactivePart = interactivePart
@@ -339,9 +341,10 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         container.addArrangedSubview(label)
 
         if interactive {
+            let showCustomSubtitleImage = (accessoryType == .custom) && (container == subtitleContainer)
             container.accessibilityTraits.insert(.button)
             container.accessibilityTraits.remove(.staticText)
-            trailingImageView.image = (accessoryType == .custom) ? customSubtitleTrailingImage : accessoryType.image(isTitle: container == titleContainer)
+            trailingImageView.image = showCustomSubtitleImage ? customSubtitleTrailingImage : accessoryType.image(isTitle: container == titleContainer)
         } else {
             container.accessibilityTraits.insert(.staticText)
             container.accessibilityTraits.remove(.button)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

There's a partner request to be able to customize the trailing image of the `TwoLineTitleView`'s subtitle on our navigation bar. 
To that end I created a new `customSubtitleTrailingImage` property in `navigationItem`. There's also a new `custom` style in `NavigationBarTitleAccessory` that allows us to check if the client passed in a custom image, in which case we use that one instead of the default chevrons.

### Binary change
Total increase: 7,512 bytes
Total decrease: -1,816 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,992,728 bytes | 29,998,424 bytes | ⚠️ 5,696 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| UINavigationItem+Navigation.o | 72,928 bytes | 75,584 bytes | ⚠️ 2,656 bytes |
| __.SYMDEF | 4,662,168 bytes | 4,664,192 bytes | ⚠️ 2,024 bytes |
| TwoLineTitleView.o | 255,168 bytes | 257,040 bytes | ⚠️ 1,872 bytes |
| FocusRingView.o | 792,512 bytes | 793,248 bytes | ⚠️ 736 bytes |
| TwoLineTitleView+Navigation.o | 27,720 bytes | 27,944 bytes | ⚠️ 224 bytes |
| FluentTheme+Tokens.o | 74,336 bytes | 74,320 bytes | 🎉 -16 bytes |
| AliasTokens.o | 282,616 bytes | 280,816 bytes | 🎉 -1,800 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="484" alt="after_nav_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/71cb4dc0-3126-45ab-83c4-48bbee80dc5d"> | <img width="484" alt="after_nav_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/795bfa06-0b76-4eaa-8b9d-6e5e45e380e2"> |
| <img width="484" alt="after_twoline_light" src="https://github.com/microsoft/fluentui-apple/assets/106181067/2766301f-6765-49f3-829f-2b2ff2ceb688"> | <img width="484" alt="after_two_line_dark" src="https://github.com/microsoft/fluentui-apple/assets/106181067/5e3946ec-8860-4698-91e0-aa592e429363"> |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)