### PR TITLE
Change alpha of ListItem when disabled

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -32,6 +32,7 @@ struct ListItemDemoView: View {
     @State var showFooter: Bool = false
     @State var showLeadingContent: Bool = true
     @State var showTrailingContent: Bool = true
+    @State var isDisabled: Bool = false
     @State var accessoryType: ListItemAccessoryType = .none
     @State var leadingContentSize: ListItemLeadingContentSize = .default
     @State var backgroundStyle: ListItemBackgroundStyleType = .grouped
@@ -72,6 +73,7 @@ struct ListItemDemoView: View {
                 .accessibilityIdentifier("leadingContentSwitch")
             FluentUIDemoToggle(titleKey: "Show trailing content", isOn: $showTrailingContent)
                 .accessibilityIdentifier("trailingContentSwitch")
+            FluentUIDemoToggle(titleKey: "Disabled", isOn: $isDisabled)
         }
 
         @ViewBuilder
@@ -179,6 +181,7 @@ struct ListItemDemoView: View {
                         .onAccessoryTapped {
                             showingAlert = true
                         }
+                        .disabled(isDisabled)
                         .alert("Detail button tapped", isPresented: $showingAlert) {
                             Button("OK", role: .cancel) { }
                         }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -189,6 +189,7 @@ public struct ListItem<LeadingContent: View,
                 accessoryView
             }
             .frame(minHeight: layoutType.minHeight)
+            .opacity(isEnabled ? ListItemTokenSet.enabledAlpha : ListItemTokenSet.disabledAlpha)
             .background(backgroundView)
             .listRowInsets(EdgeInsets())
         }
@@ -274,6 +275,7 @@ public struct ListItem<LeadingContent: View,
     // MARK: Private variables
 
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+    @Environment(\.isEnabled) private var isEnabled: Bool
 
     private var leadingContent: (() -> LeadingContent)?
     private var trailingContent: (() -> TrailingContent)?


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

Adds support for changing the alpha of a ListItem when it is disabled.

### Binary change

N/A

### Verification

Added a toggle in the test app to visually test this change.

<details>
<summary>Visual Verification</summary>

| Disabled                                       | Enabled                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screenshot - iPad Air (5th generation) - 2023-09-07 at 11 45 02](https://github.com/microsoft/fluentui-apple/assets/21343215/1fa935e0-961f-47f3-b1fc-16fe0f3b4b74) | ![Simulator Screenshot - iPad Air (5th generation) - 2023-09-07 at 11 45 07](https://github.com/microsoft/fluentui-apple/assets/21343215/ab912e0c-56fc-4284-9b59-863ddbb32a0a) |
</details>


### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1887)