### PR TITLE
Update deprecated `Label` inits in demo app

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoController.swift
@@ -59,7 +59,7 @@ class DemoController: UIViewController {
     }
 
     func addTitle(text: String) {
-        let titleLabel = Label(style: .body1Strong)
+        let titleLabel = Label(textStyle: .body1Strong)
         titleLabel.text = text
         titleLabel.textAlignment = .center
         titleLabel.accessibilityTraits.insert(.header)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift
@@ -7,7 +7,7 @@ import FluentUI
 import UIKit
 
 class DateTimePickerDemoController: DemoController {
-    private let dateLabel = Label(style: .body1Strong)
+    private let dateLabel = Label(textStyle: .body1Strong)
     private let dateTimePicker = DateTimePicker()
 
     private let datePickerTypeSelector: UISegmentedControl = {
@@ -166,7 +166,7 @@ class DateTimePickerDemoController: DemoController {
         container.alignment = .center
         container.distribution = .equalSpacing
 
-        let label = Label(style: .body1Strong, colorStyle: .regular)
+        let label = Label(textStyle: .body1Strong, colorStyle: .regular)
         label.text = "Date picker type"
         label.numberOfLines = 0
         container.addArrangedSubview(label)
@@ -178,10 +178,10 @@ class DateTimePickerDemoController: DemoController {
     }
 
     func createCustomCalendarConfigurationUI() -> UIStackView {
-        let customCalendarConfigurationTitleLabel = Label(style: .body1Strong, colorStyle: .regular)
+        let customCalendarConfigurationTitleLabel = Label(textStyle: .body1Strong, colorStyle: .regular)
         customCalendarConfigurationTitleLabel.text = "Custom calendar configuration"
 
-        let customCalendarConfigurationBodyLabel = Label(style: .caption1, colorStyle: .regular)
+        let customCalendarConfigurationBodyLabel = Label(textStyle: .caption1, colorStyle: .regular)
         customCalendarConfigurationBodyLabel.text = "First weekday: Monday\nReference start date: Today\nReference end date: One month from today"
         customCalendarConfigurationBodyLabel.numberOfLines = 0
 
@@ -206,7 +206,7 @@ class DateTimePickerDemoController: DemoController {
         validationRow.alignment = .center
         validationRow.distribution = .equalSpacing
 
-        let validationLabel = Label(style: .body1Strong, colorStyle: .regular)
+        let validationLabel = Label(textStyle: .body1Strong, colorStyle: .regular)
         validationLabel.text = "Validate for date in future"
 
         validationRow.addArrangedSubview(validationLabel)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -311,7 +311,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     private func presentSideDrawer(presentingGesture: UIPanGestureRecognizer? = nil) {
-        let meControl = Label(style: .title2, colorStyle: .regular)
+        let meControl = Label(textStyle: .title2, colorStyle: .regular)
         meControl.text = "Me Control goes here"
         meControl.textAlignment = .center
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
@@ -75,7 +75,7 @@ class TooltipDemoController: DemoController {
         topContainer.addArrangedSubview(topleftButton)
         topContainer.addArrangedSubview(topRightButton)
 
-        let middleLabel = Label(style: .body1Strong, colorStyle: .regular)
+        let middleLabel = Label(textStyle: .body1Strong, colorStyle: .regular)
         middleLabel.text = "Press corner buttons to show offset tooltips"
         middleLabel.numberOfLines = 0
         middleLabel.textAlignment = .center

--- a/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/TableViewCellSampleData.swift
@@ -97,7 +97,7 @@ class TableViewCellSampleData: TableViewSampleData {
     ]
 
     static var customAccessoryView: UIView {
-        let label = Label(style: .body1, colorStyle: .secondary)
+        let label = Label(textStyle: .body1, colorStyle: .secondary)
         label.text = "PowerPoint Presentation"
         label.sizeToFit()
         label.numberOfLines = 0
@@ -171,7 +171,7 @@ class TableViewCellSampleData: TableViewSampleData {
         stackView.distribution = .fill
         stackView.axis = .vertical
 
-        let label = Label(style: .caption1)
+        let label = Label(textStyle: .caption1)
         label.textColor = stackView.fluentTheme.color(.foreground3)
         label.text = text
         stackView.addArrangedSubview(label)

--- a/ios/docs/Controls/Label.md
+++ b/ios/docs/Controls/Label.md
@@ -9,7 +9,7 @@ The design tokens determining the font size and weight represent Apple's fundame
 ### UIKit
 ```Swift
 // Label with tokenized style/color
-let label = Label(style: style, colorStyle: colorStyle)
+let label = Label(textStyle: style, colorStyle: colorStyle)
 label.text = text
 label.numberOfLines = 0
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#1914 deprecated the init of `Label` that used the typography alias tokens, but the demo didn't complain loudly enough that it was still using the deprecated init for these to get removed in that PR.

### Verification

No deprecation warnings while building

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1917)