### PR TITLE
Call updateAppearance in BadgeField

### DIFF
--- a/ios/FluentUI/Badge Field/BadgeField.swift
+++ b/ios/FluentUI/Badge Field/BadgeField.swift
@@ -168,6 +168,8 @@ open class BadgeField: UIView, TokenizedControlInternal {
         resetTextFieldContent()
         addSubview(textField)
 
+        updateAppearance()
+
         setupTextField(selectedBadgeTextField)
         selectedBadgeTextField.delegate = self
         selectedBadgeTextField.frame = .zero


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

When #1843 was checked in, it removed calls to set the `BadgeField`'s colors and fonts. This PR adds a call to `updateAppearance` so that tokens can be set on `init`.

### Binary change

Total increase: 64 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 46,915,960 bytes | 46,916,024 bytes | ⚠️ 64 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BadgeField.o | 961,144 bytes | 961,208 bytes | ⚠️ 64 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

No visual changes
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1852&drop=dogfoodAlpha