### PR TITLE
XCTests for ListItem

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		ECD95F5E2A0B19FF00152742 /* BrandedSwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD95F5D2A0B19FF00152742 /* BrandedSwitch.swift */; };
 		F362C8082A780EA500BB32BB /* ListItemDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F362C8072A780EA500BB32BB /* ListItemDemoController_SwiftUI.swift */; };
 		F362C80A2A780EBF00BB32BB /* ListItemDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F362C8092A780EBF00BB32BB /* ListItemDemoController.swift */; };
+		F3DFD3632A7C358000014C6E /* ListItemTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3DFD3622A7C358000014C6E /* ListItemTest.swift */; };
 		FC414E3725888BC300069E73 /* CommandBarDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC414E3625888BC300069E73 /* CommandBarDemoController.swift */; };
 		FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCF7C8221BF35680058E9E6 /* SegmentedControlDemoController.swift */; };
 /* End PBXBuildFile section */
@@ -267,6 +268,7 @@
 		ECD95F5D2A0B19FF00152742 /* BrandedSwitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandedSwitch.swift; sourceTree = "<group>"; };
 		F362C8072A780EA500BB32BB /* ListItemDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		F362C8092A780EBF00BB32BB /* ListItemDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemDemoController.swift; sourceTree = "<group>"; };
+		F3DFD3622A7C358000014C6E /* ListItemTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTest.swift; sourceTree = "<group>"; };
 		FC414E3625888BC300069E73 /* CommandBarDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarDemoController.swift; sourceTree = "<group>"; };
 		FD41C8F322E28EEB0086F899 /* NavigationControllerDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerDemoController.swift; sourceTree = "<group>"; };
 		FD6AE76C225679A4002CFDFE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 				3A83F8E02953B99A00EF6629 /* IndeterminateProgressBarTest.swift */,
 				3A83F8E22953B9A800EF6629 /* IndeterminateProgressBarTest_SwiftUI.swift */,
 				3A83F8E42953B9B800EF6629 /* LabelTest.swift */,
+				F3DFD3622A7C358000014C6E /* ListItemTest.swift */,
 				3AC1024B29DB969D002BF27E /* MultilineCommandBarTest.swift */,
 				3A83F8E62953B9D100EF6629 /* NavigationControllerTest.swift */,
 				3A83F8E82953BA4500EF6629 /* NotificationViewTest.swift */,
@@ -745,6 +748,7 @@
 				3A83F8CD2953B8F200EF6629 /* BottomSheetControllerTest.swift in Sources */,
 				3A83F8D12953B90D00EF6629 /* CardTest.swift in Sources */,
 				3A83F8CF2953B90000EF6629 /* ButtonTest.swift in Sources */,
