### PR TITLE
Tokenize the BottomCommandingController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -23,6 +23,7 @@ struct Demos {
         DemoDescriptor("Avatar", AvatarDemoController.self),
         DemoDescriptor("AvatarGroup", AvatarGroupDemoController.self),
         DemoDescriptor("BadgeView", BadgeViewDemoController.self),
+        DemoDescriptor("BottomCommandingController", BottomCommandingDemoController.self),
         DemoDescriptor("BottomSheetController", BottomSheetDemoController.self),
         DemoDescriptor("Button", ButtonDemoController.self),
         DemoDescriptor("CardNudge", CardNudgeDemoController.self),
@@ -60,7 +61,6 @@ struct Demos {
 
     static let controls: [DemoDescriptor] = [
         DemoDescriptor("BadgeField", BadgeFieldDemoController.self),
-        DemoDescriptor("BottomCommandingController", BottomCommandingDemoController.self),
         DemoDescriptor("Card", CardViewDemoController.self),
         DemoDescriptor("DateTimePicker", DateTimePickerDemoController.self),
         DemoDescriptor("PeoplePicker", PeoplePickerDemoController.self),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -6,10 +6,10 @@
 import FluentUI
 import UIKit
 
-class BottomCommandingDemoController: UIViewController {
+class BottomCommandingDemoController: DemoController {
 
-    override func loadView() {
-        view = UIView()
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
         let optionTableViewController = UITableViewController(style: .insetGrouped)
         mainTableViewController = optionTableViewController
@@ -446,5 +446,104 @@ extension BottomCommandingDemoController: BottomCommandingControllerDelegate {
         if let tableView = mainTableViewController?.tableView {
             tableView.contentInset.bottom = bottomCommandingController.collapsedHeightInSafeArea
         }
+    }
+}
+
+extension BottomCommandingDemoController: DemoAppearanceDelegate {
+    func themeWideOverrideDidChange(isOverrideEnabled: Bool) {
+        guard let fluentTheme = self.view.window?.fluentTheme else {
+            return
+        }
+
+        fluentTheme.register(tokenSetType: BottomCommandingTokenSet.self, tokenSet: isOverrideEnabled ? themeWideOverrideBottomCommandingTokens : nil)
+    }
+
+    func perControlOverrideDidChange(isOverrideEnabled: Bool) {
+        bottomCommandingController?.tokenSet.replaceAllOverrides(with: isOverrideEnabled ? perControlOverrideBottomCommandingTokens : nil)
+    }
+
+    func isThemeWideOverrideApplied() -> Bool {
+        return self.view.window?.fluentTheme.tokens(for: BottomCommandingTokenSet.self)?.isEmpty == false
+    }
+
+    // MARK: - Custom tokens
+    private var themeWideOverrideBottomCommandingTokens: [BottomCommandingTokenSet.Tokens: ControlTokenValue] {
+        let foregroundColor = UIColor(light: GlobalTokens.sharedColor(.plum, .shade30),
+                                      dark: GlobalTokens.sharedColor(.plum, .tint40))
+        return [
+            .backgroundColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.plum, .tint40),
+                               dark: GlobalTokens.sharedColor(.plum, .shade30))
+            },
+            .cornerRadius: .float { GlobalTokens.corner(.radiusNone) },
+            .heroDisabledColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.plum, .tint30),
+                               dark: GlobalTokens.sharedColor(.plum, .tint20))
+            },
+            .heroLabelFont: .uiFont {
+                return UIFont(descriptor: .init(name: "Times", size: 20.0),
+                              size: 20.0)
+            },
+            .heroRestIconColor: .uiColor { foregroundColor },
+            .heroRestLabelColor: .uiColor { foregroundColor },
+            .heroSelectedColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.forest, .shade30),
+                               dark: GlobalTokens.sharedColor(.forest, .tint40))
+            },
+            .listIconColor: .uiColor { foregroundColor },
+            .listLabelColor: .uiColor { foregroundColor },
+            .listLabelFont: .uiFont {
+                return UIFont(descriptor: .init(name: "Times", size: 20.0),
+                              size: 20.0)
+            },
+            .listSectionLabelColor: .uiColor { foregroundColor },
+            .listSectionLabelFont: .uiFont {
+                return UIFont(descriptor: .init(name: "Times", size: 16.0),
+                              size: 16.0)
+            },
+            .resizingHandleMarkColor: .uiColor { foregroundColor },
+            .strokeColor: .uiColor { foregroundColor },
+            .shadow: .shadowInfo { FluentTheme.shared.shadow(.clear) }
+        ]
+    }
+
+    private var perControlOverrideBottomCommandingTokens: [BottomCommandingTokenSet.Tokens: ControlTokenValue] {
+        let foregroundColor = UIColor(light: GlobalTokens.sharedColor(.forest, .shade30),
+                                      dark: GlobalTokens.sharedColor(.forest, .tint40))
+        return [
+            .backgroundColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.forest, .tint40),
+                               dark: GlobalTokens.sharedColor(.forest, .shade30))
+            },
+            .cornerRadius: .float { GlobalTokens.corner(.radius40) },
+            .heroDisabledColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.forest, .tint20),
+                               dark: GlobalTokens.sharedColor(.forest, .shade10))
+            },
+            .heroLabelFont: .uiFont {
+                return UIFont(descriptor: .init(name: "Papyrus", size: 20.0),
+                              size: 20.0)
+            },
+            .heroRestIconColor: .uiColor { foregroundColor },
+            .heroRestLabelColor: .uiColor { foregroundColor },
+            .heroSelectedColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.plum, .primary),
+                               dark: GlobalTokens.sharedColor(.plum, .tint40))
+            },
+            .listIconColor: .uiColor { foregroundColor },
+            .listLabelColor: .uiColor { foregroundColor },
+            .listLabelFont: .uiFont {
+                return UIFont(descriptor: .init(name: "Papyrus", size: 20.0),
+                              size: 20.0)
+            },
+            .listSectionLabelColor: .uiColor { foregroundColor },
+            .listSectionLabelFont: .uiFont {
+                return UIFont(descriptor: .init(name: "Papyrus", size: 16.0),
+                              size: 16.0)
+            },
+            .resizingHandleMarkColor: .uiColor { foregroundColor },
+            .strokeColor: .uiColor { foregroundColor },
+            .shadow: .shadowInfo { FluentTheme.shared.shadow(.shadow64) }
+        ]
     }
 }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		EC98E2B4298D989100B9DF91 /* FluentTextInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC98E2B3298D989100B9DF91 /* FluentTextInputError.swift */; };
 		ECA9218627A3301C00B66117 /* MSFAvatarGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */; };
 		ECA9218A27A33A2D00B66117 /* AvatarGroupModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218927A33A2D00B66117 /* AvatarGroupModifiers.swift */; };
