### PR TITLE
[ListItem] Support VoiceOver

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -182,51 +182,6 @@ struct ListItemDemoView: View {
                         .alert("Detail button tapped", isPresented: $showingAlert) {
                             Button("OK", role: .cancel) { }
                         }
-                        ListItem(title: title,
-                                 subtitle: showSubtitle ? subtitle : "",
-                                 footer: showFooter ? footer : "",
-                                 leadingContent: {
-                            if showLeadingContent {
-                                leadingContent
-                            }
-                        },
-                                 trailingContent: {
-                            if showTrailingContent {
-                                switch trailingContentFocusableElementCount {
-                                case 0:
-                                    Text("Spreadsheet")
-                                case 1:
-                                    Toggle("", isOn: $trailingContentToggleEnabled)
-                                default:
-                                    HStack {
-                                        Button {
-                                            showingAlert = true
-                                        } label: {
-                                            Text("Button 1")
-                                        }
-                                        Button {
-                                            showingAlert = true
-                                        } label: {
-                                            Text("Button 2")
-                                        }
-
-                                    }
-                                }
-                            }
-                        })
-                        .backgroundStyleType(backgroundStyle)
-                        .accessoryType(accessoryType)
-                        .leadingContentSize(leadingContentSize)
-                        .titleLineLimit(titleLineLimit)
-                        .subtitleLineLimit(subtitleLineLimit)
-                        .footerLineLimit(footerLineLimit)
-                        .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-                        .onAccessoryTapped {
-                            showingAlert = true
-                        }
-                        .alert("Detail button tapped", isPresented: $showingAlert) {
-                            Button("OK", role: .cancel) { }
-                        }
                     } header: {
                         Text("ListItem")
                     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -38,6 +38,8 @@ struct ListItemDemoView: View {
     @State var titleLineLimit: Int = 1
     @State var subtitleLineLimit: Int = 1
     @State var footerLineLimit: Int = 1
+    @State var trailingContentFocusableElementCount: Int = 0
+    @State var trailingContentToggleEnabled: Bool = true
 
     public var body: some View {
 
@@ -107,6 +109,9 @@ struct ListItemDemoView: View {
             Stepper(value: $footerLineLimit, in: 0...5) {
                 Text("Footer Line Limit: \(footerLineLimit)")
             }
+            Stepper(value: $trailingContentFocusableElementCount, in: 0...2) {
+                Text("Trailing Content focusable element count: \(trailingContentFocusableElementCount)")
+            }
         }
 
         @ViewBuilder
@@ -129,11 +134,6 @@ struct ListItemDemoView: View {
         }
 
         @ViewBuilder
-        var trailingContent: some View {
-            Text("Spreadsheet")
-        }
-
-        @ViewBuilder
         var content: some View {
             VStack {
                 List {
@@ -148,7 +148,25 @@ struct ListItemDemoView: View {
                         },
                                  trailingContent: {
                             if showTrailingContent {
-                                trailingContent
+                                switch trailingContentFocusableElementCount {
+                                case 0:
+                                    Text("Spreadsheet")
+                                case 1:
+                                    Toggle("", isOn: $trailingContentToggleEnabled)
+                                default:
+                                    HStack {
+                                        Button {
+                                            showingAlert = true
+                                        } label: {
+                                            Text("Button 1")
+                                        }
+                                        Button {
+                                            showingAlert = true
+                                        } label: {
+                                            Text("Button 2")
+                                        }
+                                    }
+                                }
                             }
                         })
                         .backgroundStyleType(backgroundStyle)
@@ -157,6 +175,52 @@ struct ListItemDemoView: View {
                         .titleLineLimit(titleLineLimit)
                         .subtitleLineLimit(subtitleLineLimit)
                         .footerLineLimit(footerLineLimit)
+                        .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
+                        .onAccessoryTapped {
+                            showingAlert = true
+                        }
+                        .alert("Detail button tapped", isPresented: $showingAlert) {
+                            Button("OK", role: .cancel) { }
+                        }
+                        ListItem(title: title,
+                                 subtitle: showSubtitle ? subtitle : "",
+                                 footer: showFooter ? footer : "",
+                                 leadingContent: {
+                            if showLeadingContent {
+                                leadingContent
+                            }
+                        },
+                                 trailingContent: {
+                            if showTrailingContent {
+                                switch trailingContentFocusableElementCount {
+                                case 0:
+                                    Text("Spreadsheet")
+                                case 1:
+                                    Toggle("", isOn: $trailingContentToggleEnabled)
+                                default:
+                                    HStack {
+                                        Button {
+                                            showingAlert = true
+                                        } label: {
+                                            Text("Button 1")
+                                        }
+                                        Button {
+                                            showingAlert = true
+                                        } label: {
+                                            Text("Button 2")
+                                        }
+
+                                    }
+                                }
+                            }
+                        })
+                        .backgroundStyleType(backgroundStyle)
+                        .accessoryType(accessoryType)
+                        .leadingContentSize(leadingContentSize)
+                        .titleLineLimit(titleLineLimit)
+                        .subtitleLineLimit(subtitleLineLimit)
+                        .footerLineLimit(footerLineLimit)
+                        .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
                         .onAccessoryTapped {
                             showingAlert = true
                         }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -160,8 +160,6 @@ public struct ListItem<LeadingContent: View,
                                     leading: ListItemTokenSet.paddingLeading,
                                     bottom: ListItemTokenSet.paddingVertical,
                                     trailing: accessoryType == .none ? ListItemTokenSet.paddingTrailing : 0))
-                // A non clear background must be applied for VoiceOver focus ring to be around the padded view
-                .background(backgroundView)
                 .accessibilityElement(children: .combine)
                 .accessibilitySortPriority(2)
                 if !combineTrailingContentAccessibilityElement {

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -147,7 +147,7 @@ public struct ListItem<LeadingContent: View,
                                 bottom: ListItemTokenSet.paddingVertical,
                                 trailing: ListItemTokenSet.paddingTrailing))
             .frame(minHeight: layoutType.minHeight)
-            .background(backgroundView)
+            .listRowBackground(backgroundView)
             .listRowInsets(EdgeInsets())
             .modifyIf(accessoryType != .detailButton) { content in
                 content

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -101,6 +101,8 @@ public struct ListItem<LeadingContent: View,
                         image
                     }
                     .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
+                    .accessibility(label: Text("Accessibility.TableViewCell.MoreActions.Label".localized))
+                    .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
                 } else {
                     image
                 }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -163,10 +163,17 @@ public struct ListItem<LeadingContent: View,
                 // A non clear background must be applied for VoiceOver focus ring to be around the padded view
                 .background(backgroundView)
                 .accessibilityElement(children: .combine)
+                .accessibilitySortPriority(2)
                 if !combineTrailingContentAccessibilityElement {
                     trailingContentView
+                        .modifyIf(accessoryType == .none, { content in
+                            content
+                                .padding(.trailing, ListItemTokenSet.paddingTrailing)
+                        })
+                        .accessibilitySortPriority(1)
                 }
                 accessoryView
+                    .accessibilityElement(children: .contain)
             }
             .frame(minHeight: layoutType.minHeight)
             .background(backgroundView)

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -86,7 +86,7 @@ public struct ListItem<LeadingContent: View,
 
         @ViewBuilder
         var accessoryView: some View {
-            if let accessoryType = accessoryType,
+            if accessoryType != .none,
                let icon = accessoryType.icon,
                let iconColor = accessoryType.iconColor(tokenSet: tokenSet, fluentTheme: fluentTheme) {
                 let image = Image(uiImage: icon)
@@ -121,21 +121,24 @@ public struct ListItem<LeadingContent: View,
         @ViewBuilder
         var contentView: some View {
             HStack(alignment: .center) {
-                if let leadingContent {
-                    leadingContent()
-                        .frame(width: tokenSet[.customViewDimensions].float,
-                               height: tokenSet[.customViewDimensions].float)
-                        .padding(.trailing, tokenSet[.customViewTrailingMargin].float)
-                        .accessibilityIdentifier(AccessibilityIdentifiers.leadingContent)
+                HStack {
+                    if let leadingContent {
+                        leadingContent()
+                            .frame(width: tokenSet[.customViewDimensions].float,
+                                   height: tokenSet[.customViewDimensions].float)
+                            .padding(.trailing, tokenSet[.customViewTrailingMargin].float)
+                            .accessibilityIdentifier(AccessibilityIdentifiers.leadingContent)
+                    }
+                    labelStack
+                        .padding(.trailing, ListItemTokenSet.horizontalSpacing)
+                    Spacer()
+                    if let trailingContent {
+                        trailingContent()
+                            .tint(Color(fluentTheme.color(.brandForeground1)))
+                            .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
+                    }
                 }
-                labelStack
-                    .padding(.trailing, ListItemTokenSet.horizontalSpacing)
-                Spacer()
-                if let trailingContent {
-                    trailingContent()
-                        .tint(Color(fluentTheme.color(.brandForeground1)))
-                        .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
-                }
+                .accessibilityElement(children: .combine)
                 accessoryView
                     .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
@@ -146,6 +149,10 @@ public struct ListItem<LeadingContent: View,
             .frame(minHeight: layoutType.minHeight)
             .background(backgroundView)
             .listRowInsets(EdgeInsets())
+            .modifyIf(accessoryType != .detailButton) { content in
+                content
+                    .accessibilityElement(children: .combine)
+            }
         }
 
         return contentView
@@ -194,7 +201,7 @@ public struct ListItem<LeadingContent: View,
     // MARK: Internal variables
 
     /// The `ListItemAccessoryType` that the view should display.
-    var accessoryType: ListItemAccessoryType?
+    var accessoryType: ListItemAccessoryType = .none
 
     /// The background styling of the `ListItem` to match the type of `List` it is displayed in.
     var backgroundStyleType: ListItemBackgroundStyleType = .plain

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -111,6 +111,7 @@ public struct ListItem<LeadingContent: View,
                     .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
                 } else {
                     image
+                        .accessibilityHidden(true)
                 }
             }
         }
@@ -125,22 +126,34 @@ public struct ListItem<LeadingContent: View,
         }
 
         @ViewBuilder
+        var leadingContentView: some View {
+            if let leadingContent {
+                leadingContent()
+                    .frame(width: tokenSet[.customViewDimensions].float,
+                           height: tokenSet[.customViewDimensions].float)
+                    .padding(.trailing, tokenSet[.customViewTrailingMargin].float)
+                    .accessibilityIdentifier(AccessibilityIdentifiers.leadingContent)
+            }
+        }
+
+        @ViewBuilder
+        var trailingContentView: some View {
+            if let trailingContent {
+                trailingContent()
+                    .tint(Color(fluentTheme.color(.brandForeground1)))
+                    .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
+            }
+        }
+
+        @ViewBuilder
         var contentView: some View {
             HStack(alignment: .center) {
                 HStack {
-                    if let leadingContent {
-                        leadingContent()
-                            .frame(width: tokenSet[.customViewDimensions].float,
-                                   height: tokenSet[.customViewDimensions].float)
-                            .padding(.trailing, tokenSet[.customViewTrailingMargin].float)
-                            .accessibilityIdentifier(AccessibilityIdentifiers.leadingContent)
-                    }
+                    leadingContentView
                     labelStack
                     Spacer()
-                    if let trailingContent {
-                        trailingContent()
-                            .tint(Color(fluentTheme.color(.brandForeground1)))
-                            .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
+                    if combineTrailingContentAccessibilityElement {
+                        trailingContentView
                     }
                 }
                 .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
@@ -148,18 +161,16 @@ public struct ListItem<LeadingContent: View,
                                     bottom: ListItemTokenSet.paddingVertical,
                                     trailing: accessoryType == .none ? ListItemTokenSet.paddingTrailing : 0))
                 // A non clear background must be applied for VoiceOver focus ring to be around the padded view
-
                 .background(backgroundView)
                 .accessibilityElement(children: .combine)
+                if !combineTrailingContentAccessibilityElement {
+                    trailingContentView
+                }
                 accessoryView
             }
             .frame(minHeight: layoutType.minHeight)
             .background(backgroundView)
             .listRowInsets(EdgeInsets())
-            .modifyIf(accessoryType != .detailButton) { content in
-                content
-                    .accessibilityElement(children: .combine)
-            }
         }
 
         return contentView
