### PR TITLE
[main_0.11] Truncate navigation bar title if too long

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -280,9 +280,9 @@ class BottomCommandingDemoController: UIViewController {
         return viewController
     }()
 
-    private let homeImage = UIImage(named: "Home_24")!
-    private let homeSelectedImage = UIImage(named: "Home_Selected_24")!
-    private let boldImage = UIImage(named: "textBold24Regular")!
+    private let homeImage: UIImage = UIImage(named: "Home_24")!
+    private let homeSelectedImage: UIImage = UIImage(named: "Home_Selected_24")!
+    private let boldImage: UIImage = UIImage(named: "textBold24Regular")!
 
     private var heroIconChanged: Bool = false
     private var listIconChanged: Bool = false

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -128,7 +128,7 @@ open class Button: UIButton, TokenizedControlInternal {
 
     open override func didUpdateFocus(in context: UIFocusUpdateContext, with coordinator: UIFocusAnimationCoordinator) {
         guard style == .primaryFilled || style == .dangerFilled,
-              (self == context.nextFocusedView || self == context.previouslyFocusedView) else {
+              self == context.nextFocusedView || self == context.previouslyFocusedView else {
             return
         }
 

--- a/ios/FluentUI/Calendar/CalendarConfiguration.swift
+++ b/ios/FluentUI/Calendar/CalendarConfiguration.swift
@@ -15,7 +15,6 @@ open class CalendarConfiguration: NSObject {
         static let endYearsInterval: Int = 10
     }
 
-    // swiftlint:disable:next explicit_type_interface
     @objc public static let `default` = CalendarConfiguration()
 
     /// By default, this is Sunday ('1')

--- a/ios/FluentUI/Date Time Pickers/DayOfMonth.swift
+++ b/ios/FluentUI/Date Time Pickers/DayOfMonth.swift
@@ -59,7 +59,7 @@ public enum DayOfWeek: Int {
         return daysOfWeek
     }
 
-    private static let weekdaySymbols = Calendar.sharedCalendarWithTimeZone(nil).weekdaySymbols
+    private static let weekdaySymbols: [String] = Calendar.sharedCalendarWithTimeZone(nil).weekdaySymbols
 
     public var label: String {
         return DayOfWeek.weekdaySymbols[rawValue]

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -205,8 +205,9 @@ class LargeTitleView: UIView {
         titleButton.contentHorizontalAlignment = .left
         titleButton.titleLabel?.adjustsFontSizeToFitWidth = true
         titleButton.addTarget(self, action: #selector(LargeTitleView.titleButtonTapped(sender:)), for: .touchUpInside)
-        titleButton.setContentCompressionResistancePriority(.required,
-                                                            for: .horizontal)
+		titleButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+		titleButton.titleLabel?.lineBreakMode = .byTruncatingTail
+		titleButton.titleLabel?.adjustsFontSizeToFitWidth = false
 
         // tap gesture for entire titleView
         tapGesture.addTarget(self, action: #selector(LargeTitleView.handleTitleViewTapped(sender:)))

--- a/ios/FluentUI/Navigation/Views/LargeTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/LargeTitleView.swift
@@ -205,9 +205,9 @@ class LargeTitleView: UIView {
         titleButton.contentHorizontalAlignment = .left
         titleButton.titleLabel?.adjustsFontSizeToFitWidth = true
         titleButton.addTarget(self, action: #selector(LargeTitleView.titleButtonTapped(sender:)), for: .touchUpInside)
-		titleButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-		titleButton.titleLabel?.lineBreakMode = .byTruncatingTail
-		titleButton.titleLabel?.adjustsFontSizeToFitWidth = false
+        titleButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleButton.titleLabel?.lineBreakMode = .byTruncatingTail
+        titleButton.titleLabel?.adjustsFontSizeToFitWidth = false
 
         // tap gesture for entire titleView
         tapGesture.addTarget(self, action: #selector(LargeTitleView.handleTitleViewTapped(sender:)))

--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -447,7 +447,7 @@ open class AvatarView: NSView {
 	static let maximumNumberOfInitials: Int = 2
 
 	/// the color used for the border
-	static let defaultBorderColor = NSColor(named: "AvatarView/borderColor", bundle: FluentUIResources.resourceBundle)!
+	static let defaultBorderColor: NSColor = NSColor(named: "AvatarView/borderColor", bundle: FluentUIResources.resourceBundle)!
 
 	static let borderWidth: CGFloat = 2.0
 
@@ -606,7 +606,7 @@ extension Character {
 
 fileprivate extension Unicode.Scalar {
 	/// Unicode representation of a  zero width space
-	static let zeroWidthSpace = Unicode.Scalar(0x200B)!
+	static let zeroWidthSpace: Unicode.Scalar = Unicode.Scalar(0x200B)!
 }
 
 extension AvatarView {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

There's a partner request to truncate the  navigation bar title if it's too long. This is because a long navigation bar title will push the right bar button items off the screen. Even though a long title goes against Apple guidelines, the partners need this because of long titles in German. 

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/106181067/d7580898-fffc-4115-9e9b-853617aa1ba7) | ![after](https://github.com/microsoft/fluentui-apple/assets/106181067/21964577-45c4-4c84-9c5b-0521d7f3bd30) |
| ![before_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/bcd56513-61c3-4466-b128-f5bb5efd7939) | ![after_landscape](https://github.com/microsoft/fluentui-apple/assets/106181067/e7410731-23ee-42ed-af9b-8e071bf596ea) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1919)