### PR TITLE
Fix pod publish to use macOS 13

### DIFF
--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -7,7 +7,7 @@ on:
       - 0.2.[0-9]+_main_0.2
 jobs:
   Pod-Publish:
-    runs-on: macos-12
+    runs-on: macos-13
     
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

#1819 updated the Xcode version to 14.3, which requires macOS 13. `ci.yml` was updated but not `podPublish.yml`. This PR updates the yml file to fix the broken pod publish.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1836&drop=dogfoodAlpha