+		ECF3C9882A67495A00CA35FC /* BottomCommandingTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */; };
 		FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -426,6 +427,7 @@
 		ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFAvatarGroup.swift; sourceTree = "<group>"; };
 		ECA9218927A33A2D00B66117 /* AvatarGroupModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarGroupModifiers.swift; sourceTree = "<group>"; };
 		ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
+		ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomCommandingTokenSet.swift; sourceTree = "<group>"; };
 		F5784DB9285D031800DBEAD6 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docs; sourceTree = "<group>"; };
 		FC414E1E258876FB00069E73 /* CommandBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBar.swift; sourceTree = "<group>"; };
 		FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarButtonGroupView.swift; sourceTree = "<group>"; };
@@ -770,6 +772,7 @@
 			isa = PBXGroup;
 			children = (
 				8035CAAA2633A442007B3FD1 /* BottomCommandingController.swift */,
+				ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */,
 				8035CACA26377C14007B3FD1 /* CommandingItem.swift */,
 				8035CADC2638E435007B3FD1 /* CommandingSection.swift */,
 			);
@@ -1615,6 +1618,7 @@
 				5314E01625F00CF70099271A /* BarButtonItems.swift in Sources */,
 				5314E25425F023650099271A /* UIImage+Extensions.swift in Sources */,
 				92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */,
+				ECF3C9882A67495A00CA35FC /* BottomCommandingTokenSet.swift in Sources */,
 				532FE3D826EA6D74007539C0 /* ActivityIndicator.swift in Sources */,
 				5314E0E625F012C00099271A /* UIViewController+Navigation.swift in Sources */,
 				5314E29725F024760099271A /* String+Extension.swift in Sources */,

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -353,8 +353,8 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
     }
 
