### PR TITLE
Use `addTitle` for headings in LabelDemo

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift
@@ -14,7 +14,7 @@ class LabelDemoController: DemoController {
         super.viewDidLoad()
         readmeString = "Labels are used to standardize text across your app."
 
-        addLabel(text: "Text Styles", style: .body1Strong, colorStyle: .regular).textAlignment = .center
+        addTitle(text: "Text Styles")
 
         for style in FluentTheme.TypographyToken.allCases {
             let font = view.fluentTheme.typography(style)
@@ -25,12 +25,12 @@ class LabelDemoController: DemoController {
 
         container.addArrangedSubview(UIView())  // spacer
 
-        addLabel(text: "Text Color Styles", style: .body1Strong, colorStyle: .regular).textAlignment = .center
+        addTitle(text: "Text Color Styles")
         for colorStyle in TextColorStyle.allCases {
             textColorLabels.append(addLabel(text: colorStyle.description, style: .body1, colorStyle: colorStyle))
         }
 
-        addLabel(text: "Text Color Custom Styles", style: .body1Strong, colorStyle: .regular).textAlignment = .center
+        addTitle(text: "Text Color Custom Styles")
 
         let dangerSuccessLabel = Label(textStyle: .body1Strong, colorForTheme: {
             theme in


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fix accessibility issue in `LabelDemoController` by making its headings use the existing `addTitle` method instead of a custom label.

### Binary change

n/a - demo app only

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/4934719/f87cf856-1f65-4b43-bab3-be1094199291) | ![after](https://github.com/microsoft/fluentui-apple/assets/4934719/e5f4416f-2e93-4e43-8fc3-be70d3fb7150) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1916)