### PR TITLE
Bump to 23

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUI'
-  s.version          = '0.22.0'
+  s.version          = '0.23.0'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.22.0</string>
+	<string>1.23.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>137.22.0</string>
+	<string>137.23.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/FluentUI.Resources/Info.plist
+++ b/ios/FluentUI.Resources/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.22.0</string>
+	<string>0.23.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.22.0</string>
+	<string>0.23.0</string>
 </dict>
 </plist>

--- a/macos/FluentUI/FluentUI-Info.plist
+++ b/macos/FluentUI/FluentUI-Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.22.0</string>
+	<string>0.23.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.22.0</string>
+	<string>0.23.0</string>
 </dict>
 </plist>

--- a/macos/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/macos/FluentUITestApp/FluentUITestApp-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.22.0</string>
+	<string>0.23.0</string>
 	<key>CFBundleVersion</key>
-	<string>62.22.0</string>
+	<string>62.23.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## What's Changed
* Require admin approval for `Package.swift` by @mischreiber in https://github.com/microsoft/fluentui-apple/pull/1880
* add xcbeautify for our ci results by @harrieshin in https://github.com/microsoft/fluentui-apple/pull/1882
* Enable list item cell swipe actions inside bottom sheet component by @nodes11 in https://github.com/microsoft/fluentui-apple/pull/1881
* Update FluentTextField becomeFirstResponder by @cmzubrecki in https://github.com/microsoft/fluentui-apple/pull/1905
* Updating SwiftLint failures by @sophialee0416 in https://github.com/microsoft/fluentui-apple/pull/1909
* Adding titleNumberOfLines to PopupMenuItem by @sophialee0416 in https://github.com/microsoft/fluentui-apple/pull/1908
* Deprecate outline button style by @huwilkes in https://github.com/microsoft/fluentui-apple/pull/1913
* Updating a11y for PersonaList when `onPersonaSelected` is defined by @sophialee0416 in https://github.com/microsoft/fluentui-apple/pull/1912
* Deprecating `AliasTokens` by @mischreiber in https://github.com/microsoft/fluentui-apple/pull/1914
* Use `addTitle` for headings in LabelDemo by @mischreiber in https://github.com/microsoft/fluentui-apple/pull/1916
* Update deprecated `Label` inits in demo app by @huwilkes in https://github.com/microsoft/fluentui-apple/pull/1917
* Deprecated ColorValue and DynamicColor by @mischreiber in https://github.com/microsoft/fluentui-apple/pull/1915

## New Contributors
* @cmzubrecki made their first contribution in https://github.com/microsoft/fluentui-apple/pull/1905
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1918)