### PR TITLE
Update the AvatarGroup's accessibility label

### DIFF
--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -249,7 +249,7 @@ public struct AvatarGroup: View, TokenizedControlView {
         }
 
         var str: String = ""
-        for i in 0..<displayedAvatarAccessibilityLabels.count - 1 {
+        for i in 0..<displayedAvatarCount - 1 {
             str += String(format: "Accessibility.AvatarGroup.AvatarList".localized, displayedAvatarAccessibilityLabels[i])
         }
         str += String(format: "Accessibility.AvatarGroup.AvatarListLast".localized, displayedAvatarAccessibilityLabels.last ?? "")

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -112,7 +112,7 @@ public struct AvatarGroup: View, TokenizedControlView {
         let enumeratedAvatars = Array(avatars.enumerated())
         let avatarCount: Int = avatars.count
         let maxDisplayedAvatars: Int = state.maxDisplayedAvatars
-        let avatarsToDisplay: Int = min(maxDisplayedAvatars, avatarCount)
+        let avatarsToDisplay = avatarsToDisplay
         let overflowCount: Int = (avatarCount > maxDisplayedAvatars ? avatarCount - maxDisplayedAvatars : 0) + state.overflowCount
         let hasOverflow: Bool = overflowCount > 0
         let isStackStyle = state.style == .stack
@@ -221,6 +221,10 @@ public struct AvatarGroup: View, TokenizedControlView {
         }
 
         return avatarGroupContent
+    }
+
+    var avatarsToDisplay: Int {
+        return min(state.maxDisplayedAvatars, state.avatars.count)
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -218,6 +218,7 @@ public struct AvatarGroup: View, TokenizedControlView {
                    minHeight: groupHeight,
                    maxHeight: .infinity,
                    alignment: .leading)
+            .accessibilityElement(children: .combine)
         }
 
         return avatarGroupContent

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -219,6 +219,7 @@ public struct AvatarGroup: View, TokenizedControlView {
                    maxHeight: .infinity,
                    alignment: .leading)
             .accessibilityElement(children: .combine)
+            .accessibilityLabel(groupLabel)
         }
 
         return avatarGroupContent

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -228,6 +228,33 @@ public struct AvatarGroup: View, TokenizedControlView {
         return min(state.maxDisplayedAvatars, state.avatars.count)
     }
 
+    var displayedAvatarAccessibilityLabels: [String] {
+        var labels: [String] = []
+        for i in 0..<avatarsToDisplay {
+            let avatar = state.avatars[i]
+            labels.append(avatar.accessibilityLabel ?? avatar.primaryText ?? avatar.secondaryText ?? "")
+        }
+        let overflowCount = state.avatars.count - avatarsToDisplay + state.overflowCount
+        if overflowCount > 0 {
+            labels.append(String(format: "Accessibility.AvatarGroup.Overflow.Value".localized, overflowCount))
+        }
+        return labels
+    }
+
+    var groupLabel: String {
+        let displayedAvatarCount = displayedAvatarAccessibilityLabels.count
+        guard displayedAvatarCount > 1 else {
+            return displayedAvatarAccessibilityLabels.last ?? ""
+        }
+        
+        var str: String = ""
+        for i in 0..<displayedAvatarAccessibilityLabels.count - 1 {
+            str += String(format: "Accessibility.AvatarGroup.AvatarList".localized, displayedAvatarAccessibilityLabels[i])
+        }
+        str += String(format: "Accessibility.AvatarGroup.AvatarListLast".localized, displayedAvatarAccessibilityLabels.last ?? "")
+        return str
+    }
+
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.layoutDirection) var layoutDirection: LayoutDirection
     @ObservedObject var state: MSFAvatarGroupStateImpl

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -247,7 +247,7 @@ public struct AvatarGroup: View, TokenizedControlView {
         guard displayedAvatarCount > 1 else {
             return displayedAvatarAccessibilityLabels.last ?? ""
         }
-        
+
         var str: String = ""
         for i in 0..<displayedAvatarAccessibilityLabels.count - 1 {
             str += String(format: "Accessibility.AvatarGroup.AvatarList".localized, displayedAvatarAccessibilityLabels[i])

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 /* Accessibility multi select hint for common use */
 "Accessibility.MultiSelect.Hint" = "Double tap to toggle selection";
 
+/* Accessibility: Used to list the Avatars in the AvatarGroup, i.e. 'Kat Larsson, Kristin Patterson, ' */
+"Accessibility.AvatarGroup.AvatarList" = "%@, ";
+/* Accessibility: Used for the last Avatar in the AvatarGroup, i.e. 'and Ashley McCarthy' or 'and 1 other' */
+"Accessibility.AvatarGroup.AvatarListLast" = "and %@";
+
 /* Accessibility label for the upper calendar date picker view. */
 "Accessibility.Calendar.Label" = "Calendar";
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.stringsdict
@@ -2,6 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!--> Accessibility: Used in the AvatarGroup for how many Avatars are represented by the overflow, i.e. "3 others" </!-->
 	<key>Accessibility.AvatarGroup.Overflow.Value</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.stringsdict
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.stringsdict
@@ -2,6 +2,28 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Accessibility.AvatarGroup.Overflow.Value</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@others@</string>
+		<key>others</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d other</string>
+			<key>two</key>
+			<string>%d others</string>
+			<key>few</key>
+			<string>%d others</string>
+			<key>many</key>
+			<string>%d others</string>
+			<key>other</key>
+			<string>%d others</string>
+		</dict>
+	</dict>
 	<key>Accessibility.DateTime.Hour.Value</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

The current AvatarGroup VoiceOver experience makes the user iterate through each individual Avatar, rather than reading out the entire group. With this change, VoiceOver will read the entire AvatarGroup as a single group, which also allows the user to get over the AvatarGroup faster. This also uses the .stringsdict to localize the overflow count, so that we can better match plurality in other localizations.

### Binary change

Total increase: 43,792 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,470,952 bytes | 30,514,744 bytes | ⚠️ 43,792 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| AvatarGroup.o | 321,064 bytes | 357,400 bytes | ⚠️ 36,336 bytes |
| __.SYMDEF | 4,692,248 bytes | 4,699,688 bytes | ⚠️ 7,440 bytes |
| MSFAvatarGroup.o | 27,688 bytes | 27,704 bytes | ⚠️ 16 bytes |
</details>

### Verification

Videos below, but edge cases here:
- Reads out just the name of the person if there's a single avatar
- Reads out "X others" if there's only overflow
- Has no label if there's no avatars
- Overflow label is "1 other" for 1 overflow, "X others" for any number greater (in English).

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![AvatarGroup_Before](https://github.com/microsoft/fluentui-apple/assets/67026548/638779df-c82d-4c02-b4d3-8f84743dee82) | ![AvatarGroup_After](https://github.com/microsoft/fluentui-apple/assets/67026548/05c6657f-01f4-408a-aa0f-73823543f57a) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1863)