### PR TITLE
Fix NavigationBar's title view constraints

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -873,21 +873,17 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     }
 
     private func updateTitleViewConstraints() {
-        if var titleViewConstraints = titleViewConstraints {
-            NSLayoutConstraint.deactivate(titleViewConstraints)
-            titleViewConstraints.removeAll()
-        }
-
-        titleViewConstraints = [titleView.topAnchor.constraint(equalTo: topAnchor),
-                                titleView.bottomAnchor.constraint(equalTo: bottomAnchor)]
-        
-        if usesLeadingTitle {
-            titleViewConstraints?.append(preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0))
-        }
-
         if let titleViewConstraints = titleViewConstraints {
-            NSLayoutConstraint.activate(titleViewConstraints)
+            NSLayoutConstraint.deactivate(titleViewConstraints)
         }
+
+        let constraints = [titleView.topAnchor.constraint(equalTo: topAnchor),
+                           titleView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+
+        preTitleSpacerView.isHidden = usesLeadingTitle
+
+        NSLayoutConstraint.activate(constraints)
+        titleViewConstraints = constraints
     }
 
     private func updateShadow(for navigationItem: UINavigationItem?) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -571,7 +571,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             updateElementSizes()
             updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
             updateViewsForLargeTitlePresentation(for: topItem)
