### PR TITLE
Buttons in scrollable CommandBar are filling containing view equally, creating undesirable layout

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -324,11 +324,10 @@ public class CommandBar: UIView, TokenizedControlInternal {
         NSLayoutConstraint.deactivate(mainCommandGroupsViewConstraints)
         if isScrollable {
             mainCommandGroupsViewConstraints = [
-                mainCommandGroupsView.widthAnchor.constraint(equalTo: scrollView.contentLayoutGuide.widthAnchor),
                 mainCommandGroupsView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
                 mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor),
                 mainCommandGroupsView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-                mainCommandGroupsView.centerXAnchor.constraint(greaterThanOrEqualTo: scrollView.centerXAnchor)
+                mainCommandGroupsView.trailingAnchor.constraint(greaterThanOrEqualTo: scrollView.trailingAnchor)
             ]
         } else {
             mainCommandGroupsViewConstraints = [

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -201,13 +201,24 @@ public class CommandBar: UIView, TokenizedControlInternal {
         }
     }
 
-    /// Whether or not the CommandBar is scrollable
+    /// Whether or not the `CommandBar` is scrollable
+    /// Defaults to `false`
     public var isScrollable: Bool = true {
         didSet {
             updateViewHierarchy()
             updateMainCommandGroupsViewConstraints()
             if !isScrollable {
-                mainCommandGroupsView.setEqualWidthGroups()
+                mainCommandGroupsView.equalWidthGroups = true
+            }
+        }
+    }
+
+    /// Whether or not the `CommandBar` scrollable content is centered in its container
+    /// Defaults to `false`
+    public var isScrollableContentCentered: Bool = false {
+        didSet {
+            if isScrollable {
+                updateMainCommandGroupsViewConstraints()
             }
         }
     }
@@ -325,10 +336,15 @@ public class CommandBar: UIView, TokenizedControlInternal {
         if isScrollable {
             mainCommandGroupsViewConstraints = [
                 mainCommandGroupsView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-                mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor),
                 mainCommandGroupsView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+                mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor),
                 mainCommandGroupsView.trailingAnchor.constraint(greaterThanOrEqualTo: scrollView.trailingAnchor)
             ]
+
+            if isScrollableContentCentered {
+                let centerConstraint = mainCommandGroupsView.centerXAnchor.constraint(greaterThanOrEqualTo: scrollView.centerXAnchor)
+                mainCommandGroupsViewConstraints.append(centerConstraint)
+            }
         } else {
             mainCommandGroupsViewConstraints = [
                 mainCommandGroupsView.topAnchor.constraint(equalTo: containerView.topAnchor),

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -202,7 +202,6 @@ public class CommandBar: UIView, TokenizedControlInternal {
     }
 
     /// Whether or not the `CommandBar` is scrollable
-    /// Defaults to `false`
     public var isScrollable: Bool = true {
         didSet {
             updateViewHierarchy()
@@ -214,7 +213,6 @@ public class CommandBar: UIView, TokenizedControlInternal {
     }
 
     /// Whether or not the `CommandBar` scrollable content is centered in its container
-    /// Defaults to `false`
     public var isScrollableContentCentered: Bool = false {
         didSet {
             if isScrollable {

--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -335,8 +335,7 @@ public class CommandBar: UIView, TokenizedControlInternal {
             mainCommandGroupsViewConstraints = [
                 mainCommandGroupsView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
                 mainCommandGroupsView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-                mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor),
-                mainCommandGroupsView.trailingAnchor.constraint(greaterThanOrEqualTo: scrollView.trailingAnchor)
+                mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor)
             ]
 
             if isScrollableContentCentered {

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -42,8 +42,10 @@ class CommandBarButtonGroupView: UIView {
         isHidden = allViewsHidden
     }
 
-    func setEqualWidthButtons() {
-        stackView.distribution = .fillEqually
+    var equalWidthButtons: Bool = false {
+        didSet {
+            stackView.distribution = equalWidthButtons ? .fillEqually : .fill
+        }
     }
 
     private lazy var stackView: UIStackView = {

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -42,12 +42,15 @@ class CommandBarButtonGroupView: UIView {
         isHidden = allViewsHidden
     }
 
+    func setEqualWidthButtons() {
+        stackView.distribution = .fillEqually
+    }
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.spacing = CommandBarTokenSet.itemInterspace
-        stackView.distribution = .fillEqually
 
         return stackView
     }()

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -93,9 +93,7 @@ class CommandBarCommandGroupsView: UIView {
 
         updateButtonGroupViews()
         for view in buttonGroupViews {
-            if usesEqualWidthGroups() {
-                view.setEqualWidthButtons()
-            }
+            view.equalWidthButtons = equalWidthGroups
             buttonGroupsStackView.addArrangedSubview(view)
         }
     }
@@ -107,8 +105,10 @@ class CommandBarCommandGroupsView: UIView {
         }
     }
 
-    func setEqualWidthGroups() {
-        buttonGroupsStackView.distribution = .fillEqually
+    var equalWidthGroups: Bool = false {
+        didSet {
+            buttonGroupsStackView.distribution = equalWidthGroups ? .fillEqually : .fill
+        }
     }
 
     // MARK: - Private properties
@@ -137,9 +137,5 @@ class CommandBarCommandGroupsView: UIView {
     @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
         sender.item.handleTapped(sender)
         sender.updateState()
-    }
-
-    private func usesEqualWidthGroups() -> Bool {
-        return buttonGroupsStackView.distribution == .fillEqually
     }
 }

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -93,6 +93,9 @@ class CommandBarCommandGroupsView: UIView {
 
         updateButtonGroupViews()
         for view in buttonGroupViews {
+            if usesEqualWidthGroups() {
+                view.setEqualWidthButtons()
+            }
             buttonGroupsStackView.addArrangedSubview(view)
         }
     }
@@ -134,5 +137,9 @@ class CommandBarCommandGroupsView: UIView {
     @objc private func handleCommandButtonTapped(_ sender: CommandBarButton) {
         sender.item.handleTapped(sender)
         sender.updateState()
+    }
+
+    private func usesEqualWidthGroups() -> Bool {
+        return buttonGroupsStackView.distribution == .fillEqually
     }
 }

--- a/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
+++ b/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
@@ -127,6 +127,7 @@ public class MultilineCommandBar: UIViewController {
         for row in rows {
             let commandBarRow = CommandBar(itemGroups: row.itemGroups, leadingItemGroups: nil)
             commandBarRow.isScrollable = row.isScrollable
+            commandBarRow.isScrollableContentCentered = row.isScrollable
             commandBarRow.translatesAutoresizingMaskIntoConstraints = false
 
             if row.isScrollable {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

An issue was observed with the scrollable `CommandBar` component where items would expand to fill the visible space when only a couple of items are shown in the bar.

This issue was caused by two constraints in `mainCommandGroupsViewConstraints` and the `UIStackView.distribution` property set on the `CommandBarButtonGroupView`.

The change fixes the behavior by:
- Replace the `widthAnchor` constraint with a `trailingAnchor` constraint which pairs with the existing `leadingAnchor` constraint
- Conditionally apply `centerX` constraint when the `CommandBar.isScrollableContentCentered` property is `true`
- Only set the `stackView.distribution = .fillEqually` on `CommandBarButtonGroupView` when the `CommandBar.isScrollable` is `false`. This value is set from `CommandBarCommandGroupsView.updateButtonsShown()` when needed.
- Update the `setEqualWidthGroups()` and `setEqualWidthButtons()` to properties with `didSet` implementations

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

- Verified behavior in CommandBar demo
- Verified behavior in MultilineCommandBar demo
- Verified behavior in affected applications

<details>
<summary>Visual Verification</summary>

**Before:**
![Screenshot 2023-07-13 at 11 55 18 AM](https://github.com/microsoft/fluentui-apple/assets/10938746/c9ed2f5b-a3ba-472e-860d-c107ec05f62e)
_Above image shows that buttons are stretched to fill the view._

**After:**
![Screenshot 2023-07-13 at 11 46 29 AM](https://github.com/microsoft/fluentui-apple/assets/10938746/15b5253b-009c-4d05-9f56-b18fb34fdee9)
_Above image shows that buttons are not stretched to fill the view._

![Screenshot 2023-07-13 at 12 31 59 PM](https://github.com/microsoft/fluentui-apple/assets/10938746/0999ecab-affc-4340-bed8-e0be3a16efcd)
_Above image shows that sibling buttons of different sizes do not stretch to fill their containing view equally (see "Body", undo, redo button group)._

![Screenshot 2023-07-13 at 12 26 28 PM](https://github.com/microsoft/fluentui-apple/assets/10938746/60d642e0-da82-4a1a-a791-5eaf2006552b)
_Above image shows that the Multiline CommandBar is unchanged with these modifications._

<img width="405" alt="Screenshot 2023-07-18 at 10 36 03 AM" src="https://github.com/microsoft/fluentui-apple/assets/10938746/103148e0-a6c8-4413-85e9-e0d851fbc137">
_Above image shows that the Multiline CommandBar is centered when in landscape._

<img width="1030" alt="Screenshot 2023-07-18 at 11 56 28 AM" src="https://github.com/microsoft/fluentui-apple/assets/10938746/1554932a-294b-4b0c-907d-b49e2ae01950">
_Above images that the CommandBar lays out correctly on iPad_

<img width="615" alt="Screenshot 2023-07-18 at 11 56 47 AM" src="https://github.com/microsoft/fluentui-apple/assets/10938746/d13a662e-b50d-4051-bd7a-8c33506498bd">
_Above image shows that the Multiline CommandBar lays out correctly on iPad._

<img width="1043" alt="Screenshot 2023-07-18 at 11 56 40 AM" src="https://github.com/microsoft/fluentui-apple/assets/10938746/e19057e0-d276-47c1-98a5-813ede81827b">
_Above image shows that the Multiline CommandBar lays out correctly in landscape on iPad._


### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1826&drop=dogfoodAlpha