@@ -236,6 +247,9 @@ public struct ListItem<LeadingContent: View,
 
     /// Tokens associated with the `ListItem`.
     var tokenSet: ListItemTokenSet
+
+    /// Whether or not the `TrailingContent` should be combined or be a separate accessibility element.
+    var combineTrailingContentAccessibilityElement: Bool = true
 
     // MARK: Private variables
 

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -92,6 +92,12 @@ public struct ListItem<LeadingContent: View,
                 let image = Image(uiImage: icon)
                     .foregroundColor(Color(uiColor: iconColor))
                     .accessibilityIdentifier(AccessibilityIdentifiers.accessoryImage)
+                    .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
+                                        leading: ListItemTokenSet.horizontalSpacing,
+                                        bottom: ListItemTokenSet.paddingVertical,
+                                        trailing: ListItemTokenSet.paddingTrailing))
+                    // A non clear background must be applied for VoiceOver focus ring to be around the padded view
+                    .background(backgroundView)
                 if accessoryType == .detailButton {
                     SwiftUI.Button {
                         if let onAccessoryTapped = onAccessoryTapped {
@@ -130,7 +136,6 @@ public struct ListItem<LeadingContent: View,
                             .accessibilityIdentifier(AccessibilityIdentifiers.leadingContent)
                     }
                     labelStack
-                        .padding(.trailing, ListItemTokenSet.horizontalSpacing)
                     Spacer()
                     if let trailingContent {
                         trailingContent()
@@ -138,16 +143,18 @@ public struct ListItem<LeadingContent: View,
                             .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
                     }
                 }
+                .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
+                                    leading: ListItemTokenSet.paddingLeading,
+                                    bottom: ListItemTokenSet.paddingVertical,
+                                    trailing: accessoryType == .none ? ListItemTokenSet.paddingTrailing : 0))
+                // A non clear background must be applied for VoiceOver focus ring to be around the padded view
+
+                .background(backgroundView)
                 .accessibilityElement(children: .combine)
                 accessoryView
