### PR TITLE
ListItem initial MVP

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -225,6 +225,9 @@
 		ECA9218627A3301C00B66117 /* MSFAvatarGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218527A3301C00B66117 /* MSFAvatarGroup.swift */; };
 		ECA9218A27A33A2D00B66117 /* AvatarGroupModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218927A33A2D00B66117 /* AvatarGroupModifiers.swift */; };
 		ECF3C9882A67495A00CA35FC /* BottomCommandingTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */; };
+		F3F113892A705AD500DA852A /* ListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F113882A705AD500DA852A /* ListItem.swift */; };
+		F3F1138B2A705B4700DA852A /* ListItemState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F1138A2A705B4700DA852A /* ListItemState.swift */; };
+		F3F1138D2A705B6900DA852A /* ListItemModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F1138C2A705B6900DA852A /* ListItemModifiers.swift */; };
 		FD053A352224CA33009B6378 /* DatePickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD053A342224CA33009B6378 /* DatePickerControllerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -430,6 +433,9 @@
 		ECA9218927A33A2D00B66117 /* AvatarGroupModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarGroupModifiers.swift; sourceTree = "<group>"; };
 		ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
 		ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomCommandingTokenSet.swift; sourceTree = "<group>"; };
+		F3F113882A705AD500DA852A /* ListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItem.swift; sourceTree = "<group>"; };
+		F3F1138A2A705B4700DA852A /* ListItemState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemState.swift; sourceTree = "<group>"; };
+		F3F1138C2A705B6900DA852A /* ListItemModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemModifiers.swift; sourceTree = "<group>"; };
 		F5784DB9285D031800DBEAD6 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docs; sourceTree = "<group>"; };
 		FC414E1E258876FB00069E73 /* CommandBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBar.swift; sourceTree = "<group>"; };
 		FC414E242588798000069E73 /* CommandBarButtonGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarButtonGroupView.swift; sourceTree = "<group>"; };
@@ -939,6 +945,7 @@
 				B483323121CC71700022B4CC /* HUD */,
 				5314DFF425F0069C0099271A /* IndeterminateProgressBar */,
 				5314DFF025F0042E0099271A /* Label */,
+				F3F113872A705AC300DA852A /* List */,
 				3AABE97B29DF4CAC00406C6E /* MultilineCommandBar */,
 				FD41C86D22DD12A20086F899 /* Navigation */,
 				4BA9B8B5279F2940007536F5 /* Notification */,
@@ -1148,6 +1155,16 @@
 				EC1C31722923022E00CF052C /* SegmentedControlTokenSet.swift */,
 			);
 			path = SegmentedControl;
