### PR TITLE
respect default render mode for main icon of cardnudge

### DIFF
--- a/ios/FluentUI/Card Nudge/CardNudge.swift
+++ b/ios/FluentUI/Card Nudge/CardNudge.swift
@@ -61,8 +61,7 @@ public struct CardNudge: View, TokenizedControlView {
                 RoundedRectangle(cornerRadius: tokenSet[.circleRadius].float)
                     .frame(width: CardNudgeTokenSet.circleSize, height: CardNudgeTokenSet.circleSize)
                     .foregroundColor(Color(tokenSet[.buttonBackgroundColor].uiColor))
-                Image(uiImage: icon)
-                    .renderingMode(.template)
+                Image(uiImage: icon.renderingMode == .automatic ? icon.withRenderingMode(.alwaysTemplate) : icon)
                     .frame(width: CardNudgeTokenSet.iconSize, height: CardNudgeTokenSet.iconSize, alignment: .center)
                     .foregroundColor(Color(tokenSet[.buttonForegroundColor].uiColor))
             }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

If client wants to have its own colored image passed in for main icon for card nudge, lets respect that. 

### Binary change
Total increase: 152 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,488,200 bytes | 30,488,352 bytes | ⚠️ 152 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| CardNudge.o | 447,784 bytes | 447,936 bytes | ⚠️ 152 bytes |
</details>

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  ![Simulator Screenshot - iPhone 14 Pro - 2023-08-24 at 13 10 22](https://github.com/microsoft/fluentui-apple/assets/20715435/320396c7-6e48-49d2-b9d3-4605d28dac80) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-24 at 13 11 02](https://github.com/microsoft/fluentui-apple/assets/20715435/7a2e2457-2cb3-4c85-b863-db92e5eaf3d2) |



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1874)