-    public override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
 
         tokenSet.update(fluentTheme)
     }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -411,7 +411,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         headerView.addSubview(heroCommandStack)
 
         let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
-        sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
+        sheetController.headerContentHeight = BottomCommandingTokenSet.handleHeaderHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
         sheetController.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth
@@ -458,9 +458,9 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         let bottomBarView = UIView()
 
         let roundedCornerView = UIView()
-        roundedCornerView.backgroundColor = bottomBarBackgroundColor
+        roundedCornerView.backgroundColor = tokenSet[.backgroundColor].uiColor
         roundedCornerView.translatesAutoresizingMaskIntoConstraints = false
-        roundedCornerView.layer.cornerRadius = Constants.BottomBar.cornerRadius
+        roundedCornerView.layer.cornerRadius = BottomCommandingTokenSet.cornerRadius
         roundedCornerView.layer.cornerCurve = .continuous
         roundedCornerView.clipsToBounds = true
 
@@ -473,9 +473,9 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
             roundedCornerView.trailingAnchor.constraint(equalTo: bottomBarView.trailingAnchor),
             roundedCornerView.topAnchor.constraint(equalTo: bottomBarView.topAnchor),
             roundedCornerView.bottomAnchor.constraint(equalTo: bottomBarView.bottomAnchor),
-            contentView.leadingAnchor.constraint(equalTo: bottomBarView.leadingAnchor, constant: Constants.BottomBar.heroStackLeadingTrailingMargin),
-            contentView.trailingAnchor.constraint(equalTo: bottomBarView.trailingAnchor, constant: -Constants.BottomBar.heroStackLeadingTrailingMargin),
-            contentView.topAnchor.constraint(equalTo: bottomBarView.topAnchor, constant: Constants.BottomBar.heroStackTopMargin)
+            contentView.leadingAnchor.constraint(equalTo: bottomBarView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: bottomBarView.trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: bottomBarView.topAnchor, constant: BottomCommandingTokenSet.tabVerticalPadding)
         ])
 
         return bottomBarView
@@ -557,7 +557,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
             let rowStack = UIStackView(arrangedSubviews: rowViews)
             rowStack.axis = .horizontal
             rowStack.distribution = .fillEqually
-            let horizontalMargin = Constants.BottomSheet.headerLeadingTrailingMargin
+            let horizontalMargin = BottomCommandingTokenSet.tabHorizontalPadding
             rowStack.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: horizontalMargin, bottom: 0, trailing: horizontalMargin)
             rowStack.isLayoutMarginsRelativeArrangement = true
             heroCommandOverflowStack.addArrangedSubview(rowStack)
@@ -584,14 +584,14 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addInteraction(UILargeContentViewerInteraction())
         stackView.alignment = .top
