### PR TITLE
Bottom Commanding more button is showing up unexpectedly & Overflowed HeroItems appear squashed in some cases

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -519,7 +519,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         NSLayoutConstraint.deactivate(heroOverflowStackConstraints)
         let featuredHeroCount: Int
         let featuredHeroItems: [CommandingItem]
-        if prefersSheetMoreButtonVisible {
+        if shouldDisplayMoreButton {
             featuredHeroCount = Constants.heroCommandsPerRow - 1
             featuredHeroItems = (visibleHeroItems.prefix(featuredHeroCount) + [moreHeroItem])
         } else {
@@ -538,7 +538,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
     private func reloadHeroCommandOverflowStack() {
         let commandsPerRow = Constants.heroCommandsPerRow
         heroCommandOverflowStack.removeAllSubviews()
-        let heroOverflowViews = visibleHeroItems.suffix(from: commandsPerRow - (prefersSheetMoreButtonVisible ? 1 : 0)).map { createAndBindHeroCommandView(with: $0, isOverflow: true) }
+        let heroOverflowViews = visibleHeroItems.suffix(from: commandsPerRow - (shouldDisplayMoreButton ? 1 : 0)).map { createAndBindHeroCommandView(with: $0, isOverflow: true) }
         for i in 0...(heroOverflowViews.count / commandsPerRow) {
             var rowViews = Array(heroOverflowViews.suffix(from: i * commandsPerRow).prefix(commandsPerRow))
             let heroCount = rowViews.count
@@ -1045,12 +1045,19 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
 
     private var isExpandable: Bool { visibleExpandedListSections.count > 0 }
 
+    /// Returns `true` if a more button should be shown.
+    ///
+    /// Note: Checking this property is the preferred way to determine if a more button should displayed. Just calling
+    /// `prefersSheetMoreButtonVisible` does not suffice as it does not make all the same checks.
+    private var shouldDisplayMoreButton: Bool {
+        return isExpandable && (prefersSheetMoreButtonVisible || !isInSheetMode)
+    }
+
     private var bottomSheetHeroStackTopConstraint: NSLayoutConstraint?
 
     // Hero items that include the more button if it should be shown
     private var extendedHeroItems: [CommandingItem] {
-        let shouldShowMoreButton = isExpandable && (prefersSheetMoreButtonVisible || !isInSheetMode)
-        return heroItems + (shouldShowMoreButton ? [moreHeroItem] : [])
+        return heroItems + (shouldDisplayMoreButton ? [moreHeroItem] : [])
     }
 
     private var heroCommandWidthConstraints: [NSLayoutConstraint] {

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -743,7 +743,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
             popoverContentViewController.modalPresentationStyle = .popover
             popoverContentViewController.popoverPresentationController?.sourceView = moreButtonView
             popoverContentViewController.popoverPresentationController?.delegate = self
-            popoverContentViewController.preferredContentSize.height = estimatedTableViewHeight
 
             NSLayoutConstraint.activate([
                 tableView.leadingAnchor.constraint(equalTo: popoverContentViewController.view.leadingAnchor),
@@ -751,11 +750,15 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
                 tableView.topAnchor.constraint(equalTo: popoverContentViewController.view.topAnchor),
                 tableView.bottomAnchor.constraint(equalTo: popoverContentViewController.view.bottomAnchor)
             ])
+
             if let tableHeaderView = tableView.tableHeaderView {
                 let fittingSize = tableHeaderView.systemLayoutSizeFitting(CGSize(width: tableView.bounds.width, height: 0))
                 tableHeaderView.frame = CGRect(origin: .zero, size: fittingSize)
                 popoverContentViewController.view.setNeedsLayout()
             }
+
+            popoverContentViewController.preferredContentSize.height = estimatedTableViewHeight
+
             present(popoverContentViewController, animated: true) { [weak self] in
                 guard let strongSelf = self else {
                     return


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#### Issue 1:
It was discovered that the `BottomCommandingController` "More" button was showing up unexpectedly in some cases.

**Root Cause:**
[This change](https://github.com/microsoft/fluentui-apple/commit/2f04446f7c84952205fc8d1f1ad887f9c705faf2) to add overflow support for the BottomCommandingController introduced 2 new checks of `prefersSheetMoreButtonVisible` to determine if the `moreHeroItem` should be shown. These checks are inconsistent with the existing check in `extendedHeroItems`:

```
    private var extendedHeroItems: [CommandingItem] {
        let shouldShowMoreButton = isExpandable && (prefersSheetMoreButtonVisible || !isInSheetMode)
        return heroItems + (shouldShowMoreButton ? [moreHeroItem] : [])
    }
```

This inconsistency is causing the more button to be displayed when it shouldn't be.

**Fix:**
Create a private computed property `shouldDisplayMoreButton` which makes all of the same checks made in `extendedHeroItems`. Replace any internal checks of `prefersSheetMoreButtonVisible` with this new property.

**Verification:**

- Validated in internal application use case
- Validated in Fluent Demo application on iPhone and iPad

<details>
<summary>Visual Verification</summary>

**Before:**

https://github.com/microsoft/fluentui-apple/assets/10938746/54907f2d-2191-467a-ae62-c128acc8a550
The More button is visible and untappable when the "Expanded list items" is `OFF`. This creates what feels like broken UI. More should be hidden.

**After:**

https://github.com/microsoft/fluentui-apple/assets/10938746/6c80f996-763e-4ddd-9cc7-330dbf76b1b6
The More button hides when "Expanded list items" is `OFF` because it would be untappable if shown.

</details>

---

#### Issue 2:
Overflowed hero items shown in the `UITableView.tableHeaderView` of the `presentedPopoverContentViewController` appear squashed on presentation.

**Repro steps:**
- Open BottomCommandController demo on iPad
- Decrement "Hero command count" to show less than 5 items
- Increment "Hero command count" to show 5 or more items
- Tap "More button" 
- Observe

The issue is specific to the iPad.

**Root Cause:**
The `popoverContentViewController.preferredContentSize.height` is to the `estimatedTableViewHeight` before teh the constraining the `tableView` to the `UIViewController.view` resolves the issue. It seems calculating the estimated height for the table view is constraint 

**Fix:**
Move the call to set the `popoverContentViewController.preferredContentSize.height` after the constraining the `tableView` to the `UIViewController.view`.

**Verification:**

- Validated in internal application use case
- Validated in Fluent Demo application on iPhone and iPad

<details>
<summary>Visual Verification</summary>

**Before:**
https://github.com/microsoft/fluentui-apple/assets/10938746/53f47ff0-4203-4f20-9b88-f4249ac45f06
Issue shown with repro steps listed above.

**After:**
https://github.com/microsoft/fluentui-apple/assets/10938746/6bca356b-f7c1-420f-8811-171f56c3c6e7
Fix shown with repro steps listed above.

</details>

---

### Binary change

N/A

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1872)