+			sourceTree = "<group>";
+		};
+		F3F113872A705AC300DA852A /* List */ = {
+			isa = PBXGroup;
+			children = (
+				F3F113882A705AD500DA852A /* ListItem.swift */,
+				F3F1138A2A705B4700DA852A /* ListItemState.swift */,
+				F3F1138C2A705B6900DA852A /* ListItemModifiers.swift */,
+			);
+			path = List;
 			sourceTree = "<group>";
 		};
 		FC414E1D258876D400069E73 /* Command Bar */ = {
@@ -1512,6 +1529,7 @@
 				5314E30325F0260E0099271A /* AccessibleViewDelegate.swift in Sources */,
 				6EB4B25F270ED6B30005B808 /* BadgeLabel.swift in Sources */,
 				EC98E2B2298D97EC00B9DF91 /* TextFieldTokenSet.swift in Sources */,
+				F3F1138B2A705B4700DA852A /* ListItemState.swift in Sources */,
 				9231491528BF026A001B033E /* HUD.swift in Sources */,
 				5314E1A725F01A7C0099271A /* ActionsCell.swift in Sources */,
 				5314E07B25F00F1A0099271A /* DateTimePickerViewDataSource.swift in Sources */,
@@ -1621,6 +1639,7 @@
 				5314E05925F00EF50099271A /* CalendarViewDataSource.swift in Sources */,
 				5314E01625F00CF70099271A /* BarButtonItems.swift in Sources */,
 				5314E25425F023650099271A /* UIImage+Extensions.swift in Sources */,
+				F3F113892A705AD500DA852A /* ListItem.swift in Sources */,
 				92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */,
 				ECF3C9882A67495A00CA35FC /* BottomCommandingTokenSet.swift in Sources */,
 				532FE3D826EA6D74007539C0 /* ActivityIndicator.swift in Sources */,
@@ -1698,6 +1717,7 @@
 				EC1C31732923022E00CF052C /* SegmentedControlTokenSet.swift in Sources */,
 				5314E19825F019650099271A /* SideTabBar.swift in Sources */,
 				5314E10A25F014600099271A /* Obscurable.swift in Sources */,
+				F3F1138D2A705B6900DA852A /* ListItemModifiers.swift in Sources */,
 				5314E07D25F00F1A0099271A /* DateTimePickerViewComponentTableView.swift in Sources */,
 				0AE3041D29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift in Sources */,
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -1161,8 +1161,8 @@
 			isa = PBXGroup;
 			children = (
 				F3F113882A705AD500DA852A /* ListItem.swift */,
-				F3F1138A2A705B4700DA852A /* ListItemState.swift */,
 				F3F1138C2A705B6900DA852A /* ListItemModifiers.swift */,
+				F3F1138A2A705B4700DA852A /* ListItemState.swift */,
 			);
 			path = List;
 			sourceTree = "<group>";

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -11,10 +11,10 @@ public typealias ListItemTokenSet = TableViewCellTokenSet
 
 /// View that represents an item in a List.
 public struct ListItem<LeadingView: View,
-					   TrailingView: View,
-					   Title: StringProtocol,
-					   Subtitle: StringProtocol,
-					   Footer: StringProtocol>: View {
+                       TrailingView: View,
+                       Title: StringProtocol,
+                       Subtitle: StringProtocol,
+                       Footer: StringProtocol>: View {
 
 	// MARK: Initializer
 
@@ -25,7 +25,7 @@ public struct ListItem<LeadingView: View,
 	///   - footer: Text that appears as the third line of text
 	///   - leadingView: The view that appears on the leading edge of the view
 	///   - trailingView: The view that appears on the trailing edge of the view, next to the accessory type if provided
-	public init(title: Title,
+    public init(title: Title,
                 subtitle: Subtitle = String(""),
                 footer: Footer = String(""),
                 leadingView: @escaping () -> LeadingView = { EmptyView() },
@@ -116,10 +116,10 @@ public struct ListItem<LeadingView: View,
 					.tint(Color(fluentTheme.color(.brandForeground1)))
 				accessoryView
 			}
-			.padding(EdgeInsets(top: ListItemTokenSet.paddingVertical + 1,
-								leading: ListItemTokenSet.paddingLeading,
-								bottom: ListItemTokenSet.paddingVertical + 1,
-								trailing: ListItemTokenSet.paddingTrailing))
+            .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical + 1,
+                                leading: ListItemTokenSet.paddingLeading,
+                                bottom: ListItemTokenSet.paddingVertical + 1,
+                                trailing: ListItemTokenSet.paddingTrailing))
 			.frame(minHeight: minHeight)
 			.background(backgroundView)
 			.listRowInsets(EdgeInsets())

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -11,8 +11,8 @@ public typealias ListItemCustomViewSize = MSFTableViewCellCustomViewSize
 public typealias ListItemTokenSet = TableViewCellTokenSet
 
 /// View that represents an item in a List.
-public struct ListItem<LeadingView: View,
-                       TrailingView: View,
+public struct ListItem<LeadingContent: View,
+                       TrailingContent: View,
                        Title: StringProtocol,
                        Subtitle: StringProtocol,
                        Footer: StringProtocol>: View {
@@ -24,18 +24,18 @@ public struct ListItem<LeadingView: View,
 	///   - title: Text that appears as the first line of text
 	///   - subtitle: Text that appears as the second line of text
 	///   - footer: Text that appears as the third line of text
-	///   - leadingView: The view that appears on the leading edge of the view
-	///   - trailingView: The view that appears on the trailing edge of the view, next to the accessory type if provided
+	///   - leadingContent: The content that appears on the leading edge of the view
+	///   - trailingContent: The content that appears on the trailing edge of the view, next to the accessory type if provided
     public init(title: Title,
                 subtitle: Subtitle = String(),
                 footer: Footer = String(),
-                @ViewBuilder leadingView: @escaping () -> LeadingView,
-                @ViewBuilder trailingView: @escaping () -> TrailingView) {
+                @ViewBuilder leadingContent: @escaping () -> LeadingContent,
+                @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
-        self.leadingView = leadingView()
-        self.trailingView = trailingView()
+        self.leadingContent = leadingContent
+        self.trailingContent = trailingContent
     }
 
     public var body: some View {
@@ -110,19 +110,23 @@ public struct ListItem<LeadingView: View,
         @ViewBuilder
         var contentView: some View {
             HStack(alignment: .center) {
-                leadingView
-                    .padding(.trailing, ListItemTokenSet.horizontalSpacing)
+                if let leadingContent {
+                    leadingContent()
+                        .padding(.trailing, ListItemTokenSet.horizontalSpacing)
+                }
                 labelStack
                     .padding(.trailing, ListItemTokenSet.horizontalSpacing)
                 Spacer()
-                trailingView
-                    .tint(Color(fluentTheme.color(.brandForeground1)))
+                if let trailingContent {
+                    trailingContent()
+                        .tint(Color(fluentTheme.color(.brandForeground1)))
+                }
                 accessoryView
                     .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
-            .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical + 1,
+            .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
                                 leading: ListItemTokenSet.paddingLeading,
-                                bottom: ListItemTokenSet.paddingVertical + 1,
+                                bottom: ListItemTokenSet.paddingVertical,
                                 trailing: ListItemTokenSet.paddingTrailing))
             .frame(minHeight: layoutType.minHeight)
             .background(backgroundView)
@@ -132,7 +136,7 @@ public struct ListItem<LeadingView: View,
         return contentView
     }
 
-    var state: ListItemState = ListItemState()
+    @StateObject var state: ListItemState = ListItemState()
 
     private var layoutType: LayoutType {
         if !subtitle.isEmpty {
@@ -163,8 +167,8 @@ public struct ListItem<LeadingView: View,
 
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 
-    private var leadingView: LeadingView?
-    private var trailingView: TrailingView?
+    private var leadingContent: (() -> LeadingContent)?
+    private var trailingContent: (() -> TrailingContent)?
 
     private let footer: Footer
     private let subtitle: Subtitle
@@ -174,7 +178,7 @@ public struct ListItem<LeadingView: View,
 
 // MARK: Additional Initializers
 
-public extension ListItem where LeadingView == EmptyView, TrailingView == EmptyView {
+public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String()) {
@@ -184,26 +188,26 @@ public extension ListItem where LeadingView == EmptyView, TrailingView == EmptyV
     }
 }
 
-public extension ListItem where TrailingView == EmptyView {
+public extension ListItem where TrailingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
-         @ViewBuilder leadingView: @escaping () -> LeadingView) {
+         @ViewBuilder leadingContent: @escaping () -> LeadingContent) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
-        self.leadingView = leadingView()
+        self.leadingContent = leadingContent
     }
 }
 
-public extension ListItem where LeadingView == EmptyView {
+public extension ListItem where LeadingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
-         @ViewBuilder trailingView: @escaping () -> TrailingView) {
+         @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
-        self.trailingView = trailingView()
+        self.trailingContent = trailingContent
     }
 }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -49,34 +49,32 @@ public struct ListItem<LeadingView: View,
                                 .frame(minHeight: ListItemTokenSet.titleHeight)
                                 .lineLimit(state.titleLineLimit)
                                 .truncationMode(state.titleTruncationMode)
-            let subtitleView = Text(subtitle)
-                                   .foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
-                                   .lineLimit(state.subtitleLineLimit)
-                                   .truncationMode(state.subtitleTruncationMode)
-            let footerView = Text(footer)
-                                 .foregroundColor(Color(uiColor: tokenSet[.footerColor].uiColor))
-                                 .font(Font(tokenSet[.footerFont].uiFont))
-                                 .frame(minHeight: ListItemTokenSet.footerHeight)
-                                 .lineLimit(state.footerLineLimit)
-                                 .truncationMode(state.footerTruncationMode)
 
             switch layoutType {
             case .oneLine:
                 titleView
-            case .twoLines:
+            case .twoLines, .threeLines:
+                let subtitleView = Text(subtitle)
+                    .foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
+                    .lineLimit(state.subtitleLineLimit)
+                    .truncationMode(state.subtitleTruncationMode)
                 VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
                     titleView
-                    subtitleView
-                        .font(Font(tokenSet[.subtitleTwoLinesFont].uiFont))
-                        .frame(minHeight: ListItemTokenSet.subtitleTwoLineHeight)
-                }
-            case .threeLines:
-                VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
-                    titleView
-                    subtitleView
-                        .font(Font(tokenSet[.subtitleThreeLinesFont].uiFont))
-                        .frame(minHeight: ListItemTokenSet.subtitleThreeLineHeight)
-                    footerView
+                    if layoutType == .twoLines {
+                        subtitleView
+                            .font(Font(tokenSet[.subtitleTwoLinesFont].uiFont))
+                            .frame(minHeight: ListItemTokenSet.subtitleTwoLineHeight)
+                    } else if layoutType == .threeLines {
+                        subtitleView
+                            .font(Font(tokenSet[.subtitleThreeLinesFont].uiFont))
+                            .frame(minHeight: ListItemTokenSet.subtitleThreeLineHeight)
+                        Text(footer)
+                            .foregroundColor(Color(uiColor: tokenSet[.footerColor].uiColor))
+                            .font(Font(tokenSet[.footerFont].uiFont))
+                            .frame(minHeight: ListItemTokenSet.footerHeight)
+                            .lineLimit(state.footerLineLimit)
+                            .truncationMode(state.footerTruncationMode)
+                    }
                 }
             }
         }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -1,0 +1,154 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public typealias ListItemAccessoryType = TableViewCellAccessoryType