-        let horizontalMargin = Constants.BottomSheet.headerLeadingTrailingMargin
+        let horizontalMargin = BottomCommandingTokenSet.tabHorizontalPadding
         stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: horizontalMargin, bottom: 0, trailing: horizontalMargin)
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
 
     private lazy var heroCommandOverflowStack: UIStackView = {
-        let spacing = Constants.heroCommandOverflowStackSpacing
+        let spacing = BottomCommandingTokenSet.gridSpacing
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addInteraction(UILargeContentViewerInteraction())
@@ -616,7 +616,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         tableView.separatorStyle = .none
         tableView.alwaysBounceVertical = false
         tableView.sectionFooterHeight = 0
-        tableView.backgroundColor = tableViewBackgroundColor
+        tableView.backgroundColor = tokenSet[.backgroundColor].uiColor
         tableView.register(TableViewCell.self, forCellReuseIdentifier: TableViewCell.identifier)
         tableView.register(BooleanCell.self, forCellReuseIdentifier: BooleanCell.identifier)
         tableView.register(TableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: TableViewHeaderFooterView.identifier)
@@ -758,7 +758,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
 
     private func setupTableViewCell(_ cell: TableViewCell, with item: CommandingItem) {
         let iconView = UIImageView(image: item.image)
-        iconView.tintColor = tableViewIconTintColor
+        iconView.tintColor = tokenSet[.listIconColor].uiColor
 
         if item.isToggleable, let booleanCell = cell as? BooleanCell {
             booleanCell.setup(title: item.title ?? "", customView: iconView, isOn: item.isOn)
@@ -775,7 +775,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
         cell.isEnabled = item.isEnabled
         cell.backgroundStyleType = .clear
-        cell.backgroundColor = tableViewBackgroundColor
+        cell.backgroundColor = tokenSet[.backgroundColor].uiColor
         cell.accessibilityIdentifier = item.accessibilityIdentifier
 
         let shouldShowSeparator = expandedListSections
@@ -815,7 +815,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         bottomSheetController.isExpandable = isExpandable
 
         let maxHeroItemHeight = heroCommandStack.arrangedSubviews.map { $0.intrinsicContentSize.height }.max() ?? Constants.defaultHeroButtonHeight
-        let headerHeightWithoutBottomWhitespace = Constants.BottomSheet.headerTopMargin + maxHeroItemHeight
+        let headerHeightWithoutBottomWhitespace = BottomCommandingTokenSet.handleHeaderHeight + maxHeroItemHeight
 
         // How much more whitespace is required at the bottom of the sheet header
         let requiredBottomWhitespace = max(0, Constants.BottomSheet.headerHeight - headerHeightWithoutBottomWhitespace)
@@ -828,7 +828,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         let addedHeaderTopMargin = !isExpandable
             ? BottomSheetController.resizingHandleHeight
             : 0
-        bottomSheetHeroStackTopConstraint?.constant = Constants.BottomSheet.headerTopMargin + addedHeaderTopMargin
+        bottomSheetHeroStackTopConstraint?.constant = BottomCommandingTokenSet.handleHeaderHeight + addedHeaderTopMargin
 
         let oldCollapsedContentHeight = bottomSheetController.collapsedContentHeight
         let newCollapsedContentHeight = headerHeightWithoutBottomWhitespace + reducedBottomWhitespace + addedHeaderTopMargin
@@ -987,26 +987,18 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
     }
 
-    private lazy var tableViewIconTintColor: UIColor = GlobalTokens.neutralColor(.grey50)
-    private lazy var tableViewBackgroundColor: UIColor = view.fluentTheme.color(.background2)
-    private lazy var bottomBarBackgroundColor: UIColor = view.fluentTheme.color(.background2)
-
     private struct Constants {
         static let defaultHeroButtonHeight: CGFloat = 40
         static let heroButtonWidth: CGFloat = 96
         static let heroButtonLabelMaxWidth: CGFloat = 72
         static let heroButtonMaxTitleLines: Int = 2
         static let heroCommandsPerRow: Int = 5
-        static let heroCommandOverflowStackSpacing: CGFloat = 8
 
         struct BottomBar {
             static let height: CGFloat = 80
-            static let cornerRadius: CGFloat = 14
 
             static let bottomOffset: CGFloat = 8
             static let hiddenBottomOffset: CGFloat = -110
-            static let heroStackLeadingTrailingMargin: CGFloat = 8
-            static let heroStackTopMargin: CGFloat = 20
 
             static let hidingSpringDuration: TimeInterval = 0.4
             static let hidingSpringDamping: CGFloat = 1.0
@@ -1017,8 +1009,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
 
         struct BottomSheet {
             static let headerHeight: CGFloat = 66
-            static let headerTopMargin: CGFloat = 8
-            static let headerLeadingTrailingMargin: CGFloat = 16
         }
     }
 }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -476,7 +476,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
             roundedCornerView.bottomAnchor.constraint(equalTo: bottomBarView.bottomAnchor),
             contentView.leadingAnchor.constraint(equalTo: bottomBarView.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: bottomBarView.trailingAnchor),
-            contentView.topAnchor.constraint(equalTo: bottomBarView.topAnchor, constant: BottomCommandingTokenSet.tabVerticalPadding)
+            contentView.topAnchor.constraint(equalTo: bottomBarView.topAnchor, constant: BottomCommandingTokenSet.bottomBarTopSpacing)
         ])
         bottomBarBackgroundView = roundedCornerView
         return bottomBarView

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -411,7 +411,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         headerView.addSubview(heroCommandStack)
 
         let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
