### PR TITLE
Fix TableViewHeaderFooterView being cropped on large text 

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -39,20 +39,14 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
                                    containerWidth: CGFloat = .greatestFiniteMagnitude,
                                    accessoryView: UIView? = nil) -> CGFloat {
         let tokenSet: TableViewHeaderFooterViewTokenSet = .init(style: { style }, accessoryButtonStyle: { AccessoryButtonStyle.regular })
-        let verticalMargin: CGFloat
         let font = tokenSet[.textFont].uiFont
-        switch style {
-        case .header, .footer:
-            verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
-        case .headerPrimary:
-            verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
-        }
+        let verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
 
         if let accessoryView = accessoryView {
             accessoryView.frame.size = accessoryView.systemLayoutSizeFitting(CGSize(width: containerWidth, height: .infinity))
         }
 
-        let titleWidth = containerWidth - (TableViewHeaderFooterViewTokenSet.horizontalMargin + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView) + TableViewHeaderFooterView.titleLeadingOffset())
+        let titleWidth = containerWidth - (TableViewHeaderFooterView.titleLeadingOffset() + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView))
         let titleHeight = title.preferredSize(for: font, width: titleWidth, numberOfLines: titleNumberOfLines).height
 
         return verticalMargin + titleHeight
@@ -413,7 +407,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
                 style: style,
                 title: titleView.text ?? "",
                 titleNumberOfLines: titleNumberOfLines,
-                containerWidth: size.width,
+                containerWidth: contentView.frame.width,
                 accessoryView: accessoryView
             )
         )


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There is a bug where the `TableViewHeaderFooterView` gets cropped on large text mode with the inset grouped style. This is caused by the height function miscalculating the width of the title view since it takes into account the header footer view's frame instead of the content view's frame. 
To fix the bug, we explicitly pass in the `contentView`'s width in `sizeThatFits(_ size: CGSize)` for the height calculations. In the height func, I also removed the extra`TableViewHeaderFooterViewTokenSet.horizontalMargin` from the width calculations since `TableViewHeaderFooterView.titleLeadingOffset()` and `TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView)` already add the necessary leading and trailing paddings. With these adjustments, `layoutSubviews` and `height()` now use the exact same width values to calculate the view's height.

### Binary change

Total increase: 632 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,610,192 bytes | 31,610,824 bytes | ⚠️ 632 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterView.o | 282,656 bytes | 283,208 bytes | ⚠️ 552 bytes |
| __.SYMDEF | 4,956,736 bytes | 4,956,816 bytes | ⚠️ 80 bytes |
</details>

### Verification

Tested the footer on the demo app.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="484" alt="before_large" src="https://github.com/microsoft/fluentui-apple/assets/106181067/fe486724-6f22-44c0-8a29-3f71eba57960"> | <img width="484" alt="after_large" src="https://github.com/microsoft/fluentui-apple/assets/106181067/ec6a4990-8be0-435b-a947-4118340b4a47"> |
| <img width="484" alt="before_small" src="https://github.com/microsoft/fluentui-apple/assets/106181067/90453ca2-3eed-40ee-85ca-9645399ef320"> | <img width="484" alt="after_small" src="https://github.com/microsoft/fluentui-apple/assets/106181067/d9c8b5dc-f3a0-4299-87e3-f79b374f099a"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1899)