### PR TITLE
[FluentButton] For smooth background color transition, trigger updateLayer() Immediately after Appearance Changes

### DIFF
--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -265,7 +265,7 @@ open class Button: NSButton {
 
 	open override func viewDidChangeEffectiveAppearance() {
 		super.viewDidChangeEffectiveAppearance()
-		
+
 		// At this point in code, the Appearance of the View has been changed either to darkAqua or
 		// aqua and since this button has Shadow Layers, it relies on updateLayer() getting called
 		// immediately after this function so that all the layers get the correct backgroundColors.

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -263,6 +263,25 @@ open class Button: NSButton {
 		}
 	}
 
+	open override func viewDidChangeEffectiveAppearance() {
+		super.viewDidChangeEffectiveAppearance()
+		
+		// At this point in code, the Appearance of the View has been changed either to darkAqua or
+		// aqua and since this button has Shadow Layers, it relies on updateLayer() getting called
+		// immediately after this function so that all the layers get the correct backgroundColors.
+		// However, based on how layer-backed views operate, updateLayer() isn't called immediately
+		// and is instead backloaded, to be called asynchronously along with all other UI updates
+		// already queued up, at a time determined by the system APIs. Call displayIfNeeded here to
+		// immediately invoke an updateLayer() call. This is especially need in the case where the
+		// Button's container view performs a
+		// (1) setAppearance, (which then triggers a viewDidChangeEffectiveAppearance call)
+		// immediately followed by a
+		// (2) window.toggleFullScreen
+		// where we need the appearance change effects on the layers to to take place BEFORE the
+		// FullScreen toggle, to prevent an overlap in animation changes in Button background colors.
+		displayIfNeeded()
+	}
+
 	open override func updateLayer() {
 		guard let layer = layer else {
 			return

--- a/macos/FluentUI/Button/Button.swift
+++ b/macos/FluentUI/Button/Button.swift
@@ -263,25 +263,6 @@ open class Button: NSButton {
 		}
 	}
 
-	open override func viewDidChangeEffectiveAppearance() {
-		super.viewDidChangeEffectiveAppearance()
-
-		// At this point in code, the Appearance of the View has been changed either to darkAqua or
-		// aqua and since this button has Shadow Layers, it relies on updateLayer() getting called
-		// immediately after this function so that all the layers get the correct backgroundColors.
-		// However, based on how layer-backed views operate, updateLayer() isn't called immediately
-		// and is instead backloaded, to be called asynchronously along with all other UI updates
-		// already queued up, at a time determined by the system APIs. Call displayIfNeeded here to
-		// immediately invoke an updateLayer() call. This is especially need in the case where the
-		// Button's container view performs a
-		// (1) setAppearance, (which then triggers a viewDidChangeEffectiveAppearance call)
-		// immediately followed by a
-		// (2) window.toggleFullScreen
-		// where we need the appearance change effects on the layers to to take place BEFORE the
-		// FullScreen toggle, to prevent an overlap in animation changes in Button background colors.
-		displayIfNeeded()
-	}
-
 	open override func updateLayer() {
 		guard let layer = layer else {
 			return
@@ -333,6 +314,25 @@ open class Button: NSButton {
 		// rather than just around the image or title.
 		let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius)
 		path.fill()
+	}
+
+	open override func viewDidChangeEffectiveAppearance() {
+		super.viewDidChangeEffectiveAppearance()
+
+		// At this point in code, the Appearance of the View has been changed either to darkAqua or
+		// aqua and since this button has Shadow Layers, it relies on updateLayer() getting called
+		// immediately after this function so that all the layers get the correct backgroundColors.
+		// However, based on how layer-backed views operate, updateLayer() isn't called immediately
+		// and is instead backloaded, to be called asynchronously along with all other UI updates
+		// already queued up, at a time determined by the system APIs. Call displayIfNeeded here to
+		// immediately invoke an updateLayer() call. This addresses a specific case where the
+		// Button's container view performs a
+		// (1) setAppearance, (which then triggers a viewDidChangeEffectiveAppearance call)
+		// immediately followed by a
+		// (2) window.toggleFullScreen
+		// where we need the appearance change effects on the layers to to take place BEFORE the
+		// FullScreen toggle, to prevent an overlap in animation changes in Button background colors.
+		displayIfNeeded()
 	}
 
 	public override func viewDidMoveToWindow() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes
When we perform an 
**1. Appearance Change command** on the Button's Container View and then immediately follow that up with a 
**2. FullScreen toggle command**, 
then the button's backgroundColors choke whilst getting updated (when there's a different color for light and dark modes). This is because of how Layer-backed views in Apple work. Realistically viewDidChangeAppearance doesn't immediately invoke an updateLayer (where all the backgroundColors get updated) function call immediately, since the system queues the layer update to be performed at some later UI-update-cycle time on the main thread, along with all the other backlogged updates. But this results in button color updates that appear to "lag" behind in the cases like the one mentioned above. 

### FIX
invoke a `displayIfNeeded()` at the end of the AppearanceChange override, so that the system will "This invoke the NSView draw/update methods _as necessary._" (as per Apple's documentation). 

### Verification
In sample test code, performed an Appearance Toggle immediately followed by a FullScreen Toggle and observed smooth transition of Button Background colors:

		 // Toggle to dark appearance
		 if window.effectiveAppearance.name == .aqua {
			 window.appearance = NSAppearance(named: .darkAqua)
		 } else {
			 window.appearance = NSAppearance(named: .aqua)
		 }
		// Toggle Full Screen
		self.window.toggleFullScreen(nil)

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1875)