### PR TITLE
Add accessibility label to navigation bar's back button

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -349,6 +349,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
                                              target: nil,
                                              action: #selector(NavigationBarBackButtonDelegate.backButtonWasPressed))
         backButtonItem.accessibilityIdentifier = "Back"
+        backButtonItem.accessibilityLabel = "Accessibility.NavigationBar.BackLabel".localized
         return backButtonItem
     }()
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -103,6 +103,9 @@
 /* Accessibility label for the avatar (or profile) view */
 "Accessibility.LargeTitle.ProfileView" = "Account Profile";
 
+/* Accessibility label for the navigation bar's back button */
+"Accessibility.NavigationBar.BackLabel" = "Back";
+
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
 

--- a/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
+++ b/ios/FluentUI/Resources/Localization/en.lproj/Localizable.strings
@@ -9,25 +9,24 @@
 
 /* Accessibility alert for common use */
 "Accessibility.Alert" = "Alert";
-/* Accessibility dismiss label for common use */
-"Accessibility.Dismiss.Label" = "Dismiss";
-/* Accessibility dismiss hint for common use */
-"Accessibility.Dismiss.Hint" = "Double tap to dismiss";
-/* Accessibility done label for common use */
-"Accessibility.Done.Label" = "Done";
-/* Accessibility multi select hint for common use */
-"Accessibility.MultiSelect.Hint" = "Double tap to toggle selection";
-
 /* Accessibility: Used to list the Avatars in the AvatarGroup, i.e. 'Kat Larsson, Kristin Patterson, ' */
 "Accessibility.AvatarGroup.AvatarList" = "%@, ";
 /* Accessibility: Used for the last Avatar in the AvatarGroup, i.e. 'and Ashley McCarthy' or 'and 1 other' */
 "Accessibility.AvatarGroup.AvatarListLast" = "and %@";
-
-/* Accessibility label for the upper calendar date picker view. */
-"Accessibility.Calendar.Label" = "Calendar";
-
+/* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
+"Accessibility.AvatarView.LabelFormat" = "%@, %@";
 /* Accessibility hint for the upper calendar date picker view */
 "Accessibility.Calendar.Hint" = "Select a date";
+/* Accessibility label for the upper calendar date picker view. */
+"Accessibility.Calendar.Label" = "Calendar";
+/* Accessibility dismiss hint for common use */
+"Accessibility.Dismiss.Hint" = "Double tap to dismiss";
+/* Accessibility dismiss label for common use */
+"Accessibility.Dismiss.Label" = "Dismiss";
+/* Accessibility done label for common use */
+"Accessibility.Done.Label" = "Done";
+/* Accessibility multi select hint for common use */
+"Accessibility.MultiSelect.Hint" = "Double tap to toggle selection";
 
 // TODO: Change to a stringsdict format
 // TODO: Reassess for generic indicator
@@ -97,17 +96,14 @@
 /* Accessibility label for when a task is in progress */
 "Accessibility.HUD.Loading" = "Loading";
 
-/* Accessibility hint for MSPillButtons in an MSPillButtonBar. %1$d is placeholder for index and %2$d is a placeholder for total number of items */
-"Accessibility.MSPillButtonBar.Hint" = "%1$d of %2$d";
-
 /* Accessibility label for the avatar (or profile) view */
 "Accessibility.LargeTitle.ProfileView" = "Account Profile";
 
+/* Accessibility hint for MSPillButtons in an MSPillButtonBar. %1$d is placeholder for index and %2$d is a placeholder for total number of items */
+"Accessibility.MSPillButtonBar.Hint" = "%1$d of %2$d";
+
 /* Accessibility label for the navigation bar's back button */
 "Accessibility.NavigationBar.BackLabel" = "Back";
-
-/* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
-"Accessibility.AvatarView.LabelFormat" = "%@, %@";
 
 /* Accessibility hint for TabBarItemView in TabBarView. %1$d is placeholder for index and %2$d is a placeholder for total number of tab items  */
 "Accessibility.TabBarItemView.Hint" = "%1d of %2d";


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

There is a voiceover regression where the navigation bar's back button reads "button" instead of "back button". It's a regression because old nav bar used to have the native back button which was already set up with the correct accessibility label. In the new nav bar, we use a [custom back button item](https://github.com/microsoft/fluentui-apple/pull/1731/files#diff-525ee9b5c92f443b1a34cc5182f719cab1854bfdc605164eab9033ed6cabbfc5R330) so we need to set up the accessibility label manually. 
This PR adds "back" to localizable resources and uses it as the new accessibility label for the back button.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| VO: "button" | VO: "back button" |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1869)