-        sheetController.headerContentHeight = BottomCommandingTokenSet.handleHeaderHeight
+        sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
         sheetController.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -60,7 +60,7 @@ public protocol BottomCommandingControllerDelegate: AnyObject {
 /// Items from the `expandedListSections` are either presented in an expanded sheet or a popover, depending on the current style.
 ///
 @objc(MSFBottomCommandingController)
-open class BottomCommandingController: UIViewController {
+open class BottomCommandingController: UIViewController, TokenizedControlInternal {
 
     /// View controller that will be displayed below the bottom commanding UI.
     @objc public var contentViewController: UIViewController? {
@@ -280,6 +280,11 @@ open class BottomCommandingController: UIViewController {
         if let contentViewController = contentViewController {
             addChildContentViewController(contentViewController)
         }
+
+        // Update appearance whenever `tokenSet` changes.
+        tokenSet.registerOnUpdate(for: view) { [weak self] in
+            self?.updateAppearance()
+        }
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -347,6 +352,17 @@ open class BottomCommandingController: UIViewController {
             bottomSheetController?.handleCollapseCustomAccessibilityLabel = handleCollapseCustomAccessibilityLabel
         }
     }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        tokenSet.update(fluentTheme)
+    }
+
+    public typealias TokenSetKeyType = BottomCommandingTokenSet.Tokens
+    public var tokenSet: BottomCommandingTokenSet = .init()
+
+    var fluentTheme: FluentTheme { return view.fluentTheme }
 
     private func setupCommandingLayout(traitCollection: UITraitCollection, forceLayoutPass: Bool = false) {
         if traitCollection.horizontalSizeClass == .regular && traitCollection.userInterfaceIdiom == .pad {
@@ -551,6 +567,10 @@ open class BottomCommandingController: UIViewController {
         if isInSheetMode {
             view.setNeedsLayout()
         }
+    }
+
+    private func updateAppearance() {
+        
     }
 
     private lazy var moreHeroItem: CommandingItem = {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
@@ -57,7 +57,7 @@ public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingTokenSet.
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .uiColor { theme.color(.background1) }
+                return .uiColor { theme.color(.background2) }
             case .cornerRadius:
                 return .float { GlobalTokens.corner(.radius120) }
             case .heroDisabledColor:

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
@@ -92,6 +92,7 @@ public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingTokenSet.
 }
 
 extension BottomCommandingTokenSet {
+    static let bottomBarTopSpacing: CGFloat = GlobalTokens.spacing(.size200)
     static let gridSpacing: CGFloat = GlobalTokens.spacing(.size80)
     static let tabVerticalPadding: CGFloat = GlobalTokens.spacing(.size80)
     static let tabHorizontalPadding: CGFloat = GlobalTokens.spacing(.size160)

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingTokenSet.Tokens> {
+    public enum Tokens: TokenSetKey {
+        /// The color of the background of the `BottomCommandingController`.
+        case backgroundColor
+
+        case heroDisabledColor
+
+        case heroLabelFont
+
+        case heroRestIconColor
+
+        case heroRestLabelColor
+
+        case heroSelectedColor
+
+        case listIconColor
+
+        case listLabelColor
+
+        case listLabelFont
+
+        case listSectionLabelColor
+
+        case listSectionLabelFont
+
+        case resizingHandleMarkColor
+
+        case strokeColor
+
+        case shadow
+    }
+
+    init() {
+        super.init { token, theme in
+            switch token {
+            case .backgroundColor:
+                return .uiColor { theme.color(.background1) }
+            case .heroDisabledColor:
+                return .uiColor { theme.color(.foregroundDisabled1) }
+            case .heroLabelFont:
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
+            case .heroRestIconColor:
+                return .uiColor { theme.color(.foreground3) }
+            case .heroRestLabelColor:
+                return .uiColor { theme.color(.foreground2) }
+            case .heroSelectedColor:
+                return .uiColor { theme.color(.brandForeground1) }
+            case .listIconColor:
+                return .uiColor { theme.color(.foreground2) }
+            case .listLabelColor:
+                return .uiColor { theme.color(.foreground1) }
+            case .listLabelFont:
+                return .uiFont { theme.typography(.body1) }
+            case .listSectionLabelColor:
+                return .uiColor { theme.color(.foreground2) }
+            case .listSectionLabelFont:
+                return .uiFont { theme.typography(.caption1) }
+            case .resizingHandleMarkColor:
+                return .uiColor { theme.color(.strokeAccessible) }
+            case .strokeColor:
+                return .uiColor { theme.color(.stroke2) }
+            case .shadow:
+                return .shadowInfo { theme.shadow(.shadow28) }
+            }
+        }
+    }
+}
+
+extension BottomCommandingTokenSet {
+    static let gridSpacing: CGFloat = GlobalTokens.spacing(.size80)
+    static let cornerRadius: CGFloat = GlobalTokens.corner(.radius120)
+    static let tabVerticalPadding: CGFloat = GlobalTokens.spacing(.size80)
+    static let tabHorizontalPadding: CGFloat = GlobalTokens.spacing(.size160)
+    static let strokeWidth: CGFloat = GlobalTokens.stroke(.width05)
+    static let handleHeaderHeight: CGFloat = GlobalTokens.spacing(.size120)
+}

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
@@ -7,33 +7,49 @@ import SwiftUI
 
 public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
-        /// The color of the background of the `BottomCommandingController`.
+        /// Defines the color of the background of the `BottomCommandingController`.
         case backgroundColor
 
+        /// Defines the corner radius of the `BottomCommandingController`.
+        case cornerRadius
+
+        /// Defines the color of the disabled hero items of the `BottomCommandingController`.
         case heroDisabledColor
 
+        /// Defines the font of the hero items of the `BottomCommandingController`.
         case heroLabelFont
 
+        /// Defines the color of the icon of the hero items of the `BottomCommandingController`.
         case heroRestIconColor
 
+        /// Defines the color of the label of the hero items of the `BottomCommandingController`.
         case heroRestLabelColor
 
+        /// Defines the color of the hero item of the `BottomCommandingController` when `isOn` is true.
         case heroSelectedColor
 
+        /// Defines the color of the icons in the list of the `BottomCommandingController`.
         case listIconColor
 
+        /// Defines the color of the labels in the list of the `BottomCommandingController`.
         case listLabelColor
 
+        /// Defines the font of the items in the list of the `BottomCommandingController`.
         case listLabelFont
 
+        /// Defines the color of the section labels in the list of the `BottomCommandingController`.
         case listSectionLabelColor
 
+        /// Defines the font of the section labels in the list of the `BottomCommandingController`.
         case listSectionLabelFont
 
+        /// Defines the color of the resizing handle of the `BottomCommandingController`.
         case resizingHandleMarkColor
 
+        /// Defines the color of the separator in the `BottomCommandingController`.
         case strokeColor
 
+        /// Defines the shadows used by the `BottomCommandingController`.
         case shadow
     }
 
@@ -42,6 +58,8 @@ public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingTokenSet.
             switch token {
             case .backgroundColor:
                 return .uiColor { theme.color(.background1) }
+            case .cornerRadius:
+                return .float { GlobalTokens.corner(.radius120) }
             case .heroDisabledColor:
                 return .uiColor { theme.color(.foregroundDisabled1) }
             case .heroLabelFont:
@@ -75,7 +93,6 @@ public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingTokenSet.
 
 extension BottomCommandingTokenSet {
     static let gridSpacing: CGFloat = GlobalTokens.spacing(.size80)
-    static let cornerRadius: CGFloat = GlobalTokens.corner(.radius120)
     static let tabVerticalPadding: CGFloat = GlobalTokens.spacing(.size80)
     static let tabHorizontalPadding: CGFloat = GlobalTokens.spacing(.size160)
     static let strokeWidth: CGFloat = GlobalTokens.stroke(.width05)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -455,6 +455,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     private func updateAppearance() {
         updateBackgroundColor()
+        updateResizingHandleColor()
         updateShadow()
         updateCornerRadius()
     }
@@ -463,6 +464,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         let backgroundColor = tokenSet[.backgroundColor].uiColor
         bottomSheetView.subviews[0].backgroundColor = backgroundColor
         overflowView.backgroundColor = backgroundColor
+    }
+
+    private func updateResizingHandleColor() {
+        resizingHandleView.tokenSet.setOverrideValue(tokenSet[.resizingHandleMarkColor], forToken: .markColor)
     }
 
     private func updateShadow() {
@@ -498,6 +503,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         resizingHandleView.accessibilityTraits = .button
         resizingHandleView.isUserInteractionEnabled = true
         resizingHandleView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleResizingHandleViewTap)))
+        resizingHandleView.tokenSet.setOverrideValue(tokenSet[.resizingHandleMarkColor], forToken: .markColor)
         return resizingHandleView
     }()
 

--- a/ios/FluentUI/Bottom Sheet/BottomSheetTokenSet.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetTokenSet.swift
@@ -7,8 +7,16 @@ import UIKit
 
 public class BottomSheetTokenSet: ControlTokenSet<BottomSheetTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
+        /// Defines the background color of the `BottomSheetController`.
         case backgroundColor
+
+        /// Defines the corner radius of the `BottomSheetController`.
         case cornerRadius
+
+        /// Defines the color of the resizing handle of the `BottomSheetController`.
+        case resizingHandleMarkColor
+
+        /// Defines the shadows used by the `BottomSheetController`.
         case shadow
     }
 
@@ -21,6 +29,8 @@ public class BottomSheetTokenSet: ControlTokenSet<BottomSheetTokenSet.Tokens> {
                 }
             case .cornerRadius:
                 return .float { GlobalTokens.corner(.radius120) }
+            case .resizingHandleMarkColor:
+                return .uiColor { theme.color(.strokeAccessible) }
             case .shadow:
                 return .shadowInfo { theme.shadow(.shadow28) }
             }

--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -63,6 +63,10 @@ open class Separator: UIView, TokenizedControlInternal {
                                                selector: #selector(themeDidChange),
                                                name: .didChangeTheme,
                                                object: nil)
+
+        tokenSet.registerOnUpdate(for: self) { [weak self] in
+            self?.backgroundColor = self?.tokenSet[.color].uiColor
+        }
     }
 
     @objc private func themeDidChange(_ notification: Notification) {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1202,6 +1202,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             if let customView = customView {
                 contentView.addSubview(customView)
                 customView.accessibilityElementsHidden = true
+                updateCustomViewColor()
             }
         }
     }
