### PR TITLE
publish test result artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       matrix:
         build_command: [
           'macos_build FluentUITestApp-macOS Release build test',
-          'macos_build FluentUITestApp-macOS Debug build test -destination "platform=macOS,arch=x86_64"',
-          'ios_simulator_build Demo.Development Debug build test -destination "platform=iOS Simulator,name=iPhone 14 Pro" -test-iterations "2" -retry-tests-on-failure',
+          'macos_build FluentUITestApp-macOS Debug build -resultBundlePath TestResults test -destination "platform=macOS,arch=x86_64"',
+          'ios_simulator_build Demo.Development Debug build test -resultBundlePath TestResults -destination "platform=iOS Simulator,name=iPhone 14 Pro"',
           'ios_device_build Demo.Development Release build',
         ]
 
@@ -43,3 +43,18 @@ jobs:
       run: brew install xcbeautify
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
+      continue-on-error: true
+    - name: Zip if TestResults.xcresult bundle exists
+      run: |
+        if [ -d "TestResults.xcresult" ]; then
+          zip -r TestResults.zip TestResults.xcresult
+        else
+          echo "TestResults.xcresult not found."
+        fi
+    - name: Upload TestResults.zip
+      uses: actions/upload-artifact@v3
+      with:
+        name: xctest-results
+        path: TestResults.zip
+        retention-days: 3
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       fail-fast: false
       matrix:
         build_command: [
-          'macos_build FluentUITestApp-macOS Release build test',
-          'macos_build FluentUITestApp-macOS Debug build -resultBundlePath TestResults test -destination "platform=macOS,arch=x86_64"',
-          'ios_simulator_build Demo.Development Debug build test -resultBundlePath TestResults -destination "platform=iOS Simulator,name=iPhone 14 Pro"',
+          'macos_build FluentUITestApp-macOS Release build',
+          'macos_build FluentUITestApp-macOS Debug build -resultBundlePath TestResultsMac test -destination "platform=macOS,arch=x86_64"',
+          'ios_simulator_build Demo.Development Debug build test -resultBundlePath TestResultsiOS -destination "platform=iOS Simulator,name=iPhone 14 Pro"',
           'ios_device_build Demo.Development Release build',
         ]
 
@@ -44,17 +44,29 @@ jobs:
     - name: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
       run: scripts/xcodebuild_wrapper.sh ${{ matrix.build_command }} | xcbeautify
       continue-on-error: true
-    - name: Zip if TestResults.xcresult bundle exists
+    - name: Zip if TestResultsMac.xcresult bundle exists
       run: |
-        if [ -d "TestResults.xcresult" ]; then
-          zip -r TestResults.zip TestResults.xcresult
+        if [ -d "TestResultsMac.xcresult" ]; then
+          zip -r TestResultsMac.zip TestResultsMac.xcresult
         else
-          echo "TestResults.xcresult not found."
+          echo "TestResultsMac.xcresult not found."
         fi
-    - name: Upload TestResults.zip
+    - name: Upload TestResultsMac.zip
       uses: actions/upload-artifact@v3
       with:
-        name: xctest-results
-        path: TestResults.zip
+        name: xctest-resultsMac
+        path: TestResultsMac.zip
         retention-days: 3
-
+    - name: Zip if TestResultsiOS.xcresult bundle exists
+      run: |
+        if [ -d "TestResultsiOS.xcresult" ]; then
+          zip -r TestResultsiOS.zip TestResultsiOS.xcresult
+        else
+          echo "TestResultsiOS.xcresult not found."
+        fi
+    - name: Upload TestResultsiOS.zip
+      uses: actions/upload-artifact@v3
+      with:
+        name: xctest-resultsiOS
+        path: TestResultsiOS.zip
+        retention-days: 3


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

When the CI completes the test, save the xcode test results (which will mega bytes of content), zip it and store it in github artifact for 3 days. 
![image](https://github.com/microsoft/fluentui-apple/assets/20715435/ff4778db-8260-48c9-9b93-e4bdb8d6887e)
<img width="1512" alt="image" src="https://github.com/microsoft/fluentui-apple/assets/20715435/6c9d8251-5d65-49b2-a4dd-35c5b9c57c13">


### Binary change
n/a

### Verification
download artifact after CI and open in xcode

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1885)