+public typealias ListItemBackgroundStyleType = TableViewCellBackgroundStyleType
+public typealias ListItemTokenSet = TableViewCellTokenSet
+
+/// View that represents an item in a List.
+public struct ListItem<LeadingView: View,
+					   TrailingView: View,
+					   Title: StringProtocol,
+					   Subtitle: StringProtocol,
+					   Footer: StringProtocol>: View {
+
+	// MARK: Initializer
+
+	/// Creates a ListItem view
+	/// - Parameters:
+	///   - title: Text that appears as the first line of text
+	///   - subtitle: Text that appears as the second line of text
+	///   - footer: Text that appears as the third line of text
+	///   - leadingView: The view that appears on the leading edge of the view
+	///   - trailingView: The view that appears on the trailing edge of the view, next to the accessory type if provided
+	public init(title: Title,
+                subtitle: Subtitle = String(""),
+                footer: Footer = String(""),
+                leadingView: @escaping () -> LeadingView = { EmptyView() },
+                trailingView: @escaping () -> TrailingView = { EmptyView() }) {
+		self.title = title
+		self.subtitle = subtitle
+		self.footer = footer
+		self.leadingView = leadingView
+		self.trailingView = trailingView
+	}
+
+	public var body: some View {
+		tokenSet.update(fluentTheme)
+
+		@ViewBuilder
+		var labelsView: some View {
+			VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
+				Text(title)
+					.foregroundColor(Color(uiColor: tokenSet[.titleColor].uiColor))
+					.font(Font(tokenSet[.titleFont].uiFont))
+					.frame(minHeight: ListItemTokenSet.titleHeight)
+					.lineLimit(state.titleLineLimit)
+					.truncationMode(state.titleTruncationMode)
+
+				if !subtitle.isEmpty {
+					let subtitleView = Text(subtitle)
+						.foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
+						.lineLimit(state.subtitleLineLimit)
+						.truncationMode(state.subtitleTruncationMode)
+					if footer.isEmpty {
+						subtitleView
+							.font(Font(tokenSet[.subtitleTwoLinesFont].uiFont))
+							.frame(minHeight: ListItemTokenSet.subtitleTwoLineHeight)
+					} else {
+						subtitleView
+							.font(Font(tokenSet[.subtitleThreeLinesFont].uiFont))
+							.frame(minHeight: ListItemTokenSet.subtitleThreeLineHeight)
+						Text(footer)
+							.foregroundColor(Color(uiColor: tokenSet[.footerColor].uiColor))
+							.font(Font(tokenSet[.footerFont].uiFont))
+							.frame(minHeight: ListItemTokenSet.footerHeight)
+							.lineLimit(state.footerLineLimit)
+							.truncationMode(state.footerTruncationMode)
+					}
+				}
+			}
+		}
+
+		@ViewBuilder
+		var accessoryView: some View {
+			if let accessoryType = state.accessoryType,
+			   let icon = accessoryType.icon,
+			   let iconColor = accessoryType.iconColor(tokenSet: tokenSet, fluentTheme: fluentTheme) {
+				let image = Image(uiImage: icon)
+					.foregroundColor(Color(uiColor: iconColor))
+				if accessoryType == .detailButton {
+					SwiftUI.Button {
+						if let onAccessoryTapped = state.onAccessoryTapped {
+							onAccessoryTapped()
+						}
+					} label: {
+						image
+					}
+				} else {
+					image
+				}
+			}
+		}
+
+		@ViewBuilder
+		var backgroundView: some View {
+			if let backgroundColor = state.backgroundStyleType.defaultColor(tokenSet: tokenSet) {
+				Color(backgroundColor)
+			}
+			EmptyView()
+		}
+
+		@ViewBuilder
+		var contentView: some View {
+			HStack(alignment: .center) {
+				leadingView()
+					.padding(.trailing, ListItemTokenSet.horizontalSpacing)
+				labelsView
+					.padding(.trailing, ListItemTokenSet.horizontalSpacing)
+				Spacer()
+				trailingView()
+					.padding(.trailing, ListItemTokenSet.horizontalSpacing)
+					.tint(Color(fluentTheme.color(.brandForeground1)))
+				accessoryView
+			}
+			.padding(EdgeInsets(top: ListItemTokenSet.paddingVertical + 1,
+								leading: ListItemTokenSet.paddingLeading,
+								bottom: ListItemTokenSet.paddingVertical + 1,
+								trailing: ListItemTokenSet.paddingTrailing))
+			.frame(minHeight: minHeight)
+			.background(backgroundView)
+			.listRowInsets(EdgeInsets())
+		}
+
+		return contentView
+	}
+
+	var state: ListItemState = ListItemState()
+
+	private var minHeight: CGFloat {
+		if !subtitle.isEmpty {
+			if !footer.isEmpty {
+				return ListItemTokenSet.threeLineMinHeight
+			} else {
+				return ListItemTokenSet.twoLineMinHeight
+			}
+		}
+
+		return ListItemTokenSet.oneLineMinHeight
+	}
+
+	@Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+
+	@ViewBuilder private let leadingView: () -> LeadingView
+	@ViewBuilder private let trailingView: () -> TrailingView
+ 
+	private let footer: Footer
+	private let subtitle: Subtitle
+	private let title: Title
+	private let tokenSet: ListItemTokenSet = ListItemTokenSet(customViewSize: { MSFTableViewCellCustomViewSize.zero })
+}

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -30,11 +30,11 @@ public struct ListItem<LeadingView: View,
                 footer: Footer = String(""),
                 leadingView: @escaping () -> LeadingView = { EmptyView() },
                 trailingView: @escaping () -> TrailingView = { EmptyView() }) {
-		self.title = title
-		self.subtitle = subtitle
-		self.footer = footer
-		self.leadingView = leadingView
-		self.trailingView = trailingView
+        self.title = title
+        self.subtitle = subtitle
+        self.footer = footer
+        self.leadingView = leadingView
+        self.trailingView = trailingView
 	}
 
 	public var body: some View {

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -112,9 +112,9 @@ public struct ListItem<LeadingView: View,
                     .padding(.trailing, ListItemTokenSet.horizontalSpacing)
                 Spacer()
                 trailingView()
-                    .padding(.trailing, ListItemTokenSet.horizontalSpacing)
                     .tint(Color(fluentTheme.color(.brandForeground1)))
                 accessoryView
+                    .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
             .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical + 1,
                                 leading: ListItemTokenSet.paddingLeading,

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -35,120 +35,120 @@ public struct ListItem<LeadingView: View,
         self.footer = footer
         self.leadingView = leadingView
         self.trailingView = trailingView
-	}
+    }
 
