### PR TITLE
Fix no such module 'FluentUI_ios' on MacCatalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .target(
             name: "FluentUI",
             dependencies: [
-                .target(name: "FluentUI_ios", condition: .when(platforms: [.iOS])),
+                .target(name: "FluentUI_ios", condition: .when(platforms: [.iOS, .macCatalyst])),
                 .target(name: "FluentUI_macos", condition: .when(platforms: [.macOS]))
             ],
             path: "public"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In Swift Package, use FluentUI_ios target for `MacCatalyst` platform.

### Binary change

N/A - Change to Package.swift

### Verification

Before:

Build target on MacCatalyst will fail as no module FluentUI_ios configured for platform.

<img width="720" alt="截屏2023-08-27 下午9 33 06" src="https://github.com/microsoft/fluentui-apple/assets/6781789/c0f34b94-bbc5-4fc2-9b6a-db799b991464">

After:

MacCatalyst target with FluentUI dependency builds successfully.

<img width="544" alt="截屏2023-08-27 下午9 40 08" src="https://github.com/microsoft/fluentui-apple/assets/6781789/f5cdaf09-0f1f-464c-8071-4fe0d87d9cca">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1878)