### PR TITLE
[ListItem] fix spacing and provide background color API

### DIFF
--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -68,7 +68,7 @@ public struct ListItem<LeadingContent: View,
                         subtitleView
                             .font(Font(tokenSet[.subtitleTwoLinesFont].uiFont))
                             .frame(minHeight: ListItemTokenSet.subtitleTwoLineHeight)
-                    } else if layoutType == .threeLines {
+                    } else {
                         subtitleView
                             .font(Font(tokenSet[.subtitleThreeLinesFont].uiFont))
                             .frame(minHeight: ListItemTokenSet.subtitleThreeLineHeight)
@@ -148,12 +148,13 @@ public struct ListItem<LeadingContent: View,
         @ViewBuilder
         var contentView: some View {
             HStack(alignment: .center) {
-                HStack {
+                HStack(spacing: 0) {
                     leadingContentView
                     labelStack
-                    Spacer()
+                    Spacer(minLength: 0)
                     if combineTrailingContentAccessibilityElement {
                         trailingContentView
+                            .padding(.leading, ListItemTokenSet.horizontalSpacing)
                     }
                 }
                 .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -43,7 +43,7 @@ public struct ListItem<LeadingContent: View,
     /// The background color of `List` based on the style.
     /// - Parameter backgroundStyle: The background style of the `List`.
     /// - Returns: The color to use for the background of `List`.
-    public static func listbackgroundColor(for backgroundStyle: ListItemBackgroundStyleType) -> Color {
+    public static func listBackgroundColor(for backgroundStyle: ListItemBackgroundStyleType) -> Color {
         let tokenSet = ListItemTokenSet(customViewSize: { .default })
         switch backgroundStyle {
         case .grouped:

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -40,6 +40,21 @@ public struct ListItem<LeadingContent: View,
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
     }
 
+    /// The background color of `List` based on the style.
+    /// - Parameter backgroundStyle: The background style of the `List`.
+    /// - Returns: The color to use for the background of `List`.
+    public static func listbackgroundColor(for backgroundStyle: ListItemBackgroundStyleType) -> Color {
+        let tokenSet = ListItemTokenSet(customViewSize: { .default })
+        switch backgroundStyle {
+        case .grouped:
+            return Color(uiColor: tokenSet[.backgroundGroupedColor].uiColor)
+        case .plain:
+            return Color(uiColor: tokenSet[.backgroundColor].uiColor)
+        case .clear, .custom:
+            return .clear
+        }
+    }
+
     public var body: some View {
         tokenSet.update(fluentTheme)
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

The default spacing of an HStack was getting added, making the spacing between the leading content and labels have an extra 8 points.

Also added an API so that the correct fluent color could be retrieved for the background of the list where the ListItem will be displayed.

### Binary change

N/A

### Verification

<details>
<summary>Visual Verification</summary>

Blue box added to show difference in spacing.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-apple/assets/21343215/4da3b727-bee8-4c82-8011-50afc2cd02b0)| 
![image](https://github.com/microsoft/fluentui-apple/assets/21343215/c5c7327d-976d-447f-ae86-b87e6e71be6f)|
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1876)