### PR TITLE
[ListItem] Fix static method for getting background color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -179,6 +179,8 @@ struct ListItemDemoView: View {
                         .onAccessoryTapped {
                             showingAlert = true
                         }
+                        .background(ListItem.listBackgroundColor(for: .grouped))
+                        .disabled(isDisabled)
                         .alert("Detail button tapped", isPresented: $showingAlert) {
                             Button("OK", role: .cancel) { }
                         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -180,7 +180,6 @@ struct ListItemDemoView: View {
                             showingAlert = true
                         }
                         .background(ListItem.listBackgroundColor(for: .grouped))
-                        .disabled(isDisabled)
                         .alert("Detail button tapped", isPresented: $showingAlert) {
                             Button("OK", role: .cancel) { }
                         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -181,7 +181,6 @@ struct ListItemDemoView: View {
                         .onAccessoryTapped {
                             showingAlert = true
                         }
-                        .background(ListItem.listBackgroundColor(for: .grouped))
                         .disabled(isDisabled)
                         .alert("Detail button tapped", isPresented: $showingAlert) {
                             Button("OK", role: .cancel) { }
@@ -191,6 +190,7 @@ struct ListItemDemoView: View {
                     }
                     controls
                 }
+                .background(ListItem.listBackgroundColor(for: .grouped))
                 .fluentTheme(fluentTheme)
                 .listStyle(.insetGrouped)
             }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -40,21 +40,6 @@ public struct ListItem<LeadingContent: View,
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
     }
 
-    /// The background color of `List` based on the style.
-    /// - Parameter backgroundStyle: The background style of the `List`.
-    /// - Returns: The color to use for the background of `List`.
-    public static func listBackgroundColor(for backgroundStyle: ListItemBackgroundStyleType) -> Color {
-        let tokenSet = ListItemTokenSet(customViewSize: { .default })
-        switch backgroundStyle {
-        case .grouped:
-            return Color(uiColor: tokenSet[.backgroundGroupedColor].uiColor)
-        case .plain:
-            return Color(uiColor: tokenSet[.backgroundColor].uiColor)
-        case .clear, .custom:
-            return .clear
-        }
-    }
-
     public var body: some View {
         tokenSet.update(fluentTheme)
 
@@ -334,5 +319,24 @@ public extension ListItem where LeadingContent == EmptyView {
         self.trailingContent = trailingContent
         let layoutType = ListItem.layoutType(subtitle: subtitle, footer: footer)
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
+    }
+}
+
+/// Provide defaults for generic types so static methods can be called without needing to specify them.
+public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, Title == String, Subtitle == String, Footer == String {
+
+    /// The background color of `List` based on the style.
+    /// - Parameter backgroundStyle: The background style of the `List`.
+    /// - Returns: The color to use for the background of `List`.
+    static func listBackgroundColor(for backgroundStyle: ListItemBackgroundStyleType) -> Color {
+        let tokenSet = ListItemTokenSet(customViewSize: { .default })
+        switch backgroundStyle {
+        case .grouped:
+            return Color(uiColor: tokenSet[.backgroundGroupedColor].uiColor)
+        case .plain:
+            return Color(uiColor: tokenSet[.backgroundColor].uiColor)
+        case .clear, .custom:
+            return .clear
+        }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

A static method was provided on ListItem to get the background color of the list. This allows for implementations of ListItem to ensure the list has the correct background color. 

The issue is that calling a static method requires that we know the types of the generic content for ListItem. This would require the call to the static method to be something like:
`ListItem<EmptyView, EmptyView, String, String, String>.listBackgroundColor(for: .grouped)`

To handle this scenario better, we can provide default values for the generic content so we can call it like:
`ListItem.listBackgroundColor(for: .grouped)`

### Binary change

N/A

### Verification

Added to the Fluent UI demo app and tested that the background color is shown.


This PR has considered:
- [X] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1889)