### PR TITLE
[macOS Avatar] Fix custom border drawing when built with Xcode 15

### DIFF
--- a/macos/FluentUI/AvatarView/AvatarView.swift
+++ b/macos/FluentUI/AvatarView/AvatarView.swift
@@ -730,7 +730,7 @@ class BorderView: NSView {
 	}
 
 	override func draw(_ dirtyRect: NSRect) {
-		let pathFrame = dirtyRect.insetBy(dx: strokeWidth / 2, dy: strokeWidth / 2)
+		let pathFrame = bounds.insetBy(dx: strokeWidth / 2, dy: strokeWidth / 2)
 		path = NSBezierPath(ovalIn: pathFrame)
 		path?.lineWidth = strokeWidth
 		strokeColor.set()


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] macOS

### Description of changes

In AvatarView's drawRect override, we're drawing relative to the `dirtyRect` parameter instead of drawing to our bounds. This was already technically a bug because `dirtyRect` since this could have been incorrect if `setNeedsDisplayInRect:` was used to invalidate part of the view. In practice that probably wasn't happening. But now `NSView.clipsToBounds` defaults to true when building with Xcode 15+ and running on macOS 14.0+ so AppKit now often gives us a `dirtyRect` which extends beyond the bounds of our view. That makes this much more obviously incorrect.

To fix, just draw the border relative to our bounds.

### Binary change

No impact

### Verification

See screenshots
<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-apple/assets/49537028/4d93ab88-f5d8-452a-8b41-6ac2b557bf3f) | 
![image](https://github.com/microsoft/fluentui-apple/assets/49537028/23cb184d-1203-45c1-b5b9-3a7378878b8c)
 |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1921)