### PR TITLE
Deprecated ColorValue and DynamicColor

### DIFF
--- a/ios/FluentUI.Tests/ColorTests.swift
+++ b/ios/FluentUI.Tests/ColorTests.swift
@@ -8,6 +8,7 @@ import XCTest
 
 class ColorTests: XCTestCase {
 
+    @available(*, deprecated)
     func testColorValue() {
         let hexColorValue = ColorValue(0xC7E0F4)
         XCTAssertEqual(hexColorValue.a, 1.0)
@@ -22,6 +23,7 @@ class ColorTests: XCTestCase {
         XCTAssertEqual(rgbaColorValue.b, 0.82, accuracy: 0.01)
     }
 
+    @available(*, deprecated)
     func testColorValueConversions() {
         let colorValue = ColorValue(r: 0.35, g: 1.0, b: 0.82, a: 0.75)
         let color = UIColor(colorValue: colorValue)
@@ -36,5 +38,61 @@ class ColorTests: XCTestCase {
         XCTAssertEqual(colorValue.r, red)
         XCTAssertEqual(colorValue.g, green)
         XCTAssertEqual(colorValue.b, blue)
+    }
+
+    func testColorHexValue() {
+        let hexValue = UInt32(0xC7E0F4)
+        let color = UIColor(hexValue: hexValue)
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
+
+        // Verify that UIColor's getters return the same values as ColorValue's
+        XCTAssertTrue(color.getRed(&red, green: &green, blue: &blue, alpha: &alpha))
+        XCTAssertEqual(1.0, alpha)
+        XCTAssertEqual(CGFloat(0xC7) / 255.0, red, accuracy: 0.01)
+        XCTAssertEqual(CGFloat(0xE0) / 255.0, green, accuracy: 0.01)
+        XCTAssertEqual(CGFloat(0xF4) / 255.0, blue, accuracy: 0.01)
+    }
+
+    func testColorExtensions() {
+        let color1 = UIColor(light: .white,
+                             dark: .red)
+
+        XCTAssertEqual(color1.light, UIColor.white)
+        XCTAssertEqual(color1.lightHighContrast, UIColor.white)
+        XCTAssertEqual(color1.lightElevated, UIColor.white)
+        XCTAssertEqual(color1.lightElevatedHighContrast, UIColor.white)
+        XCTAssertEqual(color1.dark, UIColor.red)
+        XCTAssertEqual(color1.darkHighContrast, UIColor.red)
+        XCTAssertEqual(color1.darkElevated, UIColor.red)
+        XCTAssertEqual(color1.darkElevatedHighContrast, UIColor.red)
+
+        let color2 = UIColor(light: .white,
+                             lightHighContrast: .green,
+                             lightElevated: .blue)
+
+        XCTAssertEqual(color2.light, UIColor.white)
+        XCTAssertEqual(color2.lightHighContrast, UIColor.green)
+        XCTAssertEqual(color2.lightElevated, UIColor.blue)
+        XCTAssertEqual(color2.lightElevatedHighContrast, UIColor.blue)
+        XCTAssertEqual(color2.dark, UIColor.white)
+        XCTAssertEqual(color2.darkHighContrast, UIColor.green)
+        XCTAssertEqual(color2.darkElevated, UIColor.blue)
+        XCTAssertEqual(color2.darkElevatedHighContrast, UIColor.blue)
+
+        let color3 = UIColor(light: .white,
+                             dark: .orange,
+                             darkElevatedHighContrast: .magenta)
+
+        XCTAssertEqual(color3.light, UIColor.white)
+        XCTAssertEqual(color3.lightHighContrast, UIColor.white)
+        XCTAssertEqual(color3.lightElevated, UIColor.white)
+        XCTAssertEqual(color3.lightElevatedHighContrast, UIColor.white)
+        XCTAssertEqual(color3.dark, UIColor.orange)
+        XCTAssertEqual(color3.darkHighContrast, UIColor.orange)
+        XCTAssertEqual(color3.darkElevated, UIColor.orange)
+        XCTAssertEqual(color3.darkElevatedHighContrast, UIColor.magenta)
     }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/DynamicColor.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 
 /// A platform-agnostic representation of a 32-bit RGBA color value.
+@available(*, deprecated, message: "Please use UIColor or Color directly.")
 @objc(MSFColorValue)
 public class ColorValue: NSObject {
 
@@ -54,6 +55,7 @@ public class ColorValue: NSObject {
 }
 
 /// Represents a set of color values to be used in different contexts.
+@available(*, deprecated, message: "Please use UIColor or Color directly.")
 @objc(MSFDynamicColor)
 public class DynamicColor: NSObject {
 
@@ -177,6 +179,7 @@ public extension Color {
     /// rendering context.
     ///
     /// - Parameter dynamicColor: The set of color values that may be applied based on the current context.
+    @available(*, deprecated, message: "Please use Color directly, or init via UIColor.")
     init(dynamicColor: DynamicColor) {
         self.init(UIColor(dynamicColor: dynamicColor))
     }
@@ -184,6 +187,7 @@ public extension Color {
     /// Creates a Color from a `ColorValue` instance.
     ///
     /// - Parameter colorValue: Color value to use to initialize this color.
+    @available(*, deprecated, message: "Please use Color directly, or init via UIColor.")
     init(colorValue: ColorValue) {
         self.init(UIColor(colorValue: colorValue))
     }

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -82,26 +82,27 @@ extension UIColor {
 
     /// `DynamicColor` representation of the `UIColor` object.
     /// Requires the `UIColor` to be able to resolve its color values for at least the `.light` user interface style.
+    @available(*, deprecated, message: "Please use UIColor directly.")
     public var dynamicColor: DynamicColor? {
         // Only the light color value is mandatory when making a DynamicColor.
-        if let lightColorValue = resolvedColorValue(userInterfaceStyle: .light) {
+        if let lightColorValue = resolvedColorValue(userInterfaceStyle: .light).colorValue {
             let colors = DynamicColor(
                 light: lightColorValue,
                 lightHighContrast: resolvedColorValue(userInterfaceStyle: .light,
-                                                      accessibilityContrast: .high),
+                                                      accessibilityContrast: .high).colorValue,
                 lightElevated: resolvedColorValue(userInterfaceStyle: .light,
-                                                  userInterfaceLevel: .elevated),
+                                                  userInterfaceLevel: .elevated).colorValue,
                 lightElevatedHighContrast: resolvedColorValue(userInterfaceStyle: .light,
                                                               accessibilityContrast: .high,
-                                                              userInterfaceLevel: .elevated),
-                dark: resolvedColorValue(userInterfaceStyle: .dark),
+                                                              userInterfaceLevel: .elevated).colorValue,
+                dark: resolvedColorValue(userInterfaceStyle: .dark).colorValue,
                 darkHighContrast: resolvedColorValue(userInterfaceStyle: .dark,
-                                                     accessibilityContrast: .high),
+                                                     accessibilityContrast: .high).colorValue,
                 darkElevated: resolvedColorValue(userInterfaceStyle: .dark,
-                                                 userInterfaceLevel: .elevated),
+                                                 userInterfaceLevel: .elevated).colorValue,
                 darkElevatedHighContrast: resolvedColorValue(userInterfaceStyle: .dark,
                                                              accessibilityContrast: .high,
-                                                             userInterfaceLevel: .elevated))
+                                                             userInterfaceLevel: .elevated).colorValue)
             return colors
         } else {
             return nil
@@ -111,6 +112,7 @@ extension UIColor {
     /// Creates a UIColor from a `ColorValue` instance.
     ///
     /// - Parameter colorValue: Color value to use to initialize this color.
+    @available(*, deprecated, renamed: "init(hexValue:)")
     @objc public convenience init(colorValue: ColorValue) {
         self.init(
             red: colorValue.r,
@@ -141,6 +143,7 @@ extension UIColor {
     /// rendering context.
     ///
     /// - Parameter dynamicColor: The set of color values that may be applied based on the current context.
+    @available(*, deprecated, message: "Please use UIColor directly.")
     @objc public convenience init(dynamicColor: DynamicColor) {
         self.init { traits -> UIColor in
             let colorValue = dynamicColor.value(colorScheme: (traits.userInterfaceStyle == .dark ? .dark : .light),
@@ -151,69 +154,54 @@ extension UIColor {
     }
 
     @objc public var light: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .light) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .light)
+        return color
     }
 
     @objc public var lightHighContrast: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .light,
-                                             accessibilityContrast: .high) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .light,
+                                       accessibilityContrast: .high)
+        return color
     }
 
     @objc public var lightElevated: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .light,
-                                             userInterfaceLevel: .elevated) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .light,
+                                       userInterfaceLevel: .elevated)
+        return color
     }
 
     @objc public var lightElevatedHighContrast: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .light,
-                                             accessibilityContrast: .high,
-                                             userInterfaceLevel: .elevated) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .light,
+                                       accessibilityContrast: .high,
+                                       userInterfaceLevel: .elevated)
+        return color
     }
 
     @objc public var dark: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .dark) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .dark)
