### PR TITLE
adjust header color for popup menu

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -340,6 +340,7 @@ extension PopupMenuController: UITableViewDelegate {
         }
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: PopupMenuSectionHeaderView.identifier) as? PopupMenuSectionHeaderView
         headerView?.setup(section: section)
+        headerView?.tableViewCellStyle = .clear
         return headerView
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes
adjust the popupmenu headerfooterview background color to be clear to blend better with the overall drawercontroller

### Binary change

Total increase: 2,200 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 29,686,720 bytes | 29,688,920 bytes | ⚠️ 2,200 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| PopupMenuController.o | 380,256 bytes | 382,072 bytes | ⚠️ 1,816 bytes |
| __.SYMDEF | 4,497,496 bytes | 4,497,880 bytes | ⚠️ 384 bytes |
</details>

### Verification
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-apple/assets/20715435/d4fedcd5-10dc-45e8-8093-a6374fb66d93) | ![image](https://github.com/microsoft/fluentui-apple/assets/20715435/46f46e5e-b3b3-491f-8c7d-1782b4609f62) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)