### PR TITLE
[main_0.22] Cherry-pick: Fixing view cutoff in iPad when showing DrawerController (#1893)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -15,6 +15,10 @@ class PopupMenuDemoController: DemoController {
         case month
     }
 
+    private let navButtonTitleSwitch = BrandedSwitch()
+    private let navButtonSubtitleSwitch = BrandedSwitch()
+    private let switchTextWidth: CGFloat = 150
+
     private var calendarLayout: CalendarLayout = .agenda
     private var cityIndexPath: IndexPath? = IndexPath(item: 2, section: 1)
 
@@ -41,7 +45,11 @@ class PopupMenuDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show items without dismissal after being tapped", action: #selector(showNoDismissalItemsButtonTapped)))
         container.addArrangedSubview(UIView())
         container.addArrangedSubview(createButton(title: "Objective-C Demo", action: #selector(showObjCDemo)))
-        addTitle(text: "Show with...")
+        addTitle(text: "Navigation Button Settings")
+        addRow(text: "Show Title", items: [navButtonTitleSwitch], textWidth: switchTextWidth)
+        navButtonTitleSwitch.addTarget(self, action: #selector(handleOnSwitchChanged), for: .valueChanged)
+        addRow(text: "Show Subtitle", items: [navButtonSubtitleSwitch], textWidth: switchTextWidth)
+        navButtonSubtitleSwitch.isEnabled = false
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -61,8 +69,19 @@ class PopupMenuDemoController: DemoController {
         return accessoryView
     }
 
+    @objc private func handleOnSwitchChanged() {
+        navButtonSubtitleSwitch.isEnabled = navButtonTitleSwitch.isOn
+        if navButtonSubtitleSwitch.isOn && !navButtonSubtitleSwitch.isEnabled {
+            navButtonSubtitleSwitch.isOn = false
+        }
+    }
+
     @objc private func topBarButtonTapped(sender: UIBarButtonItem) {
         let controller = PopupMenuController(barButtonItem: sender, presentationDirection: .down)
+
+        if navButtonTitleSwitch.isOn {
+            controller.headerItem = PopupMenuItem(title: "Header Title", subtitle: navButtonSubtitleSwitch.isOn ? "Header Subtitle" : nil)
+        }
 
         controller.addItems([
             PopupMenuItem(image: UIImage(named: "mail-unread-24x24"), title: "Unread"),

--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -190,6 +190,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
             _contentView = newValue
             if let contentView = _contentView {
                 containerView.addArrangedSubview(contentView)
+                containerView.isLayoutMarginsRelativeArrangement = true
             }
         }
     }


### PR DESCRIPTION
(cherry picked from commit 1766700b5c717eec0e4d7164a465cbb1cbe23b2c)

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Cherry-picking:
- #1893 

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1894)