+        return color
     }
 
     @objc public var darkHighContrast: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .dark,
-                                             accessibilityContrast: .high) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .dark,
+                                       accessibilityContrast: .high)
+        return color
     }
 
     @objc public var darkElevated: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .dark,
-                                             userInterfaceLevel: .elevated) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .dark,
+                                       userInterfaceLevel: .elevated)
+        return color
     }
 
     @objc public var darkElevatedHighContrast: UIColor {
-        guard let color = resolvedColorValue(userInterfaceStyle: .dark,
-                                             accessibilityContrast: .high,
-                                             userInterfaceLevel: .elevated) else {
-            return self
-        }
-        return UIColor(colorValue: color)
+        let color = resolvedColorValue(userInterfaceStyle: .dark,
+                                       accessibilityContrast: .high,
+                                       userInterfaceLevel: .elevated)
+        return color
     }
 
+    @available(*, deprecated, message: "Please use UIColor directly.")
     private var colorValue: ColorValue? {
         var redValue: CGFloat = 1.0
         var greenValue: CGFloat = 1.0
@@ -236,12 +224,12 @@ extension UIColor {
     /// - Returns: The version of the color to display for the specified traits.
     private func resolvedColorValue(userInterfaceStyle: UIUserInterfaceStyle,
                                     accessibilityContrast: UIAccessibilityContrast = .unspecified,
-                                    userInterfaceLevel: UIUserInterfaceLevel = .unspecified) -> ColorValue? {
+                                    userInterfaceLevel: UIUserInterfaceLevel = .unspecified) -> UIColor {
         let traitCollectionStyle = UITraitCollection(userInterfaceStyle: userInterfaceStyle)
         let traitCollectionContrast = UITraitCollection(accessibilityContrast: accessibilityContrast)
         let traitCollectionLevel = UITraitCollection(userInterfaceLevel: userInterfaceLevel)
         let traitCollection = UITraitCollection(traitsFrom: [traitCollectionStyle, traitCollectionContrast, traitCollectionLevel])
         let resolvedColor = self.resolvedColor(with: traitCollection)
-        return resolvedColor.colorValue
+        return resolvedColor
     }
 }

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -154,51 +154,43 @@ extension UIColor {
     }
 
     @objc public var light: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .light)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .light)
     }
 
     @objc public var lightHighContrast: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .light,