-	public var body: some View {
-		tokenSet.update(fluentTheme)
+    public var body: some View {
+        tokenSet.update(fluentTheme)
 
-		@ViewBuilder
-		var labelsView: some View {
-			VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
-				Text(title)
-					.foregroundColor(Color(uiColor: tokenSet[.titleColor].uiColor))
-					.font(Font(tokenSet[.titleFont].uiFont))
-					.frame(minHeight: ListItemTokenSet.titleHeight)
-					.lineLimit(state.titleLineLimit)
-					.truncationMode(state.titleTruncationMode)
+        @ViewBuilder
+        var labelsView: some View {
+            VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
+                Text(title)
+                    .foregroundColor(Color(uiColor: tokenSet[.titleColor].uiColor))
+                    .font(Font(tokenSet[.titleFont].uiFont))
+                    .frame(minHeight: ListItemTokenSet.titleHeight)
+                    .lineLimit(state.titleLineLimit)
+                    .truncationMode(state.titleTruncationMode)
+                
+                if !subtitle.isEmpty {
+                    let subtitleView = Text(subtitle)
+                        .foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
+                        .lineLimit(state.subtitleLineLimit)
+                        .truncationMode(state.subtitleTruncationMode)
+                    if footer.isEmpty {
+                        subtitleView
+                            .font(Font(tokenSet[.subtitleTwoLinesFont].uiFont))
+                            .frame(minHeight: ListItemTokenSet.subtitleTwoLineHeight)
+                    } else {
+                        subtitleView
+                            .font(Font(tokenSet[.subtitleThreeLinesFont].uiFont))
+                            .frame(minHeight: ListItemTokenSet.subtitleThreeLineHeight)
+                        Text(footer)
+                            .foregroundColor(Color(uiColor: tokenSet[.footerColor].uiColor))
+                            .font(Font(tokenSet[.footerFont].uiFont))
+                            .frame(minHeight: ListItemTokenSet.footerHeight)
+                            .lineLimit(state.footerLineLimit)
+                            .truncationMode(state.footerTruncationMode)
+                    }
+                }
+            }
+        }
 
-				if !subtitle.isEmpty {
-					let subtitleView = Text(subtitle)
-						.foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
-						.lineLimit(state.subtitleLineLimit)
-						.truncationMode(state.subtitleTruncationMode)
-					if footer.isEmpty {
-						subtitleView
-							.font(Font(tokenSet[.subtitleTwoLinesFont].uiFont))
-							.frame(minHeight: ListItemTokenSet.subtitleTwoLineHeight)
-					} else {
-						subtitleView
-							.font(Font(tokenSet[.subtitleThreeLinesFont].uiFont))
-							.frame(minHeight: ListItemTokenSet.subtitleThreeLineHeight)
-						Text(footer)
-							.foregroundColor(Color(uiColor: tokenSet[.footerColor].uiColor))
-							.font(Font(tokenSet[.footerFont].uiFont))
-							.frame(minHeight: ListItemTokenSet.footerHeight)
-							.lineLimit(state.footerLineLimit)
-							.truncationMode(state.footerTruncationMode)
-					}
-				}
-			}
-		}
+        @ViewBuilder
+        var accessoryView: some View {
+            if let accessoryType = state.accessoryType,
+               let icon = accessoryType.icon,
+               let iconColor = accessoryType.iconColor(tokenSet: tokenSet, fluentTheme: fluentTheme) {
+                let image = Image(uiImage: icon)
+                    .foregroundColor(Color(uiColor: iconColor))
+                if accessoryType == .detailButton {
+                    SwiftUI.Button {
+                        if let onAccessoryTapped = state.onAccessoryTapped {
+                            onAccessoryTapped()
+                        }
+                    } label: {
+                        image
+                    }
+                } else {
+                    image
+                }
+            }
+        }
 
