### PR TITLE
Add an unread dot to the AvatarGroup

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -588,6 +588,7 @@ class AvatarGroupDemoController: DemoTableViewController {
 
                 avatarGroup.state.maxDisplayedAvatars = maxDisplayedAvatars
                 avatarGroup.state.overflowCount = overflowCount
+                avatarGroup.state.isUnread = row.avatarSize == .size20
                 avatarGroupsForCurrentSection.updateValue(avatarGroup, forKey: row)
                 allDemoAvatarGroupsCombined.append(avatarGroup)
             }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -227,7 +227,7 @@ public struct AvatarGroup: View, TokenizedControlView {
                             // dot instead of having the stroke centered on the edge of the dot, but it needs to be
                             // inset slightly to not have a gap.
                             .padding(strokeWidth / 2 - strokeInset)
-                            .overlay() {
+                            .overlay {
                                 Circle()
                                     .stroke(Color(tokenSet[.backgroundColor].uiColor),
                                             lineWidth: strokeWidth)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -197,9 +197,7 @@ public struct AvatarGroup: View, TokenizedControlView {
         }
 
         @ViewBuilder
-        var avatarGroupContent: some View {
-            let animation = Animation.linear(duration: animationDuration)
-
+        var avatarGroup: some View {
             HStack(spacing: 0) {
                 ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
                     avatarView(at: index, for: avatar)
@@ -213,19 +211,52 @@ public struct AvatarGroup: View, TokenizedControlView {
                     .transition(AnyTransition.opacity)
                 }
             }
-            .animation(animation, value: state.avatars)
-            .animation(animation, value: [state.maxDisplayedAvatars, state.overflowCount])
-            .animation(animation, value: state.style)
-            .animation(animation, value: state.size)
-            .frame(maxWidth: .infinity,
-                   minHeight: groupHeight,
-                   maxHeight: .infinity,
-                   alignment: .leading)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(groupLabel)
         }
 
-        return avatarGroupContent
+        @ViewBuilder
+        var unreadGroup: some View {
+            if state.isUnread {
+                let strokeWidth = AvatarGroupTokenSet.unreadDotStrokeWidth
+                let dotSize = AvatarGroupTokenSet.unreadDotSize
+                avatarGroup
+                    .overlay(alignment: .topTrailing) {
+                        Circle()
+                            .foregroundColor(Color(tokenSet[.unreadDotColor].uiColor))
+                            .frame(width: dotSize, height: dotSize)
+                            // Add half the strokeWidth as padding to get the stroke drawn around the outside of the
+                            // dot instead of having the stroke centered on the edge of the dot, but it needs to be
+                            // inset slightly to not have a gap.
+                            .padding(strokeWidth / 2 - strokeInset)
+                            .overlay() {
+                                Circle()
+                                    .stroke(Color(tokenSet[.backgroundColor].uiColor),
+                                            lineWidth: strokeWidth)
+                            }
+                            .offset(x: AvatarGroupTokenSet.unreadDotHorizontalOffset,
+                                    y: AvatarGroupTokenSet.unreadDotVerticalOffset)
+                    }
+            } else {
+                avatarGroup
+            }
+        }
+
+        @ViewBuilder
+        var animatedGroup: some View {
+            let animation = Animation.linear(duration: animationDuration)
+            unreadGroup
+                .animation(animation, value: state.avatars)
+                .animation(animation, value: [state.maxDisplayedAvatars, state.overflowCount])
+                .animation(animation, value: state.style)
+                .animation(animation, value: state.size)
+                .frame(maxWidth: .infinity,
+                       minHeight: groupHeight,
+                       maxHeight: .infinity,
+                       alignment: .leading)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(groupLabel)
+        }
+
+        return animatedGroup
     }
 
     var avatarsToDisplay: Int {
@@ -269,6 +300,7 @@ public struct AvatarGroup: View, TokenizedControlView {
     @ObservedObject var state: MSFAvatarGroupStateImpl
 
     private let animationDuration: CGFloat = 0.1
+    private let strokeInset: CGFloat = 0.1
 
     private func createOverflow(count: Int) -> Avatar {
         let state = MSFAvatarStateImpl(style: .overflow, size: state.size)

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -193,7 +193,7 @@ public struct AvatarGroup: View, TokenizedControlView {
                                        style: FillStyle(eoFill: true))
                     })
             }
-            .padding(.trailing, isStackStyle ? stackPadding : interspace)
+            .padding(.trailing, (isLastDisplayed && !hasOverflow) ? 0 : isStackStyle ? stackPadding : interspace)
         }
 
         @ViewBuilder

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -16,6 +16,9 @@ import SwiftUI
     /// items than just the remainder of the avatars that could not be displayed due to the maxDisplayedAvatars property.
     var overflowCount: Int { get set }
 
+    /// Show a top-trailing aligned unread dot when set to true.
+    var isUnread: Bool { get set }
+
     ///  Style of the AvatarGroup.
     var style: MSFAvatarGroupStyle { get set }
 
@@ -301,6 +304,7 @@ class MSFAvatarGroupStateImpl: ControlState, MSFAvatarGroupState {
     @Published var avatars: [MSFAvatarGroupAvatarStateImpl] = []
     @Published var maxDisplayedAvatars: Int = Int.max
     @Published var overflowCount: Int = 0
+    @Published var isUnread: Bool = false
 
     @Published var style: MSFAvatarGroupStyle
     @Published var size: MSFAvatarSize

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -256,6 +256,11 @@ public struct AvatarGroup: View, TokenizedControlView {
             str += String(format: "Accessibility.AvatarGroup.AvatarList".localized, displayedAvatarAccessibilityLabels[i])
         }
         str += String(format: "Accessibility.AvatarGroup.AvatarListLast".localized, displayedAvatarAccessibilityLabels.last ?? "")
+
+        if state.isUnread {
+            str = String(format: "Accessibility.TabBarItemView.UnreadFormat".localized, str)
+        }
+
         return str
     }
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroupTokenSet.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroupTokenSet.swift
@@ -9,18 +9,26 @@ import SwiftUI
 /// Design token set for the `AvatarGroup` control
 public class AvatarGroupTokenSet: ControlTokenSet<AvatarGroupTokenSet.Tokens> {
     public enum Tokens: TokenSetKey {
+        /// Defines the color around the unread dot.
+        case backgroundColor
+
         /// CGFloat that defines the space between  the `Avatar` controls hosted by the `AvatarGroup`.
         case interspace
+
+        /// Defines the color of the unread dot.
+        case unreadDotColor
     }
 
     init(style: @escaping () -> MSFAvatarGroupStyle,
          size: @escaping () -> MSFAvatarSize) {
         self.style = style
         self.size = size
-        super.init { [style, size] token, _ in
-            return .float {
-                switch token {
-                case .interspace:
+        super.init { [style, size] token, theme in
+            switch token {
+            case .backgroundColor:
+                return .uiColor { theme.color(.background1) }
+            case .interspace:
+                return .float {
                     switch style() {
                     case .stack:
                         switch size() {
@@ -43,6 +51,8 @@ public class AvatarGroupTokenSet: ControlTokenSet<AvatarGroupTokenSet.Tokens> {
                         }
                     }
                 }
+            case .unreadDotColor:
+                return .uiColor { theme.color(.brandForeground1) }
             }
         }
     }
@@ -52,4 +62,18 @@ public class AvatarGroupTokenSet: ControlTokenSet<AvatarGroupTokenSet.Tokens> {
 
     /// Defines the size of the `Avatar` controls in the `AvatarGroup`.
     var size: () -> MSFAvatarSize
+}
+
+extension AvatarGroupTokenSet {
+    /// Size of the background behind the unread dot.
+    static let unreadDotStrokeWidth: CGFloat = GlobalTokens.stroke(.width20)
+
+    /// Size of the unread dot.
+    static let unreadDotSize: CGFloat = 8.0
+
+    /// Vertical offset of the unread dot.
+    static let unreadDotVerticalOffset: CGFloat = -3.0
+
+    /// Horizontal offset of the unread dot.
+    static let unreadDotHorizontalOffset: CGFloat = 7.0
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adds an 8pt unread dot to the AvatarGroup. The dot will also draw with a 2pt `background1` stroke around it. I also had to adjust the padding of the final Avatar in the group, since we usually inset the trailing padding of the Avatars in the group to draw the next Avatar in the correct location.

### Binary change

Total increase: 99,480 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,514,784 bytes | 30,614,264 bytes | 🛑 99,480 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| AvatarGroup.o | 357,440 bytes | 423,088 bytes | 🛑 65,648 bytes |
| __.SYMDEF | 4,699,688 bytes | 4,721,200 bytes | ⚠️ 21,512 bytes |
| AvatarGroupTokenSet.o | 46,440 bytes | 53,296 bytes | ⚠️ 6,856 bytes |
| IndeterminateProgressBar.o | 231,616 bytes | 234,176 bytes | ⚠️ 2,560 bytes |
| FluentTheme.o | 183,352 bytes | 184,848 bytes | ⚠️ 1,496 bytes |
| FocusRingView.o | 801,968 bytes | 803,296 bytes | ⚠️ 1,328 bytes |
| TokenizedControlView.o | 166,280 bytes | 166,360 bytes | ⚠️ 80 bytes |
</details>

### Verification

<img width="145" alt="AvatarGroup_UnreadDot" src="https://github.com/microsoft/fluentui-apple/assets/67026548/000017ed-002d-4763-9d44-8f8932b91c66">

VoiceOver will also read out that the AvatarGroup is unread, along with the rest of the updated accessibility label.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1866)