@@ -1894,6 +1895,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         updateSelectionImageColor()
         setupBackgroundColors()
         updateAccessoryViewColor()
+        updateCustomViewColor()
     }
 
     private func updateAccessoryViewColor() {
@@ -2000,6 +2002,13 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     private func updateSelectionImageColor() {
         selectionImageView.tintColor = isSelected ? tokenSet[.brandTextColor].uiColor : tokenSet[.selectionIndicatorOffColor].uiColor
         unreadDotLayer.backgroundColor = tokenSet[.brandTextColor].uiColor.cgColor
+    }
+    
+    private func updateCustomViewColor() {
+        guard let customView else {
+            return
+        }
+        customView.tintColor = tokenSet[.imageColor].uiColor
     }
 
     private func updateSeparator(_ separator: Separator, with type: SeparatorType) {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -2003,7 +2003,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         selectionImageView.tintColor = isSelected ? tokenSet[.brandTextColor].uiColor : tokenSet[.selectionIndicatorOffColor].uiColor
         unreadDotLayer.backgroundColor = tokenSet[.brandTextColor].uiColor.cgColor
     }
-    
+
     private func updateCustomViewColor() {
         guard let customView else {
             return


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updates the `BottomCommandingController` to have tokens. I also had to update the `Separator`, `BottomSheetController`, and `TableViewCell` to fix a few problems with their tokens.

### Binary change

There's an unusually amount of growth coming out of the NavigationBar, so not too sure what's going on there. The growth from `BottomCommandingController` and `BottomCommandingTokenSet` are around what was expected, though.

Total increase: 303,440 bytes
Total decrease: -264 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,644,072 bytes | 31,947,248 bytes | ⛔️ 303,176 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| NavigationBar.o | 717,760 bytes | 799,432 bytes | 🛑 81,672 bytes |
| BottomCommandingTokenSet.o | 0 bytes | 69,480 bytes | 🛑 69,480 bytes |
| BottomCommandingController.o | 778,960 bytes | 834,848 bytes | 🛑 55,888 bytes |
| __.SYMDEF | 4,758,928 bytes | 4,794,616 bytes | ⚠️ 35,688 bytes |
| BadgeView.o | 607,392 bytes | 630,992 bytes | ⚠️ 23,600 bytes |
| HUD.o | 301,744 bytes | 309,920 bytes | ⚠️ 8,176 bytes |
| String+Extension.o | 67,016 bytes | 75,096 bytes | ⚠️ 8,080 bytes |
| Separator.o | 78,552 bytes | 84,056 bytes | ⚠️ 5,504 bytes |
| BottomSheetController.o | 512,208 bytes | 517,432 bytes | ⚠️ 5,224 bytes |
| TableViewCell.o | 852,176 bytes | 856,368 bytes | ⚠️ 4,192 bytes |
| DateTimePickerView.o | 286,272 bytes | 288,984 bytes | ⚠️ 2,712 bytes |
| BottomSheetTokenSet.o | 48,496 bytes | 49,744 bytes | ⚠️ 1,248 bytes |
| FocusRingView.o | 777,456 bytes | 778,680 bytes | ⚠️ 1,224 bytes |
| PopupMenuItemCell.o | 178,136 bytes | 178,376 bytes | ⚠️ 240 bytes |
| TextFieldTokenSet.o | 96,032 bytes | 96,232 bytes | ⚠️ 200 bytes |
| BooleanCell.o | 96,872 bytes | 97,064 bytes | ⚠️ 192 bytes |
| PersonaCell.o | 64,272 bytes | 64,392 bytes | ⚠️ 120 bytes |
| BadgeLabelButton.o | 165,992 bytes | 165,728 bytes | 🎉 -264 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before | After | Control Overrides | Theme Overrides |
|---|---|---|---|
| <img width="564" alt="BottomCommanding_iPhone_Light_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/1f4c0cd2-5538-4bca-9d36-6342aac2679e"> | <img width="564" alt="BottomCommanding_iPhone_Light_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e90bc875-798d-4297-b211-964ec87a8f17"> | <img width="564" alt="BottomCommanding_iPhone_Light_ControlOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/56d03c42-a9f4-42af-ac22-bc9457f953ca"> | <img width="564" alt="BottomCommanding_iPhone_ThemeOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/f8334641-6193-46d2-a4f7-3d890964ac5d"> |
| <img width="564" alt="BottomCommanding_iPhone_Dark_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/5bdebf1b-b03b-4b64-9beb-d223cb88190d"> | <img width="564" alt="BottomCommanding_iPhone_Dark_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/74d9d78d-d407-4ae7-8391-9734472beb20"> | <img width="564" alt="BottomCommanding_iPhone_Dark_ControlOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e0f67c00-38fb-40f1-88db-7a2230c26ecf"> | <img width="564" alt="BottomCommanding_iPhone_Dark_ThemeOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/c25e51b2-76d9-4851-bdf1-86bb9fac98d3"> |
| <img width="716" alt="BottomCommanding_iPad_Light_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/e3bd3722-2916-4bc7-9ac3-8858e0318d33"> | <img width="716" alt="BottomCommanding_iPad_Light_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/ae32a2e5-7805-4029-bbe9-c7acf88fa852"> | <img width="716" alt="BottomCommanding_iPad_Light_ControlOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/45573866-6d0d-46a5-8cc2-c849b5ac8ce1"> | <img width="716" alt="BottomCommanding_iPad_Light_ThemeOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/7599cd77-1f4a-4879-baf4-7d9c5cc80826"> |
| <img width="716" alt="BottomCommanding_iPad_Dark_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/4c2beefe-9a77-492f-85e1-7fa6f6387032"> | <img width="716" alt="BottomCommanding_iPad_Dark_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/12aac551-c8d7-4fbc-bbb3-15a6ebde462a"> | <img width="716" alt="BottomCommanding_iPad_Dark_ControlOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/604a2338-4b0c-4991-b3b3-c1c57490f604"> | <img width="716" alt="BottomCommanding_iPad_Dark_ThemeOverride_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/27de77f7-14c9-4748-90fd-6432ddae12be"> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1841&drop=dogfoodAlpha