-                    .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
-            .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
-                                leading: ListItemTokenSet.paddingLeading,
-                                bottom: ListItemTokenSet.paddingVertical,
-                                trailing: ListItemTokenSet.paddingTrailing))
             .frame(minHeight: layoutType.minHeight)
-            .listRowBackground(backgroundView)
+            .background(backgroundView)
             .listRowInsets(EdgeInsets())
             .modifyIf(accessoryType != .detailButton) { content in
                 content

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -171,7 +171,6 @@ public struct ListItem<LeadingContent: View,
                         .accessibilitySortPriority(1)
                 }
                 accessoryView
-                    .accessibilityElement(children: .contain)
             }
             .frame(minHeight: layoutType.minHeight)
             .background(backgroundView)

--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -67,4 +67,14 @@ public extension ListItem {
         listItem.tokenSet = ListItemTokenSet(customViewSize: { size })
         return listItem
     }
+
+    /// If the `TrailingContent` should be handled as its own accessibility element or not. If the `TrailingContent` has multiple
+    /// focusable elements, then not combining it would allow for each element to receive focus with VoiceOver.
+    /// - Parameter value: Whether or not the trailing content should be combined or be a separate accessibility element.
+    /// - Returns: The modified `ListItem` with the property set.
+    func combineTrailingContentAccessibilityElement(_ value: Bool) -> ListItem {
+        var listItem = self
+        listItem.combineTrailingContentAccessibilityElement = value
+        return listItem
+    }
 }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

