### PR TITLE
Deprecate outline button style

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -135,7 +135,7 @@ extension ButtonStyle {
         switch self {
         case .accent:
             return "Accent"
-        case .outline:
+        case .outlineAccent:
             return "Outline accent"
         case .outlineNeutral:
             return "Outline neutral"
@@ -151,6 +151,8 @@ extension ButtonStyle {
             return "Floating accent"
         case .floatingSubtle:
             return "Floating subtle"
+        case .outline:
+            return "Outline accent"
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -194,37 +194,37 @@ class CommandBarDemoController: DemoController {
 
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
-        let refreshButton = Button(style: .outline)
+        let refreshButton = Button(style: .outlineAccent)
         refreshButton.sizeCategory = .small
         refreshButton.setTitle("Refresh 'Default' Bar", for: .normal)
         refreshButton.addTarget(self, action: #selector(refreshDefaultBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshButton)
 
-        let removeTrailingItemButton = Button(style: .outline)
+        let removeTrailingItemButton = Button(style: .outlineAccent)
         removeTrailingItemButton.sizeCategory = .small
         removeTrailingItemButton.setTitle("Remove Trailing Button", for: .normal)
         removeTrailingItemButton.addTarget(self, action: #selector(removeDefaultTrailingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(removeTrailingItemButton)
 
-        let refreshTrailingItemButton = Button(style: .outline)
+        let refreshTrailingItemButton = Button(style: .outlineAccent)
         refreshTrailingItemButton.sizeCategory = .small
         refreshTrailingItemButton.setTitle("Refresh Trailing Button", for: .normal)
         refreshTrailingItemButton.addTarget(self, action: #selector(refreshDefaultTrailingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshTrailingItemButton)
 
-        let removeLeadingItemButton = Button(style: .outline)
+        let removeLeadingItemButton = Button(style: .outlineAccent)
         removeLeadingItemButton.sizeCategory = .small
         removeLeadingItemButton.setTitle("Remove Leading Button", for: .normal)
         removeLeadingItemButton.addTarget(self, action: #selector(removeDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(removeLeadingItemButton)
 
-        let refreshLeadingItemButton = Button(style: .outline)
+        let refreshLeadingItemButton = Button(style: .outlineAccent)
         refreshLeadingItemButton.sizeCategory = .small
         refreshLeadingItemButton.setTitle("Refresh Leading Button", for: .normal)
         refreshLeadingItemButton.addTarget(self, action: #selector(refreshDefaultLeadingBarItems), for: .touchUpInside)
         itemCustomizationContainer.addArrangedSubview(refreshLeadingItemButton)
 
-        let resetScrollPositionButton = Button(style: .outline)
+        let resetScrollPositionButton = Button(style: .outlineAccent)
         resetScrollPositionButton.sizeCategory = .small
         resetScrollPositionButton.setTitle("Reset Scroll Position", for: .normal)
         resetScrollPositionButton.addTarget(self, action: #selector(resetScrollPosition), for: .touchUpInside)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
@@ -19,7 +19,7 @@
 
 - (void)loadView {
     [super loadView];
-    MSFButton *demoButton = [[MSFButton alloc] initWithStyle:MSFButtonStyleOutline];
+    MSFButton *demoButton = [[MSFButton alloc] initWithStyle:MSFButtonStyleOutlineAccent];
     [demoButton setTitle:@"Show PopupMenu" forState:UIControlStateNormal];
     [demoButton addTarget:self action:@selector(showPopupMenu) forControlEvents:UIControlEventTouchUpInside];
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldDemoController.swift
@@ -31,7 +31,7 @@ class TextFieldDemoController: DemoController {
         textField3.onReturn = onReturn
         textfields.append(textField3)
 
-        let objcDemoButton = Button(style: .outline)
+        let objcDemoButton = Button(style: .outlineAccent)
         objcDemoButton.setTitle("Show Objective C Demo", for: .normal)
         objcDemoButton.addTarget(self, action: #selector(showObjCDemo), for: .touchUpInside)
 

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -11,7 +11,7 @@ import UIKit
 @IBDesignable
 @objc(MSFButton)
 open class Button: UIButton, Shadowable, TokenizedControlInternal {
-    @objc open var style: ButtonStyle = .outline {
+    @objc open var style: ButtonStyle = .outlineAccent {
         didSet {
             if style != oldValue {
                 update()
@@ -146,7 +146,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         return bounds.insetBy(dx: -growX, dy: -growY).contains(point)
     }
 
-    @objc public init(style: ButtonStyle = .outline) {
+    @objc public init(style: ButtonStyle = .outlineAccent) {
         self.style = style
         super.init(frame: .zero)
         initialize()
@@ -192,7 +192,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
     @objc public var tappableSize: CGSize = .zero
 
     lazy public var tokenSet: ButtonTokenSet = .init(style: { [weak self] in
-        return self?.style ?? .outline
+        return self?.style ?? .outlineAccent
     },
                                                      size: { [weak self] in
         return self?.sizeCategory ?? .medium

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -9,11 +9,26 @@ import UIKit
 
 @objc(MSFButtonStyle)
 public enum ButtonStyle: Int, CaseIterable {
+    // Added while we have deprecated styles. Can be removed once deprecated styles are removed.
+    public static var allCases: [ButtonStyle] = [accent,
+                                                 outlineAccent,
+                                                 outlineNeutral,
+                                                 subtle,
+                                                 danger,
+                                                 dangerOutline,
+                                                 dangerSubtle,
+                                                 floatingAccent,
+                                                 floatingSubtle]
+    
     /// A button with no border, neutral foreground, and brand background.
     case accent
 
     /// A button with brand border, brand foreground, and no background.
+    @available(*, deprecated, message: "The outline style is being changed to use neutral colors (currently outlineNeutral). Please use outlineAccent instead.")
     case outline
+
+    /// A button with brand border, brand foreground, and no background.
+    case outlineAccent
 
     /// A button with neutral border, neutral foreground, and no brackground.
     case outlineNeutral
@@ -118,7 +133,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .floatingAccent:
                         return theme.color(.brandBackground1)
-                    case .outline, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
+                    case .outline, .outlineAccent, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
                         return .clear
                     case .danger:
                         return theme.color(.dangerBackground2)
@@ -131,7 +146,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .floatingAccent:
                         return theme.color(.brandBackground1Selected)
-                    case .outline, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
+                    case .outline, .outlineAccent, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
                         return .clear
                     case .danger:
                         return theme.color(.dangerBackground2)
@@ -144,7 +159,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .danger, .floatingAccent, .floatingSubtle:
                         return theme.color(.background5)
-                    case .outline, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
+                    case .outline, .outlineAccent, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
                         return .clear
                     }
                 }
@@ -153,7 +168,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .floatingAccent:
                         return theme.color(.brandBackground1Pressed)
-                    case .outline, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
+                    case .outline, .outlineAccent, .outlineNeutral, .subtle, .dangerOutline, .dangerSubtle:
                         return .clear
                     case .danger:
                         return theme.color(.dangerBackground2)
@@ -166,7 +181,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .subtle, .danger, .dangerSubtle, .floatingAccent, .floatingSubtle:
                         return .clear
-                    case .outline:
+                    case .outline, .outlineAccent:
                         return theme.color(.brandStroke1)
                     case .outlineNeutral:
                         return theme.color(.stroke1)
@@ -179,7 +194,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .subtle, .danger, .dangerSubtle, .floatingAccent, .floatingSubtle:
                         return .clear
-                    case .outline, .outlineNeutral, .dangerOutline:
+                    case .outline, .outlineAccent, .outlineNeutral, .dangerOutline:
                         return theme.color(.strokeFocus2)
                     }
                 }
@@ -188,7 +203,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .subtle, .danger, .dangerSubtle, .floatingAccent, .floatingSubtle:
                         return .clear
-                    case .outline, .outlineNeutral, .dangerOutline:
+                    case .outline, .outlineAccent, .outlineNeutral, .dangerOutline:
                         return theme.color(.strokeDisabled)
                     }
                 }
@@ -197,7 +212,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .subtle, .danger, .dangerSubtle, .floatingAccent, .floatingSubtle:
                         return .clear
-                    case .outline:
+                    case .outline, .outlineAccent:
                         return theme.color(.brandStroke1Pressed)
                     case .outlineNeutral:
                         return theme.color(.stroke1Pressed)
@@ -210,7 +225,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .subtle, .danger, .dangerSubtle, .floatingAccent, .floatingSubtle:
                         return GlobalTokens.stroke(.widthNone)
-                    case .outline, .outlineNeutral, .dangerOutline:
+                    case .outline, .outlineAccent, .outlineNeutral, .dangerOutline:
                         return GlobalTokens.stroke(.width10)
                     }
                 }
@@ -228,7 +243,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .floatingAccent:
                         return theme.color(.foregroundOnColor)
-                    case .outline, .subtle:
+                    case .outline, .outlineAccent, .subtle:
                         return theme.color(.brandForeground1)
                     case .outlineNeutral:
                         return theme.color(.foreground1)
@@ -247,7 +262,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonTokenSet.Tokens> {
                     switch style() {
                     case .accent, .floatingAccent:
                         return theme.color(.foregroundOnColor)
-                    case .outline, .subtle:
+                    case .outline, .outlineAccent, .subtle:
                         return theme.color(.brandForeground1Pressed)
                     case .outlineNeutral:
                         return theme.color(.foreground1)

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -19,7 +19,7 @@ public enum ButtonStyle: Int, CaseIterable {
                                                  dangerSubtle,
                                                  floatingAccent,
                                                  floatingSubtle]
-    
+
     /// A button with no border, neutral foreground, and brand background.
     case accent
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

To align with Fluent Web, we're renaming the neutral outline button style to just `.outline`. In order to do that, we need to get clients off of the current `.outline` style, and get them on to `.outlineAccent`. This is part 1 of that effort. In future PRs, we'll need to deprecate `.outlineNeutral`, then eventually remove `.outlineNeutral` entirely and have `.outline` use the neutral tokens.

### Binary change

Total increase: 3,448 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,396,368 bytes | 31,399,816 bytes | ⚠️ 3,448 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ButtonTokenSet.o | 121,992 bytes | 125,136 bytes | ⚠️ 3,144 bytes |
| __.SYMDEF | 4,861,208 bytes | 4,861,448 bytes | ⚠️ 240 bytes |
| FocusRingView.o | 822,600 bytes | 822,656 bytes | ⚠️ 56 bytes |
| Button.o | 213,320 bytes | 213,328 bytes | ⚠️ 8 bytes |
</details>

### Verification

Brand colored outline buttons are still brand colored, and there's no deprecation warnings.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="506" alt="Button_Outline_Before" src="https://github.com/microsoft/fluentui-apple/assets/67026548/6842fbf9-da5f-49eb-a0e8-41f5425f2151"> | <img width="506" alt="Button_Outline_After" src="https://github.com/microsoft/fluentui-apple/assets/67026548/923abac9-4040-48e6-807c-9f105d18bb2e"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1913)