### PR TITLE
Add optional customBackgroundColor to TableViewHeaderFooterView

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -176,6 +176,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     }
 
     private let titleView = TableViewHeaderFooterTitleView()
+    private var customBackgroundColor: UIColor?
 
     private var accessoryView: UIView? {
         didSet {
@@ -295,6 +296,24 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         setup(style: style, title: title, accessoryButtonTitle: "")
         self.accessoryView = accessoryView
         self.leadingView = leadingView
+    }
+
+    /// - Parameters:
+    ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
+    ///   - title: The title string.
+    ///   - backgroundColor: The background color of the `backgroundView`
+    @objc open func setup(style: Style, title: String, backgroundColor: UIColor) {
+        setup(style: style, title: title, accessoryButtonTitle: "")
+        customBackgroundColor = backgroundColor
+    }
+
+    /// - Parameters:
+    ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
+    ///   - attributedTitle: Title as an NSAttributedString for additional attributes.
+    ///   - backgroundColor: The background color of the `backgroundView`
+    @objc open func setup(style: Style, attributedTitle: NSAttributedString, backgroundColor: UIColor) {
+        setup(style: style, attributedTitle: attributedTitle)
+        customBackgroundColor = backgroundColor
     }
 
     /// - Parameters:
@@ -443,7 +462,9 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     private func updateTitleAndBackgroundColors() {
         titleView.textColor = tokenSet[.textColor].uiColor
 
-        if tableViewCellStyle == .grouped {
+        if let customBackgroundColor {
+            backgroundView?.backgroundColor = customBackgroundColor
+        } else if tableViewCellStyle == .grouped {
             backgroundView?.backgroundColor = tokenSet[.backgroundColorGrouped].uiColor
         } else if tableViewCellStyle == .plain {
             backgroundView?.backgroundColor = tokenSet[.backgroundColorPlain].uiColor


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adds two new setup methods for `TableViewHeaderFooterView` to allow adding a custom background color. 

### Verification

Tested both methods.; here is a screenshot of a `TableViewHeaderFooterView` with a custom background color.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![Screenshot 2023-09-25 at 6 55 06 PM](https://github.com/microsoft/fluentui-apple/assets/92546865/076fa41a-9f12-44c2-9733-81bfdc68ce0b) | ![Screenshot 2023-09-25 at 6 57 28 PM](https://github.com/microsoft/fluentui-apple/assets/92546865/7383b3ed-fd61-4476-977a-549a8ea75bde) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1901)