### PR TITLE
Update CardNudge to allow multi-line title and message action

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CardNudgeDemoController.swift
@@ -79,7 +79,8 @@ class CardNudgeDemoController: DemoTableViewController {
              .accentIcon,
              .accentText,
              .dismissButton,
-             .actionButton:
+             .actionButton,
+             .messageAction:
             guard let cell: BooleanCell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 preconditionFailure("Wrong kind of cell in BooleanCell index path")
             }
@@ -130,6 +131,15 @@ class CardNudgeDemoController: DemoTableViewController {
                 cardNudge.state.actionButtonTitle = (isOn ? "Action" : nil)
                 cardNudge.state.actionButtonAction = (isOn ? { state in
                     let alert = UIAlertController(title: "\(state.title) action performed", message: nil, preferredStyle: .alert)
+                    let action = UIAlertAction(title: "OK", style: .default, handler: nil)
+                    alert.addAction(action)
+                    self.present(alert, animated: true)
+                } : nil)
+            }
+        case .messageAction:
+            cardNudges.forEach { cardNudge in
+                cardNudge.state.messageButtonAction = (isOn ? { state in
+                    let alert = UIAlertController(title: "\(state.title) message action performed", message: nil, preferredStyle: .alert)
                     let action = UIAlertAction(title: "OK", style: .default, handler: nil)
                     alert.addAction(action)
                     self.present(alert, animated: true)
@@ -195,7 +205,8 @@ class CardNudgeDemoController: DemoTableViewController {
                         .accentIcon,
                         .accentText,
                         .dismissButton,
-                        .actionButton]
+                        .actionButton,
+                        .messageAction]
             }
         }
     }
@@ -209,6 +220,7 @@ class CardNudgeDemoController: DemoTableViewController {
         case accentText
         case dismissButton
         case actionButton
+        case messageAction
 
         var text: String {
             switch self {
@@ -227,6 +239,8 @@ class CardNudgeDemoController: DemoTableViewController {
                 return "Dismiss Button"
             case .actionButton:
                 return "Action Button"
+            case .messageAction:
+                return "Message Action"
             }
         }
     }

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -40,6 +40,9 @@ public typealias CardNudgeButtonAction = ((_ state: MSFCardNudgeState) -> Void)
 
     /// Action to be dispatched by the dismiss ("close") button on the trailing edge of the control.
     @objc var dismissButtonAction: CardNudgeButtonAction? { get set }
+
+    /// Action to be dispatched by tapping on the `CardNudge`.
+    @objc var messageButtonAction: CardNudgeButtonAction? { get set }
 }
 
 /// View that represents the CardNudge.