-		@ViewBuilder
-		var accessoryView: some View {
-			if let accessoryType = state.accessoryType,
-			   let icon = accessoryType.icon,
-			   let iconColor = accessoryType.iconColor(tokenSet: tokenSet, fluentTheme: fluentTheme) {
-				let image = Image(uiImage: icon)
-					.foregroundColor(Color(uiColor: iconColor))
-				if accessoryType == .detailButton {
-					SwiftUI.Button {
-						if let onAccessoryTapped = state.onAccessoryTapped {
-							onAccessoryTapped()
-						}
-					} label: {
-						image
-					}
-				} else {
-					image
-				}
-			}
-		}
+        @ViewBuilder
+        var backgroundView: some View {
+            if let backgroundColor = state.backgroundStyleType.defaultColor(tokenSet: tokenSet) {
+                Color(backgroundColor)
+            }
+            EmptyView()
+        }
 
-		@ViewBuilder
-		var backgroundView: some View {
-			if let backgroundColor = state.backgroundStyleType.defaultColor(tokenSet: tokenSet) {
-				Color(backgroundColor)
-			}
-			EmptyView()
-		}
-
-		@ViewBuilder
-		var contentView: some View {
-			HStack(alignment: .center) {
-				leadingView()
-					.padding(.trailing, ListItemTokenSet.horizontalSpacing)
-				labelsView
-					.padding(.trailing, ListItemTokenSet.horizontalSpacing)
-				Spacer()
-				trailingView()
-					.padding(.trailing, ListItemTokenSet.horizontalSpacing)
-					.tint(Color(fluentTheme.color(.brandForeground1)))
-				accessoryView
-			}
+        @ViewBuilder
+        var contentView: some View {
+            HStack(alignment: .center) {
+                leadingView()
+                    .padding(.trailing, ListItemTokenSet.horizontalSpacing)
+                labelsView
+                    .padding(.trailing, ListItemTokenSet.horizontalSpacing)
+                Spacer()
+                trailingView()
+                    .padding(.trailing, ListItemTokenSet.horizontalSpacing)
+                    .tint(Color(fluentTheme.color(.brandForeground1)))
+                accessoryView
+            }
             .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical + 1,
                                 leading: ListItemTokenSet.paddingLeading,
                                 bottom: ListItemTokenSet.paddingVertical + 1,
                                 trailing: ListItemTokenSet.paddingTrailing))
-			.frame(minHeight: minHeight)
-			.background(backgroundView)
-			.listRowInsets(EdgeInsets())
-		}
+            .frame(minHeight: minHeight)
+            .background(backgroundView)
+            .listRowInsets(EdgeInsets())
+        }
+        
+        return contentView
+    }
 
-		return contentView
-	}
-
-	var state: ListItemState = ListItemState()
-
-	private var minHeight: CGFloat {
-		if !subtitle.isEmpty {
-			if !footer.isEmpty {
-				return ListItemTokenSet.threeLineMinHeight
-			} else {
-				return ListItemTokenSet.twoLineMinHeight
-			}
-		}
-
-		return ListItemTokenSet.oneLineMinHeight
-	}
-
-	@Environment(\.fluentTheme) private var fluentTheme: FluentTheme
-
-	@ViewBuilder private let leadingView: () -> LeadingView
-	@ViewBuilder private let trailingView: () -> TrailingView
- 
-	private let footer: Footer
-	private let subtitle: Subtitle
-	private let title: Title
-	private let tokenSet: ListItemTokenSet = ListItemTokenSet(customViewSize: { MSFTableViewCellCustomViewSize.zero })
+    var state: ListItemState = ListItemState()
+    
+    private var minHeight: CGFloat {
+        if !subtitle.isEmpty {
+            if !footer.isEmpty {
+                return ListItemTokenSet.threeLineMinHeight
+            } else {
+                return ListItemTokenSet.twoLineMinHeight
+            }
+        }
+        
+        return ListItemTokenSet.oneLineMinHeight
+    }
+    
+    @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+    
+    @ViewBuilder private let leadingView: () -> LeadingView
+    @ViewBuilder private let trailingView: () -> TrailingView
+    
+    private let footer: Footer
+    private let subtitle: Subtitle
+    private let title: Title
+    private let tokenSet: ListItemTokenSet = ListItemTokenSet(customViewSize: { MSFTableViewCellCustomViewSize.zero })
 }

