### PR TITLE
Updating a11y for PersonaList when `onPersonaSelected` is defined

### DIFF
--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -201,9 +201,11 @@ extension PersonaListView: UITableViewDataSource {
             }
             let index = indexPath.row
             let persona = personaList[index]
+            let isPersonaSelectable = onPersonaSelected != nil
             cell.setup(persona: persona, accessoryType: accessoryType)
+            cell.isUserInteractionEnabled = isPersonaSelectable ? true : false
             cell.backgroundStyleType = .clear
-            cell.accessibilityTraits = .button
+            cell.accessibilityTraits = isPersonaSelectable ? .button : .none
             cell.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, personaList.count)
             return cell
         case .searchDirectory:

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -203,7 +203,7 @@ extension PersonaListView: UITableViewDataSource {
             let persona = personaList[index]
             let isPersonaSelectable = onPersonaSelected != nil
             cell.setup(persona: persona, accessoryType: accessoryType)
-            cell.isUserInteractionEnabled = isPersonaSelectable ? true : false
+            cell.isUserInteractionEnabled = isPersonaSelectable
             cell.backgroundStyleType = .clear
             cell.accessibilityTraits = isPersonaSelectable ? .button : .none
             cell.accessibilityHint = String.localizedStringWithFormat( "Accessibility.TabBarItemView.Hint".localized, index + 1, personaList.count)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently, VoiceOver will read a persona cell as a button even if an action is not assigned. Let's add a check to see if the `onPersonaSelected` property is nil, and if so, to make sure that the PersonaCell is not read as a button.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Using the a11y inspector to make sure that the type is not a button:
When `onPersonaSelected` is defined:
<img width="500" alt="image" src="https://github.com/microsoft/fluentui-apple/assets/22566866/c70abfe8-b74d-48fa-884d-3328451f0364">

When `onPersonaSelected` is undefined:
<img width="500" alt="image" src="https://github.com/microsoft/fluentui-apple/assets/22566866/c09e28bb-5a91-4f68-ae12-1819a48fca1b">


<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1912)