-                                       accessibilityContrast: .high)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .light,
+                                  accessibilityContrast: .high)
     }
 
     @objc public var lightElevated: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .light,
-                                       userInterfaceLevel: .elevated)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .light,
+                                  userInterfaceLevel: .elevated)
     }
 
     @objc public var lightElevatedHighContrast: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .light,
-                                       accessibilityContrast: .high,
-                                       userInterfaceLevel: .elevated)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .light,
+                                  accessibilityContrast: .high,
+                                  userInterfaceLevel: .elevated)
     }
 
     @objc public var dark: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .dark)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .dark)
     }
 
     @objc public var darkHighContrast: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .dark,
-                                       accessibilityContrast: .high)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .dark,
+                                  accessibilityContrast: .high)
     }
 
     @objc public var darkElevated: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .dark,
-                                       userInterfaceLevel: .elevated)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .dark,
+                                  userInterfaceLevel: .elevated)
     }
 
     @objc public var darkElevatedHighContrast: UIColor {
-        let color = resolvedColorValue(userInterfaceStyle: .dark,
-                                       accessibilityContrast: .high,
-                                       userInterfaceLevel: .elevated)
-        return color
+        return resolvedColorValue(userInterfaceStyle: .dark,
+                                  accessibilityContrast: .high,
+                                  userInterfaceLevel: .elevated)
     }
 
     @available(*, deprecated, message: "Please use UIColor directly.")

--- a/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
+++ b/ios/FluentUI/PersonaButton/PersonaButtonTokenSet.swift
@@ -35,13 +35,13 @@ public class PersonaButtonTokenSet: ControlTokenSet<PersonaButtonTokenSet.Tokens
         /// The background color for the `PersonaButton`.
         case backgroundColor
 
-        /// The `DynamicColor` to use for the control's primary label.
+        /// The color to use for the control's primary label.
         case labelColor
 
         /// The `FontInfo` to use for the control's primary label.
         case labelFont
 
-        /// The `DynamicColor` to use for the control's secondary label.
+        /// The color to use for the control's secondary label.
         case sublabelColor
 
         /// The `FontInfo` to use for the control's secondary label.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

As a follow-up to #1914, let's deprecate the `ColorValue` and `DynamicColor` objects, since they aren't used/needed by the new `FluentTheme` APIs.

Also added some new unit tests to augment the now deprecated ones around `ColorValue` and `DynamicColor`.

### Binary change

Total increase: 8 bytes
Total decrease: -8,344 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,912,584 bytes | 30,904,248 bytes | 🎉 -8,336 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| DynamicColor.o | 49,280 bytes | 49,288 bytes | ⚠️ 8 bytes |
| __.SYMDEF | 4,823,000 bytes | 4,822,976 bytes | 🎉 -24 bytes |
| UIColor+Extensions.o | 81,576 bytes | 73,256 bytes | 🎉 -8,320 bytes |
</details>


### Verification

Built and tested -- no real code changes are made, so no behavior changes to verify.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1915)