### PR TITLE
Cleanup Separator tokenization

### DIFF
--- a/ios/FluentUI/Separator/Separator.swift
+++ b/ios/FluentUI/Separator/Separator.swift
@@ -45,6 +45,14 @@ open class Separator: UIView, TokenizedControlInternal {
         return fluentTheme.color(.stroke2)
     }
 
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let newWindow else {
+            return
+        }
+        tokenSet.update(newWindow.fluentTheme)
+    }
+
     private func initialize(orientation: SeparatorOrientation) {
         backgroundColor = tokenSet[.color].uiColor
         self.orientation = orientation
@@ -59,21 +67,9 @@ open class Separator: UIView, TokenizedControlInternal {
         isAccessibilityElement = false
         isUserInteractionEnabled = false
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(themeDidChange),
-                                               name: .didChangeTheme,
-                                               object: nil)
-
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.backgroundColor = self?.tokenSet[.color].uiColor
         }
-    }
-
-    @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
-            return
-        }
-        backgroundColor = tokenSet[.color].uiColor
     }
 
     open override var intrinsicContentSize: CGSize {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

This PR cleans up `Separator` by removing `themeDidChange` and adding a token set update in `willMove(toWindow:)`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)