### PR TITLE
Update Mac legacy Avatar color lookup

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -434,7 +434,7 @@ open class AvatarView: NSView {
 	@available(*, deprecated, message: "Use getInitialsColorSetFromPrimaryText:secondaryText: instead")
 	public static func getLegacyColor(for hashValue: Int) -> NSColor {
 		let legacyAvatarBackgroundColors = AvatarView.legacyAvatarViewBackgroundColor
-		return legacyAvatarBackgroundColors[abs(hashValue) % legacyAvatarBackgroundColors.count]
+		return legacyAvatarBackgroundColors[abs(hashValue % legacyAvatarBackgroundColors.count)]
 	}
 
 	/// the font size in the initials view will be scaled to this fraction of the avatarSize passed in


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

I tried to fix this in #1817, but we're still seeing a crash.
It turns out that `abs(Int.min)` will crash, since it's 1 greater than `Int.max`. I'm not sure that that's the issue causing the crash, but it *could* crash, so it's worth fixing. Moving the `%` operator inside the call to `abs` should only affect users that would've originally been crashing with a negative hash.

### Verification

Sanity check in the test app that the colors of positive hashes remain unchanged.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1873)