+				F3DFD3632A7C358000014C6E /* ListItemTest.swift in Sources */,
 				3A83F8DF2953B97900EF6629 /* HUDTest_SwiftUI.swift in Sources */,
 				3A83F9012953BAEB00EF6629 /* SideTabBarTest.swift in Sources */,
 				3A83F8FF2953BADF00EF6629 /* ShimmerViewTest.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -49,22 +49,29 @@ struct ListItemDemoView: View {
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("titleTextField")
             TextField("Subtitle", text: $subtitle)
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("subtitleTextField")
             TextField("Footer", text: $footer)
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityIdentifier("footerTextField")
         }
 
         @ViewBuilder
         var toggles: some View {
             FluentUIDemoToggle(titleKey: "Show subtitle", isOn: $showSubtitle)
+                .accessibilityIdentifier("subtitleSwitch")
             FluentUIDemoToggle(titleKey: "Show footer", isOn: $showFooter)
+                .accessibilityIdentifier("footerSwitch")
             FluentUIDemoToggle(titleKey: "Show leading content", isOn: $showLeadingContent)
+                .accessibilityIdentifier("leadingContentSwitch")
             FluentUIDemoToggle(titleKey: "Show trailing content", isOn: $showTrailingContent)
+                .accessibilityIdentifier("trailingContentSwitch")
         }
 
         @ViewBuilder
@@ -75,12 +82,14 @@ struct ListItemDemoView: View {
                 Text(".checkmark").tag(ListItemAccessoryType.checkmark)
                 Text(".detailButton").tag(ListItemAccessoryType.detailButton)
             }
+            .accessibilityIdentifier("accessoryTypePicker")
             Picker("Leading Content Size", selection: $leadingContentSize) {
                 Text(".default").tag(ListItemLeadingContentSize.default)
                 Text(".zero").tag(ListItemLeadingContentSize.zero)
                 Text(".small").tag(ListItemLeadingContentSize.small)
                 Text(".medium").tag(ListItemLeadingContentSize.medium)
             }
+            .accessibilityIdentifier("leadingContentSizePicker")
             Picker("Background Style", selection: $backgroundStyle) {
                 Text(".plain").tag(ListItemBackgroundStyleType.plain)
                 Text(".grouped").tag(ListItemBackgroundStyleType.grouped)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -27,49 +27,146 @@ struct ListItemDemoView: View {
     @ObservedObject var fluentTheme: FluentTheme = .shared
     let accessoryTypes: [ListItemAccessoryType] = [.none, .checkmark, .detailButton, .disclosureIndicator]
 
+    @State var title: String = "Contoso Survey"
+    @State var subtitle: String = "Research Notes"
+    @State var footer: String = "22 views"
+    @State var showSubtitle: Bool = false
+    @State var showFooter: Bool = false
+    @State var showLeadingContent: Bool = true
+    @State var showTrailingContent: Bool = true
+    @State var accessoryType: ListItemAccessoryType = .none
+    @State var leadingContentSize: ListItemLeadingContentSize = .default
+    @State var backgroundStyle: ListItemBackgroundStyleType = .grouped
+    @State var titleLineLimit: Int = 1
+    @State var subtitleLineLimit: Int = 1
+    @State var footerLineLimit: Int = 1
+
     public var body: some View {
-        List {
-            ForEach(ListItemSampleData.sections, id: \.title) { section in
-                Section {
-                    ForEach(accessoryTypes, id: \.rawValue) { accessoryType in
-                        ListItem(title: section.item.text1,
-                                 subtitle: section.item.text2,
-                                 footer: section.item.text3,
+
+        @ViewBuilder
+        var textFields: some View {
+            TextField("Title", text: $title)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .textFieldStyle(.roundedBorder)
+            TextField("Subtitle", text: $subtitle)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .textFieldStyle(.roundedBorder)
+            TextField("Footer", text: $footer)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .textFieldStyle(.roundedBorder)
+        }
+
+        @ViewBuilder
+        var toggles: some View {
+            FluentUIDemoToggle(titleKey: "Show subtitle", isOn: $showSubtitle)
+            FluentUIDemoToggle(titleKey: "Show footer", isOn: $showFooter)
+            FluentUIDemoToggle(titleKey: "Show leading content", isOn: $showLeadingContent)
+            FluentUIDemoToggle(titleKey: "Show trailing content", isOn: $showTrailingContent)
+        }
+
+        @ViewBuilder
+        var pickers: some View {
+            Picker("Accessory Type", selection: $accessoryType) {
+                Text(".none").tag(ListItemAccessoryType.none)
+                Text(".disclosureIndicator").tag(ListItemAccessoryType.disclosureIndicator)
+                Text(".checkmark").tag(ListItemAccessoryType.checkmark)
+                Text(".detailButton").tag(ListItemAccessoryType.detailButton)
+            }
+            Picker("Leading Content Size", selection: $leadingContentSize) {
+                Text(".default").tag(ListItemLeadingContentSize.default)
+                Text(".zero").tag(ListItemLeadingContentSize.zero)
+                Text(".small").tag(ListItemLeadingContentSize.small)
+                Text(".medium").tag(ListItemLeadingContentSize.medium)
+            }
+            Picker("Background Style", selection: $backgroundStyle) {
+                Text(".plain").tag(ListItemBackgroundStyleType.plain)
+                Text(".grouped").tag(ListItemBackgroundStyleType.grouped)
+                Text(".clear").tag(ListItemBackgroundStyleType.clear)
+                Text(".custom").tag(ListItemBackgroundStyleType.custom)
+            }
+        }
+
+        @ViewBuilder
+        var steppers: some View {
+            Stepper(value: $titleLineLimit, in: 0...5) {
+                Text("Title Line Limit: \(titleLineLimit)")
+            }
+            Stepper(value: $subtitleLineLimit, in: 0...5) {
+                Text("Subtitle Line Limit: \(subtitleLineLimit)")
+            }
+            Stepper(value: $footerLineLimit, in: 0...5) {
+                Text("Footer Line Limit: \(footerLineLimit)")
+            }
+        }
+
+        @ViewBuilder
+        var controls: some View {
+            Section {
+                textFields
+                    .listRowSeparator(.hidden)
+                toggles
+                pickers
+                steppers
+            } header: {
+                Text("Settings")
+            }
+        }
+
+        @ViewBuilder
+        var leadingContent: some View {
+            Image("excelIcon")
+                .resizable()
+        }
+
+        @ViewBuilder
+        var trailingContent: some View {
+            Text("Spreadsheet")
+        }
+
+        @ViewBuilder
+        var content: some View {
+            VStack {
+                List {
+                    Section {
+                        ListItem(title: title,
+                                 subtitle: showSubtitle ? subtitle : "",
+                                 footer: showFooter ? footer : "",
                                  leadingContent: {
-                            if !section.item.image.isEmpty {
-                                Image(section.item.image)
+                            if showLeadingContent {
+                                leadingContent
                             }
                         },
                                  trailingContent: {
-                            if section.hasAccessory {
-                                UIViewWrapper {
-                                    ListItemSampleData.customAccessoryView
-                                }
-                                .fixedSize()
+                            if showTrailingContent {
+                                trailingContent
                             }
                         })
-                            .backgroundStyleType(.grouped)
-                            .accessoryType(accessoryType)
-                            .titleLineLimit(section.numberOfLines)
-                            .subtitleLineLimit(section.numberOfLines)
-                            .footerLineLimit(section.numberOfLines)
-                            .onAccessoryTapped {
-                                if accessoryType == .detailButton {
-                                    showingAlert.toggle()
-                                }
-                            }
-                            .alert("Detail button tapped", isPresented: $showingAlert) {
-                                Button("OK", role: .cancel) { }
-                            }
+                        .backgroundStyleType(backgroundStyle)
+                        .accessoryType(accessoryType)
+                        .leadingContentSize(leadingContentSize)
+                        .titleLineLimit(titleLineLimit)
+                        .subtitleLineLimit(subtitleLineLimit)
+                        .footerLineLimit(footerLineLimit)
+                        .onAccessoryTapped {
+                            showingAlert = true
+                        }
+                        .alert("Detail button tapped", isPresented: $showingAlert) {
+                            Button("OK", role: .cancel) { }
+                        }
+                    } header: {
+                        Text("ListItem")
                     }
-                } header: {
-                    Text(section.title)
-                        .textCase(nil)
+                    controls
                 }
+                .fluentTheme(fluentTheme)
+                .listStyle(.insetGrouped)
             }
         }
-        .listStyle(.insetGrouped)
-        .fluentTheme(fluentTheme)
+
+        return content
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
@@ -13,43 +13,130 @@ class ListItemTest: BaseTest {
         XCTAssert(app.navigationBars[controlName].exists)
     }
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        // Set starting values for all settings
+    func testTitle() throws {
+        let titleElement = app.staticTexts.matching(identifier: "title").firstMatch
+        let textField: XCUIElement = app.textFields.matching(identifier: "titleTextField").firstMatch
+        let newTitle = "A new title"
+
+        clearText(in: textField)
+        textField.typeText(newTitle)
+        XCTAssert(titleElement.label == newTitle, "Title should update when passed in value changes")
     }
 
     func testSubtitle() throws {
-        let showSubtitleSwitch: XCUIElement = app.switches["Show subtitle"].switches.firstMatch
+        let subtitleElement: XCUIElement = app.staticTexts.matching(identifier: "subtitle").firstMatch
+        let textField: XCUIElement = app.textFields.matching(identifier: "subtitleTextField").firstMatch
+        let newSubtitle = "A new subtitle"
 
         showSubtitleSwitch.tap()
-        XCTAssert(app.staticTexts.matching(identifier: "subtitle").firstMatch.exists)
-        showSubtitleSwitch.tap()
-        XCTAssert(!app.staticTexts.matching(identifier: "subtitle").firstMatch.exists)
+        XCTAssert(subtitleElement.exists, "Subtitle should appear if a non empty string is passed in")
+
+        clearText(in: textField)
+        textField.typeText(newSubtitle)
+        XCTAssert(subtitleElement.label == newSubtitle, "Subtitle should update when passed in value changes")
+
+        clearText(in: textField)
+        XCTAssertFalse(subtitleElement.exists, "Subtitle should not appear when string is empty")
     }
 
     func testFooter() throws {
-        let showSubtitleSwitch: XCUIElement = app.switches["Show subtitle"].switches.firstMatch
-        let showFooterSwitch: XCUIElement = app.switches["Show footer"].switches.firstMatch
-        // footer should not be shown if subtitle is not
-        XCTAssert(!app.staticTexts.matching(identifier: "footer").firstMatch.exists)
+        let footerElement: XCUIElement = app.staticTexts.matching(identifier: "footer").firstMatch
+        let textField: XCUIElement = app.textFields.matching(identifier: "footerTextField").firstMatch
+        let newFooter = "A new footer"
+
+        XCTAssertFalse(footerElement.exists, "Footer should not appear unless a subtitle is passed in")
+
         showSubtitleSwitch.tap()
         showFooterSwitch.tap()
-        XCTAssert(app.staticTexts.matching(identifier: "footer").firstMatch.exists)
+        XCTAssert(footerElement.exists, "Footer should appear if a non empty string is passed in")
+
+        clearText(in: textField)
+        textField.typeText(newFooter)
+        XCTAssert(footerElement.label == newFooter, "Footer should update when passed in value changes")
+
         showFooterSwitch.tap()
-        XCTAssert(!app.staticTexts.matching(identifier: "footer").firstMatch.exists)
+        XCTAssertFalse(footerElement.exists, "Footer should not appear when string is empty")
     }
 
     func testLeadingContent() throws {
-        let showLeadingContentSwitch: XCUIElement = app.switches["Show leading content"].switches.firstMatch
-        XCTAssert(app.images.matching(identifier: "leadingContent").firstMatch.exists)
+        let showLeadingContentSwitch: XCUIElement = app.switches.matching(identifier: "leadingContentSwitch").switches.firstMatch
+        let leadingContentElement: XCUIElement = app.images.matching(identifier: "leadingContent").firstMatch
+        let leadingContentSizeButton: XCUIElement = app.buttons.matching(identifier: "leadingContentSizePicker").firstMatch
+        let zeroSizeButton: XCUIElement = app.buttons[".zero"].firstMatch
+        let smallSizeButton: XCUIElement = app.buttons[".small"].firstMatch
+        let mediumSizeButton: XCUIElement = app.buttons[".medium"].firstMatch
+
+        XCTAssert(leadingContentElement .exists, "Leading content should appear when a value is passed in")
+
         showLeadingContentSwitch.tap()
-        XCTAssert(!app.images.matching(identifier: "leadingContent").firstMatch.exists)
+        XCTAssertFalse(leadingContentElement.exists, "Leading content should not appear when no value is passed in")
+
+        showLeadingContentSwitch.tap()
+        leadingContentSizeButton.tap()
+        zeroSizeButton.tap()
+        XCTAssertFalse(leadingContentElement.isHittable, "Leading content should not appear for size .zero")
+
+        leadingContentSizeButton.tap()
+        smallSizeButton.tap()
+        XCTAssert(leadingContentElement.exists, "Leading content should appear for size .small")
+
+        leadingContentSizeButton.tap()
+        mediumSizeButton.tap()
+        XCTAssert(leadingContentElement.exists, "Leading content should appear for size .medium")
     }
 
     func testTrailingContent() throws {
-        let showTrailingContentSwitch: XCUIElement = app.switches["Show trailing content"].switches.firstMatch
-        XCTAssert(app.staticTexts.matching(identifier: "trailingContent").firstMatch.exists)
+        let showTrailingContentSwitch: XCUIElement = app.switches.matching(identifier: "trailingContentSwitch").switches.firstMatch
+        let leadingContentElement: XCUIElement = app.staticTexts.matching(identifier: "trailingContent").firstMatch
+
+        XCTAssert(leadingContentElement.exists, "Trailing content should appear when a value is passed in")
+
         showTrailingContentSwitch.tap()
-        XCTAssert(!app.staticTexts.matching(identifier: "trailingContent").firstMatch.exists)
+        XCTAssertFalse(leadingContentElement.exists, "Trailing content should not appear when no value is passed in")
+    }
+
+    func testAccessoryType() throws {
+        let accessoryImageElement: XCUIElement = app.images.matching(identifier: "accessoryImage").firstMatch
+        let accessoryButtonElement: XCUIElement = app.buttons.matching(identifier: "accessoryDetailButton").firstMatch
+        let accessoryTypeButton: XCUIElement = app.buttons.matching(identifier: "accessoryTypePicker").firstMatch
+        let noneTypeButton: XCUIElement = app.buttons[".none"].firstMatch
+        let disclosureIndicatorTypeButton: XCUIElement = app.buttons[".disclosureIndicator"].firstMatch
+        let checkmarkTypeButton: XCUIElement = app.buttons[".checkmark"].firstMatch
+        let detailButtonTypeButton: XCUIElement = app.buttons[".detailButton"].firstMatch
+
+        accessoryTypeButton.tap()
+        noneTypeButton.tap()
+        XCTAssertFalse(accessoryImageElement.exists, "Accessory should not appear for .none type")
+
+        accessoryTypeButton.tap()
+        disclosureIndicatorTypeButton.tap()
+        XCTAssert(accessoryImageElement.exists, "Accessory should appear for .disclosureIndicator type")
+        XCTAssertFalse(accessoryImageElement.isHittable, "Accessory should not not have a tap target for .disclosureIndicator type")
+
+        accessoryTypeButton.tap()
+        checkmarkTypeButton.tap()
+        XCTAssert(accessoryImageElement.exists, "Accessory should appear for .checkmark type")
+        XCTAssertFalse(accessoryImageElement.isHittable, "Accessory should not not have a tap target for .checkmark type")
+
+        accessoryTypeButton.tap()
+        detailButtonTypeButton.tap()
+        XCTAssert(accessoryButtonElement.exists, "Accessory should appear for .detailButton type")
+        XCTAssert(accessoryButtonElement.isEnabled, "Accessory should have a tap target for .detailButton type")
+    }
+
+    // MARK: Helper functions and variables
+
+    func clearText(in textField: XCUIElement) {
+        textField.tap()
+        let currentText = textField.value as? String ?? ""
+        textField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: currentText.count))
+    }
+
+    var showSubtitleSwitch: XCUIElement {
+        app.switches.matching(identifier: "subtitleSwitch").switches.firstMatch
+    }
+
+    var showFooterSwitch: XCUIElement {
+        app.switches.matching(identifier: "footerSwitch").switches.firstMatch
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
@@ -62,11 +62,11 @@ class ListItemTest: BaseTest {
         let showLeadingContentSwitch: XCUIElement = app.switches.matching(identifier: "leadingContentSwitch").switches.firstMatch
         let leadingContentElement: XCUIElement = app.images.matching(identifier: "ListItemLeadingContent").firstMatch
         let leadingContentSizeButton: XCUIElement = app.buttons.matching(identifier: "leadingContentSizePicker").firstMatch
-        let zeroSizeButton: XCUIElement = app.buttons[".zero"].firstMatch
-        let smallSizeButton: XCUIElement = app.buttons[".small"].firstMatch
-        let mediumSizeButton: XCUIElement = app.buttons[".medium"].firstMatch
+        let zeroSizeButton: XCUIElement = app.buttons.matching(identifier: ".zero").firstMatch
+        let smallSizeButton: XCUIElement = app.buttons.matching(identifier: ".small").firstMatch
+        let mediumSizeButton: XCUIElement = app.buttons.matching(identifier: ".medium").firstMatch
 
-        XCTAssert(leadingContentElement .exists, "Leading content should appear when a value is passed in")
+        XCTAssert(leadingContentElement.exists, "Leading content should appear when a value is passed in")
 
         showLeadingContentSwitch.tap()
         XCTAssertFalse(leadingContentElement.exists, "Leading content should not appear when no value is passed in")
@@ -99,10 +99,10 @@ class ListItemTest: BaseTest {
         let accessoryImageElement: XCUIElement = app.images.matching(identifier: "ListItemAccessoryImage").firstMatch
         let accessoryButtonElement: XCUIElement = app.buttons.matching(identifier: "ListItemAccessoryDetailButton").firstMatch
         let accessoryTypeButton: XCUIElement = app.buttons.matching(identifier: "accessoryTypePicker").firstMatch
-        let noneTypeButton: XCUIElement = app.buttons[".none"].firstMatch
-        let disclosureIndicatorTypeButton: XCUIElement = app.buttons[".disclosureIndicator"].firstMatch
-        let checkmarkTypeButton: XCUIElement = app.buttons[".checkmark"].firstMatch
-        let detailButtonTypeButton: XCUIElement = app.buttons[".detailButton"].firstMatch
+        let noneTypeButton: XCUIElement = app.buttons.matching(identifier: ".none").firstMatch
+        let disclosureIndicatorTypeButton: XCUIElement = app.buttons.matching(identifier: ".disclosureIndicator").firstMatch
+        let checkmarkTypeButton: XCUIElement = app.buttons.matching(identifier: ".checkmark").firstMatch
+        let detailButtonTypeButton: XCUIElement = app.buttons.matching(identifier: ".detailButton").firstMatch
 
         accessoryTypeButton.tap()
         noneTypeButton.tap()

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
@@ -14,7 +14,7 @@ class ListItemTest: BaseTest {
     }
 
     func testTitle() throws {
-        let titleElement = app.staticTexts.matching(identifier: "title").firstMatch
+        let titleElement = app.staticTexts.matching(identifier: "ListItemTitle").firstMatch
         let textField: XCUIElement = app.textFields.matching(identifier: "titleTextField").firstMatch
         let newTitle = "A new title"
 
@@ -24,7 +24,7 @@ class ListItemTest: BaseTest {
     }
 
     func testSubtitle() throws {
-        let subtitleElement: XCUIElement = app.staticTexts.matching(identifier: "subtitle").firstMatch
+        let subtitleElement: XCUIElement = app.staticTexts.matching(identifier: "ListItemSubtitle").firstMatch
         let textField: XCUIElement = app.textFields.matching(identifier: "subtitleTextField").firstMatch
         let newSubtitle = "A new subtitle"
 
@@ -40,7 +40,7 @@ class ListItemTest: BaseTest {
     }
 
     func testFooter() throws {
-        let footerElement: XCUIElement = app.staticTexts.matching(identifier: "footer").firstMatch
+        let footerElement: XCUIElement = app.staticTexts.matching(identifier: "ListItemFooter").firstMatch
         let textField: XCUIElement = app.textFields.matching(identifier: "footerTextField").firstMatch
         let newFooter = "A new footer"
 
@@ -60,7 +60,7 @@ class ListItemTest: BaseTest {
 
     func testLeadingContent() throws {
         let showLeadingContentSwitch: XCUIElement = app.switches.matching(identifier: "leadingContentSwitch").switches.firstMatch
-        let leadingContentElement: XCUIElement = app.images.matching(identifier: "leadingContent").firstMatch
+        let leadingContentElement: XCUIElement = app.images.matching(identifier: "ListItemLeadingContent").firstMatch
         let leadingContentSizeButton: XCUIElement = app.buttons.matching(identifier: "leadingContentSizePicker").firstMatch
         let zeroSizeButton: XCUIElement = app.buttons[".zero"].firstMatch
         let smallSizeButton: XCUIElement = app.buttons[".small"].firstMatch
@@ -87,7 +87,7 @@ class ListItemTest: BaseTest {
 
     func testTrailingContent() throws {
         let showTrailingContentSwitch: XCUIElement = app.switches.matching(identifier: "trailingContentSwitch").switches.firstMatch
-        let leadingContentElement: XCUIElement = app.staticTexts.matching(identifier: "trailingContent").firstMatch
+        let leadingContentElement: XCUIElement = app.staticTexts.matching(identifier: "ListItemTrailingContent").firstMatch
 
         XCTAssert(leadingContentElement.exists, "Trailing content should appear when a value is passed in")
 
@@ -96,8 +96,8 @@ class ListItemTest: BaseTest {
     }
 
     func testAccessoryType() throws {
-        let accessoryImageElement: XCUIElement = app.images.matching(identifier: "accessoryImage").firstMatch
-        let accessoryButtonElement: XCUIElement = app.buttons.matching(identifier: "accessoryDetailButton").firstMatch
+        let accessoryImageElement: XCUIElement = app.images.matching(identifier: "ListItemAccessoryImage").firstMatch
+        let accessoryButtonElement: XCUIElement = app.buttons.matching(identifier: "ListItemAccessoryDetailButton").firstMatch
         let accessoryTypeButton: XCUIElement = app.buttons.matching(identifier: "accessoryTypePicker").firstMatch
         let noneTypeButton: XCUIElement = app.buttons[".none"].firstMatch
         let disclosureIndicatorTypeButton: XCUIElement = app.buttons[".disclosureIndicator"].firstMatch

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
@@ -13,7 +13,43 @@ class ListItemTest: BaseTest {
         XCTAssert(app.navigationBars[controlName].exists)
     }
 
-    func testTitle() throws {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Set starting values for all settings
+    }
 
+    func testSubtitle() throws {
+        let showSubtitleSwitch: XCUIElement = app.switches["Show subtitle"].switches.firstMatch
+
+        showSubtitleSwitch.tap()
+        XCTAssert(app.staticTexts.matching(identifier: "subtitle").firstMatch.exists)
+        showSubtitleSwitch.tap()
+        XCTAssert(!app.staticTexts.matching(identifier: "subtitle").firstMatch.exists)
+    }
+
+    func testFooter() throws {
+        let showSubtitleSwitch: XCUIElement = app.switches["Show subtitle"].switches.firstMatch
+        let showFooterSwitch: XCUIElement = app.switches["Show footer"].switches.firstMatch
+        // footer should not be shown if subtitle is not
+        XCTAssert(!app.staticTexts.matching(identifier: "footer").firstMatch.exists)
+        showSubtitleSwitch.tap()
+        showFooterSwitch.tap()
+        XCTAssert(app.staticTexts.matching(identifier: "footer").firstMatch.exists)
+        showFooterSwitch.tap()
+        XCTAssert(!app.staticTexts.matching(identifier: "footer").firstMatch.exists)
+    }
+
+    func testLeadingContent() throws {
+        let showLeadingContentSwitch: XCUIElement = app.switches["Show leading content"].switches.firstMatch
+        XCTAssert(app.images.matching(identifier: "leadingContent").firstMatch.exists)
+        showLeadingContentSwitch.tap()
+        XCTAssert(!app.images.matching(identifier: "leadingContent").firstMatch.exists)
+    }
+
+    func testTrailingContent() throws {
+        let showTrailingContentSwitch: XCUIElement = app.switches["Show trailing content"].switches.firstMatch
+        XCTAssert(app.staticTexts.matching(identifier: "trailingContent").firstMatch.exists)
+        showTrailingContentSwitch.tap()
+        XCTAssert(!app.staticTexts.matching(identifier: "trailingContent").firstMatch.exists)
     }
 }

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ListItemTest.swift
@@ -1,0 +1,19 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import XCTest
+
+class ListItemTest: BaseTest {
+    override var controlName: String { "ListItem" }
+
+    // launch test that ensures the demo app does not crash and is on the correct control page
+    func testLaunch() throws {
+        XCTAssert(app.navigationBars[controlName].exists)
+    }
+
+    func testTitle() throws {
+
+    }
+}

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -60,6 +60,7 @@ public struct ListItem<LeadingContent: View,
                     .foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
                     .lineLimit(subtitleLineLimit)
                     .truncationMode(subtitleTruncationMode)
+                    .accessibilityIdentifier("subtitle")
                 VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
                     titleView
                     if layoutType == .twoLines {
@@ -76,6 +77,7 @@ public struct ListItem<LeadingContent: View,
                             .frame(minHeight: ListItemTokenSet.footerHeight)
                             .lineLimit(footerLineLimit)
                             .truncationMode(footerTruncationMode)
+                            .accessibilityIdentifier("footer")
                     }
                 }
             }
@@ -117,6 +119,7 @@ public struct ListItem<LeadingContent: View,
                         .frame(width: tokenSet[.customViewDimensions].float,
                                height: tokenSet[.customViewDimensions].float)
                         .padding(.trailing, tokenSet[.customViewTrailingMargin].float)
+                        .accessibilityIdentifier("leadingContent")
                 }
                 labelStack
                     .padding(.trailing, ListItemTokenSet.horizontalSpacing)
@@ -124,6 +127,7 @@ public struct ListItem<LeadingContent: View,
                 if let trailingContent {
                     trailingContent()
                         .tint(Color(fluentTheme.color(.brandForeground1)))
+                        .accessibilityIdentifier("trailingContent")
                 }
                 accessoryView
                     .padding(.leading, ListItemTokenSet.horizontalSpacing)

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -51,6 +51,7 @@ public struct ListItem<LeadingContent: View,
                                 .frame(minHeight: ListItemTokenSet.titleHeight)
                                 .lineLimit(titleLineLimit)
                                 .truncationMode(titleTruncationMode)
+                                .accessibilityIdentifier("title")
 
             switch layoutType {
             case .oneLine:
@@ -90,6 +91,7 @@ public struct ListItem<LeadingContent: View,
                let iconColor = accessoryType.iconColor(tokenSet: tokenSet, fluentTheme: fluentTheme) {
                 let image = Image(uiImage: icon)
                     .foregroundColor(Color(uiColor: iconColor))
+                    .accessibilityIdentifier("accessoryImage")
                 if accessoryType == .detailButton {
                     SwiftUI.Button {
                         if let onAccessoryTapped = onAccessoryTapped {
@@ -98,6 +100,7 @@ public struct ListItem<LeadingContent: View,
                     } label: {
                         image
                     }
+                    .accessibilityIdentifier("accessoryDetailButton")
                 } else {
                     image
                 }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -51,7 +51,7 @@ public struct ListItem<LeadingContent: View,
                                 .frame(minHeight: ListItemTokenSet.titleHeight)
                                 .lineLimit(titleLineLimit)
                                 .truncationMode(titleTruncationMode)
-                                .accessibilityIdentifier("title")
+                                .accessibilityIdentifier(AccessibilityIdentifiers.title)
 
             switch layoutType {
             case .oneLine:
@@ -61,7 +61,7 @@ public struct ListItem<LeadingContent: View,
                     .foregroundColor(Color(uiColor: tokenSet[.subtitleColor].uiColor))
                     .lineLimit(subtitleLineLimit)
                     .truncationMode(subtitleTruncationMode)
-                    .accessibilityIdentifier("subtitle")
+                    .accessibilityIdentifier(AccessibilityIdentifiers.subtitle)
                 VStack(alignment: .leading, spacing: ListItemTokenSet.labelVerticalSpacing) {
                     titleView
                     if layoutType == .twoLines {
@@ -78,7 +78,7 @@ public struct ListItem<LeadingContent: View,
                             .frame(minHeight: ListItemTokenSet.footerHeight)
                             .lineLimit(footerLineLimit)
                             .truncationMode(footerTruncationMode)
-                            .accessibilityIdentifier("footer")
+                            .accessibilityIdentifier(AccessibilityIdentifiers.footer)
                     }
                 }
             }
@@ -91,7 +91,7 @@ public struct ListItem<LeadingContent: View,
                let iconColor = accessoryType.iconColor(tokenSet: tokenSet, fluentTheme: fluentTheme) {
                 let image = Image(uiImage: icon)
                     .foregroundColor(Color(uiColor: iconColor))
-                    .accessibilityIdentifier("accessoryImage")
+                    .accessibilityIdentifier(AccessibilityIdentifiers.accessoryImage)
                 if accessoryType == .detailButton {
                     SwiftUI.Button {
                         if let onAccessoryTapped = onAccessoryTapped {
@@ -100,7 +100,7 @@ public struct ListItem<LeadingContent: View,
                     } label: {
                         image
                     }
-                    .accessibilityIdentifier("accessoryDetailButton")
+                    .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
                 } else {
                     image
                 }
@@ -122,7 +122,7 @@ public struct ListItem<LeadingContent: View,
                         .frame(width: tokenSet[.customViewDimensions].float,
                                height: tokenSet[.customViewDimensions].float)
                         .padding(.trailing, tokenSet[.customViewTrailingMargin].float)
-                        .accessibilityIdentifier("leadingContent")
+                        .accessibilityIdentifier(AccessibilityIdentifiers.leadingContent)
                 }
                 labelStack
                     .padding(.trailing, ListItemTokenSet.horizontalSpacing)
@@ -130,7 +130,7 @@ public struct ListItem<LeadingContent: View,
                 if let trailingContent {
                     trailingContent()
                         .tint(Color(fluentTheme.color(.brandForeground1)))
-                        .accessibilityIdentifier("trailingContent")
+                        .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
                 }
                 accessoryView
                     .padding(.leading, ListItemTokenSet.horizontalSpacing)
@@ -229,6 +229,18 @@ public struct ListItem<LeadingContent: View,
     private let footer: Footer
     private let subtitle: Subtitle
     private let title: Title
+}
+
+// MARK: Constants
+
+private struct AccessibilityIdentifiers {
+    static let title: String = "ListItemTitle"
+    static let subtitle: String = "ListItemSubtitle"
+    static let footer: String = "ListItemFooter"
+    static let leadingContent: String = "ListItemLeadingContent"
+    static let trailingContent: String = "ListItemTrailingContent"
+    static let accessoryImage: String = "ListItemAccessoryImage"
+    static let accessoryDetailButton: String = "ListItemAccessoryDetailButton"
 }
 
 // MARK: Additional Initializers


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Adding XCTest for the `ListItem` SwiftUI view. The test cases cover anything that modifies the content of what is shown in the `ListItem` view based on different state. These tests will ensure that when a client optionally provides title, subtitle, 
footer, leadingContent, trailingContent, and accessoryType that the `ListItem` shows that information correctly.

Also updated the demo app to only show one `ListItem` that is modified passed on a set of controls provided. This is inline with other demos for SwiftUI views.

<img src="https://github.com/microsoft/fluentui-apple/assets/21343215/f315e7d1-3af8-4105-a8e3-fb446011faf7" height="550">


### Binary change

no impact, the changes are only in the demo app.

### Verification

Automated tests are ran and pass.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1858&drop=dogfoodAlpha