### PR TITLE
Add isHidden property to CommandingItem

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -48,8 +48,8 @@ class BottomCommandingDemoController: DemoController {
         return Array(1...25).map {
             let item = CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
             item.selectedImage = homeSelectedImage
-            item.isOn = $0 % 3 == 1 ? true : false
-            item.isEnabled = $0 % 2 == 1 ? true : false
+            item.isOn = modifiedCommandIndices.contains($0) ? true : false
+            item.isEnabled = modifiedCommandIndices.contains($0) ? true : false
             return item
         }
     }()
@@ -103,17 +103,17 @@ class BottomCommandingDemoController: DemoController {
                 DemoItem(title: "Expanded list items", type: .boolean, action: #selector(toggleExpandedItems), isOn: expandedItemsVisible),
                 DemoItem(title: "Additional expanded list items", type: .boolean, action: #selector(toggleAdditionalExpandedItems(_:)), isOn: additionalExpandedItemsVisible),
                 DemoItem(title: "Popover on hero command tap", type: .boolean, action: #selector(toggleHeroPopover)),
-                DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleHeroCommandOnOff), isOn: true),
-                DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: false),
-                DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
+                DemoItem(title: "Hero command isOn", type: .boolean, action: #selector(toggleModifiableHeroCommandsOnOff), isOn: true),
+                DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleModifiableHeroCommandsEnabled), isOn: false),
+                DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleModifiableListCommandsEnabled), isOn: true),
                 DemoItem(title: "Long title hero items", type: .boolean, action: #selector(toggleLongTitleHeroItems), isOn: false),
-                DemoItem(title: "Hero command isHidden", type: .boolean, action: #selector(toggleHeroCommandHidden), isOn: false),
-                DemoItem(title: "List command isHidden", type: .boolean, action: #selector(toggleListCommandHidden), isOn: false),
+                DemoItem(title: "Hero command isHidden", type: .boolean, action: #selector(toggleModifiableHeroCommandsHidden), isOn: false),
+                DemoItem(title: "List command isHidden", type: .boolean, action: #selector(toggleModifiableListCommandsHidden), isOn: false),
                 DemoItem(title: "Toggle boolean cells", type: .action, action: #selector(toggleBooleanCells)),
-                DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeHeroCommandTitle)),
-                DemoItem(title: "Change hero command images", type: .action, action: #selector(changeHeroCommandIcon)),
-                DemoItem(title: "Change list command titles", type: .action, action: #selector(changeListCommandTitle)),
-                DemoItem(title: "Change list command images", type: .action, action: #selector(changeListCommandIcon))
+                DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeModifiableHeroCommandsTitle)),
+                DemoItem(title: "Change hero command images", type: .action, action: #selector(changeModifiableHeroCommandsIcon)),
+                DemoItem(title: "Change list command titles", type: .action, action: #selector(changeModifiableListCommandsTitle)),
+                DemoItem(title: "Change list command images", type: .action, action: #selector(changeModifiableListCommandsIcon))
             ]
         ]
     }
@@ -155,37 +155,31 @@ class BottomCommandingDemoController: DemoController {
 
     private let modifiedCommandIndices: [Int] = [0, 3]
 
-    @objc private func toggleHeroCommandOnOff(_ sender: BooleanCell) {
-        for (index, heroItem) in heroItems.enumerated() {
-            if (index + 1) % 3 == 1 {
-                heroItem.isOn = sender.isOn
-            }
+    @objc private func toggleModifiableHeroCommandsOnOff(_ sender: BooleanCell) {
+        modifiedCommandIndices.forEach {
+            heroItems[$0].isOn = sender.isOn
         }
     }
 
-    @objc private func toggleHeroCommandEnabled(_ sender: BooleanCell) {
-        for (index, heroItem) in heroItems.enumerated() {
-            if index % 2 == 1 {
-                heroItem.isEnabled = sender.isOn
-            }
+    @objc private func toggleModifiableHeroCommandsEnabled(_ sender: BooleanCell) {
+        modifiedCommandIndices.forEach {
+            heroItems[$0].isEnabled = sender.isOn
         }
     }
 
-    @objc private func toggleListCommandEnabled(_ sender: BooleanCell) {
+    @objc private func toggleModifiableListCommandsEnabled(_ sender: BooleanCell) {
         modifiedCommandIndices.forEach {
             currentExpandedListSections[0].items[$0].isEnabled = sender.isOn
         }
     }
 
-    @objc private func toggleHeroCommandHidden(_ sender: BooleanCell) {
-        for (index, heroItem) in heroItems.enumerated() {
-            if index % 2 == 1 {
-                heroItem.isHidden = sender.isOn
-            }
+    @objc private func toggleModifiableHeroCommandsHidden(_ sender: BooleanCell) {
+        modifiedCommandIndices.forEach {
+            heroItems[$0].isHidden = sender.isOn
         }
     }
 
-    @objc private func toggleListCommandHidden(_ sender: BooleanCell) {
+    @objc private func toggleModifiableListCommandsHidden(_ sender: BooleanCell) {
         modifiedCommandIndices.forEach {
             currentExpandedListSections[0].items[$0].isHidden = sender.isOn
         }
@@ -201,19 +195,19 @@ class BottomCommandingDemoController: DemoController {
         heroCommandPopoverEnabled = sender.isOn
     }
 
-    @objc private func changeHeroCommandTitle() {
+    @objc private func changeModifiableHeroCommandsTitle() {
         modifiedCommandIndices.forEach {
             heroItems[$0].title = "Item " + String(Int.random(in: 6..<100))
         }
     }
 
-    @objc private func changeListCommandTitle() {
+    @objc private func changeModifiableListCommandsTitle() {
         modifiedCommandIndices.forEach {
             currentExpandedListSections[0].items[$0].title = "Item " + String(Int.random(in: 6..<100))
         }
     }
 
-    @objc private func changeHeroCommandIcon() {
+    @objc private func changeModifiableHeroCommandsIcon() {
         modifiedCommandIndices.forEach {
             heroItems[$0].image = heroIconChanged ? homeImage : boldImage
             heroItems[$0].selectedImage = heroIconChanged ? homeSelectedImage : boldImage
@@ -221,7 +215,7 @@ class BottomCommandingDemoController: DemoController {
         heroIconChanged.toggle()
     }
 
-    @objc private func changeListCommandIcon() {
+    @objc private func changeModifiableListCommandsIcon() {
         modifiedCommandIndices.forEach {
             currentExpandedListSections[0].items[$0].image = listIconChanged ? homeImage : boldImage
             currentExpandedListSections[0].items[$0].selectedImage = listIconChanged ? homeSelectedImage : boldImage

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -107,6 +107,8 @@ class BottomCommandingDemoController: DemoController {
                 DemoItem(title: "Hero command isEnabled", type: .boolean, action: #selector(toggleHeroCommandEnabled), isOn: false),
                 DemoItem(title: "List command isEnabled", type: .boolean, action: #selector(toggleListCommandEnabled), isOn: true),
                 DemoItem(title: "Long title hero items", type: .boolean, action: #selector(toggleLongTitleHeroItems), isOn: false),
+                DemoItem(title: "Hero command isHidden", type: .boolean, action: #selector(toggleHeroCommandHidden), isOn: false),
+                DemoItem(title: "List command isHidden", type: .boolean, action: #selector(toggleListCommandHidden), isOn: false),
                 DemoItem(title: "Toggle boolean cells", type: .action, action: #selector(toggleBooleanCells)),
                 DemoItem(title: "Change hero command titles", type: .action, action: #selector(changeHeroCommandTitle)),
                 DemoItem(title: "Change hero command images", type: .action, action: #selector(changeHeroCommandIcon)),
@@ -172,6 +174,20 @@ class BottomCommandingDemoController: DemoController {
     @objc private func toggleListCommandEnabled(_ sender: BooleanCell) {
         modifiedCommandIndices.forEach {
             currentExpandedListSections[0].items[$0].isEnabled = sender.isOn
+        }
+    }
+
+    @objc private func toggleHeroCommandHidden(_ sender: BooleanCell) {
+        for (index, heroItem) in heroItems.enumerated() {
+            if index % 2 == 1 {
+                heroItem.isHidden = sender.isOn
+            }
+        }
+    }
+
+    @objc private func toggleListCommandHidden(_ sender: BooleanCell) {
+        modifiedCommandIndices.forEach {
+            currentExpandedListSections[0].items[$0].isHidden = sender.isOn
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -48,8 +48,8 @@ class BottomCommandingDemoController: DemoController {
         return Array(1...25).map {
             let item = CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
             item.selectedImage = homeSelectedImage
-            item.isOn = modifiedCommandIndices.contains($0)
-            item.isEnabled = modifiedCommandIndices.contains($0)
+            item.isOn = ($0 % 3 == 1)
+            item.isEnabled = ($0 % 2 == 1)
             return item
         }
     }()
@@ -156,14 +156,18 @@ class BottomCommandingDemoController: DemoController {
     private let modifiedCommandIndices: [Int] = [0, 3]
 
     @objc private func toggleModifiableHeroCommandsOnOff(_ sender: BooleanCell) {
-        modifiedCommandIndices.forEach {
-            heroItems[$0].isOn = sender.isOn
+        for (index, heroItem) in heroItems.enumerated() {
+            if (index + 1) % 3 == 1 {
+                heroItem.isOn = sender.isOn
+            }
         }
     }
 
     @objc private func toggleModifiableHeroCommandsEnabled(_ sender: BooleanCell) {
-        modifiedCommandIndices.forEach {
-            heroItems[$0].isEnabled = sender.isOn
+        for (index, heroItem) in heroItems.enumerated() {
+            if index % 2 == 1 {
+                heroItem.isEnabled = sender.isOn
+            }
         }
     }
 
@@ -174,8 +178,10 @@ class BottomCommandingDemoController: DemoController {
     }
 
     @objc private func toggleModifiableHeroCommandsHidden(_ sender: BooleanCell) {
-        modifiedCommandIndices.forEach {
-            heroItems[$0].isHidden = sender.isOn
+        for (index, heroItem) in heroItems.enumerated() {
+            if index % 2 == 1 {
+                heroItem.isHidden = sender.isOn
+            }
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -48,8 +48,8 @@ class BottomCommandingDemoController: DemoController {
         return Array(1...25).map {
             let item = CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
             item.selectedImage = homeSelectedImage
-            item.isOn = modifiedCommandIndices.contains($0) ? true : false
-            item.isEnabled = modifiedCommandIndices.contains($0) ? true : false
+            item.isOn = modifiedCommandIndices.contains($0)
+            item.isEnabled = modifiedCommandIndices.contains($0)
             return item
         }
     }()

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -676,15 +676,19 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
     /// Filters the `expandedListSections` 2D array for items with that are not hidden
     private func updateVisibleExpandedListSections() {
         /// Filter for all `CommandingSection`  that have at least 1 visible `CommandingItem`
-        let updatedVisibleExpandedListSections = expandedListSections.filter {$0.items.filter {!$0.isHidden}.count > 0}
+        let updatedVisibleExpandedListSections = expandedListSections.filter { expandedListSection in
+            return expandedListSection.items.contains { item in
+                return !item.isHidden
+            }
+        }
 
         /// Filter all `CommandingItem` that are not hidden and add to a new `CommandingSection` to holds the filtered items
-        visibleExpandedListSections = updatedVisibleExpandedListSections.map({ (section: CommandingSection) -> CommandingSection in
-            return CommandingSection(title: section.title,
-                                     items: section.items.filter({ item in
-                !item.isHidden
-            }))
-        })
+        visibleExpandedListSections = updatedVisibleExpandedListSections.map { expandedListSection in
+            return CommandingSection(title: expandedListSection.title,
+                                     items: expandedListSection.items.filter { item in
+                return !item.isHidden
+            })
+        }
     }
 
     /// Array of `CommandingItems` in the tab bar view which are visible

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -777,6 +777,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         itemView.numberOfTitleLines = Constants.heroButtonMaxTitleLines
         itemView.isSelected = item.isOn
         itemView.isEnabled = item.isEnabled
+        itemView.isHidden = item.isHidden
         itemView.accessibilityTraits.insert(.button)
         itemView.preferredLabelMaxLayoutWidth = Constants.heroButtonLabelMaxWidth
         itemView.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -825,6 +826,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
             }
         }
         cell.isEnabled = item.isEnabled
+        cell.isHidden = item.isHidden
         cell.backgroundStyleType = .clear
         cell.accessibilityIdentifier = item.accessibilityIdentifier
         cell.tokenSet.setOverrides(from: tokenSet,
@@ -1133,6 +1135,13 @@ extension BottomCommandingController: UITableViewDelegate {
         return configuredHeader
     }
 
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let section = expandedListSections[indexPath.section]
+        let item = section.items[indexPath.row]
+
+        return item.isHidden ? 0 : UITableView.automaticDimension
+    }
+
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let cell = tableView.cellForRow(at: indexPath), let binding = viewToBindingMap[cell] else {
             return
@@ -1205,6 +1214,26 @@ extension BottomCommandingController: CommandingItemDelegate {
         case let booleanCell as BooleanCell:
             if booleanCell.isOn != value {
                 booleanCell.isOn = value
+            }
+        default:
+            break
+        }
+    }
+
+    func commandingItem(_ item: CommandingItem, didChangeHiddenTo value: Bool) {
+        guard let view = itemToBindingMap[item]?.view else {
+            return
+        }
+
+        switch view {
+        case let tabBarItemView as TabBarItemView:
+            if tabBarItemView.isHidden != value {
+                tabBarItemView.isHidden = value
+            }
+        case let cell as TableViewCell:
+            if cell.isHidden != value {
+                cell.isHidden = value
+                tableView.reloadData()
             }
         default:
             break

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -685,9 +685,8 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         /// Filter all `CommandingItem` that are not hidden and add to a new `CommandingSection` to holds the filtered items
         visibleExpandedListSections = updatedVisibleExpandedListSections.map { expandedListSection in
             return CommandingSection(title: expandedListSection.title,
-                                     items: expandedListSection.items.filter { item in
-                return !item.isHidden
-            })
+                                     items: expandedListSection.items.filter { item in return !item.isHidden }
+            )
         }
     }
 

--- a/ios/FluentUI/Bottom Commanding/CommandingItem.swift
+++ b/ios/FluentUI/Bottom Commanding/CommandingItem.swift
@@ -82,6 +82,15 @@ open class CommandingItem: NSObject {
         }
     }
 
+    /// Indicates whether the command is hidden.
+    @objc open var isHidden: Bool = false {
+        didSet {
+            if isHidden != oldValue {
+                delegate?.commandingItem(self, didChangeHiddenTo: isHidden)
+            }
+        }
+    }
+
     /// The accessibility identifier of the command item.
     @objc open var accessibilityIdentifier: String?
 
@@ -126,4 +135,7 @@ protocol CommandingItemDelegate: AnyObject {
 
     /// Called after the `isEnabled` property changed.
     func commandingItem(_ item: CommandingItem, didChangeEnabledTo value: Bool)
+
+    /// Called after the `isHidden` property changed.
+    func commandingItem(_ item: CommandingItem, didChangeHiddenTo value: Bool)
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Add an `isHidden` property to the `CommandingItem` class and update the `BottomCommandingController` implementation to update its list and tab views when that property changes. The updating in the `BottomCommandingController` was achieved by creating private filtered versions of the `heroItems` and `expandedListSections` arrays. When an item's `isHidden` property is changed, these arrays are re-filtered and the tab view and table view are refreshed to show only not hidden items.

This change is being made for an use case in an internal application.

### Binary change

Total increase: 57,120 bytes
Total decrease: -8 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,167,152 bytes | 30,224,264 bytes | 🛑 57,112 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomCommandingController.o | 889,880 bytes | 925,520 bytes | ⚠️ 35,640 bytes |
| __.SYMDEF | 4,573,832 bytes | 4,584,728 bytes | ⚠️ 10,896 bytes |
| CommandingItem.o | 87,096 bytes | 92,424 bytes | ⚠️ 5,328 bytes |
| FocusRingView.o | 791,528 bytes | 794,992 bytes | ⚠️ 3,464 bytes |
| HUD.o | 262,896 bytes | 263,832 bytes | ⚠️ 936 bytes |
| BadgeField.o | 578,376 bytes | 579,232 bytes | ⚠️ 856 bytes |
| CommandingSection.o | 27,472 bytes | 27,464 bytes | 🎉 -8 bytes |
</details>

### Verification

- Verified with internal application use case
- Verified behavior with the `BottomCommandingDemoController` when items are set to be hidden
  - Added 2 new toggles to the `BottomCommandingDemoController` to toggle the hidden state of both tab and list items 

<details>
<summary>Visual Verification</summary>

### Before
![IMG_0044](https://github.com/microsoft/fluentui-apple/assets/10938746/bb3d68fa-39fb-4f90-bbb9-7376b5461460)
__Above image shows the existing set of toggles before changes were made.__

![IMG_0043](https://github.com/microsoft/fluentui-apple/assets/10938746/0427cce9-4abd-4eac-98af-593a2777c08b)
__Above image shows the existing bottom commanding sheet before changes were made.__

### After

![IMG_0037](https://github.com/microsoft/fluentui-apple/assets/10938746/f004f61a-53cc-40b4-8e59-c629392111e2) 
_Above image shows the new toggles to hide hero and list items in untoggled states._

<img width="399" alt="Screenshot 2023-08-15 at 4 23 27 PM" src="https://github.com/microsoft/fluentui-apple/assets/10938746/54a5ce81-88e8-4ec7-b67c-e202399b0ae6">
_Above image shows the sheet with the hero and list items displayed. None of the items are hidden since the toggles are off._

![IMG_0041](https://github.com/microsoft/fluentui-apple/assets/10938746/4f2d79ed-243f-4559-986e-2ec225fbcfd1)
_Above image shows the new toggles to hide hero and list items in toggled states._

<img width="395" alt="Screenshot 2023-08-15 at 4 27 21 PM" src="https://github.com/microsoft/fluentui-apple/assets/10938746/bda6c5a8-c173-487e-83ff-4c4295da6df0">
_Above image shows the sheet with the hero and list items displayed. Some of the items are hidden since the toggles are on._


https://github.com/microsoft/fluentui-apple/assets/10938746/09da82b9-5431-4ee3-a0a2-371241a1b466
_Above video demos all of the controls touched in this PR. New behavior is the hiding and showing of `heroItems` and `expandedListSection` items._

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/fluentui-apple/pull/1862&drop=dogfoodAlpha