### PR TITLE
Disable scrolling from PopupMenu when content fits the table view

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
@@ -125,7 +125,7 @@
         [self setSelectedCityIndex:[weakMenu selectedItemIndexPath]];
     }];
 
-    [[self navigationController] presentViewController:popupMenu animated:YES completion:nil];
+    [self presentViewController:popupMenu animated:YES completion:nil];
 }
 
 @end

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -251,6 +251,7 @@ open class PopupMenuController: DrawerController {
         super.viewDidLayoutSubviews()
         tableView.layoutIfNeeded()
         tableView.scrollToNearestSelectedRow(at: .none, animated: false)
+        tableView.isScrollEnabled = preferredContentHeight > tableView.frame.height
     }
 
     private func initTableView() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

There's been a request to remove the scrolling from the popup menu when its content fits the table view. To that end, I added a line in `viewDidLayoutSubviews` that enables scrolling when the `preferredContentHeight` is greater than the table view's height, and disables it otherwise. 
This PR also has a bug fix to present the popup menu in the objc demo from the view controller and not the navigation controller so that the navigation bar still shows up when we present the popup.

### Binary change

Total increase: 88 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,081,816 bytes | 30,081,904 bytes | ⚠️ 88 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| PopupMenuController.o | 384,144 bytes | 384,232 bytes | ⚠️ 88 bytes |
</details>

### Verification

Verified large text mode and changing from portrait to landscape, where the scrolling would change depending on the heights on the orientation.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_large](https://github.com/microsoft/fluentui-apple/assets/106181067/10fbb6da-177c-473e-8ed3-6ab6ff60932d) | ![after_large](https://github.com/microsoft/fluentui-apple/assets/106181067/cae9c77c-e0f5-46f1-804b-4258ac6fbddc) |
| ![before_scroll](https://github.com/microsoft/fluentui-apple/assets/106181067/2ea36313-192c-4526-9ece-b46898e78420) | ![after_scroll](https://github.com/microsoft/fluentui-apple/assets/106181067/8c9505ca-64a7-4562-a62a-d7d518d6fdc8) |
| <img width="484" alt="before_objc" src="https://github.com/microsoft/fluentui-apple/assets/106181067/e70d2e6b-3c25-42ef-9876-99ddf57942fa"> | <img width="484" alt="after_objc" src="https://github.com/microsoft/fluentui-apple/assets/106181067/8855e2a7-93d2-4ab0-9e8c-a7ed1125628a"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1840&drop=dogfoodAlpha