### PR TITLE
Add ability to customize TableViewCell separator color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -145,9 +145,9 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
                 return 0
             },
             .separatorColor: .uiColor {
-                // "Anchor"
-                return UIColor(light: GlobalTokens.sharedColor(.anchor, .primary),
-                               dark: GlobalTokens.sharedColor(.anchor, .primary))
+                // "Red"
+                return UIColor(light: GlobalTokens.sharedColor(.red, .shade30),
+                               dark: GlobalTokens.sharedColor(.red, .tint40))
             }
         ]
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -143,6 +143,11 @@ extension TableViewCellDemoController: DemoAppearanceDelegate {
             },
             .customViewTrailingMargin: .float {
                 return 0
+            },
+            .separatorColor: .uiColor {
+                // "Anchor"
+                return UIColor(light: GlobalTokens.sharedColor(.anchor, .primary),
+                               dark: GlobalTokens.sharedColor(.anchor, .primary))
             }
         ]
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1892,6 +1892,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     func updateAppearance() {
         updateFonts()
         updateTextColors()
+        updateSeparatorColor()
         updateSelectionImageColor()
         setupBackgroundColors()
         updateAccessoryViewColor()
@@ -2014,6 +2015,11 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     private func updateSeparator(_ separator: Separator, with type: SeparatorType) {
         separator.isHidden = type == .none
         setNeedsLayout()
+    }
+
+    private func updateSeparatorColor() {
+        topSeparator.tokenSet[.color] = tokenSet[.separatorColor]
+        bottomSeparator.tokenSet[.color] = tokenSet[.separatorColor]
     }
 
     @objc private func handleContentSizeCategoryDidChange() {

--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -63,6 +63,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
         /// The color for the accessoryCheckmark.
         case accessoryCheckmarkColor
 
+        /// The color of the separator.
+        case separatorColor
+
         /// The main brand text color.
         case brandTextColor
 
@@ -154,6 +157,9 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellTokenSet.Tokens
 
             case .accessoryCheckmarkColor:
                 return .uiColor { theme.color(.brandForeground1) }
+
+            case .separatorColor:
+                return .uiColor { theme.color(.stroke2) }
 
             case .dangerTextColor:
                 return .uiColor { theme.color(.dangerForeground2) }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added ability to customize `TableViewCell`'s separator color. A new token `separatorColor` was added to `TableViewCellTokenSet`.

### Binary change

Total increase: 7,704 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,796,008 bytes | 30,803,712 bytes | ⚠️ 7,704 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewCell.o | 805,384 bytes | 809,800 bytes | ⚠️ 4,416 bytes |
| TableViewCellTokenSet.o | 108,280 bytes | 109,984 bytes | ⚠️ 1,704 bytes |
| __.SYMDEF | 4,770,960 bytes | 4,772,144 bytes | ⚠️ 1,184 bytes |
| PopupMenuItemCell.o | 174,072 bytes | 174,208 bytes | ⚠️ 136 bytes |
| PersonaCell.o | 62,704 bytes | 62,832 bytes | ⚠️ 128 bytes |
| BooleanCell.o | 89,904 bytes | 90,032 bytes | ⚠️ 128 bytes |
| ListActionItem.o | 224,808 bytes | 224,816 bytes | ⚠️ 8 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-apple/assets/55368679/4afe867f-98fb-470f-8a4b-404329cc1356) | ![image](https://github.com/microsoft/fluentui-apple/assets/55368679/c5782810-551a-43d1-b6a3-7352ed657799) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1923)