### PR TITLE
[main_0.22] Fix TableViewHeaderFooterView being cropped on large text (#1899)

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -39,20 +39,14 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
                                    containerWidth: CGFloat = .greatestFiniteMagnitude,
                                    accessoryView: UIView? = nil) -> CGFloat {
         let tokenSet: TableViewHeaderFooterViewTokenSet = .init(style: { style }, accessoryButtonStyle: { AccessoryButtonStyle.regular })
-        let verticalMargin: CGFloat
         let font = tokenSet[.textFont].uiFont
-        switch style {
-        case .header, .footer:
-            verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
-        case .headerPrimary:
-            verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
-        }
+        let verticalMargin = TableViewHeaderFooterViewTokenSet.titleDefaultTopMargin + TableViewHeaderFooterViewTokenSet.titleDefaultBottomMargin
 
         if let accessoryView = accessoryView {
             accessoryView.frame.size = accessoryView.systemLayoutSizeFitting(CGSize(width: containerWidth, height: .infinity))
         }
 
-        let titleWidth = containerWidth - (TableViewHeaderFooterViewTokenSet.horizontalMargin + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView) + TableViewHeaderFooterView.titleLeadingOffset())
+        let titleWidth = containerWidth - (TableViewHeaderFooterView.titleLeadingOffset() + TableViewHeaderFooterView.titleTrailingOffset(accessoryView: accessoryView))
         let titleHeight = title.preferredSize(for: font, width: titleWidth, numberOfLines: titleNumberOfLines).height
 
         return verticalMargin + titleHeight
@@ -413,7 +407,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
                 style: style,
                 title: titleView.text ?? "",
                 titleNumberOfLines: titleNumberOfLines,
-                containerWidth: size.width,
+                containerWidth: contentView.frame.width,
                 accessoryView: accessoryView
             )
         )


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

PR cherry-picks #1899 into main_0.22.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1900)