### PR TITLE
[main_0.20] Cherry-pick #1831, #1826, and #1833

### DIFF
--- a/ios/FluentUI/Command Bar/CommandBar.swift
+++ b/ios/FluentUI/Command Bar/CommandBar.swift
@@ -201,13 +201,22 @@ public class CommandBar: UIView, TokenizedControlInternal {
         }
     }
 
-    /// Whether or not the CommandBar is scrollable
+    /// Whether or not the `CommandBar` is scrollable
     public var isScrollable: Bool = true {
         didSet {
             updateViewHierarchy()
             updateMainCommandGroupsViewConstraints()
             if !isScrollable {
-                mainCommandGroupsView.setEqualWidthGroups()
+                mainCommandGroupsView.equalWidthGroups = true
+            }
+        }
+    }
+
+    /// Whether or not the `CommandBar` scrollable content is centered in its container
+    public var isScrollableContentCentered: Bool = false {
+        didSet {
+            if isScrollable {
+                updateMainCommandGroupsViewConstraints()
             }
         }
     }
@@ -324,12 +333,15 @@ public class CommandBar: UIView, TokenizedControlInternal {
         NSLayoutConstraint.deactivate(mainCommandGroupsViewConstraints)
         if isScrollable {
             mainCommandGroupsViewConstraints = [
-                mainCommandGroupsView.widthAnchor.constraint(equalTo: scrollView.contentLayoutGuide.widthAnchor),
                 mainCommandGroupsView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-                mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor),
                 mainCommandGroupsView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-                mainCommandGroupsView.centerXAnchor.constraint(greaterThanOrEqualTo: scrollView.centerXAnchor)
+                mainCommandGroupsView.leadingAnchor.constraint(greaterThanOrEqualTo: scrollView.leadingAnchor)
             ]
+
+            if isScrollableContentCentered {
+                let centerConstraint = mainCommandGroupsView.centerXAnchor.constraint(greaterThanOrEqualTo: scrollView.centerXAnchor)
+                mainCommandGroupsViewConstraints.append(centerConstraint)
+            }
         } else {
             mainCommandGroupsViewConstraints = [
                 mainCommandGroupsView.topAnchor.constraint(equalTo: containerView.topAnchor),

--- a/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarButtonGroupView.swift
@@ -42,12 +42,17 @@ class CommandBarButtonGroupView: UIView {
         isHidden = allViewsHidden
     }
 
+    var equalWidthButtons: Bool = false {
+        didSet {
+            stackView.distribution = equalWidthButtons ? .fillEqually : .fill
+        }
+    }
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: buttons)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.spacing = CommandBarTokenSet.itemInterspace
-        stackView.distribution = .fillEqually
 
         return stackView
     }()

--- a/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
+++ b/ios/FluentUI/Command Bar/CommandBarCommandGroupsView.swift
@@ -93,6 +93,7 @@ class CommandBarCommandGroupsView: UIView {
 
         updateButtonGroupViews()
         for view in buttonGroupViews {
+            view.equalWidthButtons = equalWidthGroups
             buttonGroupsStackView.addArrangedSubview(view)
         }
     }
@@ -104,8 +105,10 @@ class CommandBarCommandGroupsView: UIView {
         }
     }
 
-    func setEqualWidthGroups() {
-        buttonGroupsStackView.distribution = .fillEqually
+    var equalWidthGroups: Bool = false {
+        didSet {
+            buttonGroupsStackView.distribution = equalWidthGroups ? .fillEqually : .fill
+        }
     }
 
     // MARK: - Private properties

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -104,7 +104,9 @@ open class ControlHostingView: UIView {
             controller.disableSafeAreaInsets()
             return controller
         } else {
-            return UIHostingController.init(rootView: AnyView(EmptyView()))
+            let controller = UIHostingController.init(rootView: AnyView(EmptyView()))
+            controller.sizingOptions = [.intrinsicContentSize]
+            return controller
         }
     }()
     private let controlView: AnyView

--- a/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
+++ b/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
@@ -127,6 +127,7 @@ public class MultilineCommandBar: UIViewController {
         for row in rows {
             let commandBarRow = CommandBar(itemGroups: row.itemGroups, leadingItemGroups: nil)
             commandBarRow.isScrollable = row.isScrollable
+            commandBarRow.isScrollableContentCentered = row.isScrollable
             commandBarRow.translatesAutoresizingMaskIntoConstraints = false
 
             if row.isScrollable {

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -340,6 +340,7 @@ extension PopupMenuController: UITableViewDelegate {
         }
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: PopupMenuSectionHeaderView.identifier) as? PopupMenuSectionHeaderView
         headerView?.setup(section: section)
+        headerView?.tableViewCellStyle = .clear
         return headerView
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

Cherry-pick of the following PRs
- #1831
- #1826
- #1833

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1834&drop=dogfoodAlpha