### PR TITLE
add xcbeautify for our ci results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
       run: scripts/podliblint.sh
     - name: validation
       run: scripts/validation.sh
-    - name: Install xcbeautify
-      run: gem install xcbeautify
   xcodebuild:
     runs-on: macos-13
     strategy:
@@ -41,5 +39,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Switch to current version of Xcode
       run: scripts/xcode_select_current_version.sh
+    - name: Install xcbeautify
+      run: gem install xcbeautify
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
     - name: Switch to current version of Xcode
       run: scripts/xcode_select_current_version.sh
     - name: Install xcbeautify
-      run: gem install xcbeautify
+      run: brew install xcbeautify
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       run: scripts/podliblint.sh
     - name: validation
       run: scripts/validation.sh
-    - name: Install xcpretty
-      run: gem install xcpretty
+    - name: Install xcbeautify
+      run: gem install xcbeautify
   xcodebuild:
     runs-on: macos-13
     strategy:
@@ -41,5 +41,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Switch to current version of Xcode
       run: scripts/xcode_select_current_version.sh
-    - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcpretty
-      run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcpretty
+    - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
+      run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,10 @@ on:
     branches:
       - main
       - main_*
-      - fluent2-tokens
-      - fluent2-colors
   pull_request:
     branches:
       - main
       - main_*
-      - fluent2-tokens
-      - fluent2-colors
 
 jobs:
   validation:
@@ -27,23 +23,17 @@ jobs:
       run: scripts/podliblint.sh
     - name: validation
       run: scripts/validation.sh
+    - name: Install xcpretty
+      run: gem install xcpretty
   xcodebuild:
     runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
         build_command: [
-          'macos_build FluentUITestApp-macOS Debug build test',
           'macos_build FluentUITestApp-macOS Release build test',
           'macos_build FluentUITestApp-macOS Debug build test -destination "platform=macOS,arch=x86_64"',
-          'ios_simulator_build FluentUI-iOS Debug build',
-          'ios_simulator_build FluentUI-iOS Release build',
-          'ios_device_build FluentUI-iOS Debug build',
-          'ios_device_build FluentUI-iOS Release build',
-          'ios_simulator_build Demo.Development Debug build',
-          'ios_simulator_build Demo.Development Release build',
           'ios_simulator_build Demo.Development Debug build test -destination "platform=iOS Simulator,name=iPhone 14 Pro" -test-iterations "2" -retry-tests-on-failure',
-          'ios_device_build Demo.Development Debug build',
           'ios_device_build Demo.Development Release build',
         ]
 
@@ -51,5 +41,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Switch to current version of Xcode
       run: scripts/xcode_select_current_version.sh
-    - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
-      run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }}
+    - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcpretty
+      run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcpretty


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

- To make the build errors and test results little bit more human readable lets start using xcbeautfiy in our ci.
- lets remove CI checks for couple of branches we don't have any more like fluent-token.
- Our CI runs lot of different flavors but i don't think it is all necessary. We can't build and test the demo app without the fluent library builds. Most of the time we just need to ensure our release iOS device builds correctly which isn't as common for normal development cycle.

### Binary change
n/a

### Verification
run ci

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1882)