### PR TITLE
Update FluentTextField becomeFirstResponder

### DIFF
--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -92,6 +92,10 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
             updateAssistiveText()
         }
     }
+    
+    @objc public override var canBecomeFirstResponder: Bool {
+        textfield.canBecomeFirstResponder
+    }
 
     // Hierarchy:
     //
@@ -151,6 +155,13 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateTokenizedValues()
         }
+    }
+
+    @discardableResult
+    @objc public override func becomeFirstResponder() -> Bool {
+        let didBecomeFirstResponder = textfield.becomeFirstResponder()
+        updateState()
+        return didBecomeFirstResponder
     }
 
     required init?(coder: NSCoder) {

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -92,7 +92,7 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
             updateAssistiveText()
         }
     }
-    
+
     @objc public override var canBecomeFirstResponder: Bool {
         textfield.canBecomeFirstResponder
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently when a consumer of Fluent calls becomeFirstResponder on the FluentTextField nothing happens. When calling canBecomeFirstResponder it always returns false.

Adding an override to the becomeFirstResponder so that the state is updated and the FluentTextFieldInternal becomes the first responder.

### Binary change

Total increase: 0 bytes
Total decrease: -185,368 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,439,424 bytes | 31,254,056 bytes | 🎉 -185,368 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentUI_vers.o | 2,744 bytes | 2,736 bytes | 🎉 -8 bytes |
| PeoplePickerTokenSet.o | 22,240 bytes | 22,208 bytes | 🎉 -32 bytes |
| PopupMenuProtocols.o | 26,712 bytes | 26,680 bytes | 🎉 -32 bytes |
| CommandingSection.o | 27,784 bytes | 27,744 bytes | 🎉 -40 bytes |
| AccessibleViewDelegate.o | 15,280 bytes | 15,240 bytes | 🎉 -40 bytes |
| PersonaButtonCarouselModifiers.o | 10,600 bytes | 10,560 bytes | 🎉 -40 bytes |
| PersonaButtonModifiers.o | 10,560 bytes | 10,520 bytes | 🎉 -40 bytes |
| MSFIndeterminateProgressBar.o | 28,288 bytes | 28,248 bytes | 🎉 -40 bytes |
| AvatarGroupModifiers.o | 10,552 bytes | 10,512 bytes | 🎉 -40 bytes |
| PopupMenuTokenSet.o | 20,376 bytes | 20,336 bytes | 🎉 -40 bytes |
| CardNudgeModifiers.o | 44,872 bytes | 44,832 bytes | 🎉 -40 bytes |
| IndeterminateProgressBarModifiers.o | 16,712 bytes | 16,664 bytes | 🎉 -48 bytes |
| ActivityIndicatorModifiers.o | 25,808 bytes | 25,760 bytes | 🎉 -48 bytes |
| TokenizedControl.o | 13,328 bytes | 13,280 bytes | 🎉 -48 bytes |
| DateComponents+Extensions.o | 11,528 bytes | 11,480 bytes | 🎉 -48 bytes |
| ListActionItemModifiers.o | 20,368 bytes | 20,320 bytes | 🎉 -48 bytes |
| UIApplication+Extensions.o | 11,568 bytes | 11,520 bytes | 🎉 -48 bytes |
| AvatarModifiers.o | 43,440 bytes | 43,392 bytes | 🎉 -48 bytes |
| PopupMenuSection.o | 28,552 bytes | 28,504 bytes | 🎉 -48 bytes |
| TokenSet.o | 18,712 bytes | 18,664 bytes | 🎉 -48 bytes |
| PersonaBadgeViewDataSource.o | 36,744 bytes | 36,696 bytes | 🎉 -48 bytes |
| UIViewController+Navigation.o | 15,552 bytes | 15,504 bytes | 🎉 -48 bytes |
| FluentTextInputError.o | 22,672 bytes | 22,624 bytes | 🎉 -48 bytes |
| UIImage+Extensions.o | 11,352 bytes | 11,296 bytes | 🎉 -56 bytes |
| MSFAvatar.o | 27,288 bytes | 27,232 bytes | 🎉 -56 bytes |
| MSFHeadsUpDisplay.o | 33,728 bytes | 33,672 bytes | 🎉 -56 bytes |
| GenericDateTimePicker.o | 13,104 bytes | 13,048 bytes | 🎉 -56 bytes |
| MSFActivityIndicator.o | 30,824 bytes | 30,768 bytes | 🎉 -56 bytes |
| ContentHeightResolutionContext.o | 22,584 bytes | 22,528 bytes | 🎉 -56 bytes |
| GlobalTokens.o | 546,304 bytes | 546,248 bytes | 🎉 -56 bytes |
| FluentTheme+Tokens.o | 74,256 bytes | 74,200 bytes | 🎉 -56 bytes |
| AnimationSynchronizer.o | 30,896 bytes | 30,840 bytes | 🎉 -56 bytes |
| CALayer+Extensions.o | 11,320 bytes | 11,264 bytes | 🎉 -56 bytes |
| MSFAvatarGroup.o | 27,736 bytes | 27,680 bytes | 🎉 -56 bytes |
| MSFPersonaButton.o | 37,832 bytes | 37,768 bytes | 🎉 -64 bytes |
| SegmentItem.o | 32,680 bytes | 32,616 bytes | 🎉 -64 bytes |
| Obscurable.o | 24,456 bytes | 24,392 bytes | 🎉 -64 bytes |
| ContentScrollViewTraits.o | 15,424 bytes | 15,360 bytes | 🎉 -64 bytes |
| MSFPersonaButtonCarousel.o | 32,440 bytes | 32,376 bytes | 🎉 -64 bytes |
| CalendarConfiguration.o | 49,736 bytes | 49,664 bytes | 🎉 -72 bytes |
| EmptyTokenSet.o | 37,304 bytes | 37,232 bytes | 🎉 -72 bytes |
| UIScrollView+Extensions.o | 33,256 bytes | 33,184 bytes | 🎉 -72 bytes |
| EasyTapButton.o | 27,680 bytes | 27,608 bytes | 🎉 -72 bytes |
| MSFCardNudge.o | 36,520 bytes | 36,440 bytes | 🎉 -80 bytes |
| NSLayoutConstraint+Extensions.o | 25,040 bytes | 24,960 bytes | 🎉 -80 bytes |
| BottomSheetPassthroughView.o | 21,512 bytes | 21,432 bytes | 🎉 -80 bytes |
| String+Extension.o | 23,608 bytes | 23,528 bytes | 🎉 -80 bytes |
| TouchForwardingView.o | 33,768 bytes | 33,688 bytes | 🎉 -80 bytes |
| DotView.o | 31,752 bytes | 31,664 bytes | 🎉 -88 bytes |
| ColorProviding.o | 41,224 bytes | 41,136 bytes | 🎉 -88 bytes |
| PersonaButtonCarouselTokenSet.o | 41,816 bytes | 41,720 bytes | 🎉 -96 bytes |
| PersonaCell.o | 62,992 bytes | 62,896 bytes | 🎉 -96 bytes |
| CardPresenterNavigationController.o | 27,624 bytes | 27,528 bytes | 🎉 -96 bytes |
| BlurringView.o | 34,568 bytes | 34,472 bytes | 🎉 -96 bytes |
| IndeterminateProgressBarTokenSet.o | 44,248 bytes | 44,144 bytes | 🎉 -104 bytes |
| SeparatorTokenSet.o | 40,352 bytes | 40,248 bytes | 🎉 -104 bytes |
| ListItemModifiers.o | 25,424 bytes | 25,320 bytes | 🎉 -104 bytes |
| LabelTokenSet.o | 58,048 bytes | 57,936 bytes | 🎉 -112 bytes |
| ResizingHandleTokenSet.o | 44,696 bytes | 44,584 bytes | 🎉 -112 bytes |
| ShadowInfo.o | 48,008 bytes | 47,896 bytes | 🎉 -112 bytes |
| TwoLineTitleView+Navigation.o | 28,048 bytes | 27,936 bytes | 🎉 -112 bytes |
| MSFAvatarPresence.o | 43,392 bytes | 43,280 bytes | 🎉 -112 bytes |
| ShapeCutout.o | 37,384 bytes | 37,272 bytes | 🎉 -112 bytes |
| BadgeLabelTokenSet.o | 47,312 bytes | 47,200 bytes | 🎉 -112 bytes |
| TokenizedControlView.o | 166,400 bytes | 166,288 bytes | 🎉 -112 bytes |
| UIKit+SwiftUI_interoperability.o | 45,840 bytes | 45,728 bytes | 🎉 -112 bytes |
| PopupMenuSectionHeaderView.o | 28,096 bytes | 27,976 bytes | 🎉 -120 bytes |
| LinearGradientInfo.o | 45,384 bytes | 45,264 bytes | 🎉 -120 bytes |
| AvatarGroupTokenSet.o | 53,336 bytes | 53,208 bytes | 🎉 -128 bytes |
| DynamicColor.o | 49,680 bytes | 49,552 bytes | 🎉 -128 bytes |
| UIBarButtonItem+BadgeValue.o | 31,184 bytes | 31,056 bytes | 🎉 -128 bytes |
| DayOfMonth.o | 59,312 bytes | 59,176 bytes | 🎉 -136 bytes |
| SwiftUI+ViewAnimation.o | 49,112 bytes | 48,976 bytes | 🎉 -136 bytes |
| ActivityIndicatorTokenSet.o | 62,496 bytes | 62,360 bytes | 🎉 -136 bytes |
| BarButtonItems.o | 28,520 bytes | 28,384 bytes | 🎉 -136 bytes |
| SwiftUI+ViewPresentation.o | 59,032 bytes | 58,888 bytes | 🎉 -144 bytes |
| PopupMenuItemTokenSet.o | 32,320 bytes | 32,168 bytes | 🎉 -152 bytes |
| SideTabBarTokenSet.o | 50,584 bytes | 50,432 bytes | 🎉 -152 bytes |
| ControlTokenSet.o | 70,056 bytes | 69,904 bytes | 🎉 -152 bytes |
| FluentUIHostingController.o | 32,664 bytes | 32,512 bytes | 🎉 -152 bytes |
| HUDModifiers.o | 67,200 bytes | 67,048 bytes | 🎉 -152 bytes |
| HeadsUpDisplayTokenSet.o | 53,376 bytes | 53,216 bytes | 🎉 -160 bytes |
| CalendarViewMonthBannerView.o | 27,648 bytes | 27,488 bytes | 🎉 -160 bytes |
| TabBarTokenSet.o | 45,072 bytes | 44,912 bytes | 🎉 -160 bytes |
| Persona.o | 74,040 bytes | 73,880 bytes | 🎉 -160 bytes |
| DatePickerSelectionManager.o | 57,800 bytes | 57,632 bytes | 🎉 -168 bytes |
| BadgeFieldTokenSet.o | 55,416 bytes | 55,248 bytes | 🎉 -168 bytes |
| NotificationModifiers.o | 71,536 bytes | 71,368 bytes | 🎉 -168 bytes |
| BottomSheetTokenSet.o | 48,704 bytes | 48,536 bytes | 🎉 -168 bytes |
| TwoLineTitleViewTokenSet.o | 58,248 bytes | 58,072 bytes | 🎉 -176 bytes |
| PersonaButtonTokenSet.o | 66,000 bytes | 65,824 bytes | 🎉 -176 bytes |
| AvatarTitleViewTokenSet.o | 51,528 bytes | 51,352 bytes | 🎉 -176 bytes |
| DateTimePickerViewLayout.o | 45,456 bytes | 45,272 bytes | 🎉 -184 bytes |
| FontInfo.o | 70,240 bytes | 70,056 bytes | 🎉 -184 bytes |
| CommandBarButtonGroupView.o | 60,656 bytes | 60,464 bytes | 🎉 -192 bytes |
| UINavigationItem+Navigation.o | 80,552 bytes | 80,344 bytes | 🎉 -208 bytes |
| String+Date.o | 60,944 bytes | 60,736 bytes | 🎉 -208 bytes |
| DrawerTokenSet.o | 54,560 bytes | 54,352 bytes | 🎉 -208 bytes |
| Separator.o | 74,608 bytes | 74,392 bytes | 🎉 -216 bytes |
| CalendarViewDayTodayCell.o | 36,344 bytes | 36,128 bytes | 🎉 -216 bytes |
| SwiftUI+ViewModifiers.o | 215,720 bytes | 215,496 bytes | 🎉 -224 bytes |
| DimmingView.o | 51,568 bytes | 51,336 bytes | 🎉 -232 bytes |
| Date+Extensions.o | 48,640 bytes | 48,408 bytes | 🎉 -232 bytes |
| TooltipViewController.o | 46,192 bytes | 45,952 bytes | 🎉 -240 bytes |
| TooltipTokenSet.o | 56,752 bytes | 56,512 bytes | 🎉 -240 bytes |
| TableViewHeaderFooterViewTokenSet.o | 83,672 bytes | 83,424 bytes | 🎉 -248 bytes |
| UIColor+Extensions.o | 81,120 bytes | 80,872 bytes | 🎉 -248 bytes |
| CalendarViewDayMonthYearCell.o | 41,264 bytes | 41,008 bytes | 🎉 -256 bytes |
| ResizingHandleView.o | 73,272 bytes | 73,016 bytes | 🎉 -256 bytes |
| FluentUIFramework.o | 91,624 bytes | 91,368 bytes | 🎉 -256 bytes |
| Calendar+Extensions.o | 46,760 bytes | 46,496 bytes | 🎉 -264 bytes |
| ControlHostingView.o | 66,056 bytes | 65,792 bytes | 🎉 -264 bytes |
| CalendarViewWeekdayHeadingView.o | 86,288 bytes | 86,024 bytes | 🎉 -264 bytes |
| CardTransitionAnimator.o | 66,840 bytes | 66,568 bytes | 🎉 -272 bytes |
| CardPresentationController.o | 47,064 bytes | 46,792 bytes | 🎉 -272 bytes |
| FluentTheme.o | 184,904 bytes | 184,632 bytes | 🎉 -272 bytes |
| DateTimePickerViewComponentTableView.o | 67,352 bytes | 67,080 bytes | 🎉 -272 bytes |
| CalendarViewDayMonthCell.o | 42,576 bytes | 42,304 bytes | 🎉 -272 bytes |
| CommandingItem.o | 93,136 bytes | 92,856 bytes | 🎉 -280 bytes |
| PillButtonTokenSet.o | 88,816 bytes | 88,536 bytes | 🎉 -280 bytes |
| PopupMenuItem.o | 121,640 bytes | 121,360 bytes | 🎉 -280 bytes |
| AccessibilityContainerView.o | 36,888 bytes | 36,608 bytes | 🎉 -280 bytes |
| ShimmerTokenSet.o | 72,368 bytes | 72,080 bytes | 🎉 -288 bytes |
| BadgeViewTokenSet.o | 96,128 bytes | 95,840 bytes | 🎉 -288 bytes |
| UIView+Extensions.o | 45,216 bytes | 44,920 bytes | 🎉 -296 bytes |
| NavigationBarTokenSet.o | 73,296 bytes | 73,000 bytes | 🎉 -296 bytes |
| CommandBarItem.o | 106,752 bytes | 106,456 bytes | 🎉 -296 bytes |
| AliasTokens.o | 282,312 bytes | 282,016 bytes | 🎉 -296 bytes |
| SearchBarTokenSet.o | 79,992 bytes | 79,696 bytes | 🎉 -296 bytes |
| TabBarItem.o | 68,552 bytes | 68,256 bytes | 🎉 -296 bytes |
| BadgeStringExtractor.o | 63,256 bytes | 62,960 bytes | 🎉 -296 bytes |
| ActivityIndicatorCell.o | 82,776 bytes | 82,472 bytes | 🎉 -304 bytes |
| TextFieldTokenSet.o | 82,368 bytes | 82,056 bytes | 🎉 -312 bytes |
| CommandBarTokenSet.o | 63,536 bytes | 63,224 bytes | 🎉 -312 bytes |
| CenteredLabelCell.o | 85,808 bytes | 85,496 bytes | 🎉 -312 bytes |
| BooleanCell.o | 91,160 bytes | 90,848 bytes | 🎉 -312 bytes |
| TabBarItemTokenSet.o | 63,928 bytes | 63,608 bytes | 🎉 -320 bytes |
| BadgeLabel.o | 64,248 bytes | 63,920 bytes | 🎉 -328 bytes |
| CommandBarButton.o | 97,392 bytes | 97,056 bytes | 🎉 -336 bytes |
| FluentTextFieldInternal.o | 48,128 bytes | 47,792 bytes | 🎉 -336 bytes |
| CardNudgeTokenSet.o | 82,328 bytes | 81,976 bytes | 🎉 -352 bytes |
| Tooltip.o | 124,208 bytes | 123,856 bytes | 🎉 -352 bytes |
| DateTimePickerViewComponentCell.o | 57,816 bytes | 57,464 bytes | 🎉 -352 bytes |
| ShimmerLinesView.o | 107,584 bytes | 107,224 bytes | 🎉 -360 bytes |
| SegmentedControlTokenSet.o | 91,432 bytes | 91,064 bytes | 🎉 -368 bytes |
| BottomCommandingTokenSet.o | 66,992 bytes | 66,616 bytes | 🎉 -376 bytes |
| CalendarViewLayout.o | 74,144 bytes | 73,760 bytes | 🎉 -384 bytes |
| MultilineCommandBar.o | 143,776 bytes | 143,384 bytes | 🎉 -392 bytes |
| SegmentPillButton.o | 91,144 bytes | 90,744 bytes | 🎉 -400 bytes |
| DrawerTransitionAnimator.o | 71,248 bytes | 70,848 bytes | 🎉 -400 bytes |
| NotificationTokenSet.o | 91,160 bytes | 90,760 bytes | 🎉 -400 bytes |
| MSFNotification.o | 136,248 bytes | 135,832 bytes | 🎉 -416 bytes |
| DrawerShadowView.o | 78,272 bytes | 77,848 bytes | 🎉 -424 bytes |
| AvatarTokenSet.o | 118,952 bytes | 118,528 bytes | 🎉 -424 bytes |
| CalendarViewDataSource.o | 127,352 bytes | 126,904 bytes | 🎉 -448 bytes |
| PersonaButtonCarousel.o | 169,520 bytes | 169,072 bytes | 🎉 -448 bytes |
| ButtonTokenSet.o | 122,104 bytes | 121,648 bytes | 🎉 -456 bytes |
| PersonaListView.o | 176,048 bytes | 175,592 bytes | 🎉 -456 bytes |
| CommandBarCommandGroupsView.o | 197,640 bytes | 197,168 bytes | 🎉 -472 bytes |
| NavigationAnimator.o | 113,880 bytes | 113,400 bytes | 🎉 -480 bytes |
| PageCardPresenterController.o | 147,080 bytes | 146,600 bytes | 🎉 -480 bytes |
| NavigationController.o | 157,672 bytes | 157,168 bytes | 🎉 -504 bytes |
| ActivityIndicator.o | 181,424 bytes | 180,920 bytes | 🎉 -504 bytes |
| DateTimePicker.o | 165,624 bytes | 165,112 bytes | 🎉 -512 bytes |
| ShimmerView.o | 207,560 bytes | 207,032 bytes | 🎉 -528 bytes |
| HeadsUpDisplay.o | 247,640 bytes | 247,104 bytes | 🎉 -536 bytes |
| TableViewCellTokenSet.o | 108,472 bytes | 107,928 bytes | 🎉 -544 bytes |
| HUD.o | 264,976 bytes | 264,416 bytes | 🎉 -560 bytes |
| DateTimePickerViewComponent.o | 135,552 bytes | 134,984 bytes | 🎉 -568 bytes |
| CalendarView.o | 71,640 bytes | 71,072 bytes | 🎉 -568 bytes |
| ListActionItem.o | 230,536 bytes | 229,968 bytes | 🎉 -568 bytes |
| IndeterminateProgressBar.o | 236,080 bytes | 235,504 bytes | 🎉 -576 bytes |
| TabBarView.o | 134,928 bytes | 134,344 bytes | 🎉 -584 bytes |
| CardNudge.o | 448,672 bytes | 448,072 bytes | 🎉 -600 bytes |
| BadgeLabelButton.o | 109,744 bytes | 109,112 bytes | 🎉 -632 bytes |
| Label.o | 136,600 bytes | 135,944 bytes | 🎉 -656 bytes |
| PillButton.o | 167,896 bytes | 167,208 bytes | 🎉 -688 bytes |
| CommandBar.o | 199,552 bytes | 198,848 bytes | 🎉 -704 bytes |
| CalendarViewDayCell.o | 131,176 bytes | 130,472 bytes | 🎉 -704 bytes |
| DateTimePickerController.o | 139,408 bytes | 138,680 bytes | 🎉 -728 bytes |
| ActionsCell.o | 167,088 bytes | 166,352 bytes | 🎉 -736 bytes |
| ListItem.o | 282,128 bytes | 281,368 bytes | 🎉 -760 bytes |
| FluentTextField.o | 197,792 bytes | 197,032 bytes | 🎉 -760 bytes |
| ShyHeaderView.o | 120,704 bytes | 119,928 bytes | 🎉 -776 bytes |
| CardView.o | 255,640 bytes | 254,808 bytes | 🎉 -832 bytes |
| PillButtonBar.o | 246,592 bytes | 245,736 bytes | 🎉 -856 bytes |
| DateTimePickerView.o | 209,920 bytes | 209,016 bytes | 🎉 -904 bytes |
| PopupMenuController.o | 383,336 bytes | 382,384 bytes | 🎉 -952 bytes |
| TooltipView.o | 219,056 bytes | 218,040 bytes | 🎉 -1,016 bytes |
| TwoLineTitleView.o | 269,896 bytes | 268,864 bytes | 🎉 -1,032 bytes |
| PersonaButton.o | 244,456 bytes | 243,352 bytes | 🎉 -1,104 bytes |
| Button.o | 213,560 bytes | 212,456 bytes | 🎉 -1,104 bytes |
| AvatarGroup.o | 423,320 bytes | 422,216 bytes | 🎉 -1,104 bytes |
| BadgeView.o | 616,032 bytes | 614,928 bytes | 🎉 -1,104 bytes |
| SideTabBar.o | 201,704 bytes | 200,600 bytes | 🎉 -1,104 bytes |
| PopupMenuItemCell.o | 178,592 bytes | 177,472 bytes | 🎉 -1,120 bytes |
| TableViewHeaderFooterView.o | 282,096 bytes | 280,928 bytes | 🎉 -1,168 bytes |
| TabBarItemView.o | 221,336 bytes | 220,144 bytes | 🎉 -1,192 bytes |
| SearchBar.o | 395,984 bytes | 394,672 bytes | 🎉 -1,312 bytes |
| FluentNotification.o | 689,216 bytes | 687,896 bytes | 🎉 -1,320 bytes |
| SegmentedControl.o | 342,056 bytes | 340,728 bytes | 🎉 -1,328 bytes |
| AvatarTitleView.o | 191,160 bytes | 189,816 bytes | 🎉 -1,344 bytes |
| PeoplePicker.o | 312,600 bytes | 311,152 bytes | 🎉 -1,448 bytes |
| Avatar.o | 527,496 bytes | 526,016 bytes | 🎉 -1,480 bytes |
| ShyHeaderController.o | 243,256 bytes | 241,760 bytes | 🎉 -1,496 bytes |
| DrawerPresentationController.o | 241,288 bytes | 239,728 bytes | 🎉 -1,560 bytes |
| DateTimePickerViewDataSource.o | 277,696 bytes | 275,952 bytes | 🎉 -1,744 bytes |
| DatePickerController.o | 317,440 bytes | 315,560 bytes | 🎉 -1,880 bytes |
| BottomSheetController.o | 495,048 bytes | 492,784 bytes | 🎉 -2,264 bytes |
| NavigationBar.o | 553,392 bytes | 551,000 bytes | 🎉 -2,392 bytes |
| BadgeField.o | 583,656 bytes | 581,080 bytes | 🎉 -2,576 bytes |
| DrawerController.o | 486,416 bytes | 483,840 bytes | 🎉 -2,576 bytes |
| BottomCommandingController.o | 935,488 bytes | 932,312 bytes | 🎉 -3,176 bytes |
| TableViewCell.o | 815,440 bytes | 811,112 bytes | 🎉 -4,328 bytes |
| FocusRingView.o | 823,432 bytes | 815,880 bytes | 🎉 -7,552 bytes |
| __.SYMDEF | 4,879,200 bytes | 4,792,360 bytes | 🎉 -86,840 bytes |
</details>

### Verification

Test with change using Loop iOS

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Before opening the new page or new workspace drawer would not focus on the textfield | The textfield is now focused on when opening either drawer and the keyboard appears |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1905)