### PR TITLE
Cherry-pick avatar fix

### DIFF
--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -322,7 +322,11 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
         twoLineTitleView.setup(navigationItem: navigationItem)
 
         // Hide the avatar if TwoLineTitleView has a leading image for both title and subtitle.
-        showsProfileButton = !navigationItem.isTitleImageLeadingForTitleAndSubtitle
+        if navigationItem.isTitleImageLeadingForTitleAndSubtitle {
+            showsProfileButton = false
+        } else {
+            updateProfileButtonVisibility()
+        }
 
         if navigationItem.titleAccessory == nil {
             // Use default behavior of requesting an accessory expansion


### PR DESCRIPTION

### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Fix bug in which showProfileButton was being reset to true for AvatarTitleView

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1848&drop=dogfoodAlpha