--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -7,51 +7,52 @@ import Foundation
 
 public extension ListItem {
 
-	/// The accessory type for the `ListItem`.
-	/// - Parameter accessoryType: Type of accessory to display.
-	/// - Returns: The modified `ListItem` with the property set.
-	func accessoryType(_ accessoryType: ListItemAccessoryType) -> ListItem {
-		state.accessoryType = accessoryType
-		return self
-	}
+    /// The accessory type for the `ListItem`.
+    /// - Parameter accessoryType: Type of accessory to display.
+    /// - Returns: The modified `ListItem` with the property set.
+    func accessoryType(_ accessoryType: ListItemAccessoryType) -> ListItem {
+        state.accessoryType = accessoryType
+        return self
+    }
 
-	/// The handler for when the `detailButton` accessory is tapped.
-	/// - Parameter handler: The logic to execute when the accessory is tapped.
-	/// - Returns: The modified `ListItem` with the property set.
-	func onAccessoryTapped(_ handler: @escaping (() -> Void)) -> ListItem {
-		state.onAccessoryTapped = handler
-		return self
-	}
+    /// The handler for when the `detailButton` accessory is tapped.
+    /// - Parameter handler: The logic to execute when the accessory is tapped.
+    /// - Returns: The modified `ListItem` with the property set.
+    func onAccessoryTapped(_ handler: @escaping (() -> Void)) -> ListItem {
+        state.onAccessoryTapped = handler
+        return self
+    }
 
-	/// The line limit for `title`.
-	/// - Parameter titleLineLimit: The  number of lines to display for the `title`.
-	/// - Returns: The modified `ListItem` with the property set.
-	func titleLineLimit(_ titleLineLimit: Int) -> ListItem {
-		state.titleLineLimit = titleLineLimit
-		return self
-	}
+    /// The line limit for `title`.
+    /// - Parameter titleLineLimit: The  number of lines to display for the `title`.
+    /// - Returns: The modified `ListItem` with the property set.
+    func titleLineLimit(_ titleLineLimit: Int) -> ListItem {
+        state.titleLineLimit = titleLineLimit
+        return self
+    }
 
-	/// The line limit for `subtitle`.
-	/// - Parameter subtitleLineLimit: The  number of lines to display for the `subtitle`.
-	/// - Returns: The modified `ListItem` with the property set.
-	func subtitleLineLimit(_ subtitleLineLimit: Int) -> ListItem {
-		state.subtitleLineLimit = subtitleLineLimit
-		return self
-	}
+    /// The line limit for `subtitle`.
+    /// - Parameter subtitleLineLimit: The  number of lines to display for the `subtitle`.
+    /// - Returns: The modified `ListItem` with the property set.
+    func subtitleLineLimit(_ subtitleLineLimit: Int) -> ListItem {
+        state.subtitleLineLimit = subtitleLineLimit
+        return self
+    }
 
-	/// The line limit for `footer`.
-	/// - Parameter footerLineLimit: The  number of lines to display for the `footer`.
-	/// - Returns: The modified `ListItem` with the property set.
-	func footerLineLimit(_ footerLineLimit: Int) -> ListItem {
-		state.footerLineLimit = footerLineLimit
-		return self
-	}
+    /// The line limit for `footer`.
+    /// - Parameter footerLineLimit: The  number of lines to display for the `footer`.
+    /// - Returns: The modified `ListItem` with the property set.
+    func footerLineLimit(_ footerLineLimit: Int) -> ListItem {
+        state.footerLineLimit = footerLineLimit
+        return self
+    }
 
-	/// The background styling of the `ListItem` to match the type of `List` it is displayed in.
-	/// - Parameter backgroundStyleType: The style of the background.
-	/// - Returns: The modified `ListItem` with the property set.
-	func backgroundStyleType(_ backgroundStyleType: ListItemBackgroundStyleType) -> ListItem {
-		state.backgroundStyleType = backgroundStyleType
-		return self
-	}
+    /// The background styling of the `ListItem` to match the type of `List` it is displayed in.
+    /// - Parameter backgroundStyleType: The style of the background.
+    /// - Returns: The modified `ListItem` with the property set.
+    func backgroundStyleType(_ backgroundStyleType: ListItemBackgroundStyleType) -> ListItem {
+        state.backgroundStyleType = backgroundStyleType
+        return self
+    }
 }
+

--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -53,4 +53,3 @@ public extension ListItem {
         return self
     }
 }
-

--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+
+public extension ListItem {
+
+	/// The accessory type for the `ListItem`.
+	/// - Parameter accessoryType: Type of accessory to display.
+	/// - Returns: The modified `ListItem` with the property set.
+	func accessoryType(_ accessoryType: ListItemAccessoryType) -> ListItem {
+		state.accessoryType = accessoryType
+		return self
+	}
+
+	/// The handler for when the `detailButton` accessory is tapped.
+	/// - Parameter handler: The logic to execute when the accessory is tapped.
+	/// - Returns: The modified `ListItem` with the property set.
+	func onAccessoryTapped(_ handler: @escaping (() -> Void)) -> ListItem {
+		state.onAccessoryTapped = handler
+		return self
+	}
+
+	/// The line limit for `title`.
+	/// - Parameter titleLineLimit: The  number of lines to display for the `title`.
+	/// - Returns: The modified `ListItem` with the property set.
+	func titleLineLimit(_ titleLineLimit: Int) -> ListItem {
+		state.titleLineLimit = titleLineLimit
+		return self
+	}
+
+	/// The line limit for `subtitle`.
+	/// - Parameter subtitleLineLimit: The  number of lines to display for the `subtitle`.
+	/// - Returns: The modified `ListItem` with the property set.
+	func subtitleLineLimit(_ subtitleLineLimit: Int) -> ListItem {
+		state.subtitleLineLimit = subtitleLineLimit
+		return self
+	}
+
+	/// The line limit for `footer`.
+	/// - Parameter footerLineLimit: The  number of lines to display for the `footer`.
+	/// - Returns: The modified `ListItem` with the property set.
+	func footerLineLimit(_ footerLineLimit: Int) -> ListItem {
+		state.footerLineLimit = footerLineLimit
+		return self
+	}
+
+	/// The background styling of the `ListItem` to match the type of `List` it is displayed in.
+	/// - Parameter backgroundStyleType: The style of the background.
+	/// - Returns: The modified `ListItem` with the property set.
+	func backgroundStyleType(_ backgroundStyleType: ListItemBackgroundStyleType) -> ListItem {
+		state.backgroundStyleType = backgroundStyleType
+		return self
+	}
+}

