### PR TITLE
Add ability to customize TabBarView's separator color

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -251,6 +251,10 @@ extension TabBarViewDemoController: DemoAppearanceDelegate {
                                lightHighContrast: GlobalTokens.sharedColor(.teal, .tint40),
                                dark: GlobalTokens.sharedColor(.pumpkin, .tint40),
                                darkHighContrast: GlobalTokens.sharedColor(.burgundy, .tint40))
+            },
+            .separatorColor: .uiColor {
+                return UIColor(light: GlobalTokens.sharedColor(.red, .shade10),
+                               dark: GlobalTokens.sharedColor(.red, .tint40))
             }
         ]
     }

--- a/ios/FluentUI/Tab Bar/TabBarTokenSet.swift
+++ b/ios/FluentUI/Tab Bar/TabBarTokenSet.swift
@@ -20,6 +20,9 @@ public class TabBarTokenSet: ControlTokenSet<TabBarTokenSet.Tokens> {
         /// Font info for the title label when in landscape view.
         case tabBarItemTitleLabelFontLandscape
 
+        /// Defines the color of the top separator.
+        case separatorColor
+
     }
 
     init() {
@@ -48,6 +51,9 @@ public class TabBarTokenSet: ControlTokenSet<TabBarTokenSet.Tokens> {
                     assertionFailure("TabBarItem tokens are placeholders and should not be read.")
                     return theme.typography(.body1)
                 }
+
+            case .separatorColor:
+                return .uiColor { theme.color(.stroke2) }
             }
         }
     }

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -207,5 +207,6 @@ open class TabBarView: UIView, TokenizedControlInternal {
                                                     forToken: .titleLabelFontLandscape)
             }
         }
+        topBorderLine.tokenSet[.color] = tokenSet[.separatorColor]
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added ability to customize `TabBarView`'s separator color.  A new token `separatorColor` was added to `TabBarTokenSet`.

### Binary change

Total increase: 5,112 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,803,712 bytes | 30,808,824 bytes | ⚠️ 5,112 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TabBarView.o | 133,288 bytes | 136,376 bytes | ⚠️ 3,088 bytes |
| TabBarTokenSet.o | 44,616 bytes | 45,872 bytes | ⚠️ 1,256 bytes |
| __.SYMDEF | 4,772,144 bytes | 4,772,912 bytes | ⚠️ 768 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Light                                       | Dark                                      |
|----------------------------------------------|--------------------------------------------|
| ![Simulator Screenshot - iPhone 15 Pro - 2023-11-02 at 13 25 12](https://github.com/microsoft/fluentui-apple/assets/55368679/a5c20581-0c4d-4a62-9d9f-4654c9a434c7) | ![Simulator Screenshot - iPhone 15 Pro - 2023-11-02 at 13 25 20](https://github.com/microsoft/fluentui-apple/assets/55368679/0f4931e3-8b08-4b5e-8906-a31fc1871ec0) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1924)