@@ -147,6 +150,7 @@ public struct CardNudge: View, TokenizedControlView {
 
     @ViewBuilder
     var innerContents: some View {
+        let messageAction = state.messageButtonAction
         HStack(spacing: 0) {
             icon
             textContainer
@@ -157,6 +161,16 @@ public struct CardNudge: View, TokenizedControlView {
         .padding(.vertical, CardNudgeTokenSet.mainContentVerticalPadding)
         .padding(.horizontal, CardNudgeTokenSet.horizontalPadding)
         .frame(minHeight: CardNudgeTokenSet.minimumHeight)
+        .modifyIf(messageAction != nil) { view in
+            view.accessibilityAddTraits(.isButton)
+                .hoverEffect()
+                .onTapGesture {
+                    guard let messageAction else {
+                        return
+                    }
+                    messageAction(state)
+                }
+        }
     }
 
     public var body: some View {
@@ -242,6 +256,9 @@ class MSFCardNudgeStateImpl: ControlState, MSFCardNudgeState {
 
     /// Action to be dispatched by the dismiss ("close") button on the trailing edge of the control.
     @Published var dismissButtonAction: CardNudgeButtonAction?
+
+    /// Action to be dispatched by tapping on the `CardNudge`.
+    @Published var messageButtonAction: CardNudgeButtonAction?
 
     /// Style to draw the control.
     @Published var style: MSFCardNudgeStyle

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -110,7 +110,7 @@ public struct CardNudge: View, TokenizedControlView {
 
     @ViewBuilder
     var buttons: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: CardNudgeTokenSet.buttonInnerPaddingHorizontal) {
             if let actionTitle = state.actionButtonTitle,
                       let action = state.actionButtonAction {
                 SwiftUI.Button(actionTitle) {
@@ -137,7 +137,6 @@ public struct CardNudge: View, TokenizedControlView {
                         Image(uiImage: image)
                     }
                 })
-                .padding(.horizontal, CardNudgeTokenSet.buttonInnerPaddingHorizontal)
                 .padding(.vertical, CardNudgeTokenSet.verticalPadding)
                 .accessibility(identifier: dismissLabel)
                 .foregroundColor(Color(tokenSet[.subtitleTextColor].uiColor))

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -76,7 +76,6 @@ public struct CardNudge: View, TokenizedControlView {
     var textContainer: some View {
         VStack(alignment: .leading, spacing: CardNudgeTokenSet.interTextVerticalPadding) {
             Text(state.title)
-                .lineLimit(1)
                 .foregroundColor(Color(tokenSet[.textColor].uiColor))
                 .showsLargeContentViewer(text: state.title, image: state.mainIcon)
                 .font(.init(tokenSet[.titleFont].uiFont))

--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -129,6 +129,7 @@ public struct CardNudge: View, TokenizedControlView {
                         .foregroundColor(Color(tokenSet[.buttonBackgroundColor].uiColor))
                 )
                 .showsLargeContentViewer(text: actionTitle)
+                .hoverEffect()
             }
             if let dismissAction = state.dismissButtonAction {
                 let dismissImage = UIImage.staticImageNamed("dismiss-20x20")
@@ -144,6 +145,7 @@ public struct CardNudge: View, TokenizedControlView {
                 .accessibility(identifier: dismissLabel)
                 .foregroundColor(Color(tokenSet[.subtitleTextColor].uiColor))
                 .showsLargeContentViewer(text: dismissLabel, image: dismissImage)
+                .hoverEffect()
             }
         }
     }

--- a/ios/FluentUI/Card Nudge/CardNudgeModifiers.swift
+++ b/ios/FluentUI/Card Nudge/CardNudgeModifiers.swift
@@ -51,4 +51,10 @@ public extension CardNudge {
         state.dismissButtonAction = dismissButtonAction
         return self
     }
+
+    /// Action to be dispatched by tapping on the `CardNudge`.
+    func messageButtonAction(_ messageButtonAction: CardNudgeButtonAction?) -> CardNudge {
+        state.messageButtonAction = messageButtonAction
+        return self
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Updates the `CardNudge` to allow the title to have multiple lines, and an option action for when the text/leading icon are tapped on. Also fixes an extra padding issue with the dismiss button. And adds hover effects on all the buttons.

### Binary change

Total increase: 165,632 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,256,120 bytes | 30,421,752 bytes | 🛑 165,632 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| CardNudge.o | 386,376 bytes | 448,392 bytes | 🛑 62,016 bytes |
| SwiftUI+ViewModifiers.o | 161,800 bytes | 211,432 bytes | ⚠️ 49,632 bytes |
| __.SYMDEF | 4,637,272 bytes | 4,685,568 bytes | ⚠️ 48,296 bytes |
| CardNudgeModifiers.o | 39,592 bytes | 44,856 bytes | ⚠️ 5,264 bytes |
| FocusRingView.o | 799,864 bytes | 800,248 bytes | ⚠️ 384 bytes |
| MSFCardNudge.o | 36,440 bytes | 36,480 bytes | ⚠️ 40 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="321" alt="CardNudge_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/6e75b6e2-465c-4117-8bd8-38f81f48fe23"> | <img width="321" alt="CardNudge_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/da7f0732-14dc-4007-b4b4-c4a3f2f6aa5b"> |
| n/a | ![CardNudge_MultiHover_After](https://github.com/microsoft/fluentui-apple/assets/67026548/8c2635c5-d0ec-4335-a375-4ae7eaedf6fe) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1851&drop=dogfoodAlpha