-            updateFakeCenterTitleConstraints()
+            updateTitleViewConstraints()
 
             // change bar button image size and title inset depending on device rotation
             if let navigationItem = topItem {
@@ -662,7 +662,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
         titleView.update(with: navigationItem)
 
-        updateFakeCenterTitleConstraints()
+        updateTitleViewConstraints()
 
         if navigationItem.backButtonTitle == nil {
             navigationItem.backButtonTitle = ""
@@ -872,7 +872,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         updateShadow(for: navigationItem)
     }
 
-    private func updateFakeCenterTitleConstraints() {
+    private func updateTitleViewConstraints() {
         if var titleViewConstraints = titleViewConstraints {
             NSLayoutConstraint.deactivate(titleViewConstraints)
             titleViewConstraints.removeAll()

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -878,17 +878,13 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             titleViewConstraints.removeAll()
         }
 
-        if !usesLeadingTitle && systemWantsCompactNavigationBar {
-            // If we're drawing our own system-style bar above the OS bar, align our title with the OS's
-            titleViewConstraints = [titleView.centerXAnchor.constraint(equalTo: centerXAnchor)]
-        } else {
-            // Otherwise, keep `self.titleView` leading-justified
-            titleViewConstraints = [preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0),
-                                    titleView.topAnchor.constraint(equalTo: topAnchor),
-                                    titleView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+        if usesLeadingTitle {
+            titleViewConstraints = [preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0)]
         }
 
-        if let titleViewConstraints = titleViewConstraints {
+        if var titleViewConstraints = titleViewConstraints {
+            titleViewConstraints.append(titleView.topAnchor.constraint(equalTo: topAnchor))
+            titleViewConstraints.append(titleView.bottomAnchor.constraint(equalTo: bottomAnchor))
             NSLayoutConstraint.activate(titleViewConstraints)
         }
     }

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -317,7 +317,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
-    private var titleViewConstraint: NSLayoutConstraint?
+    private var titleViewConstraints: [NSLayoutConstraint]?
 
     private(set) var usesLeadingTitle: Bool = true {
         didSet {
@@ -873,18 +873,24 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     }
 
     private func updateFakeCenterTitleConstraints() {
-        titleViewConstraint?.isActive = false
+        if var titleViewConstraints = titleViewConstraints {
+            NSLayoutConstraint.deactivate(titleViewConstraints)
+            titleViewConstraints.removeAll()
+        }
 
-        let newTitleViewConstraint: NSLayoutConstraint
         if !usesLeadingTitle && systemWantsCompactNavigationBar {
             // If we're drawing our own system-style bar above the OS bar, align our title with the OS's
-            newTitleViewConstraint = titleView.centerXAnchor.constraint(equalTo: centerXAnchor)
+            titleViewConstraints = [titleView.centerXAnchor.constraint(equalTo: centerXAnchor)]
         } else {
             // Otherwise, keep `self.titleView` leading-justified
-            newTitleViewConstraint = preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0)
+            titleViewConstraints = [preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0),
+                                    titleView.topAnchor.constraint(equalTo: topAnchor),
+                                    titleView.bottomAnchor.constraint(equalTo: bottomAnchor)]
         }
-        titleViewConstraint = newTitleViewConstraint
-        newTitleViewConstraint.isActive = true
+
+        if let titleViewConstraints = titleViewConstraints {
+            NSLayoutConstraint.activate(titleViewConstraints)
+        }
     }
 
     private func updateShadow(for navigationItem: UINavigationItem?) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -317,7 +317,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     private var topAccessoryView: UIView?
     private var topAccessoryViewConstraints: [NSLayoutConstraint] = []
 
-    private var titleViewConstraints: [NSLayoutConstraint]?
+    private var titleViewConstraint: NSLayoutConstraint?
 
     private(set) var usesLeadingTitle: Bool = true {
         didSet {
@@ -518,12 +518,11 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
     private func updateContentStackViewMargins(forExpandedContent contentIsExpanded: Bool) {
         let contentHeight = contentIsExpanded ? TokenSetType.expandedContentHeight : TokenSetType.normalContentHeight
-        let systemHeight = systemWantsCompactNavigationBar ? TokenSetType.compactSystemHeight : TokenSetType.systemHeight
 
         contentStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
             top: 0,
             leading: contentLeadingMargin,
-            bottom: systemHeight - contentHeight,
+            bottom: contentHeight - TokenSetType.systemHeight,
             trailing: contentTrailingMargin
         )
     }
@@ -873,17 +872,18 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     }
 
     private func updateTitleViewConstraints() {
-        if let titleViewConstraints = titleViewConstraints {
-            NSLayoutConstraint.deactivate(titleViewConstraints)
-        }
+        titleViewConstraint?.isActive = false
 
-        let constraints = [titleView.topAnchor.constraint(equalTo: topAnchor),
-                           titleView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+        let bottomConstraint = titleView.bottomAnchor.constraint(equalTo: bottomAnchor)
+
+        // We lower the priority of this constraint to avoid breaking auto-layout's generated constraints
+        // when the navigation bar is hidden.
+        bottomConstraint.priority = .defaultHigh
 
         preTitleSpacerView.isHidden = usesLeadingTitle
 
-        NSLayoutConstraint.activate(constraints)
-        titleViewConstraints = constraints
+        bottomConstraint.isActive = true
+        titleViewConstraint = bottomConstraint
     }
 
     private func updateShadow(for navigationItem: UINavigationItem?) {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -878,13 +878,14 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             titleViewConstraints.removeAll()
         }
 
+        titleViewConstraints = [titleView.topAnchor.constraint(equalTo: topAnchor),
+                                titleView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+        
         if usesLeadingTitle {
-            titleViewConstraints = [preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0)]
+            titleViewConstraints?.append(preTitleSpacerView.widthAnchor.constraint(equalToConstant: 0))
         }
 
-        if var titleViewConstraints = titleViewConstraints {
-            titleViewConstraints.append(titleView.topAnchor.constraint(equalTo: topAnchor))
-            titleViewConstraints.append(titleView.bottomAnchor.constraint(equalTo: bottomAnchor))
+        if let titleViewConstraints = titleViewConstraints {
             NSLayoutConstraint.activate(titleViewConstraints)
         }
     }

--- a/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
+++ b/ios/FluentUI/TwoLineTitleView/TwoLineTitleView.swift
@@ -213,10 +213,15 @@ open class TwoLineTitleView: UIView, TokenizedControlInternal {
         addSubview(containingStackView)
         containingStackView.translatesAutoresizingMaskIntoConstraints = false
 
+        // We lower the priority of the height constraint to allow auto-layout to fit the
+        // TwoLineTitleView vertically as needed when used in the NavigationBar.
+        let heightConstraint = heightAnchor.constraint(greaterThanOrEqualToConstant: TokenSetType.minimumTouchSize.height)
+        heightConstraint.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             // Ensure minimum touch size
             widthAnchor.constraint(greaterThanOrEqualToConstant: TokenSetType.minimumTouchSize.width),
-            heightAnchor.constraint(greaterThanOrEqualToConstant: TokenSetType.minimumTouchSize.height),
+            heightConstraint,
             // Contain and center containingStackView within ourself
             centerXAnchor.constraint(equalTo: containingStackView.centerXAnchor),
             centerYAnchor.constraint(equalTo: containingStackView.centerYAnchor),


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There has been an issue where the two line title view would not fit in our navigation bar (#1883). It turns out that the constraints of the title view were not set to fit the navigation bar (which is how Apple handles the native title view).
Changes:
- Margins calculations were adjusted to give proper bottom insets to the title view
- Lowered the priority of the height constraint on the TwoLineTitleView, so that autolayout can dynamically adjust it vertically in the nav bar
- Added a bottom constraint to the titleView

### Binary change

Total increase: 1,512 bytes
Total decrease: -488 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,330,440 bytes | 31,331,464 bytes | ⚠️ 1,024 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| NavigationBar.o | 549,336 bytes | 550,848 bytes | ⚠️ 1,512 bytes |
| FocusRingView.o | 818,960 bytes | 818,888 bytes | 🎉 -72 bytes |
| __.SYMDEF | 4,826,776 bytes | 4,826,360 bytes | 🎉 -416 bytes |
</details>

### Verification

Tested fix on pro, pro max, and iPad devices on the fluent demo app.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_cell_5_pro_portrait](https://github.com/microsoft/fluentui-apple/assets/106181067/075565f8-606d-44b6-936e-69b7a2bb7951) | ![after_cell_5_pro_portrait](https://github.com/microsoft/fluentui-apple/assets/106181067/5868674c-c956-4af1-8f8a-130731c9c40d) |
| ![before_cell_5_pro_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/633f9c11-11da-4872-a7ab-fac86937cbe7) | ![after_cell_5_pro_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/a07780eb-5ad3-4785-af73-8269d5f05581) |
| ![before_cell_10_pro_portrait](https://github.com/microsoft/fluentui-apple/assets/106181067/3bd74c59-fd5d-44bd-b05c-4b488b90db3e) | ![after_cell_10_pro_portrait](https://github.com/microsoft/fluentui-apple/assets/106181067/1ee1938e-ed12-4440-810f-e14c20e93522) |
| ![before_cell_10_pro_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/7c73f224-6e6f-48bb-8a48-41bb032ed9cc) | ![after_cell_10_pro_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/f969b7e3-21a6-4eab-a95a-1431104daaa6) |
| ![before_cell_11_pro_portrait](https://github.com/microsoft/fluentui-apple/assets/106181067/f715932a-f0eb-4640-a595-de2d26bebebe) | ![after_cell_11_pro_portrait](https://github.com/microsoft/fluentui-apple/assets/106181067/d1bef430-6d80-4a9b-b973-00714ab09f44) |
| ![before_cell_11_pro_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/067c3f43-9d0c-4019-899a-aeb8d8621c29) | ![after_cell_11_pro_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/d7c4a4ab-2959-45e7-b41e-29629dc97d22) |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)