The changes made are to match the VoiceOver functionality that is in `MSFTableViewCell`.

To achieve this, the views needed to be combined into one accessibility element so that they would be read together. The edge cases are for the accessory type of `detailButton` and `trailingContent`. For the `detailButton`, it will be the next item in the accessibility tree after reading out the title/subtitle/footer. It will also get its own focus.

For `trailingContent`, it has two scenarios:
1. one focusable element. For example, a toggle on the trailing edge. In this scenario we would want the toggle to be apart of the same accessibility element as the text so that it is all read at once and doesnt require another swipe to navigate to it.
2. more than one focusable element. If an array of buttons were to be supplied, we would want to be able to navigate to each individually. 

To support these variations, it requires a bit of a change of the view hierarchy. The default will be `#1`. This will put the `trailingContent` in the same `HStack` as the text so that it can be combined for one accessibility element. For `#2`, a modifier is provided so a client can explicitly tell if the `trailingContent` should not be combined. This will result in the `trailingContent` being outside of the `HStack` of the rest of the content. Because `trailingContent` is generic content we dont have a way to determine what type of view it is, so we cant just check if it is `Toggle` like we do in `MSFTableViewCell` for `UISwitch`.

### Binary change

N/A

### Verification

https://github.com/microsoft/fluentui-apple/assets/21343215/ef063ef4-af40-47a2-aed7-9f4de4459c0d

### Pull request checklist


This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1864)