### PR TITLE
Fix memory leaks in Button, PillButton and SegmentPillButton

### DIFF
--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -89,9 +89,9 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
 
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = edgeInsets
-        let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+        let titleTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
             var outgoing = incoming
-            outgoing.font = self.tokenSet[.titleFont].uiFont
+            outgoing.font = self?.tokenSet[.titleFont].uiFont
             return outgoing
         }
         configuration.titleTextAttributesTransformer = titleTransformer

--- a/ios/FluentUI/Pill Button Bar/PillButton.swift
+++ b/ios/FluentUI/Pill Button Bar/PillButton.swift
@@ -193,9 +193,9 @@ open class PillButton: UIButton, TokenizedControlInternal {
         attributedTitle.font = tokenSet[.font].uiFont
         configuration?.attributedTitle = attributedTitle
 
-        let attributedTitleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+        let attributedTitleTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
             var outgoing = incoming
-            outgoing.font = self.tokenSet[.font].uiFont
+            outgoing.font = self?.tokenSet[.font].uiFont
             return outgoing
         }
         configuration?.titleTextAttributesTransformer = attributedTitleTransformer

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -42,9 +42,9 @@ class SegmentPillButton: UIButton {
                                                                   trailing: horizontalInset)
             configuration.background.backgroundColor = .clear
             configuration.baseForegroundColor = tokenSet[.restLabelColor].uiColor
-            let titleTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            let titleTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
                 var outgoing = incoming
-                outgoing.font = self.tokenSet[.font].uiFont
+                outgoing.font = self?.tokenSet[.font].uiFont
                 return outgoing
             }
             configuration.titleTextAttributesTransformer = titleTransformer


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Strong references to self in closures in `Button`, `PillButton` and `SegmentPillButton` would keep instances alive in memory when they should be deallocated. This PR changes them to weak references to fix the memory leaks.

### Verification

Instruments leaks tool shows that these controls are no longer leaking memory.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1856&drop=dogfoodAlpha