--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -3,8 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import Foundation
-
 public extension ListItem {
 
     /// The accessory type for the `ListItem`.

--- a/ios/FluentUI/List/ListItemState.swift
+++ b/ios/FluentUI/List/ListItemState.swift
@@ -5,32 +5,32 @@
 
 import SwiftUI
 
-/// Properties available to customize the appearance of a `ListItem`
+/// Properties available to customize the appearance of a `ListItem`.
 class ListItemState: ControlState {
-    /// The `ListItemAccessoryType` that the view should display
+    /// The `ListItemAccessoryType` that the view should display.
     var accessoryType: ListItemAccessoryType?
 
-    /// The background styling of the `ListItem` to match the type of `List` it is displayed in
+    /// The background styling of the `ListItem` to match the type of `List` it is displayed in.
     var backgroundStyleType: ListItemBackgroundStyleType = .plain
 
-    /// The handler for when the `detailButton` accessory view is tapped
+    /// The handler for when the `detailButton` accessory view is tapped.
     var onAccessoryTapped: (() -> Void)?
 
-    /// The maximum amount of lines shown for the `title`
+    /// The maximum amount of lines shown for the `title`.
     var titleLineLimit: Int = 1
 
-    /// The maximum amount of lines shown for the `subtitle`
+    /// The maximum amount of lines shown for the `subtitle`.
     var subtitleLineLimit: Int = 1
 
-    /// The maximum amount of lines shown for the `footer`
+    /// The maximum amount of lines shown for the `footer`.
     var footerLineLimit: Int = 1
 
-    /// The truncation mode of the `title`
+    /// The truncation mode of the `title`.
     var titleTruncationMode: Text.TruncationMode = .tail
 
-    /// The truncation mode of the `subtitle`
+    /// The truncation mode of the `subtitle`.
     var subtitleTruncationMode: Text.TruncationMode = .tail
 
-    /// The truncation mode of the `footer`
+    /// The truncation mode of the `footer`.
     var footerTruncationMode: Text.TruncationMode = .tail
 }

--- a/ios/FluentUI/List/ListItemState.swift
+++ b/ios/FluentUI/List/ListItemState.swift
@@ -1,0 +1,36 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// Properties available to customize the appearance of a `ListItem`
+class ListItemState: ControlState {
+	/// The `ListItemAccessoryType` that the view should display
+	var accessoryType: ListItemAccessoryType?
+
+	/// The background styling of the `ListItem` to match the type of `List` it is displayed in
+	var backgroundStyleType: ListItemBackgroundStyleType = .plain
+
+	/// The handler for when the `detailButton` accessory view is tapped
+	var onAccessoryTapped: (() -> Void)?
+
+	/// The maximum amount of lines shown for the `title`
+	var titleLineLimit: Int = 1
+
+	/// The maximum amount of lines shown for the `subtitle`
+	var subtitleLineLimit: Int = 1
+
+	/// The maximum amount of lines shown for the `footer`
+	var footerLineLimit: Int = 1
+
+	/// The truncation mode of the `title`
+	var titleTruncationMode: Text.TruncationMode = .tail
+
+	/// The truncation mode of the `subtitle`
+	var subtitleTruncationMode: Text.TruncationMode = .tail
+
+	/// The truncation mode of the `footer`
+	var footerTruncationMode: Text.TruncationMode = .tail
+}

--- a/ios/FluentUI/List/ListItemState.swift
+++ b/ios/FluentUI/List/ListItemState.swift
@@ -7,30 +7,31 @@ import SwiftUI
 
 /// Properties available to customize the appearance of a `ListItem`
 class ListItemState: ControlState {
-	/// The `ListItemAccessoryType` that the view should display
-	var accessoryType: ListItemAccessoryType?
+    /// The `ListItemAccessoryType` that the view should display
+    var accessoryType: ListItemAccessoryType?
 
-	/// The background styling of the `ListItem` to match the type of `List` it is displayed in
-	var backgroundStyleType: ListItemBackgroundStyleType = .plain
+    /// The background styling of the `ListItem` to match the type of `List` it is displayed in
+    var backgroundStyleType: ListItemBackgroundStyleType = .plain
 
-	/// The handler for when the `detailButton` accessory view is tapped
-	var onAccessoryTapped: (() -> Void)?
+    /// The handler for when the `detailButton` accessory view is tapped
+    var onAccessoryTapped: (() -> Void)?
 
-	/// The maximum amount of lines shown for the `title`
-	var titleLineLimit: Int = 1
+    /// The maximum amount of lines shown for the `title`
+    var titleLineLimit: Int = 1
 
-	/// The maximum amount of lines shown for the `subtitle`
-	var subtitleLineLimit: Int = 1
+    /// The maximum amount of lines shown for the `subtitle`
+    var subtitleLineLimit: Int = 1
 
-	/// The maximum amount of lines shown for the `footer`
-	var footerLineLimit: Int = 1
+    /// The maximum amount of lines shown for the `footer`
+    var footerLineLimit: Int = 1
 
-	/// The truncation mode of the `title`
-	var titleTruncationMode: Text.TruncationMode = .tail
+    /// The truncation mode of the `title`
+    var titleTruncationMode: Text.TruncationMode = .tail
 
-	/// The truncation mode of the `subtitle`
-	var subtitleTruncationMode: Text.TruncationMode = .tail
+    /// The truncation mode of the `subtitle`
+    var subtitleTruncationMode: Text.TruncationMode = .tail
 
-	/// The truncation mode of the `footer`
-	var footerTruncationMode: Text.TruncationMode = .tail
+    /// The truncation mode of the `footer`
+    var footerTruncationMode: Text.TruncationMode = .tail
 }
+

--- a/ios/FluentUI/List/ListItemState.swift
+++ b/ios/FluentUI/List/ListItemState.swift
@@ -34,4 +34,3 @@ class ListItemState: ControlState {
     /// The truncation mode of the `footer`
     var footerTruncationMode: Text.TruncationMode = .tail
 }
-


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

This is the first of many PRs for creating a swiftUI native control for `MSFTableViewCell`. The goal of this PR is to provide the initial MVP that supports many of the common scenarios as a basis for supporting all of the functionality of `MSFTableViewCell`.

It builds upon the [initial investigations](https://github.com/microsoft/fluentui-apple/blob/fluent2-tokens/ios/FluentUI/SwiftUI%20Experiments/List/ListCell.swift) done to create a list control that is available to consume in UIKit and SwiftUI. But after discussion, the decision came that if the control is needed in UIKit `MSFTableViewCell` is sufficient, so the control should be built only for consumption in SwiftUI. It removes the UIKit wrapper that was done in the experimentation and uses SwiftUI conventions to allow for customization of the view.

Changes addressed in this PR:

- `ListItem.swift`
     -  Add support for a title, subtitle, and footer
     - Add support for a leadingView and trailingView.
         - Used `@ViewBuilder` to support passing in any view and follow the convention of other controls provided by apple. 
     - Create alias for tokens and enums used by `MSFTableViewCell` as the same values will be needed. This was to reduce binary size impact, ease of maintenance, and not requiring creating another set of tokens for the same control visually. As this is only a difference in engineering implementation (UIKit vs swiftUI), there shouldnt be a design difference.
 -  `ListItemModifiers.swift`
     - Follows the convention of other SwiftUI controls (Avatar, Notification, etc) by allowing convenience functions for changing state of the control. This makes it so the control doesnt have a massive initializer.
     - Exposes all of the customization of `ListItem` and follows the syntax of a swiftUI view. Example:
``` .swift

ListItem(title: "Title of my list item")
         .accessoryType(.checkmark)
         .titleLineLimit(2)
```` 
- `ListItemState.swift`
   -  Defines all of the properties that can be customized on the `ListItem` view.

### Example usage

``` .swift
List {
   ListItem(title: "Just a title")
   ListItem(title: "A title", subtitle: "And a subtitle too!") 
   ListItem(title: "A three line configuration", subtitle: "This is the second line", footer: "This is the third line")
   ListItem(title: "Just a custom leading view", leadingContent: {
      MyCustomLeadingView()
   })
   ListItem(title: "Just a custom trailing view", trailingContent: {
      MyCustomTrailingView()
   })
   ListItem(title: "A custom leading and trailing view", leadingContent: { 
      MyCustomLeadingView()
   }, trailingContent: {
      MyCustomTrailingView()
   })
   ListItem(title: "A disclosure indicator accessory")
            .accessoryType(.disclosureIndicator)
   ListItem(title: "A check mark accessory")
            .accessoryType(.checkmark)
   ListItem(title: "A detail button accessory")
            .accessoryType(.detailButton)
            .onAccessoryTapped {
                print("The button was tapped!")
            }
   ListItem(title: "A list item with everything", subtitle: "This is a subtitle", footer: "This is a footer", leadingContent: {
        MyCustomLeadingView()
   }, trailingContent: {
      MyCustomTrailingView()
   })
            .accessoryType(.checkmark)
}
```

### Binary change

The size impact was a known before making this change. Further analysis will be made once all of the changes are on the feature branch and before merging to main.

| File | Before | After | Delta |
|------|-------:|------:|------:|
| libFluentUI.a | 30,118,904 bytes | 30,414,816 bytes | ⛔️ 295,912 bytes |
| FluentUI.Demo | 33,764,955 bytes | 33,884,203 bytes | 🛑 119,248 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ListItem.o | 0 bytes | 194,392 bytes | 🛑 194,392 bytes |
| __.SYMDEF | 4,561,232 bytes | 4,605,136 bytes | ⚠️ 43,904 bytes |
| ListItemState.o | 0 bytes | 34,536 bytes | ⚠️ 34,536 bytes |
| ListItemModifiers.o | 0 bytes | 18,032 bytes | ⚠️ 18,032 bytes |
| FocusRingView.o | 793,488 bytes | 798,536 bytes | ⚠️ 5,048 bytes |
</details>

### Verification
Examined in the fluent test app. Adding a demo and XCUITests are out of scope for this PR and will be in the next set of changes.

| iPhone 14 Pro                                  | iPad Pro (12.9 inch)                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-07-25 at 14 51 45](https://github.com/microsoft/fluentui-apple/assets/21343215/5f07e829-ca84-4462-a63c-649f18e81648) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th xgeneration) - 2023-07-25 at 14 49 57](https://github.com/microsoft/fluentui-apple/assets/21343215/e18445b6-9506-48a1-a217-930860bdc778) |




### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)